### PR TITLE
fix: disable high quality checkbox [WPB-24521]

### DIFF
--- a/apps/webapp/src/script/components/calling/VideoControls/VideoBackgroundSettings/VideoBackgroundSettings.test.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/VideoBackgroundSettings/VideoBackgroundSettings.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render} from '@testing-library/react';
+
+import {VideoBackgroundSettings} from './VideoBackgroundSettings';
+import type {BuiltinBackground} from 'Repositories/media/VideoBackgroundEffects';
+import {withTheme} from '../../../../auth/util/test/TestUtil';
+
+jest.mock('Util/localizerUtil', () => ({
+  t: (key: string) => key,
+}));
+
+describe('VideoBackgroundSettings', () => {
+  const defaultProps = {
+    selectedEffect: {type: 'none'} as const,
+    backgrounds: [] as BuiltinBackground[],
+    onSelectEffect: jest.fn(),
+    onEnableHighQualityBlur: jest.fn(),
+    onClose: jest.fn(),
+    highQualityBlurAllowed: false,
+  };
+
+  it('renders the high quality blur checkbox as disabled', async () => {
+    const {getByTestId} = render(withTheme(<VideoBackgroundSettings {...defaultProps} />));
+    const checkbox = getByTestId('enable-high-quality-blur') as HTMLButtonElement;
+
+    expect(checkbox).toBeDisabled();
+  });
+});

--- a/apps/webapp/src/script/components/calling/VideoControls/VideoBackgroundSettings/VideoBackgroundSettings.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/VideoBackgroundSettings/VideoBackgroundSettings.tsx
@@ -160,6 +160,7 @@ export const VideoBackgroundSettings = ({
             disabled={true}
             id="enable-high-quality-blur"
             checked={highQualityBlurAllowed}
+            data-uie-name="enable-high-quality-blur"
             onChange={(event: ChangeEvent<HTMLInputElement>) => handleEnableHighQualityBlur(event)}
           >
             <CheckboxLabel htmlFor="enable-high-quality-blur">

--- a/apps/webapp/src/script/components/calling/VideoControls/VideoBackgroundSettings/VideoBackgroundSettings.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/VideoBackgroundSettings/VideoBackgroundSettings.tsx
@@ -157,6 +157,7 @@ export const VideoBackgroundSettings = ({
 
         <div>
           <Checkbox
+            disabled
             id="enable-high-quality-blur"
             checked={highQualityBlurAllowed}
             onChange={(event: ChangeEvent<HTMLInputElement>) => handleEnableHighQualityBlur(event)}

--- a/apps/webapp/src/script/components/calling/VideoControls/VideoBackgroundSettings/VideoBackgroundSettings.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/VideoBackgroundSettings/VideoBackgroundSettings.tsx
@@ -157,7 +157,7 @@ export const VideoBackgroundSettings = ({
 
         <div>
           <Checkbox
-            disabled
+            disabled={true}
             id="enable-high-quality-blur"
             checked={highQualityBlurAllowed}
             onChange={(event: ChangeEvent<HTMLInputElement>) => handleEnableHighQualityBlur(event)}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24521" title="WPB-24521" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-24521</a>  Make checkbox to disable large segment model functional
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- What did I change and why?
Disabled the checkbox for now until desktop wrapper is stabilized with hardware acceleration feature.
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
