### PR TITLE
feat: remove Countly retry reporting startup flag [WPB-24059]

### DIFF
--- a/apps/webapp/src/script/components/AppContainer/AppContainer.tsx
+++ b/apps/webapp/src/script/components/AppContainer/AppContainer.tsx
@@ -41,7 +41,6 @@ import {useTheme} from './hooks/useTheme';
 
 import {WallClock} from '../../clock/wallClock';
 import {Config, Configuration} from '../../Config';
-import {countlyIncrementalBackoffRetryReportingFeatureToggleName} from '../../featureToggles/startupFeatureToggleNames';
 import {StartupFeatureToggleName} from '../../featureToggles/startupFeatureToggles';
 import {setAppLocale} from '../../localization/Localizer';
 import {App} from '../../main/app';
@@ -60,19 +59,9 @@ type AppProps = {
 
 export const AppContainer = ({config, clientType, isFeatureToggleEnabled, wallClock}: AppProps) => {
   setAppLocale();
-  const isCountlyIncrementalBackoffRetryReportingEnabled = isFeatureToggleEnabled(
-    countlyIncrementalBackoffRetryReportingFeatureToggleName,
-  );
-  const app = useMemo(
-    () =>
-      new App(
-        container.resolve(Core),
-        container.resolve(APIClient),
-        config,
-        isCountlyIncrementalBackoffRetryReportingEnabled,
-      ),
-    [config, isCountlyIncrementalBackoffRetryReportingEnabled],
-  );
+  const app = useMemo(() => {
+    return new App(container.resolve(Core), container.resolve(APIClient), config);
+  }, [config]);
   const enableAutoLogin = Config.getConfig().FEATURE.ENABLE_AUTO_LOGIN;
 
   // Publishing application on the global scope for debug and testing purposes.

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -19,13 +19,11 @@
 
 export const reliableWebsocketConnectionFeatureToggleName = 'reliable-websocket-connection';
 export const collaboraNewDocumentCreationMenuFeatureToggleName = 'collabora-new-document-creation-menu';
-export const countlyIncrementalBackoffRetryReportingFeatureToggleName = 'countly-incremental-backoff-retry-reporting';
 export const applockRefactoredFeatureToggleName = 'applock-refactored';
 
 export const startupFeatureToggleNames = [
   reliableWebsocketConnectionFeatureToggleName,
   collaboraNewDocumentCreationMenuFeatureToggleName,
-  countlyIncrementalBackoffRetryReportingFeatureToggleName,
   applockRefactoredFeatureToggleName,
 ] as const;
 

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -25,7 +25,6 @@ import {
 import {
   applockRefactoredFeatureToggleName,
   collaboraNewDocumentCreationMenuFeatureToggleName,
-  countlyIncrementalBackoffRetryReportingFeatureToggleName,
   reliableWebsocketConnectionFeatureToggleName,
   startupFeatureToggleNames,
 } from './startupFeatureToggleNames';
@@ -33,7 +32,6 @@ import {
 const featureToggleNamesWithDedicatedExistenceTests = [
   reliableWebsocketConnectionFeatureToggleName,
   collaboraNewDocumentCreationMenuFeatureToggleName,
-  countlyIncrementalBackoffRetryReportingFeatureToggleName,
   applockRefactoredFeatureToggleName,
 ] as const;
 
@@ -85,16 +83,6 @@ describe('startupFeatureToggles', function () {
 
     expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).not.toContain('unknown-feature');
-  });
-
-  it('enables the countly incremental backoff retry reporting feature toggle when present in the query parameter', () => {
-    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=${countlyIncrementalBackoffRetryReportingFeatureToggleName}`,
-    );
-
-    expect(startupFeatureToggles.isFeatureToggleEnabled(countlyIncrementalBackoffRetryReportingFeatureToggleName)).toBe(
-      true,
-    );
   });
 
   it('enables the applock refactored feature toggle when present in the query parameter', () => {
@@ -149,7 +137,6 @@ describe('startupFeatureToggles', function () {
     expect(allowedStartupFeatureToggleNames).toEqual([
       reliableWebsocketConnectionFeatureToggleName,
       collaboraNewDocumentCreationMenuFeatureToggleName,
-      countlyIncrementalBackoffRetryReportingFeatureToggleName,
       applockRefactoredFeatureToggleName,
     ]);
   });

--- a/apps/webapp/src/script/main/app.ts
+++ b/apps/webapp/src/script/main/app.ts
@@ -171,7 +171,6 @@ export class App {
     private readonly core: Core,
     private readonly apiClient: APIClient,
     private readonly config: Configuration,
-    private readonly isCountlyIncrementalBackoffRetryReportingEnabled: boolean = false,
   ) {
     this.config = config;
     this.apiClient.on(APIClient.TOPIC.ON_LOGOUT, () =>
@@ -295,11 +294,7 @@ export class App {
       serverTimeHandler,
     );
 
-    repositories.eventTracker = new EventTrackingRepository(
-      repositories.message,
-      this.apiClient,
-      this.isCountlyIncrementalBackoffRetryReportingEnabled,
-    );
+    repositories.eventTracker = new EventTrackingRepository(repositories.message, this.apiClient);
 
     repositories.backup = new BackupRepository(new BackupService(), repositories.conversation);
 

--- a/apps/webapp/src/script/repositories/tracking/EventTrackingRepository.ts
+++ b/apps/webapp/src/script/repositories/tracking/EventTrackingRepository.ts
@@ -99,7 +99,6 @@ export class EventTrackingRepository {
   constructor(
     private readonly messageRepository: MessageRepository,
     private readonly apiClient: APIClient,
-    private readonly isCountlyIncrementalBackoffRetryReportingEnabled: boolean,
     private readonly teamState = container.resolve(TeamState),
     private readonly userState = container.resolve(UserState),
   ) {
@@ -337,13 +336,11 @@ export class EventTrackingRepository {
       },
     );
 
-    if (this.isCountlyIncrementalBackoffRetryReportingEnabled) {
-      const httpRetryReportingClient = this.apiClient.transport.http as unknown as HttpRetryReportingClient;
-      const webSocketRetryReportingClient = this.apiClient.transport.ws as unknown as WebSocketRetryReportingClient;
+    const httpRetryReportingClient = this.apiClient.transport.http as unknown as HttpRetryReportingClient;
+    const webSocketRetryReportingClient = this.apiClient.transport.ws as unknown as WebSocketRetryReportingClient;
 
-      httpRetryReportingClient.on(HttpClient.TOPIC.ON_LONG_RUNNING_RETRY, this.onLongRunningRetry);
-      webSocketRetryReportingClient.on(WebSocketClient.TOPIC.ON_LONG_RUNNING_RETRY, this.onLongRunningWebSocketRetry);
-    }
+    httpRetryReportingClient.on(HttpClient.TOPIC.ON_LONG_RUNNING_RETRY, this.onLongRunningRetry);
+    webSocketRetryReportingClient.on(WebSocketClient.TOPIC.ON_LONG_RUNNING_RETRY, this.onLongRunningWebSocketRetry);
 
     amplify.subscribe(WebAppEvents.LIFECYCLE.SIGNED_OUT, this.stopProductReportingSession);
   }
@@ -437,16 +434,14 @@ export class EventTrackingRepository {
   private unsubscribeFromProductTrackingEvents(): void {
     this.logger.debug('Unsubscribing from product tracking events');
 
-    if (this.isCountlyIncrementalBackoffRetryReportingEnabled) {
-      const httpRetryReportingClient = this.apiClient.transport.http as unknown as HttpRetryReportingClient;
-      const webSocketRetryReportingClient = this.apiClient.transport.ws as unknown as WebSocketRetryReportingClient;
+    const httpRetryReportingClient = this.apiClient.transport.http as unknown as HttpRetryReportingClient;
+    const webSocketRetryReportingClient = this.apiClient.transport.ws as unknown as WebSocketRetryReportingClient;
 
-      httpRetryReportingClient.removeListener(HttpClient.TOPIC.ON_LONG_RUNNING_RETRY, this.onLongRunningRetry);
-      webSocketRetryReportingClient.removeListener(
-        WebSocketClient.TOPIC.ON_LONG_RUNNING_RETRY,
-        this.onLongRunningWebSocketRetry,
-      );
-    }
+    httpRetryReportingClient.removeListener(HttpClient.TOPIC.ON_LONG_RUNNING_RETRY, this.onLongRunningRetry);
+    webSocketRetryReportingClient.removeListener(
+      WebSocketClient.TOPIC.ON_LONG_RUNNING_RETRY,
+      this.onLongRunningWebSocketRetry,
+    );
 
     amplify.unsubscribeAll(WebAppEvents.ANALYTICS.EVENT);
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24059" title="WPB-24059" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24059</a>  [Web] Log retried incremental backoffs to Countly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Can be published to production.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
