### PR TITLE
fix: duplicate focus outline on full search input [WPB-24903]

### DIFF
--- a/apps/webapp/src/script/page/MainContent/panels/Collection/FullSearch.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/Collection/FullSearch.tsx
@@ -19,6 +19,7 @@
 
 import {useEffect, useMemo, useRef, useState} from 'react';
 
+import {CSSObject} from '@emotion/react';
 import {useDebouncedCallback} from 'use-debounce';
 
 import {CloseIcon, Input, InputSubmitCombo, SearchIcon} from '@wireapp/react-ui-kit';
@@ -38,6 +39,26 @@ const PRE_MARKED_OFFSET = 20;
 const MAX_TEXT_LENGTH = 60;
 const MAX_OFFSET_INDEX = 30;
 const DEBOUNCE_TIME = 100;
+
+export const fullSearchInputSubmitComboStyles: CSSObject = {
+  padding: '0 16px',
+  marginBottom: '20px',
+};
+
+export const fullSearchInputWrapperStyles: CSSObject = {
+  marginBottom: 0,
+  width: '100%',
+  '> div': {
+    width: '100%',
+  },
+  '.wireinput': {
+    boxShadow: 'none',
+    marginRight: 0,
+    '&:focus, &:focus-visible, &:hover, &:active, &:invalid:not(:focus)': {
+      boxShadow: 'none',
+    },
+  },
+};
 
 interface FullSearchProps {
   change?: (query: string) => void;
@@ -123,11 +144,11 @@ const FullSearch = ({searchProvider, click = noop, change = noop}: FullSearchPro
   return (
     <div className="full-search" ref={setElement}>
       <header>
-        <InputSubmitCombo css={{padding: '0 16px', marginBottom: '20px'}}>
+        <InputSubmitCombo css={fullSearchInputSubmitComboStyles}>
           <SearchIcon />
 
           <Input
-            wrapperCSS={{marginBottom: 0, width: '100%', '> div': {width: '100%'}}}
+            wrapperCSS={fullSearchInputWrapperStyles}
             type="text"
             value={searchValue}
             ref={inputRef}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24903" title="WPB-24903" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24903</a>  [Web] Search input renders two borders
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

## Before

<img width="710" height="61" alt="Screenshot 2026-04-22 at 09 07 48" src="https://github.com/user-attachments/assets/6de143e0-3602-4d1b-a702-d203bfe45403" />

## After

<img width="710" height="61" alt="Screenshot 2026-04-22 at 09 17 45" src="https://github.com/user-attachments/assets/c4bcf1c5-c654-4e35-9a3e-3651eeaa22b6" />

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
