### PR TITLE
fix:  Messages that contain assets do not make the asset content available to the search engine(WPB-22078)

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationService.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationService.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ClientEvent} from 'Repositories/event/Client';
+import type {EventService} from 'Repositories/event/EventService';
+import type {EventRecord, StorageService} from 'Repositories/storage';
+import {StatusType} from 'src/script/message/StatusType';
+
+import {MessageCategory} from '../../message/MessageCategory';
+import type {APIClient} from '../../service/APIClientSingleton';
+import type {Core} from '../../service/CoreSingleton';
+import {ConversationService} from './ConversationService';
+
+type EventServiceLike = Pick<EventService, 'loadEventsWithCategory'>;
+
+describe('ConversationService', () => {
+  describe('searchInConversation', () => {
+    it('matches multipart message text content', async () => {
+      const multipartEvent: EventRecord = {
+        primary_key: 'primary-key',
+        category: MessageCategory.TEXT,
+        conversation: 'conversation-id',
+        from: 'user-id',
+        time: new Date(0).toISOString(),
+        id: 'event-id',
+        type: ClientEvent.CONVERSATION.MULTIPART_MESSAGE_ADD,
+        data: {attachments: [{}], text: {content: 'i am sending a file'}},
+        status: StatusType.SENT,
+        ephemeral_expires: false,
+      };
+
+      const loadEventsWithCategory = jest
+        .fn<
+          ReturnType<EventServiceLike['loadEventsWithCategory']>,
+          Parameters<EventServiceLike['loadEventsWithCategory']>
+        >()
+        .mockResolvedValue([multipartEvent]);
+      const eventService: EventServiceLike = {loadEventsWithCategory};
+
+      const conversationService = new ConversationService(
+        eventService,
+        {} as unknown as StorageService,
+        {} as unknown as APIClient,
+        {} as unknown as Core,
+      );
+
+      expect(await conversationService.searchInConversation('conversation-id', 'sending a file')).toEqual([
+        multipartEvent,
+      ]);
+      expect(await conversationService.searchInConversation('conversation-id', 'unrelated')).toEqual([]);
+    });
+
+    it('matches composite message text items', async () => {
+      const compositeEvent: EventRecord = {
+        primary_key: 'primary-key',
+        category: MessageCategory.TEXT,
+        conversation: 'conversation-id',
+        from: 'user-id',
+        time: new Date(0).toISOString(),
+        id: 'event-id',
+        type: ClientEvent.CONVERSATION.COMPOSITE_MESSAGE_ADD,
+        data: {items: [{button: {id: '', text: ''}, text: {sender: '', content: 'composite caption'}}]},
+        ephemeral_expires: false,
+      };
+
+      const loadEventsWithCategory = jest
+        .fn<
+          ReturnType<EventServiceLike['loadEventsWithCategory']>,
+          Parameters<EventServiceLike['loadEventsWithCategory']>
+        >()
+        .mockResolvedValue([compositeEvent]);
+      const eventService: EventServiceLike = {loadEventsWithCategory};
+
+      const conversationService = new ConversationService(
+        eventService,
+        {} as unknown as StorageService,
+        {} as unknown as APIClient,
+        {} as unknown as Core,
+      );
+      expect(await conversationService.searchInConversation('conversation-id', 'caption')).toEqual([compositeEvent]);
+      expect(await conversationService.searchInConversation('conversation-id', 'unrelated')).toEqual([]);
+    });
+  });
+});

--- a/apps/webapp/src/script/repositories/conversation/ConversationService.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationService.test.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/apps/webapp/src/script/repositories/conversation/ConversationService.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationService.ts
@@ -48,11 +48,13 @@ import {MLSServiceEvents} from '@wireapp/core/lib/messagingProtocols/mls';
 import {container} from 'tsyringe';
 
 import type {Conversation as ConversationEntity} from 'Repositories/entity/Conversation';
+import {ClientEvent} from 'Repositories/event/Client';
 import type {EventService} from 'Repositories/event/EventService';
 import {search as fullTextSearch} from 'Repositories/search/FullTextSearch';
 import {StorageService} from 'Repositories/storage';
 import {ConversationRecord} from 'Repositories/storage/record/ConversationRecord';
 import {StorageSchemata} from 'Repositories/storage/StorageSchemata';
+import {getLogger} from 'Util/logger';
 
 import {MLSCapableConversation} from './ConversationSelectors';
 
@@ -60,11 +62,48 @@ import {MessageCategory} from '../../message/MessageCategory';
 import {APIClient} from '../../service/APIClientSingleton';
 import {Core} from '../../service/CoreSingleton';
 
