### PR TITLE
feat: auto downgrade should stop to low instead of bypass because of privacy reasons [WPB-24687]

### DIFF
--- a/apps/webapp/src/script/repositories/media/backgroundEffects/quality/capabilityPolicy.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/quality/capabilityPolicy.ts
@@ -17,13 +17,15 @@
  *
  */
 
+import {QUALITY_TIERS} from 'Repositories/media/backgroundEffects/quality/qualityController';
+
 import {TIER_DEFINITIONS} from './definitions';
 
 import type {
   CapabilityInfo,
   QualityPolicyMode,
-  QualityPolicyResult,
   QualityPolicyResolver,
+  QualityPolicyResult,
   QualityTier,
 } from '../backgroundEffectsWorkerTypes';
 
@@ -34,16 +36,16 @@ import type {
  * @returns Next lower tier, or 'D' if already at minimum.
  */
 const downgradeTier = (tier: QualityTier): QualityTier => {
-  if (tier === 'superhigh') {
-    return 'high';
+  if (tier === QUALITY_TIERS.SUPERHIGH) {
+    return QUALITY_TIERS.HIGH;
   }
-  if (tier === 'high') {
-    return 'medium';
+  if (tier === QUALITY_TIERS.HIGH) {
+    return QUALITY_TIERS.MEDIUM;
   }
-  if (tier === 'medium') {
-    return 'low';
+  if (tier === QUALITY_TIERS.MEDIUM) {
+    return QUALITY_TIERS.LOW;
   }
-  return 'bypass';
+  return QUALITY_TIERS.BYPASS;
 };
 
 /**
@@ -53,16 +55,16 @@ const downgradeTier = (tier: QualityTier): QualityTier => {
  * @returns Next higher tier, or 'A' if already at maximum.
  */
 const upgradeTier = (tier: QualityTier): QualityTier => {
-  if (tier === 'bypass') {
-    return 'low';
+  if (tier === QUALITY_TIERS.BYPASS) {
+    return QUALITY_TIERS.LOW;
   }
-  if (tier === 'low') {
-    return 'medium';
+  if (tier === QUALITY_TIERS.LOW) {
+    return QUALITY_TIERS.MEDIUM;
   }
-  if (tier === 'medium') {
-    return 'high';
+  if (tier === QUALITY_TIERS.MEDIUM) {
+    return QUALITY_TIERS.HIGH;
   }
-  return 'superhigh';
+  return QUALITY_TIERS.SUPERHIGH;
 };
 
 /**
@@ -79,15 +81,15 @@ const upgradeTier = (tier: QualityTier): QualityTier => {
  */
 export const baselineTierForCapabilities = (capabilities: CapabilityInfo): QualityTier => {
   if (capabilities.webgl2 && capabilities.worker && capabilities.offscreenCanvas) {
-    return 'superhigh';
+    return QUALITY_TIERS.SUPERHIGH;
   }
   if (capabilities.webgl2) {
-    return 'medium';
+    return QUALITY_TIERS.MEDIUM;
   }
   if (typeof document !== 'undefined') {
-    return 'low';
+    return QUALITY_TIERS.LOW;
   }
-  return 'bypass';
+  return QUALITY_TIERS.BYPASS;
 };
 
 /**

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/quality/qualityController.test.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/quality/qualityController.test.ts
@@ -24,7 +24,8 @@ const MODE_BLUR = 'blur' as const;
 const MODE_VIRTUAL = 'virtual' as const;
 
 const TARGET_FPS = 30;
-const BUDGET_MS = 1000 / TARGET_FPS;
+const PERFORMANCE_THRESHOLD = 1000;
+const BUDGET_MS = PERFORMANCE_THRESHOLD / TARGET_FPS;
 const DOWNGRADE_THRESHOLD_MS = BUDGET_MS * DEFAULT_TUNING.downgradeThresholdRatio;
 const HYSTERESIS_FRAMES = DEFAULT_TUNING.hysteresisFrames;
 const DOWNGRADE_MIN_SAMPLES = DEFAULT_TUNING.maxSamples * DEFAULT_TUNING.downgradeWarmupWindows;
@@ -59,7 +60,7 @@ describe('QualityController', () => {
 
     // first downgrade
     let guard = 0;
-    while (params.tier === 'superhigh' && guard++ < 1000) {
+    while (params.tier === 'superhigh' && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(gpuBoundSample, MODE_BLUR);
     }
 
@@ -67,14 +68,14 @@ describe('QualityController', () => {
 
     // next downgrade
     guard = 0;
-    while (params.tier === 'high' && guard++ < 1000) {
+    while (params.tier === 'high' && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(gpuBoundSample, MODE_BLUR);
     }
 
     expect(params.tier).toBe('low');
 
     guard = 0;
-    while (guard++ < 1000) {
+    while (guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(gpuBoundSample, MODE_BLUR);
     }
     expect(params.tier).toBe('low');
@@ -144,10 +145,10 @@ describe('QualityController', () => {
 
     // Trigger downgrade with CPU-bound samples (superhigh -> high)
     let guard = 0;
-    while (params.tier === 'superhigh' && guard++ < 1000) {
+    while (params.tier === 'superhigh' && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(cpuBoundSample, MODE_BLUR);
     }
-    expect(guard).toBeLessThan(1000);
+    expect(guard).toBeLessThan(PERFORMANCE_THRESHOLD);
     expect(params.tier).toBe('high');
 
     // Provide fast samples immediately after downgrade
@@ -215,12 +216,12 @@ describe('QualityController', () => {
     // Balanced sample: neither CPU nor GPU dominates (>55%)
     let params = controller.getTier(MODE_BLUR);
     let guard = 0;
-    while (params.tier === 'superhigh' && guard++ < 1000) {
+    while (params.tier === 'superhigh' && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(balancedSample, MODE_BLUR);
     }
     // Should step down normally (superhigh -> high) for balanced workloads
     expect(params?.tier).toBe('high');
-    expect(guard).toBeLessThan(1000);
+    expect(guard).toBeLessThan(PERFORMANCE_THRESHOLD);
   });
 
   it('manually sets tier and resets counters', () => {
@@ -240,35 +241,35 @@ describe('QualityController', () => {
 
     // superhigh -> high
     let guard = 0;
-    while (params.tier === 'superhigh' && guard++ < 1000) {
+    while (params.tier === 'superhigh' && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(cpuBoundSample, MODE_BLUR);
     }
     expect(params?.tier).toBe('high');
 
     // high -> medium (CPU-bound downgrade)
     guard = 0;
-    while (params.tier === 'high' && guard++ < 1000) {
+    while (params.tier === 'high' && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(cpuBoundSample, MODE_BLUR);
     }
     expect(params.tier).toBe('medium');
 
     // medium -> low (further downgrade)
     guard = 0;
-    while (params.tier === 'medium' && guard++ < 1000) {
+    while (params.tier === 'medium' && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(slowSample, MODE_BLUR);
     }
     expect(params?.tier).toBe('low');
 
     // low must remain low, never bypass
     guard = 0;
-    while (params.tier === 'low' && guard++ < 1000) {
+    while (params.tier === 'low' && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(slowSample, MODE_BLUR);
     }
     expect(params.tier).toBe('low');
 
     // low -> medium (upgrade path still works)
     guard = 0;
-    while (params.tier === 'low' && guard++ < 1000) {
+    while (params.tier === 'low' && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(veryFastSample, MODE_BLUR);
     }
     expect(params.tier).toBe('medium');
@@ -292,7 +293,7 @@ describe('QualityController', () => {
 
   it('handles boundary conditions at thresholds', () => {
     const controller = new QualityController(TARGET_FPS);
-    const budget = 1000 / TARGET_FPS;
+    const budget = PERFORMANCE_THRESHOLD / TARGET_FPS;
     const upgradeThreshold = budget * DEFAULT_TUNING.upgradeThresholdRatio;
     const justAboveUpgrade = upgradeThreshold + 0.5;
     const clearlyBelowUpgrade = upgradeThreshold - 5;
@@ -320,7 +321,7 @@ describe('QualityController', () => {
 
     let params = controller.getTier(MODE_BLUR);
 
-    for (let i = 0; i < 1000; i += 1) {
+    for (let i = 0; i < PERFORMANCE_THRESHOLD; i += 1) {
       params = controller.update(slowSample, MODE_BLUR);
     }
 

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/quality/qualityController.test.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/quality/qualityController.test.ts
@@ -53,7 +53,7 @@ describe('QualityController', () => {
     expect(params?.tier).toBe('high');
   });
 
-  it('downgrades GPU-bound workloads more aggressively', () => {
+  it('downgrades GPU-bound workloads more aggressively without entering bypass', () => {
     const controller = new QualityController(TARGET_FPS);
     let params = controller.getTier(MODE_BLUR);
 
@@ -71,6 +71,12 @@ describe('QualityController', () => {
       params = controller.update(gpuBoundSample, MODE_BLUR);
     }
 
+    expect(params.tier).toBe('low');
+
+    guard = 0;
+    while (guard++ < 1000) {
+      params = controller.update(gpuBoundSample, MODE_BLUR);
+    }
     expect(params.tier).toBe('low');
   });
 
@@ -228,7 +234,7 @@ describe('QualityController', () => {
     expect(controller.getTier(MODE_BLUR).tier).toBe('high');
   });
 
-  it('handles multiple tier transitions', () => {
+  it('handles multiple tier transitions without auto-downgrading to bypass', () => {
     const controller = new QualityController(TARGET_FPS);
     let params = controller.getTier(MODE_BLUR);
 
@@ -253,19 +259,19 @@ describe('QualityController', () => {
     }
     expect(params?.tier).toBe('low');
 
-    // low -> bypass (final downgrade)
+    // low must remain low, never bypass
     guard = 0;
     while (params.tier === 'low' && guard++ < 1000) {
       params = controller.update(slowSample, MODE_BLUR);
     }
-    expect(params.tier).toBe('bypass');
+    expect(params.tier).toBe('low');
 
-    // bypass -> low (upgrade path)
+    // low -> medium (upgrade path still works)
     guard = 0;
-    while (params.tier === 'bypass' && guard++ < 1000) {
+    while (params.tier === 'low' && guard++ < 1000) {
       params = controller.update(veryFastSample, MODE_BLUR);
     }
-    expect(params.tier).toBe('low');
+    expect(params.tier).toBe('medium');
   });
 
   it('maintains sample window size limit', () => {
@@ -306,5 +312,18 @@ describe('QualityController', () => {
     }
     // Well below threshold, should upgrade.
     expect(params?.tier).toBe('superhigh');
+  });
+
+  it('does not auto-downgrade from low to bypass', () => {
+    const controller = new QualityController(TARGET_FPS);
+    controller.setTier('low');
+
+    let params = controller.getTier(MODE_BLUR);
+
+    for (let i = 0; i < 1000; i += 1) {
+      params = controller.update(slowSample, MODE_BLUR);
+    }
+
+    expect(params.tier).toBe('low');
   });
 });

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/quality/qualityController.test.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/quality/qualityController.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {QualityController} from './qualityController';
+import {QUALITY_TIERS, QualityController} from './qualityController';
 import {DEFAULT_TUNING} from './tuning';
 
 const MODE_BLUR = 'blur' as const;
@@ -51,7 +51,7 @@ describe('QualityController', () => {
     for (let i = 0; i < DOWNGRADE_TRIGGER_SAMPLES; i += 1) {
       params = controller.update(cpuBoundSample, MODE_BLUR);
     }
-    expect(params?.tier).toBe('high');
+    expect(params?.tier).toBe(QUALITY_TIERS.HIGH);
   });
 
   it('downgrades GPU-bound workloads more aggressively without entering bypass', () => {
@@ -60,25 +60,25 @@ describe('QualityController', () => {
 
     // first downgrade
     let guard = 0;
-    while (params.tier === 'superhigh' && guard++ < PERFORMANCE_THRESHOLD) {
+    while (params.tier === QUALITY_TIERS.SUPERHIGH && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(gpuBoundSample, MODE_BLUR);
     }
 
-    expect(params.tier).toBe('high');
+    expect(params.tier).toBe(QUALITY_TIERS.HIGH);
 
     // next downgrade
     guard = 0;
-    while (params.tier === 'high' && guard++ < PERFORMANCE_THRESHOLD) {
+    while (params.tier === QUALITY_TIERS.HIGH && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(gpuBoundSample, MODE_BLUR);
     }
 
-    expect(params.tier).toBe('low');
+    expect(params.tier).toBe(QUALITY_TIERS.LOW);
 
     guard = 0;
     while (guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(gpuBoundSample, MODE_BLUR);
     }
-    expect(params.tier).toBe('low');
+    expect(params.tier).toBe(QUALITY_TIERS.LOW);
   });
 
   it('applies mode-specific overlays', () => {
@@ -91,12 +91,12 @@ describe('QualityController', () => {
 
   it('resets hysteresis when mode changes', () => {
     const controller = new QualityController(TARGET_FPS);
-    controller.setTier('low');
+    controller.setTier(QUALITY_TIERS.LOW);
     for (let i = 0; i < HYSTERESIS_FRAMES - 1; i += 1) {
       controller.update(fastSample, MODE_BLUR);
     }
     const params = controller.update(fastSample, MODE_VIRTUAL);
-    expect(params.tier).toBe('low');
+    expect(params.tier).toBe(QUALITY_TIERS.LOW);
   });
 
   it('does not oscillate within a single hysteresis window', () => {
@@ -105,20 +105,20 @@ describe('QualityController', () => {
     for (let i = 0; i < HYSTERESIS_FRAMES - 5; i += 1) {
       params = controller.update(i % 2 === 0 ? slowSample : fastSample, MODE_BLUR);
     }
-    expect(params?.tier).toBe('superhigh');
+    expect(params?.tier).toBe(QUALITY_TIERS.SUPERHIGH);
   });
 
   it('starts at tier superhigh', () => {
     const controller = new QualityController(TARGET_FPS);
     const params = controller.getTier(MODE_BLUR);
-    expect(params.tier).toBe('superhigh');
+    expect(params.tier).toBe(QUALITY_TIERS.SUPERHIGH);
   });
 
   it('upgrades tier when performance improves', () => {
     const controller = new QualityController(TARGET_FPS);
     // Start at tier C
-    controller.setTier('low');
-    expect(controller.getTier(MODE_BLUR).tier).toBe('low');
+    controller.setTier(QUALITY_TIERS.LOW);
+    expect(controller.getTier(MODE_BLUR).tier).toBe(QUALITY_TIERS.LOW);
 
     // Provide fast samples to trigger upgrade
     let params;
@@ -126,14 +126,14 @@ describe('QualityController', () => {
       params = controller.update(veryFastSample, MODE_BLUR);
     }
     // Should upgrade from C to B
-    expect(params?.tier).toBe('medium');
+    expect(params?.tier).toBe(QUALITY_TIERS.MEDIUM);
 
     // Continue with fast samples to upgrade further
     for (let i = 0; i < HYSTERESIS_FRAMES + 1; i += 1) {
       params = controller.update(veryFastSample, MODE_BLUR);
     }
     // Should upgrade from B to A
-    expect(params?.tier).toBe('high');
+    expect(params?.tier).toBe(QUALITY_TIERS.HIGH);
   });
 
   it('prevents immediate upgrade after downgrade due to cooldown', () => {
@@ -141,15 +141,15 @@ describe('QualityController', () => {
 
     // Start at tier superhigh
     let params = controller.getTier(MODE_BLUR);
-    expect(params.tier).toBe('superhigh');
+    expect(params.tier).toBe(QUALITY_TIERS.SUPERHIGH);
 
     // Trigger downgrade with CPU-bound samples (superhigh -> high)
     let guard = 0;
-    while (params.tier === 'superhigh' && guard++ < PERFORMANCE_THRESHOLD) {
+    while (params.tier === QUALITY_TIERS.SUPERHIGH && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(cpuBoundSample, MODE_BLUR);
     }
     expect(guard).toBeLessThan(PERFORMANCE_THRESHOLD);
-    expect(params.tier).toBe('high');
+    expect(params.tier).toBe(QUALITY_TIERS.HIGH);
 
     // Provide fast samples immediately after downgrade
     // Cooldown decrements each frame, so after 60 frames it will be 0
@@ -157,7 +157,7 @@ describe('QualityController', () => {
     for (let i = 0; i < 5; i++) {
       params = controller.update(veryFastSample, MODE_BLUR);
     }
-    expect(params.tier).toBe('high'); // stay on high because cooldown > 0
+    expect(params.tier).toBe(QUALITY_TIERS.HIGH); // stay on high because cooldown > 0
 
     // Enough frames for cooldown
     guard = 0;
@@ -171,9 +171,9 @@ describe('QualityController', () => {
       params = controller.update(veryFastSample, MODE_BLUR);
     }
 
-    // must NOT exceed 'high' due to maxTier cap
-    expect(params.tier).not.toBe('superhigh');
-    expect(['high', 'medium']).toContain(params.tier);
+    // must NOT exceed QUALITY_TIERS.HIGH due to maxTier cap
+    expect(params.tier).not.toBe(QUALITY_TIERS.SUPERHIGH);
+    expect([QUALITY_TIERS.HIGH, QUALITY_TIERS.MEDIUM]).toContain(params.tier);
   });
 
   it('applies bypass mode and zero temporal alpha for tier bypass', () => {
@@ -187,7 +187,7 @@ describe('QualityController', () => {
 
   it('applies tier low virtual mode adjustments', () => {
     const controller = new QualityController(TARGET_FPS);
-    controller.setTier('low');
+    controller.setTier(QUALITY_TIERS.LOW);
     const virtualParams = controller.getTier(MODE_VIRTUAL);
     const blurParams = controller.getTier(MODE_BLUR);
 
@@ -216,23 +216,23 @@ describe('QualityController', () => {
     // Balanced sample: neither CPU nor GPU dominates (>55%)
     let params = controller.getTier(MODE_BLUR);
     let guard = 0;
-    while (params.tier === 'superhigh' && guard++ < PERFORMANCE_THRESHOLD) {
+    while (params.tier === QUALITY_TIERS.SUPERHIGH && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(balancedSample, MODE_BLUR);
     }
     // Should step down normally (superhigh -> high) for balanced workloads
-    expect(params?.tier).toBe('high');
+    expect(params?.tier).toBe(QUALITY_TIERS.HIGH);
     expect(guard).toBeLessThan(PERFORMANCE_THRESHOLD);
   });
 
   it('manually sets tier and resets counters', () => {
     const controller = new QualityController(TARGET_FPS);
     // Manually set to tier C
-    controller.setTier('low');
-    expect(controller.getTier(MODE_BLUR).tier).toBe('low');
+    controller.setTier(QUALITY_TIERS.LOW);
+    expect(controller.getTier(MODE_BLUR).tier).toBe(QUALITY_TIERS.LOW);
 
     // Should allow immediate tier change after setTier
-    controller.setTier('high');
-    expect(controller.getTier(MODE_BLUR).tier).toBe('high');
+    controller.setTier(QUALITY_TIERS.HIGH);
+    expect(controller.getTier(MODE_BLUR).tier).toBe(QUALITY_TIERS.HIGH);
   });
 
   it('handles multiple tier transitions without auto-downgrading to bypass', () => {
@@ -241,38 +241,38 @@ describe('QualityController', () => {
 
     // superhigh -> high
     let guard = 0;
-    while (params.tier === 'superhigh' && guard++ < PERFORMANCE_THRESHOLD) {
+    while (params.tier === QUALITY_TIERS.SUPERHIGH && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(cpuBoundSample, MODE_BLUR);
     }
-    expect(params?.tier).toBe('high');
+    expect(params?.tier).toBe(QUALITY_TIERS.HIGH);
 
     // high -> medium (CPU-bound downgrade)
     guard = 0;
-    while (params.tier === 'high' && guard++ < PERFORMANCE_THRESHOLD) {
+    while (params.tier === QUALITY_TIERS.HIGH && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(cpuBoundSample, MODE_BLUR);
     }
-    expect(params.tier).toBe('medium');
+    expect(params.tier).toBe(QUALITY_TIERS.MEDIUM);
 
     // medium -> low (further downgrade)
     guard = 0;
-    while (params.tier === 'medium' && guard++ < PERFORMANCE_THRESHOLD) {
+    while (params.tier === QUALITY_TIERS.MEDIUM && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(slowSample, MODE_BLUR);
     }
-    expect(params?.tier).toBe('low');
+    expect(params?.tier).toBe(QUALITY_TIERS.LOW);
 
     // low must remain low, never bypass
     guard = 0;
-    while (params.tier === 'low' && guard++ < PERFORMANCE_THRESHOLD) {
+    while (params.tier === QUALITY_TIERS.LOW && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(slowSample, MODE_BLUR);
     }
-    expect(params.tier).toBe('low');
+    expect(params.tier).toBe(QUALITY_TIERS.LOW);
 
     // low -> medium (upgrade path still works)
     guard = 0;
-    while (params.tier === 'low' && guard++ < PERFORMANCE_THRESHOLD) {
+    while (params.tier === QUALITY_TIERS.LOW && guard++ < PERFORMANCE_THRESHOLD) {
       params = controller.update(veryFastSample, MODE_BLUR);
     }
-    expect(params.tier).toBe('medium');
+    expect(params.tier).toBe(QUALITY_TIERS.MEDIUM);
   });
 
   it('maintains sample window size limit', () => {
@@ -299,25 +299,25 @@ describe('QualityController', () => {
     const clearlyBelowUpgrade = upgradeThreshold - 5;
 
     const atUpgradeThreshold = {totalMs: justAboveUpgrade, segmentationMs: 10, gpuMs: 8};
-    controller.setTier('medium');
+    controller.setTier(QUALITY_TIERS.MEDIUM);
     let params;
     for (let i = 0; i < HYSTERESIS_FRAMES + 1; i += 1) {
       params = controller.update(atUpgradeThreshold, MODE_BLUR);
     }
     // Just above threshold, should not upgrade.
-    expect(params?.tier).toBe('medium');
+    expect(params?.tier).toBe(QUALITY_TIERS.MEDIUM);
 
     const belowUpgradeThreshold = {totalMs: clearlyBelowUpgrade, segmentationMs: 9, gpuMs: 8};
     for (let i = 0; i < HYSTERESIS_FRAMES + 1; i += 1) {
       params = controller.update(belowUpgradeThreshold, MODE_BLUR);
     }
     // Well below threshold, should upgrade.
-    expect(params?.tier).toBe('superhigh');
+    expect(params?.tier).toBe(QUALITY_TIERS.SUPERHIGH);
   });
 
   it('does not auto-downgrade from low to bypass', () => {
     const controller = new QualityController(TARGET_FPS);
-    controller.setTier('low');
+    controller.setTier(QUALITY_TIERS.MIN_ALLOWED_TIER);
 
     let params = controller.getTier(MODE_BLUR);
 
@@ -325,6 +325,6 @@ describe('QualityController', () => {
       params = controller.update(slowSample, MODE_BLUR);
     }
 
-    expect(params.tier).toBe('low');
+    expect(params.tier).toBe(QUALITY_TIERS.LOW);
   });
 });

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/quality/qualityController.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/quality/qualityController.ts
@@ -440,15 +440,12 @@ export class QualityController {
       // CPU-bound: normal step down to B
       return dominant === 'gpu' ? 'low' : 'medium';
     }
-    if (this.tier === 'medium') {
+    if (this.tier === 'medium' || this.tier === 'low') {
       return 'low';
     }
-    if (this.tier === 'low') {
-      return 'bypass';
-    }
-
     // last case
-    return 'bypass';
+    // Never auto-downgrade to bypass; low is the minimum allowed tier for privacy reasons.
+    return 'low';
   }
 
   /**

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/quality/qualityController.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/quality/qualityController.ts
@@ -25,6 +25,16 @@ import type {Mode, QualityTier, QualityTierParams} from '../backgroundEffectsWor
 
 const DEFAULT_TARGET_FPS = 30;
 
+export const QUALITY_TIERS = {
+  SUPERHIGH: 'superhigh' as const,
+  HIGH: 'high' as const,
+  MEDIUM: 'medium' as const,
+  LOW: 'low' as const,
+  BYPASS: 'bypass' as const,
+  // Privacy boundary constant
+  MIN_ALLOWED_TIER: 'low' as const,
+} as const;
+
 /**
  * Adaptive quality controller that dynamically adjusts rendering quality tiers
  * based on real-time performance measurements.
@@ -55,7 +65,7 @@ export class QualityController {
   /** Total number of samples observed since the last reset. */
   private totalSamplesSeen = 0;
   /** Current quality tier. Starts at (highest quality). */
-  private tier: QualityTier = 'superhigh';
+  private tier: QualityTier = QUALITY_TIERS.SUPERHIGH;
   /** Maximum tier allowed for upgrades once performance caps are applied. */
   private maxTier: QualityTier | null = null;
   /** Frame time budget in milliseconds derived from target FPS. */
@@ -233,8 +243,8 @@ export class QualityController {
       const dominant = this.getDominantCost(ewmaTotalMs, ewmaSegmentationMs, ewmaGpuMs);
       const nextTier = this.downgradeTier(dominant);
       if (nextTier !== this.tier) {
-        if (this.tier === 'superhigh') {
-          this.applyMaxTierCap('high');
+        if (this.tier === QUALITY_TIERS.SUPERHIGH) {
+          this.applyMaxTierCap(QUALITY_TIERS.HIGH);
         }
         this.registerUpgradeFailure(nextTier);
         if (process.env.NODE_ENV !== 'production') {
@@ -431,21 +441,21 @@ export class QualityController {
    * @returns The next lower quality tier.
    */
   private downgradeTier(dominant: 'cpu' | 'gpu' | 'balanced'): QualityTier {
-    if (this.tier === 'superhigh') {
-      return 'high';
+    if (this.tier === QUALITY_TIERS.SUPERHIGH) {
+      return QUALITY_TIERS.HIGH;
     }
 
-    if (this.tier === 'high') {
+    if (this.tier === QUALITY_TIERS.HIGH) {
       // GPU-bound: skip medium tier for stronger GPU cost reduction
       // CPU-bound: normal step down to B
-      return dominant === 'gpu' ? 'low' : 'medium';
+      return dominant === 'gpu' ? QUALITY_TIERS.LOW : QUALITY_TIERS.MEDIUM;
     }
-    if (this.tier === 'medium' || this.tier === 'low') {
-      return 'low';
+    if (this.tier === QUALITY_TIERS.MEDIUM || this.tier === QUALITY_TIERS.LOW) {
+      return QUALITY_TIERS.LOW;
     }
     // last case
     // Never auto-downgrade to bypass; low is the minimum allowed tier for privacy reasons.
-    return 'low';
+    return QUALITY_TIERS.MIN_ALLOWED_TIER;
   }
 
   /**
@@ -455,21 +465,23 @@ export class QualityController {
    * @returns The next higher quality tier, or current tier if already at maximum.
    */
   private upgradeTier(): QualityTier {
-    if (this.tier === 'superhigh') {
-      return 'superhigh';
+    if (this.tier === QUALITY_TIERS.SUPERHIGH) {
+      return QUALITY_TIERS.SUPERHIGH;
     }
-    if (this.tier === 'bypass') {
-      return this.canUpgradeTo('low') ? 'low' : 'bypass';
+    if (this.tier === QUALITY_TIERS.BYPASS) {
+      return this.canUpgradeTo(QUALITY_TIERS.LOW) ? QUALITY_TIERS.LOW : QUALITY_TIERS.BYPASS;
     }
-    if (this.tier === 'low') {
-      return this.canUpgradeTo('medium') ? 'medium' : 'low';
+    if (this.tier === QUALITY_TIERS.LOW) {
+      return this.canUpgradeTo(QUALITY_TIERS.MEDIUM) ? QUALITY_TIERS.MEDIUM : QUALITY_TIERS.LOW;
     }
 
-    if (this.tier === 'medium') {
-      return this.canUpgradeTo('high') ? 'high' : 'medium';
+    if (this.tier === QUALITY_TIERS.MEDIUM) {
+      return this.canUpgradeTo(QUALITY_TIERS.HIGH) ? QUALITY_TIERS.HIGH : QUALITY_TIERS.MEDIUM;
     }
     // Tier can only go to superhigh (maximum quality)
-    return this.tier === 'high' && this.canUpgradeTo('superhigh') ? 'superhigh' : 'high';
+    return this.tier === QUALITY_TIERS.HIGH && this.canUpgradeTo(QUALITY_TIERS.SUPERHIGH)
+      ? QUALITY_TIERS.SUPERHIGH
+      : QUALITY_TIERS.HIGH;
   }
 
   /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24687" title="WPB-24687" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24687</a>  [Web] Background effects should not be bypass due to performance
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- What did I change and why?
Auto downgrade should stop to low instead of bypass because of privacy reasons
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
