### PR TITLE
test: set up mocks for addParticipants to at least render [WPB-20363]

### DIFF
--- a/apps/webapp/src/script/externalRoute.ts
+++ b/apps/webapp/src/script/externalRoute.ts
@@ -55,7 +55,7 @@ const getTermsOfUseTeamUrl = (): string | undefined => addLocaleToUrl(URL.TERMS_
  * @returns  The URL for managing services with optional UTM parameters.
  */
 export const getManageServicesUrl = (utmSource?: string): string | undefined =>
-  getTeamSettingsUrl(URL.URL_PATH.MANAGE_SERVICES, utmSource);
+  getTeamSettingsUrl(URL.URL_PATH?.MANAGE_SERVICES, utmSource);
 
 /**
  * Retrieves the URL for managing team settings with optional UTM parameters.

--- a/apps/webapp/src/script/page/RightSidebar/addParticipants/addParticipants.test.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/addParticipants/addParticipants.test.tsx
@@ -17,33 +17,68 @@
  *
  */
 
-import {render} from "@testing-library/react";
-import {AddParticipants} from "./addParticipants";
-import {Conversation} from "Repositories/entity/Conversation";
-import {ConversationRepository} from "Repositories/conversation/ConversationRepository";
-import {IntegrationRepository} from "Repositories/integration/IntegrationRepository";
-import {SearchRepository} from "Repositories/search/SearchRepository";
-import { PanelState, PanelEntity } from "..";
+import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
+import {IntegrationRepository} from 'Repositories/integration/IntegrationRepository';
+import {SearchRepository} from 'Repositories/search/SearchRepository';
+import {createConversation, mountComponent} from 'src/script/auth/util/test/TestUtil';
+import {AddParticipants} from './addParticipants';
+import {TeamState} from 'Repositories/team/TeamState';
+import ko from 'knockout';
+import {UserState} from 'Repositories/user/UserState';
+import {User} from 'Repositories/entity/User';
+import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
+import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
+import {IntegrationMapper} from 'Repositories/integration/IntegrationMapper';
+import {ROLE} from 'Repositories/user/UserPermission';
+import {TeamRepository} from 'Repositories/team/TeamRepository';
+import {mockStoreFactory} from 'src/script/auth/util/test/mockStoreFactory';
+import {initialRootState} from 'src/script/auth/module/reducer';
 
 describe('addParticipants', () => {
-  it('renders correctly', () => {
+  it('renders', () => {
     // Arrange
-    var conversation = new Conversation();
+    const conversation = createConversation(CONVERSATION_TYPE.REGULAR, CONVERSATION_PROTOCOL.MLS);
+    const teamState: Partial<TeamState> = {
+      isTeam: ko.pureComputed(() => false),
+      teamMembers: ko.pureComputed((): User[] => []),
+      teamUsers: ko.pureComputed((): User[] => []),
+    };
+    const conversationRepository: Partial<ConversationRepository> = {};
+    const searchRepository: Partial<SearchRepository> = {
+      normalizeQuery: query => ({query, isHandleQuery: true}),
+      searchUserInSet: (_term, users) => users,
+    };
+    const integrationRepository: Partial<IntegrationRepository> = {
+      services: ko.observableArray([]),
+      mapServiceFromUser: IntegrationMapper.mapServiceFromUser,
+      searchForServices: jest.fn(),
+    };
+    const teamRepository: Partial<TeamRepository> = {
+      filterRemoteDomainUsers: jest.fn(),
+    };
+    const userState: Partial<UserState> = {
+      connectedUsers: ko.pureComputed((): User[] => []),
+    };
+    const selfUser: Partial<User> = {
+      teamRole: ko.observable(ROLE.OWNER),
+    };
 
     // Act
-    render(<AddParticipants
-      activeConversation={conversation}
-      onBack={() => {
-      }}
-      onClose={() => {
-      }}
-      conversationRepository={{} as ConversationRepository}
-      integrationRepository={{} as IntegrationRepository}
-      searchRepository={{} as SearchRepository}
-      togglePanel={function (panel: PanelState, entity: PanelEntity, addMode?: boolean): void {
-        throw new Error("Function not implemented.");
-      }} teamRepository={undefined} teamState={undefined} userState={undefined} selfUser={undefined}    />);
-
-    // Assert
+    mountComponent(
+      <AddParticipants
+        activeConversation={conversation}
+        onBack={jest.fn()}
+        onClose={jest.fn()}
+        conversationRepository={conversationRepository as ConversationRepository}
+        integrationRepository={integrationRepository as IntegrationRepository}
+        searchRepository={searchRepository as SearchRepository}
+        togglePanel={jest.fn()}
+        teamRepository={teamRepository as TeamRepository}
+        teamState={teamState as TeamState}
+        userState={userState as UserState}
+        selfUser={selfUser as User}
+      />,
+      mockStoreFactory()(initialRootState),
+    );
   });
-})
+});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20363" title="WPB-20363" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20363</a>  [Web] [Integration] - Searching for Apps specifically
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- This PR adds a very basic skeleton for testing the addParticipants component, there are no tests for it yet but this PR can be followed up by actually testing business logic inside it.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
