### PR TITLE
feat: added UserType and app fields to User entity (WPB-20361)

### DIFF
--- a/apps/webapp/src/script/auth/module/reducer/selfReducer.ts
+++ b/apps/webapp/src/script/auth/module/reducer/selfReducer.ts
@@ -18,8 +18,9 @@
  */
 
 import type {Self} from '@wireapp/api-client/lib/self/';
+import {UserType} from '@wireapp/api-client/lib/user';
 
-import {AUTH_ACTION, AppActions, SELF_ACTION} from '../action/creator/';
+import {AppActions, AUTH_ACTION, SELF_ACTION} from '../action/creator/';
 
 export interface SelfState {
   consents: {[key: number]: number};
@@ -42,6 +43,7 @@ const unsetSelf: Self = {
   qualified_id: {id: '', domain: ''},
   sso_id: undefined,
   team: undefined,
+  type: UserType.REGULAR,
 };
 
 export const initialSelfState: SelfState = {

--- a/apps/webapp/src/script/auth/module/selector/SelfSelector.ts
+++ b/apps/webapp/src/script/auth/module/selector/SelfSelector.ts
@@ -18,6 +18,7 @@
  */
 
 import type {Self} from '@wireapp/api-client/lib/self/';
+import {UserType} from '@wireapp/api-client/lib/user';
 
 import {Config} from '../../../Config';
 import type {RootState} from '../reducer';
@@ -33,6 +34,7 @@ const unsetSelf: Self = {
   name: '',
   sso_id: undefined,
   team: undefined,
+  type: UserType.REGULAR,
 };
 
 export const getConsents = (state: RootState) => state.selfState.consents || {};

--- a/apps/webapp/src/script/repositories/entity/User/User.ts
+++ b/apps/webapp/src/script/repositories/entity/User/User.ts
@@ -19,7 +19,7 @@
 
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
-import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {QualifiedId, UserType} from '@wireapp/api-client/lib/user';
 import {amplify} from 'amplify';
 import ko from 'knockout';
 
@@ -102,6 +102,9 @@ export class User {
   public teamId?: string;
   /** The federated domain (when the user is on a federated server) */
   public domain: string;
+  public type: UserType;
+  public category?: string;
+  public description?: string;
   public readonly isBlockedLegalHold: ko.PureComputed<boolean>;
   public readonly supportedProtocols: ko.Observable<null | CONVERSATION_PROTOCOL[]>;
 
@@ -140,6 +143,8 @@ export class User {
     this.isDeleted = false;
     this.providerId = undefined;
     this.serviceId = undefined;
+    this.category = undefined;
+    this.description = undefined;
 
     this.isAvailable = ko.pureComputed(() => this.id !== '' && this.name() !== '');
 

--- a/apps/webapp/src/script/repositories/user/UserMapper.ts
+++ b/apps/webapp/src/script/repositories/user/UserMapper.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {UserType} from '@wireapp/api-client/lib/user';
+
 import {MappedAsset, mapProfileAssets, updateUserEntityAssets} from 'Repositories/assets/assetMapper';
 import {User} from 'Repositories/entity/User';
 import {UserRecord} from 'Repositories/storage';
@@ -26,8 +28,6 @@ import {isSelfAPIUser} from './UserGuards';
 
 import type {ServerTimeHandler} from '../../time/serverTimeHandler';
 import '../../view_model/bindings/CommonBindings';
-
-import {UserType} from '@wireapp/api-client/lib/user';
 
 export class UserMapper {
   private readonly logger: Logger;

--- a/apps/webapp/src/script/repositories/user/UserMapper.ts
+++ b/apps/webapp/src/script/repositories/user/UserMapper.ts
@@ -27,6 +27,8 @@ import {isSelfAPIUser} from './UserGuards';
 import type {ServerTimeHandler} from '../../time/serverTimeHandler';
 import '../../view_model/bindings/CommonBindings';
 
+import {UserType} from '@wireapp/api-client/lib/user';
+
 export class UserMapper {
   private readonly logger: Logger;
 
@@ -183,9 +185,7 @@ export class UserMapper {
       userEntity.isDeleted = true;
     }
 
-    if (type) {
-      userEntity.type = type;
-    }
+    userEntity.type = type ?? UserType.REGULAR;
 
     if (app) {
       userEntity.description = app.description;
@@ -193,9 +193,6 @@ export class UserMapper {
     } else {
       userEntity.description = undefined;
       userEntity.category = undefined;
-    }
-      userEntity.description = app.description;
-      userEntity.category = app.category;
     }
 
     return userEntity;

--- a/apps/webapp/src/script/repositories/user/UserMapper.ts
+++ b/apps/webapp/src/script/repositories/user/UserMapper.ts
@@ -190,6 +190,12 @@ export class UserMapper {
     if (app) {
       userEntity.description = app.description;
       userEntity.category = app.category;
+    } else {
+      userEntity.description = undefined;
+      userEntity.category = undefined;
+    }
+      userEntity.description = app.description;
+      userEntity.category = app.category;
     }
 
     return userEntity;

--- a/apps/webapp/src/script/repositories/user/UserMapper.ts
+++ b/apps/webapp/src/script/repositories/user/UserMapper.ts
@@ -99,6 +99,7 @@ export class UserMapper {
     const {
       accent_id: accentId,
       availability,
+      app,
       assets,
       deleted,
       email,
@@ -108,6 +109,7 @@ export class UserMapper {
       service,
       team: teamId,
       supported_protocols: supportedProtocols,
+      type,
     } = userData;
 
     if (accentId) {
@@ -179,6 +181,15 @@ export class UserMapper {
 
     if (deleted) {
       userEntity.isDeleted = true;
+    }
+
+    if (type) {
+      userEntity.type = type;
+    }
+
+    if (app) {
+      userEntity.description = app.description;
+      userEntity.category = app.category;
     }
 
     return userEntity;

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -44,6 +44,8 @@ test(
       const team = await createTeam('Critical', {users: [member1, member2]});
       owner = team.owner;
 
+      await api.team.addServiceToTeamWhitelist(owner.teamId, Services.POLL_SERVICE, owner.token);
+
       const [pmOwner, pm1, pm2] = await Promise.all([
         PageManager.from(createPage(withLogin(owner))),
         PageManager.from(createPage(withLogin(member1))),
@@ -62,7 +64,6 @@ test(
 
     await test.step('Team owner adds a service to newly created group', async () => {
       const {pages} = ownerPageManager.webapp;
-      await api.team.addServiceToTeamWhitelist(owner.teamId, Services.POLL_SERVICE, owner.token);
       // Add the Poll service to the conversation
       await pages.conversation().clickConversationTitle();
       await pages.conversationDetails().waitForSidebar();

--- a/libraries/api-client/src/user/app.ts
+++ b/libraries/api-client/src/user/app.ts
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export interface App {
+  category: string;
+  description: string;
+}

--- a/libraries/api-client/src/user/user.ts
+++ b/libraries/api-client/src/user/user.ts
@@ -19,6 +19,7 @@
 
 import {AccentColor} from '@wireapp/commons';
 
+import {App} from './app';
 import {QualifiedId} from './qualifiedId';
 
 import {ServiceRef} from '../conversation/';
@@ -26,8 +27,15 @@ import {Picture} from '../self/';
 import {CONVERSATION_PROTOCOL} from '../team';
 import {UserAsset} from '../user/';
 
+export enum UserType {
+  REGULAR = 'regular',
+  APP = 'app',
+  BOT = 'bot',
+}
+
 export interface User {
   accent_id?: AccentColor.AccentColorID;
+  app?: App;
   assets?: UserAsset[];
   deleted?: boolean;
   email?: string;
@@ -42,4 +50,5 @@ export interface User {
   team?: string;
   searchable?: boolean;
   supported_protocols?: CONVERSATION_PROTOCOL[];
+  type: UserType;
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20361" title="WPB-20361" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20361</a>  [Web] [Integration] Client should understand the User entity Type field
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- In preparation for implementing the search for apps, the user entity needs to know about the new UserType inidcating whether a UserEntity is a regular user or an app

---

## Security Checklist (required)

- [ X ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ X ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ X ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ X ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ X ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ X ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
