### PR TITLE
fix: add e2e test for new appLock pass flow [WPB-23186]

### DIFF
--- a/apps/webapp/src/script/page/AppLock/AppLock.tsx
+++ b/apps/webapp/src/script/page/AppLock/AppLock.tsx
@@ -485,7 +485,7 @@ const AppLock = ({
               >
                 {t('modalAppLockForgotGoBackButton')}
               </Button>
-              <Button css={applockStyles.buttonStyle} onClick={onClickLogout} data-uie-name="go-wipe-database">
+              <Button css={applockStyles.buttonStyle} onClick={onClickLogout} data-uie-name="go-proceed-to-logout">
                 {t('modalAccountLogoutAction')}
               </Button>
             </div>

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/appLock.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/appLock.modal.ts
@@ -30,7 +30,7 @@ export class AppLockModal {
   readonly loadingBar: Locator;
   readonly errorMessage: Locator;
   readonly forgotPassphraseButton: Locator;
-  readonly wipeDatabaseButton: Locator;
+  readonly proceedToLogoutButton: Locator;
 
   constructor(page: Page) {
     this.appLockModal = page.locator("[data-uie-name='applock-modal']");
@@ -43,7 +43,7 @@ export class AppLockModal {
     this.loadingBar = page.locator('.progress-bar');
     this.errorMessage = this.appLockModal.getByTestId(/label-applock-(unlock|wipe)-error/);
     this.forgotPassphraseButton = this.appLockModal.getByTestId('go-forgot-passphrase');
-    this.wipeDatabaseButton = this.appLockModal.getByTestId('go-wipe-database');
+    this.proceedToLogoutButton = this.appLockModal.getByTestId('go-proceed-to-logout');
   }
 
   async setPasscode(passcode: string) {
@@ -85,7 +85,7 @@ export class AppLockModal {
   async clickReset() {
     await this.appLockActionButton.click();
   }
-  async clickWipeDB() {
-    await this.wipeDatabaseButton.click();
+  async clickProceedToLogout() {
+    await this.proceedToLogoutButton.click();
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/appLock.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/appLock.modal.ts
@@ -22,7 +22,7 @@ import {expect, Locator, Page} from '@playwright/test';
 export class AppLockModal {
   readonly lockPasscodeInput: Locator;
   readonly unlockPasscodeInput: Locator;
-  readonly appLockWipeInput: Locator;
+  readonly clearDataCheckbox: Locator;
   readonly appLockModal: Locator;
   readonly appLockActionButton: Locator;
   readonly appLockModalHeader: Locator;
@@ -36,7 +36,7 @@ export class AppLockModal {
     this.appLockModal = page.locator("[data-uie-name='applock-modal']");
     this.lockPasscodeInput = page.locator("[data-uie-name='applock-modal'] [data-uie-name='input-applock-set-a']");
     this.unlockPasscodeInput = page.locator("[data-uie-name='applock-modal'] [data-uie-name='input-applock-unlock']");
-    this.appLockWipeInput = this.appLockModal.getByTestId('input-applock-wipe');
+    this.clearDataCheckbox = this.appLockModal.getByTestId('modal-option-checkbox');
     this.appLockActionButton = this.appLockModal.locator("[data-uie-name='do-action']");
     this.appLockModalHeader = page.locator("[data-uie-name='applock-modal'] [data-uie-name='applock-modal-header']");
     this.appLockModalText = page.locator("[data-uie-name='applock-modal'] [data-uie-name='label-applock-unlock-text']");
@@ -57,9 +57,8 @@ export class AppLockModal {
     await this.appLockActionButton.click();
   }
 
-  async inputUserPassword(password: string) {
-    await this.appLockWipeInput.fill(password);
-    await this.appLockActionButton.click();
+  async checkClearData() {
+    await this.clearDataCheckbox.dispatchEvent('click');
   }
 
   async isVisible() {

--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -149,7 +149,7 @@ test.describe('AppLock', () => {
 
         await page.reload();
         await modals.appLock().clickForgotPassphrase();
-        await modals.appLock().clickWipeDB();
+        await modals.appLock().clickProceedToLogout();
         await modals.appLock().checkClearData();
         await modals.appLock().clickReset();
 
@@ -160,29 +160,8 @@ test.describe('AppLock', () => {
     );
 
     test(
-      'Web: I should not wipe database if I logout without checking the clear data option',
+      'Web: I should not wipe database if I logout without checking the clear data option and recover my session on next login',
       {tag: ['@TC-2763', '@regression']},
-      async ({createPage}) => {
-        const page = await createPage(withLogin(memberA));
-        const pageManager = PageManager.from(page);
-        const {modals} = PageManager.from(page).webapp;
-
-        await handleAppLockState(pageManager, appLockPassCode);
-
-        await page.reload();
-        await modals.appLock().clickForgotPassphrase();
-        await modals.appLock().clickWipeDB();
-        // Intentionally do not check the clear data checkbox
-        await modals.appLock().clickReset();
-
-        // The database should not be wiped when the checkbox was not checked
-        await expect.poll(() => page.evaluate(() => indexedDB.databases())).not.toHaveLength(0);
-      },
-    );
-
-    test(
-      'Web: I should be able to login and recover my existing session after logout without wiping data',
-      {tag: ['@TC-2764', '@regression']},
       async ({createPage}) => {
         const page = await createPage(withLogin(memberA));
         const pageManager = PageManager.from(page);
@@ -192,9 +171,12 @@ test.describe('AppLock', () => {
 
         await page.reload();
         await modals.appLock().clickForgotPassphrase();
-        await modals.appLock().clickWipeDB();
+        await modals.appLock().clickProceedToLogout();
         // Intentionally do not check the clear data checkbox
         await modals.appLock().clickReset();
+
+        // The database should not be wiped when the checkbox was not checked
+        await expect.poll(() => page.evaluate(() => indexedDB.databases())).not.toHaveLength(0);
 
         // Log back in with the same user and verify the existing session is intact
         await loginUser(memberA, pageManager);

--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -19,7 +19,7 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {handleAppLockState} from 'test/e2e_tests/utils/userActions';
+import {handleAppLockState, loginUser} from 'test/e2e_tests/utils/userActions';
 
 import {test, expect, withLogin} from '../../test.fixtures';
 
@@ -150,8 +150,8 @@ test.describe('AppLock', () => {
         await page.reload();
         await modals.appLock().clickForgotPassphrase();
         await modals.appLock().clickWipeDB();
+        await modals.appLock().checkClearData();
         await modals.appLock().clickReset();
-        await modals.appLock().inputUserPassword(memberA.password);
 
         // After redirect to login page verify the whole indexDB was cleared
         await expect(pages.singleSignOn().ssoCodeEmailInput).toBeVisible();
@@ -160,7 +160,7 @@ test.describe('AppLock', () => {
     );
 
     test(
-      'Web: I should not be able to wipe database with wrong account password',
+      'Web: I should not wipe database if I logout without checking the clear data option',
       {tag: ['@TC-2763', '@regression']},
       async ({createPage}) => {
         const page = await createPage(withLogin(memberA));
@@ -172,11 +172,37 @@ test.describe('AppLock', () => {
         await page.reload();
         await modals.appLock().clickForgotPassphrase();
         await modals.appLock().clickWipeDB();
+        // Intentionally do not check the clear data checkbox
         await modals.appLock().clickReset();
-        await modals.appLock().inputUserPassword('invalid');
 
-        // The modal should show an error for the invalid password and not wipe indexDB
-        await expect(modals.appLock().errorMessage).toContainText('Wrong password');
+        // The database should not be wiped when the checkbox was not checked
+        await expect.poll(() => page.evaluate(() => indexedDB.databases())).not.toHaveLength(0);
+      },
+    );
+
+    test(
+      'Web: I should be able to login and recover my existing session after logout without wiping data',
+      {tag: ['@TC-2764', '@regression']},
+      async ({createPage}) => {
+        const page = await createPage(withLogin(memberA));
+        const pageManager = PageManager.from(page);
+        const {modals} = pageManager.webapp;
+
+        await handleAppLockState(pageManager, appLockPassCode);
+
+        await page.reload();
+        await modals.appLock().clickForgotPassphrase();
+        await modals.appLock().clickWipeDB();
+        // Intentionally do not check the clear data checkbox
+        await modals.appLock().clickReset();
+
+        // Log back in with the same user and verify the existing session is intact
+        await loginUser(memberA, pageManager);
+
+        // App lock setup modal should appear again (passcode was cleared on logout, session data is preserved)
+        await expect(modals.appLock().appLockModal).toBeVisible();
+        await expect(modals.appLock().lockPasscodeInput).toBeVisible();
+
         await expect.poll(() => page.evaluate(() => indexedDB.databases())).not.toHaveLength(0);
       },
     );


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23186" title="WPB-23186" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-23186</a>  [Web] Applock forgot password - Users prompted to log out, log in, set new applock password
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

Added e2e tests for appLock new flow added here: https://github.com/wireapp/wire-webapp/pull/21025
<img width="1728" height="555" alt="Screenshot 2026-04-21 at 10 32 58" src="https://github.com/user-attachments/assets/990683bc-db6e-4a29-bb4b-847d400a0247" />

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
