### PR TITLE
Fix copy-pasting text in the input area adding empty lines (WPB-18219)

### DIFF
--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/plugins/ReplaceCarriageReturnPlugin/ReplaceCarriageReturnPlugin.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/plugins/ReplaceCarriageReturnPlugin/ReplaceCarriageReturnPlugin.ts
@@ -24,11 +24,8 @@ import {mergeRegister} from '@lexical/utils';
 import {COMMAND_PRIORITY_LOW, PASTE_COMMAND, TextNode} from 'lexical';
 
 function replaceCarriageReturnWithLineFeed(input: string) {
-  // ASCII code for Carriage Return ("\r") is 13
-  return input
-    .split('')
-    .map(char => (char.charCodeAt(0) === 13 ? '\n' : char))
-    .join('');
+  // Replace \r\n (Windows CRLF) first, then any remaining standalone \r (old Mac CR)
+  return input.replaceAll(/\r\n/g, '\n').replaceAll(/\r/g, '\n');
 }
 
 export const ReplaceCarriageReturnPlugin = (): null => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18219" title="WPB-18219" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18219</a>  Copy-pasting text messes up new lines 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

On Windows, if I type the following text in notepad

```
a

b

c
```

Copy it, and paste it in Wire, I end up with:

```
a



b



c
```

I.e. each new line (`\r\n`) becomes 2 new lines. This messes up any formatting you might want to copy-paste, especially for pre-formatted text.

Claude found the code that handles copy paste for me, and it looks like it was splitting the string by character, checking if it was 13, replacing the 13 with `\n`, and then joining the string again. 

I'm not sure why we could not just do a replace without splitting and rejoining the string. In any case, since on windows you get `\r\n`, this would effectively turn any windows "new line" into `\n\n`. 

I changed the code to treat `\r\n` as one single new line (becomes `\n`), and then, if there are still stray `\r`, convert those to `\n`. This is done all at once, without splitting and joining the string.

I tried to run the tests on my changes with `yarn nx run-many -t test --all`, somehow I got 400+ failures, on tests that are completely unrelated. I blame my local setup, and I can't figure out what's wrong. I hope the CI will run the tests on this PR properly :)

Note: I did not read the "Tech Radar" as requested by the checklist in the PR template, because the link is broken.

## Testing

I manually tested the fix by running a local webapp from my code, and the issue is gone (new lines are respected). I also manually tested for regressions:
- copy-paste formatted text (e.g. the result of this markdown text rendered as H1, H2, ...)  -> it pastes correctly
- a text with empty lines -> it pastes correctly
- pre-formatted text (i.e. the 3 \` quotes)  -> it pastes correctly

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).
