### PR TITLE
test: assert message deletion for userB [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -80,7 +80,7 @@ test.describe('Delete', () => {
       messageA = userAPages.conversation().getMessage({sender: userA});
       await expect(messageA).toContainText('Test Message');
 
-      messageB = userAPages.conversation().getMessage({sender: userA});
+      messageB = userBPages.conversation().getMessage({sender: userA});
       await expect(messageB).toContainText('Test Message');
     });
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This fixes a small bug inside the test case TC-570 where a the locator for the message deleted for userB was actually looking for the same message on userAs side.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
