### PR TITLE
fix: camera permission issue for fresh session where deviceId is empty [WPB-22321]

### DIFF
--- a/apps/webapp/src/script/repositories/media/MediaConstraintsHandler.test.ts
+++ b/apps/webapp/src/script/repositories/media/MediaConstraintsHandler.test.ts
@@ -24,19 +24,25 @@ import {createUuid} from 'Util/uuid';
 
 import {MediaConstraintsHandler, ScreensharingMethods} from './MediaConstraintsHandler';
 
+interface SelectedDeviceId {
+  exact?: string;
+}
+
 interface ExtendedMediaTrackConstraints extends MediaTrackConstraints {
   audio: {
     autoGainControl?: boolean;
-    deviceId?: {
-      exact?: string;
-    };
+    deviceId?: SelectedDeviceId;
   };
   video: {
     facingMode?: string;
-    deviceId?: {
-      exact?: string;
-    };
+    deviceId?: SelectedDeviceId;
   };
+}
+
+interface CreateAvailableDevicesParams {
+  audio?: string;
+  video?: string;
+  screen?: string;
 }
 
 describe('MediaConstraintsHandler', () => {
@@ -44,7 +50,7 @@ describe('MediaConstraintsHandler', () => {
     audio = 'mic',
     video = 'camera1',
     screen = 'screen1',
-  }: {audio?: string; video?: string; screen?: string} = {}) => {
+  }: CreateAvailableDevicesParams = {}) => {
     mediaDevicesStore.setState({
       audio: {
         input: {devices: [], supported: false, selectedId: audio},

--- a/apps/webapp/src/script/repositories/media/MediaConstraintsHandler.test.ts
+++ b/apps/webapp/src/script/repositories/media/MediaConstraintsHandler.test.ts
@@ -18,7 +18,7 @@
  */
 
 import {User} from 'Repositories/entity/User';
-import {defaultAudioOutputId, mediaDevicesStore,} from 'Repositories/media/useMediaDevicesStore';
+import {defaultAudioOutputId, mediaDevicesStore} from 'Repositories/media/useMediaDevicesStore';
 import {UserState} from 'Repositories/user/UserState';
 import {createUuid} from 'Util/uuid';
 
@@ -40,7 +40,11 @@ interface ExtendedMediaTrackConstraints extends MediaTrackConstraints {
 }
 
 describe('MediaConstraintsHandler', () => {
-  const createAvailableDevices = async ({audio = 'mic', video = 'camera1', screen = 'screen1'}: {audio?: string; video?: string, screen?: string} = {}) => {
+  const createAvailableDevices = async ({
+    audio = 'mic',
+    video = 'camera1',
+    screen = 'screen1',
+  }: {audio?: string; video?: string; screen?: string} = {}) => {
     mediaDevicesStore.setState({
       audio: {
         input: {devices: [], supported: false, selectedId: audio},
@@ -85,7 +89,11 @@ describe('MediaConstraintsHandler', () => {
       createAvailableDevices();
 
       const constraintsHandler = createConstraintsHandler();
-      const constraints = constraintsHandler.getMediaStreamConstraints(true, true, false) as ExtendedMediaTrackConstraints;
+      const constraints = constraintsHandler.getMediaStreamConstraints(
+        true,
+        true,
+        false,
+      ) as ExtendedMediaTrackConstraints;
 
       expect(constraints.audio.deviceId.exact).toBe('mic');
       expect(constraints.video.deviceId.exact).toBe('camera1');
@@ -96,7 +104,11 @@ describe('MediaConstraintsHandler', () => {
       createAvailableDevices({audio: defaultId, video: defaultId});
 
       const constraintsHandler = createConstraintsHandler();
-      const constraints = constraintsHandler.getMediaStreamConstraints(true, true, false) as ExtendedMediaTrackConstraints;
+      const constraints = constraintsHandler.getMediaStreamConstraints(
+        true,
+        true,
+        false,
+      ) as ExtendedMediaTrackConstraints;
 
       expect(constraints.audio.deviceId).toBeUndefined();
       expect(constraints.audio).toEqual({autoGainControl: false});

--- a/apps/webapp/src/script/repositories/media/MediaConstraintsHandler.test.ts
+++ b/apps/webapp/src/script/repositories/media/MediaConstraintsHandler.test.ts
@@ -18,29 +18,41 @@
  */
 
 import {User} from 'Repositories/entity/User';
-import {mediaDevicesStore} from 'Repositories/media/useMediaDevicesStore';
+import {defaultAudioOutputId, mediaDevicesStore,} from 'Repositories/media/useMediaDevicesStore';
 import {UserState} from 'Repositories/user/UserState';
 import {createUuid} from 'Util/uuid';
 
 import {MediaConstraintsHandler, ScreensharingMethods} from './MediaConstraintsHandler';
 
+interface ExtendedMediaTrackConstraints extends MediaTrackConstraints {
+  audio: {
+    autoGainControl?: boolean;
+    deviceId?: {
+      exact?: string;
+    };
+  };
+  video: {
+    facingMode?: string;
+    deviceId?: {
+      exact?: string;
+    };
+  };
+}
+
 describe('MediaConstraintsHandler', () => {
-  const createAvailableDevices = ({
-    audio = 'mic',
-    video = 'screen1',
-    output = 'speaker',
-    screen = 'camera',
-  }: {
-    audio?: string;
-    video?: string;
-    output?: string;
-    screen?: string;
-  } = {}) => {
-    const state = mediaDevicesStore.getState();
-    state.setAudioInputDeviceId(audio);
-    state.setVideoInputDeviceId(video);
-    state.setAudioOutputDeviceId(output);
-    state.setScreenInputDeviceId(screen);
+  const createAvailableDevices = async ({audio = 'mic', video = 'camera1', screen = 'screen1'}: {audio?: string; video?: string, screen?: string} = {}) => {
+    mediaDevicesStore.setState({
+      audio: {
+        input: {devices: [], supported: false, selectedId: audio},
+        output: {devices: [], supported: false, selectedId: defaultAudioOutputId},
+      },
+      video: {
+        input: {devices: [], selectedId: video, supported: false},
+      },
+      screen: {
+        input: {devices: [], selectedId: screen, supported: false},
+      },
+    });
   };
 
   const resetStore = () => {
@@ -58,19 +70,25 @@ describe('MediaConstraintsHandler', () => {
     return new MediaConstraintsHandler(userState as UserState);
   };
 
-  afterEach(() => resetStore());
+  const defaultId = MediaConstraintsHandler.CONFIG.DEFAULT_DEVICE_ID;
+
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
 
   describe('getMediaStreamConstraints', () => {
     it('returns devices id constraints if current devices are defined', () => {
       createAvailableDevices();
 
-      setTimeout(() => {
-        const constraintsHandler = createConstraintsHandler();
-        const constraints = constraintsHandler.getMediaStreamConstraints(true, true, false) as any;
+      const constraintsHandler = createConstraintsHandler();
+      const constraints = constraintsHandler.getMediaStreamConstraints(true, true, false) as ExtendedMediaTrackConstraints;
 
-        expect(constraints.audio.deviceId.exact).toBe('mic');
-        expect(constraints.video.deviceId.exact).toBe('screen1');
-      });
+      expect(constraints.audio.deviceId.exact).toBe('mic');
+      expect(constraints.video.deviceId.exact).toBe('camera1');
     });
 
     it('returns default constraints when current devices are not defined', () => {
@@ -78,7 +96,7 @@ describe('MediaConstraintsHandler', () => {
       createAvailableDevices({audio: defaultId, video: defaultId});
 
       const constraintsHandler = createConstraintsHandler();
-      const constraints = constraintsHandler.getMediaStreamConstraints(true, true, false) as any;
+      const constraints = constraintsHandler.getMediaStreamConstraints(true, true, false) as ExtendedMediaTrackConstraints;
 
       expect(constraints.audio.deviceId).toBeUndefined();
       expect(constraints.audio).toEqual({autoGainControl: false});
@@ -91,6 +109,60 @@ describe('MediaConstraintsHandler', () => {
           resizeMode: 'none',
         }),
       );
+    });
+
+    describe('Audio Constraints', () => {
+      it('should apply the AGC preference from storage to the audio constraints', () => {
+        const selfUserId = createUuid();
+        const constraintsHandler = createConstraintsHandler(selfUserId);
+
+        localStorage.setItem(`agc_enabled_${selfUserId}`, 'true');
+
+        const constraints = constraintsHandler.getMediaStreamConstraints(true, false) as ExtendedMediaTrackConstraints;
+
+        expect(constraints.audio.autoGainControl).toBe(true);
+      });
+
+      it('should include exact deviceId when a specific audio device is selected', () => {
+        createAvailableDevices({audio: 'specific-mic-id'});
+        const constraintsHandler = createConstraintsHandler();
+
+        const constraints = constraintsHandler.getMediaStreamConstraints(true, false) as ExtendedMediaTrackConstraints;
+
+        expect(constraints.audio.deviceId.exact).toBe('specific-mic-id');
+      });
+
+      it('should NOT include deviceId when the default audio device is selected', () => {
+        createAvailableDevices({audio: defaultId});
+        const constraintsHandler = createConstraintsHandler();
+
+        const constraints = constraintsHandler.getMediaStreamConstraints(true, false) as ExtendedMediaTrackConstraints;
+
+        expect(constraints.audio.deviceId).toBeUndefined();
+      });
+    });
+
+    describe('Video Constraints', () => {
+      it('should apply facingMode: user ONLY when no specific video device is selected', () => {
+        createAvailableDevices({video: defaultId});
+        const constraintsHandler = createConstraintsHandler();
+        const preferredFacing = MediaConstraintsHandler.CONFIG.CONSTRAINTS.VIDEO.PREFERRED_FACING_MODE;
+
+        const constraints = constraintsHandler.getMediaStreamConstraints(false, true) as ExtendedMediaTrackConstraints;
+
+        expect(constraints.video.facingMode).toBe(preferredFacing);
+        expect(constraints.video.deviceId).toBeUndefined();
+      });
+
+      it('should apply exact deviceId and OMIT facingMode when a specific video device is selected', () => {
+        createAvailableDevices({video: 'webcam-123'});
+        const constraintsHandler = createConstraintsHandler();
+
+        const constraints = constraintsHandler.getMediaStreamConstraints(false, true) as ExtendedMediaTrackConstraints;
+
+        expect(constraints.video.deviceId.exact).toBe('webcam-123');
+        expect(constraints.video.facingMode).toBeUndefined();
+      });
     });
   });
 
@@ -108,7 +180,7 @@ describe('MediaConstraintsHandler', () => {
     });
 
     it('returns constraints to get the screen stream if browser uses desktopCapturer in one to one call', () => {
-      createAvailableDevices({screen: 'camera'});
+      createAvailableDevices({screen: 'screen2'});
       const constraintsHandler = createConstraintsHandler();
 
       const constraints: MediaStreamConstraints | undefined = constraintsHandler.getScreenStreamConstraints(
@@ -119,7 +191,7 @@ describe('MediaConstraintsHandler', () => {
         expect(constraints?.audio).toBe(false);
         expect((constraints?.video as MediaTrackConstraintsExt).mandatory).toEqual({
           chromeMediaSource: 'desktop',
-          chromeMediaSourceId: 'camera',
+          chromeMediaSourceId: 'screen2',
           maxFrameRate: 5,
         });
       });

--- a/apps/webapp/src/script/repositories/media/MediaConstraintsHandler.ts
+++ b/apps/webapp/src/script/repositories/media/MediaConstraintsHandler.ts
@@ -187,22 +187,34 @@ export class MediaConstraintsHandler {
     }
   }
 
+  private getDeviceConstraint(mediaDeviceId?: string) {
+    const hasMediaDevice = mediaDeviceId && mediaDeviceId !== MediaConstraintsHandler.CONFIG.DEFAULT_DEVICE_ID;
+
+    return hasMediaDevice ? {deviceId: {exact: mediaDeviceId}} : {};
+  }
+
   private getAudioStreamConstraints(mediaDeviceId: string = ''): MediaTrackConstraints & {autoGainControl: boolean} {
-    const requireExactMediaDevice = mediaDeviceId && mediaDeviceId !== MediaConstraintsHandler.CONFIG.DEFAULT_DEVICE_ID;
-    return requireExactMediaDevice
-      ? {autoGainControl: this.getAgcPreference(), deviceId: {exact: mediaDeviceId}}
-      : {autoGainControl: this.getAgcPreference()};
+    return {
+      autoGainControl: this.getAgcPreference(),
+      ...this.getDeviceConstraint(mediaDeviceId),
+    };
   }
 
   private getVideoStreamConstraints(mediaDeviceId?: string, mode: VIDEO_QUALITY_MODE = VIDEO_QUALITY_MODE.MOBILE) {
     const streamConstraints = MediaConstraintsHandler.CONFIG.CONSTRAINTS.VIDEO[mode];
 
-    if (typeof mediaDeviceId === 'string' && mediaDeviceId !== MediaConstraintsHandler.CONFIG.DEFAULT_DEVICE_ID) {
-      streamConstraints.deviceId = {exact: mediaDeviceId};
-    } else {
-      streamConstraints.facingMode = MediaConstraintsHandler.CONFIG.CONSTRAINTS.VIDEO.PREFERRED_FACING_MODE;
+    const deviceConstraint = this.getDeviceConstraint(mediaDeviceId);
+
+    if (deviceConstraint.deviceId) {
+      return {
+        ...streamConstraints,
+        ...deviceConstraint,
+      };
     }
 
-    return streamConstraints;
+    return {
+      ...streamConstraints,
+      facingMode: MediaConstraintsHandler.CONFIG.CONSTRAINTS.VIDEO.PREFERRED_FACING_MODE,
+    };
   }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22321" title="WPB-22321" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22321</a>  [Web] Camera can't be allowed due to overlapping info that camera is not allowed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- What did I change and why?
DeviceID was only checked for the type but not for the value.
for empty string `''` type is also string but this doesn't give the DeviceID
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
