### PR TITLE
ci: add realistic timeouts to Playwright workflows [WPB-22420]

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -63,6 +63,7 @@ jobs:
   test:
     name: Run E2E Tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false
@@ -87,7 +88,9 @@ jobs:
           cache: 'yarn'
 
       - run: yarn --immutable
-      - run: yarn playwright install --only-shell --with-deps chromium
+      - name: Install Playwright browsers
+        timeout-minutes: 30
+        run: yarn playwright install --only-shell --with-deps chromium
       - uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4
 
       - name: Generate env file
@@ -116,6 +119,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ !cancelled() }}
     needs: [test]
+    timeout-minutes: 20
 
     env:
       PLAYWRIGHT_REPORT_PATH: apps/webapp/playwright-report

--- a/.github/workflows/playwright-crit-flow-tests.yml
+++ b/.github/workflows/playwright-crit-flow-tests.yml
@@ -10,6 +10,7 @@ jobs:
     name: Run Playwright Critical Flow Tests
     if: github.repository == 'wireapp/wire-webapp'
     runs-on: [self-hosted, Linux, X64, office]
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository
@@ -27,6 +28,7 @@ jobs:
         run: yarn --immutable
 
       - name: Install Playwright browsers
+        timeout-minutes: 30
         run: yarn playwright install --only-shell --with-deps chromium
 
       - name: Install 1Password

--- a/.github/workflows/playwright-smoke-tests.yml
+++ b/.github/workflows/playwright-smoke-tests.yml
@@ -8,6 +8,7 @@ jobs:
     name: Run Playwright Smoke Tests
     if: github.repository == 'wireapp/wire-webapp'
     runs-on: [self-hosted, Linux, X64, office]
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository
@@ -25,6 +26,7 @@ jobs:
         run: yarn --immutable
 
       - name: Install Playwright browsers
+        timeout-minutes: 30
         run: yarn playwright install --only-shell --with-deps chromium
 
       - name: Install 1Password

--- a/.github/workflows/run-cells-crit-flow-e2e-tests.yml
+++ b/.github/workflows/run-cells-crit-flow-e2e-tests.yml
@@ -17,6 +17,7 @@ jobs:
     name: Run Playwright Cells Critical Flow Tests
     if: github.repository == 'wireapp/wire-webapp'
     runs-on: [self-hosted, Linux, X64, office]
+    timeout-minutes: 45
     env:
       ENV: ${{ inputs.environment }}
       SLACK_WEBHOOK_URL: ${{ secrets.WIRE_CELLS_E2E_TEST_BOT_WEBHOOK_URL }}
@@ -37,6 +38,7 @@ jobs:
         run: yarn --immutable
 
       - name: Install Playwright browsers
+        timeout-minutes: 30
         run: yarn playwright install --only-shell --with-deps chromium
 
       - name: Install 1Password


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Because sometimes we have something like this and need to timeout at some point:

<img width="2992" height="111" alt="2026-04-22 13 29 33 github com e98abe0df643" src="https://github.com/user-attachments/assets/9dc67097-4a92-4aed-8a05-19cfa85df6e9" />

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
