### PR TITLE
fix: replace close button with x and update performance panel styles [WPB-24452]

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -2051,6 +2051,8 @@
   "videoCallBackgroundVirtualSectionLabel": "Virtual Backgrounds",
   "videoCallBackgroundWire1": "Wire 1",
   "videoCallBackgroundsLabel": "Backgrounds",
+  "videoCallBackgroundsPerformancePanel": "Performance Panel",
+  "videoCallBackgroundsPerformancePanelClose": "Close performance panel",
   "videoCallMenuMoreAddReaction": "Add reaction",
   "videoCallMenuMoreAudioSettings": "Audio Settings",
   "videoCallMenuMoreCameraSettings": "Camera Settings",

--- a/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.styles.ts
+++ b/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.styles.ts
@@ -27,21 +27,34 @@ export const performancePanelContainerStyles = css({
 });
 
 export const performancePanelStyles = css({
-  background: '#fff',
+  background: 'var(--app-bg-secondary)',
   borderRadius: 12,
   padding: 16,
   minWidth: 220,
   boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
 });
 
-export const performancePanelButtonStyles = css({
-  marginBottom: 8,
-});
-
-export const performancePanelSelectStyles = css({
-  width: '100%',
+export const performancePanelHeaderStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 8,
   marginBottom: 12,
 });
