### PR TITLE
test: write the group conversation tests [WPB-19952]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/groupCreation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/groupCreation.page.ts
@@ -31,6 +31,7 @@ export class GroupCreationPage {
 
   readonly searchPeopleInput: Locator;
   readonly searchPeopleResults: Locator;
+  readonly errorGroupName: Locator;
 
   constructor(page: Page) {
     this.groupCreationModal = page.locator('#group-creation-modal');
@@ -44,6 +45,7 @@ export class GroupCreationPage {
     this.searchPeopleInput = page.getByRole('dialog').getByLabel('Search by name');
     this.searchPeopleList = page.getByRole('dialog').getByRole('list');
     this.searchPeopleResults = this.searchPeopleList.getByRole('listitem');
+    this.errorGroupName = page.getByTestId('error-group-name');
   }
 
   async setGroupName(name: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/groupCreation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/groupCreation.page.ts
@@ -31,7 +31,7 @@ export class GroupCreationPage {
 
   readonly searchPeopleInput: Locator;
   readonly searchPeopleResults: Locator;
-  readonly selectedPeopleList: Locator;
+  readonly selectedMembers: Locator;
   readonly toggleSelectedListButton: Locator;
   readonly errorGroupName: Locator;
 
@@ -47,7 +47,7 @@ export class GroupCreationPage {
     this.searchPeopleInput = page.getByRole('dialog').getByLabel('Search by name');
     this.searchPeopleList = page.getByRole('dialog').getByRole('list');
     this.searchPeopleResults = this.searchPeopleList.getByRole('listitem');
-    this.selectedPeopleList = page.getByTestId('selected-search-list');
+    this.selectedMembers = page.getByTestId('selected-search-list').getByRole('listitem');
     this.toggleSelectedListButton = page.getByTestId('do-toggle-selected-search-list');
     this.errorGroupName = page.getByTestId('error-group-name');
   }
@@ -91,6 +91,6 @@ export class GroupCreationPage {
 
   async deselectGroupMember(username: string) {
     await this.groupCreationModal.getByTestId('do-toggle-selected-search-list').click();
-    await this.selectedPeopleList.filter({hasText: username}).click();
+    await this.selectedMembers.filter({hasText: username}).click();
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/groupCreation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/groupCreation.page.ts
@@ -31,6 +31,8 @@ export class GroupCreationPage {
 
   readonly searchPeopleInput: Locator;
   readonly searchPeopleResults: Locator;
+  readonly selectedPeopleList: Locator;
+  readonly toggleSelectedListButton: Locator;
   readonly errorGroupName: Locator;
 
   constructor(page: Page) {
@@ -45,6 +47,8 @@ export class GroupCreationPage {
     this.searchPeopleInput = page.getByRole('dialog').getByLabel('Search by name');
     this.searchPeopleList = page.getByRole('dialog').getByRole('list');
     this.searchPeopleResults = this.searchPeopleList.getByRole('listitem');
+    this.selectedPeopleList = page.getByTestId('selected-search-list');
+    this.toggleSelectedListButton = page.getByTestId('do-toggle-selected-search-list');
     this.errorGroupName = page.getByTestId('error-group-name');
   }
 
@@ -83,5 +87,10 @@ export class GroupCreationPage {
       await this.searchPeopleInput.fill(username);
       await this.searchPeopleResults.filter({hasText: username}).click();
     }
+  }
+
+  async deselectGroupMember(username: string) {
+    await this.groupCreationModal.getByTestId('do-toggle-selected-search-list').click();
+    await this.selectedPeopleList.filter({hasText: username}).click();
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -92,4 +92,37 @@ test.describe('Group Conversation', () => {
       await expect(userAPages.groupCreation().toggleSelectedListButton).toContainText('Selected (1)');
     },
   );
+
+  test(
+    'I want to delete a group as the Group Creator',
+    {tag: ['@TC-1089', '@TC-1090', '@TC-1090', '@regression']},
+    async ({createPage}) => {
+      const {pages, modals} = PageManager.from(
+        await createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC)),
+      ).webapp;
+
+      await createGroup(pages, groupName, [userB, userC]);
+      const conversation = pages.conversationList().list.filter({hasText: groupName});
+
+      await pages.conversationList().openConversation(groupName);
+      await pages.conversation().clickConversationInfoButton();
+      await pages.conversationDetails().deleteGroupButton.click();
+
+      // User sees a confirmation dialog with explanation when he initiates delete group
+      await expect(modals.confirm().modalText).toContainText(
+        'This will delete the conversation and all content for all participants on all devices',
+      );
+
+      // User can cancel the delete group from the confirmation dialog
+      await modals.confirm().cancelButton.click();
+      await expect(conversation).toBeVisible();
+
+      // User can delete group as the group creator
+      await pages.conversationDetails().deleteGroupButton.click();
+      await modals.confirm().actionButton.click();
+
+      await conversation.waitFor({state: 'detached'});
+      await expect(conversation).not.toBeVisible();
+    },
+  );
 });

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -165,4 +165,41 @@ test.describe('Group Conversation', () => {
         );
     },
   );
+
+  test('I should not be able to search for deleted group', {tag: ['@TC-1095', '@regression']}, async ({createPage}) => {
+    const [userAPageManager, userBPageManager, userCPageManager] = await Promise.all([
+      createPage(withLogin(userA)),
+      createPage(withLogin(userB)),
+      createPage(withLogin(userC), withConnectedUser(userA)),
+    ]);
+
+    const userAPages = PageManager.from(userAPageManager).webapp.pages;
+    const userBPages = PageManager.from(userBPageManager).webapp.pages;
+    const userCPages = PageManager.from(userCPageManager).webapp.pages;
+
+    await createGroup(userAPages, 'Group A', [userB, userC]);
+    await createGroup(userBPages, 'Group B', [userA, userC]);
+    await expect(userCPages.conversationList().list.getByRole('listitem')).toHaveCount(3);
+
+    const groups = [
+      {name: 'Group A', owner: userAPageManager, members: [userB, userC]},
+      {name: 'Group B', owner: userBPageManager, members: [userA, userC]},
+    ];
+
+    for (const group of groups) {
+      const {pages, modals} = PageManager.from(group.owner).webapp;
+
+      await pages.conversationList().openConversation(group.name);
+      await pages.conversation().clickConversationInfoButton();
+      await pages.conversationDetails().deleteGroupButton.click();
+      await modals.confirm().actionButton.click();
+      await pages.conversationList().list.filter({hasText: group.name}).waitFor({state: 'detached'});
+
+      await expect(userCPages.conversationList().list.filter({hasText: group.name})).not.toBeVisible();
+      
+      await userCPages.conversationList().searchConversationsInput.fill(group.name);
+      await expect(userCPages.conversationList().list).toContainText('No results found');
+      await userCPages.conversationList().searchConversationsInput.fill(''); // Clear search input for next iteration
+    }
+  });
 });

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Page} from 'playwright/test';
+import {ApiManagerE2E} from 'test/e2e_tests/backend/apiManager.e2e';
+import {User} from 'test/e2e_tests/data/user';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {test, expect, withConnectedUser, withLogin, Team} from 'test/e2e_tests/test.fixtures';
+import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
+import {interceptNotifications} from 'test/e2e_tests/utils/mockNotifications.util';
+import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
+import {createGroup} from 'test/e2e_tests/utils/userActions';
+
+test.describe('Group Conversation', () => {
+  let team: Team;
+  let userA: User;
+  let userB: User;
+  let userC: User;
+  const groupName = 'Test group';
+
+  test.beforeEach(async ({createTeam, createUser}) => {
+    userB = await createUser();
+    team = await createTeam('Test Team', {users: [userB]});
+    userA = team.owner;
+  });
+
+  test('I can create a conversation with myself only', {tag: ['@TC-509', '@regression']}, async ({createPage}) => {
+    const userAPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
+
+    await createGroup(userAPages, groupName, []);
+    await userAPages.conversationList().openConversation(groupName);
+
+    await userAPages.conversation().sendMessage('Message');
+    const message = userAPages.conversation().getMessage({content: 'Message'});
+
+    await userAPages.conversation().toggleGroupInformation();
+    await expect(userAPages.conversation().membersList.getByRole('listitem')).toHaveCount(0);
+
+    await expect(
+      userAPages.conversation().systemMessages.filter({hasText: 'ALL FINGERPRINTS ARE VERIFIED'}),
+    ).toBeVisible();
+    await expect(message).toBeVisible();
+  });
+});

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -207,10 +207,7 @@ test.describe('Group Conversation', () => {
     'I want to leave a group conversation via conversation list dropdown options',
     {tag: ['@TC-1197', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
 
       const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
       const userBPages = PageManager.from(userBPage).webapp.pages;
@@ -224,6 +221,28 @@ test.describe('Group Conversation', () => {
       await userAModals.leaveConversation().confirmButton.click();
 
       await expect(userBPages.conversation().systemMessages.filter({hasText: `${userA.fullName} left`})).toBeVisible();
+    },
+  );
+
+  test(
+    'Verify you can remove participants from a group conversation',
+    {tag: ['@TC-1475', '@regression']},
+    async ({createPage}) => {
+      const pages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
+
+      await createGroup(pages, groupName, [userB, userC]);
+      await pages.conversationList().openConversation(groupName);
+      await pages.conversation().toggleGroupInformation();
+
+      await expect(pages.conversationDetails().groupMembers.filter({hasText: userB.fullName})).toBeVisible();
+
+      await pages.conversationDetails().openParticipantDetails(userB.fullName);
+      await pages.participantDetails().removeFromGroup();
+
+      await expect(pages.conversationDetails().groupMembers.filter({hasText: userB.fullName})).not.toBeVisible();
+      await expect(
+        pages.conversation().systemMessages.filter({hasText: `You removed ${userB.fullName}`}),
+      ).toBeVisible();
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -196,10 +196,34 @@ test.describe('Group Conversation', () => {
       await pages.conversationList().list.filter({hasText: group.name}).waitFor({state: 'detached'});
 
       await expect(userCPages.conversationList().list.filter({hasText: group.name})).not.toBeVisible();
-      
+
       await userCPages.conversationList().searchConversationsInput.fill(group.name);
       await expect(userCPages.conversationList().list).toContainText('No results found');
       await userCPages.conversationList().searchConversationsInput.fill(''); // Clear search input for next iteration
     }
   });
+
+  test(
+    'I want to leave a group conversation via conversation list dropdown options',
+    {tag: ['@TC-1197', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA)),
+        createPage(withLogin(userB)),
+      ]);
+
+      const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      await createGroup(userBPages, groupName, [userA]);
+      await userBPages.conversationList().openConversation(groupName);
+
+      // User A leaves conversation through options menu from conversation list
+      await userAPages.conversationList().clickConversationOptions(groupName);
+      await userAPages.conversationList().leaveConversation();
+      await userAModals.leaveConversation().confirmButton.click();
+
+      await expect(userBPages.conversation().systemMessages.filter({hasText: `${userA.fullName} left`})).toBeVisible();
+    },
+  );
 });

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -280,4 +280,51 @@ test.describe('Group Conversation', () => {
       await expect(userBPages.conversation().makeAdminToggle).not.toBeVisible();
     },
   );
