### PR TITLE
style: fix spelling of "allConversationsButton" [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/components/conversationSidebar.component.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/components/conversationSidebar.component.ts
@@ -28,7 +28,7 @@ export class ConversationSidebar {
   readonly personalStatusName: Locator;
   readonly personalUserName: Locator;
   readonly preferencesButton: Locator;
-  readonly allConverationsButton: Locator;
+  readonly allConversationsButton: Locator;
   readonly connectButton: Locator;
   readonly archiveButton: Locator;
   readonly manageTeamButton: Locator;
@@ -44,7 +44,7 @@ export class ConversationSidebar {
     this.personalStatusName = page.getByTestId('status-name');
     this.personalUserName = page.getByTestId('user-handle');
     this.preferencesButton = page.getByTestId('go-preferences');
-    this.allConverationsButton = page.getByTestId('go-recent-view');
+    this.allConversationsButton = page.getByTestId('go-recent-view');
     this.connectButton = page.getByTestId('go-people');
     this.archiveButton = page.getByTestId('go-archive');
     this.manageTeamButton = page.getByTestId('go-team-management');
@@ -57,7 +57,7 @@ export class ConversationSidebar {
   }
 
   async clickAllConversationsButton() {
-    await this.allConverationsButton.click();
+    await this.allConversationsButton.click();
   }
 
   async clickConnectButton() {

--- a/apps/webapp/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
@@ -59,7 +59,7 @@ test.describe('Accessibility', () => {
       });
 
       await test.step('User A types more into group', async () => {
-        await userAPages.sidebar().allConverationsButton.click();
+        await userAPages.sidebar().allConversationsButton.click();
         await userAPages.conversationList().openConversation('Accessible Group');
         await userAPages.conversation().messageInput.pressSequentially('Test', {delay: 100});
         // Since A disabled the typing indicator B should not see it

--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -238,7 +238,7 @@ test.describe('account settings', () => {
       });
 
       await test.step('Channel details', async () => {
-        await components.conversationSidebar().allConverationsButton.click();
+        await components.conversationSidebar().allConversationsButton.click();
 
         await pages.conversationList().clickCreateGroup();
         await modals.createConversation().createChannel('Test Channel', {members: [memberB]});

--- a/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
@@ -125,7 +125,7 @@ test.describe('Archive', () => {
       });
 
       await test.step('The conversation should still not be shown within all conversations', async () => {
-        await components.conversationSidebar().allConverationsButton.click();
+        await components.conversationSidebar().allConversationsButton.click();
         await expect(pages.conversationList().getConversationLocator(memberB.fullName)).not.toBeVisible();
       });
     });

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -112,7 +112,7 @@ test.describe('Folders', () => {
 
       // Preconditions: Create a custom folder with group conversation
       await createCustomFolder(userAPageManager, conversationName, customFolderName);
-      await userAComponents.conversationSidebar().allConverationsButton.click();
+      await userAComponents.conversationSidebar().allConversationsButton.click();
 
       // Step 1: User A moves 1:1 conversation with User B into an existing custom folder
       await moveConversationToFolder(userAPageManager, userB.fullName, customFolderName);
@@ -136,7 +136,7 @@ test.describe('Folders', () => {
 
       // Preconditions: Create a custom folder with 1:1 conversation
       await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
-      await userAComponents.conversationSidebar().allConverationsButton.click();
+      await userAComponents.conversationSidebar().allConversationsButton.click();
 
       // Step 1: User A moves group with User B into an existing custom folder
       await moveConversationToFolder(userAPageManager, conversationName, customFolderName);

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -102,7 +102,7 @@ test.describe('History Backup', () => {
       await userAPages2.account().backupFileInput.setInputFiles(backupName);
 
       await test.step('Validate conversation is still visible with all messages after restoring backup', async () => {
-        await userAComponents2.conversationSidebar().allConverationsButton.click();
+        await userAComponents2.conversationSidebar().allConversationsButton.click();
         await userAPages2.conversationList().openConversation(conversationName);
         await expect(userAPages2.conversation().getMessage({sender: userB})).toContainText(messageUserB);
         await expect(userAPages2.conversation().getMessage({sender: userA})).toContainText(messageUserA);
@@ -188,7 +188,7 @@ test.describe('History Backup', () => {
       await test.step('User A creates History Backup', async () => {
         await userAComponents.conversationSidebar().clickPreferencesButton();
         backupName = await createAndSaveBackup(testInfo, userAPageManager);
-        await userAComponents.conversationSidebar().allConverationsButton.click();
+        await userAComponents.conversationSidebar().allConversationsButton.click();
         await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
       });
 
@@ -204,7 +204,7 @@ test.describe('History Backup', () => {
 
       await test.step('Validate User A sees renamed conversation and system message', async () => {
         // User A sees renamed conversation
-        await userAComponents.conversationSidebar().allConverationsButton.click();
+        await userAComponents.conversationSidebar().allConversationsButton.click();
         await expect(userAPages.conversationList().getConversationLocator(renamedConversationName)).toBeVisible();
 
         // User A sees system message that User B had renamed the conversation
@@ -271,7 +271,7 @@ test.describe('History Backup', () => {
       });
 
       await test.step('Validate muted and archived state are the same', async () => {
-        await userAComponents.conversationSidebar().allConverationsButton.click();
+        await userAComponents.conversationSidebar().allConversationsButton.click();
         await userAPages.conversationList().openConversation(conversationName);
         await expect(
           userAPages.conversationList().getConversationLocator(conversationName).mutedIndicator,
@@ -373,7 +373,7 @@ test.describe('History Backup', () => {
       });
 
       await test.step('Validate deleted group conversation is no longer visible', async () => {
-        await userAComponents.conversationSidebar().allConverationsButton.click();
+        await userAComponents.conversationSidebar().allConversationsButton.click();
         await expect(userAPages.conversationList().getConversationLocator(conversationName)).not.toBeVisible();
       });
     },

--- a/apps/webapp/test/e2e_tests/specs/Localization/localization.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Localization/localization.spec.ts
@@ -144,7 +144,7 @@ test.describe('Localization', () => {
       const messagePlaceholder = page.locator('[data-uie-name="input-placeholder"]');
       await expect(messagePlaceholder).toHaveText(deTranslations['tooltipConversationInputPlaceholder']);
 
-      await components.conversationSidebar().allConverationsButton.click();
+      await components.conversationSidebar().allConversationsButton.click();
       await pages
         .conversationList()
         .getConversationLocator(userB.fullName)

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -332,7 +332,7 @@ test.describe('Notifications', () => {
         await userAComponents.conversationSidebar().preferencesButton.click();
         await userAPages.settings().accountButton.click();
         await userAPages.account().uploadProfilePicture(getImageFilePath());
-        await userAComponents.conversationSidebar().allConverationsButton.click();
+        await userAComponents.conversationSidebar().allConversationsButton.click();
       });
 
       await test.step(`User B navigates to preferences and sets "${notificationPreference}"`, async () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Nothing major, just a small rename of a locator since the typo in it's name triggered my OCD ^^'

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
