### PR TITLE
fix: handle broken conversation after restore [WPB-24192]

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
@@ -2612,29 +2612,23 @@ describe('ConversationRepository', () => {
   });
 
   describe('checkForDeletedConversations', () => {
-    it('removes conversations that have been deleted on the backend', async () => {
-      const deletedGroup = _generateConversation();
-      const oldGroup = _generateConversation();
+    it('marks inaccessible conversations as past member', async () => {
+      const inaccessibleGroup = _generateConversation();
+      const activeGroup = _generateConversation();
       const conversationRepository = testFactory.conversation_repository!;
 
       jest.spyOn(testFactory.conversation_service!, 'getConversationByIds').mockResolvedValue({
-        not_found: [deletedGroup, oldGroup],
+        not_found: [inaccessibleGroup],
       });
-      jest
-        .spyOn(conversationRepository['conversationService'], 'getConversationById')
-        .mockImplementation(async conversationId => {
-          if (matchQualifiedIds(conversationId, deletedGroup.qualifiedId)) {
-            throw new BackendError('', BackendErrorLabel.NO_CONVERSATION);
-          }
-          return {} as any;
-        });
-      await conversationRepository['saveConversation'](deletedGroup);
-      await conversationRepository['saveConversation'](oldGroup);
+      await conversationRepository['saveConversation'](inaccessibleGroup);
+      await conversationRepository['saveConversation'](activeGroup);
 
       const currentNbConversations = conversationRepository['conversationState'].conversations().length;
       await testFactory.conversation_repository!.syncDeletedConversations();
 
-      expect(conversationRepository['conversationState'].conversations()).toHaveLength(currentNbConversations - 1);
+      expect(conversationRepository['conversationState'].conversations()).toHaveLength(currentNbConversations);
+      expect(inaccessibleGroup.status()).toBe(ConversationStatus.PAST_MEMBER);
+      expect(activeGroup.status()).toBe(ConversationStatus.CURRENT_MEMBER);
     });
   });
 

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import is from '@sindresorhus/is';
 import {
   ADD_PERMISSION,
   Conversation as BackendConversation,
@@ -2365,15 +2366,10 @@ export class ConversationRepository {
     const conversationIds = this.conversationState.conversations().map(conversation => conversation.qualifiedId);
     const {not_found = []} = await this.conversationService.getConversationByIds(conversationIds);
     for (const inccessibleConversation of not_found) {
-      try {
-        // a conversation marked `not_found` could be either non existing on backend or it could mean the self user is not part of it
-        // We need to check if the conversation exists on backend
-        await this.conversationService.getConversationById(inccessibleConversation);
-      } catch (error: unknown) {
-        if (isBackendError(error) && error.label === BackendErrorLabel.NO_CONVERSATION) {
-          // Only if the conversation triggers a not found error, we delete it locally
-          await this.deleteConversationLocally(inccessibleConversation, true);
-        }
+      // a conversation marked `not_found` could be either non existing on backend or it could mean the self user is not part of it
+      const conversationEntity = this.conversationState.findConversation(inccessibleConversation);
+      if (!is.nullOrUndefined(conversationEntity)) {
+        conversationEntity.status(ConversationStatus.PAST_MEMBER);
       }
     }
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24192" title="WPB-24192" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24192</a>  [Web] Group that I left is partially restored when I restore a backup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Handle broken conversation when we backup and restore.

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
