### PR TITLE
fix: remove adding service to group [WPB-23669]

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -141,8 +141,13 @@ jobs:
       - name: Merge playwright reports
         working-directory: apps/webapp
         run: |
-          yarn playwright merge-reports --config ./playwright.config.ts playwright-report/blob-reports
-          rm -rf playwright-report/blob-reports
+          if [ -d "playwright-report/blob-reports" ]; then
+            yarn playwright merge-reports --config ./playwright.config.ts playwright-report/blob-reports
+            rm -rf playwright-report/blob-reports
+          else
+            echo "No blob-reports directory found; skipping merge."
+            ls -la playwright-report || true
+          fi
 
       - name: Delete trace artifacts
         if: ${{ !inputs.keep_traces }}

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -166,6 +166,10 @@ test(
 
     await test.step('Team owner removes one group member from a group', async () => {
       const {pages} = ownerPageManager.webapp;
+      await pages.conversation().clickConversationInfoButton();
+      expect(pages.conversation().membersList).toBeVisible();
+      expect(pages.conversation().membersList.getByRole('listitem')).toHaveCount(1);
+
       // Get the member from the members list and remove them
       await pages.conversation().removeMemberFromGroup(member2.fullName);
 
@@ -173,15 +177,6 @@ test(
       await expect(
         pages.conversation().systemMessages.filter({hasText: `You removed ${member2.fullName}`}),
       ).toBeVisible();
-    });
-
-    await test.step('Team owner removes a service from a group', async () => {
-      const {pages} = ownerPageManager.webapp;
-      // Remove the Poll service (services appear in the members list)
-      await pages.conversationDetails().removeServiceFromConversation('Poll');
-
-      // Verify service was removed by checking for system message
-      await expect(pages.conversation().systemMessages.filter({hasText: 'You removed Poll Bot'})).toBeVisible();
     });
   },
 );

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/addMembersToChat-TC-8631.spec.ts
@@ -19,7 +19,6 @@
 
 import {User} from 'test/e2e_tests/data/user';
 
-import {Services} from '../../data/serviceInfo';
 import {PageManager} from '../../pageManager';
 import {test, expect, withLogin} from '../../test.fixtures';
 import {createGroup} from 'test/e2e_tests/utils/userActions';
@@ -58,18 +57,6 @@ test(
       const {pages} = ownerPageManager.webapp;
       await createGroup(pages, conversationName, [member1, member2]);
       await expect(pages.conversationList().getConversationLocator(conversationName)).toBeVisible();
-    });
-
-    await test.step('Team owner adds a service to newly created group', async () => {
-      const {pages} = ownerPageManager.webapp;
-      await api.team.addServiceToTeamWhitelist(owner.teamId, Services.POLL_SERVICE, owner.token);
-      // Add the Poll service to the conversation
-      await pages.conversation().clickConversationTitle();
-      await pages.conversationDetails().waitForSidebar();
-      await pages.conversationDetails().clickAddPeopleButton();
-      await pages.conversationDetails().addServiceToConversation('Poll');
-      // Verify service was added by checking for system message
-      await expect(ownerPageManager.page.getByText('You added Poll Bot to the')).toBeVisible();
     });
 
     await test.step('All group participants send messages in a group', async () => {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23669" title="WPB-23669" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-23669</a>  [Web][Integrations] Toggle app slider at conversation creation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

By default the apps [are disabled now ](https://github.com/wireapp/wire-webapp/pull/21003)causing test to fail when adding a bot in a group.


## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
