### PR TITLE
fix: Add monotonic timestamp handling and adjust WebGL pipeline logging [WPB-24373]

### DIFF
--- a/apps/webapp/src/script/repositories/media/backgroundEffects/effects/capability.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/effects/capability.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {Runtime} from '@wireapp/commons';
+
 import type {CapabilityInfo} from '../backgroundEffectsWorkerTypes';
 
 /**
@@ -108,7 +110,7 @@ export function choosePipeline(
   preferWorker: boolean,
 ): 'worker-webgl2' | 'main-webgl2' | 'canvas2d' | 'passthrough' {
   // Priority 1: Worker + OffscreenCanvas + WebGL2 (best performance)
-  if (cap.webgl2 && cap.worker && cap.offscreenCanvas && preferWorker) {
+  if (cap.webgl2 && cap.worker && cap.offscreenCanvas && preferWorker && !Runtime.isFirefox()) {
     return 'worker-webgl2';
   }
   // Priority 2: Main-thread WebGL2 (GPU-accelerated, but blocks main thread)

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipelines/mainWebGlPipeline.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipelines/mainWebGlPipeline.ts
@@ -69,6 +69,7 @@ export class MainWebGlPipeline implements BackgroundEffectsRenderingPipeline {
   private segmenter: SegmenterLike | null = null;
   private segmenterFactory: SegmenterFactory = MediaPipeSegmenterFactory;
   private segmentationModelByTier: SegmentationModelByTier = {};
+  private lastSegmentationTimestampMs = -1;
   private currentModelPath: string | null = null;
   private maskPostProcessor: MaskPostProcessor = new NoopMaskPostProcessor();
   private qualityController: QualityController | null = null;
@@ -203,7 +204,16 @@ export class MainWebGlPipeline implements BackgroundEffectsRenderingPipeline {
       if (frameIndex % qualityTier.segmentationCadence === 0) {
         this.segmenter.configure(qualityTier.segmentationWidth, qualityTier.segmentationHeight);
         const segStart = performance.now();
-        const timestampMs = timestamp * 1000;
+        const timestampMs = this.getMonotonicTimestampMs(timestamp);
+
+        if (timestampMs <= this.lastSegmentationTimestampMs) {
+          this.logger.warn('Frame due to non-monotonic timestamp', {
+            timestampMs,
+            lastTimestampMs: this.lastSegmentationTimestampMs,
+            rawTimestamp: timestamp,
+          });
+        }
+
         const includeClassMask = this.config.debugMode === 'classOverlay' || this.config.debugMode === 'classOnly';
         const result = await this.segmenter.segment(frame, timestampMs, {includeClassMask});
         segmentationMs = performance.now() - segStart;
@@ -452,5 +462,15 @@ export class MainWebGlPipeline implements BackgroundEffectsRenderingPipeline {
 
   public getCurrentModelPath(): string | null {
     return '';
+  }
+
+  private getMonotonicTimestampMs(inputTimestamp: number): number {
+    if (Number.isFinite(inputTimestamp) && inputTimestamp > 0) {
+      const candidateMs = Math.floor(inputTimestamp * 1000);
+      if (candidateMs > this.lastSegmentationTimestampMs) {
+        return candidateMs;
+      }
+    }
+    return Math.max(Math.floor(performance.now()), this.lastSegmentationTimestampMs + 1);
   }
 }

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipelines/mainWebGlPipeline.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipelines/mainWebGlPipeline.ts
@@ -69,7 +69,6 @@ export class MainWebGlPipeline implements BackgroundEffectsRenderingPipeline {
   private segmenter: SegmenterLike | null = null;
   private segmenterFactory: SegmenterFactory = MediaPipeSegmenterFactory;
   private segmentationModelByTier: SegmentationModelByTier = {};
-  private lastSegmentationTimestampMs = -1;
   private currentModelPath: string | null = null;
   private maskPostProcessor: MaskPostProcessor = new NoopMaskPostProcessor();
   private qualityController: QualityController | null = null;
@@ -206,10 +205,9 @@ export class MainWebGlPipeline implements BackgroundEffectsRenderingPipeline {
         const segStart = performance.now();
         const timestampMs = this.getMonotonicTimestampMs(timestamp);
 
-        if (timestampMs <= this.lastSegmentationTimestampMs) {
+        if (timestampMs <= 0) {
           this.logger.warn('Frame due to non-monotonic timestamp', {
             timestampMs,
-            lastTimestampMs: this.lastSegmentationTimestampMs,
             rawTimestamp: timestamp,
           });
         }
@@ -467,10 +465,10 @@ export class MainWebGlPipeline implements BackgroundEffectsRenderingPipeline {
   private getMonotonicTimestampMs(inputTimestamp: number): number {
     if (Number.isFinite(inputTimestamp) && inputTimestamp > 0) {
       const candidateMs = Math.floor(inputTimestamp * 1000);
-      if (candidateMs > this.lastSegmentationTimestampMs) {
+      if (candidateMs > 0) {
         return candidateMs;
       }
     }
-    return Math.max(Math.floor(performance.now()), this.lastSegmentationTimestampMs + 1);
+    return Math.floor(performance.now());
   }
 }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24373" title="WPB-24373" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-24373</a>  [Web] Firefox MediaPipe segmentation crash due to timestamp mismatch (norm_rect stream)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

 - fix MediaPipe segmentation failures caused by non-monotonic timestamps  in Firefox
 - temporary deactivate webgl segmentation worker for Firefox
---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):