### PR TITLE
test: write the calling regression tests - the first part [WPB-19943]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
@@ -28,7 +28,7 @@ export const FullScreenCallPage = (page: Page) => {
   const raiseHandButton = component.getByTestId('do-toggle-hand-raise');
   const toggleParticipantsBtn = component.getByTestId('do-toggle-call-participants-list');
   const selfVideoThumbnail = page.getByTestId('self-video-thumbnail-wrapper');
-  const callParticipants = component.getByTestId('list-call-ui-participants').getByRole('listitem');
+  const participantListItems = component.getByTestId('list-call-ui-participants').getByRole('listitem');
   const gridTiles = component.getByTestId('item-grid');
 
   /* Press the react button and click the given emoji within the opened toolbar */
@@ -58,16 +58,17 @@ export const FullScreenCallPage = (page: Page) => {
     await toggleParticipantsBtn.click();
   };
 
-  const getCallParticipant = (userName: string) => {
-    const user = callParticipants.filter({hasText: userName});
+  // Sidebar list of participants in the call
+  const getSidebarParticipant = (userName: string) => {
+    const participant = participantListItems.filter({hasText: userName});
 
-    return Object.assign(user, {
-      muteIcon: user.getByTestId('status-audio-off'),
-      guestIcon: user.getByTestId('status-guest'),
+    return Object.assign(participant, {
+      muteIcon: participant.getByTestId('status-audio-off'),
+      guestIcon: participant.getByTestId('status-guest'),
       // User is an active speaker
-      speakIcon: user.getByTestId('status-active-speaking'),
-      videoIcon: user.getByTestId('status-video'),
-      screenShareIcon: user.getByTestId('status-screenshare'),
+      speakIcon: participant.getByTestId('status-active-speaking'),
+      videoIcon: participant.getByTestId('status-video'),
+      screenShareIcon: participant.getByTestId('status-screenshare'),
     });
   };
 
@@ -88,7 +89,7 @@ export const FullScreenCallPage = (page: Page) => {
     toggleHandRaise,
     selfVideoThumbnail,
     toggleParticipantsList,
-    getCallParticipant,
+    getSidebarParticipant,
     getGridTile,
   };
 };

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
@@ -25,6 +25,8 @@ export const FullScreenCallPage = (page: Page) => {
   const component = page.locator('.video-calling-wrapper');
 
   const reactButton = component.getByTitle('Reactions');
+  const raiseHandButton = component.getByTestId('do-toggle-hand-raise');
+  const selfVideoThumbnail = page.getByTestId('self-video-thumbnail-wrapper');
 
   /* Press the react button and click the given emoji within the opened toolbar */
   const sendReaction = async (emoji: '👍') => {
@@ -45,8 +47,14 @@ export const FullScreenCallPage = (page: Page) => {
     });
   };
 
+  const toggleHandRaise = async () => {
+    await raiseHandButton.click();
+  };
+
   return {
     sendReaction,
     getReaction,
+    toggleHandRaise,
+    selfVideoThumbnail,
   };
 };

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
@@ -26,7 +26,10 @@ export const FullScreenCallPage = (page: Page) => {
 
   const reactButton = component.getByTitle('Reactions');
   const raiseHandButton = component.getByTestId('do-toggle-hand-raise');
+  const toggleParticipantsBtn = component.getByTestId('do-toggle-call-participants-list');
   const selfVideoThumbnail = page.getByTestId('self-video-thumbnail-wrapper');
+  const callParticipants = component.getByTestId('list-call-ui-participants').getByRole('listitem');
+  const gridTiles = component.getByTestId('item-grid');
 
   /* Press the react button and click the given emoji within the opened toolbar */
   const sendReaction = async (emoji: '👍') => {
@@ -51,10 +54,41 @@ export const FullScreenCallPage = (page: Page) => {
     await raiseHandButton.click();
   };
 
+  const toggleParticipantsList = async () => {
+    await toggleParticipantsBtn.click();
+  };
+
+  const getCallParticipant = (userName: string) => {
+    const user = callParticipants.filter({hasText: userName});
+
+    return Object.assign(user, {
+      muteIcon: user.getByTestId('status-audio-off'),
+      guestIcon: user.getByTestId('status-guest'),
+      // User is an active speaker
+      speakIcon: user.getByTestId('status-active-speaking'),
+      videoIcon: user.getByTestId('status-video'),
+      screenShareIcon: user.getByTestId('status-screenshare'),
+    });
+  };
+
+  const getGridTile = (name: string) => {
+    const tile = gridTiles.filter({hasText: name});
+
+    return Object.assign(tile, {
+      /** Icon indicating that the given user is muted */
+      muteIcon: tile.getByTestId('mic-icon-off'),
+      videoElement: tile.locator('video'),
+    });
+  };
+
   return {
     sendReaction,
     getReaction,
+    toggleParticipantsBtn,
     toggleHandRaise,
     selfVideoThumbnail,
+    toggleParticipantsList,
+    getCallParticipant,
+    getGridTile,
   };
 };

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -22,6 +22,7 @@ import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, withConnectedUser, withLogin, expect} from 'test/e2e_tests/test.fixtures';
 import {isPlayingAudio} from 'test/e2e_tests/utils/audio.util';
+import {createGroup} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Calling', () => {
   let userA: User;
@@ -31,7 +32,10 @@ test.describe('Calling', () => {
   test.beforeEach(async ({createTeam, createUser}) => {
     userB = await createUser();
     userC = await createUser();
-    const team = await createTeam('Team Call Team', {users: [userB, userC]});
+    const team = await createTeam('Team Call Team', {
+      users: [userB, userC],
+      features: {conferenceCalling: true},
+    });
     userA = team.owner;
   });
 
@@ -106,10 +110,19 @@ test.describe('Calling', () => {
     },
   );
 
-  test(
-    'Verify 1on1 call ringing terminates on second client when accepting call',
-    {tag: ['@TC-2823', '@regression']},
-    async ({createPage}) => {
+  [
+    {
+      description: 'Verify 1on1 call ringing terminates on second client when accepting call',
+      tag: '@TC-2823',
+      conversationType: '1on1',
+    },
+    {
+      description: 'Verify group call ringing stops on second client when accepting call',
+      tag: '@TC-2824',
+      conversationType: 'group',
+    },
+  ].forEach(({description, tag, conversationType}) => {
+    test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
       const [userAPage, userBPage1] = await Promise.all([
         createPage(withLogin(userA), withConnectedUser(userB)),
         createPage(withLogin(userB)),
@@ -121,13 +134,22 @@ test.describe('Calling', () => {
       const userBPage2 = await createPage(withLogin(userB, {confirmNewHistory: true}));
       const userBDevice2Pages = PageManager.from(userBPage2).webapp.pages;
 
+      if (conversationType === '1on1') {
+        await userAPages.conversationList().openConversation(userB.fullName);
+      } else {
+        await createGroup(userAPages, 'Calling group', [userB]);
+        await userAPages.conversationList().openConversation('Calling group');
+      }
+
       // Ensure no audio is playing on both devices initially
-      await userAPages.conversationList().openConversation(userB.fullName);
       await expect.poll(() => isPlayingAudio(userBPage1, AudioType.INCOMING_CALL)).toBe(false);
       await expect.poll(() => isPlayingAudio(userBPage2, AudioType.INCOMING_CALL)).toBe(false);
 
       // User A calls user B, confirming both devices are ringing
       await userAPages.conversation().clickCallButton();
+      await expect(userAPages.calling().callCell).toBeVisible();
+
+      await expect(userBDevice1Pages.calling().callCell).toBeVisible();
       await expect.poll(() => isPlayingAudio(userBPage1, AudioType.INCOMING_CALL)).toBe(true);
       await expect.poll(() => isPlayingAudio(userBPage2, AudioType.INCOMING_CALL)).toBe(true);
 
@@ -137,8 +159,8 @@ test.describe('Calling', () => {
       await expect.poll(() => isPlayingAudio(userBPage1, AudioType.INCOMING_CALL)).toBe(false);
       await expect(userBDevice2Pages.calling().callCell).not.toBeVisible();
       await expect.poll(() => isPlayingAudio(userBPage2, AudioType.INCOMING_CALL)).toBe(false);
-    },
-  );
+    });
+  });
 
   test(
     'Verify I can make another call while current one is ignored',

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -400,7 +400,7 @@ test.describe('Calling', () => {
         await member.calling().clickAcceptCallButton();
         await expect(member.calling().goFullScreen).toBeVisible();
       }
-      
+
       // User A removes User B from the group
       await userAPages.conversation().toggleGroupInformation();
       await userAPages.conversation().removeMemberFromGroup(userB.fullName);
@@ -410,6 +410,38 @@ test.describe('Calling', () => {
 
       // User B is kicked out of a call
       await expect(userBPages.calling().callCell).not.toBeAttached();
+    },
+  );
+
+  test(
+    'I should not be able to join a call when I get removed from the group',
+    {tag: ['@TC-2838', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      ]);
+
+      await createGroup(userAPages, groupName, [userB]);
+
+      // User A initiates the call
+      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversation().clickCallButton();
+
+      await expect(userAPages.calling().callCell).toBeVisible();
+      await expect(userBPages.calling().callCell).toBeVisible();
+      await expect(userBPages.conversationList().joinCallButton).toBeVisible();
+
+      // User A removes User B from the group
+      await userAPages.conversation().toggleGroupInformation();
+      await userAPages.conversation().removeMemberFromGroup(userB.fullName);
+      await expect(
+        userAPages.conversation().systemMessages.filter({hasText: `You removed ${userB.fullName}`}),
+      ).toBeVisible();
+
+      // User B cannot join the group call
+      await expect(userBPages.calling().callCell).not.toBeAttached();
+      await expect(userBPages.conversationList().joinCallButton).not.toBeAttached();
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -251,4 +251,26 @@ test.describe('Calling', () => {
     // Confirm that user C joined the call
     await expect(userCPages.calling().goFullScreen).toBeVisible();
   });
+
+  test('Verify Call UI checks', {tag: ['@TC-8771', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+    ]);
+
+    await createGroup(userAPages, groupName, [userB, userC]);
+
+    await userAPages.conversationList().openConversation(groupName);
+    await userAPages.conversation().clickCallButton();
+
+    await expect(userAPages.calling().callCell).toBeVisible();
+    await expect(userBPages.calling().callCell).toBeVisible();
+
+    await userBPages.calling().clickAcceptCallButton();
+    await expect(userBPages.calling().goFullScreen).toBeVisible();
+
+    await userAPages.calling().maximizeCell();
+    await expect(userAPages.calling().selfVideoThumbnail).toBeVisible();
+    await expect(userAPages.calling().getGridTile(userA.fullName).muteIcon).not.toBeAttached();
+  });
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -325,4 +325,54 @@ test.describe('Calling', () => {
     await expect(userBPages.calling().callCell).toBeHidden();
     await expect.poll(() => isPlayingAudio(userBPage, AudioType.INCOMING_CALL)).toBe(false);
   });
+
+  test(
+    'Verify joining and leaving call from second client does not disconnect the first client',
+    {tag: ['@TC-2827', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      // Log in a second session/device for User A.
+      const userAPage2 = await createPage(withLogin(userA, {confirmNewHistory: true}));
+      const userADevice2Pages = PageManager.from(userAPage2).webapp.pages;
+
+      // Setup: Create a group to host the call
+      await createGroup(userAPages, groupName, [userB]);
+
+      await test.step('User A starts a call and User B joins', async () => {
+        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversation().clickCallButton();
+
+        await expect(userAPages.calling().callCell).toBeVisible();
+        await expect(userBPages.calling().callCell).toBeVisible();
+
+        await userBPages.calling().clickAcceptCallButton();
+        await expect(userBPages.calling().goFullScreen).toBeVisible();
+      });
+
+      await test.step('User A joins then leaves the call from their second device', async () => {
+        await userADevice2Pages.conversationList().openConversation(groupName);
+        await userADevice2Pages.conversation().clickCallButton();
+        await expect(userADevice2Pages.calling().callCell).toBeVisible();
+
+        await userAPage2.waitForTimeout(30_000);
+        await expect(userADevice2Pages.calling().gridTiles).toHaveCount(3);
+
+        // Verify second device successfully disconnected
+        await userADevice2Pages.calling().clickLeaveCallButton();
+        await expect(userADevice2Pages.calling().callCell).not.toBeAttached();
+      });
+
+      await test.step('Verify User A’s first device remains in the call throughout', async () => {
+        await expect(userAPages.calling().goFullScreen).toBeVisible();
+
+        await userAPages.calling().clickLeaveCallButton();
+        await expect(userAPages.calling().callCell).not.toBeAttached();
+        // Verify the call is still "joinable" (User B is still there)
+        await expect(userAPages.conversationList().joinCallButton).toBeVisible({timeout: 1_000});
+      });
+    },
+  );
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -28,6 +28,7 @@ test.describe('Calling', () => {
   let userA: User;
   let userB: User;
   let userC: User;
+  const groupName = 'Calling group';
 
   test.beforeEach(async ({createTeam, createUser}) => {
     userB = await createUser();
@@ -68,6 +69,40 @@ test.describe('Calling', () => {
       await expect(userBPages.calling().callCell).not.toBeVisible();
     },
   );
+
+  test('Verify Raise hand functionality', {tag: ['@TC-8773', '@regression']}, async ({createPage}) => {
+    const [userAPage, userBPage] = await Promise.all([
+      createPage(withLogin(userA), withConnectedUser(userB)),
+      createPage(withLogin(userB)),
+    ]);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
+
+    await createGroup(userAPages, groupName, [userB]);
+
+    // Establish group call; required precondition for hand-raise testing
+    await userAPages.conversationList().openConversation(groupName);
+    await userAPages.conversation().clickCallButton();
+    await userBPages.calling().clickAcceptCallButton();
+
+    await expect(userBPages.calling().callCell).toBeVisible();
+
+    const userACall = await userAPages.calling().maximizeCell();
+    await expect(userACall.selfVideoThumbnail).toBeVisible();
+
+    // User A raises hand and verifies the indicator appears on their thumbnail
+    await userACall.toggleHandRaise();
+    await expect(userACall.selfVideoThumbnail.getByText('✋')).toBeVisible();
+
+    const toast = userAPage.getByText('You have raised your hand up');
+    await expect(toast).toBeVisible();
+
+    await expect(toast).toBeHidden({timeout: 3000});
+
+    await userACall.toggleHandRaise();
+    await expect(userACall.selfVideoThumbnail.getByText('✋')).toBeHidden();
+  });
 
   test('Verify in call reactions', {tag: ['@TC-8774', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages] = await Promise.all([

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -94,13 +94,14 @@ test.describe('Calling', () => {
     const userACall = await userAPages.calling().maximizeCell();
     await expect(userACall.selfVideoThumbnail).toBeVisible();
 
+    // Wait for the call to stabilize before testing the toast and thumbnail indicators
+    await userAPage.waitForTimeout(2000);
     // User A raises hand and verifies the indicator appears on their thumbnail
     await userACall.toggleHandRaise();
     const toast = userAPage.getByText('You have raised your hand up');
 
-    await expect(toast).toBeVisible({timeout: 2000});
+    await expect(toast).toBeVisible();
     await expect(userACall.selfVideoThumbnail.getByText('✋')).toBeVisible();
-
     await expect(toast).toBeHidden({timeout: 3000});
 
     await userACall.toggleHandRaise();
@@ -246,9 +247,9 @@ test.describe('Calling', () => {
     await expect(userBPages.calling().goFullScreen).toBeVisible();
 
     // User C joins the ongoing call
-    await userCPage.waitForTimeout(5_000);
-    await expect(userCPages.conversationList().joinCallButton).toBeVisible();
-    await userCPages.conversationList().joinCallButton.click();
+    await userCPage.waitForTimeout(5000);
+    await expect(userCPages.conversationList().getConversationLocator(groupName).joinCallButton).toBeVisible();
+    await userCPages.conversationList().getConversationLocator(groupName).joinCallButton.click();
 
     // Confirm that user C joined the call
     await expect(userCPages.calling().goFullScreen).toBeVisible();
@@ -301,7 +302,7 @@ test.describe('Calling', () => {
     await expect(userBPages.calling().callCell).toBeHidden();
 
     // User B re-joins the ongoing call from the conversation list
-    const joinButton = userBPages.conversationList().joinCallButton;
+    const joinButton = userBPages.conversationList().getConversationLocator(groupName).joinCallButton;
     await expect(joinButton).toBeVisible({timeout: 5000});
     await joinButton.click();
 
@@ -374,7 +375,9 @@ test.describe('Calling', () => {
         await userAPages.calling().clickLeaveCallButton();
         await expect(userAPages.calling().callCell).not.toBeAttached();
         // Verify the call is still "joinable" (User B is still there)
-        await expect(userAPages.conversationList().joinCallButton).toBeVisible({timeout: 1_000});
+        await expect(userAPages.conversationList().getConversationLocator(groupName).joinCallButton).toBeVisible({
+          timeout: 1000,
+        });
       });
     },
   );
@@ -433,7 +436,7 @@ test.describe('Calling', () => {
 
       await expect(userAPages.calling().callCell).toBeVisible();
       await expect(userBPages.calling().callCell).toBeVisible();
-      await expect(userBPages.conversationList().joinCallButton).toBeVisible();
+      await expect(userBPages.conversationList().getConversationLocator(groupName).joinCallButton).toBeVisible();
 
       // User A removes User B from the group
       await userAPages.conversation().toggleGroupInformation();
@@ -444,7 +447,7 @@ test.describe('Calling', () => {
 
       // User B cannot join the group call
       await expect(userBPages.calling().callCell).not.toBeAttached();
-      await expect(userBPages.conversationList().joinCallButton).not.toBeAttached();
+      await expect(userBPages.conversationList().getConversationLocator(groupName).joinCallButton).not.toBeAttached();
     },
   );
 

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -20,7 +20,7 @@
 import {AudioType} from 'Repositories/audio/audioType';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, withConnectedUser, withLogin, expect} from 'test/e2e_tests/test.fixtures';
+import {test, withConnectedUser, withLogin, expect, Team} from 'test/e2e_tests/test.fixtures';
 import {isPlayingAudio} from 'test/e2e_tests/utils/audio.util';
 import {createGroup} from 'test/e2e_tests/utils/userActions';
 
@@ -29,11 +29,12 @@ test.describe('Calling', () => {
   let userB: User;
   let userC: User;
   const groupName = 'Calling group';
+  let team: Team;
 
   test.beforeEach(async ({createTeam, createUser}) => {
     userB = await createUser();
     userC = await createUser();
-    const team = await createTeam('Team Call Team', {
+    team = await createTeam('Team Call Team', {
       users: [userB, userC],
       features: {conferenceCalling: true},
     });
@@ -442,6 +443,31 @@ test.describe('Calling', () => {
       // User B cannot join the group call
       await expect(userBPages.calling().callCell).not.toBeAttached();
       await expect(userBPages.conversationList().joinCallButton).not.toBeAttached();
+    },
+  );
+
+  test(
+    'I want to see warning when calling a big group',
+    {tag: ['@TC-2842', '@regression']},
+    async ({createPage, createUser}) => {
+      // Create Users and add to team
+      const extraMembers = await Promise.all(Array.from({length: 4}, () => createUser()));
+
+      for (const member of extraMembers) {
+        team.addTeamMember(member);
+      }
+
+      const allMembers = [userB, userC, ...extraMembers];
+      const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+
+      await createGroup(userAPages, groupName, allMembers);
+      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversation().clickCallButton();
+
+      await expect(userAPage.getByTestId('modal-without-title')).toContainText(
+        `Are you sure you want to call ${allMembers.length} people?`,
+      );
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -304,4 +304,25 @@ test.describe('Calling', () => {
 
     await expect(userBPages.calling().goFullScreen).toBeVisible();
   });
+
+  test('Verify ignoring group call', {tag: ['@TC-2811', '@regression']}, async ({createPage}) => {
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
+
+    await createGroup(userAPages, groupName, [userB]);
+
+    // User A initiates the call
+    await userAPages.conversationList().openConversation(groupName);
+    await userAPages.conversation().clickCallButton();
+
+    await expect(userAPages.calling().callCell).toBeVisible();
+    await expect(userBPages.calling().callCell).toBeVisible();
+    await expect.poll(() => isPlayingAudio(userBPage, AudioType.INCOMING_CALL)).toBe(true);
+
+    await userBPages.calling().clickLeaveCallButton();
+    await expect(userBPages.calling().callCell).toBeHidden();
+    await expect.poll(() => isPlayingAudio(userBPage, AudioType.INCOMING_CALL)).toBe(false);
+  });
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -84,19 +84,21 @@ test.describe('Calling', () => {
     // Establish group call; required precondition for hand-raise testing
     await userAPages.conversationList().openConversation(groupName);
     await userAPages.conversation().clickCallButton();
-    await userBPages.calling().clickAcceptCallButton();
 
     await expect(userBPages.calling().callCell).toBeVisible();
+    await userBPages.calling().clickAcceptCallButton();
+
+    await expect(userBPages.calling().goFullScreen).toBeVisible();
 
     const userACall = await userAPages.calling().maximizeCell();
     await expect(userACall.selfVideoThumbnail).toBeVisible();
 
     // User A raises hand and verifies the indicator appears on their thumbnail
     await userACall.toggleHandRaise();
-    await expect(userACall.selfVideoThumbnail.getByText('✋')).toBeVisible();
-
     const toast = userAPage.getByText('You have raised your hand up');
-    await expect(toast).toBeVisible();
+
+    await expect(toast).toBeVisible({timeout: 1_000});
+    await expect(userACall.selfVideoThumbnail.getByText('✋')).toBeVisible();
 
     await expect(toast).toBeHidden({timeout: 3000});
 
@@ -221,4 +223,32 @@ test.describe('Calling', () => {
       await expect(userBPages.calling().callCell).toBeVisible();
     },
   );
+
+  test('Verify able to join ongoing call', {tag: ['@TC-2820', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages, userCPage] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB), withConnectedUser(userC))).then(pm => pm.webapp.pages),
+      createPage(withLogin(userC)),
+    ]);
+
+    const userCPages = PageManager.from(userCPage).webapp.pages;
+    await createGroup(userAPages, groupName, [userB, userC]);
+
+    await userAPages.conversationList().openConversation(groupName);
+    await userAPages.conversation().clickCallButton();
+
+    await expect(userAPages.calling().callCell).toBeVisible();
+    await expect(userBPages.calling().callCell).toBeVisible();
+
+    await userBPages.calling().clickAcceptCallButton();
+    // Confirm the calls grid is visible
+    await expect(userBPages.calling().goFullScreen).toBeVisible();
+
+    // User C joins the ongoing call
+    await expect(userCPages.conversationList().joinCallButton).toBeVisible();
+    await userCPages.conversationList().joinCallButton.click();
+
+    // Confirm that user C joined the call
+    await expect(userCPages.calling().goFullScreen).toBeVisible();
+  });
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -246,9 +246,8 @@ test.describe('Calling', () => {
     // Confirm the calls grid is visible
     await expect(userBPages.calling().goFullScreen).toBeVisible();
 
-    // User C joins the ongoing call
+    // // User C joins the ongoing call
     await userCPage.waitForTimeout(5000);
-    await expect(userCPages.conversationList().getConversationLocator(groupName).joinCallButton).toBeVisible();
     await userCPages.conversationList().getConversationLocator(groupName).joinCallButton.click();
 
     // Confirm that user C joined the call
@@ -302,9 +301,7 @@ test.describe('Calling', () => {
     await expect(userBPages.calling().callCell).toBeHidden();
 
     // User B re-joins the ongoing call from the conversation list
-    const joinButton = userBPages.conversationList().getConversationLocator(groupName).joinCallButton;
-    await expect(joinButton).toBeVisible({timeout: 5000});
-    await joinButton.click();
+    await userBPages.conversationList().getConversationLocator(groupName).joinCallButton.click({timeout: 30_000});
 
     await expect(userBPages.calling().goFullScreen).toBeVisible();
   });
@@ -361,7 +358,6 @@ test.describe('Calling', () => {
         await userADevice2Pages.conversation().clickCallButton();
         await expect(userADevice2Pages.calling().callCell).toBeVisible();
 
-        await userAPage2.waitForTimeout(30_000);
         await expect(userADevice2Pages.calling().gridTiles).toHaveCount(3);
 
         // Verify second device successfully disconnected
@@ -376,7 +372,7 @@ test.describe('Calling', () => {
         await expect(userAPages.calling().callCell).not.toBeAttached();
         // Verify the call is still "joinable" (User B is still there)
         await expect(userAPages.conversationList().getConversationLocator(groupName).joinCallButton).toBeVisible({
-          timeout: 1000,
+          timeout: 30_000,
         });
       });
     },
@@ -459,7 +455,7 @@ test.describe('Calling', () => {
       const extraMembers = await Promise.all(Array.from({length: 4}, () => createUser()));
 
       for (const member of extraMembers) {
-        team.addTeamMember(member);
+        await team.addTeamMember(member);
       }
 
       const allMembers = [userB, userC, ...extraMembers];
@@ -477,7 +473,7 @@ test.describe('Calling', () => {
   );
 
   test(
-    'I want to see the full call participant list and verify all media toggles',
+    'I want to see the full call participant list',
     {tag: ['@TC-2844', '@regression']},
     async ({createPage, createUser}) => {
       const guestUser = await createUser();
@@ -510,7 +506,7 @@ test.describe('Calling', () => {
 
       const userACall = await userAPages.calling().maximizeCell();
       await userACall.toggleParticipantsList();
-      await expect(userACall.getCallParticipant(guestUser.fullName).guestIcon).toBeVisible();
+      await expect(userACall.getSidebarParticipant(guestUser.fullName).guestIcon).toBeVisible();
 
       const participants = [
         {pages: userBPages, name: userB.fullName, label: 'User B'},
@@ -522,7 +518,7 @@ test.describe('Calling', () => {
           name: 'Mute',
           action: (p: PageManager['webapp']['pages']) => p.calling().toggleMuteButton.click(),
           verify: async (name: string) => {
-            await expect(userACall.getCallParticipant(name).muteIcon).not.toBeVisible();
+            await expect(userACall.getSidebarParticipant(name).muteIcon).not.toBeVisible();
             await expect(userACall.getGridTile(name).muteIcon).not.toBeVisible();
           },
         },
@@ -530,7 +526,7 @@ test.describe('Calling', () => {
           name: 'Screenshare',
           action: (p: PageManager['webapp']['pages']) => p.calling().clickToggleScreenShareButton(),
           verify: async (name: string) => {
-            await expect(userACall.getCallParticipant(name).screenShareIcon).toBeVisible();
+            await expect(userACall.getSidebarParticipant(name).screenShareIcon).toBeVisible();
             await expect(userACall.getGridTile(name).videoElement).toBeVisible();
           },
         },
@@ -538,7 +534,7 @@ test.describe('Calling', () => {
           name: 'Video',
           action: (p: PageManager['webapp']['pages']) => p.calling().clickToggleVideoButton(),
           verify: async (name: string) => {
-            await expect(userACall.getCallParticipant(name).videoIcon).toBeVisible();
+            await expect(userACall.getSidebarParticipant(name).videoIcon).toBeVisible();
             await expect(userACall.getGridTile(name).videoElement).toBeVisible();
           },
         },
@@ -549,7 +545,6 @@ test.describe('Calling', () => {
           await test.step(`${participant.label}: Verify ${feature.name}`, async () => {
             await feature.action(participant.pages);
             await feature.verify(participant.name);
-            await feature.action(participant.pages);
           });
         }
       }

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -375,4 +375,41 @@ test.describe('Calling', () => {
       });
     },
   );
+
+  test(
+    'I should not stay in the call when I get removed from the group',
+    {tag: ['@TC-2837', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages, userCPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+      ]);
+
+      await createGroup(userAPages, groupName, [userB, userC]);
+
+      // User A initiates the call
+      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversation().clickCallButton();
+
+      await expect(userAPages.calling().callCell).toBeVisible();
+
+      // Ensure all invited members join the call
+      for (const member of [userBPages, userCPages]) {
+        await expect(member.calling().callCell).toBeVisible();
+        await member.calling().clickAcceptCallButton();
+        await expect(member.calling().goFullScreen).toBeVisible();
+      }
+      
+      // User A removes User B from the group
+      await userAPages.conversation().toggleGroupInformation();
+      await userAPages.conversation().removeMemberFromGroup(userB.fullName);
+      await expect(
+        userAPages.conversation().systemMessages.filter({hasText: `You removed ${userB.fullName}`}),
+      ).toBeVisible();
+
+      // User B is kicked out of a call
+      await expect(userBPages.calling().callCell).not.toBeAttached();
+    },
+  );
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -20,7 +20,7 @@
 import {AudioType} from 'Repositories/audio/audioType';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, withConnectedUser, withLogin, expect, Team} from 'test/e2e_tests/test.fixtures';
+import {test, withConnectedUser, withLogin, expect, Team, withConnectionRequest} from 'test/e2e_tests/test.fixtures';
 import {isPlayingAudio} from 'test/e2e_tests/utils/audio.util';
 import {createGroup} from 'test/e2e_tests/utils/userActions';
 
@@ -98,7 +98,7 @@ test.describe('Calling', () => {
     await userACall.toggleHandRaise();
     const toast = userAPage.getByText('You have raised your hand up');
 
-    await expect(toast).toBeVisible({timeout: 1_000});
+    await expect(toast).toBeVisible({timeout: 2000});
     await expect(userACall.selfVideoThumbnail.getByText('✋')).toBeVisible();
 
     await expect(toast).toBeHidden({timeout: 3000});
@@ -246,11 +246,13 @@ test.describe('Calling', () => {
     await expect(userBPages.calling().goFullScreen).toBeVisible();
 
     // User C joins the ongoing call
+    await userCPage.waitForTimeout(5_000);
     await expect(userCPages.conversationList().joinCallButton).toBeVisible();
     await userCPages.conversationList().joinCallButton.click();
 
     // Confirm that user C joined the call
     await expect(userCPages.calling().goFullScreen).toBeVisible();
+    await expect(userCPages.calling().gridTiles).toHaveCount(3);
   });
 
   test('Verify Call UI checks', {tag: ['@TC-8771', '@regression']}, async ({createPage}) => {
@@ -300,7 +302,7 @@ test.describe('Calling', () => {
 
     // User B re-joins the ongoing call from the conversation list
     const joinButton = userBPages.conversationList().joinCallButton;
-    await expect(joinButton).toBeVisible({timeout: 10_000});
+    await expect(joinButton).toBeVisible({timeout: 5000});
     await joinButton.click();
 
     await expect(userBPages.calling().goFullScreen).toBeVisible();
@@ -468,6 +470,86 @@ test.describe('Calling', () => {
       await expect(userAPage.getByTestId('modal-without-title')).toContainText(
         `Are you sure you want to call ${allMembers.length} people?`,
       );
+    },
+  );
+
+  test(
+    'I want to see the full call participant list and verify all media toggles',
+    {tag: ['@TC-2844', '@regression']},
+    async ({createPage, createUser}) => {
+      const guestUser = await createUser();
+      const [userAPages, userBPages, guestPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectionRequest(guestUser))).then(
+          pm => pm.webapp.pages,
+        ),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(guestUser))).then(pm => pm.webapp.pages),
+      ]);
+
+      // --- Setup and Call Initialization ---
+      await test.step('Setup: Accept connection and start group call', async () => {
+        await guestPages.conversationList().openPendingConnectionRequest();
+        await guestPages.connectRequest().clickConnectButton();
+
+        await createGroup(userAPages, groupName, [userB, guestUser]);
+
+        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversation().clickCallButton();
+      });
+
+      await test.step('Join call with all participants', async () => {
+        for (const member of [userBPages, guestPages]) {
+          await expect(member.calling().callCell).toBeVisible();
+          await member.calling().clickAcceptCallButton();
+          await expect(member.calling().goFullScreen).toBeVisible();
+        }
+      });
+
+      const userACall = await userAPages.calling().maximizeCell();
+      await userACall.toggleParticipantsList();
+      await expect(userACall.getCallParticipant(guestUser.fullName).guestIcon).toBeVisible();
+
+      const participants = [
+        {pages: userBPages, name: userB.fullName, label: 'User B'},
+        {pages: guestPages, name: guestUser.fullName, label: 'Guest User'},
+      ];
+
+      const features = [
+        {
+          name: 'Mute',
+          action: (p: PageManager['webapp']['pages']) => p.calling().toggleMuteButton.click(),
+          verify: async (name: string) => {
+            await expect(userACall.getCallParticipant(name).muteIcon).not.toBeVisible();
+            await expect(userACall.getGridTile(name).muteIcon).not.toBeVisible();
+          },
+        },
+        {
+          name: 'Screenshare',
+          action: (p: PageManager['webapp']['pages']) => p.calling().clickToggleScreenShareButton(),
+          verify: async (name: string) => {
+            await expect(userACall.getCallParticipant(name).screenShareIcon).toBeVisible();
+            await expect(userACall.getGridTile(name).videoElement).toBeVisible();
+          },
+        },
+        {
+          name: 'Video',
+          action: (p: PageManager['webapp']['pages']) => p.calling().clickToggleVideoButton(),
+          verify: async (name: string) => {
+            await expect(userACall.getCallParticipant(name).videoIcon).toBeVisible();
+            await expect(userACall.getGridTile(name).videoElement).toBeVisible();
+          },
+        },
+      ];
+
+      for (const participant of participants) {
+        for (const feature of features) {
+          await test.step(`${participant.label}: Verify ${feature.name}`, async () => {
+            await feature.action(participant.pages);
+            await feature.verify(participant.name);
+            await feature.action(participant.pages);
+          });
+        }
+      }
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -273,4 +273,35 @@ test.describe('Calling', () => {
     await expect(userAPages.calling().selfVideoThumbnail).toBeVisible();
     await expect(userAPages.calling().getGridTile(userA.fullName).muteIcon).not.toBeAttached();
   });
+
+  test('Verify leaving and coming back to the group call', {tag: ['@TC-2808', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+    ]);
+
+    await createGroup(userAPages, groupName, [userB]);
+
+    // User A initiates the call
+    await userAPages.conversationList().openConversation(groupName);
+    await userAPages.conversation().clickCallButton();
+
+    await expect(userAPages.calling().callCell).toBeVisible();
+    await expect(userBPages.calling().callCell).toBeVisible();
+
+    // User B joins the call
+    await userBPages.calling().clickAcceptCallButton();
+    await expect(userBPages.calling().goFullScreen).toBeVisible();
+
+    // User B leaves the group call
+    await userBPages.calling().clickLeaveCallButton();
+    await expect(userBPages.calling().callCell).toBeHidden();
+
+    // User B re-joins the ongoing call from the conversation list
+    const joinButton = userBPages.conversationList().joinCallButton;
+    await expect(joinButton).toBeVisible({timeout: 10_000});
+    await joinButton.click();
+
+    await expect(userBPages.calling().goFullScreen).toBeVisible();
+  });
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19943" title="WPB-19943" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19943</a>  [Web/QA] Write the calling regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This PR introduces the first phase of the Calling regression E2E test suite. To ensure a manageable review process, the full suite has been split into two logical parts.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
