### PR TITLE
ci: remove Yarn deduplication in lockfile maintenance pull requests [WPB-24758]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,10 +13,6 @@
   },
   "packageRules": [
     {
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "postUpdateOptions": ["yarnDedupeHighest"]
-    },
-    {
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true
     },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24758" title="WPB-24758" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24758</a>  [Web] Replace Dependabot with Renovate
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

-

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
