### PR TITLE
fix: handle folder sync issue [WPB-24217]

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
@@ -32,6 +32,7 @@ import {getLogger, Logger} from 'Util/logger';
 import {fixWebsocketString} from 'Util/stringUtil';
 import {TypedEventTarget} from 'Util/typedEventTarget';
 import {createUuid} from 'Util/uuid';
+import is from '@sindresorhus/is';
 
 export enum LabelType {
   Custom = 0,
@@ -183,9 +184,11 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
         const localVersion = localData.version || 0;
         const remoteVersion = labelProperties.version || 0;
 
-        // Use local data if it has a newer timestamp, or same timestamp but higher version
+        // Use local data if it has a newer timestamp, or same timestamp but higher version.
+        // If remote has no timestamp, treat remote as source of truth.
         const isLocalNewer =
-          localTimestamp > remoteTimestamp || (localTimestamp === remoteTimestamp && localVersion > remoteVersion);
+          remoteTimestamp > 0 &&
+          (localTimestamp > remoteTimestamp || (localTimestamp === remoteTimestamp && localVersion > remoteVersion));
 
         if (isLocalNewer) {
           // Local data is newer, use it and update backend
@@ -241,6 +244,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
         labels: normalizedLabels ?? [],
       };
       this.unmarshal(value);
+      this.persistValues(value);
     }
   };
 
@@ -361,8 +365,8 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
     this.labels.splice(folderIndex, 1, updatedFolder);
 
     // Delete folder if it no longer contains any conversation
-    if (!label.conversations().length) {
-      this.labels.remove(label);
+    if (!is.nonEmptyArray(updatedFolder.conversations())) {
+      this.labels.remove(updatedFolder);
       // switch sidebar to recent tabs
       setCurrentTab(SidebarTabs.RECENT);
     } else {

--- a/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
@@ -365,13 +365,13 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
     this.labels.splice(folderIndex, 1, updatedFolder);
 
     // Delete folder if it no longer contains any conversation
-    if (!is.nonEmptyArray(updatedFolder.conversations())) {
+    if (is.nonEmptyArray(updatedFolder.conversations())) {
+      // trigger rerender on folders to remove conversation from folder
+      setCurrentTab(SidebarTabs.FOLDER);
+    } else {
       this.labels.remove(updatedFolder);
       // switch sidebar to recent tabs
       setCurrentTab(SidebarTabs.RECENT);
-    } else {
-      // trigger rerender on folders to remove conversation from folder
-      setCurrentTab(SidebarTabs.FOLDER);
     }
     this.saveLabels();
   };

--- a/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import is from '@sindresorhus/is';
 import {USER_EVENT} from '@wireapp/api-client/lib/event/';
 import {amplify} from 'amplify';
 import ko from 'knockout';
@@ -32,7 +33,6 @@ import {getLogger, Logger} from 'Util/logger';
 import {fixWebsocketString} from 'Util/stringUtil';
 import {TypedEventTarget} from 'Util/typedEventTarget';
 import {createUuid} from 'Util/uuid';
-import is from '@sindresorhus/is';
 
 export enum LabelType {
   Custom = 0,

--- a/apps/webapp/src/script/ui/ContextMenu.tsx
+++ b/apps/webapp/src/script/ui/ContextMenu.tsx
@@ -174,7 +174,7 @@ const ContextMenu = ({
       // context menu options such as 10 seconds etc begings with digit which is an invalid querySelector
       // param append btn- to avoid such errors
       const selectedButton = activeWindow.document.querySelector(
-        `#${getButtonId(labelWithoutQuotes!)}`,
+        `#${CSS.escape(getButtonId(labelWithoutQuotes!))}`,
       ) as HTMLButtonElement;
       selectedButton?.focus();
     }

--- a/apps/webapp/test/unit_tests/conversation/ConversationLabelRepositorySyncSpec.ts
+++ b/apps/webapp/test/unit_tests/conversation/ConversationLabelRepositorySyncSpec.ts
@@ -25,6 +25,7 @@ import {
 } from 'Repositories/conversation/ConversationLabelRepository';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {PropertiesService} from 'Repositories/properties/PropertiesService';
+import {SidebarTabs, useSidebarStore} from 'src/script/page/LeftSidebar/panels/Conversations/useSidebarStore';
 import {createUuid} from 'Util/uuid';
 
 describe('ConversationLabelRepository Synchronization', () => {
@@ -258,6 +259,52 @@ describe('ConversationLabelRepository Synchronization', () => {
           version: expect.any(Number),
         }),
       );
+    });
+  });
+
+  describe('removeConversationFromLabel', () => {
+    let setCurrentTab: jest.Mock;
+
+    beforeEach(() => {
+      setCurrentTab = jest.fn();
+      jest.spyOn(useSidebarStore, 'getState').mockReturnValue({
+        ...useSidebarStore.getState(),
+        setCurrentTab,
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should remove folder and switch to RECENT when last conversation is removed', () => {
+      const conversation = new Conversation(createUuid());
+      mockAllConversations([conversation]);
+      mockConversations([conversation]);
+
+      const folder = createLabel('My Folder', [conversation], createUuid(), LabelType.Custom);
+      conversationLabelRepository.labels([folder]);
+
+      conversationLabelRepository.removeConversationFromLabel(folder, conversation);
+
+      expect(conversationLabelRepository.labels()).toHaveLength(0);
+      expect(setCurrentTab).toHaveBeenCalledWith(SidebarTabs.RECENT);
+    });
+
+    it('should keep folder and stay on FOLDER tab when other conversations remain', () => {
+      const conversation1 = new Conversation(createUuid());
+      const conversation2 = new Conversation(createUuid());
+      mockAllConversations([conversation1, conversation2]);
+      mockConversations([conversation1, conversation2]);
+
+      const folder = createLabel('My Folder', [conversation1, conversation2], createUuid(), LabelType.Custom);
+      conversationLabelRepository.labels([folder]);
+
+      conversationLabelRepository.removeConversationFromLabel(folder, conversation1);
+
+      expect(conversationLabelRepository.labels()).toHaveLength(1);
+      expect(conversationLabelRepository.labels()[0].conversations()).toEqual([conversation2]);
+      expect(setCurrentTab).toHaveBeenCalledWith(SidebarTabs.FOLDER);
     });
   });
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24217" title="WPB-24217" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24217</a>  [iOS & WEB] Folders are not showing on Web after creating it on iOS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Android/iOS folder changes lost on reload: onUserEvent updated labels in memory but never persisted to localStorage. On reconnect, stale local data (with a higher lastSyncTimestamp) always won over remote data from other clients — and was pushed back to the backend, overwriting their changes.

Empty folder not cleaned up: removeConversationFromLabel checked the pre-removal label reference for emptiness instead of the updated one, so empty folders were never removed and the folder name remained visible in the header.

Crash on special characters in folder names: querySelector was called with an unescaped folder name as a CSS selector, throwing a SyntaxError for names containing characters like backticks. Fixed with CSS.escape().---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
