### PR TITLE
ci: replace ubuntu-latest with explicit ubuntu-24.04 runners [WPB-22420]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout (pull_request)

--- a/.github/workflows/create-master-to-dev-backport-pull-request.yml
+++ b/.github/workflows/create-master-to-dev-backport-pull-request.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   create_master_to_dev_backport_pull_request:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.OTTO_THE_BOT_GH_TOKEN != '' && secrets.OTTO_THE_BOT_GH_TOKEN || github.token }}
       REPOSITORY_NAME: ${{ github.repository }}

--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   create_image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       UNIT_TEST_REPORT_FILE: './unit-tests.log'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       DEPLOYMENT_RECOVERY_TIMEOUT_SECONDS: 150

--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -23,7 +23,7 @@ jobs:
   report-to-testiny:
     name: Upload test report to Testiny
     if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: e2e_tests
 
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,7 +60,7 @@ on:
 jobs:
   test:
     name: Run E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -111,7 +111,7 @@ jobs:
           retention-days: 1
 
   e2e-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ !cancelled() }}
     needs: [test]
 

--- a/.github/workflows/generate_test_report.yml
+++ b/.github/workflows/generate_test_report.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   generate_test_report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       UNIT_TEST_REPORT_FILE: './unit-tests.log'

--- a/.github/workflows/jira-lint-and-link.yml
+++ b/.github/workflows/jira-lint-and-link.yml
@@ -8,7 +8,7 @@ jobs:
   add-jira-description:
     # On merge_group there is no pull request payload; keep the required check green there.
     if: ${{ github.event_name == 'merge_group' || (github.actor != 'dependabot[bot]' && github.actor != 'otto-the-bot') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Skip on merge queue
         if: ${{ github.event_name == 'merge_group' }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   label:
     name: Label PR based on title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: srvaroa/labeler@v1.11
         env:

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 # This job will enable auto merge on dependabots and otto-the-bot's PRs
 jobs:
   activate-auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{github.actor == 'dependabot[bot]' || github.actor == 'otto-the-bot'}}
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     outputs:
@@ -106,7 +106,7 @@ jobs:
   # An extra step is needed to see if the e2e_tests folder was touched as part of the PR
   check_edits_to_e2e_tests:
     name: Check if the PR touches e2e tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       tests_to_run: ${{ steps.check_e2e_tests.outputs.tests_to_run || steps.set_default_tests_for_merge_queue.outputs.tests_to_run }}
@@ -155,7 +155,7 @@ jobs:
     name: Playwright Critical Flow (precommit)
     if: ${{ success() && github.repository == 'wireapp/wire-webapp' }}
     needs: [deploy_and_run_e2e]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Report Status
@@ -165,7 +165,7 @@ jobs:
     name: Generate test report
     needs: deploy_and_run_e2e
     if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/precommit-slot-run.yml
+++ b/.github/workflows/precommit-slot-run.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   deploy_to_aws:
     name: Deploy to precommit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     env:
       AWS_REGION: eu-central-1

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     outputs:
       unit_tests_report: ${{ env.UNIT_TEST_REPORT_FILE }}
@@ -70,7 +70,7 @@ jobs:
 
   deploy_to_aws:
     name: 'Deploy to live environments'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       AWS_REGION: eu-central-1
     needs: [build]

--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: Build Docker image and Helm Chart
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     outputs:
       wire_builds_target_branches: ${{ steps.output_target_branches.outputs.targets }}
@@ -72,12 +72,12 @@ jobs:
       - name: Build and package
         run: yarn nx run server:package
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: 'build-artifact'
           path: '${{env.BUILD_DIR}}${{env.BUILD_ARTIFACT}}'
 
-      - uses: kanga333/variable-mapper@master
+      - uses: kanga333/variable-mapper@3681b75f5c6c00162721168fb91ab74925eaebcb
         id: changelog
         with:
           key: '${{github.ref}}'
@@ -99,7 +99,7 @@ jobs:
           yarn nx run workspace-tools:changelog-${{ env.changelog_type }} > ${{ env.CHANGELOG_FILE }}
           echo "changelog=${{ env.CHANGELOG_FILE }}" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ env.changelog_type }}
         with:
           name: 'changelog'
@@ -122,7 +122,7 @@ jobs:
           release_name="${TAG:-v${packageVersion}}"
           echo "release_name=$release_name" >> $GITHUB_OUTPUT
 
