### PR TITLE
chore: add feature flag applockV2FeatureToggleName [WPB-23186]

### DIFF
--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -20,11 +20,13 @@
 export const reliableWebsocketConnectionFeatureToggleName = 'reliable-websocket-connection';
 export const collaboraNewDocumentCreationMenuFeatureToggleName = 'collabora-new-document-creation-menu';
 export const countlyIncrementalBackoffRetryReportingFeatureToggleName = 'countly-incremental-backoff-retry-reporting';
+export const applockForgotPasswordFeatureToggleName = 'applock-forgot-password';
 
 export const startupFeatureToggleNames = [
   reliableWebsocketConnectionFeatureToggleName,
   collaboraNewDocumentCreationMenuFeatureToggleName,
   countlyIncrementalBackoffRetryReportingFeatureToggleName,
+  applockForgotPasswordFeatureToggleName,
 ] as const;
 
 export type StartupFeatureToggleName = (typeof startupFeatureToggleNames)[number];

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -20,13 +20,13 @@
 export const reliableWebsocketConnectionFeatureToggleName = 'reliable-websocket-connection';
 export const collaboraNewDocumentCreationMenuFeatureToggleName = 'collabora-new-document-creation-menu';
 export const countlyIncrementalBackoffRetryReportingFeatureToggleName = 'countly-incremental-backoff-retry-reporting';
-export const applockForgotPasswordFeatureToggleName = 'applock-forgot-password';
+export const applockV2FeatureToggleName = 'applock-v2';
 
 export const startupFeatureToggleNames = [
   reliableWebsocketConnectionFeatureToggleName,
   collaboraNewDocumentCreationMenuFeatureToggleName,
   countlyIncrementalBackoffRetryReportingFeatureToggleName,
-  applockForgotPasswordFeatureToggleName,
+  applockV2FeatureToggleName,
 ] as const;
 
 export type StartupFeatureToggleName = (typeof startupFeatureToggleNames)[number];

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -20,13 +20,13 @@
 export const reliableWebsocketConnectionFeatureToggleName = 'reliable-websocket-connection';
 export const collaboraNewDocumentCreationMenuFeatureToggleName = 'collabora-new-document-creation-menu';
 export const countlyIncrementalBackoffRetryReportingFeatureToggleName = 'countly-incremental-backoff-retry-reporting';
-export const applockV2FeatureToggleName = 'applock-v2';
+export const applockRefactoredFeatureToggleName = 'applock-refactored';
 
 export const startupFeatureToggleNames = [
   reliableWebsocketConnectionFeatureToggleName,
   collaboraNewDocumentCreationMenuFeatureToggleName,
   countlyIncrementalBackoffRetryReportingFeatureToggleName,
-  applockV2FeatureToggleName,
+  applockRefactoredFeatureToggleName,
 ] as const;
 
 export type StartupFeatureToggleName = (typeof startupFeatureToggleNames)[number];

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -23,6 +23,7 @@ import {
   startupFeatureToggleQueryParameterName,
 } from './startupFeatureToggles';
 import {
+  applockRefactoredFeatureToggleName,
   collaboraNewDocumentCreationMenuFeatureToggleName,
   countlyIncrementalBackoffRetryReportingFeatureToggleName,
   reliableWebsocketConnectionFeatureToggleName,
@@ -33,6 +34,7 @@ const featureToggleNamesWithDedicatedExistenceTests = [
   reliableWebsocketConnectionFeatureToggleName,
   collaboraNewDocumentCreationMenuFeatureToggleName,
   countlyIncrementalBackoffRetryReportingFeatureToggleName,
+  applockRefactoredFeatureToggleName,
 ] as const;
 
 describe('startupFeatureToggles', function () {
@@ -95,6 +97,14 @@ describe('startupFeatureToggles', function () {
     );
   });
 
+  it('enables the applock refactored feature toggle when present in the query parameter', () => {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
+    );
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(true);
+  });
+
   it('trims whitespace around feature toggle names', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}= ${reliableWebsocketConnectionFeatureToggleName} `,
@@ -140,6 +150,7 @@ describe('startupFeatureToggles', function () {
       reliableWebsocketConnectionFeatureToggleName,
       collaboraNewDocumentCreationMenuFeatureToggleName,
       countlyIncrementalBackoffRetryReportingFeatureToggleName,
+      applockRefactoredFeatureToggleName,
     ]);
   });
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23186" title="WPB-23186" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-23186</a>  [Web] Applock forgot password - Users prompted to log out, log in, set new applock password
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Add feature flag applockV2FeatureToggleName for new appLock functionality.

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
