### PR TITLE
fix(ci): fail the required precommit Playwright check when upstream E2E fails [WPB-22420]

### DIFF
--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -160,13 +160,21 @@ jobs:
 
   run_e2e_tests:
     name: Playwright Critical Flow (precommit)
-    if: ${{ success() && github.repository == 'wireapp/wire-webapp' }}
+    if: ${{ always() && github.repository == 'wireapp/wire-webapp' }}
     needs: [deploy_and_run_e2e]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Report Status
-        run: echo "E2E tests completed with status - ${{ needs.deploy_and_run_e2e.result }}"
+        env:
+          DEPLOY_AND_RUN_E2E_RESULT: ${{ needs.deploy_and_run_e2e.result }}
+        run: |
+          echo "E2E tests completed with status - $DEPLOY_AND_RUN_E2E_RESULT"
+
+          if [ "$DEPLOY_AND_RUN_E2E_RESULT" != "success" ]; then
+            echo "Playwright Critical Flow failed because the upstream E2E workflow did not succeed."
+            exit 1
+          fi
 
   e2e-report:
     name: Generate test report


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

The dev branch protection currently requires the check named "Playwright Critical Flow (precommit)".

That check was implemented as a thin wrapper job in [.github/workflows/precommit-crit-flows.yml](https://github.com/wireapp/wire-webapp/blob/beae0c9edc8ee3796b7284078a318ebea69c58d7/.github/workflows/precommit-crit-flows.yml). The wrapper depended on the reusable precommit E2E workflow via `needs: [deploy_and_run_e2e]`, but it was guarded by `if: ${{ success() && github.repository == 'wireapp/wire-webapp' }}`.

This created a branch protection gap:

- When the underlying reusable E2E workflow failed, `success()` evaluated to false.
- GitHub therefore skipped the wrapper job instead of running it.
- The actual Playwright shards were red, and the overall workflow run could be red as well, but the required check itself was not failing.
- For required checks, GitHub treats a skipped job as acceptable, so pull requests could still be added to the merge queue even though the real Playwright execution had failed.

This change closes that gap by making the required wrapper job run with `if: ${{ always() && github.repository == 'wireapp/wire-webapp' }}` and by checking `needs.deploy_and_run_e2e.result` explicitly.

The wrapper job now behaves as follows:

- If the upstream deploy-and-E2E workflow succeeds, the required check passes.
- If the upstream deploy-and-E2E workflow fails, the required check exits with a non-zero status and fails explicitly.
- If the upstream workflow is cancelled or otherwise does not complete successfully, the required check also fails explicitly.

This keeps the existing branch protection check name unchanged while aligning its result with the actual Playwright outcome. As a result, merge queue entry and merge decisions for `dev` should now be blocked whenever the upstream precommit Playwright execution does not succeed.

The root cause was potentially the introduction of https://github.com/wireapp/wire-webapp/pull/20937

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
