### PR TITLE
test: improve stability of enterprise feature enablement [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/backend/apiManager.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/apiManager.e2e.ts
@@ -108,7 +108,7 @@ export class ApiManagerE2E {
     token: string,
     state: 'enabled' | 'disabled' | 'unlocked' | 'locked' = 'enabled',
   ): Promise<boolean> {
-    const timeout = 300000;
+    const timeout = 60_000;
     const interval = 1000;
     const startTime = Date.now();
 

--- a/apps/webapp/test/e2e_tests/backend/apiManager.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/apiManager.e2e.ts
@@ -100,26 +100,33 @@ export class ApiManagerE2E {
    * This is to wait until stripe/ibis has set free account restrictions after team creation.
    *
    * @param token - The access token of the user.
+   * @param state - The expected state of the feature
    * @returns A promise that resolves to true if the feature is enabled, false otherwise.
    */
-  async waitForFeatureToBeEnabled(featureKey: FEATURE_KEY, teamId: string, token?: string): Promise<boolean> {
-    if (!token) {
-      throw new Error('Token is required to check for feature');
-    }
-
+  async waitForFeature(
+    featureKey: FEATURE_KEY,
+    token: string,
+    state: 'enabled' | 'disabled' | 'unlocked' | 'locked' = 'enabled',
+  ): Promise<boolean> {
     const timeout = 300000;
     const interval = 1000;
     const startTime = Date.now();
 
     while (Date.now() - startTime < timeout) {
-      const isEnabled = await this.featureConfig.isFeatureEnabled(token, featureKey);
-      if (isEnabled) {
-        return true;
+      if (state === 'enabled' || state === 'disabled') {
+        const isEnabled = await this.featureConfig.isFeatureEnabled(token, featureKey);
+        if (isEnabled && state === 'enabled') return true;
+        if (!isEnabled && state === 'disabled') return true;
+      } else {
+        const isUnlocked = await this.featureConfig.isFeatureUnlocked(token, featureKey);
+        if (isUnlocked && state === 'unlocked') return true;
+        if (!isUnlocked && state === 'locked') return true;
       }
+
       await new Promise(resolve => setTimeout(resolve, interval));
     }
 
-    throw new Error(`${featureKey} feature is not enabled after waiting for ${timeout / 1000} seconds`);
+    throw new Error(`${featureKey} feature is not ${state} after waiting for ${timeout / 1000} seconds`);
   }
 
   async createTeamOwner(user: User, teamName: string) {

--- a/apps/webapp/test/e2e_tests/backend/featureConfigRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/featureConfigRepository.e2e.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {FeatureList, FEATURE_KEY, FEATURE_STATUS} from '@wireapp/api-client/lib/team/feature';
+import {FeatureList, FEATURE_KEY, FEATURE_STATUS, FEATURE_LOCK_STATUS} from '@wireapp/api-client/lib/team/feature';
 
 import {BackendClientE2E} from './backendClient.e2e';
 
@@ -32,6 +32,13 @@ export class FeatureConfigRepositoryE2E extends BackendClientE2E {
     });
 
     return response.data[FeatureKey]?.status === FEATURE_STATUS.ENABLED;
+  }
+
+  async isFeatureUnlocked(token: string, featureKey: FEATURE_KEY): Promise<boolean> {
+    const res = await this.axiosInstance.get<FeatureList>('feature-configs', {
+      headers: {Authorization: `Bearer ${token}`},
+    });
+    return res.data[featureKey]?.lockStatus === FEATURE_LOCK_STATUS.UNLOCKED;
   }
 
   async changeStateSndFactorPasswordChallenge(user: User, teamId: string, status: string) {

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -168,31 +168,31 @@ export const test = baseTest.extend<Fixtures>({
       }
 
       if (options?.features && Object.values(options.features).every(Boolean)) {
-        // The team will be reset right after initialization, so we need to wait a short time for it to finish
+        // The team will be reset right after initialization, so we wait for a feature which is unlocked by default to be locked by ibis
         // before changing feature configs since they would otherwise be overwritten (See WPB-23698)
-        await new Promise(resolve => setTimeout(resolve, 5000));
+        await api.waitForFeature(FEATURE_KEY.CONVERSATION_GUEST_LINKS, owner.token, 'locked');
 
         if (options.features.conferenceCalling) {
           await api.enableConferenceCallingFeature(teamId);
-          await api.waitForFeatureToBeEnabled(FEATURE_KEY.CONFERENCE_CALLING, teamId, owner.token);
+          await api.waitForFeature(FEATURE_KEY.CONFERENCE_CALLING, owner.token);
         }
 
         // Creating channels depends on MLS to be enabled
         if (options.features.mls || options.features.channels) {
           await api.brig.enableMLSFeature(owner.teamId);
-          await api.waitForFeatureToBeEnabled(FEATURE_KEY.MLS, teamId, owner.token);
+          await api.waitForFeature(FEATURE_KEY.MLS, owner.token);
         }
 
         if (options.features.channels) {
           await api.brig.unlockChannelFeature(teamId);
           await api.brig.enableChannelsFeature(teamId);
-          await api.waitForFeatureToBeEnabled(FEATURE_KEY.CHANNELS, teamId, owner.token);
+          await api.waitForFeature(FEATURE_KEY.CHANNELS, owner.token);
         }
 
         if (options.features.cells) {
           await api.brig.unlockCellsFeature(teamId);
           await api.brig.enableCells(teamId);
-          await api.waitForFeatureToBeEnabled(FEATURE_KEY.CELLS, teamId, owner.token);
+          await api.waitForFeature(FEATURE_KEY.CELLS, owner.token);
         }
       }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This is an intermediate solution to make tests depending on enterprise features more reliable. Instead of just waiting some amount of time we now poll for a feature known to be unlocked initially to be locked, since IBIS will lock it when it finished its initialization.
We're already investigating to find a even more future proof way to ensure teams features are unlocked reliably, but for now this is already an improvement.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers

- 
