### PR TITLE
fix: restore last used virtual background [WPB-24451]

### DIFF
--- a/apps/webapp/src/script/components/calling/VideoControls/VideoControls.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/VideoControls.tsx
@@ -92,7 +92,7 @@ const mapValueToEffect = (value: BackgroundOptionValue, lastVirtualBackgroundId:
     case 'blur-low':
       return {type: 'blur', level: 'low'};
     case 'virtual':
-      return {type: 'virtual', backgroundId: lastVirtualBackgroundId || DEFAULT_BUILTIN_BACKGROUND_ID};
+      return {type: 'virtual', backgroundId: lastVirtualBackgroundId ?? DEFAULT_BUILTIN_BACKGROUND_ID};
     default:
       return {type: 'none'};
   }

--- a/apps/webapp/src/script/components/calling/VideoControls/VideoControls.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/VideoControls.tsx
@@ -47,8 +47,11 @@ import {Conversation} from 'Repositories/entity/Conversation';
 import {ElectronDesktopCapturerSource, MediaDevicesHandler} from 'Repositories/media/MediaDevicesHandler';
 import {useBackgroundEffectsStore} from 'Repositories/media/useBackgroundEffectsStore';
 import {useMediaDevicesStore} from 'Repositories/media/useMediaDevicesStore';
-import {BackgroundEffectSelection, DEFAULT_BUILTIN_BACKGROUND_ID} from 'Repositories/media/VideoBackgroundEffects';
-import {DEFAULT_BACKGROUND_EFFECT} from 'Repositories/media/VideoBackgroundEffects';
+import {
+  BackgroundEffectSelection,
+  DEFAULT_BACKGROUND_EFFECT,
+  DEFAULT_BUILTIN_BACKGROUND_ID,
+} from 'Repositories/media/VideoBackgroundEffects';
 import {PropertiesRepository} from 'Repositories/properties/PropertiesRepository';
 import {PROPERTIES_TYPE} from 'Repositories/properties/PropertiesType';
 import {TeamState} from 'Repositories/team/TeamState';
@@ -80,7 +83,7 @@ type BackgroundOptionValue = 'none' | 'blur-high' | 'blur-low' | 'virtual' | 'se
 
 const BACKGROUND_OPTION_VALUES = new Set<string>(['none', 'blur-high', 'blur-low', 'virtual', 'settings']);
 
