### PR TITLE
fix: Broken dashed line and dots behavior in the version history modal(WPB-24287)

### DIFF
--- a/apps/webapp/src/script/components/Modals/FileHistoryModal/FileHistoryContent.tsx
+++ b/apps/webapp/src/script/components/Modals/FileHistoryModal/FileHistoryContent.tsx
@@ -47,6 +47,7 @@ export const FileHistoryContent = ({
                   key={version.versionId}
                   version={version}
                   isCurrentVersion={versionIndex === 0 && groupIndex === 0}
+                  showTimelineConnector={versionIndex < fileVersions[date].length - 1}
                   onDownload={handleDownload}
                   onRestore={handleRestore}
                 />

--- a/apps/webapp/src/script/components/Modals/FileHistoryModal/FileHistoryModal.styles.ts
+++ b/apps/webapp/src/script/components/Modals/FileHistoryModal/FileHistoryModal.styles.ts
@@ -65,19 +65,28 @@ export const fileHeaderFileInfoCss: CSSObject = {
   display: 'flex',
   alignItems: 'center',
   gap: '6px',
-  color: 'var(--gray-70)',
+  color: 'var(--base-secondary-text)',
   height: '21px',
 };
 
 export const fileHistoryCloseButtonCss: CSSObject = {
   background: 'none',
   border: 'none',
+  color: 'var(--main-color)',
   cursor: 'pointer',
   display: 'flex',
   alignSelf: 'flex-start',
-  padding: '0px',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '32px',
+  height: '32px',
+  padding: 0,
+  borderRadius: '8px',
+  '& svg': {
+    fill: 'currentColor',
+  },
   '&:hover': {
-    opacity: 0.7,
+    backgroundColor: 'var(--cells-version-history-item-hover-bg)',
   },
 };
 
@@ -105,48 +114,72 @@ export const fileHistoryDateHeadingCss: CSSObject = {
 
 export const fileHistoryTimelineContainerCss: CSSObject = {
   position: 'relative',
-  ':before': {
-    content: '""',
-    position: 'absolute',
-    left: '20px',
-    top: '15px',
-    bottom: '40px',
-    borderLeft: '1px dashed var(--gray-50)',
-  },
 };
 
 // Version item styles
 export const fileVersionItemWrapperCss: CSSObject = {
+  // Keep these values in `rem` so they scale with the user's font size.
+  '--cells-vh-item-padding-y': '0.5rem',
+  '--cells-vh-item-padding-x': '1rem',
+  '--cells-vh-dot-size': '0.5625rem',
+  '--cells-vh-dot-margin-top': '0.5rem',
+  '--cells-vh-dot-center-offset':
+    'calc(var(--cells-vh-item-padding-y) + var(--cells-vh-dot-margin-top) + (var(--cells-vh-dot-size) / 2))',
   display: 'flex',
   gap: '12px',
-  padding: '8px 16px',
+  padding: 'var(--cells-vh-item-padding-y) var(--cells-vh-item-padding-x)',
   borderRadius: '8px',
+  position: 'relative',
   ':hover': {
-    backgroundColor: 'var(--gray-20)',
+    backgroundColor: 'var(--cells-version-history-item-hover-bg)',
     '& [data-version-actions="true"]': {
       display: 'flex',
     },
   },
+  ':focus-within': {
+    backgroundColor: 'var(--cells-version-history-item-hover-bg)',
+    '& [data-version-actions="true"]': {
+      display: 'flex',
+    },
+  },
+  ':focus-visible': {
+    outline: '2px solid var(--accent-color)',
+    outlineOffset: '2px',
+  },
 };
 
 export const versionDotCurrentCss: CSSObject = {
-  width: '9px',
-  height: '9px',
+  width: 'var(--cells-vh-dot-size)',
+  height: 'var(--cells-vh-dot-size)',
   backgroundColor: 'var(--accent-color)',
   border: 'none',
   borderRadius: '50%',
-  marginTop: '8px',
+  marginTop: 'var(--cells-vh-dot-margin-top)',
   position: 'relative',
+  zIndex: 1,
 };
 
 export const versionDotOldCss: CSSObject = {
-  width: '9px',
-  height: '9px',
-  backgroundColor: 'var(--modal-bg)',
-  border: '1px solid var(--gray-70)',
+  width: 'var(--cells-vh-dot-size)',
+  height: 'var(--cells-vh-dot-size)',
+  backgroundColor: 'var(--cells-version-history-dot-fill-color)',
+  border: '1px solid var(--cells-version-history-dot-border-color)',
   borderRadius: '50%',
-  marginTop: '8px',
+  marginTop: 'var(--cells-vh-dot-margin-top)',
   position: 'relative',
+  zIndex: 1,
+};
+
+export const versionTimelineConnectorCss: CSSObject = {
+  position: 'absolute',
+  left: 'calc(var(--cells-vh-item-padding-x) + (var(--cells-vh-dot-size) / 2))',
+  top: 'var(--cells-vh-dot-center-offset)',
+  bottom: 'calc(-1 * var(--cells-vh-dot-center-offset))',
+  width: '1px',
+  backgroundImage:
+    'repeating-linear-gradient(to bottom, var(--cells-version-history-timeline-color) 0 4px, transparent 4px 12px)',
+  pointerEvents: 'none',
+  zIndex: 0,
 };
 
 export const versionInfoContainerCss: CSSObject = {
@@ -161,7 +194,7 @@ export const versionTimeTextCss: CSSObject = {
 };
 
 export const versionMetaTextCss: CSSObject = {
-  color: 'var(--gray-70)',
+  color: 'var(--base-secondary-text)',
   marginTop: '4px',
   margin: 0,
   display: 'flex',

--- a/apps/webapp/src/script/components/Modals/FileHistoryModal/FileVersionItem.tsx
+++ b/apps/webapp/src/script/components/Modals/FileHistoryModal/FileVersionItem.tsx
@@ -25,6 +25,7 @@ import {
   fileVersionItemWrapperCss,
   iconMarginRightCss,
   restoreIconCss,
+  versionTimelineConnectorCss,
   versionActionsWrapperCss,
   versionButtonCss,
   versionDotCurrentCss,
@@ -45,15 +46,23 @@ interface FileVersionItemProps {
     downloadUrl: string;
   };
   isCurrentVersion: boolean;
+  showTimelineConnector: boolean;
   onDownload: (downloadUrl: string) => void | Promise<void>;
   onRestore: (versionId: string) => void;
 }
 
-export const FileVersionItem = ({version, isCurrentVersion, onDownload, onRestore}: FileVersionItemProps) => {
+export const FileVersionItem = ({
+  version,
+  isCurrentVersion,
+  showTimelineConnector,
+  onDownload,
+  onRestore,
+}: FileVersionItemProps) => {
   const versionDetailsTitle = `${version.ownerName} ${version.size}`.trim();
 
   return (
     <div key={version.versionId} css={fileVersionItemWrapperCss}>
+      {showTimelineConnector && <div css={versionTimelineConnectorCss} aria-hidden="true" />}
       <div css={isCurrentVersion ? versionDotCurrentCss : versionDotOldCss} aria-hidden="true" />
       <div css={versionInfoContainerCss}>
         <p css={versionTimeTextCss}>

--- a/apps/webapp/src/style/common/mixins.less
+++ b/apps/webapp/src/style/common/mixins.less
@@ -44,6 +44,12 @@
   .setVariables(app-bg sidebar-bg input-bar-bg transparent-img-bg sidebar-border-color sidebar-folder-selected-bg main-color border-color app-bg-secondary conversation-list-bg-opacity group-icon-bg base-secondary-text);
   .setVariables(group-video-bg group-video-tile-bg participant-audio-connecting-color inactive-call-button-bg inactive-call-button-border inactive-call-button-hover-bg inactive-call-button-hover-border disabled-call-button-bg disabled-call-button-border disabled-call-button-svg button-group-left-hover button-group-right-hover toggle-button-unselected-hover-border toggle-button-unselected-hover-bg);
   .setVariables(modal-bg modal-border-color);
+  .setVariables(cells-version-history-item-hover-bg);
+  .setVariables(
+    cells-version-history-timeline-color
+    cells-version-history-dot-border-color
+    cells-version-history-dot-fill-color
+  );
   .setVariables(preference-account-input-bg);
   .setVariables(text-input-editing text-input-background text-input-border text-input-border-hover text-input-placeholder text-input-color text-input-alert text-input-disabled text-input-label text-input-success);
   .setVariables(checkbox-background checkbox-background-selected checkbox-background-disabled checkbox-background-disabled-selected checkbox-border checkbox-border-hover checkbox-border-disabled checkbox-alert);

--- a/apps/webapp/src/style/foundation/themes.less
+++ b/apps/webapp/src/style/foundation/themes.less
@@ -64,6 +64,10 @@ body.theme-default {
   // ----------------------------------------------------------------------------
   @modal-bg: #f8f8f8;
   @modal-border-color: 1px solid transparent;
+  @cells-version-history-item-hover-bg: @gray-20;
+  @cells-version-history-timeline-color: @gray-50;
+  @cells-version-history-dot-border-color: @gray-70;
+  @cells-version-history-dot-fill-color: @modal-bg;
 
   // ----------------------------------------------------------------------------
   // Preferences Input
@@ -169,6 +173,10 @@ body.theme-dark {
   // ----------------------------------------------------------------------------
   @modal-bg: #26272c;
   @modal-border-color: 1px solid rgba(255, 255, 255, 0.12);
+  @cells-version-history-item-hover-bg: @gray-100;
+  @cells-version-history-timeline-color: @gray-60;
+  @cells-version-history-dot-border-color: @white;
+  @cells-version-history-dot-fill-color: @white;
 
   // ----------------------------------------------------------------------------
   // Preferences Input


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24287" title="WPB-24287" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24287</a>  [Web][versions] Broken dashed line and dots behavior in the version history modal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

### Expected state:
1. if only one version is display per date, don’t display the dashed line
2. the dashed line should be displayed between the two middles of the dots
3. correct the shape of the dots
4. Fix dark mode issues on hover of file versions and close button


### Before:
The alignment and shape of dots and dashed line is off 
<img width="777" height="954" alt="image-20260324-132229" src="https://github.com/user-attachments/assets/ecfd9f6e-8cf8-4d76-990a-6f020b95eb0f" />

<img width="1512" height="982" alt="Screenshot 2026-04-14 at 15 42 05" src="https://github.com/user-attachments/assets/acf8b8ff-1c01-4845-8b05-02d1446489f7" />

### After:
<img width="1512" height="982" alt="Screenshot 2026-04-14 at 15 40 15" src="https://github.com/user-attachments/assets/d6ba67f7-9ed5-4ad6-9c61-19e20b542371" />

<img width="1512" height="982" alt="Screenshot 2026-04-14 at 15 40 23" src="https://github.com/user-attachments/assets/4353db9a-bc43-46b0-ba9c-eca3963d58d2" />

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
