### PR TITLE
test: fix duplicate test tag TC-1319 in markdown tests [WPB-24820]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
@@ -142,7 +142,7 @@ test.describe('Markdown', () => {
     }
   });
 
-  test('I want to edit a markdown message', {tag: ['@TC-1319', '@regression']}, async ({createPage}) => {
+  test('I want to edit a markdown message', {tag: ['@TC-1318', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24820" title="WPB-24820" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24820</a>  [Web][QA] Change wrong tag for the Markdown test case TC-1318 "I want to edit a markdown message" 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Removed duplicate test tag and replaced it with the right unique one

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
