### PR TITLE
test: add critical-flow smoke test for bootstrap runtime errors [WPB-22420]

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,10 +60,45 @@ on:
         value: ${{ jobs.e2e-report.outputs.reportUrl }}
 
 jobs:
+  bootstrap_smoke_test:
+    name: Run bootstrap smoke test
+    runs-on: ubuntu-24.04
+
+    services:
+      testservice:
+        image: quay.io/wire/testservice:5ec1c95b75daa7241e38c97f2916a06a2e40ce1b
+        ports:
+          - 8080:8080
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - run: yarn --immutable
+      - run: yarn playwright install --only-shell --with-deps chromium
+      - uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4
+
+      - name: Generate env file
+        run: op inject -i apps/webapp/test/e2e_tests/.env.staging.tpl -o apps/webapp/test/e2e_tests/.env
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Run bootstrap smoke test
+        env:
+          WEBAPP_URL: ${{ inputs.webappUrl }}
+          BACKEND_URL: ${{ inputs.backendUrl }}
+          TEST_SERVICE_URL: http://localhost:8080
+        run: yarn playwright test -c apps/webapp/playwright.config.ts apps/webapp/test/e2e_tests/specs/CriticalFlow/startupHasNoConsoleErrors.spec.ts
+
   test:
     name: Run E2E Tests
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    needs: [bootstrap_smoke_test]
 
     strategy:
       fail-fast: false
@@ -146,15 +181,25 @@ jobs:
           pattern: blob-report-*
           merge-multiple: true
 
+      - name: Check for blob reports
+        id: check_blob_reports
+        run: |
+          if [ -d "${{ env.PLAYWRIGHT_REPORT_PATH }}/blob-reports" ]; then
+            echo "has_blob_reports=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_blob_reports=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Merge reports and delete blob reports and zip archives for traces, only keep resources to include within the artifact
       - name: Merge playwright reports
+        if: ${{ steps.check_blob_reports.outputs.has_blob_reports == 'true' }}
         working-directory: apps/webapp
         run: |
           yarn playwright merge-reports --config ./playwright.config.ts playwright-report/blob-reports
           rm -rf playwright-report/blob-reports
 
       - name: Delete trace artifacts
-        if: ${{ !inputs.keep_traces }}
+        if: ${{ !inputs.keep_traces && steps.check_blob_reports.outputs.has_blob_reports == 'true' }}
         working-directory: apps/webapp
         run: |
           if [ -d "playwright-report/html/data" ]; then
@@ -165,13 +210,14 @@ jobs:
           fi
 
       - name: Delete blob report artifacts
-        if: always()
+        if: ${{ always() && steps.check_blob_reports.outputs.has_blob_reports == 'true' }}
         uses: geekyeggo/delete-artifact@d79b2442431e4adbc383d29a28e630374eceb303
         with:
           name: blob-report-*
 
       - name: Upload test report
         id: upload_playwright_report
