### PR TITLE
fix(mls): log actual conversation IDs in MLS decryption messages [WPB-24348]

### DIFF
--- a/libraries/core/src/messagingProtocols/mls/eventHandler/events/messageAdd/messageAdd.ts
+++ b/libraries/core/src/messagingProtocols/mls/eventHandler/events/messageAdd/messageAdd.ts
@@ -18,6 +18,7 @@
  */
 
 import {ConversationMLSMessageAddEvent} from '@wireapp/api-client/lib/event';
+import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {Decoder} from 'bazinga64';
 
 import {LogFactory} from '@wireapp/commons';
@@ -35,18 +36,24 @@ interface HandleMLSMessageAddParams {
   event: ConversationMLSMessageAddEvent;
   groupId: string;
   mlsService: MLSService;
+  qualifiedConversationId: QualifiedId;
 }
 
 export const handleMLSMessageAdd = async ({
   event,
   groupId,
   mlsService,
+  qualifiedConversationId,
 }: HandleMLSMessageAddParams): Promise<HandledEventPayload | null> => {
   const encryptedData = Decoder.fromBase64(event.data).asBytes;
 
   const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
 
-  const decryptedMessage = await mlsService.decryptMessage(new ConversationId(groupIdBytes), encryptedData);
+  const decryptedMessage = await mlsService.decryptMessage(
+    new ConversationId(groupIdBytes),
+    encryptedData,
+    qualifiedConversationId,
+  );
 
   if (!decryptedMessage) {
     // If the message is not decrypted, we return null

--- a/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.ts
+++ b/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.ts
@@ -524,18 +524,19 @@ export class MLSService extends TypedEventEmitter<Events> {
   public async decryptMessage(
     conversationId: ConversationId,
     payload: Uint8Array,
+    qualifiedConversationId: QualifiedId,
   ): Promise<DecryptedMessage | undefined> {
     try {
       const start = Date.now();
-      this.logger.info('Decrypting message', {conversationId});
+      this.logger.info('Decrypting message', {qualifiedConversationId});
       const decryptedMessage = await this.coreCryptoClient.transaction(cx =>
         cx.decryptMessage(conversationId, payload),
       );
       this.dispatchNewCrlDistributionPoints(decryptedMessage.crlNewDistributionPoints);
-      this.logger.info('Message decrypted successfully', {conversationId, duration: Date.now() - start});
+      this.logger.info('Message decrypted successfully', {qualifiedConversationId, duration: Date.now() - start});
       return decryptedMessage;
     } catch (error: unknown) {
-      this.logger.warn('Failed to decrypt MLS message', {conversationId, error});
+      this.logger.warn('Failed to decrypt MLS message', {qualifiedConversationId, error});
       // According to CoreCrypto JS doc on .decryptMessage method, we should ignore some errors (corecrypto handle them internally)
       if (shouldMLSDecryptionErrorBeIgnored(error)) {
         return {
@@ -1124,7 +1125,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       );
     }
 
-    return handleMLSMessageAdd({event, mlsService: this, groupId});
+    return handleMLSMessageAdd({event, mlsService: this, groupId, qualifiedConversationId});
   }
 
   public async handleMLSWelcomeMessageEvent(event: ConversationMLSWelcomeEvent, clientId: string) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24348" title="WPB-24348" target="_blank"><img alt="Spike" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10820?size=medium" />WPB-24348</a>  [Web] Investigate and reduce MLS decryption failures for MlsErrorOther (top decryption error type)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The ConversationId is serialized as {"__wbg_ptr": <number>} instead of the actual ID string, making MLS decryption errors undebuggable in Datadog. This change adds a qualifiedConversationId parameter to decryptMessage() so we can log the real conversation ID in both success and error paths.

When MLS decryption fails, the error logged to Datadog shows:
```json
{
  "conversationId": {"__wbg_ptr": 2900544},
  "error": {"context": {"msg": "Couldn't find conversation"}}
}
```

The `__wbg_ptr` is a byte array that has no meaning outside the
running process. To debug which conversation is failing, we need the
actual conversation ID string like `abc123@wire.com`.
