### PR TITLE
test: reduce flake by limiting number of parallel tests per agent to 1 [WPB-22420]

### DIFF
--- a/apps/webapp/playwright.config.ts
+++ b/apps/webapp/playwright.config.ts
@@ -23,8 +23,9 @@ import {resolve} from 'node:path';
 
 config({path: resolve(__dirname, './test/e2e_tests/.env'), quiet: true});
 
+// The number of parallel workers needs to be limited since otherwise the number of parallel requests could run into rate limiting by the backend
+const numberOfParallelWorkersOnCI = 1;
 const numberOfRetriesOnCI = 2;
-const numberOfParallelWorkersOnCI = 3;
 
 /**
  * See https://playwright.dev/docs/test-configuration.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This PR is an attempt to reduce flake by setting the number of parallel tests per worker back to 1. It was increased to 3 some time ago but since we're recently encountering a lot of flake it might still be better to rather execute less tests in parallel but have them pass then having to retry a lot.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Notes for reviewers

- 