+const logger = getLogger('AccountForm');
+
+type CompositeMessageItem = {
+  text?: {content?: string; message?: string};
+  button?: {text?: string};
+};
+
+type ConversationEventData = {
+  content?: string;
+  message?: string;
+  text?: {content?: string};
+  items?: CompositeMessageItem[];
+};
+
+type ConversationEvent = {type?: string; data?: ConversationEventData};
+type ConversationSearchEventLoader = Pick<EventService, 'loadEventsWithCategory'>;
+
+const TextExtractors: Partial<Record<string, (event: ConversationEvent) => string>> = {
+  [ClientEvent.CONVERSATION.MESSAGE_ADD]: event => event.data?.content || event.data?.message || '',
+  [ClientEvent.CONVERSATION.MULTIPART_MESSAGE_ADD]: event => event.data?.text?.content || '',
+  [ClientEvent.CONVERSATION.COMPOSITE_MESSAGE_ADD]: event => {
+    const items = Array.isArray(event.data?.items) ? event.data.items : [];
+    return items
+      .flatMap(item => {
+        if (item?.text) {
+          return [item.text.content || item.text.message || ''];
+        }
+        if (item?.button) {
+          return [item.button.text || ''];
+        }
+        return [];
+      })
+      .filter((text: string) => text.length > 0)
+      .join(' ');
+  },
+};
+
 export class ConversationService {
-  private readonly eventService: EventService;
+  private readonly eventService: ConversationSearchEventLoader;
 
   constructor(
-    eventService: EventService,
+    eventService: ConversationSearchEventLoader,
     private readonly storageService = container.resolve(StorageService),
     private readonly apiClient = container.resolve(APIClient),
     private readonly core = container.resolve(Core),
@@ -433,7 +472,22 @@ export class ConversationService {
     const events = await this.eventService.loadEventsWithCategory(conversation_id, category_min, category_max);
     return events
       .filter(record => record.ephemeral_expires !== true)
-      .filter(({data: event_data}: any) => fullTextSearch(event_data.content, query));
+      .filter(event => {
+        const searchableText = this.getEventSearchableText(event);
+        return searchableText ? fullTextSearch(searchableText, query) : false;
+      });
+  }
+
+  private getEventSearchableText(event: ConversationEvent): string {
+    try {
+      const contentOrLegacyText = event.data?.content || event.data?.message || '';
+      const extractor = event.type ? TextExtractors[event.type] : undefined;
+      const extractedText = extractor?.(event) || '';
+      return extractedText.length ? extractedText : contentOrLegacyText;
+    } catch (err) {
+      logger.error('Error extracting searchable text from event', {event, error: err});
+      return '';
+    }
   }
 
   /**

--- a/apps/webapp/src/script/repositories/conversation/ConversationService.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationService.ts
@@ -76,10 +76,10 @@ type ConversationEventData = {
   items?: CompositeMessageItem[];
 };
 
-type ConversationEvent = {type?: string; data?: ConversationEventData};
+type SearchableConversationEvent = {type?: string; data?: ConversationEventData};
 type ConversationSearchEventLoader = Pick<EventService, 'loadEventsWithCategory'>;
 
-const TextExtractors: Partial<Record<string, (event: ConversationEvent) => string>> = {
+const TextExtractors: Partial<Record<string, (event: SearchableConversationEvent) => string>> = {
   [ClientEvent.CONVERSATION.MESSAGE_ADD]: event => event.data?.content || event.data?.message || '',
   [ClientEvent.CONVERSATION.MULTIPART_MESSAGE_ADD]: event => event.data?.text?.content || '',
   [ClientEvent.CONVERSATION.COMPOSITE_MESSAGE_ADD]: event => {
@@ -478,7 +478,7 @@ export class ConversationService {
       });
   }
 
-  private getEventSearchableText(event: ConversationEvent): string {
+  private getEventSearchableText(event: SearchableConversationEvent): string {
     try {
       const contentOrLegacyText = event.data?.content || event.data?.message || '';
       const extractor = event.type ? TextExtractors[event.type] : undefined;

--- a/apps/webapp/src/script/repositories/conversation/ConversationService.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationService.ts
@@ -62,7 +62,7 @@ import {MessageCategory} from '../../message/MessageCategory';
 import {APIClient} from '../../service/APIClientSingleton';
 import {Core} from '../../service/CoreSingleton';
 
-const logger = getLogger('AccountForm');
+const logger = getLogger('ConversationService');
 
 type CompositeMessageItem = {
   text?: {content?: string; message?: string};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22078" title="WPB-22078" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22078</a>  [Web] Messages that contain assets do not make the asset content available to the search engine
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- User should be able to search all text messages with and without files.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
