### PR TITLE
fix: keep sso login button disabled instead of doing nothing on click [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/auth/page/SingleSignOnForm.tsx
+++ b/apps/webapp/src/script/auth/page/SingleSignOnForm.tsx
@@ -343,7 +343,7 @@ const SingleSignOnFormComponent = ({
         <Button
           block
           type="submit"
-          disabled={!codeOrMail}
+          disabled={isFetching || !codeOrMail}
           formNoValidate
           onClick={handleSubmit}
           aria-label={t('login.headline')}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

While investigating I noticed that sometimes the login button on the SSO page was enabled but clicking it would simply do nothing. I traced the cause of this down to the early return within handleSubmit if some auth request is still ongoing in the background. So I updated this condition to reflect reality and disable the button while clicking it would be pointless.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