+
+  test(
+    'I should not be admin anymore after being removed and re-added to the group',
+    {tag: ['@TC-1649', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      await test.step('Setup: Create group and promote User B to Admin', async () => {
+        await createGroup(userAPages, groupName, [userB, userC]);
+        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversation().toggleGroupInformation();
+        await userAPages.conversation().makeUserAdmin(userB.fullName);
+
+        // Verify User B is an admin
+        await userBPages.conversationList().openConversation(groupName);
+        await userBPages.conversation().toggleGroupInformation();
+        await expect(userBPages.conversationDetails().groupAdmins.filter({hasText: userB.fullName})).toBeVisible();
+      });
+
+      await test.step('Act: User A removes User B from the group', async () => {
+        await userAPages.conversation().toggleGroupInformation();
+        await userAPages.conversation().removeAdminFromGroup(userB.fullName);
+        await userAModals.confirm().actionButton.click();
+
+        await expect(
+          userAPages.conversation().systemMessages.filter({hasText: `You removed ${userB.fullName}`}),
+        ).toBeVisible();
+      });
+
+      await test.step('Act: User A re-adds User B to the group', async () => {
+        await userAPages.conversation().clickAddMemberButton();
+        await userAPages.conversationDetails().addUsersToConversation([userB.fullName]);
+
+        await expect(
+          userAPages.conversation().systemMessages.filter({hasText: `You added ${userB.fullName} to the conversation`}),
+        ).toBeVisible();
+      });
+
+      await test.step('Assert: Verify User B is a regular member and not an admin', async () => {
+        // User B should appear in members list but NOT in admin list
+        await expect(userBPages.conversationDetails().groupAdmins.filter({hasText: userB.fullName})).not.toBeVisible();
+        await expect(userBPages.conversationDetails().groupMembers.filter({hasText: userB.fullName})).toBeVisible();
+      });
+    },
+  );
 });

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -17,14 +17,10 @@
  *
  */
 
