### PR TITLE
test: avoid flake by scoping conversationList locators by protocol [WPB-24429]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
@@ -20,6 +20,8 @@
 import {Locator, Page} from '@playwright/test';
 import {GuestOptionsPage} from './guestOptions.page';
 
+type NotificationLevel = 'Everything' | 'Mentions and replies' | 'Nothing';
+
 export class ConversationDetailsPage {
   private readonly page: Page;
 
@@ -219,16 +221,16 @@ export class ConversationDetailsPage {
     await this.clearConversationContentButton.click();
   }
 
-  async setNotifications(value: Parameters<typeof this.selectNotificationsLevel>[0]) {
+  async setNotifications(level: NotificationLevel) {
     await this.notificationsButton.click();
-    await this.selectNotificationsLevel(value);
+    await this.selectNotificationsLevel(level);
 
     // Close the settings by clicking "Go back" button.
     await this.page.getByRole('button', {name: 'Go back'}).click();
   }
 
-  async selectNotificationsLevel(value: 'Everything' | 'Mentions and replies' | 'Nothing') {
-    await this.page.getByRole('radiogroup').getByText(value).click();
+  async selectNotificationsLevel(level: NotificationLevel) {
+    await this.page.getByRole('radiogroup').getByText(level).click();
   }
 
   async changeConversationName(newConversationName: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
@@ -219,12 +219,16 @@ export class ConversationDetailsPage {
     await this.clearConversationContentButton.click();
   }
 
-  async setNotifications(value: 'Everything' | 'Mentions and replies' | 'Nothing') {
+  async setNotifications(value: Parameters<typeof this.selectNotificationsLevel>[0]) {
     await this.notificationsButton.click();
-    await this.page.getByRole('radiogroup').getByText(value).click();
+    await this.selectNotificationsLevel(value);
 
     // Close the settings by clicking "Go back" button.
     await this.page.getByRole('button', {name: 'Go back'}).click();
+  }
+
+  async selectNotificationsLevel(value: 'Everything' | 'Mentions and replies' | 'Nothing') {
+    await this.page.getByRole('radiogroup').getByText(value).click();
   }
 
   async changeConversationName(newConversationName: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -28,7 +28,6 @@ export class ConversationListPage {
   readonly createGroupButton: Locator;
   readonly pendingConnectionRequest: Locator;
   readonly searchConversationsInput: Locator;
-  readonly moveToMenu: Locator;
   readonly conversationListHeaderTitle: Locator;
   readonly joinCallButton: Locator;
   readonly clearContentButton: Locator;
@@ -42,7 +41,6 @@ export class ConversationListPage {
     this.pendingConnectionRequest = page.locator('[data-uie-name="connection-request"]');
     this.createGroupButton = page.getByTestId('conversation-list-header').getByTestId('go-create-group');
     this.searchConversationsInput = page.getByTestId('search-conversations');
-    this.moveToMenu = page.getByRole('menu');
     this.conversationListHeaderTitle = page.locator('[data-uie-name="conversation-list-header-title"]');
     this.joinCallButton = page.getByRole('button', {name: 'Join'});
     this.clearContentButton = page.getByRole('button', {name: 'Clear content'});

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -80,10 +80,6 @@ export class ConversationListPage {
     await this.pendingConnectionRequest.click();
   }
 
-  async clickConversationOptions(conversationName: string) {
-    await this.getConversationLocator(conversationName).getByTestId('go-options').first().click();
-  }
-
   async clickBlockConversation() {
     await this.blockConversationMenuButton.click();
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -29,7 +29,6 @@ export class ConversationListPage {
   readonly pendingConnectionRequest: Locator;
   readonly searchConversationsInput: Locator;
   readonly conversationListHeaderTitle: Locator;
-  readonly addToFavoritesButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -39,7 +38,6 @@ export class ConversationListPage {
     this.createGroupButton = page.getByTestId('conversation-list-header').getByTestId('go-create-group');
     this.searchConversationsInput = page.getByTestId('search-conversations');
     this.conversationListHeaderTitle = page.locator('[data-uie-name="conversation-list-header-title"]');
-    this.addToFavoritesButton = page.getByRole('menuitem', {name: 'Add to favorites'});
   }
 
   async openConversation(conversationName: string, options?: Parameters<typeof this.getConversationLocator>[1]) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -29,7 +29,6 @@ export class ConversationListPage {
   readonly pendingConnectionRequest: Locator;
   readonly searchConversationsInput: Locator;
   readonly conversationListHeaderTitle: Locator;
-  readonly notificationsButton: Locator;
   readonly addToFavoritesButton: Locator;
 
   constructor(page: Page) {
@@ -40,7 +39,6 @@ export class ConversationListPage {
     this.createGroupButton = page.getByTestId('conversation-list-header').getByTestId('go-create-group');
     this.searchConversationsInput = page.getByTestId('search-conversations');
     this.conversationListHeaderTitle = page.locator('[data-uie-name="conversation-list-header-title"]');
-    this.notificationsButton = page.getByRole('menuitem', {name: 'Notifications'});
     this.addToFavoritesButton = page.getByRole('menuitem', {name: 'Add to favorites'});
   }
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -68,10 +68,6 @@ export class ConversationListPage {
     this.addToFavoritesButton = page.getByRole('menuitem', {name: 'Add to favorites'});
   }
 
-  async isConversationBlocked(conversationName: string) {
-    return await this.getConversationLocator(conversationName).getByTestId('status-blocked').isVisible();
-  }
-
   async openConversation(conversationName: string, options?: Parameters<typeof this.getConversationLocator>[1]) {
     await this.getConversationLocator(conversationName, options).click();
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -29,7 +29,6 @@ export class ConversationListPage {
   readonly pendingConnectionRequest: Locator;
   readonly searchConversationsInput: Locator;
   readonly moveToMenu: Locator;
-  readonly createNewFolderButton: Locator;
   readonly conversationListHeaderTitle: Locator;
   readonly joinCallButton: Locator;
   readonly clearContentButton: Locator;
@@ -44,7 +43,6 @@ export class ConversationListPage {
     this.createGroupButton = page.getByTestId('conversation-list-header').getByTestId('go-create-group');
     this.searchConversationsInput = page.getByTestId('search-conversations');
     this.moveToMenu = page.getByRole('menu');
-    this.createNewFolderButton = this.moveToMenu.getByRole('button', {name: 'Create new folder'});
     this.conversationListHeaderTitle = page.locator('[data-uie-name="conversation-list-header-title"]');
     this.joinCallButton = page.getByRole('button', {name: 'Join'});
     this.clearContentButton = page.getByRole('button', {name: 'Clear content'});

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -27,7 +27,6 @@ export class ConversationListPage {
   readonly list: Locator;
   readonly createGroupButton: Locator;
   readonly pendingConnectionRequest: Locator;
-  readonly leaveConversationButton: Locator;
   readonly searchConversationsInput: Locator;
   readonly blockedChip: Locator;
   readonly moveToMenu: Locator;
@@ -44,7 +43,6 @@ export class ConversationListPage {
     this.list = page.getByRole('list', {name: 'Conversation list'});
     this.pendingConnectionRequest = page.locator('[data-uie-name="connection-request"]');
     this.createGroupButton = page.getByTestId('conversation-list-header').getByTestId('go-create-group');
-    this.leaveConversationButton = page.getByTestId('conversation-leave');
     this.searchConversationsInput = page.getByTestId('search-conversations');
     this.blockedChip = page.locator(`span[data-uie-name="status-label"] + span`);
     this.moveToMenu = page.getByRole('menu');
@@ -118,11 +116,8 @@ export class ConversationListPage {
       blockButton: contextMenu.getByRole('button', {name: 'Block'}),
       unblockButton: contextMenu.getByRole('button', {name: 'Unblock'}),
       moveToButton: contextMenu.getByRole('button', {name: 'Move to'}),
+      leaveConversationButton: contextMenu.getByRole('button', {name: 'Leave'}),
     });
-  }
-
-  async leaveConversation() {
-    await this.leaveConversationButton.click();
   }
 
   async searchConversation(conversationName: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -25,7 +25,6 @@ export class ConversationListPage {
   private readonly page: Page;
 
   readonly list: Locator;
-  readonly blockConversationMenuButton: Locator;
   readonly createGroupButton: Locator;
   readonly pendingConnectionRequest: Locator;
   readonly leaveConversationButton: Locator;
@@ -47,7 +46,6 @@ export class ConversationListPage {
     this.page = page;
 
     this.list = page.getByRole('list', {name: 'Conversation list'});
-    this.blockConversationMenuButton = page.getByRole('menu').getByRole('button', {name: 'Block'});
     this.pendingConnectionRequest = page.locator('[data-uie-name="connection-request"]');
     this.createGroupButton = page.getByTestId('conversation-list-header').getByTestId('go-create-group');
     this.leaveConversationButton = page.getByTestId('conversation-leave');
@@ -74,10 +72,6 @@ export class ConversationListPage {
 
   async openPendingConnectionRequest() {
     await this.pendingConnectionRequest.click();
-  }
-
-  async clickBlockConversation() {
-    await this.blockConversationMenuButton.click();
   }
 
   async archiveConversation() {
@@ -123,8 +117,22 @@ export class ConversationListPage {
     });
   }
 
+  /**
+   * Open the context menu of the given conversation
+   * @returns an enhanced locator for the open context menu
+   *
+   * @example
+   * const contextMenu = await pages.conversationList().openContextMenu(conversationLocator);
+   * await contextMenu.archiveButton.click();
+   */
   async openContextMenu(conversation: Locator) {
     await conversation.getByRole('button', {name: 'Open conversation options'}).click();
+
+    const contextMenu = this.page.getByRole('menu');
+
+    return Object.assign(contextMenu, {
+      blockButton: contextMenu.getByRole('button', {name: 'Block'}),
+    });
   }
 
   async leaveConversation() {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -19,8 +19,6 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {User} from 'test/e2e_tests/data/user';
-
 export class ConversationListPage {
   private readonly page: Page;
 
@@ -72,6 +70,7 @@ export class ConversationListPage {
 
     return Object.assign(conversation, {
       userAvatar: conversation.getByTestId('element-avatar-user'),
+      statusAvailabilityIcon: conversation.getByTestId('status-availability-icon'),
       unreadIndicator: conversation.getByTitle('Unread message'),
       mutedIndicator: conversation.getByTitle('Muted conversation'),
       mentionIndicator: conversation.getByTitle('Unread mention'),
@@ -104,9 +103,5 @@ export class ConversationListPage {
       clearContentButton: contextMenu.getByRole('button', {name: 'Clear content'}),
       leaveConversationButton: contextMenu.getByRole('button', {name: 'Leave'}),
     });
-  }
-
-  getUserStatusIcon(user: User) {
-    return this.getConversationLocator(user.fullName).getByTestId('status-availability-icon');
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -137,8 +137,4 @@ export class ConversationListPage {
   getUserStatusIcon(user: User) {
     return this.getConversationLocator(user.fullName).getByTestId('status-availability-icon');
   }
-
-  async getMutedConversationBadge(conversationName: string) {
-    return this.getConversationLocator(conversationName).getByTitle('Muted conversation');
-  }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -30,7 +30,6 @@ export class ConversationListPage {
   readonly searchConversationsInput: Locator;
   readonly conversationListHeaderTitle: Locator;
   readonly joinCallButton: Locator;
-  readonly clearContentButton: Locator;
   readonly notificationsButton: Locator;
   readonly addToFavoritesButton: Locator;
 
@@ -43,7 +42,6 @@ export class ConversationListPage {
     this.searchConversationsInput = page.getByTestId('search-conversations');
     this.conversationListHeaderTitle = page.locator('[data-uie-name="conversation-list-header-title"]');
     this.joinCallButton = page.getByRole('button', {name: 'Join'});
-    this.clearContentButton = page.getByRole('button', {name: 'Clear content'});
     this.notificationsButton = page.getByRole('menuitem', {name: 'Notifications'});
     this.addToFavoritesButton = page.getByRole('menuitem', {name: 'Add to favorites'});
   }
@@ -111,6 +109,7 @@ export class ConversationListPage {
       blockButton: contextMenu.getByRole('button', {name: 'Block'}),
       unblockButton: contextMenu.getByRole('button', {name: 'Unblock'}),
       moveToButton: contextMenu.getByRole('button', {name: 'Move to'}),
+      clearContentButton: contextMenu.getByRole('button', {name: 'Clear content'}),
       leaveConversationButton: contextMenu.getByRole('button', {name: 'Leave'}),
     });
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -28,7 +28,6 @@ export class ConversationListPage {
   readonly createGroupButton: Locator;
   readonly pendingConnectionRequest: Locator;
   readonly searchConversationsInput: Locator;
-  readonly blockedChip: Locator;
   readonly moveToMenu: Locator;
   readonly createNewFolderButton: Locator;
   readonly conversationListHeaderTitle: Locator;
@@ -44,7 +43,6 @@ export class ConversationListPage {
     this.pendingConnectionRequest = page.locator('[data-uie-name="connection-request"]');
     this.createGroupButton = page.getByTestId('conversation-list-header').getByTestId('go-create-group');
     this.searchConversationsInput = page.getByTestId('search-conversations');
-    this.blockedChip = page.locator(`span[data-uie-name="status-label"] + span`);
     this.moveToMenu = page.getByRole('menu');
     this.createNewFolderButton = this.moveToMenu.getByRole('button', {name: 'Create new folder'});
     this.conversationListHeaderTitle = page.locator('[data-uie-name="conversation-list-header-title"]');
@@ -93,6 +91,7 @@ export class ConversationListPage {
       unreadIndicator: conversation.getByTitle('Unread message'),
       mutedIndicator: conversation.getByTitle('Muted conversation'),
       mentionIndicator: conversation.getByTitle('Unread mention'),
+      blockedIndicator: conversation.locator(`span[data-uie-name="status-label"] + span`),
       openContextMenu: () => this.openContextMenu(conversation),
     });
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -120,11 +120,6 @@ export class ConversationListPage {
     });
   }
 
-  async searchConversation(conversationName: string) {
-    await this.searchConversationsInput.fill(conversationName);
-    await this.openConversation(conversationName);
-  }
-
   async getUserAvatarWrapper(user: User): Promise<Locator> {
     return this.getConversationLocator(user.fullName).getByTestId('element-avatar-user');
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -32,7 +32,6 @@ export class ConversationListPage {
   readonly archiveConversationMenuButton: Locator;
   readonly unarchiveConversationMenuButton: Locator;
   readonly blockedChip: Locator;
-  readonly unblockConversationMenuButton: Locator;
   readonly moveConversationButton: Locator;
   readonly moveToMenu: Locator;
   readonly createNewFolderButton: Locator;
@@ -53,9 +52,6 @@ export class ConversationListPage {
     this.archiveConversationMenuButton = page.locator('#btn-archive');
     this.unarchiveConversationMenuButton = page.locator('#btn-unarchive');
     this.blockedChip = page.locator(`span[data-uie-name="status-label"] + span`);
-    this.unblockConversationMenuButton = page
-      .getByTestId('conversation-list-options-menu')
-      .and(page.locator('#btn-unblock'));
     this.moveConversationButton = page.getByRole('menu').getByRole('button', {name: 'Move to'});
     this.moveToMenu = page.getByRole('menu');
     this.createNewFolderButton = this.moveToMenu.getByRole('button', {name: 'Create new folder'});
@@ -132,6 +128,7 @@ export class ConversationListPage {
 
     return Object.assign(contextMenu, {
       blockButton: contextMenu.getByRole('button', {name: 'Block'}),
+      unblockButton: contextMenu.getByRole('button', {name: 'Unblock'}),
     });
   }
 
@@ -150,10 +147,6 @@ export class ConversationListPage {
 
   getUserStatusIcon(user: User) {
     return this.getConversationLocator(user.fullName).getByTestId('status-availability-icon');
-  }
-
-  async clickUnblockConversation() {
-    await this.unblockConversationMenuButton.click();
   }
 
   getRemoveConversationFromFolderButton(folderName: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -29,7 +29,6 @@ export class ConversationListPage {
   readonly pendingConnectionRequest: Locator;
   readonly leaveConversationButton: Locator;
   readonly searchConversationsInput: Locator;
-  readonly archiveConversationMenuButton: Locator;
   readonly unarchiveConversationMenuButton: Locator;
   readonly blockedChip: Locator;
   readonly moveConversationButton: Locator;
@@ -49,7 +48,6 @@ export class ConversationListPage {
     this.createGroupButton = page.getByTestId('conversation-list-header').getByTestId('go-create-group');
     this.leaveConversationButton = page.getByTestId('conversation-leave');
     this.searchConversationsInput = page.getByTestId('search-conversations');
-    this.archiveConversationMenuButton = page.locator('#btn-archive');
     this.unarchiveConversationMenuButton = page.locator('#btn-unarchive');
     this.blockedChip = page.locator(`span[data-uie-name="status-label"] + span`);
     this.moveConversationButton = page.getByRole('menu').getByRole('button', {name: 'Move to'});
@@ -68,10 +66,6 @@ export class ConversationListPage {
 
   async openPendingConnectionRequest() {
     await this.pendingConnectionRequest.click();
-  }
-
-  async archiveConversation() {
-    await this.archiveConversationMenuButton.click();
   }
 
   async setNotifications(level: 'Everything' | 'Mentions and replies' | 'Nothing') {
@@ -127,6 +121,7 @@ export class ConversationListPage {
     const contextMenu = this.page.getByRole('menu');
 
     return Object.assign(contextMenu, {
+      archiveButton: contextMenu.getByRole('button', {name: 'Archive'}),
       blockButton: contextMenu.getByRole('button', {name: 'Block'}),
       unblockButton: contextMenu.getByRole('button', {name: 'Unblock'}),
     });

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -30,7 +30,6 @@ export class ConversationListPage {
   readonly leaveConversationButton: Locator;
   readonly searchConversationsInput: Locator;
   readonly blockedChip: Locator;
-  readonly moveConversationButton: Locator;
   readonly moveToMenu: Locator;
   readonly createNewFolderButton: Locator;
   readonly conversationListHeaderTitle: Locator;
@@ -48,7 +47,6 @@ export class ConversationListPage {
     this.leaveConversationButton = page.getByTestId('conversation-leave');
     this.searchConversationsInput = page.getByTestId('search-conversations');
     this.blockedChip = page.locator(`span[data-uie-name="status-label"] + span`);
-    this.moveConversationButton = page.getByRole('menu').getByRole('button', {name: 'Move to'});
     this.moveToMenu = page.getByRole('menu');
     this.createNewFolderButton = this.moveToMenu.getByRole('button', {name: 'Create new folder'});
     this.conversationListHeaderTitle = page.locator('[data-uie-name="conversation-list-header-title"]');
@@ -119,6 +117,7 @@ export class ConversationListPage {
       unarchiveButton: contextMenu.getByRole('button', {name: 'Unarchive'}),
       blockButton: contextMenu.getByRole('button', {name: 'Block'}),
       unblockButton: contextMenu.getByRole('button', {name: 'Unblock'}),
+      moveToButton: contextMenu.getByRole('button', {name: 'Move to'}),
     });
   }
 
@@ -141,10 +140,6 @@ export class ConversationListPage {
 
   getRemoveConversationFromFolderButton(folderName: string) {
     return this.page.getByRole('button', {name: `Remove from "${folderName}"`});
-  }
-
-  getMoveToFolderButton(folderName: string) {
-    return this.moveToMenu.getByRole('button', {name: folderName, exact: true});
   }
 
   async getMutedConversationBadge(conversationName: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -71,6 +71,7 @@ export class ConversationListPage {
     }
 
     return Object.assign(conversation, {
+      userAvatar: conversation.getByTestId('element-avatar-user'),
       unreadIndicator: conversation.getByTitle('Unread message'),
       mutedIndicator: conversation.getByTitle('Muted conversation'),
       mentionIndicator: conversation.getByTitle('Unread mention'),
@@ -103,10 +104,6 @@ export class ConversationListPage {
       clearContentButton: contextMenu.getByRole('button', {name: 'Clear content'}),
       leaveConversationButton: contextMenu.getByRole('button', {name: 'Leave'}),
     });
-  }
-
-  async getUserAvatarWrapper(user: User): Promise<Locator> {
-    return this.getConversationLocator(user.fullName).getByTestId('element-avatar-user');
   }
 
   getUserStatusIcon(user: User) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -29,7 +29,6 @@ export class ConversationListPage {
   readonly pendingConnectionRequest: Locator;
   readonly leaveConversationButton: Locator;
   readonly searchConversationsInput: Locator;
-  readonly unarchiveConversationMenuButton: Locator;
   readonly blockedChip: Locator;
   readonly moveConversationButton: Locator;
   readonly moveToMenu: Locator;
@@ -48,7 +47,6 @@ export class ConversationListPage {
     this.createGroupButton = page.getByTestId('conversation-list-header').getByTestId('go-create-group');
     this.leaveConversationButton = page.getByTestId('conversation-leave');
     this.searchConversationsInput = page.getByTestId('search-conversations');
-    this.unarchiveConversationMenuButton = page.locator('#btn-unarchive');
     this.blockedChip = page.locator(`span[data-uie-name="status-label"] + span`);
     this.moveConversationButton = page.getByRole('menu').getByRole('button', {name: 'Move to'});
     this.moveToMenu = page.getByRole('menu');
@@ -71,10 +69,6 @@ export class ConversationListPage {
   async setNotifications(level: 'Everything' | 'Mentions and replies' | 'Nothing') {
     await this.notificationsButton.click(); // Click the "Notifications" menu item
     await this.page.getByRole('radiogroup').locator('label', {hasText: level}).click(); // Click the specified radio button
-  }
-
-  async unarchiveConversation() {
-    await this.unarchiveConversationMenuButton.click();
   }
 
   async clickCreateGroup() {
@@ -122,6 +116,7 @@ export class ConversationListPage {
 
     return Object.assign(contextMenu, {
       archiveButton: contextMenu.getByRole('button', {name: 'Archive'}),
+      unarchiveButton: contextMenu.getByRole('button', {name: 'Unarchive'}),
       blockButton: contextMenu.getByRole('button', {name: 'Block'}),
       unblockButton: contextMenu.getByRole('button', {name: 'Unblock'}),
     });

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -52,11 +52,6 @@ export class ConversationListPage {
     await this.pendingConnectionRequest.click();
   }
 
-  async setNotifications(level: 'Everything' | 'Mentions and replies' | 'Nothing') {
-    await this.notificationsButton.click(); // Click the "Notifications" menu item
-    await this.page.getByRole('radiogroup').locator('label', {hasText: level}).click(); // Click the specified radio button
-  }
-
   async clickCreateGroup() {
     await this.createGroupButton.click();
   }
@@ -108,6 +103,7 @@ export class ConversationListPage {
       blockButton: contextMenu.getByRole('button', {name: 'Block'}),
       unblockButton: contextMenu.getByRole('button', {name: 'Unblock'}),
       moveToButton: contextMenu.getByRole('button', {name: 'Move to'}),
+      notificationsButton: contextMenu.getByRole('menuitem', {name: 'Notifications'}),
       clearContentButton: contextMenu.getByRole('button', {name: 'Clear content'}),
       leaveConversationButton: contextMenu.getByRole('button', {name: 'Leave'}),
     });

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -138,10 +138,6 @@ export class ConversationListPage {
     return this.getConversationLocator(user.fullName).getByTestId('status-availability-icon');
   }
 
-  getRemoveConversationFromFolderButton(folderName: string) {
-    return this.page.getByRole('button', {name: `Remove from "${folderName}"`});
-  }
-
   async getMutedConversationBadge(conversationName: string) {
     return this.getConversationLocator(conversationName).getByTitle('Muted conversation');
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -127,12 +127,12 @@ export class ConversationListPage {
       unreadIndicator: conversation.getByTitle('Unread message'),
       mutedIndicator: conversation.getByTitle('Muted conversation'),
       mentionIndicator: conversation.getByTitle('Unread mention'),
+      openContextMenu: () => this.openContextMenu(conversation),
     });
   }
 
-  async openContextMenu(conversationName: string) {
-    await this.getConversationLocator(conversationName).click();
-    await this.getConversationLocator(conversationName).click({button: 'right'});
+  async openContextMenu(conversation: Locator) {
+    await conversation.getByRole('button', {name: 'Open conversation options'}).click();
   }
 
   async leaveConversation() {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -29,7 +29,6 @@ export class ConversationListPage {
   readonly pendingConnectionRequest: Locator;
   readonly searchConversationsInput: Locator;
   readonly conversationListHeaderTitle: Locator;
-  readonly joinCallButton: Locator;
   readonly notificationsButton: Locator;
   readonly addToFavoritesButton: Locator;
 
@@ -41,7 +40,6 @@ export class ConversationListPage {
     this.createGroupButton = page.getByTestId('conversation-list-header').getByTestId('go-create-group');
     this.searchConversationsInput = page.getByTestId('search-conversations');
     this.conversationListHeaderTitle = page.locator('[data-uie-name="conversation-list-header-title"]');
-    this.joinCallButton = page.getByRole('button', {name: 'Join'});
     this.notificationsButton = page.getByRole('menuitem', {name: 'Notifications'});
     this.addToFavoritesButton = page.getByRole('menuitem', {name: 'Add to favorites'});
   }
@@ -86,6 +84,7 @@ export class ConversationListPage {
       mutedIndicator: conversation.getByTitle('Muted conversation'),
       mentionIndicator: conversation.getByTitle('Unread mention'),
       blockedIndicator: conversation.locator(`span[data-uie-name="status-label"] + span`),
+      joinCallButton: conversation.getByRole('button', {name: 'Join'}),
       openContextMenu: () => this.openContextMenu(conversation),
     });
   }

--- a/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
@@ -40,14 +40,14 @@ test.describe('Archive', () => {
       const page = await createPage(withLogin(memberA), withConnectedUser(memberB));
       const {pages, components} = PageManager.from(page).webapp;
 
-      await pages.conversationList().clickConversationOptions(memberB.fullName);
+      await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
       await pages.conversationList().archiveConversation();
       await expect(pages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
 
       await components.conversationSidebar().clickArchive();
       await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
 
-      await pages.conversationList().clickConversationOptions(memberB.fullName);
+      await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
       await pages.conversationList().unarchiveConversation();
       await expect(pages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
 
@@ -69,7 +69,10 @@ test.describe('Archive', () => {
       await memberBPages.conversationList().openConversation(memberA.fullName, {protocol: 'mls'});
 
       await test.step('MemberA archives conversation with memberB', async () => {
-        await memberAPages.conversationList().clickConversationOptions(memberB.fullName);
+        await memberAPages
+          .conversationList()
+          .getConversationLocator(memberB.fullName, {protocol: 'mls'})
+          .openContextMenu();
         await memberAPages.conversationList().archiveConversation();
       });
 
@@ -99,13 +102,13 @@ test.describe('Archive', () => {
 
       if (tag === '@TC-103') {
         await test.step('User mutes the conversation', async () => {
-          await pages.conversationList().clickConversationOptions(memberB.fullName);
+          await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
           await pages.conversationList().setNotifications('Nothing');
         });
       }
 
       await test.step('User archives the conversation', async () => {
-        await pages.conversationList().clickConversationOptions(memberB.fullName);
+        await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
         await pages.conversationList().archiveConversation();
         await expect(pages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
       });

--- a/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
@@ -40,8 +40,8 @@ test.describe('Archive', () => {
       const page = await createPage(withLogin(memberA), withConnectedUser(memberB));
       const {pages, components} = PageManager.from(page).webapp;
 
-      await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
-      await pages.conversationList().archiveConversation();
+      const contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
+      await contextMenu.archiveButton.click();
       await expect(pages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
 
       await components.conversationSidebar().clickArchive();
@@ -69,11 +69,11 @@ test.describe('Archive', () => {
       await memberBPages.conversationList().openConversation(memberA.fullName, {protocol: 'mls'});
 
       await test.step('MemberA archives conversation with memberB', async () => {
-        await memberAPages
+        const contextMenu = await memberAPages
           .conversationList()
           .getConversationLocator(memberB.fullName, {protocol: 'mls'})
           .openContextMenu();
-        await memberAPages.conversationList().archiveConversation();
+        await contextMenu.archiveButton.click();
       });
 
       await test.step('MemberB sends message in archived conversation', async () => {
@@ -108,8 +108,8 @@ test.describe('Archive', () => {
       }
 
       await test.step('User archives the conversation', async () => {
-        await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
-        await pages.conversationList().archiveConversation();
+        const contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
+        await contextMenu.archiveButton.click();
         await expect(pages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
       });
 

--- a/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
@@ -102,8 +102,9 @@ test.describe('Archive', () => {
 
       if (tag === '@TC-103') {
         await test.step('User mutes the conversation', async () => {
-          await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
-          await pages.conversationList().setNotifications('Nothing');
+          const contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
+          await contextMenu.notificationsButton.click();
+          await pages.conversationDetails().selectNotificationsLevel('Nothing');
         });
       }
 

--- a/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
@@ -40,15 +40,15 @@ test.describe('Archive', () => {
       const page = await createPage(withLogin(memberA), withConnectedUser(memberB));
       const {pages, components} = PageManager.from(page).webapp;
 
-      const contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
+      let contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
       await contextMenu.archiveButton.click();
       await expect(pages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
 
       await components.conversationSidebar().clickArchive();
       await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
 
-      await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
-      await pages.conversationList().unarchiveConversation();
+      contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
+      await contextMenu.unarchiveButton.click();
       await expect(pages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
 
       await components.conversationSidebar().clickAllConversationsButton();

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -207,8 +207,11 @@ test.describe('User Blocking', () => {
         await blockUserFromProfileView(userAPageManagerInstance);
         await expect(userAPages.conversation().messageInput).toBeHidden();
         // Step 3: User A unblocks User B from Conversation Details Options
-        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).openContextMenu();
-        await userAPages.conversationList().clickUnblockConversation();
+        const contextMenu = await userAPages
+          .conversationList()
+          .getConversationLocator(userB.fullName, {protocol: 'mls'})
+          .openContextMenu();
+        await contextMenu.unblockButton.click();
         await userAModals.confirm().clickAction();
         // Step 4: User A send message to User B
         await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -33,8 +33,8 @@ export async function blockUserFromConversationList(pageManager: PageManager, us
   const {pages, modals} = pageManager.webapp;
 
   await pages.conversationList().openConversation(userToBlock.fullName);
-  await pages.conversationList().getConversationLocator(userToBlock.fullName).openContextMenu();
-  await pages.conversationList().clickBlockConversation();
+  const contextMenu = await pages.conversationList().getConversationLocator(userToBlock.fullName).openContextMenu();
+  await contextMenu.blockButton.click();
   await modals.blockWarning().clickBlock();
 }
 
@@ -94,9 +94,12 @@ test.describe('User Blocking', () => {
         // Step 1: User A opens conversation with User B
         await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
         // Step 2: User A opens the options menu for user B
-        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).openContextMenu();
+        const contextMenu = await userAPages
+          .conversationList()
+          .getConversationLocator(userB.fullName, {protocol: 'mls'})
+          .openContextMenu();
         // Step 3: User A opens modal and clicks 'Block' button
-        await userAPages.conversationList().clickBlockConversation();
+        await contextMenu.blockButton.click();
         // Step 4: User A clicks 'Cancel' button
         await userAModals.blockWarning().clickCancel();
         // Step 5: Conversation is still present, and User A can open it
@@ -343,10 +346,10 @@ test.describe('User Blocking', () => {
       await userAPages.conversationList().openConversation(userB.fullName);
 
       // Step 2: User A opens the options menu for user B
-      await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+      const contextMenu = await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
 
       // Step 3: Block conversation button is not visible for team members
-      await expect(userAPages.conversationList().blockConversationMenuButton).not.toBeAttached();
+      await expect(contextMenu.blockButton).not.toBeAttached();
     });
   });
 });

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -33,7 +33,7 @@ export async function blockUserFromConversationList(pageManager: PageManager, us
   const {pages, modals} = pageManager.webapp;
 
   await pages.conversationList().openConversation(userToBlock.fullName);
-  await pages.conversationList().clickConversationOptions(userToBlock.fullName);
+  await pages.conversationList().getConversationLocator(userToBlock.fullName).openContextMenu();
   await pages.conversationList().clickBlockConversation();
   await modals.blockWarning().clickBlock();
 }
@@ -94,7 +94,7 @@ test.describe('User Blocking', () => {
         // Step 1: User A opens conversation with User B
         await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
         // Step 2: User A opens the options menu for user B
-        await userAPages.conversationList().clickConversationOptions(userB.fullName);
+        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).openContextMenu();
         // Step 3: User A opens modal and clicks 'Block' button
         await userAPages.conversationList().clickBlockConversation();
         // Step 4: User A clicks 'Cancel' button
@@ -204,7 +204,7 @@ test.describe('User Blocking', () => {
         await blockUserFromProfileView(userAPageManagerInstance);
         await expect(userAPages.conversation().messageInput).toBeHidden();
         // Step 3: User A unblocks User B from Conversation Details Options
-        await userAPages.conversationList().clickConversationOptions(userB.fullName);
+        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).openContextMenu();
         await userAPages.conversationList().clickUnblockConversation();
         await userAModals.confirm().clickAction();
         // Step 4: User A send message to User B
@@ -343,7 +343,7 @@ test.describe('User Blocking', () => {
       await userAPages.conversationList().openConversation(userB.fullName);
 
       // Step 2: User A opens the options menu for user B
-      await userAPages.conversationList().clickConversationOptions(userB.fullName);
+      await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
 
       // Step 3: Block conversation button is not visible for team members
       await expect(userAPages.conversationList().blockConversationMenuButton).not.toBeAttached();

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -138,7 +138,9 @@ test.describe('User Blocking', () => {
         const message = userAPages.conversation().getMessage({sender: userB});
         await expect(message).not.toBeVisible();
         // Step 7: 'Blocked' chip is visible next to the name of User B in the conversation list
-        const statusTextElement = userAPages.conversationList().blockedChip;
+        const statusTextElement = userAPages
+          .conversationList()
+          .getConversationLocator(userB.fullName, {protocol: 'mls'}).blockedIndicator;
         await expect(statusTextElement).toBeVisible();
         await expect(statusTextElement).toHaveText('Blocked');
         // Step 8: Profile Picture of User B is replaced by 'blocked' picture

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -143,9 +143,10 @@ test.describe('User Blocking', () => {
           .getConversationLocator(userB.fullName, {protocol: 'mls'}).blockedIndicator;
         await expect(statusTextElement).toBeVisible();
         await expect(statusTextElement).toHaveText('Blocked');
+
         // Step 8: Profile Picture of User B is replaced by 'blocked' picture
-        const avatarWrapperUserB = await userAPages.conversationList().getUserAvatarWrapper(userB);
-        const blockedIcon = avatarWrapperUserB.locator('[data-uie-value="blocked"]');
+        const {userAvatar} = userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'});
+        const blockedIcon = userAvatar.locator('[data-uie-value="blocked"]');
         await expect(blockedIcon).toBeVisible();
       },
     );

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -94,13 +94,14 @@ test.describe('Calling', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName);
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
       await userAPages.conversation().clickCallButton();
 
-      await expect(userBPages.conversationList().joinCallButton).toBeVisible();
+      const {joinCallButton} = userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'});
+      await expect(joinCallButton).toBeVisible();
       await expect(userBPages.calling().acceptCallButton).toBeVisible();
 
-      await userBPages.conversationList().joinCallButton.click();
+      await joinCallButton.click();
       await expect(userBPages.calling().acceptCallButton).not.toBeVisible();
     },
   );

--- a/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -76,7 +76,10 @@ test.describe('Clear Conversation Content', () => {
         await expect(userAPages.conversation().messages).toHaveCount(3);
 
         // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-        await userAPages.conversationList().openContextMenu(conversationName);
+        await userAPages
+          .conversationList()
+          .getConversationLocator(conversationName, {protocol: 'mls'})
+          .openContextMenu();
         await userAPages.conversationList().clearContentButton.click();
         // Step 4: Warning Popup should open
         await expect(userAModals.optionModal().modal).toBeVisible();
@@ -124,7 +127,7 @@ test.describe('Clear Conversation Content', () => {
         await expect(userAPages.conversation().messages).toHaveCount(2);
 
         // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-        await userAPages.conversationList().openContextMenu(userB.fullName);
+        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).openContextMenu();
         await userAPages.conversationList().clearContentButton.click();
         // Step 4: Warning Popup should open
         await expect(userAModals.confirm().modal).toBeVisible();
@@ -192,7 +195,10 @@ test.describe('Clear Conversation Content', () => {
         }
 
         // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-        await userAPages.conversationList().openContextMenu(conversationName);
+        await userAPages
+          .conversationList()
+          .getConversationLocator(conversationName, {protocol: conversationType === '1:1' ? 'mls' : undefined})
+          .openContextMenu();
         await userAPages.conversationList().clearContentButton.click();
 
         // Step 4: Warning Popup should open and User A clicks 'Clear'

--- a/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -76,11 +76,11 @@ test.describe('Clear Conversation Content', () => {
         await expect(userAPages.conversation().messages).toHaveCount(3);
 
         // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-        await userAPages
+        const contextMenu = await userAPages
           .conversationList()
-          .getConversationLocator(conversationName, {protocol: 'mls'})
+          .getConversationLocator(conversationName)
           .openContextMenu();
-        await userAPages.conversationList().clearContentButton.click();
+        await contextMenu.clearContentButton.click();
         // Step 4: Warning Popup should open
         await expect(userAModals.optionModal().modal).toBeVisible();
 
@@ -127,8 +127,11 @@ test.describe('Clear Conversation Content', () => {
         await expect(userAPages.conversation().messages).toHaveCount(2);
 
         // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).openContextMenu();
-        await userAPages.conversationList().clearContentButton.click();
+        const contextMenu = await userAPages
+          .conversationList()
+          .getConversationLocator(userB.fullName, {protocol: 'mls'})
+          .openContextMenu();
+        await contextMenu.clearContentButton.click();
         // Step 4: Warning Popup should open
         await expect(userAModals.confirm().modal).toBeVisible();
 
@@ -195,11 +198,11 @@ test.describe('Clear Conversation Content', () => {
         }
 
         // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-        await userAPages
+        const contextMenu = await userAPages
           .conversationList()
           .getConversationLocator(conversationName, {protocol: conversationType === '1:1' ? 'mls' : undefined})
           .openContextMenu();
-        await userAPages.conversationList().clearContentButton.click();
+        await contextMenu.clearContentButton.click();
 
         // Step 4: Warning Popup should open and User A clicks 'Clear'
         if (conversationType === 'group') {

--- a/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
@@ -106,7 +106,7 @@ test.describe('Connections', () => {
     async ({createPage}) => {
       const {pages} = PageManager.from(await createPage(withLogin(memberA), withConnectionRequest(memberB))).webapp;
 
-      await pages.conversationList().clickConversationOptions(memberB.fullName);
+      await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
       await pages.conversationList().archiveConversation();
 
       await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
@@ -106,8 +106,8 @@ test.describe('Connections', () => {
     async ({createPage}) => {
       const {pages} = PageManager.from(await createPage(withLogin(memberA), withConnectionRequest(memberB))).webapp;
 
-      await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
-      await pages.conversationList().archiveConversation();
+      const contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
+      await contextMenu.archiveButton.click();
 
       await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
     },

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -97,8 +97,8 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
 
   await test.step('Team owner leave conversation with clear history', async () => {
     const {pages, modals} = ownerPageManager.webapp;
-    await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
-    await pages.conversationList().leaveConversation();
+    const contextMenu = await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
+    await contextMenu.leaveConversationButton.click();
     await modals.leaveConversation().toggleCheckbox();
     await modals.leaveConversation().clickConfirm();
     await expect(pages.conversation().messageInput).not.toBeAttached();

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -97,7 +97,7 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
 
   await test.step('Team owner leave conversation with clear history', async () => {
     const {pages, modals} = ownerPageManager.webapp;
-    await pages.conversationList().openContextMenu(conversationName);
+    await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
     await pages.conversationList().leaveConversation();
     await modals.leaveConversation().toggleCheckbox();
     await modals.leaveConversation().clickConfirm();

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -89,7 +89,7 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
 
   await test.step('Team owner open searched conversation', async () => {
     const {pages} = ownerPageManager.webapp;
-    await pages.conversationList().searchConversation(conversationName);
+    await pages.conversationList().searchConversationsInput.fill(conversationName);
     await pages.conversationList().openConversation(conversationName);
     await expect(pages.conversationList().getConversationLocator(conversationName)).toBeVisible();
     await pages.conversationList().openConversation(conversationName);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
@@ -119,8 +119,8 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
     const conversation = pages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'});
 
     await expect(conversation).not.toContainText('Blocked');
-    await conversation.openContextMenu();
-    await pages.conversationList().clickBlockConversation();
+    const contextMenu = await conversation.openContextMenu();
+    await contextMenu.blockButton.click();
     await expect(modals.blockWarning().modal).toBeVisible();
     await expect(modals.blockWarning().modalTitle).toContainText(`Block ${userB.fullName}`);
     await expect(modals.blockWarning().modalText).toContainText(

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
@@ -116,10 +116,10 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
 
   await test.step('Personal user A blocks personal user B', async () => {
     const {pages, modals} = pageManagerA.webapp;
-    const conversation = pages.conversationList().getConversationLocator(userB.fullName);
+    const conversation = pages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'});
 
     await expect(conversation).not.toContainText('Blocked');
-    await pages.conversationList().clickConversationOptions(userB.fullName);
+    await conversation.openContextMenu();
     await pages.conversationList().clickBlockConversation();
     await expect(modals.blockWarning().modal).toBeVisible();
     await expect(modals.blockWarning().modalTitle).toContainText(`Block ${userB.fullName}`);

--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -139,7 +139,7 @@ test.describe('Delete', () => {
 
       await test.step('Unarchive conversation', async () => {
         await components.conversationSidebar().clickArchive();
-        await pages.conversationList().clickConversationOptions(userB.fullName);
+        await pages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
         await pages.conversationList().unarchiveConversation();
         await components.conversationSidebar().clickAllConversationsButton();
       });

--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -139,8 +139,8 @@ test.describe('Delete', () => {
 
       await test.step('Unarchive conversation', async () => {
         await components.conversationSidebar().clickArchive();
-        await pages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
-        await pages.conversationList().unarchiveConversation();
+        const contextMenu = await pages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+        await contextMenu.unarchiveButton.click();
         await components.conversationSidebar().clickAllConversationsButton();
       });
 

--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -133,8 +133,8 @@ test.describe('Delete', () => {
       });
 
       await test.step('Archive conversation', async () => {
-        await pages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
-        await pages.conversationList().archiveConversation();
+        const contextMenu = await pages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+        await contextMenu.archiveButton.click();
       });
 
       await test.step('Unarchive conversation', async () => {

--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -133,7 +133,7 @@ test.describe('Delete', () => {
       });
 
       await test.step('Archive conversation', async () => {
-        await pages.conversationList().openContextMenu(userB.fullName);
+        await pages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
         await pages.conversationList().archiveConversation();
       });
 

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -161,17 +161,27 @@ test.describe('Folders', () => {
       await userAPages.conversationList().openConversation(userB.fullName);
       await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
 
-      // Step 1: User A clicks 'remove from custom folder' button
-      await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
-      await userAPages.conversationList().getRemoveConversationFromFolderButton(customFolderName).click();
-      // Step 2: The conversation list header is changed to 'All Conversations'
-      const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
+      await test.step("User A clicks 'remove from custom folder' button", async () => {
+        const contextMenu = await userAPages
+          .conversationList()
+          .getConversationLocator(userB.fullName)
+          .openContextMenu();
+        await contextMenu.getByRole('button', {name: `Remove from "${customFolderName}"`}).click();
+      });
 
-      await expect(actualTitle).toHaveText('All Conversations');
-      // Step 3: Custom Folder Name is no longer visible in the Move-To-Menu
-      await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
-      await userAPages.conversationList().moveConversationButton.click();
-      await expect(userAPages.conversationList().getMoveToFolderButton(customFolderName)).not.toBeVisible();
+      await test.step("The conversation list header is changed to 'All Conversations'", async () => {
+        const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
+        await expect(actualTitle).toHaveText('All Conversations');
+      });
+
+      await test.step('Custom Folder Name is no longer visible in the Move-To-Menu', async () => {
+        const contextMenu = await userAPages
+          .conversationList()
+          .getConversationLocator(userB.fullName)
+          .openContextMenu();
+        await contextMenu.moveToButton.click();
+        await expect(contextMenu.getByRole('button', {name: customFolderName})).not.toBeVisible();
+      });
     },
   );
 
@@ -198,14 +208,16 @@ test.describe('Folders', () => {
     await userAPages.conversationList().openConversation(userB.fullName);
     await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
 
-    // Step 1: User A removes conversation with User B from custom folder
-    await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
-    await userAPages.conversationList().getRemoveConversationFromFolderButton(customFolderName).click();
+    await test.step('User A removes conversation with User B from custom folder', async () => {
+      const contextMenu = await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+      await contextMenu.getByRole('button', {name: `Remove from "${customFolderName}"`}).click();
+    });
 
-    // Step 2: User A tries to move conversation with User B back into the folder, custom folder name should no longer be visible in the folder menu
-    await userAPages.conversationList().openConversation(userB.fullName);
-    await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
-    await userAPages.conversationList().moveConversationButton.click();
-    await expect(userAPages.conversationList().getMoveToFolderButton(customFolderName)).not.toBeVisible();
+    await test.step('User A tries to move conversation with User B back into the folder, custom folder name should no longer be visible in the folder menu', async () => {
+      await userAPages.conversationList().openConversation(userB.fullName);
+      const contextMenu = await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+      await contextMenu.moveToButton.click();
+      await expect(contextMenu.getByRole('button', {name: customFolderName})).not.toBeVisible();
+    });
   });
 });

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -31,7 +31,7 @@ import {createGroup} from 'test/e2e_tests/utils/userActions';
  */
 async function createCustomFolder(pageManager: PageManager, conversationName: string, folderName: string) {
   const {pages, modals} = pageManager.webapp;
-  await pages.conversationList().openContextMenu(conversationName);
+  await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
   await pages.conversationList().moveConversationButton.click();
 
   await pages.conversationList().createNewFolderButton.click();
@@ -48,7 +48,7 @@ async function createCustomFolder(pageManager: PageManager, conversationName: st
  */
 async function moveConversationToFolder(pageManager: PageManager, conversationName: string, folderName: string) {
   const pages = pageManager.webapp.pages;
-  await pages.conversationList().openContextMenu(conversationName);
+  await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
   await pages.conversationList().moveConversationButton.click();
   await pages.conversationList().getMoveToFolderButton(folderName).click();
 }
@@ -162,14 +162,14 @@ test.describe('Folders', () => {
       await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
 
       // Step 1: User A clicks 'remove from custom folder' button
-      await userAPages.conversationList().openContextMenu(userB.fullName);
+      await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
       await userAPages.conversationList().getRemoveConversationFromFolderButton(customFolderName).click();
       // Step 2: The conversation list header is changed to 'All Conversations'
       const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
 
       await expect(actualTitle).toHaveText('All Conversations');
       // Step 3: Custom Folder Name is no longer visible in the Move-To-Menu
-      await userAPages.conversationList().openContextMenu(userB.fullName);
+      await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
       await userAPages.conversationList().moveConversationButton.click();
       await expect(userAPages.conversationList().getMoveToFolderButton(customFolderName)).not.toBeVisible();
     },
@@ -181,7 +181,7 @@ test.describe('Folders', () => {
     // Step 1: User A opens 1:1 conversation with User B
     await userAPages.conversationList().openConversation(userB.fullName);
     // Step 2: User A wants to move 1:1 conversation with User B into custom folder
-    await userAPages.conversationList().openContextMenu(userB.fullName);
+    await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
     await userAPages.conversationList().moveConversationButton.click();
     await userAPages.conversationList().createNewFolderButton.click();
 
@@ -199,12 +199,12 @@ test.describe('Folders', () => {
     await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
 
     // Step 1: User A removes conversation with User B from custom folder
-    await userAPages.conversationList().openContextMenu(userB.fullName);
+    await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
     await userAPages.conversationList().getRemoveConversationFromFolderButton(customFolderName).click();
 
     // Step 2: User A tries to move conversation with User B back into the folder, custom folder name should no longer be visible in the folder menu
     await userAPages.conversationList().openConversation(userB.fullName);
-    await userAPages.conversationList().openContextMenu(userB.fullName);
+    await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
     await userAPages.conversationList().moveConversationButton.click();
     await expect(userAPages.conversationList().getMoveToFolderButton(customFolderName)).not.toBeVisible();
   });

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -31,8 +31,8 @@ import {createGroup} from 'test/e2e_tests/utils/userActions';
  */
 async function createCustomFolder(pageManager: PageManager, conversationName: string, folderName: string) {
   const {pages, modals} = pageManager.webapp;
-  await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
-  await pages.conversationList().moveConversationButton.click();
+  const contextMenu = await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
+  await contextMenu.moveToButton.click();
 
   await pages.conversationList().createNewFolderButton.click();
 
@@ -48,9 +48,9 @@ async function createCustomFolder(pageManager: PageManager, conversationName: st
  */
 async function moveConversationToFolder(pageManager: PageManager, conversationName: string, folderName: string) {
   const pages = pageManager.webapp.pages;
-  await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
-  await pages.conversationList().moveConversationButton.click();
-  await pages.conversationList().getMoveToFolderButton(folderName).click();
+  const contextMenu = await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
+  await contextMenu.moveToButton.click();
+  await contextMenu.getByRole('button', {name: folderName, exact: true}).click();
 }
 
 /* ============================ */
@@ -181,8 +181,8 @@ test.describe('Folders', () => {
     // Step 1: User A opens 1:1 conversation with User B
     await userAPages.conversationList().openConversation(userB.fullName);
     // Step 2: User A wants to move 1:1 conversation with User B into custom folder
-    await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
-    await userAPages.conversationList().moveConversationButton.click();
+    const contextMenu = await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+    await contextMenu.moveToButton.click();
     await userAPages.conversationList().createNewFolderButton.click();
 
     // Step 3: 'Create Folder Modal' should still be visible after click on create

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -33,8 +33,7 @@ async function createCustomFolder(pageManager: PageManager, conversationName: st
   const {pages, modals} = pageManager.webapp;
   const contextMenu = await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
   await contextMenu.moveToButton.click();
-
-  await pages.conversationList().createNewFolderButton.click();
+  await contextMenu.getByRole('button', {name: 'Create new folder'}).click();
 
   await modals.optionModal().modal.getByPlaceholder('Folder Name').fill(folderName);
   await modals.optionModal().clickAction();
@@ -193,7 +192,7 @@ test.describe('Folders', () => {
     // Step 2: User A wants to move 1:1 conversation with User B into custom folder
     const contextMenu = await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
     await contextMenu.moveToButton.click();
-    await userAPages.conversationList().createNewFolderButton.click();
+    await contextMenu.getByRole('button', {name: 'Create new folder'}).click();
 
     // Step 3: 'Create Folder Modal' should still be visible after click on create
     await expect(userAModals.optionModal().actionButton).toBeDisabled();

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -216,8 +216,8 @@ test.describe('Group Conversation', () => {
       await userBPages.conversationList().openConversation(groupName);
 
       // User A leaves conversation through options menu from conversation list
-      await userAPages.conversationList().getConversationLocator(groupName).openContextMenu();
-      await userAPages.conversationList().leaveConversation();
+      const contextMenu = await userAPages.conversationList().getConversationLocator(groupName).openContextMenu();
+      await contextMenu.leaveConversationButton.click();
       await userAModals.leaveConversation().confirmButton.click();
 
       await expect(userBPages.conversation().systemMessages.filter({hasText: `${userA.fullName} left`})).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -216,7 +216,7 @@ test.describe('Group Conversation', () => {
       await userBPages.conversationList().openConversation(groupName);
 
       // User A leaves conversation through options menu from conversation list
-      await userAPages.conversationList().clickConversationOptions(groupName);
+      await userAPages.conversationList().getConversationLocator(groupName).openContextMenu();
       await userAPages.conversationList().leaveConversation();
       await userAModals.leaveConversation().confirmButton.click();
 

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -273,7 +273,9 @@ test.describe('History Backup', () => {
       await test.step('Validate muted and archived state are the same', async () => {
         await userAComponents.conversationSidebar().allConverationsButton.click();
         await userAPages.conversationList().openConversation(conversationName);
-        await expect(await userAPages.conversationList().getMutedConversationBadge(conversationName)).toBeVisible();
+        await expect(
+          userAPages.conversationList().getConversationLocator(conversationName).mutedIndicator,
+        ).toBeVisible();
 
         await userAComponents.conversationSidebar().archiveButton.click();
         const archivedConversation = userAPages.conversationList().getConversationLocator(userB.fullName);

--- a/apps/webapp/test/e2e_tests/specs/Localization/localization.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Localization/localization.spec.ts
@@ -145,9 +145,13 @@ test.describe('Localization', () => {
       await expect(messagePlaceholder).toHaveText(deTranslations['tooltipConversationInputPlaceholder']);
 
       await components.conversationSidebar().allConverationsButton.click();
-      await pages.conversationList().clickConversationOptions(userB.fullName);
+      await pages
+        .conversationList()
+        .getConversationLocator(userB.fullName)
+        .getByRole('button', {name: deTranslations['accessibility.conversationOptionsMenu']})
+        .click();
 
-      const menuList = page.getByTestId('conversation-list-options-menu');
+      const menuList = page.getByRole('menu').getByRole('menuitem');
 
       await expect
         .poll(async () => await menuList.allInnerTexts())

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -86,8 +86,9 @@ test.describe('Notifications', () => {
     async ({createPage}) => {
       const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
 
-      await pages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
-      await pages.conversationList().setNotifications('Nothing');
+      const contextMenu = await pages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+      await contextMenu.notificationsButton.click();
+      await pages.conversationDetails().selectNotificationsLevel('Nothing');
 
       const conversation = pages.conversationList().getConversationLocator(userB.fullName);
       await expect(conversation.mutedIndicator).toBeVisible();
@@ -99,16 +100,23 @@ test.describe('Notifications', () => {
     {tag: ['@TC-1438', '@regression']},
     async ({createPage}) => {
       const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
-
       const conversation = pages.conversationList().getConversationLocator(userB.fullName);
-      await conversation.openContextMenu();
-      await pages.conversationList().setNotifications('Nothing');
-      await expect(conversation.mutedIndicator).toBeVisible();
 
-      await conversation.openContextMenu();
-      await pages.conversationList().setNotifications('Everything');
+      await test.step('Mute conversation', async () => {
+        const contextMenu = await conversation.openContextMenu();
+        await contextMenu.notificationsButton.click();
+        await pages.conversationDetails().selectNotificationsLevel('Nothing');
 
-      await expect(conversation.mutedIndicator).not.toBeVisible();
+        await expect(conversation.mutedIndicator).toBeVisible();
+      });
+
+      await test.step('Unmute conversation', async () => {
+        const contextMenu = await conversation.openContextMenu();
+        await contextMenu.notificationsButton.click();
+        await pages.conversationDetails().selectNotificationsLevel('Everything');
+
+        await expect(conversation.mutedIndicator).not.toBeVisible();
+      });
     },
   );
 
@@ -163,8 +171,12 @@ test.describe('Notifications', () => {
 
       // User B mutes the conversation with User A
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).openContextMenu();
-      await userBPages.conversationList().setNotifications('Nothing');
+      const contextMenu = await userBPages
+        .conversationList()
+        .getConversationLocator(userA.fullName, {protocol: 'mls'})
+        .openContextMenu();
+      await contextMenu.notificationsButton.click();
+      await userBPages.conversationDetails().selectNotificationsLevel('Nothing');
 
       // User A initiates a call to User B
       await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
@@ -192,8 +204,12 @@ test.describe('Notifications', () => {
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
 
       // User B mutes the conversation with User A via recent view
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).openContextMenu();
-      await userBPages.conversationList().setNotifications('Nothing');
+      const contextMenu = await userBPages
+        .conversationList()
+        .getConversationLocator(userA.fullName, {protocol: 'mls'})
+        .openContextMenu();
+      await contextMenu.notificationsButton.click();
+      await userBPages.conversationDetails().selectNotificationsLevel('Nothing');
 
       // Create group and open it for user B so the message won't be read immediately
       await createGroup(userAPages, 'Test Group', [userB]);

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -60,7 +60,7 @@ test.describe('Notifications', () => {
 
       // Archive conversation for user B
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().clickConversationOptions(userA.fullName);
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).openContextMenu();
       await userBPages.conversationList().archiveConversation();
 
       // Send message from A to B in 1on1 conversation
@@ -83,7 +83,7 @@ test.describe('Notifications', () => {
     async ({createPage}) => {
       const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
 
-      await pages.conversationList().clickConversationOptions(userB.fullName);
+      await pages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
       await pages.conversationList().setNotifications('Nothing');
 
       const conversation = pages.conversationList().getConversationLocator(userB.fullName);
@@ -97,13 +97,12 @@ test.describe('Notifications', () => {
     async ({createPage}) => {
       const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
 
-      await pages.conversationList().clickConversationOptions(userB.fullName);
-      await pages.conversationList().setNotifications('Nothing');
-
       const conversation = pages.conversationList().getConversationLocator(userB.fullName);
+      await conversation.openContextMenu();
+      await pages.conversationList().setNotifications('Nothing');
       await expect(conversation.mutedIndicator).toBeVisible();
 
-      await pages.conversationList().clickConversationOptions(userB.fullName);
+      await conversation.openContextMenu();
       await pages.conversationList().setNotifications('Everything');
 
       await expect(conversation.mutedIndicator).not.toBeVisible();
@@ -161,7 +160,7 @@ test.describe('Notifications', () => {
 
       // User B mutes the conversation with User A
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().clickConversationOptions(userA.fullName);
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).openContextMenu();
       await userBPages.conversationList().setNotifications('Nothing');
 
       // User A initiates a call to User B
@@ -189,7 +188,7 @@ test.describe('Notifications', () => {
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
 
       // User B mutes the conversation with User A via recent view
-      await userBPages.conversationList().clickConversationOptions(userA.fullName);
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).openContextMenu();
       await userBPages.conversationList().setNotifications('Nothing');
 
       // Create group and open it for user B so the message won't be read immediately

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -171,7 +171,8 @@ test.describe('Notifications', () => {
       await userAPages.conversation().clickCallButton();
 
       // Verify that User B sees a "Join" button on the muted conversation
-      await expect(userBPages.conversationList().joinCallButton).toBeVisible();
+      const {joinCallButton} = userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'});
+      await expect(joinCallButton).toBeVisible();
     },
   );
 

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -60,8 +60,11 @@ test.describe('Notifications', () => {
 
       // Archive conversation for user B
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).openContextMenu();
-      await userBPages.conversationList().archiveConversation();
+      const contextMenu = await userBPages
+        .conversationList()
+        .getConversationLocator(userA.fullName, {protocol: 'mls'})
+        .openContextMenu();
+      await contextMenu.archiveButton.click();
 
       // Send message from A to B in 1on1 conversation
       await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});

--- a/apps/webapp/test/e2e_tests/specs/Search/search.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Search/search.spec.ts
@@ -51,7 +51,7 @@ test.describe('Search', () => {
       await createGroup(userAPages, conversationName, [userB]);
       await userAPages.conversationList().openConversation(conversationName);
       await userAPages.conversation().sendMessage(`@${userB.username} Group message with mention of User B`);
-      await userAPages.conversationList().searchConversation(`@${userB.username}`);
+      await userAPages.conversationList().searchConversationsInput.fill(`@${userB.username}`);
 
       await expect(userAPages.conversationList().getConversationLocator(conversationName)).toBeVisible();
       await expect(userAPages.conversationList().getConversationLocator(userB.fullName)).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
@@ -434,8 +434,11 @@ test.describe('Status', () => {
     const userBPages = userBPageManager.webapp.pages;
 
     // User B verify no status is set in conversation list
-    await userBPages.conversationList().openConversation(userA.fullName);
-    await expect(userBPages.conversationList().getUserStatusIcon(userA)).not.toBeVisible();
+    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    const {statusAvailabilityIcon} = userBPages
+      .conversationList()
+      .getConversationLocator(userA.fullName, {protocol: 'mls'});
+    await expect(statusAvailabilityIcon).not.toBeVisible();
 
     // User A opens preferences by clicking the gear button
     await components.conversationSidebar().clickPreferencesButton();
@@ -456,8 +459,8 @@ test.describe('Status', () => {
     await expect(pages.account().statusOption(UserStatus.None)).not.toHaveAccessibleName('Selected, None');
 
     // User B verifies status is Available in conversation list
-    await expect(userBPages.conversationList().getUserStatusIcon(userA)).toBeVisible();
-    await expect(userBPages.conversationList().getUserStatusIcon(userA)).toHaveAttribute('data-uie-value', 'available');
+    await expect(statusAvailabilityIcon).toBeVisible();
+    await expect(statusAvailabilityIcon).toHaveAttribute('data-uie-value', 'available');
   });
 
   test(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24429" title="WPB-24429" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24429</a>  [Web][QA] Investigate E2E tests that are flaky because of possible race condition.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

While investigating flaky tests I noticed that one cause of flake is the usage of all the unscoped utils for the conversation list. While the `openConversattion()` function allows passing a protocol to ensure the right conversation will be picked independent of the background migration to MLS this isn't the case for the others.
So I took it as the opportunity to clean out the POM and have utils only relevant for individual conversations be scoped to them.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers

- This PR may look big and scary but it's atomic, when stepping through the commits you can review only one change at a time only touching a few files (or review the whole thing at once, whatever floats your boat :))