-      - uses: azure/setup-helm@v5.0.0
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: '3.12.2'
 
@@ -184,7 +184,7 @@ jobs:
 
   publish_wire_builds:
     name: Bump webapp chart in wire-builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
     if: ${{needs.build.outputs.wire_builds_target_branches}}
 
@@ -255,14 +255,14 @@ jobs:
 
   set_deployment_targets:
     name: 'Set deployment targets'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
     outputs:
       deployment_targets: ${{env.targets}}
 
     steps:
       # generates a mapping between branches/tag to aws envs to deploy to
-      - uses: kanga333/variable-mapper@master
+      - uses: kanga333/variable-mapper@3681b75f5c6c00162721168fb91ab74925eaebcb
         id: targets
         with:
           key: '${{github.ref}}'
@@ -285,7 +285,7 @@ jobs:
 
   deploy_to_aws:
     name: 'Deploy to live environments'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       AWS_REGION: eu-central-1
     environment: ${{ matrix.target }}
@@ -297,7 +297,7 @@ jobs:
         target: ${{fromJson(needs.set_deployment_targets.outputs.deployment_targets)}}
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: 'build-artifact'
 
@@ -324,7 +324,7 @@ jobs:
 
   create_gh_release:
     name: 'Create Github release'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [deploy_to_aws, build]
     if: ${{ needs.build.outputs.changelog }}
 
@@ -332,7 +332,7 @@ jobs:
       release_url: ${{ steps.release.outputs.url }}
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: 'changelog'
 
@@ -346,3 +346,18 @@ jobs:
           body_path: ${{ needs.build.outputs.changelog }}
           draft: true
           prerelease: ${{contains(needs.build.outputs.release_name, 'staging')}}
+
+  announce_deployment:
+    name: 'Announce deployment to wire chats'
+    runs-on: ubuntu-24.04
+    needs: create_gh_release
+
+    steps:
+      - name: Announce staging release
+        if: ${{ needs.create_gh_release.outputs.release_url }}
+        uses: wireapp/github-action-wire-messenger@52e881163d104d9431fe66f2e5587b209eeaa63f
+        with:
+          email: ${{secrets.WIRE_BOT_EMAIL}}
+          password: ${{secrets.WIRE_BOT_PASSWORD}}
+          conversation: '697c93e8-0b13-4204-a35e-59270462366a'
+          send_text: 'New release done ([full changelog](${{ needs.create_gh_release.outputs.release_url }})) 🚀'

--- a/.github/workflows/publish-libraries-on-merge.yml
+++ b/.github/workflows/publish-libraries-on-merge.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   publish:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'publish-to-npm'))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/publish-libraries.yml
+++ b/.github/workflows/publish-libraries.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   create-release-pr:
     name: Create Release PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/pull-translations-from-crowdin.yml
+++ b/.github/workflows/pull-translations-from-crowdin.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   pull_from_crowdin:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/push-translations-to-crowdin.yml
+++ b/.github/workflows/push-translations-to-crowdin.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   push_to_crowdin:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   validate_request:
     name: Validate redeploy request
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       tag: ${{ steps.validate.outputs.tag }}
 
@@ -47,7 +47,7 @@ jobs:
 
   build_artifact:
     name: Rebuild tagged release artifact
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: validate_request
     outputs:
       commit_sha: ${{ steps.git_metadata.outputs.commit_sha }}
@@ -106,7 +106,7 @@ jobs:
 
   deploy_to_production:
     name: Deploy to production
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       AWS_REGION: eu-central-1
     needs: [validate_request, build_artifact]
@@ -141,7 +141,7 @@ jobs:
 
   notify_redeploy:
     name: Notify redeploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [validate_request, build_artifact, deploy_to_production]
     if: ${{ needs.deploy_to_production.result == 'success' }}
 

--- a/.github/workflows/semantic-commit-lint.yml
+++ b/.github/workflows/semantic-commit-lint.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   semantic-commit-pr-title-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Skip on merge queue
         if: ${{ github.event_name == 'merge_group' }}

--- a/.github/workflows/translations-auto-merge.yml
+++ b/.github/workflows/translations-auto-merge.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   activate-auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{github.actor == 'otto-the-bot' && github.head_ref == 'translations'}}
     steps:
       - name: Enable auto-merge for Dependabot PRs


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

`ubuntu-latest` is a moving target and can change behavior underneath the pipeline.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
