### PR TITLE
revert: don't show apps tab in connect flow [WPB-21440]

### DIFF
--- a/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
+++ b/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/StartUI.tsx
@@ -90,14 +90,10 @@ const StartUI = ({
 
   const actions = mainViewModel.actions;
   const isTeam = teamState.isTeam();
-  const appsEnabled = teamState?.isAppsEnabled();
   const defaultProtocol = teamState.teamFeatures()?.mls?.config.defaultProtocol;
   const isProteus = defaultProtocol !== CONVERSATION_PROTOCOL.MLS;
 
-  const showServiceTab =
-    isTeam &&
-    canChatWithServices() &&
-    ((isProteus && teamState?.hasWhitelistedServices()) || (!isProteus && appsEnabled));
+  const showServiceTab = isTeam && canChatWithServices() && isProteus && teamState?.hasWhitelistedServices();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [activeTab, setActiveTab] = useState(Tabs.PEOPLE);


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21440" title="WPB-21440" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-21440</a>  [Web] [Integration] Toggle Apps in Conversation Flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Summary

This commit was originally part of #21099 

Connecting to an App via a 1on1 conversation isn't working at the moment, so the App tab should not be displayed within the connect flow for now

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