+        if: ${{ steps.check_blob_reports.outputs.has_blob_reports == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: playwright-report
@@ -185,6 +231,7 @@ jobs:
 
       - name: Extract test results
         id: test-results
+        if: ${{ steps.check_blob_reports.outputs.has_blob_reports == 'true' }}
         run: |
           REPORT="${{ env.PLAYWRIGHT_REPORT_PATH }}/report.json"
           if [ ! -f "$REPORT" ]; then

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/startupHasNoConsoleErrors.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/startupHasNoConsoleErrors.spec.ts
@@ -1,0 +1,96 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {expect, test, type ConsoleMessage, type Page} from '@playwright/test';
+import is from '@sindresorhus/is';
+
+import {PageManager} from 'test/e2e_tests/pageManager';
+
+type ConsoleErrorRecord = {
+  readonly message: string;
+  readonly location: string;
+};
+
+type StartupErrorCollection = {
+  readonly pageErrors: string[];
+  readonly consoleErrors: ConsoleErrorRecord[];
+};
+
+function formatConsoleMessageLocation(consoleMessage: ConsoleMessage): string {
+  const location = consoleMessage.location();
+
+  if (is.emptyString(location.url)) {
+    return 'unknown location';
+  }
+
+  return `${location.url}:${location.lineNumber}:${location.columnNumber}`;
+}
+
+function collectUnexpectedConsoleErrors(page: Page): StartupErrorCollection {
+  const pageErrors: string[] = [];
+  const consoleErrors: ConsoleErrorRecord[] = [];
+
+  page.on('pageerror', error => {
+    pageErrors.push(error.stack ?? error.message);
+  });
+
+  page.on('console', consoleMessage => {
+    if (consoleMessage.type() !== 'error') {
+      return;
+    }
+
+    consoleErrors.push({
+      message: consoleMessage.text(),
+      location: formatConsoleMessageLocation(consoleMessage),
+    });
+  });
+
+  return {pageErrors, consoleErrors};
+}
+
+function formatCollectedErrors(pageErrors: string[], consoleErrors: ConsoleErrorRecord[]): string {
+  const formattedPageErrors = pageErrors.map(error => {
+    return `pageerror: ${error}`;
+  });
+  const formattedConsoleErrors = consoleErrors.map(consoleError => {
+    return `console.error: ${consoleError.message} (${consoleError.location})`;
+  });
+
+  return [...formattedPageErrors, ...formattedConsoleErrors].join('\n\n');
+}
+
+test('Application startup does not emit uncaught runtime errors', {tag: ['@crit-flow-web']}, async ({page}) => {
+  const {pageErrors, consoleErrors} = collectUnexpectedConsoleErrors(page);
+  const pageManager = PageManager.from(page);
+
+  await test.step('Application renders the bootstrap entry page', async () => {
+    await pageManager.openMainPage();
+    await expect(pageManager.webapp.pages.singleSignOn().header).toBeVisible();
+    await expect(pageManager.webapp.pages.singleSignOn().ssoSignInButton).toBeVisible();
+  });
+
+  await test.step('No uncaught runtime errors were emitted during startup', async () => {
+    const formattedErrors = formatCollectedErrors(pageErrors, consoleErrors);
+    const expectationMessage = is.emptyString(formattedErrors)
+      ? 'Unexpected startup errors were emitted:\n\nNo errors were captured.'
+      : `Unexpected startup errors were emitted:\n\n${formattedErrors}`;
+
+    expect({pageErrors, consoleErrors}, expectationMessage).toEqual({pageErrors: [], consoleErrors: []});
+  });
+});

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/startupHasNoConsoleErrors.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/startupHasNoConsoleErrors.spec.ts
@@ -32,6 +32,17 @@ type StartupErrorCollection = {
   readonly consoleErrors: ConsoleErrorRecord[];
 };
 
+function isUncaughtRuntimeErrorMessage(message: string): boolean {
+  return (
+    message.startsWith('Uncaught ') ||
+    message.startsWith('Error: Uncaught ') ||
+    message.includes('TypeError:') ||
+    message.includes('ReferenceError:') ||
+    message.includes('SyntaxError:') ||
+    message.includes('RangeError:')
+  );
+}
+
 function formatConsoleMessageLocation(consoleMessage: ConsoleMessage): string {
   const location = consoleMessage.location();
 
@@ -52,6 +63,10 @@ function collectUnexpectedConsoleErrors(page: Page): StartupErrorCollection {
 
   page.on('console', consoleMessage => {
     if (consoleMessage.type() !== 'error') {
+      return;
+    }
+
+    if (!isUncaughtRuntimeErrorMessage(consoleMessage.text())) {
       return;
     }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

Add a minimal Playwright critical-flow smoke test that fails when the app bootstrap emits uncaught browser errors or console errors, so white-screen regressions are caught early.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
