### PR TITLE
chore(ci): wait for Elastic Beanstalk deployments before reporting CI success [WPB-22420]

### DIFF
--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -63,7 +63,7 @@ jobs:
           environment-name: ${{ inputs.env }}
           version-label: ${{ github.run_id }}
           deployment-package-path: ${{ env.AWS_BUILD_ZIP_PATH }}
-          wait-for-deployment: false
+          wait-for-deployment: true
           wait-for-environment-recovery: true
           deployment-timeout: ${{ env.DEPLOYMENT_RECOVERY_TIMEOUT_SECONDS }}
           use-existing-application-version-if-available: true

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -105,7 +105,7 @@ jobs:
           environment-name: wire-webapp-precommit
           version-label: ${{ github.run_id }}
           deployment-package-path: ${{ needs.build.outputs.build_artifact }}
-          wait-for-deployment: false
+          wait-for-deployment: true
           wait-for-environment-recovery: true
           deployment-timeout: 150
           use-existing-application-version-if-available: true

--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -317,7 +317,7 @@ jobs:
           environment-name: ${{ matrix.target }}
           version-label: ${{ github.run_id }}-${{ matrix.target }}
           deployment-package-path: ${{ needs.build.outputs.build_artifact }}
-          wait-for-deployment: false
+          wait-for-deployment: true
           wait-for-environment-recovery: true
           deployment-timeout: 150
           use-existing-application-version-if-available: true

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -134,7 +134,7 @@ jobs:
           environment-name: wire-webapp-prod
           version-label: ${{ github.run_id }}-wire-webapp-prod-redeploy
           deployment-package-path: ebs.zip
-          wait-for-deployment: false
+          wait-for-deployment: true
           wait-for-environment-recovery: true
           deployment-timeout: 150
           use-existing-application-version-if-available: true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

We had errors in our AWS deployments but the GitHub actions staid green because of this.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