-import {Page} from 'playwright/test';
-import {ApiManagerE2E} from 'test/e2e_tests/backend/apiManager.e2e';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withConnectedUser, withLogin, Team} from 'test/e2e_tests/test.fixtures';
-import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
 import {interceptNotifications} from 'test/e2e_tests/utils/mockNotifications.util';
-import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
 import {createGroup} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Group Conversation', () => {
@@ -99,8 +95,8 @@ test.describe('Group Conversation', () => {
     const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await createGroup(userAPages, groupName, [userB, userC]);
-    const adminGroupLocator = userAPages.conversationList().list.filter({hasText: groupName});
-    const memberGroupLocator = userBPages.conversationList().list.filter({hasText: groupName});
+    const adminGroupLocator = userAPages.conversationList().getConversationLocator(groupName);
+    const memberGroupLocator = userBPages.conversationList().getConversationLocator(groupName);
 
     // Pre-condition: Ensure the member can see the group before the creator deletes it
     await expect(memberGroupLocator).toBeVisible();
@@ -124,9 +120,8 @@ test.describe('Group Conversation', () => {
     await userAModals.confirm().actionButton.click();
 
     // Verify the group no longer exists for any user
-    await adminGroupLocator.waitFor({state: 'detached'});
-    await expect(adminGroupLocator).toBeHidden();
-    await expect(memberGroupLocator).toBeHidden();
+    await expect(adminGroupLocator).toBeHidden({timeout: 20_000});
+    await expect(memberGroupLocator).toBeHidden({timeout: 20_000});
   });
 
   test(
@@ -139,8 +134,10 @@ test.describe('Group Conversation', () => {
       ]);
 
       const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userAPages, groupName, [userB]);
+      await expect(userBPages.conversationList().getConversationLocator(groupName)).toBeVisible();
 
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
@@ -152,7 +149,7 @@ test.describe('Group Conversation', () => {
       await userAPages.conversation().clickConversationInfoButton();
       await userAPages.conversationDetails().deleteGroupButton.click();
       await userAModals.confirm().actionButton.click();
-      await userAPages.conversationList().list.filter({hasText: groupName}).waitFor({state: 'detached'});
+      await expect(userAPages.conversationList().getConversationLocator(groupName)).not.toBeAttached({timeout: 20_000});
 
       await expect
         .poll(() => getUserBNotifications())
@@ -196,9 +193,9 @@ test.describe('Group Conversation', () => {
       await pages.conversation().clickConversationInfoButton();
       await pages.conversationDetails().deleteGroupButton.click();
       await modals.confirm().actionButton.click();
-      await pages.conversationList().list.filter({hasText: group.name}).waitFor({state: 'detached'});
-
-      await expect(userCPages.conversationList().list.filter({hasText: group.name})).not.toBeVisible();
+      await expect(userCPages.conversationList().getConversationLocator(group.name)).not.toBeAttached({
+        timeout: 20_000,
+      });
 
       await userCPages.conversationList().searchConversationsInput.fill(group.name);
       await expect(userCPages.conversationList().list).toContainText('No results found');

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -245,4 +245,39 @@ test.describe('Group Conversation', () => {
       ).toBeVisible();
     },
   );
+
+  test(
+    'As an Admin I want to see the group admin toggle on a participants profile in Conversation details',
+    {tag: ['@TC-1481', '@regression']},
+    async ({createPage}) => {
+      const pages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
+
+      await createGroup(pages, groupName, [userB]);
+      await pages.conversationList().openConversation(groupName);
+      await pages.conversation().toggleGroupInformation();
+
+      await expect(pages.conversationDetails().groupMembers.filter({hasText: userB.fullName})).toBeVisible();
+      await pages.conversationDetails().openParticipantDetails(userB.fullName);
+      await expect(pages.conversation().makeAdminToggle).toBeVisible();
+    },
+  );
+
+  test(
+    'As a group member I should not see group admin toggle while viewing Admin`s profile in Conversation details',
+    {tag: ['@TC-1483', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      ]);
+
+      await createGroup(userAPages, groupName, [userB]);
+      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversation().toggleGroupInformation();
+
+      await expect(userBPages.conversationDetails().groupAdmins.filter({hasText: userA.fullName})).toBeVisible();
+      await userBPages.conversationDetails().openParticipantDetails(userA.fullName);
+      await expect(userBPages.conversation().makeAdminToggle).not.toBeVisible();
+    },
+  );
 });

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -93,38 +93,41 @@ test.describe('Group Conversation', () => {
     },
   );
 
-  test(
-    'I want to delete a group as the Group Creator',
-    {tag: ['@TC-1089', '@TC-1090', '@TC-1090', '@regression']},
-    async ({createPage}) => {
-      const {pages, modals} = PageManager.from(
-        await createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC)),
-      ).webapp;
+  test('I want to delete a group as the Group Creator', {tag: ['@TC-1089', '@regression']}, async ({createPage}) => {
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await createGroup(pages, groupName, [userB, userC]);
-      const conversation = pages.conversationList().list.filter({hasText: groupName});
+    await createGroup(userAPages, groupName, [userB, userC]);
+    const adminGroupLocator = userAPages.conversationList().list.filter({hasText: groupName});
+    const memberGroupLocator = userBPages.conversationList().list.filter({hasText: groupName});
 
-      await pages.conversationList().openConversation(groupName);
-      await pages.conversation().clickConversationInfoButton();
-      await pages.conversationDetails().deleteGroupButton.click();
+    // Pre-condition: Ensure the member can see the group before the creator deletes it
+    await expect(memberGroupLocator).toBeVisible();
 
-      // User sees a confirmation dialog with explanation when he initiates delete group
-      await expect(modals.confirm().modalText).toContainText(
-        'This will delete the conversation and all content for all participants on all devices',
-      );
+    // User A initiate group deletion
+    await userAPages.conversationList().openConversation(groupName);
+    await userAPages.conversation().clickConversationInfoButton();
+    await userAPages.conversationDetails().deleteGroupButton.click();
 
-      // User can cancel the delete group from the confirmation dialog
-      await modals.confirm().cancelButton.click();
-      await expect(conversation).toBeVisible();
+    // User sees a confirmation dialog with explanation when he initiates delete group
+    await expect(userAModals.confirm().modalText).toContainText(
+      'This will delete the conversation and all content for all participants on all devices',
+    );
 
-      // User can delete group as the group creator
-      await pages.conversationDetails().deleteGroupButton.click();
-      await modals.confirm().actionButton.click();
+    // User can cancel the delete group from the confirmation dialog
+    await userAModals.confirm().cancelButton.click();
+    await expect(adminGroupLocator).toBeVisible();
 
-      await conversation.waitFor({state: 'detached'});
-      await expect(conversation).not.toBeVisible();
-    },
-  );
+    // User can delete group as the group creator
+    await userAPages.conversationDetails().deleteGroupButton.click();
+    await userAModals.confirm().actionButton.click();
+
+    // Verify the group no longer exists for any user
+    await adminGroupLocator.waitFor({state: 'detached'});
+    await expect(adminGroupLocator).toBeHidden();
+    await expect(memberGroupLocator).toBeHidden();
+  });
 
   test(
     'I want to be notified about the group deletion when app is in background',

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -36,7 +36,8 @@ test.describe('Group Conversation', () => {
 
   test.beforeEach(async ({createTeam, createUser}) => {
     userB = await createUser();
-    team = await createTeam('Test Team', {users: [userB]});
+    userC = await createUser();
+    team = await createTeam('Test Team', {users: [userB, userC]});
     userA = team.owner;
   });
 
@@ -67,6 +68,28 @@ test.describe('Group Conversation', () => {
       await userAPages.conversationList().clickCreateGroup();
       await userAPages.groupCreation().groupNameInput.fill(' ');
       await expect(userAPages.groupCreation().errorGroupName).toHaveText('At least 1 character');
+    },
+  );
+
+  test(
+    'I see count of participants increase and decrease when I select or unselect',
+    {tag: ['@TC-516', '@regression']},
+    async ({createPage}) => {
+      const userAPages = PageManager.from(
+        await createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC)),
+      ).webapp.pages;
+
+      await userAPages.conversationList().clickCreateGroup();
+      await userAPages.groupCreation().setGroupName(groupName);
+
+      await userAPages.groupCreation().selectGroupMembers(userB.fullName);
+      await expect(userAPages.groupCreation().toggleSelectedListButton).toContainText('Selected (1)');
+
+      await userAPages.groupCreation().selectGroupMembers(userC.fullName);
+      await expect(userAPages.groupCreation().toggleSelectedListButton).toContainText('Selected (2)');
+
+      await userAPages.groupCreation().deselectGroupMember(userB.fullName);
+      await expect(userAPages.groupCreation().toggleSelectedListButton).toContainText('Selected (1)');
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -57,4 +57,16 @@ test.describe('Group Conversation', () => {
     ).toBeVisible();
     await expect(message).toBeVisible();
   });
+
+  test(
+    'I cannot set empty or space-only conversation name',
+    {tag: ['@TC-514', '@regression']},
+    async ({createPage}) => {
+      const userAPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
+
+      await userAPages.conversationList().clickCreateGroup();
+      await userAPages.groupCreation().groupNameInput.fill(' ');
+      await expect(userAPages.groupCreation().errorGroupName).toHaveText('At least 1 character');
+    },
+  );
 });

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -125,4 +125,44 @@ test.describe('Group Conversation', () => {
       await expect(conversation).not.toBeVisible();
     },
   );
