### PR TITLE
fix: access state on group creation (WPB-23669)

### DIFF
--- a/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/Preference.tsx
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/Preference.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import {useEffect} from 'react';
+
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 import {container} from 'tsyringe';
 
@@ -70,6 +72,12 @@ export const Preference = () => {
     isAppsEnabled,
     hasWhitelistedServices,
   });
+
+  useEffect(() => {
+    if (!isAppsFeatureAvailable && isServicesEnabled) {
+      setIsServicesEnabled(false);
+    }
+  }, [isAppsFeatureAvailable, isServicesEnabled, setIsServicesEnabled]);
 
   return (
     <>

--- a/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/Preference.tsx
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/Preference.tsx
@@ -77,7 +77,7 @@ export const Preference = () => {
     if (!isAppsFeatureAvailable && isServicesEnabled) {
       setIsServicesEnabled(false);
     }
-  }, [isAppsFeatureAvailable, isServicesEnabled, setIsServicesEnabled]);
+  }, [isAppsFeatureAvailable, isServicesEnabled]);
 
   return (
     <>

--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -239,7 +239,6 @@ const GroupCreationModal = ({
     setParticipantsInput('');
     setSelectedContacts([]);
     setGroupCreationState(GroupCreationModalState.DEFAULT);
-
     setAccessState(isAppsFeatureAvailable ? ACCESS_STATE.TEAM.GUESTS_SERVICES : ACCESS_STATE.TEAM.GUEST_ROOM);
   };
 

--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -148,8 +148,8 @@ const GroupCreationModal = ({
   const rootContext = useContext(RootContext);
 
   useEffect(() => {
-    console.log(`accessState changed to ${accessState}`);
-  }, [accessState]);
+    setAccessState(isAppsFeatureAvailable ? ACCESS_STATE.TEAM.GUESTS_SERVICES : ACCESS_STATE.TEAM.GUEST_ROOM);
+  }, [isShown, isAppsFeatureAvailable]);
 
   useEffect(() => {
     const showCreateGroup = (_: string, userEntity: User) => {
@@ -240,7 +240,6 @@ const GroupCreationModal = ({
     setSelectedContacts([]);
     setGroupCreationState(GroupCreationModalState.DEFAULT);
 
-    // TODO: THIS IS THE PROBLEM! ACCESS STATE IS ONLY REFRESHED WHEN THE DIALOG IS CLOSED --.--
     setAccessState(isAppsFeatureAvailable ? ACCESS_STATE.TEAM.GUESTS_SERVICES : ACCESS_STATE.TEAM.GUEST_ROOM);
   };
 
@@ -262,7 +261,6 @@ const GroupCreationModal = ({
           },
         );
 
-        console.log(`created conversation ${JSON.stringify(conversation)}`);
         setCurrentSidebarTab(SidebarTabs.RECENT);
 
         if (isKeyboardEvent(event)) {

--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -148,10 +148,6 @@ const GroupCreationModal = ({
   const rootContext = useContext(RootContext);
 
   useEffect(() => {
-    setAccessState(isAppsFeatureAvailable ? ACCESS_STATE.TEAM.GUESTS_SERVICES : ACCESS_STATE.TEAM.GUEST_ROOM);
-  }, [isShown, isAppsFeatureAvailable]);
-
-  useEffect(() => {
     const showCreateGroup = (_: string, userEntity: User) => {
       setEnableReadReceipts(isTeam);
       setIsShown(true);
@@ -231,6 +227,10 @@ const GroupCreationModal = ({
 
   const maxNameLength = ConversationRepository.CONFIG.GROUP.MAX_NAME_LENGTH;
   const maxSize = ConversationRepository.CONFIG.GROUP.MAX_SIZE;
+
+  const onOpen = () => {
+    setAccessState(isAppsFeatureAvailable ? ACCESS_STATE.TEAM.GUESTS_SERVICES : ACCESS_STATE.TEAM.GUEST_ROOM);
+  };
 
   const onClose = () => {
     setIsCreatingConversation(false);
@@ -379,6 +379,7 @@ const GroupCreationModal = ({
       className="group-creation__modal"
       wrapperCSS={{overflow: 'unset', overflowY: 'unset'}}
       isShown={isShown}
+      onOpened={onOpen}
       onClosed={onClose}
       data-uie-name="group-creation-label"
       onKeyDown={stateIsPreferences ? handleEscape : undefined}

--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -148,6 +148,10 @@ const GroupCreationModal = ({
   const rootContext = useContext(RootContext);
 
   useEffect(() => {
+    console.log(`accessState changed to ${accessState}`);
+  }, [accessState]);
+
+  useEffect(() => {
     const showCreateGroup = (_: string, userEntity: User) => {
       setEnableReadReceipts(isTeam);
       setIsShown(true);
@@ -235,7 +239,9 @@ const GroupCreationModal = ({
     setParticipantsInput('');
     setSelectedContacts([]);
     setGroupCreationState(GroupCreationModalState.DEFAULT);
-    setAccessState(ACCESS_STATE.TEAM.GUESTS_SERVICES);
+
+    // TODO: THIS IS THE PROBLEM! ACCESS STATE IS ONLY REFRESHED WHEN THE DIALOG IS CLOSED --.--
+    setAccessState(isAppsFeatureAvailable ? ACCESS_STATE.TEAM.GUESTS_SERVICES : ACCESS_STATE.TEAM.GUEST_ROOM);
   };
 
   const clickOnCreate = async (
@@ -256,6 +262,7 @@ const GroupCreationModal = ({
           },
         );
 
+        console.log(`created conversation ${JSON.stringify(conversation)}`);
         setCurrentSidebarTab(SidebarTabs.RECENT);
 
         if (isKeyboardEvent(event)) {

--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -124,9 +124,20 @@ const GroupCreationModal = ({
   const [selectedContacts, setSelectedContacts] = useState<User[]>([]);
   const [enableReadReceipts, setEnableReadReceipts] = useState<boolean>(false);
   const [selectedProtocol, setSelectedProtocol] = useState<ProtocolOption>(initialProtocol);
+
+  const isAppsFeatureAvailable =
+    isTeam &&
+    checkAppsFeatureAvailability({
+      protocol: selectedProtocol.value,
+      isAppsEnabled: isAppsEnabledForTeam,
+      hasWhitelistedServices: hasWhitelistedServicesInTeam,
+    });
+
   const [showContacts, setShowContacts] = useState<boolean>(false);
   const [isCreatingConversation, setIsCreatingConversation] = useState<boolean>(false);
-  const [accessState, setAccessState] = useState<ACCESS_STATE>(ACCESS_STATE.TEAM.GUESTS_SERVICES);
+  const [accessState, setAccessState] = useState<ACCESS_STATE>(
+    isAppsFeatureAvailable ? ACCESS_STATE.TEAM.GUESTS_SERVICES : ACCESS_STATE.TEAM.GUEST_ROOM,
+  );
   const [nameError, setNameError] = useState<string>('');
   const [groupName, setGroupName] = useState<string>('');
   const [participantsInput, setParticipantsInput] = useState<string>('');
@@ -160,14 +171,6 @@ const GroupCreationModal = ({
   const isGuestAndServicesRoom = accessState === ACCESS_STATE.TEAM.GUESTS_SERVICES;
   const isGuestRoom = accessState === ACCESS_STATE.TEAM.GUEST_ROOM;
   const isGuestEnabled = isGuestRoom || isGuestAndServicesRoom;
-
-  const isAppsFeatureAvailable =
-    isTeam &&
-    checkAppsFeatureAvailability({
-      protocol: selectedProtocol.value,
-      isAppsEnabled: isAppsEnabledForTeam,
-      hasWhitelistedServices: hasWhitelistedServicesInTeam,
-    });
 
   const isServicesEnabled = isAppsFeatureAvailable && (isServicesRoom || isGuestAndServicesRoom);
 

--- a/apps/webapp/src/script/components/Modals/ModalComponent/ModalComponent.tsx
+++ b/apps/webapp/src/script/components/Modals/ModalComponent/ModalComponent.tsx
@@ -41,6 +41,7 @@ interface ModalComponentProps extends HTMLProps<HTMLDivElement> {
   id?: string;
   className?: string;
   onBgClick?: () => void;
+  onOpened?: () => void;
   onClosed?: () => void;
   showLoading?: boolean;
   wrapperCSS?: CSSObject;
@@ -54,6 +55,7 @@ const ModalComponent = ({
   className = '',
   isShown,
   onBgClick = noop,
+  onOpened = noop,
   onClosed = noop,
   showLoading = false,
   wrapperCSS,
@@ -88,6 +90,7 @@ const ModalComponent = ({
     const mounting = isMounting.current;
     isMounting.current = false;
     if (isShown) {
+      onOpened();
       return setDisplayNone(false);
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23669" title="WPB-23669" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-23669</a>  [Web][Integrations] Toggle app slider at conversation creation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- This fixes an issue where disabling the apps feature will deactivate the apps slider when creating a new conversation but the access state will still be allowed for apps by making the default value of the access state depend on the apps feature flag.

---

## Security Checklist (required)

- [ X ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ X ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ X ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ X ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ X ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ X ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
