### PR TITLE
test: ensure users are connected before creating group [WPB-24429]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -163,7 +163,8 @@ test.describe('User Blocking', () => {
         // Preconditions: User B accepts the connection request
         const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
         await userBPages.connectRequest().clickConnectButton();
-        await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+
+        await expect(userAPages.conversationList().getConversationLocator(userB.fullName)).toBeAttached();
         await createGroup(userAPages, conversationName, [userB]);
 
         await test.step('Step 1: User B sends message to group chat with User A', async () => {

--- a/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
@@ -68,6 +68,9 @@ test.describe('Connections', () => {
       });
 
       await test.step('A creates a group with B & C', async () => {
+        await expect(memberAPages.conversationList().getConversationLocator(memberB.fullName)).toBeAttached();
+        await expect(memberAPages.conversationList().getConversationLocator(memberC.fullName)).toBeAttached();
+
         await createGroup(memberAPages, 'Group', [memberB, memberC]);
       });
 

--- a/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
@@ -142,6 +142,7 @@ test.describe('Conversations', () => {
 
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();
+      await expect(adminPage.conversationList().getConversationLocator(guestUser.fullName)).toBeAttached();
 
       await createGroup(adminPage, groupName, [userB, guestUser]);
 
@@ -167,6 +168,7 @@ test.describe('Conversations', () => {
 
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();
+      await expect(adminPage.conversationList().getConversationLocator(guestUser.fullName)).toBeAttached();
 
       await createGroup(adminPage, groupName, [userB, guestUser]);
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
@@ -42,6 +42,7 @@ test('Group Video call', {tag: ['@TC-8637', '@crit-flow-web']}, async ({createTe
   await test.step('Guest user accepts connection request from owner', async () => {
     await guestPages.conversationList().openPendingConnectionRequest();
     await guestPages.connectRequest().clickConnectButton();
+    await expect(ownerPages.conversationList().getConversationLocator(guestUser.fullName)).toBeAttached();
   });
 
   await test.step('Owner and team member are in a group conversation together', async () => {

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -186,6 +186,7 @@ test.describe('Guestroom', () => {
 
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();
+      await expect(ownerPages.conversationList().getConversationLocator(guestUser.fullName)).toBeAttached();
 
       await test.step('Owner creates a group with guest', async () => {
         await createGroup(ownerPages, groupName, [guestUser]);

--- a/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
@@ -524,6 +524,7 @@ test.describe('Mention', () => {
 
       await otherUserPages.conversationList().pendingConnectionRequest.click();
       await otherUserPages.connectRequest().connectButton.click();
+      await expect(userAPages.conversationList().getConversationLocator(otherUser.fullName)).toBeAttached();
 
       await test.step('UserA creates a group including userB and otherUser', async () => {
         await createGroup(userAPages, 'Test Group', [userB, otherUser]);

--- a/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
@@ -99,6 +99,7 @@ test.describe('Participant Profile', () => {
       ]);
 
       await acceptConnectionRequest(userCPages);
+      await expect(userAPages.conversationList().getConversationLocator(userC.fullName)).toBeAttached();
 
       await test.step('User C is in group with User A and B. User C is not connected to user B', async () => {
         await createGroup(userAPages, groupName, [userB, userC]);
@@ -139,6 +140,7 @@ test.describe('Participant Profile', () => {
 
       const {pages, modals} = userAPageManager.webapp;
       await acceptConnectionRequest(userCPages);
+      await expect(pages.conversationList().getConversationLocator(userC.fullName)).toBeAttached();
 
       await createGroup(pages, groupName, [userB, userC]);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24429" title="WPB-24429" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24429</a>  [Web][QA] Investigate E2E tests that are flaky because of possible race condition.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This should fix the issue where sometimes a user can't be found during group creation. This could occur if the user which should be added to the group was connected to the group creator via connection request. In this case we need to ensure the connection was established before creating the group.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