+
+export const performancePanelTitleStyles = css({
+  margin: 0,
+  fontSize: 16,
+  fontWeight: 600,
+});
+
+export const performancePanelCloseButtonStyles = css({
+  minWidth: 0,
+});
+
+export const performancePanelResetButtonContainerStyles = css({display: 'flex', justifyContent: 'flex-end'});
+
+export const performancePanelResetButtonStyles = css({marginBottom: 0});
 
 export const buttonBaseStyles = css({
   display: 'flex',
@@ -64,47 +77,18 @@ export const buttonBaseStyles = css({
 });
 
 export const buttonNeutralStyles = css({
-  background: '#fff',
-  color: '#000',
+  background: 'var(--inactive-call-button-bg)',
+  color: 'var(--app-bg-primary)',
 
   '&:hover': {
-    background: '#f2f2f2',
+    background: 'var(--inactive-call-button-hover-bg)',
   },
-});
-
-export const buttonPrimaryStyles = css({
-  background: '#111',
-  color: '#fff',
-
-  '&:hover': {
-    background: '#000',
-  },
-});
-
-export const buttonDangerStyles = css({
-  background: '#e53935',
-  color: '#fff',
-
-  '&:hover': {
-    background: '#c62828',
-  },
-});
-
-export const buttonIconOnlyStyles = css({
-  width: 40,
-  padding: 0,
-});
-
-export const buttonRowStyles = css({
-  display: 'flex',
-  gap: 8, // Abstand zwischen Buttons
-  marginTop: 12,
 });
 
 export const metricsListStyles = css({
   marginTop: 12,
   padding: 12,
-  background: '#f7f7f7',
+  background: 'var(--inactive-call-button-bg)',
   borderRadius: 8,
   fontSize: 12,
 });

--- a/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.tsx
@@ -19,6 +19,8 @@
 
 import {ReactNode, useCallback, useEffect, useMemo, useState} from 'react';
 
+import {Maybe} from 'true-myth';
+
 import {Button, ButtonVariant, CloseIcon, Option, Select} from '@wireapp/react-ui-kit';
 
 import {
@@ -39,7 +41,7 @@ import {
 import {QualityMode} from 'Repositories/media/backgroundEffects';
 import {CapabilityInfo} from 'Repositories/media/backgroundEffects/backgroundEffectsWorkerTypes';
 import type {BackgroundEffectsHandler} from 'Repositories/media/backgroundEffectsHandler';
-import {useBackgroundEffectsStore} from 'Repositories/media/useBackgroundEffectsStore';
+import {RenderMetrics, useBackgroundEffectsStore} from 'Repositories/media/useBackgroundEffectsStore';
 import {t} from 'Util/localizerUtil';
 
 type PerformancePanelProps = {
@@ -60,9 +62,45 @@ const formatValue = (value?: string | number | null): string => {
   return value === null || value === undefined || value === '' ? '-' : String(value);
 };
 
+const getMetricRows = (renderMetrics: RenderMetrics) => {
+  return Maybe.of(renderMetrics)
+    .map(metrics => [
+      {label: 'Quality', value: formatValue(metrics.tier)},
+      {label: 'Total', value: formatMs(metrics.avgTotalMs)},
+      {label: 'Segmentation', value: formatMs(metrics.avgSegmentationMs)},
+      {label: 'GPU', value: formatMs(metrics.avgGpuMs)},
+      {label: 'Budget', value: formatMs(metrics.budget)},
+      {label: 'ML delegate type', value: formatValue(metrics.ml)},
+      {label: 'Utilization', value: formatPercent(metrics.utilShare)},
+      {label: 'ML', value: formatPercent(metrics.mlShare)},
+      {label: 'WebGL', value: formatPercent(metrics.webglShare)},
+      {
+        label: 'Delegate',
+        value: formatValue(metrics.segmentationDelegate),
+      },
+      {label: 'Dropped', value: formatValue(metrics.droppedFrames)},
+    ])
+    .unwrapOr([]);
+};
+
+const getCapabilityRows = (capabilityInfo: CapabilityInfo | null | undefined) => {
+  return Maybe.of(capabilityInfo)
+    .map(info => [
+      {label: 'WebGL2', value: info.webgl2 ? '✔' : '✖'},
+      {label: 'Worker', value: info.worker ? '✔' : '✖'},
+      {label: 'OffscreenCanvas', value: info.offscreenCanvas ? '✔' : '✖'},
+      {label: 'VideoFrameCallback', value: info.requestVideoFrameCallback ? '✔' : '✖'},
+    ])
+    .unwrapOr([]);
+};
+
 type MetricRowProps = {
   label: string;
   value: ReactNode;
+};
+
+type MetricsDisplayProps = {
+  readonly capabilityInfo: CapabilityInfo;
 };
 
 const MetricRow = ({label, value}: MetricRowProps) => (
@@ -74,42 +112,13 @@ const MetricRow = ({label, value}: MetricRowProps) => (
 
 const POLLING_INTERVAL = 500;
 
-const MetricsDisplay = ({capabilityInfo}: {capabilityInfo: CapabilityInfo | null}) => {
+const MetricsDisplay = ({capabilityInfo}: MetricsDisplayProps) => {
   const renderMetrics = useBackgroundEffectsStore(state => state.metrics);
   const model = useBackgroundEffectsStore(state => state.model);
 
-  const metricRows = useMemo(() => {
-    if (!renderMetrics) {
-      return [];
-    }
+  const metricRows = getMetricRows(renderMetrics);
 
-    return [
-      {label: 'Quality', value: formatValue(renderMetrics.tier)},
-      {label: 'Total', value: formatMs(renderMetrics.avgTotalMs)},
-      {label: 'Segmentation', value: formatMs(renderMetrics.avgSegmentationMs)},
-      {label: 'GPU', value: formatMs(renderMetrics.avgGpuMs)},
-      {label: 'Budget', value: formatMs(renderMetrics.budget)},
-      {label: 'ML delegate type', value: formatValue(renderMetrics.ml)},
-      {label: 'Utilization', value: formatPercent(renderMetrics.utilShare)},
-      {label: 'ML', value: formatPercent(renderMetrics.mlShare)},
-      {label: 'WebGL', value: formatPercent(renderMetrics.webglShare)},
-      {label: 'Delegate', value: formatValue(renderMetrics.segmentationDelegate)},
-      {label: 'Dropped', value: formatValue(renderMetrics.droppedFrames)},
-    ];
-  }, [renderMetrics]);
-
-  const capabilityRows = useMemo(() => {
-    if (!capabilityInfo) {
-      return [];
-    }
-
-    return [
-      {label: 'WebGL2', value: capabilityInfo.webgl2 ? '✔' : '✖'},
-      {label: 'Worker', value: capabilityInfo.worker ? '✔' : '✖'},
-      {label: 'OffscreenCanvas', value: capabilityInfo.offscreenCanvas ? '✔' : '✖'},
-      {label: 'VideoFrameCallback', value: capabilityInfo.requestVideoFrameCallback ? '✔' : '✖'},
-    ];
-  }, [capabilityInfo]);
+  const capabilityRows = getCapabilityRows(capabilityInfo);
 
   return (
     <div css={metricsListStyles}>
@@ -184,7 +193,7 @@ export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: Perf
 
   const handleQualityChange = useCallback(
     (quality: Option) => {
-      if (!quality) {
+      if (quality === undefined || quality === null) {
         return;
       }
 

--- a/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.tsx
@@ -17,24 +17,30 @@
  *
  */
 
-import {ChangeEvent, ReactNode, useCallback, useEffect, useMemo, useState} from 'react';
+import {ReactNode, useCallback, useEffect, useMemo, useState} from 'react';
+
+import {Button, ButtonVariant, CloseIcon, Option, Select} from '@wireapp/react-ui-kit';
 
 import {
   buttonBaseStyles,
   buttonNeutralStyles,
-  buttonRowStyles,
   metricsLabelStyles,
   metricsListStyles,
   metricsRowStyles,
   metricsValueStyles,
+  performancePanelCloseButtonStyles,
   performancePanelContainerStyles,
-  performancePanelSelectStyles,
+  performancePanelHeaderStyles,
+  performancePanelResetButtonContainerStyles,
+  performancePanelResetButtonStyles,
   performancePanelStyles,
+  performancePanelTitleStyles,
 } from 'Components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.styles';
 import {QualityMode} from 'Repositories/media/backgroundEffects';
 import {CapabilityInfo} from 'Repositories/media/backgroundEffects/backgroundEffectsWorkerTypes';
 import type {BackgroundEffectsHandler} from 'Repositories/media/backgroundEffectsHandler';
 import {useBackgroundEffectsStore} from 'Repositories/media/useBackgroundEffectsStore';
+import {t} from 'Util/localizerUtil';
 
 type PerformancePanelProps = {
   backgroundEffectsHandler: BackgroundEffectsHandler;
@@ -68,14 +74,76 @@ const MetricRow = ({label, value}: MetricRowProps) => (
 
 const POLLING_INTERVAL = 500;
 
-export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: PerformancePanelProps) => {
-  const isFeatureEnabled = useBackgroundEffectsStore(state => state.isFeatureEnabled);
+const MetricsDisplay = ({capabilityInfo}: {capabilityInfo: CapabilityInfo | null}) => {
   const renderMetrics = useBackgroundEffectsStore(state => state.metrics);
   const model = useBackgroundEffectsStore(state => state.model);
+
+  const metricRows = useMemo(() => {
+    if (!renderMetrics) {
+      return [];
+    }
+
+    return [
+      {label: 'Quality', value: formatValue(renderMetrics.tier)},
+      {label: 'Total', value: formatMs(renderMetrics.avgTotalMs)},
+      {label: 'Segmentation', value: formatMs(renderMetrics.avgSegmentationMs)},
+      {label: 'GPU', value: formatMs(renderMetrics.avgGpuMs)},
+      {label: 'Budget', value: formatMs(renderMetrics.budget)},
+      {label: 'ML delegate type', value: formatValue(renderMetrics.ml)},
+      {label: 'Utilization', value: formatPercent(renderMetrics.utilShare)},
+      {label: 'ML', value: formatPercent(renderMetrics.mlShare)},
+      {label: 'WebGL', value: formatPercent(renderMetrics.webglShare)},
+      {label: 'Delegate', value: formatValue(renderMetrics.segmentationDelegate)},
+      {label: 'Dropped', value: formatValue(renderMetrics.droppedFrames)},
+    ];
+  }, [renderMetrics]);
+
+  const capabilityRows = useMemo(() => {
+    if (!capabilityInfo) {
+      return [];
+    }
+
+    return [
+      {label: 'WebGL2', value: capabilityInfo.webgl2 ? '✔' : '✖'},
+      {label: 'Worker', value: capabilityInfo.worker ? '✔' : '✖'},
+      {label: 'OffscreenCanvas', value: capabilityInfo.offscreenCanvas ? '✔' : '✖'},
+      {label: 'VideoFrameCallback', value: capabilityInfo.requestVideoFrameCallback ? '✔' : '✖'},
+    ];
+  }, [capabilityInfo]);
+
+  return (
+    <div css={metricsListStyles}>
+      <MetricRow label="Model" value={formatValue(model)} />
+      {metricRows.map(row => (
+        <MetricRow key={row.label} label={row.label} value={row.value} />
+      ))}
+      {capabilityRows.map(row => (
+        <MetricRow key={row.label} label={row.label} value={row.value} />
+      ))}
+    </div>
+  );
+};
+
+export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: PerformancePanelProps) => {
+  const isFeatureEnabled = useBackgroundEffectsStore(state => state.isFeatureEnabled);
 
   const [selectedQuality, setSelectedQuality] = useState<QualityMode>(() => backgroundEffectsHandler.getQuality());
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [capabilityInfo, setCapabilityInfo] = useState<CapabilityInfo | null>(null);
+
+  const qualitySelectOptions = useMemo(
+    () =>
+      QUALITY_OPTIONS.map(option => ({
+        label: option,
+        value: option,
+      })),
+    [],
+  );
+
+  const selectedOption = useMemo(
+    () => qualitySelectOptions.find(option => option.value === selectedQuality) ?? null,
+    [qualitySelectOptions, selectedQuality],
+  );
 
   useEffect(() => {
     setCapabilityInfo(backgroundEffectsHandler.getCapabilityInfo());
@@ -106,66 +174,32 @@ export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: Perf
     setIsPanelOpen(false);
   }, []);
 
+  const togglePerformancePanel = useCallback(() => {
+    if (isPanelOpen) {
+      handleClosePanel();
+    } else {
+      handleOpenPanel();
+    }
+  }, [handleClosePanel, handleOpenPanel, isPanelOpen]);
+
   const handleQualityChange = useCallback(
-    (event: ChangeEvent<HTMLSelectElement>) => {
-      const nextQuality = event.target.value as QualityMode;
+    (quality: Option) => {
+      if (!quality) {
+        return;
+      }
+
+      const nextQuality = quality.value as QualityMode;
       setSelectedQuality(nextQuality);
       backgroundEffectsHandler.applyQuality(nextQuality);
     },
     [backgroundEffectsHandler],
   );
 
-  const handleApplyQuality = useCallback(() => {
-    backgroundEffectsHandler.applyQuality(selectedQuality);
-  }, [backgroundEffectsHandler, selectedQuality]);
-
   const handleResetQuality = useCallback(() => {
     const defaultQuality: QualityMode = 'auto';
     setSelectedQuality(defaultQuality);
     backgroundEffectsHandler.applyQuality(defaultQuality);
   }, [backgroundEffectsHandler]);
-
-  const metricRows = useMemo(() => {
-    if (!renderMetrics) {
-      return [];
-    }
-
-    return [
-      {label: 'Quality', value: formatValue(renderMetrics.tier)},
-      {label: 'Total', value: formatMs(renderMetrics.avgTotalMs)},
-      {label: 'Segmentation', value: formatMs(renderMetrics.avgSegmentationMs)},
-      {label: 'GPU', value: formatMs(renderMetrics.avgGpuMs)},
-      {label: 'Budget', value: formatMs(renderMetrics.budget)},
-      {label: 'ML delegate type', value: formatValue(renderMetrics.ml)},
-      {label: 'Utilization', value: formatPercent(renderMetrics.utilShare)},
-      {label: 'ML', value: formatPercent(renderMetrics.mlShare)},
-      {label: 'WebGL', value: formatPercent(renderMetrics.webglShare)},
-      {
-        label: 'Delegate',
-        value: formatValue(renderMetrics.segmentationDelegate),
-      },
-      {label: 'Dropped', value: formatValue(renderMetrics.droppedFrames)},
-    ];
-  }, [renderMetrics]);
-
-  const capabilityRows = useMemo(() => {
-    if (!capabilityInfo) {
-      return [];
-    }
-
-    return [
-      {label: 'WebGL2', value: capabilityInfo.webgl2 ? '✔' : '✖'},
-      {label: 'Worker', value: capabilityInfo.worker ? '✔' : '✖'},
-      {
-        label: 'OffscreenCanvas',
-        value: capabilityInfo.offscreenCanvas ? '✔' : '✖',
-      },
-      {
-        label: 'VideoFrameCallback',
-        value: capabilityInfo.requestVideoFrameCallback ? '✔' : '✖',
-      },
-    ];
-  }, [capabilityInfo]);
 
   if (!isFeatureEnabled) {
     return null;
@@ -175,7 +209,7 @@ export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: Perf
     <div css={performancePanelContainerStyles}>
       <button
         type="button"
-        onClick={handleOpenPanel}
+        onClick={togglePerformancePanel}
         css={[buttonBaseStyles, buttonNeutralStyles]}
         aria-expanded={isPanelOpen}
         aria-haspopup="dialog"
@@ -184,47 +218,43 @@ export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: Perf
       </button>
 
       {isPanelOpen && (
-        <div css={performancePanelStyles} role="dialog" aria-label="Performance Panel">
-          <h3>Performance Panel</h3>
+        <div css={performancePanelStyles} role="dialog" aria-label={t('videoCallBackgroundsPerformancePanel')}>
+          <div css={performancePanelHeaderStyles}>
+            <h3 css={performancePanelTitleStyles}>{t('videoCallBackgroundsPerformancePanel')}</h3>
+            <button
+              type="button"
+              className="icon-button"
+              css={performancePanelCloseButtonStyles}
+              onClick={handleClosePanel}
+              aria-label={t('modalCloseButton')}
+            >
+              <CloseIcon width={12} height={12} />
+            </button>
+          </div>
 
-          <select
-            css={performancePanelSelectStyles}
-            value={selectedQuality}
-            onChange={handleQualityChange}
+          <Select
+            id="background-effects-quality"
+            inputId="background-effects-quality"
+            dataUieName="background-effects-quality"
             aria-label="Background effects quality"
-          >
-            {QUALITY_OPTIONS.map(qualityOption => (
-              <option key={qualityOption} value={qualityOption}>
-                {qualityOption}
-              </option>
-            ))}
-          </select>
+            value={selectedOption}
+            options={qualitySelectOptions}
+            isSearchable={true}
+            menuPlacement="auto"
+            onChange={handleQualityChange}
+          />
 
-          <div css={buttonRowStyles}>
-            <button type="button" onClick={handleApplyQuality} css={buttonBaseStyles}>
-              Apply
-            </button>
-
-            <button type="button" onClick={handleResetQuality} css={buttonBaseStyles}>
+          <div css={performancePanelResetButtonContainerStyles}>
+            <Button
+              css={performancePanelResetButtonStyles}
+              variant={ButtonVariant.TERTIARY}
+              onClick={handleResetQuality}
+            >
               Reset (Auto)
-            </button>
-
-            <button type="button" onClick={handleClosePanel} css={buttonBaseStyles}>
-              Close
-            </button>
+            </Button>
           </div>
 
-          <div css={metricsListStyles}>
-            <MetricRow label="Model" value={formatValue(model)} />
-
-            {metricRows.map(row => (
-              <MetricRow key={row.label} label={row.label} value={row.value} />
-            ))}
-
-            {capabilityRows.map(row => (
-              <MetricRow key={row.label} label={row.label} value={row.value} />
-            ))}
-          </div>
+          <MetricsDisplay capabilityInfo={capabilityInfo} />
         </div>
       )}
     </div>

--- a/apps/webapp/src/types/i18n.d.ts
+++ b/apps/webapp/src/types/i18n.d.ts
@@ -2055,6 +2055,8 @@ declare module 'I18n/en-US.json' {
     'videoCallBackgroundVirtualSectionLabel': `Virtual Backgrounds`;
     'videoCallBackgroundWire1': `Wire 1`;
     'videoCallBackgroundsLabel': `Backgrounds`;
+    'videoCallBackgroundsPerformancePanel': `Performance Panel`;
+    'videoCallBackgroundsPerformancePanelClose': `Close performance panel`;
     'videoCallMenuMoreAddReaction': `Add reaction`;
     'videoCallMenuMoreAudioSettings': `Audio Settings`;
     'videoCallMenuMoreCameraSettings': `Camera Settings`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24452" title="WPB-24452" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24452</a>  Close button for the performance pop-up should be replaced with 'X'.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- What did I change and why?
Replace close button with x
Update performance panel UI and make it compatible with dark mode.
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
