### PR TITLE
chore(ci): notify Wire on failures [WPB-24699]

### DIFF
--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -346,27 +346,9 @@ jobs:
           body_path: ${{ needs.build.outputs.changelog }}
           draft: true
           prerelease: ${{contains(needs.build.outputs.release_name, 'staging')}}
-
-  announce_deployment:
-    name: 'Announce deployment to wire chats'
-    runs-on: ubuntu-24.04
-    needs: create_gh_release
-
-    steps:
-      - name: Announce staging release
-        if: ${{ needs.create_gh_release.outputs.release_url }}
-        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
-        with:
-          status: success
-          text: |
-            ✅ New release done ✅
-            **Changelog:** ${{ needs.create_gh_release.outputs.release_url }}
-
   notify_deployment_failure:
     name: 'Notify deployment failure to wire chats'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build, deploy_to_aws]
     if: ${{ always() && needs.deploy_to_aws.result == 'failure' }}
 

--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -355,9 +355,29 @@ jobs:
     steps:
       - name: Announce staging release
         if: ${{ needs.create_gh_release.outputs.release_url }}
-        uses: wireapp/github-action-wire-messenger@52e881163d104d9431fe66f2e5587b209eeaa63f
+        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
         with:
-          email: ${{secrets.WIRE_BOT_EMAIL}}
-          password: ${{secrets.WIRE_BOT_PASSWORD}}
-          conversation: '697c93e8-0b13-4204-a35e-59270462366a'
-          send_text: 'New release done ([full changelog](${{ needs.create_gh_release.outputs.release_url }})) 🚀'
+          status: success
+          text: |
+            ✅ New release done ✅
+            **Changelog:** ${{ needs.create_gh_release.outputs.release_url }}
+
+  notify_deployment_failure:
+    name: 'Notify deployment failure to wire chats'
+    runs-on: ubuntu-latest
+    needs: [build, deploy_to_aws]
+    if: ${{ always() && needs.deploy_to_aws.result == 'failure' }}
+
+    steps:
+      - name: Announce deployment failure
+        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+        with:
+          status: failure
+          text: |
+            ❌ Deployment failed for ${{ needs.build.outputs.release_name }} ❌
+            **Triggered by:** ${{ github.actor }}
+            **Build log:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -138,28 +138,9 @@ jobs:
           wait-for-environment-recovery: true
           deployment-timeout: 150
           use-existing-application-version-if-available: true
-
-  notify_redeploy:
-    name: Notify redeploy
-    runs-on: ubuntu-24.04
-    needs: [validate_request, build_artifact, deploy_to_production]
-    if: ${{ needs.deploy_to_production.result == 'success' }}
-
-    steps:
-      - name: Announce production redeploy
-        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
-        with:
-          status: success
-          text: |
-            ✅ Production redeploy completed for tag ${{ needs.validate_request.outputs.tag }} ✅
-            **Triggered by:** ${{ github.actor }}
-            **Commit:** [${{ needs.build_artifact.outputs.commit_sha }}](${{ needs.build_artifact.outputs.commit_url }}) — ${{ needs.build_artifact.outputs.commit_subject }}
-
   notify_redeploy_failure:
     name: Notify redeploy failure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [validate_request, build_artifact, deploy_to_production]
     if: ${{ always() && needs.deploy_to_production.result == 'failure' }}
 

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -147,9 +147,31 @@ jobs:
 
     steps:
       - name: Announce production redeploy
-        uses: wireapp/github-action-wire-messenger@52e881163d104d9431fe66f2e5587b209eeaa63f
+        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
         with:
-          email: ${{ secrets.WIRE_BOT_EMAIL }}
-          password: ${{ secrets.WIRE_BOT_PASSWORD }}
-          conversation: '697c93e8-0b13-4204-a35e-59270462366a'
-          send_text: 'Production redeploy completed for tag ${{ needs.validate_request.outputs.tag }} by ${{ github.actor }}. Commit: [${{ needs.build_artifact.outputs.commit_sha }}](${{ needs.build_artifact.outputs.commit_url }}) — ${{ needs.build_artifact.outputs.commit_subject }}'
+          status: success
+          text: |
+            ✅ Production redeploy completed for tag ${{ needs.validate_request.outputs.tag }} ✅
+            **Triggered by:** ${{ github.actor }}
+            **Commit:** [${{ needs.build_artifact.outputs.commit_sha }}](${{ needs.build_artifact.outputs.commit_url }}) — ${{ needs.build_artifact.outputs.commit_subject }}
+
+  notify_redeploy_failure:
+    name: Notify redeploy failure
+    runs-on: ubuntu-latest
+    needs: [validate_request, build_artifact, deploy_to_production]
+    if: ${{ always() && needs.deploy_to_production.result == 'failure' }}
+
+    steps:
+      - name: Announce production redeploy failure
+        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+        with:
+          status: failure
+          text: |
+            ❌ Production redeploy failed for tag ${{ needs.validate_request.outputs.tag }} ❌
+            **Triggered by:** ${{ github.actor }}
+            **Commit:** [${{ needs.build_artifact.outputs.commit_sha }}](${{ needs.build_artifact.outputs.commit_url }}) — ${{ needs.build_artifact.outputs.commit_subject }}
+            **Build log:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24699" title="WPB-24699" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24699</a>  [Web] Report failed deployments to Wire Web team channel
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

We want to have a notification when a deployment to AWS fails.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