-const mapValueToEffect = (value: BackgroundOptionValue): BackgroundEffectSelection => {
+const mapValueToEffect = (value: BackgroundOptionValue, lastVirtualBackgroundId: string): BackgroundEffectSelection => {
   switch (value) {
     case 'none':
       return {type: 'none'};
@@ -89,7 +92,7 @@ const mapValueToEffect = (value: BackgroundOptionValue): BackgroundEffectSelecti
     case 'blur-low':
       return {type: 'blur', level: 'low'};
     case 'virtual':
-      return {type: 'virtual', backgroundId: DEFAULT_BUILTIN_BACKGROUND_ID};
+      return {type: 'virtual', backgroundId: lastVirtualBackgroundId || DEFAULT_BUILTIN_BACKGROUND_ID};
     default:
       return {type: 'none'};
   }
@@ -214,6 +217,8 @@ export const VideoControls = ({
 
   const selectedBackgroundEffect =
     useBackgroundEffectsStore(state => state.preferredEffect) ?? DEFAULT_BACKGROUND_EFFECT;
+  const lastVirtualBackgroundId =
+    useBackgroundEffectsStore(state => state.lastVirtualBackgroundId) ?? DEFAULT_BUILTIN_BACKGROUND_ID;
   const isVideoBackgroundEffectsFeatureEnabled = useBackgroundEffectsStore(state => state.isFeatureEnabled);
 
   const {participants} = useKoSubscribableChildren(call, ['participants']);
@@ -431,7 +436,7 @@ export const VideoControls = ({
       }
       if (value && BACKGROUND_OPTION_VALUES.has(value)) {
         setVideoOptionsOpen(false);
-        const effect = mapValueToEffect(value as BackgroundOptionValue);
+        const effect = mapValueToEffect(value as BackgroundOptionValue, lastVirtualBackgroundId);
         handleBackgroundSelect(effect);
         return;
       }
@@ -440,7 +445,7 @@ export const VideoControls = ({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [onOpenBackgroundSettings, handleBackgroundSelect],
+    [onOpenBackgroundSettings, handleBackgroundSelect, lastVirtualBackgroundId],
   );
 
   const selectedBackgroundValue = mapEffectToValue(selectedBackgroundEffect);

--- a/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.test.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.test.ts
@@ -47,6 +47,7 @@ describe('BackgroundEffectsHandler', () => {
     backgroundEffectsStore.getState().setIsFeatureEnabled(false);
     backgroundEffectsStore.getState().setPreferredEffect({type: 'none'});
     backgroundEffectsStore.getState().setMetrics(undefined);
+    backgroundEffectsStore.getState().setLastVirtualBackgroundId(undefined);
   });
 
   beforeEach(() => {
@@ -261,5 +262,44 @@ describe('BackgroundEffectsHandler', () => {
 
     expect(result).toBe(false);
     expect(backgroundEffectsStore.getState().isFeatureEnabled).toBe(true);
+  });
+
+  it('restores last virtual background ID from storage on init', () => {
+    mockStorage.getItem.mockImplementation((key: string) => {
+      if (key === 'video-background-effects-last-virtual-id') {
+        return 'office-1';
+      }
+      return null;
+    });
+
+    new BackgroundEffectsHandler(mockController);
+
+    expect(backgroundEffectsStore.getState().lastVirtualBackgroundId).toBe('office-1');
+  });
+
+  it('saves last virtual background ID when a virtual effect is selected', () => {
+    const handler = new BackgroundEffectsHandler(mockController);
+
+    handler.setPreferredBackgroundEffect({type: 'virtual', backgroundId: 'office-2'});
+
+    expect(mockStorage.setItem).toHaveBeenCalledWith('video-background-effects-last-virtual-id', 'office-2');
+    expect(backgroundEffectsStore.getState().lastVirtualBackgroundId).toBe('office-2');
+  });
+
+  it('does not overwrite last virtual background ID when a non-virtual effect is selected', () => {
+    const handler = new BackgroundEffectsHandler(mockController);
+
+    handler.setPreferredBackgroundEffect({type: 'virtual', backgroundId: 'office-2'});
+    handler.setPreferredBackgroundEffect({type: 'blur', level: 'high'});
+
+    // lastVirtualBackgroundId in the store should still point to the last virtual one
+    expect(backgroundEffectsStore.getState().lastVirtualBackgroundId).toBe('office-2');
+
+    // setItem for the virtual ID key should have been called exactly once — only for the virtual selection, not for blur
+    const virtualIdCalls = (mockStorage.setItem as jest.Mock).mock.calls.filter(
+      ([key]) => key === 'video-background-effects-last-virtual-id',
+    );
+    expect(virtualIdCalls).toHaveLength(1);
+    expect(virtualIdCalls[0][1]).toBe('office-2');
   });
 });

--- a/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.test.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.test.ts
@@ -19,6 +19,7 @@
 
 import {BackgroundEffectsHandler, ReleasableMediaStream} from './backgroundEffectsHandler';
 import {backgroundEffectsStore} from './useBackgroundEffectsStore';
+import {DEFAULT_BUILTIN_BACKGROUND_ID} from 'Repositories/media/VideoBackgroundEffects';
 
 // Mocks
 jest.mock('Util/localStorage', () => ({
@@ -47,7 +48,7 @@ describe('BackgroundEffectsHandler', () => {
     backgroundEffectsStore.getState().setIsFeatureEnabled(false);
     backgroundEffectsStore.getState().setPreferredEffect({type: 'none'});
     backgroundEffectsStore.getState().setMetrics(undefined);
-    backgroundEffectsStore.getState().setLastVirtualBackgroundId(undefined);
+    backgroundEffectsStore.getState().setLastVirtualBackgroundId(DEFAULT_BUILTIN_BACKGROUND_ID);
   });
 
   beforeEach(() => {

--- a/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.ts
@@ -202,7 +202,7 @@ export class BackgroundEffectsHandler {
     try {
       return this.storage.getItem(VIDEO_BACKGROUND_EFFECTS_FEATURE_STORAGE_KEY) === 'true';
     } catch (error) {
-      console.error('Failed to read video background effect feature state', error);
+      this.logger.error('Failed to read video background effect feature state', error);
       return false;
     }
   }
@@ -218,7 +218,7 @@ export class BackgroundEffectsHandler {
       this.storage.setItem(VIDEO_BACKGROUND_EFFECTS_FEATURE_STORAGE_KEY, `${flag}`);
       return flag;
     } catch (error) {
-      console.error('Failed to persist video background effect feature state', error);
+      this.logger.error('Failed to persist video background effect feature state', error);
       return false;
     }
   }
@@ -271,7 +271,7 @@ export class BackgroundEffectsHandler {
     try {
       return parseStoredPreferredEffect(this.storage.getItem(VIDEO_BACKGROUND_EFFECT_STORAGE_KEY));
     } catch (error) {
-      console.error('Failed to read persisted preferred video background effect', error);
+      this.logger.error('Failed to read persisted preferred video background effect', error);
       return DEFAULT_BACKGROUND_EFFECT;
     }
   }
@@ -289,16 +289,16 @@ export class BackgroundEffectsHandler {
     }
   }
 
-  private readLastVirtualBackgroundIdFromStore(): string | undefined {
+  private readLastVirtualBackgroundIdFromStore(): string {
     if (this.storage === undefined) {
-      return undefined;
+      return DEFAULT_BUILTIN_BACKGROUND_ID;
     }
 
     try {
-      return this.storage.getItem(VIDEO_BACKGROUND_LAST_VIRTUAL_ID_STORAGE_KEY) ?? undefined;
+      return this.storage.getItem(VIDEO_BACKGROUND_LAST_VIRTUAL_ID_STORAGE_KEY) ?? DEFAULT_BUILTIN_BACKGROUND_ID;
     } catch (error) {
-      console.error('Failed to read last virtual background ID', error);
-      return undefined;
+      this.logger.error('Failed to read last virtual background ID', error);
+      return DEFAULT_BUILTIN_BACKGROUND_ID;
     }
   }
 

--- a/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.ts
@@ -38,6 +38,7 @@ export const DEBOUNCE_TIMER = 500;
 
 const VIDEO_BACKGROUND_EFFECT_STORAGE_KEY = 'video-background-effects';
 const VIDEO_BACKGROUND_EFFECTS_FEATURE_STORAGE_KEY = 'video-background-effects-feature-enabled';
+const VIDEO_BACKGROUND_LAST_VIRTUAL_ID_STORAGE_KEY = 'video-background-effects-last-virtual-id';
 
 const isVirtualEffect = (effect: BackgroundEffectSelection): boolean => {
   return effect.type === 'virtual' || effect.type === 'custom';
@@ -94,6 +95,7 @@ export class BackgroundEffectsHandler {
     this.storage = getStorage();
     backgroundEffectsStore.getState().setIsFeatureEnabled(this.readFeatureEnabledStateFromStore());
     backgroundEffectsStore.getState().setPreferredEffect(this.readPreferredBackgroundEffectFromStore());
+    backgroundEffectsStore.getState().setLastVirtualBackgroundId(this.readLastVirtualBackgroundIdFromStore());
 
     backgroundEffectsStore.subscribe((state, prevState) => {
       if (state.preferredEffect !== prevState.preferredEffect) {
@@ -104,6 +106,11 @@ export class BackgroundEffectsHandler {
           () => this.savePreferredBackgroundEffectInStore(state.preferredEffect),
           DEBOUNCE_TIMER,
         );
+
+        if (state.preferredEffect.type === 'virtual') {
+          backgroundEffectsStore.getState().setLastVirtualBackgroundId(state.preferredEffect.backgroundId);
+          this.saveLastVirtualBackgroundIdInStore(state.preferredEffect.backgroundId);
+        }
       }
     });
   }
@@ -279,6 +286,31 @@ export class BackgroundEffectsHandler {
       this.storage.setItem(VIDEO_BACKGROUND_EFFECT_STORAGE_KEY, serialized);
     } catch (error) {
       this.logger.error('Failed to persist preferred video background effect', error);
+    }
+  }
+
+  private readLastVirtualBackgroundIdFromStore(): string | undefined {
+    if (this.storage === undefined) {
+      return undefined;
+    }
+
+    try {
+      return this.storage.getItem(VIDEO_BACKGROUND_LAST_VIRTUAL_ID_STORAGE_KEY) ?? undefined;
+    } catch (error) {
+      console.error('Failed to read last virtual background ID', error);
+      return undefined;
+    }
+  }
+
+  private saveLastVirtualBackgroundIdInStore(backgroundId: string): void {
+    if (this.storage === undefined) {
+      return;
+    }
+
+    try {
+      this.storage.setItem(VIDEO_BACKGROUND_LAST_VIRTUAL_ID_STORAGE_KEY, backgroundId);
+    } catch (error) {
+      this.logger.error('Failed to persist last virtual background ID', error);
     }
   }
 

--- a/apps/webapp/src/script/repositories/media/useBackgroundEffectsStore.test.ts
+++ b/apps/webapp/src/script/repositories/media/useBackgroundEffectsStore.test.ts
@@ -1,0 +1,25 @@
+import {backgroundEffectsStore} from './useBackgroundEffectsStore';
+import {DEFAULT_BUILTIN_BACKGROUND_ID} from 'Repositories/media/VideoBackgroundEffects';
+
+describe('backgroundEffectsStore:lastVirtualBackgroundId', () => {
+  beforeEach(() => {
+    backgroundEffectsStore.setState(backgroundEffectsStore.getInitialState(), true);
+  });
+
+  it('initializes lastVirtualBackgroundId with the default builtin background id', () => {
+    expect(backgroundEffectsStore.getState().lastVirtualBackgroundId).toBe(DEFAULT_BUILTIN_BACKGROUND_ID);
+  });
+
+  it('updates lastVirtualBackgroundId when setLastVirtualBackgroundId is called', () => {
+    backgroundEffectsStore.getState().setLastVirtualBackgroundId('custom-bg-id');
+
+    expect(backgroundEffectsStore.getState().lastVirtualBackgroundId).toBe('custom-bg-id');
+  });
+
+  it('always has a defined lastVirtualBackgroundId', () => {
+    const state = backgroundEffectsStore.getState();
+
+    expect(state.lastVirtualBackgroundId).toBeDefined();
+    expect(typeof state.lastVirtualBackgroundId).toBe('string');
+  });
+});

--- a/apps/webapp/src/script/repositories/media/useBackgroundEffectsStore.ts
+++ b/apps/webapp/src/script/repositories/media/useBackgroundEffectsStore.ts
@@ -22,7 +22,11 @@ import {immer} from 'zustand/middleware/immer';
 import {createStore} from 'zustand/vanilla';
 
 import {Metrics, QualityTier} from 'Repositories/media/backgroundEffects';
-import {BackgroundEffectSelection, DEFAULT_BACKGROUND_EFFECT} from 'Repositories/media/VideoBackgroundEffects';
+import {
+  BackgroundEffectSelection,
+  DEFAULT_BACKGROUND_EFFECT,
+  DEFAULT_BUILTIN_BACKGROUND_ID,
+} from 'Repositories/media/VideoBackgroundEffects';
 
 export interface RenderMetrics extends Metrics {
   budget: number;
@@ -38,11 +42,11 @@ export type BackgroundEffectsState = {
   preferredEffect: BackgroundEffectSelection;
   metrics: RenderMetrics | undefined;
   model: string;
-  lastVirtualBackgroundId: string | undefined;
+  lastVirtualBackgroundId: string;
 
   setIsFeatureEnabled(value: boolean): void;
   setPreferredEffect(effect: BackgroundEffectSelection): void;
-  setLastVirtualBackgroundId(backgroundId: string | undefined): void;
+  setLastVirtualBackgroundId(backgroundId: string): void;
   setMetrics(metrics: RenderMetrics | undefined): void;
   setModel(model: string | undefined): void;
 };
@@ -53,7 +57,7 @@ export const backgroundEffectsStore = createStore<BackgroundEffectsState>()(
     preferredEffect: DEFAULT_BACKGROUND_EFFECT,
     metrics: undefined,
     model: 'unknown',
-    lastVirtualBackgroundId: undefined,
+    lastVirtualBackgroundId: DEFAULT_BUILTIN_BACKGROUND_ID,
 
     setIsFeatureEnabled: value =>
       set(state => {

--- a/apps/webapp/src/script/repositories/media/useBackgroundEffectsStore.ts
+++ b/apps/webapp/src/script/repositories/media/useBackgroundEffectsStore.ts
@@ -38,9 +38,11 @@ export type BackgroundEffectsState = {
   preferredEffect: BackgroundEffectSelection;
   metrics: RenderMetrics | undefined;
   model: string;
+  lastVirtualBackgroundId: string | undefined;
 
   setIsFeatureEnabled(value: boolean): void;
   setPreferredEffect(effect: BackgroundEffectSelection): void;
+  setLastVirtualBackgroundId(backgroundId: string | undefined): void;
   setMetrics(metrics: RenderMetrics | undefined): void;
   setModel(model: string | undefined): void;
 };
@@ -51,6 +53,7 @@ export const backgroundEffectsStore = createStore<BackgroundEffectsState>()(
     preferredEffect: DEFAULT_BACKGROUND_EFFECT,
     metrics: undefined,
     model: 'unknown',
+    lastVirtualBackgroundId: undefined,
 
     setIsFeatureEnabled: value =>
       set(state => {
@@ -60,6 +63,10 @@ export const backgroundEffectsStore = createStore<BackgroundEffectsState>()(
     setPreferredEffect: effect =>
       set(state => {
         state.preferredEffect = effect;
+      }),
+    setLastVirtualBackgroundId: backgroundId =>
+      set(state => {
+        state.lastVirtualBackgroundId = backgroundId;
       }),
 
     setMetrics: metrics =>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24451" title="WPB-24451" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24451</a>  Clicking “Virtual Background” overrides an already selected background by applying the default Wire background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- What did I change and why?
Store last used virtual background id in the store and also in the local storage.
And restore it when user need to apply virtual background again.
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