+
+  test(
+    'I want to be notified about the group deletion when app is in background',
+    {tag: ['@TC-1093', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+
+      const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+
+      await createGroup(userAPages, groupName, [userB]);
+
+      const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
+
+      const blankTab = await userBPage.context().newPage();
+      await blankTab.goto('about:blank');
+      await blankTab.bringToFront();
+
+      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversation().clickConversationInfoButton();
+      await userAPages.conversationDetails().deleteGroupButton.click();
+      await userAModals.confirm().actionButton.click();
+      await userAPages.conversationList().list.filter({hasText: groupName}).waitFor({state: 'detached'});
+
+      await expect
+        .poll(() => getUserBNotifications())
+        .toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              body: `${groupName} has been deleted`,
+              data: expect.objectContaining({
+                messageType: 'team.delete',
+              }),
+            }),
+          ]),
+        );
+    },
+  );
 });

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -525,7 +525,7 @@ test.describe('Guestroom', () => {
 
       await guestPages.conversationJoin().joinAsMemberButton.click();
       await guestPages.conversation().conversationTitle.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
-      await expect(guestPages.conversationList().list.filter({hasText: groupName})).toBeVisible();
+      await expect(guestPages.conversationList().getConversationLocator(groupName)).toBeVisible();
     },
   );
 
@@ -627,7 +627,7 @@ test.describe('Guestroom', () => {
         },
       );
 
-      await expect(guestPages.conversationList().list.filter({hasText: groupName})).toBeVisible();
+      await expect(guestPages.conversationList().getConversationLocator(groupName)).toBeVisible();
     },
   );
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19952" title="WPB-19952" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19952</a>  [Web/QA] Write the Group Conversation tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This PR introduces new regression tests for Group Conversations.
---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
