### PR TITLE
test: replace util "openConversation" with generic "getConversation().open()" [WPB-24429]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -38,10 +38,6 @@ export class ConversationListPage {
     this.conversationListHeaderTitle = page.locator('[data-uie-name="conversation-list-header-title"]');
   }
 
-  async openConversation(conversationName: string, options?: Parameters<typeof this.getConversationLocator>[1]) {
-    await this.getConversationLocator(conversationName, options).click();
-  }
-
   async openPendingConnectionRequest() {
     await this.pendingConnectionRequest.click();
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -57,7 +57,7 @@ export class ConversationListPage {
    * @param conversationName Name of the conversation to search for
    * @param options.protocol Only locate conversations matching this protocol (mls only works for 1on1 conversations as groups still use proteus) - Default: "mls"
    */
-  getConversationLocator(conversationName: string, options?: {protocol?: 'mls' | 'proteus'}) {
+  getConversation(conversationName: string, options?: {protocol?: 'mls' | 'proteus'}) {
     let conversation = this.page.getByTestId('item-conversation').filter({hasText: conversationName});
 
     if (options?.protocol) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -68,7 +68,7 @@ export class ConversationListPage {
       conversation = conversation.and(this.page.locator(`[data-protocol="${options.protocol}"]`));
     }
 
-    return Object.assign(conversation, {
+    const enhancedLocator = Object.assign(conversation, {
       userAvatar: conversation.getByTestId('element-avatar-user'),
       statusAvailabilityIcon: conversation.getByTestId('status-availability-icon'),
       unreadIndicator: conversation.getByTitle('Unread message'),
@@ -76,8 +76,17 @@ export class ConversationListPage {
       mentionIndicator: conversation.getByTitle('Unread mention'),
       blockedIndicator: conversation.locator(`span[data-uie-name="status-label"] + span`),
       joinCallButton: conversation.getByRole('button', {name: 'Join'}),
+
+      // This is just syntactic sugar to allow capturing the enhanced locator from the open function
+      open: async () => {
+        await conversation.click();
+        return enhancedLocator;
+      },
+
       openContextMenu: () => this.openContextMenu(conversation),
     });
+
+    return enhancedLocator;
   }
 
   /**

--- a/apps/webapp/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
@@ -44,8 +44,8 @@ test.describe('Accessibility', () => {
       ]);
 
       await createGroup(userAPages, 'Accessible Group', [userB]);
-      await userAPages.conversationList().openConversation('Accessible Group');
-      await userBPages.conversationList().openConversation('Accessible Group');
+      await userAPages.conversationList().getConversationLocator('Accessible Group').open();
+      await userBPages.conversationList().getConversationLocator('Accessible Group').open();
 
       await test.step('User A starts typing in group and B sees typing indicator', async () => {
         await userAPages.conversation().messageInput.pressSequentially('Test', {delay: 100});
@@ -60,7 +60,7 @@ test.describe('Accessibility', () => {
 
       await test.step('User A types more into group', async () => {
         await userAPages.sidebar().allConversationsButton.click();
-        await userAPages.conversationList().openConversation('Accessible Group');
+        await userAPages.conversationList().getConversationLocator('Accessible Group').open();
         await userAPages.conversation().messageInput.pressSequentially('Test', {delay: 100});
         // Since A disabled the typing indicator B should not see it
         await expect(userBPages.conversation().typingIndicator).not.toBeVisible();
@@ -92,11 +92,11 @@ test.describe('Accessibility', () => {
         await pages.conversation().messageInput.fill('Draft Message');
 
         await pages.conversation().backButton.click();
-        await pages.conversationList().openConversation(userB.fullName);
+        await pages.conversationList().getConversationLocator(userB.fullName).open();
         await expect(pages.conversation().messageInput).toBeEmpty();
 
         await pages.conversation().backButton.click();
-        await pages.conversationList().openConversation('Test Group');
+        await pages.conversationList().getConversationLocator('Test Group').open();
         await expect(pages.conversation().messageInput).toHaveText('Draft Message');
       },
     );

--- a/apps/webapp/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
@@ -44,8 +44,8 @@ test.describe('Accessibility', () => {
       ]);
 
       await createGroup(userAPages, 'Accessible Group', [userB]);
-      await userAPages.conversationList().getConversationLocator('Accessible Group').open();
-      await userBPages.conversationList().getConversationLocator('Accessible Group').open();
+      await userAPages.conversationList().getConversation('Accessible Group').open();
+      await userBPages.conversationList().getConversation('Accessible Group').open();
 
       await test.step('User A starts typing in group and B sees typing indicator', async () => {
         await userAPages.conversation().messageInput.pressSequentially('Test', {delay: 100});
@@ -60,7 +60,7 @@ test.describe('Accessibility', () => {
 
       await test.step('User A types more into group', async () => {
         await userAPages.sidebar().allConversationsButton.click();
-        await userAPages.conversationList().getConversationLocator('Accessible Group').open();
+        await userAPages.conversationList().getConversation('Accessible Group').open();
         await userAPages.conversation().messageInput.pressSequentially('Test', {delay: 100});
         // Since A disabled the typing indicator B should not see it
         await expect(userBPages.conversation().typingIndicator).not.toBeVisible();
@@ -92,11 +92,11 @@ test.describe('Accessibility', () => {
         await pages.conversation().messageInput.fill('Draft Message');
 
         await pages.conversation().backButton.click();
-        await pages.conversationList().getConversationLocator(userB.fullName).open();
+        await pages.conversationList().getConversation(userB.fullName).open();
         await expect(pages.conversation().messageInput).toBeEmpty();
 
         await pages.conversation().backButton.click();
-        await pages.conversationList().getConversationLocator('Test Group').open();
+        await pages.conversationList().getConversation('Test Group').open();
         await expect(pages.conversation().messageInput).toHaveText('Draft Message');
       },
     );

--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -187,7 +187,7 @@ test.describe('account settings', () => {
     const memberAPages = PageManager.from(memberAPage).webapp.pages;
     const memberBPages = PageManager.from(memberBPage).webapp.pages;
 
-    await memberAPages.conversationList().openConversation(memberB.fullName, {protocol: 'mls'});
+    await memberAPages.conversationList().getConversationLocator(memberB.fullName, {protocol: 'mls'}).open();
 
     await memberAPages.conversation().startCall();
     await memberBPages.calling().clickAcceptCallButton();
@@ -213,7 +213,7 @@ test.describe('account settings', () => {
       });
 
       await test.step('Conversation itself on top of users message', async () => {
-        await pages.conversationList().openConversation('Test Group');
+        await pages.conversationList().getConversationLocator('Test Group').open();
         await pages.conversation().sendMessage('test');
         await expect(pages.conversation().getMessage({content: 'test'})).toContainText(memberA.fullName);
       });
@@ -243,7 +243,7 @@ test.describe('account settings', () => {
         await pages.conversationList().clickCreateGroup();
         await modals.createConversation().createChannel('Test Channel', {members: [memberB]});
 
-        await pages.conversationList().openConversation('Test Channel');
+        await pages.conversationList().getConversationLocator('Test Channel').open();
         await pages.conversation().conversationInfoButton.click();
         await expect(pages.conversationDetails().groupAdmins.filter({hasText: memberA.fullName})).toBeVisible();
       });

--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -187,7 +187,7 @@ test.describe('account settings', () => {
     const memberAPages = PageManager.from(memberAPage).webapp.pages;
     const memberBPages = PageManager.from(memberBPage).webapp.pages;
 
-    await memberAPages.conversationList().getConversationLocator(memberB.fullName, {protocol: 'mls'}).open();
+    await memberAPages.conversationList().getConversation(memberB.fullName, {protocol: 'mls'}).open();
 
     await memberAPages.conversation().startCall();
     await memberBPages.calling().clickAcceptCallButton();
@@ -213,7 +213,7 @@ test.describe('account settings', () => {
       });
 
       await test.step('Conversation itself on top of users message', async () => {
-        await pages.conversationList().getConversationLocator('Test Group').open();
+        await pages.conversationList().getConversation('Test Group').open();
         await pages.conversation().sendMessage('test');
         await expect(pages.conversation().getMessage({content: 'test'})).toContainText(memberA.fullName);
       });
@@ -243,7 +243,7 @@ test.describe('account settings', () => {
         await pages.conversationList().clickCreateGroup();
         await modals.createConversation().createChannel('Test Channel', {members: [memberB]});
 
-        await pages.conversationList().getConversationLocator('Test Channel').open();
+        await pages.conversationList().getConversation('Test Channel').open();
         await pages.conversation().conversationInfoButton.click();
         await expect(pages.conversationDetails().groupAdmins.filter({hasText: memberA.fullName})).toBeVisible();
       });

--- a/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
@@ -40,7 +40,7 @@ test.describe('Archive', () => {
       const page = await createPage(withLogin(memberA), withConnectedUser(memberB));
       const {pages, components} = PageManager.from(page).webapp;
 
-      const conversation = pages.conversationList().getConversationLocator(memberB.fullName);
+      const conversation = pages.conversationList().getConversation(memberB.fullName);
       let contextMenu = await conversation.openContextMenu();
       await contextMenu.archiveButton.click();
       await expect(conversation).not.toBeVisible();
@@ -68,9 +68,9 @@ test.describe('Archive', () => {
 
       const memberAConversation = await memberAPages
         .conversationList()
-        .getConversationLocator(memberB.fullName, {protocol: 'mls'})
+        .getConversation(memberB.fullName, {protocol: 'mls'})
         .open();
-      await memberBPages.conversationList().getConversationLocator(memberA.fullName, {protocol: 'mls'}).open();
+      await memberBPages.conversationList().getConversation(memberA.fullName, {protocol: 'mls'}).open();
 
       await test.step('MemberA archives conversation with memberB', async () => {
         const contextMenu = await memberAConversation.openContextMenu();
@@ -99,7 +99,7 @@ test.describe('Archive', () => {
       const page = await createPage(withLogin(memberA), withConnectedUser(memberB));
       const {pages, components} = PageManager.from(page).webapp;
 
-      const conversation = await pages.conversationList().getConversationLocator(memberB.fullName).open();
+      const conversation = await pages.conversationList().getConversation(memberB.fullName).open();
 
       if (tag === '@TC-103') {
         await test.step('User mutes the conversation', async () => {
@@ -143,10 +143,10 @@ test.describe('Archive', () => {
         let conversation: Locator;
         if (tag === '@TC-104') {
           await createGroup(pages, 'Test Group', [memberB]);
-          conversation = pages.conversationList().getConversationLocator('Test Group');
+          conversation = pages.conversationList().getConversation('Test Group');
         } else {
           await connectWithUser(pageManager, memberB);
-          conversation = pages.conversationList().getConversationLocator(memberB.fullName);
+          conversation = pages.conversationList().getConversation(memberB.fullName);
         }
 
         await pages.conversation().conversationInfoButton.click();

--- a/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
@@ -40,19 +40,20 @@ test.describe('Archive', () => {
       const page = await createPage(withLogin(memberA), withConnectedUser(memberB));
       const {pages, components} = PageManager.from(page).webapp;
 
-      let contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
+      const conversation = pages.conversationList().getConversationLocator(memberB.fullName);
+      let contextMenu = await conversation.openContextMenu();
       await contextMenu.archiveButton.click();
-      await expect(pages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
+      await expect(conversation).not.toBeVisible();
 
       await components.conversationSidebar().clickArchive();
-      await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
+      await expect(conversation).toBeVisible();
 
-      contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
+      contextMenu = await conversation.openContextMenu();
       await contextMenu.unarchiveButton.click();
-      await expect(pages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
+      await expect(conversation).not.toBeVisible();
 
       await components.conversationSidebar().clickAllConversationsButton();
-      await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
+      await expect(conversation).toBeVisible();
     },
   );
 
@@ -65,25 +66,25 @@ test.describe('Archive', () => {
         PageManager.from(createPage(withLogin(memberB))).then(pm => pm.webapp.pages),
       ]);
 
-      await memberAPages.conversationList().openConversation(memberB.fullName, {protocol: 'mls'});
-      await memberBPages.conversationList().openConversation(memberA.fullName, {protocol: 'mls'});
+      const memberAConversation = await memberAPages
+        .conversationList()
+        .getConversationLocator(memberB.fullName, {protocol: 'mls'})
+        .open();
+      await memberBPages.conversationList().getConversationLocator(memberA.fullName, {protocol: 'mls'}).open();
 
       await test.step('MemberA archives conversation with memberB', async () => {
-        const contextMenu = await memberAPages
-          .conversationList()
-          .getConversationLocator(memberB.fullName, {protocol: 'mls'})
-          .openContextMenu();
+        const contextMenu = await memberAConversation.openContextMenu();
         await contextMenu.archiveButton.click();
       });
 
       await test.step('MemberB sends message in archived conversation', async () => {
         await memberBPages.conversation().sendMessage('Test message');
-        await expect(memberAPages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
+        await expect(memberAConversation).not.toBeVisible();
       });
 
       await test.step('MemberB pings in archived conversation', async () => {
         await memberBPages.conversation().sendPing();
-        await expect(memberAPages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
+        await expect(memberAConversation).not.toBeVisible();
       });
     },
   );
@@ -98,35 +99,35 @@ test.describe('Archive', () => {
       const page = await createPage(withLogin(memberA), withConnectedUser(memberB));
       const {pages, components} = PageManager.from(page).webapp;
 
-      await pages.conversationList().openConversation(memberB.fullName);
+      const conversation = await pages.conversationList().getConversationLocator(memberB.fullName).open();
 
       if (tag === '@TC-103') {
         await test.step('User mutes the conversation', async () => {
-          const contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
+          const contextMenu = await conversation.openContextMenu();
           await contextMenu.notificationsButton.click();
           await pages.conversationDetails().selectNotificationsLevel('Nothing');
         });
       }
 
       await test.step('User archives the conversation', async () => {
-        const contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
+        const contextMenu = await conversation.openContextMenu();
         await contextMenu.archiveButton.click();
-        await expect(pages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
+        await expect(conversation).not.toBeVisible();
       });
 
       await test.step('User switches to archived conversations and sees it there', async () => {
         await components.conversationSidebar().archiveButton.click();
-        await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
+        await expect(conversation).toBeVisible();
       });
 
       await test.step('User starts a call in the archived conversation', async () => {
-        await pages.conversationList().openConversation(memberB.fullName);
+        await conversation.open();
         await pages.conversation().startCall();
       });
 
       await test.step('The conversation should still not be shown within all conversations', async () => {
         await components.conversationSidebar().allConversationsButton.click();
-        await expect(pages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
+        await expect(conversation).not.toBeVisible();
       });
     });
   });

--- a/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -162,7 +162,7 @@ test.describe('Authentication', () => {
         });
 
         await test.step('Send a message', async () => {
-          await pages.conversationList().openConversation(userB.fullName);
+          await pages.conversationList().getConversationLocator(userB.fullName).open();
           await pages.conversation().sendMessage('Before refresh');
         });
 
@@ -172,7 +172,7 @@ test.describe('Authentication', () => {
 
           await pageManager.refreshPage({waitUntil: 'load'});
 
-          await pages.conversationList().openConversation(userB.fullName);
+          await pages.conversationList().getConversationLocator(userB.fullName).open();
           await expect(message).toBeVisible();
         });
       },
@@ -213,7 +213,7 @@ test.describe('Authentication', () => {
 
       await test.step('Connect with and send message to userB', async () => {
         await connectWithUser(pageManager, userB);
-        await pages.conversationList().openConversation(userB.fullName);
+        await pages.conversationList().getConversationLocator(userB.fullName).open();
         await pages.conversation().sendMessage('Test message');
         await expect(pages.conversation().getMessage({content: 'Test message'})).toBeVisible();
       });
@@ -233,7 +233,7 @@ test.describe('Authentication', () => {
       });
 
       await test.step('Verify previously sent message is gone', async () => {
-        await pages.conversationList().openConversation(userB.fullName);
+        await pages.conversationList().getConversationLocator(userB.fullName).open();
         await expect(pages.conversation().getMessage({content: 'Test message'})).not.toBeAttached();
       });
     },

--- a/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -162,7 +162,7 @@ test.describe('Authentication', () => {
         });
 
         await test.step('Send a message', async () => {
-          await pages.conversationList().getConversationLocator(userB.fullName).open();
+          await pages.conversationList().getConversation(userB.fullName).open();
           await pages.conversation().sendMessage('Before refresh');
         });
 
@@ -172,7 +172,7 @@ test.describe('Authentication', () => {
 
           await pageManager.refreshPage({waitUntil: 'load'});
 
-          await pages.conversationList().getConversationLocator(userB.fullName).open();
+          await pages.conversationList().getConversation(userB.fullName).open();
           await expect(message).toBeVisible();
         });
       },
@@ -213,7 +213,7 @@ test.describe('Authentication', () => {
 
       await test.step('Connect with and send message to userB', async () => {
         await connectWithUser(pageManager, userB);
-        await pages.conversationList().getConversationLocator(userB.fullName).open();
+        await pages.conversationList().getConversation(userB.fullName).open();
         await pages.conversation().sendMessage('Test message');
         await expect(pages.conversation().getMessage({content: 'Test message'})).toBeVisible();
       });
@@ -233,7 +233,7 @@ test.describe('Authentication', () => {
       });
 
       await test.step('Verify previously sent message is gone', async () => {
-        await pages.conversationList().getConversationLocator(userB.fullName).open();
+        await pages.conversationList().getConversation(userB.fullName).open();
         await expect(pages.conversation().getMessage({content: 'Test message'})).not.toBeAttached();
       });
     },

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -32,8 +32,8 @@ import {createGroup, sendConnectionRequest} from '../../utils/userActions';
 export async function blockUserFromConversationList(pageManager: PageManager, userToBlock: User) {
   const {pages, modals} = pageManager.webapp;
 
-  await pages.conversationList().openConversation(userToBlock.fullName);
-  const contextMenu = await pages.conversationList().getConversationLocator(userToBlock.fullName).openContextMenu();
+  const conversation = await pages.conversationList().getConversationLocator(userToBlock.fullName).open();
+  const contextMenu = await conversation.openContextMenu();
   await contextMenu.blockButton.click();
   await modals.blockWarning().clickBlock();
 }
@@ -92,18 +92,18 @@ test.describe('User Blocking', () => {
         await userBPages.connectRequest().clickConnectButton();
 
         // Step 1: User A opens conversation with User B
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-        // Step 2: User A opens the options menu for user B
-        const contextMenu = await userAPages
+        const conversation = await userAPages
           .conversationList()
           .getConversationLocator(userB.fullName, {protocol: 'mls'})
-          .openContextMenu();
+          .open();
+        // Step 2: User A opens the options menu for user B
+        const contextMenu = await conversation.openContextMenu();
         // Step 3: User A opens modal and clicks 'Block' button
         await contextMenu.blockButton.click();
         // Step 4: User A clicks 'Cancel' button
         await userAModals.blockWarning().clickCancel();
         // Step 5: Conversation is still present, and User A can open it
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        await conversation.open();
         // Step 6: User A still can send message to User B
         await expect(userAPages.conversation().messageInput).toBeVisible();
       },
@@ -122,7 +122,12 @@ test.describe('User Blocking', () => {
         await userBPages.connectRequest().clickConnectButton();
 
         // Step 1: User A and B have a 1:1 conversation
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        const conversation = await userAPages
+          .conversationList()
+          .getConversationLocator(userB.fullName, {protocol: 'mls'})
+          .open();
+        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+
         // Step 2: User A opens conversation info
         await userAPages.conversation().clickConversationInfoButton();
         // Step 3: User A clicks 'Block conversation' button
@@ -130,23 +135,18 @@ test.describe('User Blocking', () => {
         // Step 4: User A clicks 'Confirm' button
         await userAModals.blockWarning().clickBlock();
         // Step 5: User A cannot send message to User B
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        await conversation.open();
         await expect(userAPages.conversation().messageInput).not.toBeVisible();
         // Step 6: User B cannot send message to User A
-        await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
         await userBPages.conversation().sendMessage('Message after block');
         const message = userAPages.conversation().getMessage({sender: userB});
         await expect(message).not.toBeVisible();
         // Step 7: 'Blocked' chip is visible next to the name of User B in the conversation list
-        const statusTextElement = userAPages
-          .conversationList()
-          .getConversationLocator(userB.fullName, {protocol: 'mls'}).blockedIndicator;
-        await expect(statusTextElement).toBeVisible();
-        await expect(statusTextElement).toHaveText('Blocked');
+        await expect(conversation.blockedIndicator).toBeVisible();
+        await expect(conversation.blockedIndicator).toHaveText('Blocked');
 
         // Step 8: Profile Picture of User B is replaced by 'blocked' picture
-        const {userAvatar} = userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'});
-        const blockedIcon = userAvatar.locator('[data-uie-value="blocked"]');
+        const blockedIcon = conversation.userAvatar.locator('[data-uie-value="blocked"]');
         await expect(blockedIcon).toBeVisible();
       },
     );
@@ -172,23 +172,23 @@ test.describe('User Blocking', () => {
         await createGroup(userAPages, conversationName, [userB]);
 
         await test.step('Step 1: User B sends message to group chat with User A', async () => {
-          await userBPages.conversationList().openConversation(conversationName);
+          await userBPages.conversationList().getConversationLocator(conversationName).open();
           await userBPages.conversation().sendMessage('message before block');
         });
 
         await test.step('Step 2: User A blocks User B from group conversation', async () => {
           // Ensures User A is in the group before blocking
-          await userAPages.conversationList().openConversation(conversationName);
+          await userAPages.conversationList().getConversationLocator(conversationName).open();
           await blockUserFromOpenGroupProfileView(userAPageManager, userB);
         });
 
         await test.step('Step 3: User B writes second message to the group chat after being blocked by User A', async () => {
-          await userBPages.conversationList().openConversation(conversationName);
+          await userBPages.conversationList().getConversationLocator(conversationName).open();
           await userBPages.conversation().sendMessage('message after block');
         });
 
         await test.step('Step 4: User A receives message from User B in Group Chat even though User B is blocked', async () => {
-          await userAPages.conversationList().openConversation(conversationName);
+          await userAPages.conversationList().getConversationLocator(conversationName).open();
           await expect(userAPages.conversation().messages).toHaveCount(2);
         });
       },
@@ -208,27 +208,26 @@ test.describe('User Blocking', () => {
         await userBPages.connectRequest().clickConnectButton();
 
         // Step 1: User A and B have a 1:1 conversation
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        const conversation = await userAPages
+          .conversationList()
+          .getConversationLocator(userB.fullName, {protocol: 'mls'})
+          .open();
         // Step 2: User A blocks User B
         await blockUserFromProfileView(userAPageManagerInstance);
         await expect(userAPages.conversation().messageInput).toBeHidden();
         // Step 3: User A unblocks User B from Conversation Details Options
-        const contextMenu = await userAPages
-          .conversationList()
-          .getConversationLocator(userB.fullName, {protocol: 'mls'})
-          .openContextMenu();
+        const contextMenu = await conversation.openContextMenu();
         await contextMenu.unblockButton.click();
         await userAModals.confirm().clickAction();
         // Step 4: User A send message to User B
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        await conversation.open();
         await userAPages.conversation().sendMessage('Message after unblock');
         // Step 5: User B receives message from User A
-        await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
         await expect(userBPages.conversation().messages).toHaveCount(1);
         // Step 6: User B writes message to User A
         await userBPages.conversation().sendMessage('Message after being unblocked');
         // Step 7: User A receives message from User B
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
         const message = userAPages.conversation().getMessage({sender: userB});
         await expect(message).toContainText('Message after being unblocked');
       },
@@ -252,7 +251,7 @@ test.describe('User Blocking', () => {
         // Step 1: User B blocks User A
         await test.step('User B blocks User A', async () => {
           // Open the conversation with User C to prevent the "Wire cannot open this conversation" modal
-          await userAPages.conversationList().openConversation(userC.fullName);
+          await userAPages.conversationList().getConversationLocator(userC.fullName).open();
           await blockUserFromConversationList(userBPageManagerInstance, userA);
         });
 
@@ -302,7 +301,7 @@ test.describe('User Blocking', () => {
         await userBPages.connectRequest().clickConnectButton();
 
         await test.step('User A blocks User B', async () => {
-          await userAPages.conversationList().openConversation(userC.fullName);
+          await userAPages.conversationList().getConversationLocator(userC.fullName).open();
           await blockUserFromConversationList(userAPageManagerInstance, userB);
         });
 
@@ -315,16 +314,16 @@ test.describe('User Blocking', () => {
         });
 
         await test.step('User B receives message sent by User A', async () => {
-          await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+          await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
           await userAPages.conversation().sendMessage('Message after unblocking');
-          await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+          await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
           await expect(userBPages.conversation().messages).toHaveCount(1);
         });
 
         await test.step('User A receives message sent by User B', async () => {
-          await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+          await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
           await userBPages.conversation().sendMessage('Message after being unblocked');
-          await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+          await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
           const message = userAPages.conversation().getMessage({sender: userB});
           await expect(message).toContainText('Message after being unblocked');
         });
@@ -347,10 +346,10 @@ test.describe('User Blocking', () => {
       const userAPages = userAPageManager.pages;
 
       // Step 1: User A opens conversation with User B
-      await userAPages.conversationList().openConversation(userB.fullName);
+      const conversation = await userAPages.conversationList().getConversationLocator(userB.fullName).open();
 
       // Step 2: User A opens the options menu for user B
-      const contextMenu = await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+      const contextMenu = await conversation.openContextMenu();
 
       // Step 3: Block conversation button is not visible for team members
       await expect(contextMenu.blockButton).not.toBeAttached();

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -32,7 +32,7 @@ import {createGroup, sendConnectionRequest} from '../../utils/userActions';
 export async function blockUserFromConversationList(pageManager: PageManager, userToBlock: User) {
   const {pages, modals} = pageManager.webapp;
 
-  const conversation = await pages.conversationList().getConversationLocator(userToBlock.fullName).open();
+  const conversation = await pages.conversationList().getConversation(userToBlock.fullName).open();
   const contextMenu = await conversation.openContextMenu();
   await contextMenu.blockButton.click();
   await modals.blockWarning().clickBlock();
@@ -94,7 +94,7 @@ test.describe('User Blocking', () => {
         // Step 1: User A opens conversation with User B
         const conversation = await userAPages
           .conversationList()
-          .getConversationLocator(userB.fullName, {protocol: 'mls'})
+          .getConversation(userB.fullName, {protocol: 'mls'})
           .open();
         // Step 2: User A opens the options menu for user B
         const contextMenu = await conversation.openContextMenu();
@@ -124,9 +124,9 @@ test.describe('User Blocking', () => {
         // Step 1: User A and B have a 1:1 conversation
         const conversation = await userAPages
           .conversationList()
-          .getConversationLocator(userB.fullName, {protocol: 'mls'})
+          .getConversation(userB.fullName, {protocol: 'mls'})
           .open();
-        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+        await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
         // Step 2: User A opens conversation info
         await userAPages.conversation().clickConversationInfoButton();
@@ -168,27 +168,27 @@ test.describe('User Blocking', () => {
 
         const conversationName = 'GroupConversation';
 
-        await expect(userAPages.conversationList().getConversationLocator(userB.fullName)).toBeAttached();
+        await expect(userAPages.conversationList().getConversation(userB.fullName)).toBeAttached();
         await createGroup(userAPages, conversationName, [userB]);
 
         await test.step('Step 1: User B sends message to group chat with User A', async () => {
-          await userBPages.conversationList().getConversationLocator(conversationName).open();
+          await userBPages.conversationList().getConversation(conversationName).open();
           await userBPages.conversation().sendMessage('message before block');
         });
 
         await test.step('Step 2: User A blocks User B from group conversation', async () => {
           // Ensures User A is in the group before blocking
-          await userAPages.conversationList().getConversationLocator(conversationName).open();
+          await userAPages.conversationList().getConversation(conversationName).open();
           await blockUserFromOpenGroupProfileView(userAPageManager, userB);
         });
 
         await test.step('Step 3: User B writes second message to the group chat after being blocked by User A', async () => {
-          await userBPages.conversationList().getConversationLocator(conversationName).open();
+          await userBPages.conversationList().getConversation(conversationName).open();
           await userBPages.conversation().sendMessage('message after block');
         });
 
         await test.step('Step 4: User A receives message from User B in Group Chat even though User B is blocked', async () => {
-          await userAPages.conversationList().getConversationLocator(conversationName).open();
+          await userAPages.conversationList().getConversation(conversationName).open();
           await expect(userAPages.conversation().messages).toHaveCount(2);
         });
       },
@@ -210,7 +210,7 @@ test.describe('User Blocking', () => {
         // Step 1: User A and B have a 1:1 conversation
         const conversation = await userAPages
           .conversationList()
-          .getConversationLocator(userB.fullName, {protocol: 'mls'})
+          .getConversation(userB.fullName, {protocol: 'mls'})
           .open();
         // Step 2: User A blocks User B
         await blockUserFromProfileView(userAPageManagerInstance);
@@ -223,7 +223,7 @@ test.describe('User Blocking', () => {
         await conversation.open();
         await userAPages.conversation().sendMessage('Message after unblock');
         // Step 5: User B receives message from User A
-        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+        await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
         await expect(userBPages.conversation().messages).toHaveCount(1);
         // Step 6: User B writes message to User A
         await userBPages.conversation().sendMessage('Message after being unblocked');
@@ -251,7 +251,7 @@ test.describe('User Blocking', () => {
         // Step 1: User B blocks User A
         await test.step('User B blocks User A', async () => {
           // Open the conversation with User C to prevent the "Wire cannot open this conversation" modal
-          await userAPages.conversationList().getConversationLocator(userC.fullName).open();
+          await userAPages.conversationList().getConversation(userC.fullName).open();
           await blockUserFromConversationList(userBPageManagerInstance, userA);
         });
 
@@ -301,7 +301,7 @@ test.describe('User Blocking', () => {
         await userBPages.connectRequest().clickConnectButton();
 
         await test.step('User A blocks User B', async () => {
-          await userAPages.conversationList().getConversationLocator(userC.fullName).open();
+          await userAPages.conversationList().getConversation(userC.fullName).open();
           await blockUserFromConversationList(userAPageManagerInstance, userB);
         });
 
@@ -314,16 +314,16 @@ test.describe('User Blocking', () => {
         });
 
         await test.step('User B receives message sent by User A', async () => {
-          await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+          await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
           await userAPages.conversation().sendMessage('Message after unblocking');
-          await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+          await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
           await expect(userBPages.conversation().messages).toHaveCount(1);
         });
 
         await test.step('User A receives message sent by User B', async () => {
-          await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+          await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
           await userBPages.conversation().sendMessage('Message after being unblocked');
-          await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+          await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
           const message = userAPages.conversation().getMessage({sender: userB});
           await expect(message).toContainText('Message after being unblocked');
         });
@@ -346,7 +346,7 @@ test.describe('User Blocking', () => {
       const userAPages = userAPageManager.pages;
 
       // Step 1: User A opens conversation with User B
-      const conversation = await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+      const conversation = await userAPages.conversationList().getConversation(userB.fullName).open();
 
       // Step 2: User A opens the options menu for user B
       const contextMenu = await conversation.openContextMenu();

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -53,13 +53,13 @@ test.describe('Calling', () => {
       ]);
 
       // User A has a call with user B
-      await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+      await userAPages.conversationList().getConversation(userB.fullName).open();
       await userAPages.conversation().clickCallButton();
       await userBPages.calling().clickAcceptCallButton();
       await expect(userBPages.calling().callCell).toBeVisible();
 
       // User A starts a call with user C while in a call with user B
-      await userAPages.conversationList().getConversationLocator(userC.fullName).open();
+      await userAPages.conversationList().getConversation(userC.fullName).open();
       await userAPages.conversation().clickCallButton();
 
       // A modal is shown prompting him to confirm before cancelling the ongoing call
@@ -83,7 +83,7 @@ test.describe('Calling', () => {
     await createGroup(userAPages, groupName, [userB]);
 
     // Establish group call; required precondition for hand-raise testing
-    await userAPages.conversationList().getConversationLocator(groupName).open();
+    await userAPages.conversationList().getConversation(groupName).open();
     await userAPages.conversation().clickCallButton();
 
     await expect(userBPages.calling().callCell).toBeVisible();
@@ -114,7 +114,7 @@ test.describe('Calling', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+    await userAPages.conversationList().getConversation(userB.fullName).open();
     await userAPages.conversation().clickCallButton();
     await userBPages.calling().clickAcceptCallButton();
 
@@ -137,10 +137,10 @@ test.describe('Calling', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().clickCallButton();
 
-      const {joinCallButton} = userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'});
+      const {joinCallButton} = userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'});
       await expect(joinCallButton).toBeVisible();
       await expect(userBPages.calling().acceptCallButton).toBeVisible();
 
@@ -174,10 +174,10 @@ test.describe('Calling', () => {
       const userBDevice2Pages = PageManager.from(userBPage2).webapp.pages;
 
       if (conversationType === '1on1') {
-        await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+        await userAPages.conversationList().getConversation(userB.fullName).open();
       } else {
         await createGroup(userAPages, 'Calling group', [userB]);
-        await userAPages.conversationList().getConversationLocator('Calling group').open();
+        await userAPages.conversationList().getConversation('Calling group').open();
       }
 
       // Ensure no audio is playing on both devices initially
@@ -211,7 +211,7 @@ test.describe('Calling', () => {
       ]);
 
       // User A calls user B
-      await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+      await userAPages.conversationList().getConversation(userB.fullName).open();
       await userAPages.conversation().clickCallButton();
 
       // User B declines the call
@@ -219,7 +219,7 @@ test.describe('Calling', () => {
       await expect(userBPages.calling().callCell).not.toBeVisible();
 
       // User B calls user C instead
-      await userBPages.conversationList().getConversationLocator(userC.fullName).open();
+      await userBPages.conversationList().getConversation(userC.fullName).open();
       await expect(userBPages.conversation().callButton).toBeEnabled();
       await userBPages.conversation().startCall();
       await expect(userBPages.calling().callCell).toBeVisible();
@@ -236,7 +236,7 @@ test.describe('Calling', () => {
     const userCPages = PageManager.from(userCPage).webapp.pages;
     await createGroup(userAPages, groupName, [userB, userC]);
 
-    await userAPages.conversationList().getConversationLocator(groupName).open();
+    await userAPages.conversationList().getConversation(groupName).open();
     await userAPages.conversation().clickCallButton();
 
     await expect(userAPages.calling().callCell).toBeVisible();
@@ -248,7 +248,7 @@ test.describe('Calling', () => {
 
     // // User C joins the ongoing call
     await userCPage.waitForTimeout(5000);
-    await userCPages.conversationList().getConversationLocator(groupName).joinCallButton.click();
+    await userCPages.conversationList().getConversation(groupName).joinCallButton.click();
 
     // Confirm that user C joined the call
     await expect(userCPages.calling().goFullScreen).toBeVisible();
@@ -263,7 +263,7 @@ test.describe('Calling', () => {
 
     await createGroup(userAPages, groupName, [userB, userC]);
 
-    await userAPages.conversationList().getConversationLocator(groupName).open();
+    await userAPages.conversationList().getConversation(groupName).open();
     await userAPages.conversation().clickCallButton();
 
     await expect(userAPages.calling().callCell).toBeVisible();
@@ -286,7 +286,7 @@ test.describe('Calling', () => {
     await createGroup(userAPages, groupName, [userB]);
 
     // User A initiates the call
-    await userAPages.conversationList().getConversationLocator(groupName).open();
+    await userAPages.conversationList().getConversation(groupName).open();
     await userAPages.conversation().clickCallButton();
 
     await expect(userAPages.calling().callCell).toBeVisible();
@@ -301,7 +301,7 @@ test.describe('Calling', () => {
     await expect(userBPages.calling().callCell).toBeHidden();
 
     // User B re-joins the ongoing call from the conversation list
-    await userBPages.conversationList().getConversationLocator(groupName).joinCallButton.click({timeout: 30_000});
+    await userBPages.conversationList().getConversation(groupName).joinCallButton.click({timeout: 30_000});
 
     await expect(userBPages.calling().goFullScreen).toBeVisible();
   });
@@ -315,7 +315,7 @@ test.describe('Calling', () => {
     await createGroup(userAPages, groupName, [userB]);
 
     // User A initiates the call
-    await userAPages.conversationList().getConversationLocator(groupName).open();
+    await userAPages.conversationList().getConversation(groupName).open();
     await userAPages.conversation().clickCallButton();
 
     await expect(userAPages.calling().callCell).toBeVisible();
@@ -343,7 +343,7 @@ test.describe('Calling', () => {
       await createGroup(userAPages, groupName, [userB]);
 
       await test.step('User A starts a call and User B joins', async () => {
-        await userAPages.conversationList().getConversationLocator(groupName).open();
+        await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().clickCallButton();
 
         await expect(userAPages.calling().callCell).toBeVisible();
@@ -354,7 +354,7 @@ test.describe('Calling', () => {
       });
 
       await test.step('User A joins then leaves the call from their second device', async () => {
-        await userADevice2Pages.conversationList().getConversationLocator(groupName).open();
+        await userADevice2Pages.conversationList().getConversation(groupName).open();
         await userADevice2Pages.conversation().clickCallButton();
         await expect(userADevice2Pages.calling().callCell).toBeVisible();
 
@@ -371,7 +371,7 @@ test.describe('Calling', () => {
         await userAPages.calling().clickLeaveCallButton();
         await expect(userAPages.calling().callCell).not.toBeAttached();
         // Verify the call is still "joinable" (User B is still there)
-        await expect(userAPages.conversationList().getConversationLocator(groupName).joinCallButton).toBeVisible({
+        await expect(userAPages.conversationList().getConversation(groupName).joinCallButton).toBeVisible({
           timeout: 30_000,
         });
       });
@@ -391,7 +391,7 @@ test.describe('Calling', () => {
       await createGroup(userAPages, groupName, [userB, userC]);
 
       // User A initiates the call
-      await userAPages.conversationList().getConversationLocator(groupName).open();
+      await userAPages.conversationList().getConversation(groupName).open();
       await userAPages.conversation().clickCallButton();
 
       await expect(userAPages.calling().callCell).toBeVisible();
@@ -427,12 +427,12 @@ test.describe('Calling', () => {
       await createGroup(userAPages, groupName, [userB]);
 
       // User A initiates the call
-      await userAPages.conversationList().getConversationLocator(groupName).open();
+      await userAPages.conversationList().getConversation(groupName).open();
       await userAPages.conversation().clickCallButton();
 
       await expect(userAPages.calling().callCell).toBeVisible();
       await expect(userBPages.calling().callCell).toBeVisible();
-      await expect(userBPages.conversationList().getConversationLocator(groupName).joinCallButton).toBeVisible();
+      await expect(userBPages.conversationList().getConversation(groupName).joinCallButton).toBeVisible();
 
       // User A removes User B from the group
       await userAPages.conversation().toggleGroupInformation();
@@ -443,7 +443,7 @@ test.describe('Calling', () => {
 
       // User B cannot join the group call
       await expect(userBPages.calling().callCell).not.toBeAttached();
-      await expect(userBPages.conversationList().getConversationLocator(groupName).joinCallButton).not.toBeAttached();
+      await expect(userBPages.conversationList().getConversation(groupName).joinCallButton).not.toBeAttached();
     },
   );
 
@@ -463,7 +463,7 @@ test.describe('Calling', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
 
       await createGroup(userAPages, groupName, allMembers);
-      await userAPages.conversationList().getConversationLocator(groupName).open();
+      await userAPages.conversationList().getConversation(groupName).open();
       await userAPages.conversation().clickCallButton();
 
       await expect(userAPage.getByTestId('modal-without-title')).toContainText(
@@ -493,7 +493,7 @@ test.describe('Calling', () => {
 
         await createGroup(userAPages, groupName, [userB, guestUser]);
 
-        await userAPages.conversationList().getConversationLocator(groupName).open();
+        await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().clickCallButton();
       });
 

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -53,13 +53,13 @@ test.describe('Calling', () => {
       ]);
 
       // User A has a call with user B
-      await userAPages.conversationList().openConversation(userB.fullName);
+      await userAPages.conversationList().getConversationLocator(userB.fullName).open();
       await userAPages.conversation().clickCallButton();
       await userBPages.calling().clickAcceptCallButton();
       await expect(userBPages.calling().callCell).toBeVisible();
 
       // User A starts a call with user C while in a call with user B
-      await userAPages.conversationList().openConversation(userC.fullName);
+      await userAPages.conversationList().getConversationLocator(userC.fullName).open();
       await userAPages.conversation().clickCallButton();
 
       // A modal is shown prompting him to confirm before cancelling the ongoing call
@@ -83,7 +83,7 @@ test.describe('Calling', () => {
     await createGroup(userAPages, groupName, [userB]);
 
     // Establish group call; required precondition for hand-raise testing
-    await userAPages.conversationList().openConversation(groupName);
+    await userAPages.conversationList().getConversationLocator(groupName).open();
     await userAPages.conversation().clickCallButton();
 
     await expect(userBPages.calling().callCell).toBeVisible();
@@ -114,7 +114,7 @@ test.describe('Calling', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userAPages.conversationList().openConversation(userB.fullName);
+    await userAPages.conversationList().getConversationLocator(userB.fullName).open();
     await userAPages.conversation().clickCallButton();
     await userBPages.calling().clickAcceptCallButton();
 
@@ -137,7 +137,7 @@ test.describe('Calling', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().clickCallButton();
 
       const {joinCallButton} = userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'});
@@ -174,10 +174,10 @@ test.describe('Calling', () => {
       const userBDevice2Pages = PageManager.from(userBPage2).webapp.pages;
 
       if (conversationType === '1on1') {
-        await userAPages.conversationList().openConversation(userB.fullName);
+        await userAPages.conversationList().getConversationLocator(userB.fullName).open();
       } else {
         await createGroup(userAPages, 'Calling group', [userB]);
-        await userAPages.conversationList().openConversation('Calling group');
+        await userAPages.conversationList().getConversationLocator('Calling group').open();
       }
 
       // Ensure no audio is playing on both devices initially
@@ -211,7 +211,7 @@ test.describe('Calling', () => {
       ]);
 
       // User A calls user B
-      await userAPages.conversationList().openConversation(userB.fullName);
+      await userAPages.conversationList().getConversationLocator(userB.fullName).open();
       await userAPages.conversation().clickCallButton();
 
       // User B declines the call
@@ -219,7 +219,7 @@ test.describe('Calling', () => {
       await expect(userBPages.calling().callCell).not.toBeVisible();
 
       // User B calls user C instead
-      await userBPages.conversationList().openConversation(userC.fullName);
+      await userBPages.conversationList().getConversationLocator(userC.fullName).open();
       await expect(userBPages.conversation().callButton).toBeEnabled();
       await userBPages.conversation().startCall();
       await expect(userBPages.calling().callCell).toBeVisible();
@@ -236,7 +236,7 @@ test.describe('Calling', () => {
     const userCPages = PageManager.from(userCPage).webapp.pages;
     await createGroup(userAPages, groupName, [userB, userC]);
 
-    await userAPages.conversationList().openConversation(groupName);
+    await userAPages.conversationList().getConversationLocator(groupName).open();
     await userAPages.conversation().clickCallButton();
 
     await expect(userAPages.calling().callCell).toBeVisible();
@@ -263,7 +263,7 @@ test.describe('Calling', () => {
 
     await createGroup(userAPages, groupName, [userB, userC]);
 
-    await userAPages.conversationList().openConversation(groupName);
+    await userAPages.conversationList().getConversationLocator(groupName).open();
     await userAPages.conversation().clickCallButton();
 
     await expect(userAPages.calling().callCell).toBeVisible();
@@ -286,7 +286,7 @@ test.describe('Calling', () => {
     await createGroup(userAPages, groupName, [userB]);
 
     // User A initiates the call
-    await userAPages.conversationList().openConversation(groupName);
+    await userAPages.conversationList().getConversationLocator(groupName).open();
     await userAPages.conversation().clickCallButton();
 
     await expect(userAPages.calling().callCell).toBeVisible();
@@ -315,7 +315,7 @@ test.describe('Calling', () => {
     await createGroup(userAPages, groupName, [userB]);
 
     // User A initiates the call
-    await userAPages.conversationList().openConversation(groupName);
+    await userAPages.conversationList().getConversationLocator(groupName).open();
     await userAPages.conversation().clickCallButton();
 
     await expect(userAPages.calling().callCell).toBeVisible();
@@ -343,7 +343,7 @@ test.describe('Calling', () => {
       await createGroup(userAPages, groupName, [userB]);
 
       await test.step('User A starts a call and User B joins', async () => {
-        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversationList().getConversationLocator(groupName).open();
         await userAPages.conversation().clickCallButton();
 
         await expect(userAPages.calling().callCell).toBeVisible();
@@ -354,7 +354,7 @@ test.describe('Calling', () => {
       });
 
       await test.step('User A joins then leaves the call from their second device', async () => {
-        await userADevice2Pages.conversationList().openConversation(groupName);
+        await userADevice2Pages.conversationList().getConversationLocator(groupName).open();
         await userADevice2Pages.conversation().clickCallButton();
         await expect(userADevice2Pages.calling().callCell).toBeVisible();
 
@@ -391,7 +391,7 @@ test.describe('Calling', () => {
       await createGroup(userAPages, groupName, [userB, userC]);
 
       // User A initiates the call
-      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversationList().getConversationLocator(groupName).open();
       await userAPages.conversation().clickCallButton();
 
       await expect(userAPages.calling().callCell).toBeVisible();
@@ -427,7 +427,7 @@ test.describe('Calling', () => {
       await createGroup(userAPages, groupName, [userB]);
 
       // User A initiates the call
-      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversationList().getConversationLocator(groupName).open();
       await userAPages.conversation().clickCallButton();
 
       await expect(userAPages.calling().callCell).toBeVisible();
@@ -463,7 +463,7 @@ test.describe('Calling', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
 
       await createGroup(userAPages, groupName, allMembers);
-      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversationList().getConversationLocator(groupName).open();
       await userAPages.conversation().clickCallButton();
 
       await expect(userAPage.getByTestId('modal-without-title')).toContainText(
@@ -493,7 +493,7 @@ test.describe('Calling', () => {
 
         await createGroup(userAPages, groupName, [userB, guestUser]);
 
-        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversationList().getConversationLocator(groupName).open();
         await userAPages.conversation().clickCallButton();
       });
 

--- a/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -65,13 +65,13 @@ test.describe('Clear Conversation Content', () => {
         await createGroup(userAPages, conversationName, [userB, userC]);
 
         // Step 2: Write messages in the group conversation
-        const conversation = await userAPages.conversationList().getConversationLocator(conversationName).open();
+        const conversation = await userAPages.conversationList().getConversation(conversationName).open();
         await userAPages.conversation().sendMessage('Message from User A');
 
-        await userBPages.conversationList().getConversationLocator(conversationName).open();
+        await userBPages.conversationList().getConversation(conversationName).open();
         await userBPages.conversation().sendMessage('Message from User B');
 
-        await userCPages.conversationList().getConversationLocator(conversationName).open();
+        await userCPages.conversationList().getConversation(conversationName).open();
         await userCPages.conversation().sendMessage('Message from User C');
 
         await expect(userAPages.conversation().messages).toHaveCount(3);
@@ -116,13 +116,13 @@ test.describe('Clear Conversation Content', () => {
         // Step 1: Create a 1:1 conversation with User A and B
         const conversation = await userAPages
           .conversationList()
-          .getConversationLocator(userB.fullName, {protocol: 'mls'})
+          .getConversation(userB.fullName, {protocol: 'mls'})
           .open();
 
         // Step 2: Write messages in the conversation
         await userAPages.conversation().sendMessage('Message from User A');
 
-        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+        await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
         await userBPages.conversation().sendMessage('Message from User B');
 
         await expect(userAPages.conversation().messages).toHaveCount(2);
@@ -172,14 +172,14 @@ test.describe('Clear Conversation Content', () => {
         // Step 1: Create a group conversation with User A, B and C
         const conversationName = conversationType === 'group' ? 'Group conversation' : userB.fullName;
 
-        let userAConversation: ReturnType<ConversationListPage['getConversationLocator']>;
+        let userAConversation: ReturnType<ConversationListPage['getConversation']>;
         if (conversationType === 'group') {
           await createGroup(userAPages, conversationName, [userB, userC]);
-          userAConversation = await userAPages.conversationList().getConversationLocator(conversationName).open();
+          userAConversation = await userAPages.conversationList().getConversation(conversationName).open();
         } else {
           userAConversation = await userAPages
             .conversationList()
-            .getConversationLocator(conversationName, {protocol: 'mls'})
+            .getConversation(conversationName, {protocol: 'mls'})
             .open();
         }
 
@@ -188,12 +188,12 @@ test.describe('Clear Conversation Content', () => {
 
         const userBConversation = await userBPages
           .conversationList()
-          .getConversationLocator(conversationType === 'group' ? conversationName : userA.fullName)
+          .getConversation(conversationType === 'group' ? conversationName : userA.fullName)
           .open();
         await userBPages.conversation().sendMessage('Message from User B');
 
         if (conversationType === 'group') {
-          await userCPages.conversationList().getConversationLocator(conversationName).open();
+          await userCPages.conversationList().getConversation(conversationName).open();
           await userCPages.conversation().sendMessage('Message from User C');
           await expect(userAPages.conversation().messages).toHaveCount(3);
         } else {
@@ -270,25 +270,25 @@ test.describe('Clear Conversation Content', () => {
         const userBPages = userBPageManager.webapp.pages;
 
         const conversationName = 'Group conversation';
-        let userAConversation: ReturnType<ConversationListPage['getConversationLocator']>;
+        let userAConversation: ReturnType<ConversationListPage['getConversation']>;
 
         if (conversationType === 'group') {
           await createGroup(userAPages, conversationName, [userB]);
           // Step 1: User A and B write in group conversation
-          userAConversation = await userAPages.conversationList().getConversationLocator(conversationName).open();
+          userAConversation = await userAPages.conversationList().getConversation(conversationName).open();
           await userAPages.conversation().sendMessage('Message from User A');
 
-          await userBPages.conversationList().getConversationLocator(conversationName).open();
+          await userBPages.conversationList().getConversation(conversationName).open();
           await userBPages.conversation().sendMessage('Message from User B');
         } else {
           // Step 1: User A and B write in conversation
           userAConversation = await userAPages
             .conversationList()
-            .getConversationLocator(userB.fullName, {protocol: 'mls'})
+            .getConversation(userB.fullName, {protocol: 'mls'})
             .open();
           await userAPages.conversation().sendMessage('Message from User A');
 
-          await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+          await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
           await userBPages.conversation().sendMessage('Message from User B');
         }
         await expect(userAPages.conversation().messages).toHaveCount(2);

--- a/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -24,6 +24,7 @@ import {test, withLogin, withConnectedUser, expect} from 'test/e2e_tests/test.fi
 import {getTextFilePath, shareAssetHelper} from '../../utils/asset.util';
 import {getImageFilePath} from '../../utils/sendImage.util';
 import {createGroup} from '../../utils/userActions';
+import {ConversationListPage} from 'test/e2e_tests/pageManager/webapp/pages/conversationList.page';
 
 test.describe('Clear Conversation Content', () => {
   let userA: User;
@@ -64,22 +65,19 @@ test.describe('Clear Conversation Content', () => {
         await createGroup(userAPages, conversationName, [userB, userC]);
 
         // Step 2: Write messages in the group conversation
-        await userAPages.conversationList().openConversation(conversationName);
+        const conversation = await userAPages.conversationList().getConversationLocator(conversationName).open();
         await userAPages.conversation().sendMessage('Message from User A');
 
-        await userBPages.conversationList().openConversation(conversationName);
+        await userBPages.conversationList().getConversationLocator(conversationName).open();
         await userBPages.conversation().sendMessage('Message from User B');
 
-        await userCPages.conversationList().openConversation(conversationName);
+        await userCPages.conversationList().getConversationLocator(conversationName).open();
         await userCPages.conversation().sendMessage('Message from User C');
 
         await expect(userAPages.conversation().messages).toHaveCount(3);
 
         // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-        const contextMenu = await userAPages
-          .conversationList()
-          .getConversationLocator(conversationName)
-          .openContextMenu();
+        const contextMenu = await conversation.openContextMenu();
         await contextMenu.clearContentButton.click();
         // Step 4: Warning Popup should open
         await expect(userAModals.optionModal().modal).toBeVisible();
@@ -88,13 +86,13 @@ test.describe('Clear Conversation Content', () => {
           // Step 5: User A clicks 'Clear'
           await userAModals.optionModal().clickAction();
           // Step 6: Verify that the conversation does not contain any past messages
-          await userAPages.conversationList().openConversation(conversationName);
+          await conversation.open();
           await expect(userAPages.conversation().messages).toHaveCount(0);
         } else {
           // Step 5: User A clicks 'Cancel'
           await userAModals.optionModal().clickCancel();
           // Step 6: Verify that the conversation still contains any past messages
-          await userAPages.conversationList().openConversation(conversationName);
+          await conversation.open();
           await expect(userAPages.conversation().messages).toHaveCount(3);
         }
       },
@@ -116,21 +114,21 @@ test.describe('Clear Conversation Content', () => {
         const userBPages = userBPageManager.webapp.pages;
 
         // Step 1: Create a 1:1 conversation with User A and B
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        const conversation = await userAPages
+          .conversationList()
+          .getConversationLocator(userB.fullName, {protocol: 'mls'})
+          .open();
 
         // Step 2: Write messages in the conversation
         await userAPages.conversation().sendMessage('Message from User A');
 
-        await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
         await userBPages.conversation().sendMessage('Message from User B');
 
         await expect(userAPages.conversation().messages).toHaveCount(2);
 
         // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-        const contextMenu = await userAPages
-          .conversationList()
-          .getConversationLocator(userB.fullName, {protocol: 'mls'})
-          .openContextMenu();
+        const contextMenu = await conversation.openContextMenu();
         await contextMenu.clearContentButton.click();
         // Step 4: Warning Popup should open
         await expect(userAModals.confirm().modal).toBeVisible();
@@ -139,7 +137,7 @@ test.describe('Clear Conversation Content', () => {
           // Step 5: User A clicks 'Clear'
           await userAModals.confirm().clickAction();
           // Step 6: Verify that the conversation does not contain any past messages
-          await userAPages.conversationList().openConversation(userB.fullName);
+          await conversation.open();
           await expect(userAPages.conversation().messages).toHaveCount(0);
         } else {
           // Step 5: User A clicks 'Cancel'
@@ -174,23 +172,28 @@ test.describe('Clear Conversation Content', () => {
         // Step 1: Create a group conversation with User A, B and C
         const conversationName = conversationType === 'group' ? 'Group conversation' : userB.fullName;
 
+        let userAConversation: ReturnType<ConversationListPage['getConversationLocator']>;
         if (conversationType === 'group') {
           await createGroup(userAPages, conversationName, [userB, userC]);
+          userAConversation = await userAPages.conversationList().getConversationLocator(conversationName).open();
         } else {
-          await userAPages.conversationList().openConversation(conversationName, {protocol: 'mls'});
+          userAConversation = await userAPages
+            .conversationList()
+            .getConversationLocator(conversationName, {protocol: 'mls'})
+            .open();
         }
 
         // Step 2: Write messages in the conversation
-        await userAPages.conversationList().openConversation(conversationName);
         await userAPages.conversation().sendMessage('Message from User A');
 
-        const conversationPartnerForUserB = conversationType === 'group' ? conversationName : userA.fullName;
-
-        await userBPages.conversationList().openConversation(conversationPartnerForUserB);
+        const userBConversation = await userBPages
+          .conversationList()
+          .getConversationLocator(conversationType === 'group' ? conversationName : userA.fullName)
+          .open();
         await userBPages.conversation().sendMessage('Message from User B');
 
         if (conversationType === 'group') {
-          await userCPages.conversationList().openConversation(conversationName);
+          await userCPages.conversationList().getConversationLocator(conversationName).open();
           await userCPages.conversation().sendMessage('Message from User C');
           await expect(userAPages.conversation().messages).toHaveCount(3);
         } else {
@@ -198,10 +201,7 @@ test.describe('Clear Conversation Content', () => {
         }
 
         // Step 3: User A selects 'Clear Conversation' option from the Conversation List Context Menu
-        const contextMenu = await userAPages
-          .conversationList()
-          .getConversationLocator(conversationName, {protocol: conversationType === '1:1' ? 'mls' : undefined})
-          .openContextMenu();
+        const contextMenu = await userAConversation.openContextMenu();
         await contextMenu.clearContentButton.click();
 
         // Step 4: Warning Popup should open and User A clicks 'Clear'
@@ -217,15 +217,15 @@ test.describe('Clear Conversation Content', () => {
 
         // Step 5: Verify you can receive incoming new messages, pings, calls, pictures, and files
         // 5.1 Messages
-        await userBPages.conversationList().openConversation(conversationPartnerForUserB);
+        await userBConversation.open();
         await userBPages.conversation().sendMessage('Message from User B after Clear');
-        await userAPages.conversationList().openConversation(conversationName);
+        await userAConversation.open();
         await expect(userAPages.conversation().messages).toHaveCount(1);
 
         // 5.2 Pings
-        await userBPages.conversationList().openConversation(conversationPartnerForUserB);
+        await userBConversation.open();
         await userBPages.conversation().sendPing();
-        await userAPages.conversationList().openConversation(conversationName);
+        await userAConversation.open();
         await expect(userAPages.conversation().getPing()).toBeVisible();
 
         // 5.3 Pictures
@@ -238,7 +238,7 @@ test.describe('Clear Conversation Content', () => {
         await expect(messageWithImage).toBeVisible();
 
         // 5.4 Files
-        await userAPages.conversationList().openConversation(conversationName);
+        await userAConversation.open();
         await shareAssetHelper(getTextFilePath(), userBPage, userBPage.getByRole('button', {name: 'Add file'}));
         const messageWithFile = userAPages
           .conversation()
@@ -247,8 +247,8 @@ test.describe('Clear Conversation Content', () => {
         await expect(messageWithFile).toBeVisible();
 
         // 5.5 Calls
-        await userAPages.conversationList().openConversation(conversationName);
-        await userBPages.conversationList().openConversation(conversationPartnerForUserB);
+        await userAConversation.open();
+        await userBConversation.open();
         await userBPages.conversation().startCall();
         await expect(userAPages.calling().acceptCallButton).toBeVisible();
       },
@@ -270,20 +270,25 @@ test.describe('Clear Conversation Content', () => {
         const userBPages = userBPageManager.webapp.pages;
 
         const conversationName = 'Group conversation';
+        let userAConversation: ReturnType<ConversationListPage['getConversationLocator']>;
+
         if (conversationType === 'group') {
           await createGroup(userAPages, conversationName, [userB]);
           // Step 1: User A and B write in group conversation
-          await userAPages.conversationList().openConversation(conversationName);
+          userAConversation = await userAPages.conversationList().getConversationLocator(conversationName).open();
           await userAPages.conversation().sendMessage('Message from User A');
 
-          await userBPages.conversationList().openConversation(conversationName);
+          await userBPages.conversationList().getConversationLocator(conversationName).open();
           await userBPages.conversation().sendMessage('Message from User B');
         } else {
           // Step 1: User A and B write in conversation
-          await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+          userAConversation = await userAPages
+            .conversationList()
+            .getConversationLocator(userB.fullName, {protocol: 'mls'})
+            .open();
           await userAPages.conversation().sendMessage('Message from User A');
 
-          await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+          await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
           await userBPages.conversation().sendMessage('Message from User B');
         }
         await expect(userAPages.conversation().messages).toHaveCount(2);
@@ -299,14 +304,14 @@ test.describe('Clear Conversation Content', () => {
           // Step 5: User A clicks 'Clear'
           await userAModals.optionModal().clickAction();
           // Step 6: Verify that the conversation does not contain any past messages
-          await userAPages.conversationList().openConversation(conversationName);
+          await userAConversation.open();
         } else {
           // Step 4: Clear Conversation Content Modal appears
           await expect(userAModals.confirm().modal).toBeVisible();
           // Step 5: User A clicks 'Clear'
           await userAModals.confirm().clickAction();
           // Step 6: Verify that the conversation does not contain any past messages
-          await userAPages.conversationList().openConversation(userB.fullName);
+          await userAConversation.open();
         }
         await expect(userAPages.conversation().messages).toHaveCount(0);
       },

--- a/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
@@ -73,14 +73,14 @@ test.describe('Connections', () => {
       });
 
       await test.step('A creates a group with B & C', async () => {
-        await expect(memberAPages.conversationList().getConversationLocator(memberB.fullName)).toBeAttached();
-        await expect(memberAPages.conversationList().getConversationLocator(memberC.fullName)).toBeAttached();
+        await expect(memberAPages.conversationList().getConversation(memberB.fullName)).toBeAttached();
+        await expect(memberAPages.conversationList().getConversation(memberC.fullName)).toBeAttached();
 
         await createGroup(memberAPages, 'Group', [memberB, memberC]);
       });
 
       await test.step('B sends a connection request to C via the group conversation', async () => {
-        await memberBPages.conversationList().getConversationLocator('Group').open();
+        await memberBPages.conversationList().getConversation('Group').open();
         await memberBPages.conversation().conversationInfoButton.click();
         await memberBPages.conversationDetails().openParticipantDetails(memberC.fullName);
         await memberBPages.participantDetails().sendConnectRequest();
@@ -105,7 +105,7 @@ test.describe('Connections', () => {
       await memberBPages.conversationList().pendingConnectionRequest.click();
       await memberBPages.conversation().ignoreButton.click();
 
-      await expect(memberBPages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
+      await expect(memberBPages.conversationList().getConversation(memberB.fullName)).not.toBeVisible();
     },
   );
 
@@ -117,7 +117,7 @@ test.describe('Connections', () => {
       await sendConnectionRequest(pageManager, memberB);
 
       const {pages} = pageManager.webapp;
-      const conversation = pages.conversationList().getConversationLocator(memberB.fullName);
+      const conversation = pages.conversationList().getConversation(memberB.fullName);
       const contextMenu = await conversation.openContextMenu();
       await contextMenu.archiveButton.click();
 

--- a/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
@@ -80,7 +80,7 @@ test.describe('Connections', () => {
       });
 
       await test.step('B sends a connection request to C via the group conversation', async () => {
-        await memberBPages.conversationList().openConversation('Group');
+        await memberBPages.conversationList().getConversationLocator('Group').open();
         await memberBPages.conversation().conversationInfoButton.click();
         await memberBPages.conversationDetails().openParticipantDetails(memberC.fullName);
         await memberBPages.participantDetails().sendConnectRequest();
@@ -117,10 +117,11 @@ test.describe('Connections', () => {
       await sendConnectionRequest(pageManager, memberB);
 
       const {pages} = pageManager.webapp;
-      const contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
+      const conversation = pages.conversationList().getConversationLocator(memberB.fullName);
+      const contextMenu = await conversation.openContextMenu();
       await contextMenu.archiveButton.click();
 
-      await expect(pages.conversationList().getConversationLocator(memberB.fullName)).toBeVisible();
+      await expect(conversation).not.toBeVisible();
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
@@ -44,7 +44,7 @@ test.describe('Conversations', () => {
       const userAPages = await PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages);
 
       await createGroup(userAPages, groupName, [userB, userC]);
-      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversationList().getConversationLocator(groupName).open();
 
       const firstMessage = userAPages.conversation().systemMessages.first();
       await expect(firstMessage).toContainText(new RegExp(`You started the conversation\\s*${groupName}\\s*with`, 'i'));
@@ -63,7 +63,7 @@ test.describe('Conversations', () => {
       ]);
 
       await createGroup(userAPages, groupName, [userB, userC]);
-      userBPages.conversationList().openConversation(groupName);
+      userBPages.conversationList().getConversationLocator(groupName).open();
 
       const pattern = new RegExp(
         `${userA.fullName} started the conversation\\s*${groupName}\\s*with\\s*${userC.fullName}\\s*and\\s*you`,
@@ -113,7 +113,7 @@ test.describe('Conversations', () => {
 
       await createGroup(userAPages, groupName, [userB, userC]);
 
-      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversationList().getConversationLocator(groupName).open();
       await userAPages.conversation().clickConversationInfoButton();
       await userAPages.conversationDetails().changeConversationName('New Group Name');
 
@@ -141,7 +141,7 @@ test.describe('Conversations', () => {
 
       await createGroup(adminPages, groupName, [userB, guestUser]);
 
-      await adminPages.conversationList().openConversation(groupName);
+      await adminPages.conversationList().getConversationLocator(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
       await expect(adminPages.conversationDetails().getUserRoleIcon(guestUser.fullName)).toHaveAttribute(
         'data-uie-name',
@@ -170,7 +170,7 @@ test.describe('Conversations', () => {
 
       await createGroup(adminPages, groupName, [userB, guestUser]);
 
-      await adminPages.conversationList().openConversation(groupName);
+      await adminPages.conversationList().getConversationLocator(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
 
       await expect(adminPages.conversation().membersList.filter({hasText: guestUser.fullName})).toBeVisible();
@@ -191,20 +191,20 @@ test.describe('Conversations', () => {
       await createGroup(adminPages, groupName, [userB, userC]);
 
       // Confirm that the userA is an admin in the group
-      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversationList().getConversationLocator(groupName).open();
       await userBPages.conversation().clickConversationInfoButton();
       expect(userBPages.conversation().adminsList).toBeVisible();
       expect(userBPages.conversation().adminsList.getByRole('listitem')).toHaveCount(1);
 
       // User A leaves the group
-      await adminPages.conversationList().openConversation(groupName);
+      await adminPages.conversationList().getConversationLocator(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
       await adminPages.conversation().leaveConversation();
       await modals.leaveConversation().clickConfirm();
       await expect(adminPages.conversation().systemMessages.filter({hasText: 'You left'})).toBeVisible();
 
       // User B sees the empty admins section
-      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversationList().getConversationLocator(groupName).open();
       await userBPages.conversation().clickConversationInfoButton();
       expect(adminPages.conversation().adminsList).not.toBeVisible();
     },
@@ -222,7 +222,7 @@ test.describe('Conversations', () => {
       await createGroup(adminPages, groupName, [userB]);
 
       // User B can see members section
-      await adminPages.conversationList().openConversation(groupName);
+      await adminPages.conversationList().getConversationLocator(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
       expect(adminPages.conversation().membersList).toBeVisible();
       expect(adminPages.conversation().membersList.getByRole('listitem')).toHaveCount(1);
@@ -231,7 +231,7 @@ test.describe('Conversations', () => {
       await adminPages.conversation().makeUserAdmin(userB.fullName);
 
       // User A and B cannot see members section
-      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversationList().getConversationLocator(groupName).open();
 
       for (const userPages of [adminPages, userBPages]) {
         await userPages.conversation().clickConversationInfoButton();
@@ -248,7 +248,7 @@ test.describe('Conversations', () => {
       const adminPages = await PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages);
       await createGroup(adminPages, groupName, [userB]);
 
-      await adminPages.conversationList().openConversation(groupName);
+      await adminPages.conversationList().getConversationLocator(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
 
       await expect(adminPages.conversation().adminsList.getByRole('listitem')).toHaveCount(1);
@@ -269,7 +269,7 @@ test.describe('Conversations', () => {
 
       await createGroup(adminPage, groupName, [userB, externalUser]);
 
-      await adminPage.conversationList().openConversation(groupName);
+      await adminPage.conversationList().getConversationLocator(groupName).open();
       await adminPage.conversation().clickConversationInfoButton();
       await expect(adminPage.conversation().membersList).toBeVisible();
       await expect(adminPage.conversationDetails().getUserRoleIcon(externalUser.fullName)).toHaveAttribute(
@@ -290,12 +290,12 @@ test.describe('Conversations', () => {
       await createGroup(adminPages, groupName, [userB, userC]);
 
       // User A makes userB an admin
-      await adminPages.conversationList().openConversation(groupName);
+      await adminPages.conversationList().getConversationLocator(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
       await adminPages.conversation().makeUserAdmin(userB.fullName);
 
       // User B can see delete group and options in conversation details
-      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversationList().getConversationLocator(groupName).open();
       await userBPages.conversation().clickConversationInfoButton();
       await expect(userBPages.conversationDetails().deleteGroupButton).toBeVisible();
       await expect(userBPages.conversationDetails().guestOptionsButton).toBeVisible();
@@ -316,10 +316,10 @@ test.describe('Conversations', () => {
       const totalMessages = 20;
 
       await test.step('User B opens conversation with User A to mark previous history as read', async () => {
-        await pages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+        await pages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
         // User A sends "Read" messages while User B is looking at the chat
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
         for (let i = 1; i <= totalMessages; i++) {
           await userAPages.conversation().sendMessage(`READ message: ${i}`);
         }
@@ -333,7 +333,7 @@ test.describe('Conversations', () => {
       });
 
       await test.step('User B switches context to another conversation', async () => {
-        await pages.conversationList().openConversation(userC.fullName);
+        await pages.conversationList().getConversationLocator(userC.fullName).open();
       });
 
       await test.step('User A sends new unread messages to User B', async () => {
@@ -349,7 +349,7 @@ test.describe('Conversations', () => {
 
       await test.step('User B opens the conversation and verifies scroll position', async () => {
         await components.conversationSidebar().clickAllConversationsButton();
-        await pages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+        await pages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
         // 1. Verify conversation scroll is NOT at the very bottom (last unread shouldn't be visible yet)
         const lastUnreadMessage = pages
@@ -391,10 +391,10 @@ test.describe('Conversations', () => {
         await createGroup(userBPages, groupName, [userA, userC]);
 
         // User A and B both send messages to start conversation
-        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversationList().getConversationLocator(groupName).open();
         await userAPages.conversation().sendMessage('Message 1');
 
-        await userBPages.conversationList().openConversation(groupName);
+        await userBPages.conversationList().getConversationLocator(groupName).open();
         await userBPages.conversation().sendMessage('Message 2');
 
         // User A reacts to Message 2 while still a member
@@ -461,7 +461,7 @@ test.describe('Conversations', () => {
       pm => pm.webapp.pages,
     );
 
-    await userAPages.conversationList().openConversation(userB.fullName);
+    await userAPages.conversationList().getConversationLocator(userB.fullName).open();
 
     await userAPages.conversation().messageInput.pressSequentially(':) ', {delay: 100});
     expect(userAPages.conversation().messageInput).toContainText('🙂');
@@ -478,7 +478,7 @@ test.describe('Conversations', () => {
       await createGroup(adminPages, groupName, [userB, userC]);
 
       // User A renames the conversation
-      await adminPages.conversationList().openConversation(groupName);
+      await adminPages.conversationList().getConversationLocator(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
       await adminPages.conversationDetails().changeConversationName('New Group Name');
 
@@ -502,11 +502,11 @@ test.describe('Conversations', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(adminPages, groupName, [userB, userC]);
-      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversationList().getConversationLocator(groupName).open();
 
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
       // User A makes User C an admin
-      await adminPages.conversationList().openConversation(groupName);
+      await adminPages.conversationList().getConversationLocator(groupName).open();
       await adminPages.conversation().toggleGroupInformation();
       await adminPages.conversation().makeUserAdmin(userC.fullName);
 

--- a/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
@@ -44,7 +44,7 @@ test.describe('Conversations', () => {
       const userAPages = await PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages);
 
       await createGroup(userAPages, groupName, [userB, userC]);
-      await userAPages.conversationList().getConversationLocator(groupName).open();
+      await userAPages.conversationList().getConversation(groupName).open();
 
       const firstMessage = userAPages.conversation().systemMessages.first();
       await expect(firstMessage).toContainText(new RegExp(`You started the conversation\\s*${groupName}\\s*with`, 'i'));
@@ -63,7 +63,7 @@ test.describe('Conversations', () => {
       ]);
 
       await createGroup(userAPages, groupName, [userB, userC]);
-      userBPages.conversationList().getConversationLocator(groupName).open();
+      userBPages.conversationList().getConversation(groupName).open();
 
       const pattern = new RegExp(
         `${userA.fullName} started the conversation\\s*${groupName}\\s*with\\s*${userC.fullName}\\s*and\\s*you`,
@@ -113,7 +113,7 @@ test.describe('Conversations', () => {
 
       await createGroup(userAPages, groupName, [userB, userC]);
 
-      await userAPages.conversationList().getConversationLocator(groupName).open();
+      await userAPages.conversationList().getConversation(groupName).open();
       await userAPages.conversation().clickConversationInfoButton();
       await userAPages.conversationDetails().changeConversationName('New Group Name');
 
@@ -137,11 +137,11 @@ test.describe('Conversations', () => {
 
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();
-      await expect(adminPages.conversationList().getConversationLocator(guestUser.fullName)).toBeAttached();
+      await expect(adminPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
 
       await createGroup(adminPages, groupName, [userB, guestUser]);
 
-      await adminPages.conversationList().getConversationLocator(groupName).open();
+      await adminPages.conversationList().getConversation(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
       await expect(adminPages.conversationDetails().getUserRoleIcon(guestUser.fullName)).toHaveAttribute(
         'data-uie-name',
@@ -166,11 +166,11 @@ test.describe('Conversations', () => {
 
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();
-      await expect(adminPages.conversationList().getConversationLocator(guestUser.fullName)).toBeAttached();
+      await expect(adminPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
 
       await createGroup(adminPages, groupName, [userB, guestUser]);
 
-      await adminPages.conversationList().getConversationLocator(groupName).open();
+      await adminPages.conversationList().getConversation(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
 
       await expect(adminPages.conversation().membersList.filter({hasText: guestUser.fullName})).toBeVisible();
@@ -191,20 +191,20 @@ test.describe('Conversations', () => {
       await createGroup(adminPages, groupName, [userB, userC]);
 
       // Confirm that the userA is an admin in the group
-      await userBPages.conversationList().getConversationLocator(groupName).open();
+      await userBPages.conversationList().getConversation(groupName).open();
       await userBPages.conversation().clickConversationInfoButton();
       expect(userBPages.conversation().adminsList).toBeVisible();
       expect(userBPages.conversation().adminsList.getByRole('listitem')).toHaveCount(1);
 
       // User A leaves the group
-      await adminPages.conversationList().getConversationLocator(groupName).open();
+      await adminPages.conversationList().getConversation(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
       await adminPages.conversation().leaveConversation();
       await modals.leaveConversation().clickConfirm();
       await expect(adminPages.conversation().systemMessages.filter({hasText: 'You left'})).toBeVisible();
 
       // User B sees the empty admins section
-      await userBPages.conversationList().getConversationLocator(groupName).open();
+      await userBPages.conversationList().getConversation(groupName).open();
       await userBPages.conversation().clickConversationInfoButton();
       expect(adminPages.conversation().adminsList).not.toBeVisible();
     },
@@ -222,7 +222,7 @@ test.describe('Conversations', () => {
       await createGroup(adminPages, groupName, [userB]);
 
       // User B can see members section
-      await adminPages.conversationList().getConversationLocator(groupName).open();
+      await adminPages.conversationList().getConversation(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
       expect(adminPages.conversation().membersList).toBeVisible();
       expect(adminPages.conversation().membersList.getByRole('listitem')).toHaveCount(1);
@@ -231,7 +231,7 @@ test.describe('Conversations', () => {
       await adminPages.conversation().makeUserAdmin(userB.fullName);
 
       // User A and B cannot see members section
-      await userBPages.conversationList().getConversationLocator(groupName).open();
+      await userBPages.conversationList().getConversation(groupName).open();
 
       for (const userPages of [adminPages, userBPages]) {
         await userPages.conversation().clickConversationInfoButton();
@@ -248,7 +248,7 @@ test.describe('Conversations', () => {
       const adminPages = await PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages);
       await createGroup(adminPages, groupName, [userB]);
 
-      await adminPages.conversationList().getConversationLocator(groupName).open();
+      await adminPages.conversationList().getConversation(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
 
       await expect(adminPages.conversation().adminsList.getByRole('listitem')).toHaveCount(1);
@@ -269,7 +269,7 @@ test.describe('Conversations', () => {
 
       await createGroup(adminPage, groupName, [userB, externalUser]);
 
-      await adminPage.conversationList().getConversationLocator(groupName).open();
+      await adminPage.conversationList().getConversation(groupName).open();
       await adminPage.conversation().clickConversationInfoButton();
       await expect(adminPage.conversation().membersList).toBeVisible();
       await expect(adminPage.conversationDetails().getUserRoleIcon(externalUser.fullName)).toHaveAttribute(
@@ -290,12 +290,12 @@ test.describe('Conversations', () => {
       await createGroup(adminPages, groupName, [userB, userC]);
 
       // User A makes userB an admin
-      await adminPages.conversationList().getConversationLocator(groupName).open();
+      await adminPages.conversationList().getConversation(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
       await adminPages.conversation().makeUserAdmin(userB.fullName);
 
       // User B can see delete group and options in conversation details
-      await userBPages.conversationList().getConversationLocator(groupName).open();
+      await userBPages.conversationList().getConversation(groupName).open();
       await userBPages.conversation().clickConversationInfoButton();
       await expect(userBPages.conversationDetails().deleteGroupButton).toBeVisible();
       await expect(userBPages.conversationDetails().guestOptionsButton).toBeVisible();
@@ -316,10 +316,10 @@ test.describe('Conversations', () => {
       const totalMessages = 20;
 
       await test.step('User B opens conversation with User A to mark previous history as read', async () => {
-        await pages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+        await pages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
         // User A sends "Read" messages while User B is looking at the chat
-        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+        await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
         for (let i = 1; i <= totalMessages; i++) {
           await userAPages.conversation().sendMessage(`READ message: ${i}`);
         }
@@ -333,7 +333,7 @@ test.describe('Conversations', () => {
       });
 
       await test.step('User B switches context to another conversation', async () => {
-        await pages.conversationList().getConversationLocator(userC.fullName).open();
+        await pages.conversationList().getConversation(userC.fullName).open();
       });
 
       await test.step('User A sends new unread messages to User B', async () => {
@@ -341,15 +341,13 @@ test.describe('Conversations', () => {
           await userAPages.conversation().sendMessage(`UNREAD message: ${i}`);
         }
 
-        const conversationWithUserA = pages
-          .conversationList()
-          .getConversationLocator(userA.fullName, {protocol: 'mls'});
+        const conversationWithUserA = pages.conversationList().getConversation(userA.fullName, {protocol: 'mls'});
         await expect(conversationWithUserA.getByTestId('status-unread')).toContainText(`${totalMessages}`);
       });
 
       await test.step('User B opens the conversation and verifies scroll position', async () => {
         await components.conversationSidebar().clickAllConversationsButton();
-        await pages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+        await pages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
         // 1. Verify conversation scroll is NOT at the very bottom (last unread shouldn't be visible yet)
         const lastUnreadMessage = pages
@@ -370,9 +368,7 @@ test.describe('Conversations', () => {
         const lastMessage = pages.conversation().getMessage({sender: userA}).last();
         await lastMessage.scrollIntoViewIfNeeded();
 
-        const conversationWithUserA = pages
-          .conversationList()
-          .getConversationLocator(userA.fullName, {protocol: 'mls'});
+        const conversationWithUserA = pages.conversationList().getConversation(userA.fullName, {protocol: 'mls'});
         await expect(conversationWithUserA.getByTestId('status-unread')).not.toBeVisible();
       });
     },
@@ -391,10 +387,10 @@ test.describe('Conversations', () => {
         await createGroup(userBPages, groupName, [userA, userC]);
 
         // User A and B both send messages to start conversation
-        await userAPages.conversationList().getConversationLocator(groupName).open();
+        await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().sendMessage('Message 1');
 
-        await userBPages.conversationList().getConversationLocator(groupName).open();
+        await userBPages.conversationList().getConversation(groupName).open();
         await userBPages.conversation().sendMessage('Message 2');
 
         // User A reacts to Message 2 while still a member
@@ -461,7 +457,7 @@ test.describe('Conversations', () => {
       pm => pm.webapp.pages,
     );
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+    await userAPages.conversationList().getConversation(userB.fullName).open();
 
     await userAPages.conversation().messageInput.pressSequentially(':) ', {delay: 100});
     expect(userAPages.conversation().messageInput).toContainText('🙂');
@@ -478,7 +474,7 @@ test.describe('Conversations', () => {
       await createGroup(adminPages, groupName, [userB, userC]);
 
       // User A renames the conversation
-      await adminPages.conversationList().getConversationLocator(groupName).open();
+      await adminPages.conversationList().getConversation(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
       await adminPages.conversationDetails().changeConversationName('New Group Name');
 
@@ -502,11 +498,11 @@ test.describe('Conversations', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(adminPages, groupName, [userB, userC]);
-      await userBPages.conversationList().getConversationLocator(groupName).open();
+      await userBPages.conversationList().getConversation(groupName).open();
 
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
       // User A makes User C an admin
-      await adminPages.conversationList().getConversationLocator(groupName).open();
+      await adminPages.conversationList().getConversation(groupName).open();
       await adminPages.conversation().toggleGroupInformation();
       await adminPages.conversation().makeUserAdmin(userC.fullName);
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -59,7 +59,7 @@ test(
     await test.step('Team owner creates group conversation with team members', async () => {
       const {pages} = ownerPageManager.webapp;
       await createGroup(pages, conversationName, [member1, member2]);
-      await expect(pages.conversationList().getConversationLocator(conversationName)).toBeVisible();
+      await expect(pages.conversationList().getConversation(conversationName)).toBeVisible();
     });
 
     await test.step('Team owner adds a service to newly created group', async () => {
@@ -76,11 +76,11 @@ test(
     await test.step('All group participants send messages in a group', async () => {
       const {pages} = ownerPageManager.webapp;
       // Member1 and Member2 open the conversation (establish encrypted session)
-      await member1PageManager.webapp.pages.conversationList().getConversationLocator(conversationName).open();
-      await member2PageManager.webapp.pages.conversationList().getConversationLocator(conversationName).open();
+      await member1PageManager.webapp.pages.conversationList().getConversation(conversationName).open();
+      await member2PageManager.webapp.pages.conversationList().getConversation(conversationName).open();
 
       // Wait for encryption to be established by checking that conversation is fully loaded
-      await pages.conversationList().getConversationLocator(conversationName).open();
+      await pages.conversationList().getConversation(conversationName).open();
       await pages.conversation().conversationTitle.waitFor({state: 'visible'});
 
       // Now all members can send and receive encrypted messages
@@ -101,7 +101,7 @@ test(
       ).toBeVisible();
 
       // Owner verifies all messages are visible
-      await pages.conversationList().getConversationLocator(conversationName).open();
+      await pages.conversationList().getConversation(conversationName).open();
       await expect(pages.conversation().getMessage({content: `Hello from ${member1.firstName}!`})).toBeVisible();
       await expect(pages.conversation().getMessage({content: `Hello from ${member2.firstName}!`})).toBeVisible();
     });
@@ -109,7 +109,7 @@ test(
     await test.step('Team owner and group members react on received messages with reactions', async () => {
       const {pages} = ownerPageManager.webapp;
       // Owner reacts to member1's message with +1 (thumbs up)
-      await pages.conversationList().getConversationLocator(conversationName).open();
+      await pages.conversationList().getConversation(conversationName).open();
       const member1MessageForOwner = pages.conversation().getMessage({content: `Hello from ${member1.firstName}!`});
       await member1MessageForOwner.waitFor({state: 'visible'}); // Wait for message to be ready
       await pages.conversation().reactOnMessage(member1MessageForOwner, 'plus-one');
@@ -119,7 +119,7 @@ test(
       await pages.conversation().reactOnMessage(member2MessageForOwner, 'plus-one');
 
       // Member1 reacts to owner's message with heart (❤️)
-      await member1PageManager.webapp.pages.conversationList().getConversationLocator(conversationName).open();
+      await member1PageManager.webapp.pages.conversationList().getConversation(conversationName).open();
       const ownerMessageForMember1 = member1PageManager.webapp.pages
         .conversation()
         .getMessage({content: `Hello from ${owner.firstName}!`});
@@ -132,7 +132,7 @@ test(
       await member1PageManager.webapp.pages.conversation().reactOnMessage(member2MessageForMember1, 'heart');
 
       // Member2 reacts to owner's message with joy (😂)
-      await member2PageManager.webapp.pages.conversationList().getConversationLocator(conversationName).open();
+      await member2PageManager.webapp.pages.conversationList().getConversation(conversationName).open();
       const ownerMessageForMember2 = member2PageManager.webapp.pages
         .conversation()
         .getMessage({content: `Hello from ${owner.firstName}!`});
@@ -148,13 +148,13 @@ test(
     await test.step('All group participants make sure they see reactions from other group participants', async () => {
       const {pages} = ownerPageManager.webapp;
       // Owner verifies they can see heart (❤️) and joy (😂) reactions on their message from member1 and member2
-      await pages.conversationList().getConversationLocator(conversationName).open();
+      await pages.conversationList().getConversation(conversationName).open();
       const ownerMessage = pages.conversation().getMessage({content: `Hello from ${owner.firstName}!`});
       await expect(pages.conversation().getReactionOnMessage(ownerMessage, 'heart')).toBeVisible();
       await expect(pages.conversation().getReactionOnMessage(ownerMessage, 'joy')).toBeVisible();
 
       // Member1 verifies they can see thumbs up (+1) and joy (😂) reactions on their message from owner and member2
-      await member1PageManager.webapp.pages.conversationList().getConversationLocator(conversationName).open();
+      await member1PageManager.webapp.pages.conversationList().getConversation(conversationName).open();
       const member1Message = member1PageManager.webapp.pages
         .conversation()
         .getMessage({content: `Hello from ${member1.firstName}!`});
@@ -166,7 +166,7 @@ test(
       ).toBeVisible();
 
       // Member2 verifies they can see thumbs up (+1) and heart (❤️) reactions on their message from owner and member1
-      await member2PageManager.webapp.pages.conversationList().getConversationLocator(conversationName).open();
+      await member2PageManager.webapp.pages.conversationList().getConversation(conversationName).open();
       const member2Message = member2PageManager.webapp.pages
         .conversation()
         .getMessage({content: `Hello from ${member2.firstName}!`});

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -76,11 +76,11 @@ test(
     await test.step('All group participants send messages in a group', async () => {
       const {pages} = ownerPageManager.webapp;
       // Member1 and Member2 open the conversation (establish encrypted session)
-      await member1PageManager.webapp.pages.conversationList().openConversation(conversationName);
-      await member2PageManager.webapp.pages.conversationList().openConversation(conversationName);
+      await member1PageManager.webapp.pages.conversationList().getConversationLocator(conversationName).open();
+      await member2PageManager.webapp.pages.conversationList().getConversationLocator(conversationName).open();
 
       // Wait for encryption to be established by checking that conversation is fully loaded
-      await pages.conversationList().openConversation(conversationName);
+      await pages.conversationList().getConversationLocator(conversationName).open();
       await pages.conversation().conversationTitle.waitFor({state: 'visible'});
 
       // Now all members can send and receive encrypted messages
@@ -101,7 +101,7 @@ test(
       ).toBeVisible();
 
       // Owner verifies all messages are visible
-      await pages.conversationList().openConversation(conversationName);
+      await pages.conversationList().getConversationLocator(conversationName).open();
       await expect(pages.conversation().getMessage({content: `Hello from ${member1.firstName}!`})).toBeVisible();
       await expect(pages.conversation().getMessage({content: `Hello from ${member2.firstName}!`})).toBeVisible();
     });
@@ -109,7 +109,7 @@ test(
     await test.step('Team owner and group members react on received messages with reactions', async () => {
       const {pages} = ownerPageManager.webapp;
       // Owner reacts to member1's message with +1 (thumbs up)
-      await pages.conversationList().openConversation(conversationName);
+      await pages.conversationList().getConversationLocator(conversationName).open();
       const member1MessageForOwner = pages.conversation().getMessage({content: `Hello from ${member1.firstName}!`});
       await member1MessageForOwner.waitFor({state: 'visible'}); // Wait for message to be ready
       await pages.conversation().reactOnMessage(member1MessageForOwner, 'plus-one');
@@ -119,7 +119,7 @@ test(
       await pages.conversation().reactOnMessage(member2MessageForOwner, 'plus-one');
 
       // Member1 reacts to owner's message with heart (❤️)
-      await member1PageManager.webapp.pages.conversationList().openConversation(conversationName);
+      await member1PageManager.webapp.pages.conversationList().getConversationLocator(conversationName).open();
       const ownerMessageForMember1 = member1PageManager.webapp.pages
         .conversation()
         .getMessage({content: `Hello from ${owner.firstName}!`});
@@ -132,7 +132,7 @@ test(
       await member1PageManager.webapp.pages.conversation().reactOnMessage(member2MessageForMember1, 'heart');
 
       // Member2 reacts to owner's message with joy (😂)
-      await member2PageManager.webapp.pages.conversationList().openConversation(conversationName);
+      await member2PageManager.webapp.pages.conversationList().getConversationLocator(conversationName).open();
       const ownerMessageForMember2 = member2PageManager.webapp.pages
         .conversation()
         .getMessage({content: `Hello from ${owner.firstName}!`});
@@ -148,13 +148,13 @@ test(
     await test.step('All group participants make sure they see reactions from other group participants', async () => {
       const {pages} = ownerPageManager.webapp;
       // Owner verifies they can see heart (❤️) and joy (😂) reactions on their message from member1 and member2
-      await pages.conversationList().openConversation(conversationName);
+      await pages.conversationList().getConversationLocator(conversationName).open();
       const ownerMessage = pages.conversation().getMessage({content: `Hello from ${owner.firstName}!`});
       await expect(pages.conversation().getReactionOnMessage(ownerMessage, 'heart')).toBeVisible();
       await expect(pages.conversation().getReactionOnMessage(ownerMessage, 'joy')).toBeVisible();
 
       // Member1 verifies they can see thumbs up (+1) and joy (😂) reactions on their message from owner and member2
-      await member1PageManager.webapp.pages.conversationList().openConversation(conversationName);
+      await member1PageManager.webapp.pages.conversationList().getConversationLocator(conversationName).open();
       const member1Message = member1PageManager.webapp.pages
         .conversation()
         .getMessage({content: `Hello from ${member1.firstName}!`});
@@ -166,7 +166,7 @@ test(
       ).toBeVisible();
 
       // Member2 verifies they can see thumbs up (+1) and heart (❤️) reactions on their message from owner and member1
-      await member2PageManager.webapp.pages.conversationList().openConversation(conversationName);
+      await member2PageManager.webapp.pages.conversationList().getConversationLocator(conversationName).open();
       const member2Message = member2PageManager.webapp.pages
         .conversation()
         .getMessage({content: `Hello from ${member2.firstName}!`});

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
@@ -41,8 +41,8 @@ test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']
   const pageManager = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB)));
   const {pages, modals, components} = pageManager.webapp;
 
-  const userBConversation = pages.conversationList().getConversationLocator(userB.fullName);
-  const groupConversation = pages.conversationList().getConversationLocator(groupName);
+  const userBConversation = pages.conversationList().getConversation(userB.fullName);
+  const groupConversation = pages.conversationList().getConversation(groupName);
 
   await test.step('User generates data', async () => {
     await userBConversation.open();

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
@@ -41,13 +41,16 @@ test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']
   const pageManager = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB)));
   const {pages, modals, components} = pageManager.webapp;
 
+  const userBConversation = pages.conversationList().getConversationLocator(userB.fullName);
+  const groupConversation = pages.conversationList().getConversationLocator(groupName);
+
   await test.step('User generates data', async () => {
-    await pages.conversationList().openConversation(userB.fullName);
+    await userBConversation.open();
     await pages.conversation().sendMessage(personalMessage);
     await expect(pages.conversation().getMessage({content: personalMessage})).toBeVisible();
 
     await createGroup(pages, groupName, [userB]);
-    await pages.conversationList().openConversation(groupName);
+    await groupConversation.open();
     await pages.conversation().sendMessage(groupMessage);
 
     await expect(pages.conversation().getMessage({content: groupMessage})).toBeVisible();
@@ -73,10 +76,10 @@ test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']
   });
 
   await test.step("User doesn't see previous data (messages)", async () => {
-    await pages.conversationList().openConversation(userB.fullName);
+    await userBConversation.open();
     await expect(pages.conversation().getMessage({content: personalMessage})).not.toBeVisible();
 
-    await pages.conversationList().openConversation(groupName);
+    await groupConversation.open();
     await expect(pages.conversation().getMessage({content: groupMessage})).not.toBeVisible();
   });
 
@@ -99,10 +102,10 @@ test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']
 
   await test.step('All data (chat history, contacts) are restored', async () => {
     await components.conversationSidebar().clickAllConversationsButton();
-    await pages.conversationList().openConversation(groupName);
+    await groupConversation.open();
     await expect(pages.conversation().getMessage({content: groupMessage})).toBeVisible();
 
-    await pages.conversationList().openConversation(userB.fullName);
+    await userBConversation.open();
     await expect(pages.conversation().getMessage({content: personalMessage})).toBeVisible();
   });
 });

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
@@ -56,7 +56,7 @@ test(
         const response = await api.callingService.createInstance(member.password, member.email);
         callingServiceInstanceId = response.id;
         await api.callingService.setAcceptNextCall(callingServiceInstanceId);
-        await pages.conversationList().openConversation(channelName);
+        await pages.conversationList().getConversationLocator(channelName).open();
         await pages.conversation().clickCallButton();
       } catch (error: unknown) {
         console.error('Error during call initiation:', error);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
@@ -48,7 +48,7 @@ test(
     await test.step('Team owner creates a channel with available member', async () => {
       await pages.conversationList().clickCreateGroup();
       await modals.createConversation().createChannel(channelName, {members: [member]});
-      await expect(pages.conversationList().getConversationLocator(channelName)).toBeVisible();
+      await expect(pages.conversationList().getConversation(channelName)).toBeVisible();
     });
 
     await test.step('Owner starts a call in channel', async () => {
@@ -56,7 +56,7 @@ test(
         const response = await api.callingService.createInstance(member.password, member.email);
         callingServiceInstanceId = response.id;
         await api.callingService.setAcceptNextCall(callingServiceInstanceId);
-        await pages.conversationList().getConversationLocator(channelName).open();
+        await pages.conversationList().getConversation(channelName).open();
         await pages.conversation().clickCallButton();
       } catch (error: unknown) {
         console.error('Error during call initiation:', error);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
@@ -60,7 +60,7 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
   });
 
   await test.step('Team owner confirm member left', async () => {
-    await ownerPages.conversationList().openConversation(conversation1);
+    await ownerPages.conversationList().getConversationLocator(conversation1).open();
     await expect(ownerPages.conversation().systemMessages.filter({hasText: `${member.fullName} left`})).toBeVisible();
   });
 
@@ -76,7 +76,7 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
   });
 
   await test.step('Team member confirms admin status', async () => {
-    await memberPages.conversationList().openConversation(conversation2);
+    await memberPages.conversationList().getConversationLocator(conversation2).open();
     await memberPages.conversation().toggleGroupInformation();
     await expect(memberPages.conversation().adminsList.filter({hasText: member.fullName})).toBeVisible();
   });
@@ -88,12 +88,12 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
   });
 
   await test.step('Team member verifies they have been removed by the owner', async () => {
-    await memberPages.conversationList().openConversation(conversation2);
+    await memberPages.conversationList().getConversationLocator(conversation2).open();
     await expect(memberPages.conversation().messageInput).not.toBeAttached();
   });
 
   await test.step('Team owner add member back to the same conversation', async () => {
-    await ownerPages.conversationList().openConversation(conversation2);
+    await ownerPages.conversationList().getConversationLocator(conversation2).open();
     await expect(
       ownerPages.conversation().systemMessages.filter({hasText: `You removed ${member.fullName}`}),
     ).toBeVisible();
@@ -102,7 +102,7 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
   });
 
   await test.step('Team member confirms they have been added back to the conversation', async () => {
-    await memberPages.conversationList().openConversation(conversation2);
+    await memberPages.conversationList().getConversationLocator(conversation2).open();
     await memberPages.conversation().toggleGroupInformation();
     await expect(
       memberPages.conversation().systemMessages.filter({hasText: `${owner.fullName} added you to the conversation`}),
@@ -110,12 +110,12 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
   });
 
   await test.step('Team owner promote member to admin', async () => {
-    await ownerPages.conversationList().openConversation(conversation2);
+    await ownerPages.conversationList().getConversationLocator(conversation2).open();
     await ownerPages.conversation().makeUserAdmin(member.fullName);
   });
 
   await test.step('Team member confirms admin status', async () => {
-    await memberPages.conversationList().openConversation(conversation2);
+    await memberPages.conversationList().getConversationLocator(conversation2).open();
     await memberPages.conversation().toggleGroupInformation();
     await expect(memberPages.conversation().adminsList.filter({hasText: member.fullName})).toBeVisible();
   });

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
@@ -42,7 +42,7 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
   await test.step('Team owner creates a channel with available member', async () => {
     await ownerPages.conversationList().clickCreateGroup();
     await ownerModals.createConversation().createChannel(conversation1, {members: [member]});
-    await expect(ownerPages.conversationList().getConversationLocator(conversation1)).toBeVisible();
+    await expect(ownerPages.conversationList().getConversation(conversation1)).toBeVisible();
   });
 
   await test.step('Team members leave the conversation', async () => {
@@ -60,14 +60,14 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
   });
 
   await test.step('Team owner confirm member left', async () => {
-    await ownerPages.conversationList().getConversationLocator(conversation1).open();
+    await ownerPages.conversationList().getConversation(conversation1).open();
     await expect(ownerPages.conversation().systemMessages.filter({hasText: `${member.fullName} left`})).toBeVisible();
   });
 
   await test.step('Team owner creates another channel', async () => {
     await ownerPages.conversationList().clickCreateGroup();
     await ownerModals.createConversation().createChannel(conversation2, {members: [member]});
-    await expect(ownerPages.conversationList().getConversationLocator(conversation2)).toBeVisible();
+    await expect(ownerPages.conversationList().getConversation(conversation2)).toBeVisible();
   });
 
   await test.step('Team owner makes the member an admin', async () => {
@@ -76,7 +76,7 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
   });
 
   await test.step('Team member confirms admin status', async () => {
-    await memberPages.conversationList().getConversationLocator(conversation2).open();
+    await memberPages.conversationList().getConversation(conversation2).open();
     await memberPages.conversation().toggleGroupInformation();
     await expect(memberPages.conversation().adminsList.filter({hasText: member.fullName})).toBeVisible();
   });
@@ -88,12 +88,12 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
   });
 
   await test.step('Team member verifies they have been removed by the owner', async () => {
-    await memberPages.conversationList().getConversationLocator(conversation2).open();
+    await memberPages.conversationList().getConversation(conversation2).open();
     await expect(memberPages.conversation().messageInput).not.toBeAttached();
   });
 
   await test.step('Team owner add member back to the same conversation', async () => {
-    await ownerPages.conversationList().getConversationLocator(conversation2).open();
+    await ownerPages.conversationList().getConversation(conversation2).open();
     await expect(
       ownerPages.conversation().systemMessages.filter({hasText: `You removed ${member.fullName}`}),
     ).toBeVisible();
@@ -102,7 +102,7 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
   });
 
   await test.step('Team member confirms they have been added back to the conversation', async () => {
-    await memberPages.conversationList().getConversationLocator(conversation2).open();
+    await memberPages.conversationList().getConversation(conversation2).open();
     await memberPages.conversation().toggleGroupInformation();
     await expect(
       memberPages.conversation().systemMessages.filter({hasText: `${owner.fullName} added you to the conversation`}),
@@ -110,12 +110,12 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
   });
 
   await test.step('Team owner promote member to admin', async () => {
-    await ownerPages.conversationList().getConversationLocator(conversation2).open();
+    await ownerPages.conversationList().getConversation(conversation2).open();
     await ownerPages.conversation().makeUserAdmin(member.fullName);
   });
 
   await test.step('Team member confirms admin status', async () => {
-    await memberPages.conversationList().getConversationLocator(conversation2).open();
+    await memberPages.conversationList().getConversation(conversation2).open();
     await memberPages.conversation().toggleGroupInformation();
     await expect(memberPages.conversation().adminsList.filter({hasText: member.fullName})).toBeVisible();
   });

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -40,10 +40,12 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
     ...memberPages.map(page => PageManager.from(page)),
   ];
 
+  const conversation = ownerPageManager.webapp.pages.conversationList().getConversationLocator(conversationName);
+
   await test.step('Team owner creates a group with all the five members', async () => {
     const {pages} = ownerPageManager.webapp;
     await createGroup(pages, conversationName, members);
-    await expect(pages.conversationList().getConversationLocator(conversationName)).toBeVisible();
+    await expect(conversation).toBeVisible();
   });
 
   await test.step('Team owner sends a message in the conversation', async () => {
@@ -64,7 +66,7 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
 
   await test.step('Team owner signed in to the application and verify messages', async () => {
     const {pages} = ownerPageManager.webapp;
-    await pages.conversationList().openConversation(conversationName);
+    await conversation.open();
     await Promise.all(
       members.map(async member => {
         const message = pages.conversation().getMessage({content: `Hello team! ${member.firstName} here.`});
@@ -90,14 +92,14 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
   await test.step('Team owner open searched conversation', async () => {
     const {pages} = ownerPageManager.webapp;
     await pages.conversationList().searchConversationsInput.fill(conversationName);
-    await pages.conversationList().openConversation(conversationName);
-    await expect(pages.conversationList().getConversationLocator(conversationName)).toBeVisible();
-    await pages.conversationList().openConversation(conversationName);
+    await conversation.open();
+    await expect(conversation).toBeVisible();
+    await conversation.open();
   });
 
   await test.step('Team owner leave conversation with clear history', async () => {
     const {pages, modals} = ownerPageManager.webapp;
-    const contextMenu = await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
+    const contextMenu = await conversation.openContextMenu();
     await contextMenu.leaveConversationButton.click();
     await modals.leaveConversation().toggleCheckbox();
     await modals.leaveConversation().clickConfirm();

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -40,7 +40,7 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
     ...memberPages.map(page => PageManager.from(page)),
   ];
 
-  const conversation = ownerPageManager.webapp.pages.conversationList().getConversationLocator(conversationName);
+  const conversation = ownerPageManager.webapp.pages.conversationList().getConversation(conversationName);
 
   await test.step('Team owner creates a group with all the five members', async () => {
     const {pages} = ownerPageManager.webapp;

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
@@ -49,7 +49,7 @@ test(
 
     await test.step('Owner starts call', async () => {
       const {pages, components} = ownerPageManager.webapp;
-      await pages.conversationList().openConversation(conversationName);
+      await pages.conversationList().getConversationLocator(conversationName).open();
       await pages.conversation().startCall();
 
       await expect(components.calling().callCell).toBeVisible();
@@ -57,7 +57,7 @@ test(
 
     await test.step('Member joins call and goes full screen', async () => {
       const {pages, components} = memberPageManager.webapp;
-      await pages.conversationList().openConversation(conversationName);
+      await pages.conversationList().getConversationLocator(conversationName).open();
       const memberCalling = components.calling();
       await expect(memberCalling.callCell).toBeVisible();
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
@@ -49,7 +49,7 @@ test(
 
     await test.step('Owner starts call', async () => {
       const {pages, components} = ownerPageManager.webapp;
-      await pages.conversationList().getConversationLocator(conversationName).open();
+      await pages.conversationList().getConversation(conversationName).open();
       await pages.conversation().startCall();
 
       await expect(components.calling().callCell).toBeVisible();
@@ -57,7 +57,7 @@ test(
 
     await test.step('Member joins call and goes full screen', async () => {
       const {pages, components} = memberPageManager.webapp;
-      await pages.conversationList().getConversationLocator(conversationName).open();
+      await pages.conversationList().getConversation(conversationName).open();
       const memberCalling = components.calling();
       await expect(memberCalling.callCell).toBeVisible();
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
@@ -51,7 +51,7 @@ test('Group Video call', {tag: ['@TC-8637', '@crit-flow-web']}, async ({createTe
   });
 
   await test.step('Owner invites guest user to the group', async () => {
-    await ownerPages.conversationList().openConversation(conversationName);
+    await ownerPages.conversationList().getConversationLocator(conversationName).open();
     await ownerPages.conversation().clickConversationTitle();
     await ownerPages.conversationDetails().clickAddPeopleButton();
     await ownerPages.conversationDetails().addUsersToConversation([guestUser.fullName]);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
@@ -43,7 +43,7 @@ test('Group Video call', {tag: ['@TC-8637', '@crit-flow-web']}, async ({createTe
   await test.step('Guest user accepts connection request from owner', async () => {
     await guestPages.conversationList().openPendingConnectionRequest();
     await guestPages.connectRequest().clickConnectButton();
-    await expect(ownerPages.conversationList().getConversationLocator(guestUser.fullName)).toBeAttached();
+    await expect(ownerPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
   });
 
   await test.step('Owner and team member are in a group conversation together', async () => {
@@ -51,7 +51,7 @@ test('Group Video call', {tag: ['@TC-8637', '@crit-flow-web']}, async ({createTe
   });
 
   await test.step('Owner invites guest user to the group', async () => {
-    await ownerPages.conversationList().getConversationLocator(conversationName).open();
+    await ownerPages.conversationList().getConversation(conversationName).open();
     await ownerPages.conversation().clickConversationTitle();
     await ownerPages.conversationDetails().clickAddPeopleButton();
     await ownerPages.conversationDetails().addUsersToConversation([guestUser.fullName]);
@@ -60,7 +60,7 @@ test('Group Video call', {tag: ['@TC-8637', '@crit-flow-web']}, async ({createTe
   });
 
   await test.step('Guest user joins the group', async () => {
-    await expect(guestPages.conversationList().getConversationLocator(conversationName)).toBeVisible();
+    await expect(guestPages.conversationList().getConversation(conversationName)).toBeVisible();
   });
 
   await test.step('Owner calls the group', async () => {

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/joinTeam-TC-8635.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/joinTeam-TC-8635.spec.ts
@@ -44,10 +44,10 @@ test(
     const userAPages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(owner))).webapp.pages;
 
     await test.step('A sends text to owner', async () => {
-      await userAPages.conversationList().openConversation(owner.fullName);
+      await userAPages.conversationList().getConversationLocator(owner.fullName).open();
       await userAPages.conversation().sendMessage('Hello Team Owner!');
 
-      await ownerPages.conversationList().openConversation(userA.fullName);
+      await ownerPages.conversationList().getConversationLocator(userA.fullName).open();
       await expect(ownerPages.conversation().getMessage({content: 'Hello Team Owner!'})).toBeVisible();
     });
 
@@ -57,7 +57,7 @@ test(
     });
 
     await test.step('Owner adds A to group chat and mentions him', async () => {
-      await ownerPages.conversationList().openConversation('Test Group');
+      await ownerPages.conversationList().getConversationLocator('Test Group').open();
 
       // Add user A to group chat
       await ownerPages.conversation().toggleGroupInformation();
@@ -69,7 +69,7 @@ test(
     });
 
     await test.step('User A receives mention in group chat', async () => {
-      await userAPages.conversationList().openConversation('Test Group');
+      await userAPages.conversationList().getConversationLocator('Test Group').open();
       await expect(userAPages.conversation().getMessage({content: `@${userA.fullName}`})).toBeVisible();
     });
   },

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/joinTeam-TC-8635.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/joinTeam-TC-8635.spec.ts
@@ -44,10 +44,10 @@ test(
     const userAPages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(owner))).webapp.pages;
 
     await test.step('A sends text to owner', async () => {
-      await userAPages.conversationList().getConversationLocator(owner.fullName).open();
+      await userAPages.conversationList().getConversation(owner.fullName).open();
       await userAPages.conversation().sendMessage('Hello Team Owner!');
 
-      await ownerPages.conversationList().getConversationLocator(userA.fullName).open();
+      await ownerPages.conversationList().getConversation(userA.fullName).open();
       await expect(ownerPages.conversation().getMessage({content: 'Hello Team Owner!'})).toBeVisible();
     });
 
@@ -57,7 +57,7 @@ test(
     });
 
     await test.step('Owner adds A to group chat and mentions him', async () => {
-      await ownerPages.conversationList().getConversationLocator('Test Group').open();
+      await ownerPages.conversationList().getConversation('Test Group').open();
 
       // Add user A to group chat
       await ownerPages.conversation().toggleGroupInformation();
@@ -69,7 +69,7 @@ test(
     });
 
     await test.step('User A receives mention in group chat', async () => {
-      await userAPages.conversationList().getConversationLocator('Test Group').open();
+      await userAPages.conversationList().getConversation('Test Group').open();
       await expect(userAPages.conversation().getMessage({content: `@${userA.fullName}`})).toBeVisible();
     });
   },

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -57,12 +57,15 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTea
 
     // When a conversation between two non team members is created proteus will be used by default and later upgrade to mls.
     // To avoid loosing messages during the fast execution with playwright we wait for the upgrade is finished to open the MLS conversation.
-    await pages.conversationList().openConversation(memberB.fullName, {protocol: 'mls'});
+    await pages.conversationList().getConversationLocator(memberB.fullName, {protocol: 'mls'}).open();
     await components.inputBarControls().clickShareImage(imageFilePath);
     await expect(pages.conversation().getImageLocator(memberA)).toBeVisible();
   });
   await test.step('User B can see the image in the conversation', async () => {
-    await memberBPageManager.webapp.pages.conversationList().openConversation(memberA.fullName, {protocol: 'mls'});
+    await memberBPageManager.webapp.pages
+      .conversationList()
+      .getConversationLocator(memberA.fullName, {protocol: 'mls'})
+      .open();
 
     // Verify that the image is visible in the conversation
     await expect(memberBPageManager.webapp.pages.conversation().getImageLocator(memberA)).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -57,14 +57,14 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTea
 
     // When a conversation between two non team members is created proteus will be used by default and later upgrade to mls.
     // To avoid loosing messages during the fast execution with playwright we wait for the upgrade is finished to open the MLS conversation.
-    await pages.conversationList().getConversationLocator(memberB.fullName, {protocol: 'mls'}).open();
+    await pages.conversationList().getConversation(memberB.fullName, {protocol: 'mls'}).open();
     await components.inputBarControls().clickShareImage(imageFilePath);
     await expect(pages.conversation().getImageLocator(memberA)).toBeVisible();
   });
   await test.step('User B can see the image in the conversation', async () => {
     await memberBPageManager.webapp.pages
       .conversationList()
-      .getConversationLocator(memberA.fullName, {protocol: 'mls'})
+      .getConversation(memberA.fullName, {protocol: 'mls'})
       .open();
 
     // Verify that the image is visible in the conversation

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -54,13 +54,13 @@ test(
 
     await test.step('User A mentions User B in the channel', async () => {
       const {pages} = userAPageManager.webapp;
-      await pages.conversationList().getConversationLocator(channelName).open();
+      await pages.conversationList().getConversation(channelName).open();
       await pages.conversation().sendMessageWithUserMention(userB.fullName, messageText);
     });
 
     await test.step('User B should receive mention', async () => {
       const {pages} = userBPageManager.webapp;
-      const conversation = pages.conversationList().getConversationLocator(channelName);
+      const conversation = pages.conversationList().getConversation(channelName);
       await expect(conversation.mentionIndicator).toBeVisible();
 
       await conversation.open();
@@ -69,7 +69,7 @@ test(
 
     await test.step('User A sends image', async () => {
       const {pages, components} = userAPageManager.webapp;
-      await pages.conversationList().getConversationLocator(channelName).open();
+      await pages.conversationList().getConversation(channelName).open();
       await components.inputBarControls().clickShareImage(imageFilePath);
 
       await expect(

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -54,21 +54,22 @@ test(
 
     await test.step('User A mentions User B in the channel', async () => {
       const {pages} = userAPageManager.webapp;
-      await pages.conversationList().openConversation(channelName);
+      await pages.conversationList().getConversationLocator(channelName).open();
       await pages.conversation().sendMessageWithUserMention(userB.fullName, messageText);
     });
 
     await test.step('User B should receive mention', async () => {
       const {pages} = userBPageManager.webapp;
-      await expect(pages.conversationList().getConversationLocator(channelName).mentionIndicator).toBeVisible();
+      const conversation = pages.conversationList().getConversationLocator(channelName);
+      await expect(conversation.mentionIndicator).toBeVisible();
 
-      await pages.conversationList().openConversation(channelName);
+      await conversation.open();
       await expect(pages.conversation().getMessage({content: `@${userB.fullName} ${messageText}`})).toBeVisible();
     });
 
     await test.step('User A sends image', async () => {
       const {pages, components} = userAPageManager.webapp;
-      await pages.conversationList().openConversation(channelName);
+      await pages.conversationList().getConversationLocator(channelName).open();
       await components.inputBarControls().clickShareImage(imageFilePath);
 
       await expect(

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -52,21 +52,22 @@ test(
 
     await test.step('User A mentions User B in the group', async () => {
       const {pages} = userAPageManager.webapp;
-      await pages.conversationList().openConversation(conversationName);
+      await pages.conversationList().getConversationLocator(conversationName).open();
       await pages.conversation().sendMessageWithUserMention(userB.fullName, messageText);
     });
 
     await test.step('User B should receive mention', async () => {
       const {pages} = userBPageManager.webapp;
-      await expect(pages.conversationList().getConversationLocator(conversationName).mentionIndicator).toBeVisible();
+      const conversation = pages.conversationList().getConversationLocator(conversationName);
+      await expect(conversation.mentionIndicator).toBeVisible();
 
-      await pages.conversationList().openConversation(conversationName);
+      await conversation.open();
       await expect(pages.conversation().getMessage({content: `@${userB.fullName} ${messageText}`})).toBeVisible();
     });
 
     await test.step('User A sends image', async () => {
       const {pages, components} = userAPageManager.webapp;
-      await pages.conversationList().openConversation(conversationName);
+      await pages.conversationList().getConversationLocator(conversationName).open();
       await components.inputBarControls().clickShareImage(imageFilePath);
 
       await expect(

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -52,13 +52,13 @@ test(
 
     await test.step('User A mentions User B in the group', async () => {
       const {pages} = userAPageManager.webapp;
-      await pages.conversationList().getConversationLocator(conversationName).open();
+      await pages.conversationList().getConversation(conversationName).open();
       await pages.conversation().sendMessageWithUserMention(userB.fullName, messageText);
     });
 
     await test.step('User B should receive mention', async () => {
       const {pages} = userBPageManager.webapp;
-      const conversation = pages.conversationList().getConversationLocator(conversationName);
+      const conversation = pages.conversationList().getConversation(conversationName);
       await expect(conversation.mentionIndicator).toBeVisible();
 
       await conversation.open();
@@ -67,7 +67,7 @@ test(
 
     await test.step('User A sends image', async () => {
       const {pages, components} = userAPageManager.webapp;
-      await pages.conversationList().getConversationLocator(conversationName).open();
+      await pages.conversationList().getConversation(conversationName).open();
       await components.inputBarControls().clickShareImage(imageFilePath);
 
       await expect(

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
@@ -46,7 +46,7 @@ test(
       const {pages} = userAPageManager.webapp;
       await api.callingService.setAcceptNextCall(callingServiceInstanceId);
 
-      await pages.conversationList().getConversationLocator(userB.fullName).open();
+      await pages.conversationList().getConversation(userB.fullName).open();
       await pages.conversation().clickConversationInfoButton();
       await pages.conversation().clickCallButton();
     });

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
@@ -46,7 +46,7 @@ test(
       const {pages} = userAPageManager.webapp;
       await api.callingService.setAcceptNextCall(callingServiceInstanceId);
 
-      await pages.conversationList().openConversation(userB.fullName);
+      await pages.conversationList().getConversationLocator(userB.fullName).open();
       await pages.conversation().clickConversationInfoButton();
       await pages.conversation().clickCallButton();
     });

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
@@ -90,7 +90,7 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
   await test.step('Personal user A sends a connection request to personal user B', async () => {
     const {pages, modals} = pageManagerA.webapp;
     await modals.userProfile().clickConnectButton();
-    await pages.conversationList().openConversation(userB.fullName);
+    await pages.conversationList().getConversationLocator(userB.fullName).open();
     await expect(pages.outgoingConnection().uniqueUsernameOutgoing).toContainText(userB.username);
     await expect(pages.outgoingConnection().getPendingConnectionIconLocator(userB.fullName)).toBeVisible();
   });
@@ -103,12 +103,12 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
 
   await test.step('Personal user A send message to personal user B', async () => {
     const {pages} = pageManagerA.webapp;
-    await pages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await pages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
     await pages.conversation().sendMessage(`Hello! ${userA.firstName} here.`);
   });
 
   await test.step('Personal user B can see the message from user A', async () => {
-    await pageManagerB.webapp.pages.conversationList().openConversation(userA.fullName);
+    await pageManagerB.webapp.pages.conversationList().getConversationLocator(userA.fullName).open();
     await expect(
       pageManagerB.webapp.pages.conversation().getMessage({content: `Hello! ${userA.firstName} here.`}),
     ).toBeVisible();
@@ -135,7 +135,7 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
     await pageManagerC.webapp.components.conversationSidebar().clickConnectButton();
     await pageManagerC.webapp.pages.startUI().selectUsers(userA.username);
     await pageManagerC.webapp.modals.userProfile().clickConnectButton();
-    await pageManagerC.webapp.pages.conversationList().openConversation(userA.fullName);
+    await pageManagerC.webapp.pages.conversationList().getConversationLocator(userA.fullName).open();
     await expect(pageManagerC.webapp.pages.outgoingConnection().uniqueUsernameOutgoing).toContainText(userA.username);
     await expect(
       pageManagerC.webapp.pages.outgoingConnection().getPendingConnectionIconLocator(userA.fullName),
@@ -150,12 +150,12 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
 
   await test.step('Personal user A send message to personal user C', async () => {
     const {pages} = pageManagerA.webapp;
-    await pages.conversationList().openConversation(userC.fullName, {protocol: 'mls'});
+    await pages.conversationList().getConversationLocator(userC.fullName, {protocol: 'mls'}).open();
     await pages.conversation().sendMessage(`Hello! ${userA.firstName} here.`);
   });
 
   await test.step('Personal user C can see the message from user A', async () => {
-    await pageManagerC.webapp.pages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await pageManagerC.webapp.pages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
     await expect(
       pageManagerC.webapp.pages.conversation().getMessage({content: `Hello! ${userA.firstName} here.`}),
     ).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
@@ -90,7 +90,7 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
   await test.step('Personal user A sends a connection request to personal user B', async () => {
     const {pages, modals} = pageManagerA.webapp;
     await modals.userProfile().clickConnectButton();
-    await pages.conversationList().getConversationLocator(userB.fullName).open();
+    await pages.conversationList().getConversation(userB.fullName).open();
     await expect(pages.outgoingConnection().uniqueUsernameOutgoing).toContainText(userB.username);
     await expect(pages.outgoingConnection().getPendingConnectionIconLocator(userB.fullName)).toBeVisible();
   });
@@ -98,17 +98,17 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
   await test.step('Personal user B accepts request from A', async () => {
     await pageManagerB.webapp.pages.conversationList().openPendingConnectionRequest();
     await pageManagerB.webapp.pages.connectRequest().clickConnectButton();
-    await expect(pageManagerB.webapp.pages.conversationList().getConversationLocator(userA.fullName)).toBeVisible();
+    await expect(pageManagerB.webapp.pages.conversationList().getConversation(userA.fullName)).toBeVisible();
   });
 
   await test.step('Personal user A send message to personal user B', async () => {
     const {pages} = pageManagerA.webapp;
-    await pages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await pages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     await pages.conversation().sendMessage(`Hello! ${userA.firstName} here.`);
   });
 
   await test.step('Personal user B can see the message from user A', async () => {
-    await pageManagerB.webapp.pages.conversationList().getConversationLocator(userA.fullName).open();
+    await pageManagerB.webapp.pages.conversationList().getConversation(userA.fullName).open();
     await expect(
       pageManagerB.webapp.pages.conversation().getMessage({content: `Hello! ${userA.firstName} here.`}),
     ).toBeVisible();
@@ -116,7 +116,7 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
 
   await test.step('Personal user A blocks personal user B', async () => {
     const {pages, modals} = pageManagerA.webapp;
-    const conversation = pages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'});
+    const conversation = pages.conversationList().getConversation(userB.fullName, {protocol: 'mls'});
 
     await expect(conversation).not.toContainText('Blocked');
     const contextMenu = await conversation.openContextMenu();
@@ -135,7 +135,7 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
     await pageManagerC.webapp.components.conversationSidebar().clickConnectButton();
     await pageManagerC.webapp.pages.startUI().selectUsers(userA.username);
     await pageManagerC.webapp.modals.userProfile().clickConnectButton();
-    await pageManagerC.webapp.pages.conversationList().getConversationLocator(userA.fullName).open();
+    await pageManagerC.webapp.pages.conversationList().getConversation(userA.fullName).open();
     await expect(pageManagerC.webapp.pages.outgoingConnection().uniqueUsernameOutgoing).toContainText(userA.username);
     await expect(
       pageManagerC.webapp.pages.outgoingConnection().getPendingConnectionIconLocator(userA.fullName),
@@ -150,12 +150,12 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
 
   await test.step('Personal user A send message to personal user C', async () => {
     const {pages} = pageManagerA.webapp;
-    await pages.conversationList().getConversationLocator(userC.fullName, {protocol: 'mls'}).open();
+    await pages.conversationList().getConversation(userC.fullName, {protocol: 'mls'}).open();
     await pages.conversation().sendMessage(`Hello! ${userA.firstName} here.`);
   });
 
   await test.step('Personal user C can see the message from user A', async () => {
-    await pageManagerC.webapp.pages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await pageManagerC.webapp.pages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await expect(
       pageManagerC.webapp.pages.conversation().getMessage({content: `Hello! ${userA.firstName} here.`}),
     ).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/DeepLinks/deepLinks.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/DeepLinks/deepLinks.spec.ts
@@ -153,7 +153,7 @@ test.describe('Deep Links', () => {
       );
 
       await test.step('User B sends all profile links to User A', async () => {
-        await userBPages.conversationList().openConversation(userA.fullName);
+        await userBPages.conversationList().getConversationLocator(userA.fullName).open();
 
         const userLabels = ['A', 'B', 'C', 'D'];
 
@@ -164,17 +164,17 @@ test.describe('Deep Links', () => {
 
       await test.step('User B creates group and sends conversation join link to User A', async () => {
         await createGroup(userBPages, groupName, []);
-        await userBPages.conversationList().openConversation(groupName);
+        await userBPages.conversationList().getConversationLocator(groupName).open();
         await userBPages.conversation().toggleGroupInformation();
         await userBPages.conversationDetails().openGuestOptions();
 
         const conversationJoinLink = await userBPages.guestOptions().createLink();
-        await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
         await userBPages.conversation().sendMessage(`Group conversation: ${conversationJoinLink}`);
       });
 
       await test.step('User A verifies information for every user profile modal', async () => {
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
 
         // Verify information for User A
         await userAPages.conversation().getMessage({content: 'User A:'}).getByRole('link').click();

--- a/apps/webapp/test/e2e_tests/specs/DeepLinks/deepLinks.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/DeepLinks/deepLinks.spec.ts
@@ -153,7 +153,7 @@ test.describe('Deep Links', () => {
       );
 
       await test.step('User B sends all profile links to User A', async () => {
-        await userBPages.conversationList().getConversationLocator(userA.fullName).open();
+        await userBPages.conversationList().getConversation(userA.fullName).open();
 
         const userLabels = ['A', 'B', 'C', 'D'];
 
@@ -164,17 +164,17 @@ test.describe('Deep Links', () => {
 
       await test.step('User B creates group and sends conversation join link to User A', async () => {
         await createGroup(userBPages, groupName, []);
-        await userBPages.conversationList().getConversationLocator(groupName).open();
+        await userBPages.conversationList().getConversation(groupName).open();
         await userBPages.conversation().toggleGroupInformation();
         await userBPages.conversationDetails().openGuestOptions();
 
         const conversationJoinLink = await userBPages.guestOptions().createLink();
-        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+        await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
         await userBPages.conversation().sendMessage(`Group conversation: ${conversationJoinLink}`);
       });
 
       await test.step('User A verifies information for every user profile modal', async () => {
-        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+        await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
 
         // Verify information for User A
         await userAPages.conversation().getMessage({content: 'User A:'}).getByRole('link').click();
@@ -219,7 +219,7 @@ test.describe('Deep Links', () => {
         await expect(userAModals.confirm().modal).toBeVisible();
         await expect(userAModals.confirm().actionButton).toContainText('Join Conversation');
         await userAModals.confirm().actionButton.click();
-        await expect(userAPages.conversationList().getConversationLocator(groupName)).toBeVisible();
+        await expect(userAPages.conversationList().getConversation(groupName)).toBeVisible();
       });
     });
   }

--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -43,7 +43,7 @@ test.describe('Delete', () => {
       const deviceA = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
 
       const deviceB = (await PageManager.from(createPage(withLogin(userA, {confirmNewHistory: true})))).webapp.pages;
-      await deviceB.conversationList().getConversationLocator(userB.fullName).open();
+      await deviceB.conversationList().getConversation(userB.fullName).open();
 
       await deviceA.conversation().sendMessage('Test Message');
 
@@ -67,8 +67,8 @@ test.describe('Delete', () => {
 
     await test.step('Create test group', async () => {
       await createGroup(userAPages, 'Test Group', [userB]);
-      await userAPages.conversationList().getConversationLocator('Test Group').open();
-      await userBPages.conversationList().getConversationLocator('Test Group').open();
+      await userAPages.conversationList().getConversation('Test Group').open();
+      await userBPages.conversationList().getConversation('Test Group').open();
     });
 
     let messageA: Locator;
@@ -102,7 +102,7 @@ test.describe('Delete', () => {
       ]);
 
       await createGroup(userAPages, 'Test Group', [userB]);
-      await userBPages.conversationList().getConversationLocator('Test Group').open();
+      await userBPages.conversationList().getConversation('Test Group').open();
 
       const systemMessage = userAPages.conversation().systemMessages.last();
 
@@ -119,7 +119,7 @@ test.describe('Delete', () => {
     async ({createPage}) => {
       const {components, pages} = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))))
         .webapp;
-      const conversation = await pages.conversationList().getConversationLocator(userB.fullName).open();
+      const conversation = await pages.conversationList().getConversation(userB.fullName).open();
 
       let message: Locator;
       await test.step('Send and delete message', async () => {
@@ -162,13 +162,13 @@ test.describe('Delete', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       let userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Test Message');
 
       const messageA = userAPages.conversation().getMessage({sender: userA});
       await expect(messageA).toContainText('Test Message');
 
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       let messageB = userBPages.conversation().getMessage({sender: userA});
       await expect(messageB).toContainText('Test Message');
 
@@ -176,7 +176,7 @@ test.describe('Delete', () => {
       await userAPages.conversation().deleteMessage(messageA, 'Everyone');
 
       userBPages = (await PageManager.from(createPage(context, withLogin(userB)))).webapp.pages;
-      await userBPages.conversationList().getConversationLocator(userA.fullName).open();
+      await userBPages.conversationList().getConversation(userA.fullName).open();
 
       messageB = userBPages.conversation().getMessage({sender: userA});
 
@@ -194,8 +194,8 @@ test.describe('Delete', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Test Message');
 
       const messageA = userAPages.conversation().getMessage({sender: userA});
@@ -224,14 +224,14 @@ test.describe('Delete', () => {
 
       await test.step('Create test group', async () => {
         await createGroup(userAPages, 'Test Group', [userB]);
-        await userBPages.conversationList().getConversationLocator('Test Group').open();
+        await userBPages.conversationList().getConversation('Test Group').open();
       });
 
       let messageA: Locator;
       let messageB: Locator;
 
       await test.step('Send and delete message from user A to B', async () => {
-        await userAPages.conversationList().getConversationLocator('Test Group').open();
+        await userAPages.conversationList().getConversation('Test Group').open();
         await userAPages.conversation().sendMessage('Test Message');
 
         messageA = userAPages.conversation().getMessage({sender: userA});
@@ -328,8 +328,8 @@ test.describe('Delete', () => {
       const userBPages = PageManager.from(pageB).webapp.pages;
 
       await test.step('Await mls conversation creation', async () => {
-        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+        await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+        await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       });
 
       await test.step('Execute send action', async () => {
@@ -367,16 +367,16 @@ test.describe('Delete', () => {
       await test.step('Create group as second conversation', async () => {
         // We need to create a second conversation in order to switch to it to ensure the unread marker can be shown on the not open conversation
         await createGroup(userAPages, 'Test Group', [userB]);
-        await userBPages.conversationList().getConversationLocator('Test Group').open();
+        await userBPages.conversationList().getConversation('Test Group').open();
       });
 
       await test.step('Send message from user A to B', async () => {
-        await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+        await userAPages.conversationList().getConversation(userB.fullName).open();
         await userAPages.conversation().sendMessage('Test Message');
       });
 
       await test.step('Check user B has a unread conversation with A', async () => {
-        const conversation = userBPages.conversationList().getConversationLocator(userA.fullName);
+        const conversation = userBPages.conversationList().getConversation(userA.fullName);
         await expect(conversation.getByTestId('status-unread')).toBeVisible();
       });
 
@@ -387,7 +387,7 @@ test.describe('Delete', () => {
       });
 
       await test.step('Check B has no unread indicator anymore', async () => {
-        const conversation = userBPages.conversationList().getConversationLocator(userA.fullName);
+        const conversation = userBPages.conversationList().getConversation(userA.fullName);
         await expect(conversation.getByTestId('status-unread')).not.toBeVisible();
 
         await conversation.open();

--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -43,7 +43,7 @@ test.describe('Delete', () => {
       const deviceA = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
 
       const deviceB = (await PageManager.from(createPage(withLogin(userA, {confirmNewHistory: true})))).webapp.pages;
-      await deviceB.conversationList().openConversation(userB.fullName);
+      await deviceB.conversationList().getConversationLocator(userB.fullName).open();
 
       await deviceA.conversation().sendMessage('Test Message');
 
@@ -67,14 +67,14 @@ test.describe('Delete', () => {
 
     await test.step('Create test group', async () => {
       await createGroup(userAPages, 'Test Group', [userB]);
-      await userBPages.conversationList().openConversation('Test Group');
+      await userAPages.conversationList().getConversationLocator('Test Group').open();
+      await userBPages.conversationList().getConversationLocator('Test Group').open();
     });
 
     let messageA: Locator;
     let messageB: Locator;
 
     await test.step('Send message from user A to B', async () => {
-      await userAPages.conversationList().openConversation('Test Group');
       await userAPages.conversation().sendMessage('Test Message');
 
       messageA = userAPages.conversation().getMessage({sender: userA});
@@ -102,7 +102,7 @@ test.describe('Delete', () => {
       ]);
 
       await createGroup(userAPages, 'Test Group', [userB]);
-      await userBPages.conversationList().openConversation('Test Group');
+      await userBPages.conversationList().getConversationLocator('Test Group').open();
 
       const systemMessage = userAPages.conversation().systemMessages.last();
 
@@ -119,9 +119,9 @@ test.describe('Delete', () => {
     async ({createPage}) => {
       const {components, pages} = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))))
         .webapp;
+      const conversation = await pages.conversationList().getConversationLocator(userB.fullName).open();
 
       let message: Locator;
-
       await test.step('Send and delete message', async () => {
         await pages.conversation().sendMessage('Test Message');
 
@@ -133,19 +133,19 @@ test.describe('Delete', () => {
       });
 
       await test.step('Archive conversation', async () => {
-        const contextMenu = await pages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+        const contextMenu = await conversation.openContextMenu();
         await contextMenu.archiveButton.click();
       });
 
       await test.step('Unarchive conversation', async () => {
         await components.conversationSidebar().clickArchive();
-        const contextMenu = await pages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+        const contextMenu = await conversation.openContextMenu();
         await contextMenu.unarchiveButton.click();
         await components.conversationSidebar().clickAllConversationsButton();
       });
 
       await test.step('Verify message remains deleted', async () => {
-        await pages.conversationList().openConversation(userB.fullName);
+        await conversation.open();
         await expect(message).not.toBeAttached();
       });
     },
@@ -162,13 +162,13 @@ test.describe('Delete', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       let userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Test Message');
 
       const messageA = userAPages.conversation().getMessage({sender: userA});
       await expect(messageA).toContainText('Test Message');
 
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       let messageB = userBPages.conversation().getMessage({sender: userA});
       await expect(messageB).toContainText('Test Message');
 
@@ -176,7 +176,7 @@ test.describe('Delete', () => {
       await userAPages.conversation().deleteMessage(messageA, 'Everyone');
 
       userBPages = (await PageManager.from(createPage(context, withLogin(userB)))).webapp.pages;
-      await userBPages.conversationList().openConversation(userA.fullName);
+      await userBPages.conversationList().getConversationLocator(userA.fullName).open();
 
       messageB = userBPages.conversation().getMessage({sender: userA});
 
@@ -194,8 +194,8 @@ test.describe('Delete', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Test Message');
 
       const messageA = userAPages.conversation().getMessage({sender: userA});
@@ -224,14 +224,14 @@ test.describe('Delete', () => {
 
       await test.step('Create test group', async () => {
         await createGroup(userAPages, 'Test Group', [userB]);
-        await userBPages.conversationList().openConversation('Test Group');
+        await userBPages.conversationList().getConversationLocator('Test Group').open();
       });
 
       let messageA: Locator;
       let messageB: Locator;
 
       await test.step('Send and delete message from user A to B', async () => {
-        await userAPages.conversationList().openConversation('Test Group');
+        await userAPages.conversationList().getConversationLocator('Test Group').open();
         await userAPages.conversation().sendMessage('Test Message');
 
         messageA = userAPages.conversation().getMessage({sender: userA});
@@ -328,8 +328,8 @@ test.describe('Delete', () => {
       const userBPages = PageManager.from(pageB).webapp.pages;
 
       await test.step('Await mls conversation creation', async () => {
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-        await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       });
 
       await test.step('Execute send action', async () => {
@@ -367,11 +367,11 @@ test.describe('Delete', () => {
       await test.step('Create group as second conversation', async () => {
         // We need to create a second conversation in order to switch to it to ensure the unread marker can be shown on the not open conversation
         await createGroup(userAPages, 'Test Group', [userB]);
-        await userBPages.conversationList().openConversation('Test Group');
+        await userBPages.conversationList().getConversationLocator('Test Group').open();
       });
 
       await test.step('Send message from user A to B', async () => {
-        await userAPages.conversationList().openConversation(userB.fullName);
+        await userAPages.conversationList().getConversationLocator(userB.fullName).open();
         await userAPages.conversation().sendMessage('Test Message');
       });
 
@@ -390,7 +390,7 @@ test.describe('Delete', () => {
         const conversation = userBPages.conversationList().getConversationLocator(userA.fullName);
         await expect(conversation.getByTestId('status-unread')).not.toBeVisible();
 
-        await userBPages.conversationList().openConversation(userA.fullName);
+        await conversation.open();
         const message = userBPages.conversation().getMessage({sender: userA});
         await expect(message).not.toBeAttached();
       });

--- a/apps/webapp/test/e2e_tests/specs/Drive/drive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Drive/drive.spec.ts
@@ -80,8 +80,8 @@ test.describe('Conversations', () => {
       });
 
       await test.step('User A sends an image to User B in a group conversation', async () => {
-        await userAPages.conversationList().openConversation(conversationName);
-        await userBPages.conversationList().openConversation(conversationName);
+        await userAPages.conversationList().getConversationLocator(conversationName).open();
+        await userBPages.conversationList().getConversationLocator(conversationName).open();
         await userAComponents.inputBarControls().clickShareFile(imageFilePath);
         await userAComponents.inputBarControls().clickSendMessage();
 
@@ -127,11 +127,11 @@ test.describe('Conversations', () => {
       });
 
       await test.step('User A sends a multipart message in a group conversation', async () => {
-        await userAPages.conversationList().openConversation(conversationName);
+        await userAPages.conversationList().getConversationLocator(conversationName).open();
         await userAComponents.inputBarControls().clickShareFile(imageFilePath);
         await userAComponents.inputBarControls().setMessageInput(initialMessageText);
         await userAComponents.inputBarControls().clickSendMessage();
-        await userBPages.conversationList().openConversation(conversationName);
+        await userBPages.conversationList().getConversationLocator(conversationName).open();
 
         const multipartMessage = userBPages.conversation().getMessage({sender: userA});
         await expect(multipartMessage).toContainText(initialMessageText);
@@ -168,11 +168,11 @@ test.describe('Conversations', () => {
       });
 
       await test.step('User A sends a multipart message to User B in a group conversation', async () => {
-        await userAPages.conversationList().openConversation(conversationName);
+        await userAPages.conversationList().getConversationLocator(conversationName).open();
         await userAComponents.inputBarControls().clickShareFile(imageFilePath);
         await userAComponents.inputBarControls().setMessageInput(initialMessageText);
         await userAComponents.inputBarControls().clickSendMessage();
-        await userBPages.conversationList().openConversation(conversationName);
+        await userBPages.conversationList().getConversationLocator(conversationName).open();
 
         const multipartMessage = userBPages.conversation().getMessage({sender: userA});
         await expect(multipartMessage).toContainText(initialMessageText);
@@ -208,11 +208,11 @@ test.describe('Conversations', () => {
       });
 
       await test.step('User A sends a message with assets in a group conversation', async () => {
-        await userAPages.conversationList().openConversation(conversationName);
+        await userAPages.conversationList().getConversationLocator(conversationName).open();
         await userAComponents.inputBarControls().clickShareFile(imageFilePath);
         await userAComponents.inputBarControls().clickShareFile(videoFilePath);
         await userAComponents.inputBarControls().clickSendMessage();
-        await userBPages.conversationList().openConversation(conversationName);
+        await userBPages.conversationList().getConversationLocator(conversationName).open();
 
         await expect(getImageInMultipartMessageLocator(userBPages.conversation(), userA)).toBeVisible();
         await expect(getVideoInMultipartMessageLocator(userBPages.conversation(), userA)).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/Drive/drive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Drive/drive.spec.ts
@@ -80,8 +80,8 @@ test.describe('Conversations', () => {
       });
 
       await test.step('User A sends an image to User B in a group conversation', async () => {
-        await userAPages.conversationList().getConversationLocator(conversationName).open();
-        await userBPages.conversationList().getConversationLocator(conversationName).open();
+        await userAPages.conversationList().getConversation(conversationName).open();
+        await userBPages.conversationList().getConversation(conversationName).open();
         await userAComponents.inputBarControls().clickShareFile(imageFilePath);
         await userAComponents.inputBarControls().clickSendMessage();
 
@@ -127,11 +127,11 @@ test.describe('Conversations', () => {
       });
 
       await test.step('User A sends a multipart message in a group conversation', async () => {
-        await userAPages.conversationList().getConversationLocator(conversationName).open();
+        await userAPages.conversationList().getConversation(conversationName).open();
         await userAComponents.inputBarControls().clickShareFile(imageFilePath);
         await userAComponents.inputBarControls().setMessageInput(initialMessageText);
         await userAComponents.inputBarControls().clickSendMessage();
-        await userBPages.conversationList().getConversationLocator(conversationName).open();
+        await userBPages.conversationList().getConversation(conversationName).open();
 
         const multipartMessage = userBPages.conversation().getMessage({sender: userA});
         await expect(multipartMessage).toContainText(initialMessageText);
@@ -168,11 +168,11 @@ test.describe('Conversations', () => {
       });
 
       await test.step('User A sends a multipart message to User B in a group conversation', async () => {
-        await userAPages.conversationList().getConversationLocator(conversationName).open();
+        await userAPages.conversationList().getConversation(conversationName).open();
         await userAComponents.inputBarControls().clickShareFile(imageFilePath);
         await userAComponents.inputBarControls().setMessageInput(initialMessageText);
         await userAComponents.inputBarControls().clickSendMessage();
-        await userBPages.conversationList().getConversationLocator(conversationName).open();
+        await userBPages.conversationList().getConversation(conversationName).open();
 
         const multipartMessage = userBPages.conversation().getMessage({sender: userA});
         await expect(multipartMessage).toContainText(initialMessageText);
@@ -208,11 +208,11 @@ test.describe('Conversations', () => {
       });
 
       await test.step('User A sends a message with assets in a group conversation', async () => {
-        await userAPages.conversationList().getConversationLocator(conversationName).open();
+        await userAPages.conversationList().getConversation(conversationName).open();
         await userAComponents.inputBarControls().clickShareFile(imageFilePath);
         await userAComponents.inputBarControls().clickShareFile(videoFilePath);
         await userAComponents.inputBarControls().clickSendMessage();
-        await userBPages.conversationList().getConversationLocator(conversationName).open();
+        await userBPages.conversationList().getConversation(conversationName).open();
 
         await expect(getImageInMultipartMessageLocator(userBPages.conversation(), userA)).toBeVisible();
         await expect(getVideoInMultipartMessageLocator(userBPages.conversation(), userA)).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -51,7 +51,7 @@ test.describe('Edit', () => {
     const pages = (await PageManager.from(createPage(withLogin(userA)))).webapp.pages;
     await createGroup(pages, 'Test Group', [userB]);
 
-    await pages.conversationList().openConversation('Test Group');
+    await pages.conversationList().getConversationLocator('Test Group').open();
     await pages.conversation().sendMessage('Test Message');
 
     const message = pages.conversation().getMessage({sender: userA});
@@ -73,7 +73,7 @@ test.describe('Edit', () => {
 
       // Device 2 is intentionally created after device 1 to ensure the history info warning is confirmed
       const deviceB = (await PageManager.from(createPage(withLogin(userA, {confirmNewHistory: true})))).webapp.pages;
-      await deviceB.conversationList().openConversation(userB.fullName);
+      await deviceB.conversationList().getConversationLocator(userB.fullName).open();
 
       await deviceA.conversation().sendMessage('Message from device 1');
 
@@ -97,8 +97,8 @@ test.describe('Edit', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendMessage('Test Message');
 
     const message = userBPages.conversation().getMessage({sender: userA});
@@ -134,25 +134,25 @@ test.describe('Edit', () => {
       await test.step('Create group as second conversation', async () => {
         // We need to create a second conversation in order to switch to it to ensure the unread marker can be shown on the not open conversation
         await createGroup(userAPages, 'Test Group', [userB]);
-        await userBPages.conversationList().openConversation('Test Group');
+        await userBPages.conversationList().getConversationLocator('Test Group').open();
       });
 
       await test.step('Send message from user A to B', async () => {
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
         await userAPages.conversation().sendMessage('Test Message');
       });
 
       await test.step('Check user B has a unread conversation with A containing the sent message', async () => {
-        const conversation = userBPages.conversationList().getConversationLocator(userA.fullName);
+        const conversation = userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'});
         await expect(conversation.unreadIndicator).toBeVisible();
 
-        await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+        await conversation.open();
         await expect(conversation).toContainText('Test Message');
         await expect(conversation.unreadIndicator).not.toBeVisible();
       });
 
       await test.step("Open group conversation to ensure new messages won't be read immediately", async () => {
-        await userBPages.conversationList().openConversation('Test Group');
+        await userBPages.conversationList().getConversationLocator('Test Group').open();
         await expect(userBPages.conversation().conversationTitle).toHaveText('Test Group');
       });
 
@@ -167,7 +167,7 @@ test.describe('Edit', () => {
         const conversation = userBPages.conversationList().getConversationLocator(userA.fullName);
         await expect(conversation.unreadIndicator).not.toBeVisible();
 
-        await userBPages.conversationList().openConversation(userA.fullName);
+        await conversation.open();
         await expect(userBPages.conversation().getMessage({sender: userA})).toContainText('Edited Message');
       });
     },
@@ -182,8 +182,8 @@ test.describe('Edit', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       await userAPages.conversation().sendMessage('Test');
       const sentMessage = userAPages.conversation().getMessage({sender: userA});
@@ -207,7 +207,7 @@ test.describe('Edit', () => {
       const pages = await PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages);
       await createGroup(pages, 'Test Group', [userB]); // The message detail view is only available for group conversations
 
-      await pages.conversationList().openConversation('Test Group');
+      await pages.conversationList().getConversationLocator('Test Group').open();
       await pages.conversation().sendMessage('Test message');
 
       const message = pages.conversation().getMessage({sender: userA});

--- a/apps/webapp/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -51,7 +51,7 @@ test.describe('Edit', () => {
     const pages = (await PageManager.from(createPage(withLogin(userA)))).webapp.pages;
     await createGroup(pages, 'Test Group', [userB]);
 
-    await pages.conversationList().getConversationLocator('Test Group').open();
+    await pages.conversationList().getConversation('Test Group').open();
     await pages.conversation().sendMessage('Test Message');
 
     const message = pages.conversation().getMessage({sender: userA});
@@ -73,7 +73,7 @@ test.describe('Edit', () => {
 
       // Device 2 is intentionally created after device 1 to ensure the history info warning is confirmed
       const deviceB = (await PageManager.from(createPage(withLogin(userA, {confirmNewHistory: true})))).webapp.pages;
-      await deviceB.conversationList().getConversationLocator(userB.fullName).open();
+      await deviceB.conversationList().getConversation(userB.fullName).open();
 
       await deviceA.conversation().sendMessage('Message from device 1');
 
@@ -97,8 +97,8 @@ test.describe('Edit', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendMessage('Test Message');
 
     const message = userBPages.conversation().getMessage({sender: userA});
@@ -134,16 +134,16 @@ test.describe('Edit', () => {
       await test.step('Create group as second conversation', async () => {
         // We need to create a second conversation in order to switch to it to ensure the unread marker can be shown on the not open conversation
         await createGroup(userAPages, 'Test Group', [userB]);
-        await userBPages.conversationList().getConversationLocator('Test Group').open();
+        await userBPages.conversationList().getConversation('Test Group').open();
       });
 
       await test.step('Send message from user A to B', async () => {
-        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+        await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
         await userAPages.conversation().sendMessage('Test Message');
       });
 
       await test.step('Check user B has a unread conversation with A containing the sent message', async () => {
-        const conversation = userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'});
+        const conversation = userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'});
         await expect(conversation.unreadIndicator).toBeVisible();
 
         await conversation.open();
@@ -152,7 +152,7 @@ test.describe('Edit', () => {
       });
 
       await test.step("Open group conversation to ensure new messages won't be read immediately", async () => {
-        await userBPages.conversationList().getConversationLocator('Test Group').open();
+        await userBPages.conversationList().getConversation('Test Group').open();
         await expect(userBPages.conversation().conversationTitle).toHaveText('Test Group');
       });
 
@@ -164,7 +164,7 @@ test.describe('Edit', () => {
       });
 
       await test.step('Check B received the updated message without marking the conversation as unread', async () => {
-        const conversation = userBPages.conversationList().getConversationLocator(userA.fullName);
+        const conversation = userBPages.conversationList().getConversation(userA.fullName);
         await expect(conversation.unreadIndicator).not.toBeVisible();
 
         await conversation.open();
@@ -182,8 +182,8 @@ test.describe('Edit', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       await userAPages.conversation().sendMessage('Test');
       const sentMessage = userAPages.conversation().getMessage({sender: userA});
@@ -207,7 +207,7 @@ test.describe('Edit', () => {
       const pages = await PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages);
       await createGroup(pages, 'Test Group', [userB]); // The message detail view is only available for group conversations
 
-      await pages.conversationList().getConversationLocator('Test Group').open();
+      await pages.conversationList().getConversation('Test Group').open();
       await pages.conversation().sendMessage('Test message');
 
       const message = pages.conversation().getMessage({sender: userA});

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -31,7 +31,7 @@ import {createGroup} from 'test/e2e_tests/utils/userActions';
  */
 async function createCustomFolder(pageManager: PageManager, conversationName: string, folderName: string) {
   const {pages, modals} = pageManager.webapp;
-  const contextMenu = await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
+  const contextMenu = await pages.conversationList().getConversation(conversationName).openContextMenu();
   await contextMenu.moveToButton.click();
   await contextMenu.getByRole('button', {name: 'Create new folder'}).click();
 
@@ -47,7 +47,7 @@ async function createCustomFolder(pageManager: PageManager, conversationName: st
  */
 async function moveConversationToFolder(pageManager: PageManager, conversationName: string, folderName: string) {
   const pages = pageManager.webapp.pages;
-  const contextMenu = await pages.conversationList().getConversationLocator(conversationName).openContextMenu();
+  const contextMenu = await pages.conversationList().getConversation(conversationName).openContextMenu();
   await contextMenu.moveToButton.click();
   await contextMenu.getByRole('button', {name: folderName, exact: true}).click();
 }
@@ -72,7 +72,7 @@ test.describe('Folders', () => {
     const customFolderName = 'Custom-Folder';
 
     // Step 1: User A opens 1:1 conversation with User B
-    await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+    await userAPages.conversationList().getConversation(userB.fullName).open();
     // Step 2: User A moves 1:1 conversation with User B into new custom folder
     await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
     // Step 3: 1:1 conversation with User B is in the custom folder
@@ -90,7 +90,7 @@ test.describe('Folders', () => {
     await createGroup(userAPages, conversationName, [userB]);
 
     // Step 1: User A opens group conversation with User B
-    await userAPages.conversationList().getConversationLocator(conversationName).open();
+    await userAPages.conversationList().getConversation(conversationName).open();
     // Step 2: User A moves group conversation with User B in new custom folder
     await createCustomFolder(userAPageManager, conversationName, customFolderName);
     // Step 3: Group conversation with User B is in the custom folder
@@ -157,7 +157,7 @@ test.describe('Folders', () => {
       const customFolderName = 'Custom-Folder';
 
       // Preconditions: Conversation is in custom folder
-      const conversation = await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+      const conversation = await userAPages.conversationList().getConversation(userB.fullName).open();
       await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
 
       await test.step("User A clicks 'remove from custom folder' button", async () => {
@@ -182,7 +182,7 @@ test.describe('Folders', () => {
     const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
 
     // Step 1: User A opens 1:1 conversation with User B
-    const conversation = await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+    const conversation = await userAPages.conversationList().getConversation(userB.fullName).open();
     // Step 2: User A wants to move 1:1 conversation with User B into custom folder
     const contextMenu = await conversation.openContextMenu();
     await contextMenu.moveToButton.click();
@@ -198,7 +198,7 @@ test.describe('Folders', () => {
     const customFolderName = 'Custom-Folder';
 
     // Preconditions: Conversation is in custom folder
-    const conversation = await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+    const conversation = await userAPages.conversationList().getConversation(userB.fullName).open();
     await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
 
     await test.step('User A removes conversation with User B from custom folder', async () => {

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -72,7 +72,7 @@ test.describe('Folders', () => {
     const customFolderName = 'Custom-Folder';
 
     // Step 1: User A opens 1:1 conversation with User B
-    await userAPages.conversationList().openConversation(userB.fullName);
+    await userAPages.conversationList().getConversationLocator(userB.fullName).open();
     // Step 2: User A moves 1:1 conversation with User B into new custom folder
     await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
     // Step 3: 1:1 conversation with User B is in the custom folder
@@ -90,7 +90,7 @@ test.describe('Folders', () => {
     await createGroup(userAPages, conversationName, [userB]);
 
     // Step 1: User A opens group conversation with User B
-    await userAPages.conversationList().openConversation(conversationName);
+    await userAPages.conversationList().getConversationLocator(conversationName).open();
     // Step 2: User A moves group conversation with User B in new custom folder
     await createCustomFolder(userAPageManager, conversationName, customFolderName);
     // Step 3: Group conversation with User B is in the custom folder
@@ -157,14 +157,11 @@ test.describe('Folders', () => {
       const customFolderName = 'Custom-Folder';
 
       // Preconditions: Conversation is in custom folder
-      await userAPages.conversationList().openConversation(userB.fullName);
+      const conversation = await userAPages.conversationList().getConversationLocator(userB.fullName).open();
       await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
 
       await test.step("User A clicks 'remove from custom folder' button", async () => {
-        const contextMenu = await userAPages
-          .conversationList()
-          .getConversationLocator(userB.fullName)
-          .openContextMenu();
+        const contextMenu = await conversation.openContextMenu();
         await contextMenu.getByRole('button', {name: `Remove from "${customFolderName}"`}).click();
       });
 
@@ -174,10 +171,7 @@ test.describe('Folders', () => {
       });
 
       await test.step('Custom Folder Name is no longer visible in the Move-To-Menu', async () => {
-        const contextMenu = await userAPages
-          .conversationList()
-          .getConversationLocator(userB.fullName)
-          .openContextMenu();
+        const contextMenu = await conversation.openContextMenu();
         await contextMenu.moveToButton.click();
         await expect(contextMenu.getByRole('button', {name: customFolderName})).not.toBeVisible();
       });
@@ -188,9 +182,9 @@ test.describe('Folders', () => {
     const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
 
     // Step 1: User A opens 1:1 conversation with User B
-    await userAPages.conversationList().openConversation(userB.fullName);
+    const conversation = await userAPages.conversationList().getConversationLocator(userB.fullName).open();
     // Step 2: User A wants to move 1:1 conversation with User B into custom folder
-    const contextMenu = await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+    const contextMenu = await conversation.openContextMenu();
     await contextMenu.moveToButton.click();
     await contextMenu.getByRole('button', {name: 'Create new folder'}).click();
 
@@ -204,17 +198,17 @@ test.describe('Folders', () => {
     const customFolderName = 'Custom-Folder';
 
     // Preconditions: Conversation is in custom folder
-    await userAPages.conversationList().openConversation(userB.fullName);
+    const conversation = await userAPages.conversationList().getConversationLocator(userB.fullName).open();
     await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
 
     await test.step('User A removes conversation with User B from custom folder', async () => {
-      const contextMenu = await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+      const contextMenu = await conversation.openContextMenu();
       await contextMenu.getByRole('button', {name: `Remove from "${customFolderName}"`}).click();
     });
 
     await test.step('User A tries to move conversation with User B back into the folder, custom folder name should no longer be visible in the folder menu', async () => {
-      await userAPages.conversationList().openConversation(userB.fullName);
-      const contextMenu = await userAPages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+      await conversation.open();
+      const contextMenu = await conversation.openContextMenu();
       await contextMenu.moveToButton.click();
       await expect(contextMenu.getByRole('button', {name: customFolderName})).not.toBeVisible();
     });

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -41,7 +41,7 @@ test.describe('Group Conversation', () => {
     const userAPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
     await createGroup(userAPages, groupName, []);
-    await userAPages.conversationList().openConversation(groupName);
+    await userAPages.conversationList().getConversationLocator(groupName).open();
 
     await userAPages.conversation().sendMessage('Message');
     const message = userAPages.conversation().getMessage({content: 'Message'});
@@ -95,14 +95,13 @@ test.describe('Group Conversation', () => {
     const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await createGroup(userAPages, groupName, [userB, userC]);
-    const adminGroupLocator = userAPages.conversationList().getConversationLocator(groupName);
+    const adminGroupLocator = await userAPages.conversationList().getConversationLocator(groupName).open();
     const memberGroupLocator = userBPages.conversationList().getConversationLocator(groupName);
 
     // Pre-condition: Ensure the member can see the group before the creator deletes it
     await expect(memberGroupLocator).toBeVisible();
 
     // User A initiate group deletion
-    await userAPages.conversationList().openConversation(groupName);
     await userAPages.conversation().clickConversationInfoButton();
     await userAPages.conversationDetails().deleteGroupButton.click();
 
@@ -145,11 +144,11 @@ test.describe('Group Conversation', () => {
       await blankTab.goto('about:blank');
       await blankTab.bringToFront();
 
-      await userAPages.conversationList().openConversation(groupName);
+      const userAConversation = await userAPages.conversationList().getConversationLocator(groupName).open();
       await userAPages.conversation().clickConversationInfoButton();
       await userAPages.conversationDetails().deleteGroupButton.click();
       await userAModals.confirm().actionButton.click();
-      await expect(userAPages.conversationList().getConversationLocator(groupName)).not.toBeAttached({timeout: 20_000});
+      await expect(userAConversation).not.toBeAttached({timeout: 20_000});
 
       await expect
         .poll(() => getUserBNotifications())
@@ -189,7 +188,7 @@ test.describe('Group Conversation', () => {
     for (const group of groups) {
       const {pages, modals} = PageManager.from(group.owner).webapp;
 
-      await pages.conversationList().openConversation(group.name);
+      await pages.conversationList().getConversationLocator(group.name).open();
       await pages.conversation().clickConversationInfoButton();
       await pages.conversationDetails().deleteGroupButton.click();
       await modals.confirm().actionButton.click();
@@ -213,7 +212,7 @@ test.describe('Group Conversation', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userBPages, groupName, [userA]);
-      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversationList().getConversationLocator(groupName).open();
 
       // User A leaves conversation through options menu from conversation list
       const contextMenu = await userAPages.conversationList().getConversationLocator(groupName).openContextMenu();
@@ -231,7 +230,7 @@ test.describe('Group Conversation', () => {
       const pages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       await createGroup(pages, groupName, [userB, userC]);
-      await pages.conversationList().openConversation(groupName);
+      await pages.conversationList().getConversationLocator(groupName).open();
       await pages.conversation().toggleGroupInformation();
 
       await expect(pages.conversationDetails().groupMembers.filter({hasText: userB.fullName})).toBeVisible();
@@ -253,7 +252,7 @@ test.describe('Group Conversation', () => {
       const pages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       await createGroup(pages, groupName, [userB]);
-      await pages.conversationList().openConversation(groupName);
+      await pages.conversationList().getConversationLocator(groupName).open();
       await pages.conversation().toggleGroupInformation();
 
       await expect(pages.conversationDetails().groupMembers.filter({hasText: userB.fullName})).toBeVisible();
@@ -272,7 +271,7 @@ test.describe('Group Conversation', () => {
       ]);
 
       await createGroup(userAPages, groupName, [userB]);
-      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversationList().getConversationLocator(groupName).open();
       await userBPages.conversation().toggleGroupInformation();
 
       await expect(userBPages.conversationDetails().groupAdmins.filter({hasText: userA.fullName})).toBeVisible();
@@ -291,12 +290,12 @@ test.describe('Group Conversation', () => {
 
       await test.step('Setup: Create group and promote User B to Admin', async () => {
         await createGroup(userAPages, groupName, [userB, userC]);
-        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversationList().getConversationLocator(groupName).open();
         await userAPages.conversation().toggleGroupInformation();
         await userAPages.conversation().makeUserAdmin(userB.fullName);
 
         // Verify User B is an admin
-        await userBPages.conversationList().openConversation(groupName);
+        await userBPages.conversationList().getConversationLocator(groupName).open();
         await userBPages.conversation().toggleGroupInformation();
         await expect(userBPages.conversationDetails().groupAdmins.filter({hasText: userB.fullName})).toBeVisible();
       });

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -41,7 +41,7 @@ test.describe('Group Conversation', () => {
     const userAPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
     await createGroup(userAPages, groupName, []);
-    await userAPages.conversationList().getConversationLocator(groupName).open();
+    await userAPages.conversationList().getConversation(groupName).open();
 
     await userAPages.conversation().sendMessage('Message');
     const message = userAPages.conversation().getMessage({content: 'Message'});
@@ -95,8 +95,8 @@ test.describe('Group Conversation', () => {
     const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await createGroup(userAPages, groupName, [userB, userC]);
-    const adminGroupLocator = await userAPages.conversationList().getConversationLocator(groupName).open();
-    const memberGroupLocator = userBPages.conversationList().getConversationLocator(groupName);
+    const adminGroupLocator = await userAPages.conversationList().getConversation(groupName).open();
+    const memberGroupLocator = userBPages.conversationList().getConversation(groupName);
 
     // Pre-condition: Ensure the member can see the group before the creator deletes it
     await expect(memberGroupLocator).toBeVisible();
@@ -136,7 +136,7 @@ test.describe('Group Conversation', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userAPages, groupName, [userB]);
-      await expect(userBPages.conversationList().getConversationLocator(groupName)).toBeVisible();
+      await expect(userBPages.conversationList().getConversation(groupName)).toBeVisible();
 
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
@@ -144,7 +144,7 @@ test.describe('Group Conversation', () => {
       await blankTab.goto('about:blank');
       await blankTab.bringToFront();
 
-      const userAConversation = await userAPages.conversationList().getConversationLocator(groupName).open();
+      const userAConversation = await userAPages.conversationList().getConversation(groupName).open();
       await userAPages.conversation().clickConversationInfoButton();
       await userAPages.conversationDetails().deleteGroupButton.click();
       await userAModals.confirm().actionButton.click();
@@ -188,11 +188,11 @@ test.describe('Group Conversation', () => {
     for (const group of groups) {
       const {pages, modals} = PageManager.from(group.owner).webapp;
 
-      await pages.conversationList().getConversationLocator(group.name).open();
+      await pages.conversationList().getConversation(group.name).open();
       await pages.conversation().clickConversationInfoButton();
       await pages.conversationDetails().deleteGroupButton.click();
       await modals.confirm().actionButton.click();
-      await expect(userCPages.conversationList().getConversationLocator(group.name)).not.toBeAttached({
+      await expect(userCPages.conversationList().getConversation(group.name)).not.toBeAttached({
         timeout: 20_000,
       });
 
@@ -212,10 +212,10 @@ test.describe('Group Conversation', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userBPages, groupName, [userA]);
-      await userBPages.conversationList().getConversationLocator(groupName).open();
+      await userBPages.conversationList().getConversation(groupName).open();
 
       // User A leaves conversation through options menu from conversation list
-      const contextMenu = await userAPages.conversationList().getConversationLocator(groupName).openContextMenu();
+      const contextMenu = await userAPages.conversationList().getConversation(groupName).openContextMenu();
       await contextMenu.leaveConversationButton.click();
       await userAModals.leaveConversation().confirmButton.click();
 
@@ -230,7 +230,7 @@ test.describe('Group Conversation', () => {
       const pages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       await createGroup(pages, groupName, [userB, userC]);
-      await pages.conversationList().getConversationLocator(groupName).open();
+      await pages.conversationList().getConversation(groupName).open();
       await pages.conversation().toggleGroupInformation();
 
       await expect(pages.conversationDetails().groupMembers.filter({hasText: userB.fullName})).toBeVisible();
@@ -252,7 +252,7 @@ test.describe('Group Conversation', () => {
       const pages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       await createGroup(pages, groupName, [userB]);
-      await pages.conversationList().getConversationLocator(groupName).open();
+      await pages.conversationList().getConversation(groupName).open();
       await pages.conversation().toggleGroupInformation();
 
       await expect(pages.conversationDetails().groupMembers.filter({hasText: userB.fullName})).toBeVisible();
@@ -271,7 +271,7 @@ test.describe('Group Conversation', () => {
       ]);
 
       await createGroup(userAPages, groupName, [userB]);
-      await userBPages.conversationList().getConversationLocator(groupName).open();
+      await userBPages.conversationList().getConversation(groupName).open();
       await userBPages.conversation().toggleGroupInformation();
 
       await expect(userBPages.conversationDetails().groupAdmins.filter({hasText: userA.fullName})).toBeVisible();
@@ -290,12 +290,12 @@ test.describe('Group Conversation', () => {
 
       await test.step('Setup: Create group and promote User B to Admin', async () => {
         await createGroup(userAPages, groupName, [userB, userC]);
-        await userAPages.conversationList().getConversationLocator(groupName).open();
+        await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().toggleGroupInformation();
         await userAPages.conversation().makeUserAdmin(userB.fullName);
 
         // Verify User B is an admin
-        await userBPages.conversationList().getConversationLocator(groupName).open();
+        await userBPages.conversationList().getConversation(groupName).open();
         await userBPages.conversation().toggleGroupInformation();
         await expect(userBPages.conversationDetails().groupAdmins.filter({hasText: userB.fullName})).toBeVisible();
       });

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -14,7 +14,7 @@ import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActio
  */
 
 const generateGroupGuestsLink = async (pages: PageManager['webapp']['pages'], groupName: string, password?: string) => {
-  await pages.conversationList().getConversationLocator(groupName).open();
+  await pages.conversationList().getConversation(groupName).open();
   await pages.conversation().toggleGroupInformation();
   await pages.conversationDetails().openGuestOptions();
 
@@ -75,7 +75,7 @@ test.describe('Guestroom', () => {
     const {pages, modals} = PageManager.from(userAPage).webapp;
 
     await createGroup(pages, groupName, []);
-    await pages.conversationList().getConversationLocator(groupName).open();
+    await pages.conversationList().getConversation(groupName).open();
 
     await test.step('User A sees an error message when trying to create a password secured link with a weak password', async () => {
       await pages.conversation().toggleGroupInformation();
@@ -179,11 +179,11 @@ test.describe('Guestroom', () => {
 
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();
-      await expect(ownerPages.conversationList().getConversationLocator(guestUser.fullName)).toBeAttached();
+      await expect(ownerPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
 
       await test.step('Owner creates a group with guest', async () => {
         await createGroup(ownerPages, groupName, [guestUser]);
-        await ownerPages.conversationList().getConversationLocator(groupName).open();
+        await ownerPages.conversationList().getConversation(groupName).open();
         await ownerPages.conversation().toggleGroupInformation();
         await expect(ownerPages.conversationDetails().groupMembers.filter({hasText: guestUser.fullName})).toBeVisible();
       });
@@ -214,7 +214,7 @@ test.describe('Guestroom', () => {
       const ownerPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       await createGroup(ownerPages, groupName, []);
-      await ownerPages.conversationList().getConversationLocator(groupName).open();
+      await ownerPages.conversationList().getConversation(groupName).open();
 
       // Owner creates a guest link
       await ownerPages.conversation().toggleGroupInformation();
@@ -243,7 +243,7 @@ test.describe('Guestroom', () => {
       const ownerPages = PageManager.from(ownerPage).webapp.pages;
 
       await createGroup(ownerPages, groupName, []);
-      await ownerPages.conversationList().getConversationLocator(groupName).open();
+      await ownerPages.conversationList().getConversation(groupName).open();
       await ownerPages.conversation().toggleGroupInformation();
 
       await ownerPages.conversationDetails().openGuestOptions();
@@ -276,7 +276,7 @@ test.describe('Guestroom', () => {
       await ownerPages.groupCreation().setGroupName(groupName);
       await ownerPages.groupCreation().clickCreateGroupButton();
 
-      await ownerPages.conversationList().getConversationLocator(groupName).open();
+      await ownerPages.conversationList().getConversation(groupName).open();
       await ownerPages.conversation().toggleGroupInformation();
 
       // UserA sees guest options label shows ON in conversation details
@@ -344,7 +344,7 @@ test.describe('Guestroom', () => {
       const ownerPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       await createGroup(ownerPages, groupName, []);
-      await ownerPages.conversationList().getConversationLocator(groupName).open();
+      await ownerPages.conversationList().getConversation(groupName).open();
 
       await verify(ownerPages);
       await ownerPages.conversation().invitePeopleButton.click();
@@ -519,7 +519,7 @@ test.describe('Guestroom', () => {
 
       await guestPages.conversationJoin().joinAsMemberButton.click();
       await guestPages.conversation().conversationTitle.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
-      await expect(guestPages.conversationList().getConversationLocator(groupName)).toBeVisible();
+      await expect(guestPages.conversationList().getConversation(groupName)).toBeVisible();
     },
   );
 
@@ -621,7 +621,7 @@ test.describe('Guestroom', () => {
         },
       );
 
-      await expect(guestPages.conversationList().getConversationLocator(groupName)).toBeVisible();
+      await expect(guestPages.conversationList().getConversation(groupName)).toBeVisible();
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -14,7 +14,7 @@ import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActio
  */
 
 const generateGroupGuestsLink = async (pages: PageManager['webapp']['pages'], groupName: string, password?: string) => {
-  await pages.conversationList().openConversation(groupName);
+  await pages.conversationList().getConversationLocator(groupName).open();
   await pages.conversation().toggleGroupInformation();
   await pages.conversationDetails().openGuestOptions();
 
@@ -75,7 +75,7 @@ test.describe('Guestroom', () => {
     const {pages, modals} = PageManager.from(userAPage).webapp;
 
     await createGroup(pages, groupName, []);
-    await pages.conversationList().openConversation(groupName);
+    await pages.conversationList().getConversationLocator(groupName).open();
 
     await test.step('User A sees an error message when trying to create a password secured link with a weak password', async () => {
       await pages.conversation().toggleGroupInformation();
@@ -183,7 +183,7 @@ test.describe('Guestroom', () => {
 
       await test.step('Owner creates a group with guest', async () => {
         await createGroup(ownerPages, groupName, [guestUser]);
-        await ownerPages.conversationList().openConversation(groupName);
+        await ownerPages.conversationList().getConversationLocator(groupName).open();
         await ownerPages.conversation().toggleGroupInformation();
         await expect(ownerPages.conversationDetails().groupMembers.filter({hasText: guestUser.fullName})).toBeVisible();
       });
@@ -214,7 +214,7 @@ test.describe('Guestroom', () => {
       const ownerPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       await createGroup(ownerPages, groupName, []);
-      await ownerPages.conversationList().openConversation(groupName);
+      await ownerPages.conversationList().getConversationLocator(groupName).open();
 
       // Owner creates a guest link
       await ownerPages.conversation().toggleGroupInformation();
@@ -243,7 +243,7 @@ test.describe('Guestroom', () => {
       const ownerPages = PageManager.from(ownerPage).webapp.pages;
 
       await createGroup(ownerPages, groupName, []);
-      await ownerPages.conversationList().openConversation(groupName);
+      await ownerPages.conversationList().getConversationLocator(groupName).open();
       await ownerPages.conversation().toggleGroupInformation();
 
       await ownerPages.conversationDetails().openGuestOptions();
@@ -276,7 +276,7 @@ test.describe('Guestroom', () => {
       await ownerPages.groupCreation().setGroupName(groupName);
       await ownerPages.groupCreation().clickCreateGroupButton();
 
-      await ownerPages.conversationList().openConversation(groupName);
+      await ownerPages.conversationList().getConversationLocator(groupName).open();
       await ownerPages.conversation().toggleGroupInformation();
 
       // UserA sees guest options label shows ON in conversation details
@@ -344,7 +344,7 @@ test.describe('Guestroom', () => {
       const ownerPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
       await createGroup(ownerPages, groupName, []);
-      await ownerPages.conversationList().openConversation(groupName);
+      await ownerPages.conversationList().getConversationLocator(groupName).open();
 
       await verify(ownerPages);
       await ownerPages.conversation().invitePeopleButton.click();

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -53,9 +53,9 @@ test.describe('History Backup', () => {
       const messageUserB = 'Message from User B';
 
       await test.step('User A and B write messages to each other', async () => {
-        await userAPages.conversationList().getConversationLocator(conversationName).open();
+        await userAPages.conversationList().getConversation(conversationName).open();
         await userAPages.conversation().sendMessage(messageUserA);
-        await userBPages.conversationList().getConversationLocator(conversationName).open();
+        await userBPages.conversationList().getConversation(conversationName).open();
         await userBPages.conversation().sendMessage(messageUserB);
       });
 
@@ -104,7 +104,7 @@ test.describe('History Backup', () => {
 
       await test.step('Validate conversation is still visible with all messages after restoring backup', async () => {
         await userAComponents2.conversationSidebar().allConversationsButton.click();
-        await userAPages2.conversationList().getConversationLocator(conversationName).open();
+        await userAPages2.conversationList().getConversation(conversationName).open();
         await expect(userAPages2.conversation().getMessage({sender: userB})).toContainText(messageUserB);
         await expect(userAPages2.conversation().getMessage({sender: userA})).toContainText(messageUserA);
       });
@@ -127,9 +127,9 @@ test.describe('History Backup', () => {
       const messageUserB = 'Message from User B';
 
       await test.step('User A and B write messages to each other', async () => {
-        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+        await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
         await userAPages.conversation().sendMessage(messageUserA);
-        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+        await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
         await userBPages.conversation().sendMessage(messageUserB);
       });
 
@@ -177,9 +177,9 @@ test.describe('History Backup', () => {
       const renamedConversationName = 'renamedConversationName';
 
       await test.step('User A and B write in their group conversation', async () => {
-        await userAPages.conversationList().getConversationLocator(conversationName).open();
+        await userAPages.conversationList().getConversation(conversationName).open();
         await userAPages.conversation().sendMessage(messageUserA);
-        await userBPages.conversationList().getConversationLocator(conversationName).open();
+        await userBPages.conversationList().getConversation(conversationName).open();
         await userBPages.conversation().sendMessage(messageUserB);
       });
 
@@ -189,7 +189,7 @@ test.describe('History Backup', () => {
         await userAComponents.conversationSidebar().clickPreferencesButton();
         backupName = await createAndSaveBackup(testInfo, userAPageManager);
         await userAComponents.conversationSidebar().allConversationsButton.click();
-        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+        await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       });
 
       await test.step('User B renames group conversation', async () => {
@@ -205,10 +205,10 @@ test.describe('History Backup', () => {
       await test.step('Validate User A sees renamed conversation and system message', async () => {
         // User A sees renamed conversation
         await userAComponents.conversationSidebar().allConversationsButton.click();
-        await expect(userAPages.conversationList().getConversationLocator(renamedConversationName)).toBeVisible();
+        await expect(userAPages.conversationList().getConversation(renamedConversationName)).toBeVisible();
 
         // User A sees system message that User B had renamed the conversation
-        await userAPages.conversationList().getConversationLocator(renamedConversationName).open();
+        await userAPages.conversationList().getConversation(renamedConversationName).open();
         const renamedSystemMessage = userAPages
           .conversation()
           .systemMessages.filter({hasText: `${userB.fullName} renamed the conversation`});
@@ -234,9 +234,9 @@ test.describe('History Backup', () => {
       const messageUserB = 'Message from User B';
 
       await test.step('User A and B write messages to each other', async () => {
-        await userAPages.conversationList().getConversationLocator(conversationName).open();
+        await userAPages.conversationList().getConversation(conversationName).open();
         await userAPages.conversation().sendMessage(messageUserA);
-        await userBPages.conversationList().getConversationLocator(conversationName).open();
+        await userBPages.conversationList().getConversation(conversationName).open();
         await userBPages.conversation().sendMessage(messageUserB);
       });
 
@@ -246,7 +246,7 @@ test.describe('History Backup', () => {
       });
 
       await test.step('User A archives 1:1 conversation with User B', async () => {
-        await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+        await userAPages.conversationList().getConversation(userB.fullName).open();
         await userAPages.conversation().conversationInfoButton.click();
         await userAPages.conversationDetails().archiveButton.click();
       });
@@ -271,11 +271,11 @@ test.describe('History Backup', () => {
 
       await test.step('Validate muted and archived state are the same', async () => {
         await userAComponents.conversationSidebar().allConversationsButton.click();
-        const conversation = await userAPages.conversationList().getConversationLocator(conversationName).open();
+        const conversation = await userAPages.conversationList().getConversation(conversationName).open();
         await expect(conversation.mutedIndicator).toBeVisible();
 
         await userAComponents.conversationSidebar().archiveButton.click();
-        const archivedConversation = userAPages.conversationList().getConversationLocator(userB.fullName);
+        const archivedConversation = userAPages.conversationList().getConversation(userB.fullName);
         await expect(archivedConversation).toBeVisible();
       });
     },
@@ -297,9 +297,9 @@ test.describe('History Backup', () => {
       const messageUserB = 'Message from User B';
 
       await test.step('User A and B write messages to each other', async () => {
-        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+        await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
         await userAPages.conversation().sendMessage(messageUserA);
-        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+        await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
         await userBPages.conversation().sendMessage(messageUserB);
       });
 
@@ -346,9 +346,9 @@ test.describe('History Backup', () => {
       const messageUserB = 'Message from User B';
 
       await test.step('User A and User B write messages to each other', async () => {
-        await userAPages.conversationList().getConversationLocator(conversationName).open();
+        await userAPages.conversationList().getConversation(conversationName).open();
         await userAPages.conversation().sendMessage(messageUserA);
-        await userBPages.conversationList().getConversationLocator(conversationName).open();
+        await userBPages.conversationList().getConversation(conversationName).open();
         await userBPages.conversation().sendMessage(messageUserB);
       });
 
@@ -372,7 +372,7 @@ test.describe('History Backup', () => {
 
       await test.step('Validate deleted group conversation is no longer visible', async () => {
         await userAComponents.conversationSidebar().allConversationsButton.click();
-        await expect(userAPages.conversationList().getConversationLocator(conversationName)).not.toBeVisible();
+        await expect(userAPages.conversationList().getConversation(conversationName)).not.toBeVisible();
       });
     },
   );
@@ -391,9 +391,9 @@ test.describe('History Backup', () => {
       await createGroup(userBPages, conversationName, [userA]);
 
       await test.step('User A and User B write messages to each other', async () => {
-        await userAPages.conversationList().getConversationLocator(conversationName).open();
+        await userAPages.conversationList().getConversation(conversationName).open();
         await userAPages.conversation().sendMessage('Message from User A');
-        await userBPages.conversationList().getConversationLocator(conversationName).open();
+        await userBPages.conversationList().getConversation(conversationName).open();
         await userBPages.conversation().sendMessage('Message from User B');
         await expect(userAPages.conversation().messageItems).toHaveCount(2);
       });
@@ -421,7 +421,7 @@ test.describe('History Backup', () => {
 
       await test.step('Validate user A cannot send messages in the left group', async () => {
         await userAComponents.conversationSidebar().allConversationsButton.click();
-        await userAPages.conversationList().getConversationLocator(conversationName).open();
+        await userAPages.conversationList().getConversation(conversationName).open();
         await expect(userAPages.conversation().systemMessages.filter({hasText: 'You left'})).toBeVisible();
         await expect(userAPages.conversation().messageInput).toBeHidden();
       });

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -53,9 +53,9 @@ test.describe('History Backup', () => {
       const messageUserB = 'Message from User B';
 
       await test.step('User A and B write messages to each other', async () => {
-        await userAPages.conversationList().openConversation(conversationName);
+        await userAPages.conversationList().getConversationLocator(conversationName).open();
         await userAPages.conversation().sendMessage(messageUserA);
-        await userBPages.conversationList().openConversation(conversationName);
+        await userBPages.conversationList().getConversationLocator(conversationName).open();
         await userBPages.conversation().sendMessage(messageUserB);
       });
 
@@ -104,7 +104,7 @@ test.describe('History Backup', () => {
 
       await test.step('Validate conversation is still visible with all messages after restoring backup', async () => {
         await userAComponents2.conversationSidebar().allConversationsButton.click();
-        await userAPages2.conversationList().openConversation(conversationName);
+        await userAPages2.conversationList().getConversationLocator(conversationName).open();
         await expect(userAPages2.conversation().getMessage({sender: userB})).toContainText(messageUserB);
         await expect(userAPages2.conversation().getMessage({sender: userA})).toContainText(messageUserA);
       });
@@ -127,9 +127,9 @@ test.describe('History Backup', () => {
       const messageUserB = 'Message from User B';
 
       await test.step('User A and B write messages to each other', async () => {
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
         await userAPages.conversation().sendMessage(messageUserA);
-        await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
         await userBPages.conversation().sendMessage(messageUserB);
       });
 
@@ -177,9 +177,9 @@ test.describe('History Backup', () => {
       const renamedConversationName = 'renamedConversationName';
 
       await test.step('User A and B write in their group conversation', async () => {
-        await userAPages.conversationList().openConversation(conversationName);
+        await userAPages.conversationList().getConversationLocator(conversationName).open();
         await userAPages.conversation().sendMessage(messageUserA);
-        await userBPages.conversationList().openConversation(conversationName);
+        await userBPages.conversationList().getConversationLocator(conversationName).open();
         await userBPages.conversation().sendMessage(messageUserB);
       });
 
@@ -189,7 +189,7 @@ test.describe('History Backup', () => {
         await userAComponents.conversationSidebar().clickPreferencesButton();
         backupName = await createAndSaveBackup(testInfo, userAPageManager);
         await userAComponents.conversationSidebar().allConversationsButton.click();
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       });
 
       await test.step('User B renames group conversation', async () => {
@@ -208,7 +208,7 @@ test.describe('History Backup', () => {
         await expect(userAPages.conversationList().getConversationLocator(renamedConversationName)).toBeVisible();
 
         // User A sees system message that User B had renamed the conversation
-        await userAPages.conversationList().openConversation(renamedConversationName);
+        await userAPages.conversationList().getConversationLocator(renamedConversationName).open();
         const renamedSystemMessage = userAPages
           .conversation()
           .systemMessages.filter({hasText: `${userB.fullName} renamed the conversation`});
@@ -234,9 +234,9 @@ test.describe('History Backup', () => {
       const messageUserB = 'Message from User B';
 
       await test.step('User A and B write messages to each other', async () => {
-        await userAPages.conversationList().openConversation(conversationName);
+        await userAPages.conversationList().getConversationLocator(conversationName).open();
         await userAPages.conversation().sendMessage(messageUserA);
-        await userBPages.conversationList().openConversation(conversationName);
+        await userBPages.conversationList().getConversationLocator(conversationName).open();
         await userBPages.conversation().sendMessage(messageUserB);
       });
 
@@ -246,7 +246,7 @@ test.describe('History Backup', () => {
       });
 
       await test.step('User A archives 1:1 conversation with User B', async () => {
-        await userAPages.conversationList().openConversation(userB.fullName);
+        await userAPages.conversationList().getConversationLocator(userB.fullName).open();
         await userAPages.conversation().conversationInfoButton.click();
         await userAPages.conversationDetails().archiveButton.click();
       });
@@ -271,10 +271,8 @@ test.describe('History Backup', () => {
 
       await test.step('Validate muted and archived state are the same', async () => {
         await userAComponents.conversationSidebar().allConversationsButton.click();
-        await userAPages.conversationList().openConversation(conversationName);
-        await expect(
-          userAPages.conversationList().getConversationLocator(conversationName).mutedIndicator,
-        ).toBeVisible();
+        const conversation = await userAPages.conversationList().getConversationLocator(conversationName).open();
+        await expect(conversation.mutedIndicator).toBeVisible();
 
         await userAComponents.conversationSidebar().archiveButton.click();
         const archivedConversation = userAPages.conversationList().getConversationLocator(userB.fullName);
@@ -299,9 +297,9 @@ test.describe('History Backup', () => {
       const messageUserB = 'Message from User B';
 
       await test.step('User A and B write messages to each other', async () => {
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
         await userAPages.conversation().sendMessage(messageUserA);
-        await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+        await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
         await userBPages.conversation().sendMessage(messageUserB);
       });
 
@@ -348,9 +346,9 @@ test.describe('History Backup', () => {
       const messageUserB = 'Message from User B';
 
       await test.step('User A and User B write messages to each other', async () => {
-        await userAPages.conversationList().openConversation(conversationName);
+        await userAPages.conversationList().getConversationLocator(conversationName).open();
         await userAPages.conversation().sendMessage(messageUserA);
-        await userBPages.conversationList().openConversation(conversationName);
+        await userBPages.conversationList().getConversationLocator(conversationName).open();
         await userBPages.conversation().sendMessage(messageUserB);
       });
 
@@ -393,9 +391,9 @@ test.describe('History Backup', () => {
       await createGroup(userBPages, conversationName, [userA]);
 
       await test.step('User A and User B write messages to each other', async () => {
-        await userAPages.conversationList().openConversation(conversationName);
+        await userAPages.conversationList().getConversationLocator(conversationName).open();
         await userAPages.conversation().sendMessage('Message from User A');
-        await userBPages.conversationList().openConversation(conversationName);
+        await userBPages.conversationList().getConversationLocator(conversationName).open();
         await userBPages.conversation().sendMessage('Message from User B');
         await expect(userAPages.conversation().messageItems).toHaveCount(2);
       });
@@ -423,7 +421,7 @@ test.describe('History Backup', () => {
 
       await test.step('Validate user A cannot send messages in the left group', async () => {
         await userAComponents.conversationSidebar().allConversationsButton.click();
-        await userAPages.conversationList().openConversation(conversationName);
+        await userAPages.conversationList().getConversationLocator(conversationName).open();
         await expect(userAPages.conversation().systemMessages.filter({hasText: 'You left'})).toBeVisible();
         await expect(userAPages.conversation().messageInput).toBeHidden();
       });

--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -46,7 +46,7 @@ test.describe('In Conversation Search', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       // Preconditions: User B sends media from all categories (images, links, audio and files)
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       // Image
       await shareAssetHelper(getImageFilePath(), userBPage, userBPage.getByRole('button', {name: 'Add picture'}));
       // Audio
@@ -54,7 +54,7 @@ test.describe('In Conversation Search', () => {
       // File
       await shareAssetHelper(getTextFilePath(), userBPage, userBPage.getByRole('button', {name: 'Add file'}));
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await expect(userAPages.conversation().getMessage({sender: userB})).toHaveCount(3);
 
       await userAPages.conversation().searchButton.click();
@@ -77,11 +77,11 @@ test.describe('In Conversation Search', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().enableSelfDeletingMessages();
       await userBPages.conversation().sendMessage('Gone in 10s');
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await expect(userAPages.conversation().getMessage({sender: userB})).toBeVisible();
       await userAPage.waitForTimeout(10_000);
 
@@ -106,11 +106,11 @@ test.describe('In Conversation Search', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().enableSelfDeletingMessages();
       await userBPages.conversation().sendMessage('Gone in 10s');
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await expect(userAPages.conversation().getMessage({sender: userB})).toBeVisible();
 
       await userAPages.conversation().searchButton.click();
@@ -138,8 +138,8 @@ test.describe('In Conversation Search', () => {
       const conversationName = 'Test Group';
       await createGroup(userAPages, conversationName, [userB]);
 
-      await userBPages.conversationList().openConversation(conversationName);
-      await userAPages.conversationList().openConversation(conversationName);
+      await userBPages.conversationList().getConversationLocator(conversationName).open();
+      await userAPages.conversationList().getConversationLocator(conversationName).open();
 
       for (let imageCount = 0; imageCount < 10; imageCount++) {
         await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
@@ -167,10 +167,10 @@ test.describe('In Conversation Search', () => {
       const {pages: userAPages, modals: userAModals} = PageManager.from(pageA).webapp;
       const userBPages = PageManager.from(pageB).webapp.pages;
 
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await shareAssetHelper(getImageFilePath(), pageA, pageA.getByRole('button', {name: 'Add picture'}));
 
       await userAPages.conversation().searchButton.click();
@@ -186,10 +186,10 @@ test.describe('In Conversation Search', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
     // Step: User B sends several links
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
     // Step: User B sends several links
 
     await userAPages.conversation().searchButton.click();
@@ -205,13 +205,13 @@ test.describe('In Conversation Search', () => {
     const userAPages = PageManager.from(pageA).webapp.pages;
     const userBPages = PageManager.from(pageB).webapp.pages;
 
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
     for (let fileCount = 0; fileCount < 10; fileCount++) {
       await shareAssetHelper(getTextFilePath(), pageB, pageB.getByRole('button', {name: 'Add file'}));
     }
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
     for (let fileCount = 0; fileCount < 10; fileCount++) {
       await shareAssetHelper(getTextFilePath(), pageA, pageA.getByRole('button', {name: 'Add file'}));
     }
@@ -232,10 +232,10 @@ test.describe('In Conversation Search', () => {
       const userAPages = PageManager.from(pageA).webapp.pages;
       const userBPages = PageManager.from(pageB).webapp.pages;
 
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       const messageWithImage = userAPages.conversation().getMessage({sender: userB});
       await expect(messageWithImage).toBeVisible();
 
@@ -255,10 +255,10 @@ test.describe('In Conversation Search', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
     await userBPages.conversation().sendMessage('User B message');
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendMessage('User A Message');
 
     await userAPages.conversation().searchButton.click();
@@ -283,10 +283,10 @@ test.describe('In Conversation Search', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().sendMessage('User B message');
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Here is a link: [LinkPreview]https://www.kaufland.de');
 
       await userAPages.conversation().searchButton.click();
@@ -304,10 +304,10 @@ test.describe('In Conversation Search', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
     await userBPages.conversation().sendMessage('User B message');
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendMessage('https://www.kaufland.de');
 
     await expect(userBPages.conversation().getMessage({content: 'https://www.kaufland.de'})).toBeVisible();
@@ -326,10 +326,10 @@ test.describe('In Conversation Search', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
     await userBPages.conversation().sendMessage('User B message: Papaya');
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendMessage('User A message: Guava');
 
     const messageUserB = userBPages.conversation().getMessage({sender: userB});
@@ -351,13 +351,13 @@ test.describe('In Conversation Search', () => {
       ]);
 
       // User B sends the first (older) message
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().sendMessage('Older Message from User B');
 
       await expect(userAPages.conversation().getMessage({sender: userB})).toBeVisible();
 
       //  User A sends the second (newer) message
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Newer Message from User A');
 
       await userAPages.conversation().searchButton.click();
@@ -378,8 +378,8 @@ test.describe('In Conversation Search', () => {
 
     const specialWord = 'Crème brûlée';
 
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
 
     await userBPages.conversation().sendMessage(`Message with diacritical letter: ${specialWord}`);
     await expect(userAPages.conversation().getMessage({content: specialWord})).toBeAttached();
@@ -397,8 +397,8 @@ test.describe('In Conversation Search', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
 
     await userBPages.conversation().sendMessage('User B message');
     await expect(userAPages.conversation().getMessage({sender: userB})).toBeVisible();
@@ -419,10 +419,10 @@ test.describe('In Conversation Search', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().sendMessage('Papaya');
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await expect(userAPages.conversation().getMessage({content: 'Papaya'})).toBeVisible();
       await userAPages.conversation().sendMessage(`Message from User A: 1`);
       await userAPages.conversation().sendMessage('Empty\n'.repeat(50));

--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -46,7 +46,7 @@ test.describe('In Conversation Search', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       // Preconditions: User B sends media from all categories (images, links, audio and files)
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       // Image
       await shareAssetHelper(getImageFilePath(), userBPage, userBPage.getByRole('button', {name: 'Add picture'}));
       // Audio
@@ -54,7 +54,7 @@ test.describe('In Conversation Search', () => {
       // File
       await shareAssetHelper(getTextFilePath(), userBPage, userBPage.getByRole('button', {name: 'Add file'}));
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await expect(userAPages.conversation().getMessage({sender: userB})).toHaveCount(3);
 
       await userAPages.conversation().searchButton.click();
@@ -77,11 +77,11 @@ test.describe('In Conversation Search', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().enableSelfDeletingMessages();
       await userBPages.conversation().sendMessage('Gone in 10s');
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await expect(userAPages.conversation().getMessage({sender: userB})).toBeVisible();
       await userAPage.waitForTimeout(10_000);
 
@@ -106,11 +106,11 @@ test.describe('In Conversation Search', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().enableSelfDeletingMessages();
       await userBPages.conversation().sendMessage('Gone in 10s');
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await expect(userAPages.conversation().getMessage({sender: userB})).toBeVisible();
 
       await userAPages.conversation().searchButton.click();
@@ -138,8 +138,8 @@ test.describe('In Conversation Search', () => {
       const conversationName = 'Test Group';
       await createGroup(userAPages, conversationName, [userB]);
 
-      await userBPages.conversationList().getConversationLocator(conversationName).open();
-      await userAPages.conversationList().getConversationLocator(conversationName).open();
+      await userBPages.conversationList().getConversation(conversationName).open();
+      await userAPages.conversationList().getConversation(conversationName).open();
 
       for (let imageCount = 0; imageCount < 10; imageCount++) {
         await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
@@ -167,10 +167,10 @@ test.describe('In Conversation Search', () => {
       const {pages: userAPages, modals: userAModals} = PageManager.from(pageA).webapp;
       const userBPages = PageManager.from(pageB).webapp.pages;
 
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await shareAssetHelper(getImageFilePath(), pageA, pageA.getByRole('button', {name: 'Add picture'}));
 
       await userAPages.conversation().searchButton.click();
@@ -186,10 +186,10 @@ test.describe('In Conversation Search', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     // Step: User B sends several links
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     // Step: User B sends several links
 
     await userAPages.conversation().searchButton.click();
@@ -205,13 +205,13 @@ test.describe('In Conversation Search', () => {
     const userAPages = PageManager.from(pageA).webapp.pages;
     const userBPages = PageManager.from(pageB).webapp.pages;
 
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
     for (let fileCount = 0; fileCount < 10; fileCount++) {
       await shareAssetHelper(getTextFilePath(), pageB, pageB.getByRole('button', {name: 'Add file'}));
     }
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     for (let fileCount = 0; fileCount < 10; fileCount++) {
       await shareAssetHelper(getTextFilePath(), pageA, pageA.getByRole('button', {name: 'Add file'}));
     }
@@ -232,10 +232,10 @@ test.describe('In Conversation Search', () => {
       const userAPages = PageManager.from(pageA).webapp.pages;
       const userBPages = PageManager.from(pageB).webapp.pages;
 
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await shareAssetHelper(getImageFilePath(), pageB, pageB.getByRole('button', {name: 'Add picture'}));
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       const messageWithImage = userAPages.conversation().getMessage({sender: userB});
       await expect(messageWithImage).toBeVisible();
 
@@ -255,10 +255,10 @@ test.describe('In Conversation Search', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await userBPages.conversation().sendMessage('User B message');
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendMessage('User A Message');
 
     await userAPages.conversation().searchButton.click();
@@ -283,10 +283,10 @@ test.describe('In Conversation Search', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().sendMessage('User B message');
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Here is a link: [LinkPreview]https://www.kaufland.de');
 
       await userAPages.conversation().searchButton.click();
@@ -304,10 +304,10 @@ test.describe('In Conversation Search', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await userBPages.conversation().sendMessage('User B message');
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendMessage('https://www.kaufland.de');
 
     await expect(userBPages.conversation().getMessage({content: 'https://www.kaufland.de'})).toBeVisible();
@@ -326,10 +326,10 @@ test.describe('In Conversation Search', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await userBPages.conversation().sendMessage('User B message: Papaya');
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendMessage('User A message: Guava');
 
     const messageUserB = userBPages.conversation().getMessage({sender: userB});
@@ -351,13 +351,13 @@ test.describe('In Conversation Search', () => {
       ]);
 
       // User B sends the first (older) message
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().sendMessage('Older Message from User B');
 
       await expect(userAPages.conversation().getMessage({sender: userB})).toBeVisible();
 
       //  User A sends the second (newer) message
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Newer Message from User A');
 
       await userAPages.conversation().searchButton.click();
@@ -378,8 +378,8 @@ test.describe('In Conversation Search', () => {
 
     const specialWord = 'Crème brûlée';
 
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
 
     await userBPages.conversation().sendMessage(`Message with diacritical letter: ${specialWord}`);
     await expect(userAPages.conversation().getMessage({content: specialWord})).toBeAttached();
@@ -397,8 +397,8 @@ test.describe('In Conversation Search', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
 
     await userBPages.conversation().sendMessage('User B message');
     await expect(userAPages.conversation().getMessage({sender: userB})).toBeVisible();
@@ -419,10 +419,10 @@ test.describe('In Conversation Search', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().sendMessage('Papaya');
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await expect(userAPages.conversation().getMessage({content: 'Papaya'})).toBeVisible();
       await userAPages.conversation().sendMessage(`Message from User A: 1`);
       await userAPages.conversation().sendMessage('Empty\n'.repeat(50));

--- a/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
@@ -37,8 +37,8 @@ test.describe('Link Preview', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       const linkConfigs = [
         {

--- a/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
@@ -37,8 +37,8 @@ test.describe('Link Preview', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       const linkConfigs = [
         {

--- a/apps/webapp/test/e2e_tests/specs/Localization/localization.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Localization/localization.spec.ts
@@ -140,7 +140,7 @@ test.describe('Localization', () => {
       await pages.startUI().component.getByRole('button', {name: userB.fullName}).click();
       await modals.userProfile().startConversationButton.click();
 
-      const conversation = await pages.conversationList().getConversationLocator(userB.fullName).open();
+      const conversation = await pages.conversationList().getConversation(userB.fullName).open();
       const messagePlaceholder = page.locator('[data-uie-name="input-placeholder"]');
       await expect(messagePlaceholder).toHaveText(deTranslations['tooltipConversationInputPlaceholder']);
 

--- a/apps/webapp/test/e2e_tests/specs/Localization/localization.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Localization/localization.spec.ts
@@ -140,16 +140,12 @@ test.describe('Localization', () => {
       await pages.startUI().component.getByRole('button', {name: userB.fullName}).click();
       await modals.userProfile().startConversationButton.click();
 
-      await pages.conversationList().openConversation(userB.fullName);
+      const conversation = await pages.conversationList().getConversationLocator(userB.fullName).open();
       const messagePlaceholder = page.locator('[data-uie-name="input-placeholder"]');
       await expect(messagePlaceholder).toHaveText(deTranslations['tooltipConversationInputPlaceholder']);
 
       await components.conversationSidebar().allConversationsButton.click();
-      await pages
-        .conversationList()
-        .getConversationLocator(userB.fullName)
-        .getByRole('button', {name: deTranslations['accessibility.conversationOptionsMenu']})
-        .click();
+      await conversation.getByRole('button', {name: deTranslations['accessibility.conversationOptionsMenu']}).click();
 
       const menuList = page.getByRole('menu').getByRole('menuitem');
 

--- a/apps/webapp/test/e2e_tests/specs/Logs/logs.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Logs/logs.spec.ts
@@ -27,8 +27,8 @@ test.describe('Logs', () => {
       const messageA = 'Hello from UserA! This is a secret message.';
       const messageB = 'Hi from UserB! No logging allowed.';
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage(messageA);
       await userBPages.conversation().sendMessage(messageB);
 

--- a/apps/webapp/test/e2e_tests/specs/Logs/logs.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Logs/logs.spec.ts
@@ -27,8 +27,8 @@ test.describe('Logs', () => {
       const messageA = 'Hello from UserA! This is a secret message.';
       const messageB = 'Hi from UserB! No logging allowed.';
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage(messageA);
       await userBPages.conversation().sendMessage(messageB);
 

--- a/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
@@ -68,8 +68,8 @@ test.describe('Markdown', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendTypedMessage(message);
 
       for (const pages of [userAPages, userBPages]) {
@@ -88,7 +88,7 @@ test.describe('Markdown', () => {
       const userAPageManager = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB)));
       const {pages, modals} = userAPageManager.webapp;
 
-      await pages.conversationList().getConversationLocator(userB.fullName).open();
+      await pages.conversationList().getConversation(userB.fullName).open();
       await pages.conversation().sendTypedMessage(targetUrl);
 
       const message = pages.conversation().getMessage({sender: userA});
@@ -110,8 +110,8 @@ test.describe('Markdown', () => {
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
     const longCodeMessage = '```\nconst a = 5;\nconst b = 10;\nconsole.log(a + b);\n```';
     await userAPages.conversation().sendMessage(longCodeMessage);
@@ -129,8 +129,8 @@ test.describe('Markdown', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendTypedMessage('**Bold**, *Italic* and `Code`');
 
     for (const pages of [userAPages, userBPages]) {
@@ -148,8 +148,8 @@ test.describe('Markdown', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendTypedMessage('Start **Bold** Message');
 
     const sentMessageA = userAPages.conversation().getMessage({sender: userA});
@@ -179,8 +179,8 @@ test.describe('Markdown', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       const linkText = 'Wire Website';
       const url = 'https://wire.com';

--- a/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
@@ -68,8 +68,8 @@ test.describe('Markdown', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendTypedMessage(message);
 
       for (const pages of [userAPages, userBPages]) {
@@ -88,7 +88,7 @@ test.describe('Markdown', () => {
       const userAPageManager = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB)));
       const {pages, modals} = userAPageManager.webapp;
 
-      await pages.conversationList().openConversation(userB.fullName);
+      await pages.conversationList().getConversationLocator(userB.fullName).open();
       await pages.conversation().sendTypedMessage(targetUrl);
 
       const message = pages.conversation().getMessage({sender: userA});
@@ -110,8 +110,8 @@ test.describe('Markdown', () => {
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
     const longCodeMessage = '```\nconst a = 5;\nconst b = 10;\nconsole.log(a + b);\n```';
     await userAPages.conversation().sendMessage(longCodeMessage);
@@ -129,8 +129,8 @@ test.describe('Markdown', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendTypedMessage('**Bold**, *Italic* and `Code`');
 
     for (const pages of [userAPages, userBPages]) {
@@ -148,8 +148,8 @@ test.describe('Markdown', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendTypedMessage('Start **Bold** Message');
 
     const sentMessageA = userAPages.conversation().getMessage({sender: userA});
@@ -179,8 +179,8 @@ test.describe('Markdown', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       const linkText = 'Wire Website';
       const url = 'https://wire.com';

--- a/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
@@ -23,11 +23,11 @@ test.describe('Mention', () => {
     await createGroup(userAPages, 'Mention Group', [userB]);
 
     // User A sends a message with a mention
-    await userAPages.conversationList().openConversation('Mention Group');
+    await userAPages.conversationList().getConversationLocator('Mention Group').open();
     await userAPages.conversation().sendMessageWithUserMention(userB.fullName, 'Hey');
 
     // User B receives the message
-    await userBPages.conversationList().openConversation('Mention Group');
+    await userBPages.conversationList().getConversationLocator('Mention Group').open();
     const messageOnUserB = userBPages.conversation().getMessage({content: 'Hey', sender: userA});
     await expect(messageOnUserB).toBeVisible();
     const mentionOnUserB = messageOnUserB.getByRole('button', {name: `@${userB.fullName}`});
@@ -45,11 +45,11 @@ test.describe('Mention', () => {
       ]);
 
       await createGroup(userAPages, 'Multi-Mention Group', [userB, userC]);
-      await userBPages.conversationList().openConversation('Multi-Mention Group');
-      await userCPages.conversationList().openConversation('Multi-Mention Group');
+      await userBPages.conversationList().getConversationLocator('Multi-Mention Group').open();
+      await userCPages.conversationList().getConversationLocator('Multi-Mention Group').open();
 
       // User A sends a message with multiple mentions
-      await userAPages.conversationList().openConversation('Multi-Mention Group');
+      await userAPages.conversationList().getConversationLocator('Multi-Mention Group').open();
       const conversationPageA = userAPages.conversation();
 
       await conversationPageA.messageInput.fill('Hello ');
@@ -79,9 +79,9 @@ test.describe('Mention', () => {
 
       await test.step('Create group', async () => {
         await createGroup(userAPages, 'Edit-Mention Group', [userB, userC]);
-        await userAPages.conversationList().openConversation('Edit-Mention Group');
-        await userBPages.conversationList().openConversation('Edit-Mention Group');
-        await userCPages.conversationList().openConversation('Edit-Mention Group');
+        await userAPages.conversationList().getConversationLocator('Edit-Mention Group').open();
+        await userBPages.conversationList().getConversationLocator('Edit-Mention Group').open();
+        await userCPages.conversationList().getConversationLocator('Edit-Mention Group').open();
       });
 
       await test.step('User A sends an initial message mentioning userB', async () => {
@@ -122,8 +122,8 @@ test.describe('Mention', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
     await userAPages.conversation().sendMessageWithUserMention(userB.fullName, 'Hello');
 
@@ -145,8 +145,8 @@ test.describe('Mention', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       // User A sends a self deleting message with a mention
       await userAPages.conversation().enableSelfDeletingMessages();
@@ -174,8 +174,8 @@ test.describe('Mention', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       // User A sends a message with the same person mentioned twice
       const conversationPageA = userAPages.conversation();
@@ -199,7 +199,7 @@ test.describe('Mention', () => {
     {tag: ['@TC-3493', '@regression']},
     async ({createPage}) => {
       const userAPages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
-      await userAPages.conversationList().openConversation(userB.fullName);
+      await userAPages.conversationList().getConversationLocator(userB.fullName).open();
 
       const conversationPageA = userAPages.conversation();
       await conversationPageA.messageInput.fill(''); // Clear input
@@ -223,8 +223,8 @@ test.describe('Mention', () => {
         createPage(withLogin(userA), withConnectedUser(userB)).then(page => PageManager.from(page).webapp.pages),
         createPage(withLogin(userB)).then(page => PageManager.from(page).webapp.pages),
       ]);
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       const conversationPageA = userAPages.conversation();
 
@@ -256,8 +256,9 @@ test.describe('Mention', () => {
       await createGroup(userAPages, 'Draft Group', [userB]);
 
       const conversationPageA = userAPages.conversation();
+      const draftGroupConversation = userAPages.conversationList().getConversationLocator('Draft Group');
       await test.step('Draft a message with a mention in the group chat', async () => {
-        await userAPages.conversationList().openConversation('Draft Group');
+        await draftGroupConversation.open();
         await conversationPageA.messageInput.fill('Draft message with ');
         await conversationPageA.mentionUser(userB.fullName);
 
@@ -266,12 +267,12 @@ test.describe('Mention', () => {
       });
 
       await test.step('Switch to the 1:1 chat', async () => {
-        await userAPages.conversationList().openConversation(userB.fullName);
+        await userAPages.conversationList().getConversationLocator(userB.fullName).open();
         await expect(conversationPageA.messageInput).toBeEmpty();
       });
 
       await test.step('Switch back to the group chat and verify the draft with the mention is preserved', async () => {
-        await userAPages.conversationList().openConversation('Draft Group');
+        await draftGroupConversation.open();
         await expect(conversationPageA.messageInput).toHaveText(`Draft message with @${userB.fullName}`);
 
         const preservedMention = conversationPageA.messageInput.getByTestId('item-input-mention');
@@ -287,8 +288,8 @@ test.describe('Mention', () => {
       pm => pm.webapp.pages,
     );
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
     // User A sends a message with a mention to User B
     await userAPages.conversation().sendMessageWithUserMention(userB.fullName, 'Hello');
@@ -312,10 +313,10 @@ test.describe('Mention', () => {
 
       // Create and open a group conversation for userB to ensure the message from A won't be read immediately
       await createGroup(userBPages, 'Distraction Group', [userC]);
-      await userBPages.conversationList().openConversation('Distraction Group');
+      await userBPages.conversationList().getConversationLocator('Distraction Group').open();
 
       // User A opens conversation with user B and sends a message with mention
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessageWithUserMention(userB.fullName, 'Hey, you have an unread mention!');
 
       // User B is in the 'Distraction Group', so the conversation with user A is unread.
@@ -337,11 +338,11 @@ test.describe('Mention', () => {
       await test.step('Create and open a distraction group conversation for User B', async () => {
         // userA creates the group, userB opens it. This is the distraction.
         await createGroup(userAPages, 'Distraction Group', [userB]);
-        await userBPages.conversationList().openConversation('Distraction Group');
+        await userBPages.conversationList().getConversationLocator('Distraction Group').open();
       });
 
       await test.step('User A tries to call User B in 1:1 conversation but B declines', async () => {
-        await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
         await userAPages.conversation().startCall();
         await userBPages.calling().leaveCallButton.click();
         await userAPages.calling().leaveCallButton.click();
@@ -376,8 +377,8 @@ test.describe('Mention', () => {
       ]);
 
       await createGroup(userAPages, 'Test Group', [userB]);
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation('Test Group');
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator('Test Group').open();
 
       await userAPages.conversation().sendMessageWithUserMention(userB.fullName);
       const {mentionIndicator} = userBPages.conversationList().getConversationLocator(userA.fullName);
@@ -397,8 +398,8 @@ test.describe('Mention', () => {
         PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage(`@${userB.fullName} Hello`);
 
       for (const pages of [userAPages, userBPages]) {
@@ -414,7 +415,7 @@ test.describe('Mention', () => {
     {tag: ['@TC-3532', '@regression']},
     async ({createPage}) => {
       const {pages} = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp;
-      await pages.conversationList().openConversation(userB.fullName);
+      await pages.conversationList().getConversationLocator(userB.fullName).open();
 
       await pages.conversation().messageInput.pressSequentially(`test@${userB.firstName}`);
       await expect(pages.conversation().mentionSuggestions).toHaveCount(0);
@@ -428,7 +429,7 @@ test.describe('Mention', () => {
       const {pages} = PageManager.from(await createPage(withLogin(userA))).webapp;
 
       await createGroup(pages, 'Test Group', [userB]);
-      await pages.conversationList().openConversation('Test Group');
+      await pages.conversationList().getConversationLocator('Test Group').open();
 
       // It should be possible to mention userB as he's part of the group
       await pages.conversation().messageInput.pressSequentially(`@${userB.firstName}`);
@@ -448,7 +449,7 @@ test.describe('Mention', () => {
       const {pages} = PageManager.from(await createPage(withLogin(userA))).webapp;
 
       await createGroup(pages, 'Test Group', [userB, userC]);
-      await pages.conversationList().openConversation('Test Group');
+      await pages.conversationList().getConversationLocator('Test Group').open();
 
       // It should be possible to mention userB as he's part of the group
       await pages.conversation().messageInput.pressSequentially(`@`);
@@ -467,7 +468,7 @@ test.describe('Mention', () => {
 
       const {pages} = PageManager.from(await createPage(withLogin(userA))).webapp;
       await createGroup(pages, 'Test Group', [memberWithStrangeName]);
-      await pages.conversationList().openConversation('Test Group');
+      await pages.conversationList().getConversationLocator('Test Group').open();
 
       await pages.conversation().messageInput.pressSequentially('@Gunter');
       await expect(pages.conversation().mentionSuggestions).toHaveCount(1);
@@ -483,7 +484,7 @@ test.describe('Mention', () => {
       await createGroup(pages, 'Test Group', []);
 
       await test.step('Create guest link for group & join as guest user', async () => {
-        await pages.conversationList().openConversation('Test Group');
+        await pages.conversationList().getConversationLocator('Test Group').open();
         await pages.conversation().clickConversationTitle();
         const link = await pages.conversationDetails().createGuestLink();
         await createPage(withGuestUser(link, 'Guest User'));
@@ -523,12 +524,12 @@ test.describe('Mention', () => {
       });
 
       await test.step("UserB mentions otherUser in the group although they're not connected", async () => {
-        await userBPages.conversationList().openConversation('Test Group');
+        await userBPages.conversationList().getConversationLocator('Test Group').open();
         await userBPages.conversation().sendMessageWithUserMention(otherUser.fullName);
       });
 
       await test.step('OtherUser receives the message from userB including the mention', async () => {
-        await otherUserPages.conversationList().openConversation('Test Group');
+        await otherUserPages.conversationList().getConversationLocator('Test Group').open();
         const mentionInMessage = otherUserPages
           .conversation()
           .getMessage({sender: userB})
@@ -546,7 +547,7 @@ test.describe('Mention', () => {
       await createGroup(userAPages, 'Test Group', [userB, userC]);
 
       await test.step('UserA removes userB from the group', async () => {
-        await userAPages.conversationList().openConversation('Test Group');
+        await userAPages.conversationList().getConversationLocator('Test Group').open();
         await userAPages.conversation().conversationTitle.click();
         await userAPages.conversationDetails().openParticipantDetails(userB.fullName);
         await userAPages.participantDetails().removeFromGroup();

--- a/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
@@ -23,11 +23,11 @@ test.describe('Mention', () => {
     await createGroup(userAPages, 'Mention Group', [userB]);
 
     // User A sends a message with a mention
-    await userAPages.conversationList().getConversationLocator('Mention Group').open();
+    await userAPages.conversationList().getConversation('Mention Group').open();
     await userAPages.conversation().sendMessageWithUserMention(userB.fullName, 'Hey');
 
     // User B receives the message
-    await userBPages.conversationList().getConversationLocator('Mention Group').open();
+    await userBPages.conversationList().getConversation('Mention Group').open();
     const messageOnUserB = userBPages.conversation().getMessage({content: 'Hey', sender: userA});
     await expect(messageOnUserB).toBeVisible();
     const mentionOnUserB = messageOnUserB.getByRole('button', {name: `@${userB.fullName}`});
@@ -45,11 +45,11 @@ test.describe('Mention', () => {
       ]);
 
       await createGroup(userAPages, 'Multi-Mention Group', [userB, userC]);
-      await userBPages.conversationList().getConversationLocator('Multi-Mention Group').open();
-      await userCPages.conversationList().getConversationLocator('Multi-Mention Group').open();
+      await userBPages.conversationList().getConversation('Multi-Mention Group').open();
+      await userCPages.conversationList().getConversation('Multi-Mention Group').open();
 
       // User A sends a message with multiple mentions
-      await userAPages.conversationList().getConversationLocator('Multi-Mention Group').open();
+      await userAPages.conversationList().getConversation('Multi-Mention Group').open();
       const conversationPageA = userAPages.conversation();
 
       await conversationPageA.messageInput.fill('Hello ');
@@ -79,9 +79,9 @@ test.describe('Mention', () => {
 
       await test.step('Create group', async () => {
         await createGroup(userAPages, 'Edit-Mention Group', [userB, userC]);
-        await userAPages.conversationList().getConversationLocator('Edit-Mention Group').open();
-        await userBPages.conversationList().getConversationLocator('Edit-Mention Group').open();
-        await userCPages.conversationList().getConversationLocator('Edit-Mention Group').open();
+        await userAPages.conversationList().getConversation('Edit-Mention Group').open();
+        await userBPages.conversationList().getConversation('Edit-Mention Group').open();
+        await userCPages.conversationList().getConversation('Edit-Mention Group').open();
       });
 
       await test.step('User A sends an initial message mentioning userB', async () => {
@@ -122,8 +122,8 @@ test.describe('Mention', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
     await userAPages.conversation().sendMessageWithUserMention(userB.fullName, 'Hello');
 
@@ -145,8 +145,8 @@ test.describe('Mention', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       // User A sends a self deleting message with a mention
       await userAPages.conversation().enableSelfDeletingMessages();
@@ -174,8 +174,8 @@ test.describe('Mention', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       // User A sends a message with the same person mentioned twice
       const conversationPageA = userAPages.conversation();
@@ -199,7 +199,7 @@ test.describe('Mention', () => {
     {tag: ['@TC-3493', '@regression']},
     async ({createPage}) => {
       const userAPages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
-      await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+      await userAPages.conversationList().getConversation(userB.fullName).open();
 
       const conversationPageA = userAPages.conversation();
       await conversationPageA.messageInput.fill(''); // Clear input
@@ -223,8 +223,8 @@ test.describe('Mention', () => {
         createPage(withLogin(userA), withConnectedUser(userB)).then(page => PageManager.from(page).webapp.pages),
         createPage(withLogin(userB)).then(page => PageManager.from(page).webapp.pages),
       ]);
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       const conversationPageA = userAPages.conversation();
 
@@ -256,7 +256,7 @@ test.describe('Mention', () => {
       await createGroup(userAPages, 'Draft Group', [userB]);
 
       const conversationPageA = userAPages.conversation();
-      const draftGroupConversation = userAPages.conversationList().getConversationLocator('Draft Group');
+      const draftGroupConversation = userAPages.conversationList().getConversation('Draft Group');
       await test.step('Draft a message with a mention in the group chat', async () => {
         await draftGroupConversation.open();
         await conversationPageA.messageInput.fill('Draft message with ');
@@ -267,7 +267,7 @@ test.describe('Mention', () => {
       });
 
       await test.step('Switch to the 1:1 chat', async () => {
-        await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+        await userAPages.conversationList().getConversation(userB.fullName).open();
         await expect(conversationPageA.messageInput).toBeEmpty();
       });
 
@@ -288,8 +288,8 @@ test.describe('Mention', () => {
       pm => pm.webapp.pages,
     );
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
     // User A sends a message with a mention to User B
     await userAPages.conversation().sendMessageWithUserMention(userB.fullName, 'Hello');
@@ -313,15 +313,15 @@ test.describe('Mention', () => {
 
       // Create and open a group conversation for userB to ensure the message from A won't be read immediately
       await createGroup(userBPages, 'Distraction Group', [userC]);
-      await userBPages.conversationList().getConversationLocator('Distraction Group').open();
+      await userBPages.conversationList().getConversation('Distraction Group').open();
 
       // User A opens conversation with user B and sends a message with mention
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessageWithUserMention(userB.fullName, 'Hey, you have an unread mention!');
 
       // User B is in the 'Distraction Group', so the conversation with user A is unread.
       // Now check for the mention indicator in the conversation list.
-      const {mentionIndicator} = userBPages.conversationList().getConversationLocator(userA.fullName);
+      const {mentionIndicator} = userBPages.conversationList().getConversation(userA.fullName);
       await expect(mentionIndicator).toBeVisible();
     },
   );
@@ -338,11 +338,11 @@ test.describe('Mention', () => {
       await test.step('Create and open a distraction group conversation for User B', async () => {
         // userA creates the group, userB opens it. This is the distraction.
         await createGroup(userAPages, 'Distraction Group', [userB]);
-        await userBPages.conversationList().getConversationLocator('Distraction Group').open();
+        await userBPages.conversationList().getConversation('Distraction Group').open();
       });
 
       await test.step('User A tries to call User B in 1:1 conversation but B declines', async () => {
-        await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+        await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
         await userAPages.conversation().startCall();
         await userBPages.calling().leaveCallButton.click();
         await userAPages.calling().leaveCallButton.click();
@@ -361,7 +361,7 @@ test.describe('Mention', () => {
       });
 
       await test.step('Verify User B sees both unread mention and unread message indicators for 1:1 conversation', async () => {
-        const {mentionIndicator} = userBPages.conversationList().getConversationLocator(userA.fullName);
+        const {mentionIndicator} = userBPages.conversationList().getConversation(userA.fullName);
         await expect(mentionIndicator).toBeVisible();
       });
     },
@@ -377,11 +377,11 @@ test.describe('Mention', () => {
       ]);
 
       await createGroup(userAPages, 'Test Group', [userB]);
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator('Test Group').open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation('Test Group').open();
 
       await userAPages.conversation().sendMessageWithUserMention(userB.fullName);
-      const {mentionIndicator} = userBPages.conversationList().getConversationLocator(userA.fullName);
+      const {mentionIndicator} = userBPages.conversationList().getConversation(userA.fullName);
       await expect(mentionIndicator).toBeVisible();
 
       await userAPages.conversation().deleteMessage(userAPages.conversation().getMessage({sender: userA}), 'Everyone');
@@ -398,8 +398,8 @@ test.describe('Mention', () => {
         PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage(`@${userB.fullName} Hello`);
 
       for (const pages of [userAPages, userBPages]) {
@@ -415,7 +415,7 @@ test.describe('Mention', () => {
     {tag: ['@TC-3532', '@regression']},
     async ({createPage}) => {
       const {pages} = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp;
-      await pages.conversationList().getConversationLocator(userB.fullName).open();
+      await pages.conversationList().getConversation(userB.fullName).open();
 
       await pages.conversation().messageInput.pressSequentially(`test@${userB.firstName}`);
       await expect(pages.conversation().mentionSuggestions).toHaveCount(0);
@@ -429,7 +429,7 @@ test.describe('Mention', () => {
       const {pages} = PageManager.from(await createPage(withLogin(userA))).webapp;
 
       await createGroup(pages, 'Test Group', [userB]);
-      await pages.conversationList().getConversationLocator('Test Group').open();
+      await pages.conversationList().getConversation('Test Group').open();
 
       // It should be possible to mention userB as he's part of the group
       await pages.conversation().messageInput.pressSequentially(`@${userB.firstName}`);
@@ -449,7 +449,7 @@ test.describe('Mention', () => {
       const {pages} = PageManager.from(await createPage(withLogin(userA))).webapp;
 
       await createGroup(pages, 'Test Group', [userB, userC]);
-      await pages.conversationList().getConversationLocator('Test Group').open();
+      await pages.conversationList().getConversation('Test Group').open();
 
       // It should be possible to mention userB as he's part of the group
       await pages.conversation().messageInput.pressSequentially(`@`);
@@ -468,7 +468,7 @@ test.describe('Mention', () => {
 
       const {pages} = PageManager.from(await createPage(withLogin(userA))).webapp;
       await createGroup(pages, 'Test Group', [memberWithStrangeName]);
-      await pages.conversationList().getConversationLocator('Test Group').open();
+      await pages.conversationList().getConversation('Test Group').open();
 
       await pages.conversation().messageInput.pressSequentially('@Gunter');
       await expect(pages.conversation().mentionSuggestions).toHaveCount(1);
@@ -484,7 +484,7 @@ test.describe('Mention', () => {
       await createGroup(pages, 'Test Group', []);
 
       await test.step('Create guest link for group & join as guest user', async () => {
-        await pages.conversationList().getConversationLocator('Test Group').open();
+        await pages.conversationList().getConversation('Test Group').open();
         await pages.conversation().clickConversationTitle();
         const link = await pages.conversationDetails().createGuestLink();
         await createPage(withGuestUser(link, 'Guest User'));
@@ -517,19 +517,19 @@ test.describe('Mention', () => {
 
       await otherUserPages.conversationList().pendingConnectionRequest.click();
       await otherUserPages.connectRequest().connectButton.click();
-      await expect(userAPages.conversationList().getConversationLocator(otherUser.fullName)).toBeAttached();
+      await expect(userAPages.conversationList().getConversation(otherUser.fullName)).toBeAttached();
 
       await test.step('UserA creates a group including userB and otherUser', async () => {
         await createGroup(userAPages, 'Test Group', [userB, otherUser]);
       });
 
       await test.step("UserB mentions otherUser in the group although they're not connected", async () => {
-        await userBPages.conversationList().getConversationLocator('Test Group').open();
+        await userBPages.conversationList().getConversation('Test Group').open();
         await userBPages.conversation().sendMessageWithUserMention(otherUser.fullName);
       });
 
       await test.step('OtherUser receives the message from userB including the mention', async () => {
-        await otherUserPages.conversationList().getConversationLocator('Test Group').open();
+        await otherUserPages.conversationList().getConversation('Test Group').open();
         const mentionInMessage = otherUserPages
           .conversation()
           .getMessage({sender: userB})
@@ -547,7 +547,7 @@ test.describe('Mention', () => {
       await createGroup(userAPages, 'Test Group', [userB, userC]);
 
       await test.step('UserA removes userB from the group', async () => {
-        await userAPages.conversationList().getConversationLocator('Test Group').open();
+        await userAPages.conversationList().getConversation('Test Group').open();
         await userAPages.conversation().conversationTitle.click();
         await userAPages.conversationDetails().openParticipantDetails(userB.fullName);
         await userAPages.participantDetails().removeFromGroup();

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -27,7 +27,7 @@ test.describe('Notifications', () => {
     const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
     // Send message from A to B in 1on1 conversation
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendMessageWithUserMention(userB.fullName, 'Hello');
 
     // Check the notifications B received to contain the message from A
@@ -59,20 +59,20 @@ test.describe('Notifications', () => {
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
       // Archive conversation for user B
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      const contextMenu = await userBPages
+      const conversation = await userBPages
         .conversationList()
         .getConversationLocator(userA.fullName, {protocol: 'mls'})
-        .openContextMenu();
+        .open();
+      const contextMenu = await conversation.openContextMenu();
       await contextMenu.archiveButton.click();
 
       // Send message from A to B in 1on1 conversation
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Hello');
 
       // Open the archived conversation and ensure the message was received
       await userBComponents.conversationSidebar().clickArchive();
-      await userBPages.conversationList().openConversation(userA.fullName);
+      await conversation.open();
       await expect(userBPages.conversation().getMessage({sender: userA})).toBeVisible();
 
       // Check that B did not receive any more notifications
@@ -86,11 +86,11 @@ test.describe('Notifications', () => {
     async ({createPage}) => {
       const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
 
-      const contextMenu = await pages.conversationList().getConversationLocator(userB.fullName).openContextMenu();
+      const conversation = await pages.conversationList().getConversationLocator(userB.fullName).open();
+      const contextMenu = await conversation.openContextMenu();
       await contextMenu.notificationsButton.click();
       await pages.conversationDetails().selectNotificationsLevel('Nothing');
 
-      const conversation = pages.conversationList().getConversationLocator(userB.fullName);
       await expect(conversation.mutedIndicator).toBeVisible();
     },
   );
@@ -139,7 +139,8 @@ test.describe('Notifications', () => {
         // Depending on the current test case mute either the group or the 1on1
         await userBPages
           .conversationList()
-          .openConversation(conversationType === 'group' ? 'Test Group' : userA.fullName);
+          .getConversationLocator(conversationType === 'group' ? 'Test Group' : userA.fullName)
+          .open();
         await userBPages.conversation().clickConversationInfoButton();
         await expect(userBPages.conversationDetails().notificationsButton).toContainText('Everything');
 
@@ -153,7 +154,8 @@ test.describe('Notifications', () => {
         // User A sends a message to the muted conversation
         await userAPages
           .conversationList()
-          .openConversation(conversationType === 'group' ? 'Test Group' : userB.fullName);
+          .getConversationLocator(conversationType === 'group' ? 'Test Group' : userB.fullName)
+          .open();
         await userAPages.conversation().sendMessage('Test Message');
         await expect.poll(() => getUserBNotifications()).toHaveLength(0);
       },
@@ -170,21 +172,20 @@ test.describe('Notifications', () => {
       ]);
 
       // User B mutes the conversation with User A
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      const contextMenu = await userBPages
+      const conversation = await userBPages
         .conversationList()
         .getConversationLocator(userA.fullName, {protocol: 'mls'})
-        .openContextMenu();
+        .open();
+      const contextMenu = await conversation.openContextMenu();
       await contextMenu.notificationsButton.click();
       await userBPages.conversationDetails().selectNotificationsLevel('Nothing');
 
       // User A initiates a call to User B
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().clickCallButton();
 
       // Verify that User B sees a "Join" button on the muted conversation
-      const {joinCallButton} = userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'});
-      await expect(joinCallButton).toBeVisible();
+      await expect(conversation.joinCallButton).toBeVisible();
     },
   );
 
@@ -200,28 +201,31 @@ test.describe('Notifications', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       // Open 1on1 conversation between users
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-
-      // User B mutes the conversation with User A via recent view
-      const contextMenu = await userBPages
+      const userAConversation = await userAPages
+        .conversationList()
+        .getConversationLocator(userB.fullName, {protocol: 'mls'})
+        .open();
+      const userBConversation = await userBPages
         .conversationList()
         .getConversationLocator(userA.fullName, {protocol: 'mls'})
-        .openContextMenu();
+        .open();
+
+      // User B mutes the conversation with User A via recent view
+      const contextMenu = await userBConversation.openContextMenu();
       await contextMenu.notificationsButton.click();
       await userBPages.conversationDetails().selectNotificationsLevel('Nothing');
 
       // Create group and open it for user B so the message won't be read immediately
       await createGroup(userAPages, 'Test Group', [userB]);
-      await userBPages.conversationList().openConversation('Test Group');
+      await userBPages.conversationList().getConversationLocator('Test Group').open();
 
       // Start intercepting notifications for User B
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
       // User A sends message to User B and B received it
-      await userAPages.conversationList().openConversation(userB.fullName);
+      await userAConversation.open();
       await userAPages.conversation().sendMessage('Test Message');
-      await expect(userBPages.conversationList().getConversationLocator(userA.fullName)).toContainText('1 message');
+      await expect(userBConversation).toContainText('1 message');
 
       // Verify User B did not receive any notifications for the second message
       await expect.poll(() => getUserBNotifications()).toHaveLength(0);
@@ -242,7 +246,7 @@ test.describe('Notifications', () => {
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
       // User A sends an ephemeral message
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().enableSelfDeletingMessages();
       await userAPages.conversation().sendMessage('Ephemeral Message');
 
@@ -347,10 +351,10 @@ test.describe('Notifications', () => {
       for (const conversation of ['1on1', 'group'] as const) {
         await test.step(`User A opens the ${conversation} conversation`, async () => {
           if (conversation === '1on1') {
-            await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+            await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
           } else {
             await createGroup(userAPages, 'Test Group', [userB]);
-            await userAPages.conversationList().openConversation('Test Group');
+            await userAPages.conversationList().getConversationLocator('Test Group').open();
           }
         });
 
@@ -388,13 +392,13 @@ test.describe('Notifications', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userBPages, 'Test Group', [userA]);
-      await userBPages.conversationList().openConversation('Test Group');
+      await userBPages.conversationList().getConversationLocator('Test Group').open();
 
       // Start intercepting notifications
       const {clickNotification} = await interceptNotifications(userBPage);
 
       // User A pings User B
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendPing();
 
       await clickNotification({title: userA.fullName, body: 'Pinged'});
@@ -416,12 +420,12 @@ test.describe('Notifications', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userBPages, 'Test Group', [userA]);
-      await userBPages.conversationList().openConversation('Test Group');
+      await userBPages.conversationList().getConversationLocator('Test Group').open();
 
       const {clickNotification} = await interceptNotifications(userBPage);
 
       // User A initiates a call to User B
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().clickCallButton();
 
       // Verify user B receives the call
@@ -447,13 +451,13 @@ test.describe('Notifications', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userAPages, 'Test Group', [userB]);
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       // Start intercepting notifications
       const {clickNotification} = await interceptNotifications(userBPage);
 
       // User A sends message in group
-      await userAPages.conversationList().openConversation('Test Group');
+      await userAPages.conversationList().getConversationLocator('Test Group').open();
       await userAPages.conversation().sendMessage('Test Message');
 
       await clickNotification({title: `${userA.fullName} in Test Group`, body: 'Test Message'});
@@ -473,7 +477,7 @@ test.describe('Notifications', () => {
       ]);
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       const {getNotifications} = await interceptNotifications(userBPage);
 
@@ -504,7 +508,7 @@ test.describe('Notifications', () => {
       ]);
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       // User A creates a group with User B
       const originalGroupName = 'Original Group Name';
@@ -515,7 +519,7 @@ test.describe('Notifications', () => {
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
       // User A opens ConversationDetailsPage and changes the group name
-      await userAPages.conversationList().openConversation(originalGroupName);
+      await userAPages.conversationList().getConversationLocator(originalGroupName).open();
       await userAPages.conversation().clickConversationInfoButton();
       await userAPages.conversationDetails().changeConversationName(newGroupName);
 
@@ -577,13 +581,13 @@ test.describe('Notifications', () => {
 
       const groupName = 'Image Group';
       await createGroup(userAPages, groupName, [userB]);
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       // Start intercepting notifications for User B
       const {getNotifications} = await interceptNotifications(userBPage);
 
       // User A sends an image to the group conversation
-      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversationList().getConversationLocator(groupName).open();
       await shareAssetHelper(getImageFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add picture'}));
 
       await expect
@@ -611,12 +615,12 @@ test.describe('Notifications', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userAPages, 'Test Group', [userB]);
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       const {getNotifications} = await interceptNotifications(userBPage);
 
       // User A changes the conversation timer to 10 seconds
-      await userAPages.conversationList().openConversation('Test Group');
+      await userAPages.conversationList().getConversationLocator('Test Group').open();
       await userAPages.conversation().toggleGroupInformation();
       await userAPages.conversationDetails().setSelfDeletingMessages('10 seconds');
 

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -27,7 +27,7 @@ test.describe('Notifications', () => {
     const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
     // Send message from A to B in 1on1 conversation
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     await userAPages.conversation().sendMessageWithUserMention(userB.fullName, 'Hello');
 
     // Check the notifications B received to contain the message from A
@@ -61,13 +61,13 @@ test.describe('Notifications', () => {
       // Archive conversation for user B
       const conversation = await userBPages
         .conversationList()
-        .getConversationLocator(userA.fullName, {protocol: 'mls'})
+        .getConversation(userA.fullName, {protocol: 'mls'})
         .open();
       const contextMenu = await conversation.openContextMenu();
       await contextMenu.archiveButton.click();
 
       // Send message from A to B in 1on1 conversation
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Hello');
 
       // Open the archived conversation and ensure the message was received
@@ -86,7 +86,7 @@ test.describe('Notifications', () => {
     async ({createPage}) => {
       const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
 
-      const conversation = await pages.conversationList().getConversationLocator(userB.fullName).open();
+      const conversation = await pages.conversationList().getConversation(userB.fullName).open();
       const contextMenu = await conversation.openContextMenu();
       await contextMenu.notificationsButton.click();
       await pages.conversationDetails().selectNotificationsLevel('Nothing');
@@ -100,7 +100,7 @@ test.describe('Notifications', () => {
     {tag: ['@TC-1438', '@regression']},
     async ({createPage}) => {
       const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
-      const conversation = pages.conversationList().getConversationLocator(userB.fullName);
+      const conversation = pages.conversationList().getConversation(userB.fullName);
 
       await test.step('Mute conversation', async () => {
         const contextMenu = await conversation.openContextMenu();
@@ -139,7 +139,7 @@ test.describe('Notifications', () => {
         // Depending on the current test case mute either the group or the 1on1
         await userBPages
           .conversationList()
-          .getConversationLocator(conversationType === 'group' ? 'Test Group' : userA.fullName)
+          .getConversation(conversationType === 'group' ? 'Test Group' : userA.fullName)
           .open();
         await userBPages.conversation().clickConversationInfoButton();
         await expect(userBPages.conversationDetails().notificationsButton).toContainText('Everything');
@@ -154,7 +154,7 @@ test.describe('Notifications', () => {
         // User A sends a message to the muted conversation
         await userAPages
           .conversationList()
-          .getConversationLocator(conversationType === 'group' ? 'Test Group' : userB.fullName)
+          .getConversation(conversationType === 'group' ? 'Test Group' : userB.fullName)
           .open();
         await userAPages.conversation().sendMessage('Test Message');
         await expect.poll(() => getUserBNotifications()).toHaveLength(0);
@@ -174,14 +174,14 @@ test.describe('Notifications', () => {
       // User B mutes the conversation with User A
       const conversation = await userBPages
         .conversationList()
-        .getConversationLocator(userA.fullName, {protocol: 'mls'})
+        .getConversation(userA.fullName, {protocol: 'mls'})
         .open();
       const contextMenu = await conversation.openContextMenu();
       await contextMenu.notificationsButton.click();
       await userBPages.conversationDetails().selectNotificationsLevel('Nothing');
 
       // User A initiates a call to User B
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().clickCallButton();
 
       // Verify that User B sees a "Join" button on the muted conversation
@@ -203,11 +203,11 @@ test.describe('Notifications', () => {
       // Open 1on1 conversation between users
       const userAConversation = await userAPages
         .conversationList()
-        .getConversationLocator(userB.fullName, {protocol: 'mls'})
+        .getConversation(userB.fullName, {protocol: 'mls'})
         .open();
       const userBConversation = await userBPages
         .conversationList()
-        .getConversationLocator(userA.fullName, {protocol: 'mls'})
+        .getConversation(userA.fullName, {protocol: 'mls'})
         .open();
 
       // User B mutes the conversation with User A via recent view
@@ -217,7 +217,7 @@ test.describe('Notifications', () => {
 
       // Create group and open it for user B so the message won't be read immediately
       await createGroup(userAPages, 'Test Group', [userB]);
-      await userBPages.conversationList().getConversationLocator('Test Group').open();
+      await userBPages.conversationList().getConversation('Test Group').open();
 
       // Start intercepting notifications for User B
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
@@ -246,7 +246,7 @@ test.describe('Notifications', () => {
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
       // User A sends an ephemeral message
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().enableSelfDeletingMessages();
       await userAPages.conversation().sendMessage('Ephemeral Message');
 
@@ -351,10 +351,10 @@ test.describe('Notifications', () => {
       for (const conversation of ['1on1', 'group'] as const) {
         await test.step(`User A opens the ${conversation} conversation`, async () => {
           if (conversation === '1on1') {
-            await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+            await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
           } else {
             await createGroup(userAPages, 'Test Group', [userB]);
-            await userAPages.conversationList().getConversationLocator('Test Group').open();
+            await userAPages.conversationList().getConversation('Test Group').open();
           }
         });
 
@@ -392,13 +392,13 @@ test.describe('Notifications', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userBPages, 'Test Group', [userA]);
-      await userBPages.conversationList().getConversationLocator('Test Group').open();
+      await userBPages.conversationList().getConversation('Test Group').open();
 
       // Start intercepting notifications
       const {clickNotification} = await interceptNotifications(userBPage);
 
       // User A pings User B
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendPing();
 
       await clickNotification({title: userA.fullName, body: 'Pinged'});
@@ -420,12 +420,12 @@ test.describe('Notifications', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userBPages, 'Test Group', [userA]);
-      await userBPages.conversationList().getConversationLocator('Test Group').open();
+      await userBPages.conversationList().getConversation('Test Group').open();
 
       const {clickNotification} = await interceptNotifications(userBPage);
 
       // User A initiates a call to User B
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().clickCallButton();
 
       // Verify user B receives the call
@@ -451,13 +451,13 @@ test.describe('Notifications', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userAPages, 'Test Group', [userB]);
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       // Start intercepting notifications
       const {clickNotification} = await interceptNotifications(userBPage);
 
       // User A sends message in group
-      await userAPages.conversationList().getConversationLocator('Test Group').open();
+      await userAPages.conversationList().getConversation('Test Group').open();
       await userAPages.conversation().sendMessage('Test Message');
 
       await clickNotification({title: `${userA.fullName} in Test Group`, body: 'Test Message'});
@@ -477,7 +477,7 @@ test.describe('Notifications', () => {
       ]);
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       const {getNotifications} = await interceptNotifications(userBPage);
 
@@ -508,7 +508,7 @@ test.describe('Notifications', () => {
       ]);
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       // User A creates a group with User B
       const originalGroupName = 'Original Group Name';
@@ -519,7 +519,7 @@ test.describe('Notifications', () => {
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
       // User A opens ConversationDetailsPage and changes the group name
-      await userAPages.conversationList().getConversationLocator(originalGroupName).open();
+      await userAPages.conversationList().getConversation(originalGroupName).open();
       await userAPages.conversation().clickConversationInfoButton();
       await userAPages.conversationDetails().changeConversationName(newGroupName);
 
@@ -581,13 +581,13 @@ test.describe('Notifications', () => {
 
       const groupName = 'Image Group';
       await createGroup(userAPages, groupName, [userB]);
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       // Start intercepting notifications for User B
       const {getNotifications} = await interceptNotifications(userBPage);
 
       // User A sends an image to the group conversation
-      await userAPages.conversationList().getConversationLocator(groupName).open();
+      await userAPages.conversationList().getConversation(groupName).open();
       await shareAssetHelper(getImageFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add picture'}));
 
       await expect
@@ -615,12 +615,12 @@ test.describe('Notifications', () => {
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userAPages, 'Test Group', [userB]);
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       const {getNotifications} = await interceptNotifications(userBPage);
 
       // User A changes the conversation timer to 10 seconds
-      await userAPages.conversationList().getConversationLocator('Test Group').open();
+      await userAPages.conversationList().getConversation('Test Group').open();
       await userAPages.conversation().toggleGroupInformation();
       await userAPages.conversationDetails().setSelfDeletingMessages('10 seconds');
 

--- a/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
@@ -28,7 +28,7 @@ async function openParticipantDetailsFromGroup(
   groupName: string,
   participantName: string,
 ) {
-  await pages.conversationList().getConversationLocator(groupName).open();
+  await pages.conversationList().getConversation(groupName).open();
   await pages.conversation().clickConversationInfoButton();
   await pages.conversationDetails().openParticipantDetails(participantName);
 }
@@ -63,7 +63,7 @@ test.describe('Participant Profile', () => {
       await acceptConnectionRequest(userCPages);
 
       await test.step('Go to any 1:1 conversation', async () => {
-        await userAPages.conversationList().getConversationLocator(userC.fullName, {protocol: 'mls'}).open();
+        await userAPages.conversationList().getConversation(userC.fullName, {protocol: 'mls'}).open();
       });
 
       await test.step('Open People popover', async () => {
@@ -102,7 +102,7 @@ test.describe('Participant Profile', () => {
 
       await sendConnectionRequest(userAPage, userC);
       await acceptConnectionRequest(userCPages);
-      await expect(userAPages.conversationList().getConversationLocator(userC.fullName)).toBeAttached();
+      await expect(userAPages.conversationList().getConversation(userC.fullName)).toBeAttached();
 
       await test.step('User C is in group with User A and B. User C is not connected to user B', async () => {
         await createGroup(userAPages, groupName, [userB, userC]);
@@ -144,7 +144,7 @@ test.describe('Participant Profile', () => {
 
       await sendConnectionRequest(userAPageManager, userC);
       await acceptConnectionRequest(userCPageManager.webapp.pages);
-      await expect(pages.conversationList().getConversationLocator(userC.fullName)).toBeAttached();
+      await expect(pages.conversationList().getConversation(userC.fullName)).toBeAttached();
 
       await createGroup(pages, groupName, [userB, userC]);
 
@@ -155,7 +155,7 @@ test.describe('Participant Profile', () => {
       });
 
       await test.step('User C opens people popover', async () => {
-        await pages.conversationList().getConversationLocator(groupName).open();
+        await pages.conversationList().getConversation(groupName).open();
         await pages.conversation().clickConversationTitle();
       });
 
@@ -238,7 +238,7 @@ test.describe('Participant Profile', () => {
 
       await createGroup(adminPage, groupName, [userB]);
 
-      await adminPage.conversationList().getConversationLocator(groupName).open();
+      await adminPage.conversationList().getConversation(groupName).open();
       await adminPage.conversation().clickConversationInfoButton();
 
       await adminPage.conversation().makeUserAdmin(userB.fullName);

--- a/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
@@ -28,7 +28,7 @@ async function openParticipantDetailsFromGroup(
   groupName: string,
   participantName: string,
 ) {
-  await pages.conversationList().openConversation(groupName);
+  await pages.conversationList().getConversationLocator(groupName).open();
   await pages.conversation().clickConversationInfoButton();
   await pages.conversationDetails().openParticipantDetails(participantName);
 }
@@ -63,7 +63,7 @@ test.describe('Participant Profile', () => {
       await acceptConnectionRequest(userCPages);
 
       await test.step('Go to any 1:1 conversation', async () => {
-        await userAPages.conversationList().openConversation(userC.fullName, {protocol: 'mls'});
+        await userAPages.conversationList().getConversationLocator(userC.fullName, {protocol: 'mls'}).open();
       });
 
       await test.step('Open People popover', async () => {
@@ -155,7 +155,7 @@ test.describe('Participant Profile', () => {
       });
 
       await test.step('User C opens people popover', async () => {
-        await pages.conversationList().openConversation(groupName);
+        await pages.conversationList().getConversationLocator(groupName).open();
         await pages.conversation().clickConversationTitle();
       });
 
@@ -238,7 +238,7 @@ test.describe('Participant Profile', () => {
 
       await createGroup(adminPage, groupName, [userB]);
 
-      await adminPage.conversationList().openConversation(groupName);
+      await adminPage.conversationList().getConversationLocator(groupName).open();
       await adminPage.conversation().clickConversationInfoButton();
 
       await adminPage.conversation().makeUserAdmin(userB.fullName);

--- a/apps/webapp/test/e2e_tests/specs/Ping/ping.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Ping/ping.spec.ts
@@ -52,13 +52,13 @@ test.describe('Ping', () => {
 
         if (scenario.isGroup) {
           await createGroup(userAPages, conversationName, [userB]);
-          await userBPages.conversationList().getConversationLocator(conversationName).open();
+          await userBPages.conversationList().getConversation(conversationName).open();
           await userBPages.conversation().sendPing();
-          await userAPages.conversationList().getConversationLocator(conversationName).open();
+          await userAPages.conversationList().getConversation(conversationName).open();
         } else {
-          await userBPages.conversationList().getConversationLocator(userA.fullName).open();
+          await userBPages.conversationList().getConversation(userA.fullName).open();
           await userBPages.conversation().sendPing();
-          await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+          await userAPages.conversationList().getConversation(userB.fullName).open();
         }
 
         await expect(userAPages.conversation().getPing()).toBeVisible();
@@ -72,12 +72,12 @@ test.describe('Ping', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userBPages.conversationList().getConversationLocator(userA.fullName).open();
+    await userBPages.conversationList().getConversation(userA.fullName).open();
     await userBPages.conversation().sendPing();
     await expect(userBPages.conversation().pingButton).toBeDisabled();
     await userBPages.conversation().sendPing();
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+    await userAPages.conversationList().getConversation(userB.fullName).open();
     await expect(userAPages.conversation().getPing()).toHaveCount(2);
   });
 
@@ -98,7 +98,7 @@ test.describe('Ping', () => {
       const conversationName = 'Test Group';
       await createGroup(userAPages, conversationName, [userB, ...usersForBigGroup]);
 
-      await userAPages.conversationList().getConversationLocator(conversationName).open();
+      await userAPages.conversationList().getConversation(conversationName).open();
       await userAPages.conversation().sendPing();
 
       await expect(userAModals.confirm().modal).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/Ping/ping.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Ping/ping.spec.ts
@@ -52,13 +52,13 @@ test.describe('Ping', () => {
 
         if (scenario.isGroup) {
           await createGroup(userAPages, conversationName, [userB]);
-          await userBPages.conversationList().openConversation(conversationName);
+          await userBPages.conversationList().getConversationLocator(conversationName).open();
           await userBPages.conversation().sendPing();
-          await userAPages.conversationList().openConversation(conversationName);
+          await userAPages.conversationList().getConversationLocator(conversationName).open();
         } else {
-          await userBPages.conversationList().openConversation(userA.fullName);
+          await userBPages.conversationList().getConversationLocator(userA.fullName).open();
           await userBPages.conversation().sendPing();
-          await userAPages.conversationList().openConversation(userB.fullName);
+          await userAPages.conversationList().getConversationLocator(userB.fullName).open();
         }
 
         await expect(userAPages.conversation().getPing()).toBeVisible();
@@ -72,12 +72,12 @@ test.describe('Ping', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userBPages.conversationList().openConversation(userA.fullName);
+    await userBPages.conversationList().getConversationLocator(userA.fullName).open();
     await userBPages.conversation().sendPing();
     await expect(userBPages.conversation().pingButton).toBeDisabled();
     await userBPages.conversation().sendPing();
 
-    await userAPages.conversationList().openConversation(userB.fullName);
+    await userAPages.conversationList().getConversationLocator(userB.fullName).open();
     await expect(userAPages.conversation().getPing()).toHaveCount(2);
   });
 
@@ -98,7 +98,7 @@ test.describe('Ping', () => {
       const conversationName = 'Test Group';
       await createGroup(userAPages, conversationName, [userB, ...usersForBigGroup]);
 
-      await userAPages.conversationList().openConversation(conversationName);
+      await userAPages.conversationList().getConversationLocator(conversationName).open();
       await userAPages.conversation().sendPing();
 
       await expect(userAModals.confirm().modal).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
@@ -92,10 +92,10 @@ test.describe('Reactions', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await c.sendFromUserB(userBPage);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       const messageFromUserB = userAPages.conversation().getMessage({sender: userB});
       await expect(messageFromUserB).toBeVisible();
 
@@ -127,7 +127,7 @@ test.describe('Reactions', () => {
       });
     });
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     const messageWithLink = userAPages.conversation().getMessage({sender: userB});
     await userAPages.conversation().reactOnMessage(messageWithLink, 'heart');
 
@@ -160,8 +160,8 @@ test.describe('Reactions', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await userBPages.conversation().sendMessage('Message from User B');
 
     const messageUserB = userAPages.conversation().getMessage({sender: userB});
@@ -190,8 +190,8 @@ test.describe('Reactions', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().sendMessage('Message from User B');
 
       const messageUserB = userAPages.conversation().getMessage({sender: userB});
@@ -217,8 +217,8 @@ test.describe('Reactions', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Message to react to');
 
       const userBMessage = userBPages.conversation().getMessage({sender: userA});
@@ -241,8 +241,8 @@ test.describe('Reactions', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Message to react to');
 
       const userBMessage = userBPages.conversation().getMessage({sender: userA});
@@ -283,8 +283,8 @@ test.describe('Reactions', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().sendMessage('Message to react to');
 
       const messageInUserA = userAPages.conversation().getMessage({sender: userB});

--- a/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
@@ -92,10 +92,10 @@ test.describe('Reactions', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await c.sendFromUserB(userBPage);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
       const messageFromUserB = userAPages.conversation().getMessage({sender: userB});
       await expect(messageFromUserB).toBeVisible();
 
@@ -127,7 +127,7 @@ test.describe('Reactions', () => {
       });
     });
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
     const messageWithLink = userAPages.conversation().getMessage({sender: userB});
     await userAPages.conversation().reactOnMessage(messageWithLink, 'heart');
 
@@ -160,8 +160,8 @@ test.describe('Reactions', () => {
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
     await userBPages.conversation().sendMessage('Message from User B');
 
     const messageUserB = userAPages.conversation().getMessage({sender: userB});
@@ -190,8 +190,8 @@ test.describe('Reactions', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().sendMessage('Message from User B');
 
       const messageUserB = userAPages.conversation().getMessage({sender: userB});
@@ -217,8 +217,8 @@ test.describe('Reactions', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Message to react to');
 
       const userBMessage = userBPages.conversation().getMessage({sender: userA});
@@ -241,8 +241,8 @@ test.describe('Reactions', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Message to react to');
 
       const userBMessage = userBPages.conversation().getMessage({sender: userA});
@@ -283,8 +283,8 @@ test.describe('Reactions', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().sendMessage('Message to react to');
 
       const messageInUserA = userAPages.conversation().getMessage({sender: userB});

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -65,8 +65,8 @@ test.describe('Reply', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Test');
 
       const messageToReplyTo = userBPages.conversation().getMessage({content: 'Test'});
@@ -299,8 +299,8 @@ test.describe('Reply', () => {
       await createGroup(userAPages, 'Test Group', [userB]);
 
       await Promise.all([
-        userAPages.conversationList().getConversationLocator('Test Group').open(),
-        userBPages.conversationList().getConversationLocator('Test Group').open(),
+        userAPages.conversationList().getConversation('Test Group').open(),
+        userBPages.conversationList().getConversation('Test Group').open(),
       ]);
 
       await userAPages.conversation().sendMessage('Message');

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -65,8 +65,8 @@ test.describe('Reply', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().sendMessage('Test');
 
       const messageToReplyTo = userBPages.conversation().getMessage({content: 'Test'});
@@ -299,8 +299,8 @@ test.describe('Reply', () => {
       await createGroup(userAPages, 'Test Group', [userB]);
 
       await Promise.all([
-        userAPages.conversationList().openConversation('Test Group'),
-        userBPages.conversationList().openConversation('Test Group'),
+        userAPages.conversationList().getConversationLocator('Test Group').open(),
+        userBPages.conversationList().getConversationLocator('Test Group').open(),
       ]);
 
       await userAPages.conversation().sendMessage('Message');

--- a/apps/webapp/test/e2e_tests/specs/Search/search.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Search/search.spec.ts
@@ -49,7 +49,7 @@ test.describe('Search', () => {
 
       const conversationName = 'Group conversation';
       await createGroup(userAPages, conversationName, [userB]);
-      await userAPages.conversationList().openConversation(conversationName);
+      await userAPages.conversationList().getConversationLocator(conversationName).open();
       await userAPages.conversation().sendMessage(`@${userB.username} Group message with mention of User B`);
       await userAPages.conversationList().searchConversationsInput.fill(`@${userB.username}`);
 

--- a/apps/webapp/test/e2e_tests/specs/Search/search.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Search/search.spec.ts
@@ -49,12 +49,12 @@ test.describe('Search', () => {
 
       const conversationName = 'Group conversation';
       await createGroup(userAPages, conversationName, [userB]);
-      await userAPages.conversationList().getConversationLocator(conversationName).open();
+      await userAPages.conversationList().getConversation(conversationName).open();
       await userAPages.conversation().sendMessage(`@${userB.username} Group message with mention of User B`);
       await userAPages.conversationList().searchConversationsInput.fill(`@${userB.username}`);
 
-      await expect(userAPages.conversationList().getConversationLocator(conversationName)).toBeVisible();
-      await expect(userAPages.conversationList().getConversationLocator(userB.fullName)).toBeVisible();
+      await expect(userAPages.conversationList().getConversation(conversationName)).toBeVisible();
+      await expect(userAPages.conversationList().getConversation(userB.fullName)).toBeVisible();
     },
   );
 

--- a/apps/webapp/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -41,8 +41,8 @@ test.describe('Self Deleting Messages', () => {
     const userAPages = PageManager.from(userAPage).webapp.pages;
     const userBPages = PageManager.from(userBPage).webapp.pages;
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
     await userAPages.conversation().enableSelfDeletingMessages();
     await userAPages.conversation().sendMessage('Gone in 10s');
@@ -59,7 +59,7 @@ test.describe('Self Deleting Messages', () => {
     const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await createGroup(userAPages, 'Test Group', [userB]);
-    await userBPages.conversationList().getConversationLocator('Test Group').open();
+    await userBPages.conversationList().getConversation('Test Group').open();
 
     await userAPages.conversation().enableSelfDeletingMessages();
     await userAPages.conversation().sendMessage('Gone in 10s');
@@ -115,7 +115,7 @@ test.describe('Self Deleting Messages', () => {
       // Re-open page reusing the same context so the login is not happening on a new device
       page = await createPage(context, withLogin(userA));
       pages = PageManager.from(page).webapp.pages;
-      await pages.conversationList().getConversationLocator(userB.fullName).open();
+      await pages.conversationList().getConversation(userB.fullName).open();
 
       const selfDeletingMessage = pages.conversation().getMessage({sender: userA});
       await expect(selfDeletingMessage).toBeVisible();
@@ -134,8 +134,8 @@ test.describe('Self Deleting Messages', () => {
       const [userAPages, userBPages] = [userAPage, userBPage].map(page => PageManager.from(page).webapp.pages);
       await createGroup(userAPages, 'Test Group', [userB]);
 
-      await userAPages.conversationList().getConversationLocator('Test Group').open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open(); // User B should not read the message sent into the group immediately
+      await userAPages.conversationList().getConversation('Test Group').open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open(); // User B should not read the message sent into the group immediately
 
       await userAPages.conversation().enableSelfDeletingMessages();
       await userAPages.conversation().sendMessage('Test Message');
@@ -143,7 +143,7 @@ test.describe('Self Deleting Messages', () => {
 
       await userBPage.waitForTimeout(10_000); // Wait 10s before user B opens the group chat
 
-      await userBPages.conversationList().getConversationLocator('Test Group').open();
+      await userBPages.conversationList().getConversation('Test Group').open();
       await expect(userBPages.conversation().getMessage({content: 'Test Message'})).toBeVisible();
     },
   );
@@ -159,8 +159,8 @@ test.describe('Self Deleting Messages', () => {
       ]);
       await createGroup(userAPages, 'Test Group', [userB]);
 
-      await userAPages.conversationList().getConversationLocator('Test Group').open();
-      await userBPages.conversationList().getConversationLocator('Test Group').open();
+      await userAPages.conversationList().getConversation('Test Group').open();
+      await userBPages.conversationList().getConversation('Test Group').open();
 
       await userAPages.conversation().toggleGroupInformation();
       await userAPages.conversationDetails().setSelfDeletingMessages('10 seconds');
@@ -220,8 +220,8 @@ test.describe('Self Deleting Messages', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       await userAPages.conversation().enableSelfDeletingMessages();
       await userAPages.conversation().sendMessage('Test');

--- a/apps/webapp/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -41,8 +41,8 @@ test.describe('Self Deleting Messages', () => {
     const userAPages = PageManager.from(userAPage).webapp.pages;
     const userBPages = PageManager.from(userBPage).webapp.pages;
 
-    await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
     await userAPages.conversation().enableSelfDeletingMessages();
     await userAPages.conversation().sendMessage('Gone in 10s');
@@ -59,7 +59,7 @@ test.describe('Self Deleting Messages', () => {
     const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await createGroup(userAPages, 'Test Group', [userB]);
-    await userBPages.conversationList().openConversation('Test Group');
+    await userBPages.conversationList().getConversationLocator('Test Group').open();
 
     await userAPages.conversation().enableSelfDeletingMessages();
     await userAPages.conversation().sendMessage('Gone in 10s');
@@ -115,7 +115,7 @@ test.describe('Self Deleting Messages', () => {
       // Re-open page reusing the same context so the login is not happening on a new device
       page = await createPage(context, withLogin(userA));
       pages = PageManager.from(page).webapp.pages;
-      await pages.conversationList().openConversation(userB.fullName);
+      await pages.conversationList().getConversationLocator(userB.fullName).open();
 
       const selfDeletingMessage = pages.conversation().getMessage({sender: userA});
       await expect(selfDeletingMessage).toBeVisible();
@@ -134,8 +134,8 @@ test.describe('Self Deleting Messages', () => {
       const [userAPages, userBPages] = [userAPage, userBPage].map(page => PageManager.from(page).webapp.pages);
       await createGroup(userAPages, 'Test Group', [userB]);
 
-      await userAPages.conversationList().openConversation('Test Group');
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'}); // User B should not read the message sent into the group immediately
+      await userAPages.conversationList().getConversationLocator('Test Group').open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open(); // User B should not read the message sent into the group immediately
 
       await userAPages.conversation().enableSelfDeletingMessages();
       await userAPages.conversation().sendMessage('Test Message');
@@ -143,7 +143,7 @@ test.describe('Self Deleting Messages', () => {
 
       await userBPage.waitForTimeout(10_000); // Wait 10s before user B opens the group chat
 
-      await userBPages.conversationList().openConversation('Test Group');
+      await userBPages.conversationList().getConversationLocator('Test Group').open();
       await expect(userBPages.conversation().getMessage({content: 'Test Message'})).toBeVisible();
     },
   );
@@ -159,8 +159,8 @@ test.describe('Self Deleting Messages', () => {
       ]);
       await createGroup(userAPages, 'Test Group', [userB]);
 
-      await userAPages.conversationList().openConversation('Test Group');
-      await userBPages.conversationList().openConversation('Test Group');
+      await userAPages.conversationList().getConversationLocator('Test Group').open();
+      await userBPages.conversationList().getConversationLocator('Test Group').open();
 
       await userAPages.conversation().toggleGroupInformation();
       await userAPages.conversationDetails().setSelfDeletingMessages('10 seconds');
@@ -220,8 +220,8 @@ test.describe('Self Deleting Messages', () => {
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       await userAPages.conversation().enableSelfDeletingMessages();
       await userAPages.conversation().sendMessage('Test');

--- a/apps/webapp/test/e2e_tests/specs/SendingAssets/sendingAssets.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SendingAssets/sendingAssets.spec.ts
@@ -69,7 +69,7 @@ test.describe('Sending Assets', () => {
     const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
     const {pages} = PageManager.from(userAPage).webapp;
 
-    await pages.conversationList().openConversation(userB.fullName);
+    await pages.conversationList().getConversationLocator(userB.fullName).open();
     await shareAssetHelper(getAudioFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add file'}));
 
     const message = pages.conversation().getMessage({sender: userA});
@@ -85,7 +85,7 @@ test.describe('Sending Assets', () => {
     const buffer = await fs.readFile(getTextFilePath());
 
     await test.step('Go to any 1:1 conversation', async () => {
-      await pages.conversationList().openConversation(userB.fullName);
+      await pages.conversationList().getConversationLocator(userB.fullName).open();
     });
 
     await test.step('User B can drag & drop a file into a conversation', async () => {
@@ -140,7 +140,7 @@ test.describe('Sending Assets', () => {
 
       const pastedFileControls = userAPage.getByTestId('pasted-file-controls');
       await test.step('Go to any 1:1 conversation', async () => {
-        await pages.conversationList().openConversation(userB.fullName);
+        await pages.conversationList().getConversationLocator(userB.fullName).open();
       });
 
       await test.step('User A copy paste image into the conversation', async () => {
@@ -162,7 +162,7 @@ test.describe('Sending Assets', () => {
     const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
     const userAPages = PageManager.from(userAPage).webapp.pages;
 
-    await userAPages.conversationList().openConversation(userB.fullName);
+    await userAPages.conversationList().getConversationLocator(userB.fullName).open();
     await userAPages.conversation().sendMessage('Message to copy');
 
     const message = userAPages.conversation().getMessage({sender: userA});
@@ -198,10 +198,10 @@ test.describe('Sending Assets', () => {
 
         await test.step('User A opens the conversation', async () => {
           if (conversationType === '1on1') {
-            await pages.conversationList().openConversation(userB.fullName);
+            await pages.conversationList().getConversationLocator(userB.fullName).open();
           } else {
             await createGroup(pages, 'Test Group', [userB]);
-            await pages.conversationList().openConversation('Test Group');
+            await pages.conversationList().getConversationLocator('Test Group').open();
           }
         });
 
@@ -237,7 +237,7 @@ test.describe('Sending Assets', () => {
     // Verify uploading a file exceeding the limit isn't possible for both, 1on1 and group conversations
     for (const conversation of [userB.fullName, 'Test Group']) {
       await test.step(`Try sending a too big file to ${conversation}`, async () => {
-        await pages.conversationList().openConversation(conversation);
+        await pages.conversationList().getConversationLocator(conversation).open();
         const [fileChooser] = await Promise.all([
           page.waitForEvent('filechooser'),
           page.getByRole('button', {name: 'Add file'}).click(),
@@ -270,8 +270,8 @@ test.describe('Sending Assets', () => {
     const pages = PageManager.from(userAPage).webapp.pages;
     const userBPages = PageManager.from(userBPage).webapp.pages;
 
-    await pages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    await pages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
     const tempFilePath = path.join(tmpdir(), '25MB-testfile.tmp');
     try {
@@ -301,8 +301,8 @@ test.describe('Sending Assets', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
 
       await shareAssetHelper(getTextFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add file'}));
 
@@ -327,7 +327,7 @@ test.describe('Sending Assets', () => {
       const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
       const {pages} = PageManager.from(userAPage).webapp;
 
-      await pages.conversationList().openConversation(userB.fullName);
+      await pages.conversationList().getConversationLocator(userB.fullName).open();
       await pages.conversation().enableSelfDeletingMessages();
 
       await shareAssetHelper(getImageFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add picture'}));
@@ -350,7 +350,7 @@ test.describe('Sending Assets', () => {
       const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
       const {pages, modals} = PageManager.from(userAPage).webapp;
 
-      await pages.conversationList().openConversation(userB.fullName);
+      await pages.conversationList().getConversationLocator(userB.fullName).open();
       await shareAssetHelper(getImageFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add picture'}));
       await pages.conversation().clickImage(userA);
 

--- a/apps/webapp/test/e2e_tests/specs/SendingAssets/sendingAssets.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SendingAssets/sendingAssets.spec.ts
@@ -69,7 +69,7 @@ test.describe('Sending Assets', () => {
     const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
     const {pages} = PageManager.from(userAPage).webapp;
 
-    await pages.conversationList().getConversationLocator(userB.fullName).open();
+    await pages.conversationList().getConversation(userB.fullName).open();
     await shareAssetHelper(getAudioFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add file'}));
 
     const message = pages.conversation().getMessage({sender: userA});
@@ -85,7 +85,7 @@ test.describe('Sending Assets', () => {
     const buffer = await fs.readFile(getTextFilePath());
 
     await test.step('Go to any 1:1 conversation', async () => {
-      await pages.conversationList().getConversationLocator(userB.fullName).open();
+      await pages.conversationList().getConversation(userB.fullName).open();
     });
 
     await test.step('User B can drag & drop a file into a conversation', async () => {
@@ -140,7 +140,7 @@ test.describe('Sending Assets', () => {
 
       const pastedFileControls = userAPage.getByTestId('pasted-file-controls');
       await test.step('Go to any 1:1 conversation', async () => {
-        await pages.conversationList().getConversationLocator(userB.fullName).open();
+        await pages.conversationList().getConversation(userB.fullName).open();
       });
 
       await test.step('User A copy paste image into the conversation', async () => {
@@ -162,7 +162,7 @@ test.describe('Sending Assets', () => {
     const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
     const userAPages = PageManager.from(userAPage).webapp.pages;
 
-    await userAPages.conversationList().getConversationLocator(userB.fullName).open();
+    await userAPages.conversationList().getConversation(userB.fullName).open();
     await userAPages.conversation().sendMessage('Message to copy');
 
     const message = userAPages.conversation().getMessage({sender: userA});
@@ -198,10 +198,10 @@ test.describe('Sending Assets', () => {
 
         await test.step('User A opens the conversation', async () => {
           if (conversationType === '1on1') {
-            await pages.conversationList().getConversationLocator(userB.fullName).open();
+            await pages.conversationList().getConversation(userB.fullName).open();
           } else {
             await createGroup(pages, 'Test Group', [userB]);
-            await pages.conversationList().getConversationLocator('Test Group').open();
+            await pages.conversationList().getConversation('Test Group').open();
           }
         });
 
@@ -237,7 +237,7 @@ test.describe('Sending Assets', () => {
     // Verify uploading a file exceeding the limit isn't possible for both, 1on1 and group conversations
     for (const conversation of [userB.fullName, 'Test Group']) {
       await test.step(`Try sending a too big file to ${conversation}`, async () => {
-        await pages.conversationList().getConversationLocator(conversation).open();
+        await pages.conversationList().getConversation(conversation).open();
         const [fileChooser] = await Promise.all([
           page.waitForEvent('filechooser'),
           page.getByRole('button', {name: 'Add file'}).click(),
@@ -270,8 +270,8 @@ test.describe('Sending Assets', () => {
     const pages = PageManager.from(userAPage).webapp.pages;
     const userBPages = PageManager.from(userBPage).webapp.pages;
 
-    await pages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-    await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+    await pages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
     const tempFilePath = path.join(tmpdir(), '25MB-testfile.tmp');
     try {
@@ -301,8 +301,8 @@ test.describe('Sending Assets', () => {
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
-      await userBPages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       await shareAssetHelper(getTextFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add file'}));
 
@@ -327,7 +327,7 @@ test.describe('Sending Assets', () => {
       const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
       const {pages} = PageManager.from(userAPage).webapp;
 
-      await pages.conversationList().getConversationLocator(userB.fullName).open();
+      await pages.conversationList().getConversation(userB.fullName).open();
       await pages.conversation().enableSelfDeletingMessages();
 
       await shareAssetHelper(getImageFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add picture'}));
@@ -350,7 +350,7 @@ test.describe('Sending Assets', () => {
       const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
       const {pages, modals} = PageManager.from(userAPage).webapp;
 
-      await pages.conversationList().getConversationLocator(userB.fullName).open();
+      await pages.conversationList().getConversation(userB.fullName).open();
       await shareAssetHelper(getImageFilePath(), userAPage, userAPage.getByRole('button', {name: 'Add picture'}));
       await pages.conversation().clickImage(userA);
 

--- a/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
@@ -157,7 +157,7 @@ test.describe('Status', () => {
       name: 'Rename group',
       sendAction: async ({userAPageManager}) => {
         const userAPages = userAPageManager.pages;
-        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversationList().getConversationLocator(groupName).open();
         await userAPages.conversation().clickConversationInfoButton();
         await userAPages.conversationDetails().changeConversationName('New Group Name');
       },
@@ -188,7 +188,7 @@ test.describe('Status', () => {
       name: 'Add member to group',
       sendAction: async ({userAPageManager}) => {
         const userAPages = userAPageManager.pages;
-        await userAPages.conversationList().openConversation('Test Group 2');
+        await userAPages.conversationList().getConversationLocator('Test Group 2').open();
         await userAPages.conversation().clickConversationInfoButton();
         await userAPages.conversationDetails().clickAddPeopleButton();
         await userAPages.conversationDetails().addUsersToConversation([userC.fullName]);
@@ -249,7 +249,7 @@ test.describe('Status', () => {
 
       // User B sends initial messages for replies
       for (const {targetForUserB, options} of scenarios) {
-        await userBPages.conversationList().openConversation(targetForUserB, options);
+        await userBPages.conversationList().getConversationLocator(targetForUserB, options).open();
         await userBPages.conversation().sendMessage('Message to reply');
       }
 
@@ -261,7 +261,7 @@ test.describe('Status', () => {
 
       await updateUserStatus(userBPageManager, userB.fullName, config.status);
       // User B opens the third conversation to receive notifications
-      await userBPages.conversationList().openConversation(userC.fullName);
+      await userBPages.conversationList().getConversationLocator(userC.fullName).open();
 
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
@@ -270,7 +270,7 @@ test.describe('Status', () => {
           const filteredCases = commonTestCases.filter(
             tc => config.status === UserStatus.Away || !['Mention', 'Reply'].includes(tc.name),
           );
-          await userAPages.conversationList().openConversation(targetForUserA, options);
+          await userAPages.conversationList().getConversationLocator(targetForUserA, options).open();
 
           for (const testCase of filteredCases) {
             await test.step(`Action: ${testCase.name} message in ${type}`, async () => {
@@ -288,7 +288,7 @@ test.describe('Status', () => {
 
       // System Test Cases
       await test.step('User B should not receive any system notification', async () => {
-        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversationList().getConversationLocator(groupName).open();
         for (const systemTestCase of systemTestCases) {
           await systemTestCase.sendAction({userAPageManager});
         }
@@ -309,7 +309,7 @@ test.describe('Status', () => {
             },
           ];
 
-          await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+          await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
           for (const testCase of specialTestCases) {
             await test.step(`Action: ${testCase.name} message`, async () => {
               await testCase.sendAction({pageA: userAPage, api});
@@ -319,7 +319,7 @@ test.describe('Status', () => {
         });
       } else {
         await test.step('User B should not receive calls notification (Away status)', async () => {
-          await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+          await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
           await userAPages.conversation().startCall();
           await expect(userBPages.calling().callCell).toBeVisible();
           await expect.poll(() => getUserBNotifications()).toHaveLength(0);
@@ -368,10 +368,10 @@ test.describe('Status', () => {
       await createGroup(userAPages, groupName, [userB, userC]);
 
       // User B sends initial message and sets status to available
-      await pages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await pages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
       await pages.conversation().sendMessage('Message to reply');
 
-      await pages.conversationList().openConversation(groupName);
+      await pages.conversationList().getConversationLocator(groupName).open();
       await pages.conversation().sendMessage('Message to reply');
 
       await updateUserStatus(userBPageManager, userB.fullName, UserStatus.Available);
@@ -394,7 +394,7 @@ test.describe('Status', () => {
 
       for (const {type, target, options} of scenarios) {
         await test.step(`User A opens the ${type} conversation`, async () => {
-          await userAPages.conversationList().openConversation(target, options);
+          await userAPages.conversationList().getConversationLocator(target, options).open();
         });
 
         await test.step(`User B should receive all conversation notifications`, async () => {
@@ -409,7 +409,7 @@ test.describe('Status', () => {
       }
 
       await test.step(`User B should receive system notifications only for group creation and renaming`, async () => {
-        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversationList().getConversationLocator(groupName).open();
         for (const systemTestCase of systemTestCases) {
           await test.step(`Action: ${systemTestCase.name}`, async () => {
             await systemTestCase.sendAction({userAPageManager});
@@ -434,11 +434,11 @@ test.describe('Status', () => {
     const userBPages = userBPageManager.webapp.pages;
 
     // User B verify no status is set in conversation list
-    await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-    const {statusAvailabilityIcon} = userBPages
+    const conversation = await userBPages
       .conversationList()
-      .getConversationLocator(userA.fullName, {protocol: 'mls'});
-    await expect(statusAvailabilityIcon).not.toBeVisible();
+      .getConversationLocator(userA.fullName, {protocol: 'mls'})
+      .open();
+    await expect(conversation.statusAvailabilityIcon).not.toBeVisible();
 
     // User A opens preferences by clicking the gear button
     await components.conversationSidebar().clickPreferencesButton();
@@ -459,8 +459,8 @@ test.describe('Status', () => {
     await expect(pages.account().statusOption(UserStatus.None)).not.toHaveAccessibleName('Selected, None');
 
     // User B verifies status is Available in conversation list
-    await expect(statusAvailabilityIcon).toBeVisible();
-    await expect(statusAvailabilityIcon).toHaveAttribute('data-uie-value', 'available');
+    await expect(conversation.statusAvailabilityIcon).toBeVisible();
+    await expect(conversation.statusAvailabilityIcon).toHaveAttribute('data-uie-value', 'available');
   });
 
   test(
@@ -482,7 +482,7 @@ test.describe('Status', () => {
       await expect(components.conversationSidebar().personalStatusIcon).toBeVisible();
 
       // User B should see the BUSY status in the searchable group participant list
-      await userBPages.conversationList().openConversation(groupName);
+      await userBPages.conversationList().getConversationLocator(groupName).open();
       await userBPages.conversation().clickConversationInfoButton();
       await expect(userBPages.conversationDetails().getUserAvailabilityIcon(userA.fullName)).toBeVisible();
       await expect(userBPages.conversationDetails().getUserAvailabilityIcon(userA.fullName)).toHaveAttribute(

--- a/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
@@ -157,7 +157,7 @@ test.describe('Status', () => {
       name: 'Rename group',
       sendAction: async ({userAPageManager}) => {
         const userAPages = userAPageManager.pages;
-        await userAPages.conversationList().getConversationLocator(groupName).open();
+        await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().clickConversationInfoButton();
         await userAPages.conversationDetails().changeConversationName('New Group Name');
       },
@@ -188,7 +188,7 @@ test.describe('Status', () => {
       name: 'Add member to group',
       sendAction: async ({userAPageManager}) => {
         const userAPages = userAPageManager.pages;
-        await userAPages.conversationList().getConversationLocator('Test Group 2').open();
+        await userAPages.conversationList().getConversation('Test Group 2').open();
         await userAPages.conversation().clickConversationInfoButton();
         await userAPages.conversationDetails().clickAddPeopleButton();
         await userAPages.conversationDetails().addUsersToConversation([userC.fullName]);
@@ -249,7 +249,7 @@ test.describe('Status', () => {
 
       // User B sends initial messages for replies
       for (const {targetForUserB, options} of scenarios) {
-        await userBPages.conversationList().getConversationLocator(targetForUserB, options).open();
+        await userBPages.conversationList().getConversation(targetForUserB, options).open();
         await userBPages.conversation().sendMessage('Message to reply');
       }
 
@@ -261,7 +261,7 @@ test.describe('Status', () => {
 
       await updateUserStatus(userBPageManager, userB.fullName, config.status);
       // User B opens the third conversation to receive notifications
-      await userBPages.conversationList().getConversationLocator(userC.fullName).open();
+      await userBPages.conversationList().getConversation(userC.fullName).open();
 
       const {getNotifications: getUserBNotifications} = await interceptNotifications(userBPage);
 
@@ -270,7 +270,7 @@ test.describe('Status', () => {
           const filteredCases = commonTestCases.filter(
             tc => config.status === UserStatus.Away || !['Mention', 'Reply'].includes(tc.name),
           );
-          await userAPages.conversationList().getConversationLocator(targetForUserA, options).open();
+          await userAPages.conversationList().getConversation(targetForUserA, options).open();
 
           for (const testCase of filteredCases) {
             await test.step(`Action: ${testCase.name} message in ${type}`, async () => {
@@ -279,7 +279,7 @@ test.describe('Status', () => {
           }
 
           await components.conversationSidebar().clickAllConversationsButton();
-          await expect(userBPages.conversationList().getConversationLocator(targetForUserB, options)).toContainText(
+          await expect(userBPages.conversationList().getConversation(targetForUserB, options)).toContainText(
             /\d+ ping, \d+ messages/,
           );
           await expect.poll(() => getUserBNotifications()).toHaveLength(0);
@@ -288,7 +288,7 @@ test.describe('Status', () => {
 
       // System Test Cases
       await test.step('User B should not receive any system notification', async () => {
-        await userAPages.conversationList().getConversationLocator(groupName).open();
+        await userAPages.conversationList().getConversation(groupName).open();
         for (const systemTestCase of systemTestCases) {
           await systemTestCase.sendAction({userAPageManager});
         }
@@ -309,7 +309,7 @@ test.describe('Status', () => {
             },
           ];
 
-          await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+          await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
           for (const testCase of specialTestCases) {
             await test.step(`Action: ${testCase.name} message`, async () => {
               await testCase.sendAction({pageA: userAPage, api});
@@ -319,7 +319,7 @@ test.describe('Status', () => {
         });
       } else {
         await test.step('User B should not receive calls notification (Away status)', async () => {
-          await userAPages.conversationList().getConversationLocator(userB.fullName, {protocol: 'mls'}).open();
+          await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
           await userAPages.conversation().startCall();
           await expect(userBPages.calling().callCell).toBeVisible();
           await expect.poll(() => getUserBNotifications()).toHaveLength(0);
@@ -368,10 +368,10 @@ test.describe('Status', () => {
       await createGroup(userAPages, groupName, [userB, userC]);
 
       // User B sends initial message and sets status to available
-      await pages.conversationList().getConversationLocator(userA.fullName, {protocol: 'mls'}).open();
+      await pages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await pages.conversation().sendMessage('Message to reply');
 
-      await pages.conversationList().getConversationLocator(groupName).open();
+      await pages.conversationList().getConversation(groupName).open();
       await pages.conversation().sendMessage('Message to reply');
 
       await updateUserStatus(userBPageManager, userB.fullName, UserStatus.Available);
@@ -394,7 +394,7 @@ test.describe('Status', () => {
 
       for (const {type, target, options} of scenarios) {
         await test.step(`User A opens the ${type} conversation`, async () => {
-          await userAPages.conversationList().getConversationLocator(target, options).open();
+          await userAPages.conversationList().getConversation(target, options).open();
         });
 
         await test.step(`User B should receive all conversation notifications`, async () => {
@@ -409,7 +409,7 @@ test.describe('Status', () => {
       }
 
       await test.step(`User B should receive system notifications only for group creation and renaming`, async () => {
-        await userAPages.conversationList().getConversationLocator(groupName).open();
+        await userAPages.conversationList().getConversation(groupName).open();
         for (const systemTestCase of systemTestCases) {
           await test.step(`Action: ${systemTestCase.name}`, async () => {
             await systemTestCase.sendAction({userAPageManager});
@@ -434,10 +434,7 @@ test.describe('Status', () => {
     const userBPages = userBPageManager.webapp.pages;
 
     // User B verify no status is set in conversation list
-    const conversation = await userBPages
-      .conversationList()
-      .getConversationLocator(userA.fullName, {protocol: 'mls'})
-      .open();
+    const conversation = await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await expect(conversation.statusAvailabilityIcon).not.toBeVisible();
 
     // User A opens preferences by clicking the gear button
@@ -482,7 +479,7 @@ test.describe('Status', () => {
       await expect(components.conversationSidebar().personalStatusIcon).toBeVisible();
 
       // User B should see the BUSY status in the searchable group participant list
-      await userBPages.conversationList().getConversationLocator(groupName).open();
+      await userBPages.conversationList().getConversation(groupName).open();
       await userBPages.conversation().clickConversationInfoButton();
       await expect(userBPages.conversationDetails().getUserAvailabilityIcon(userA.fullName)).toBeVisible();
       await expect(userBPages.conversationDetails().getUserAvailabilityIcon(userA.fullName)).toHaveAttribute(

--- a/apps/webapp/test/e2e_tests/utils/userActions.ts
+++ b/apps/webapp/test/e2e_tests/utils/userActions.ts
@@ -59,7 +59,7 @@ export const sendTextMessageToConversation = async (
   message: string,
 ) => {
   const {pages} = pageManager.webapp;
-  await pages.conversationList().getConversationLocator(conversation).open();
+  await pages.conversationList().getConversation(conversation).open();
   await pages.conversation().sendMessage(message);
 };
 

--- a/apps/webapp/test/e2e_tests/utils/userActions.ts
+++ b/apps/webapp/test/e2e_tests/utils/userActions.ts
@@ -59,7 +59,7 @@ export const sendTextMessageToConversation = async (
   message: string,
 ) => {
   const {pages} = pageManager.webapp;
-  await pages.conversationList().openConversation(conversation);
+  await pages.conversationList().getConversationLocator(conversation).open();
   await pages.conversation().sendMessage(message);
 };
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24429" title="WPB-24429" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24429</a>  [Web][QA] Investigate E2E tests that are flaky because of possible race condition.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

After the cleanup of the conversationList POM the `getConversationLocator()` function got the central way of interacting with items in the conversation list. This is a follow up PR to replace the existing `openConversation()` util with it for a more unified API.
The util `getConversationLocator()` was also renamed to just `getConversation()` for a cleaner read.
Most changes are just automated renames, but in a few cases it was possible to leverage the benefits of the now unified API to save redundant locators in tests.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers

- This PR is made up of atomic commits, e.g. the rename of the util is one self containing commit easy to review ;)