### PR TITLE
fix: remove whitelisted services from app feature availability check [WPB-21440]

### DIFF
--- a/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/Preference.test.tsx
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/Preference.test.tsx
@@ -7,7 +7,6 @@ import {CONVERSATION_PROTOCOL, FEATURE_STATUS} from '@wireapp/api-client/lib/tea
 
 type TeamStateDateSet = {
   isAppsEnabled: boolean;
-  hasWhitelistedServices: boolean;
   isMLSEnabled: boolean;
   defaultProtocol: CONVERSATION_PROTOCOL;
   expectedAppsEnabled: boolean;
@@ -23,41 +22,30 @@ describe('Preference', () => {
     {
       defaultProtocol: CONVERSATION_PROTOCOL.PROTEUS,
       isAppsEnabled: false,
-      hasWhitelistedServices: true,
       isMLSEnabled: false,
       expectedAppsEnabled: true,
-    },
-    {
-      defaultProtocol: CONVERSATION_PROTOCOL.PROTEUS,
-      isAppsEnabled: false,
-      hasWhitelistedServices: false,
-      isMLSEnabled: false,
-      expectedAppsEnabled: false,
     },
 
     // MLS
     {
       defaultProtocol: CONVERSATION_PROTOCOL.MLS,
       isAppsEnabled: false,
-      hasWhitelistedServices: true,
       isMLSEnabled: true,
       expectedAppsEnabled: false,
     },
     {
       defaultProtocol: CONVERSATION_PROTOCOL.MLS,
       isAppsEnabled: true,
-      hasWhitelistedServices: false,
       isMLSEnabled: true,
       expectedAppsEnabled: true,
     },
   ])(
     'should result in expectedAppsEnabled=$expectedAppsEnabled when { protocol: $defaultProtocol, appsEnabled: $isAppsEnabled, whitelisted: $hasWhitelistedServices, mlsEnabled: $isMLSEnabled }',
-    ({isAppsEnabled, hasWhitelistedServices, isMLSEnabled, defaultProtocol, expectedAppsEnabled}) => {
+    ({isAppsEnabled, isMLSEnabled, defaultProtocol, expectedAppsEnabled}) => {
       // Arrange
       const mockTeamState: Partial<TeamState> = {
         isMLSEnabled: ko.pureComputed(() => isMLSEnabled),
         isAppsEnabled: ko.pureComputed(() => isAppsEnabled),
-        hasWhitelistedServices: ko.observable(hasWhitelistedServices),
         teamFeatures: ko.observable({
           mls: {
             config: {

--- a/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/Preference.tsx
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/Preference.tsx
@@ -50,13 +50,7 @@ export const Preference = () => {
     isCellsEnabled: isCellsEnabledForTeam,
     isMLSEnabled,
     isAppsEnabled,
-    hasWhitelistedServices,
-  } = useKoSubscribableChildren(teamState, [
-    'isCellsEnabled',
-    'isMLSEnabled',
-    'isAppsEnabled',
-    'hasWhitelistedServices',
-  ]);
+  } = useKoSubscribableChildren(teamState, ['isCellsEnabled', 'isMLSEnabled', 'isAppsEnabled']);
   const isCellsEnabledForEnvironment = Config.getConfig().FEATURE.ENABLE_CELLS;
   const isCellsOptionEnabled = isCellsEnabledForEnvironment && isCellsEnabledForTeam;
 
@@ -70,7 +64,6 @@ export const Preference = () => {
   const isAppsFeatureAvailable = checkAppsFeatureAvailability({
     protocol: defaultProtocol,
     isAppsEnabled,
-    hasWhitelistedServices,
   });
 
   useEffect(() => {

--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.test.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.test.tsx
@@ -16,7 +16,6 @@ import {TypeUtil} from '@wireapp/commons';
 
 type TeamStateDateSet = {
   isAppsEnabled: boolean;
-  hasWhitelistedServices: boolean;
   isMLSEnabled: boolean;
   defaultProtocol: CONVERSATION_PROTOCOL;
   expectedAppsEnabled: boolean;
@@ -27,37 +26,33 @@ describe('GroupCreationModal', () => {
     // PROTEUS
     {
       defaultProtocol: CONVERSATION_PROTOCOL.PROTEUS,
-      isAppsEnabled: false,
-      hasWhitelistedServices: true,
+      isAppsEnabled: true,
       isMLSEnabled: false,
       expectedAppsEnabled: true,
     },
     {
       defaultProtocol: CONVERSATION_PROTOCOL.PROTEUS,
       isAppsEnabled: false,
-      hasWhitelistedServices: false,
       isMLSEnabled: false,
-      expectedAppsEnabled: false,
+      expectedAppsEnabled: true,
     },
 
     // MLS
     {
       defaultProtocol: CONVERSATION_PROTOCOL.MLS,
       isAppsEnabled: false,
-      hasWhitelistedServices: true,
       isMLSEnabled: true,
       expectedAppsEnabled: false,
     },
     {
       defaultProtocol: CONVERSATION_PROTOCOL.MLS,
       isAppsEnabled: true,
-      hasWhitelistedServices: false,
       isMLSEnabled: true,
       expectedAppsEnabled: true,
     },
   ])(
     'should result in expectedAppsEnabled=$expectedAppsEnabled when { protocol: $defaultProtocol, appsEnabled: $isAppsEnabled, whitelisted: $hasWhitelistedServices, mlsEnabled: $isMLSEnabled }',
-    ({isAppsEnabled, hasWhitelistedServices, isMLSEnabled, defaultProtocol, expectedAppsEnabled}) => {
+    ({isAppsEnabled, isMLSEnabled, defaultProtocol, expectedAppsEnabled}) => {
       // Arrange
       const mockUser = new User('user-id', 'test-domain.wire.com');
 
@@ -71,7 +66,6 @@ describe('GroupCreationModal', () => {
       const mockTeamState: TypeUtil.RecursivePartial<TeamState> = {
         isMLSEnabled: ko.pureComputed(() => isMLSEnabled),
         isAppsEnabled: ko.pureComputed(() => isAppsEnabled),
-        hasWhitelistedServices: ko.observable(hasWhitelistedServices),
         isTeam: ko.pureComputed(() => true),
         teamFeatures: ko.observable({
           mls: {

--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -82,14 +82,12 @@ const GroupCreationModal = ({
     isProtocolToggleEnabledForUser,
     isCellsEnabled: isCellsEnabledForTeam,
     isAppsEnabled: isAppsEnabledForTeam,
-    hasWhitelistedServices: hasWhitelistedServicesInTeam,
   } = useKoSubscribableChildren(teamState, [
     'isTeam',
     'isMLSEnabled',
     'isProtocolToggleEnabledForUser',
     'isCellsEnabled',
     'isAppsEnabled',
-    'hasWhitelistedServices',
   ]);
   const {self: selfUser} = useKoSubscribableChildren(userState, ['self']);
 
@@ -130,7 +128,6 @@ const GroupCreationModal = ({
     checkAppsFeatureAvailability({
       protocol: selectedProtocol.value,
       isAppsEnabled: isAppsEnabledForTeam,
-      hasWhitelistedServices: hasWhitelistedServicesInTeam,
     });
 
   const [showContacts, setShowContacts] = useState<boolean>(false);

--- a/apps/webapp/src/script/page/RightSidebar/guestServicesOptions/components/servicesOptions/serviceOptions.test.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/guestServicesOptions/components/servicesOptions/serviceOptions.test.tsx
@@ -27,7 +27,6 @@ import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 type TestData = {
   protocol: CONVERSATION_PROTOCOL;
   isAppsEnabled: boolean;
-  hasWhitelistedServices: boolean;
   isServicesRoom: boolean;
   isGuestAndServicesRoom: boolean;
   expectedToggleToBeVisible: boolean;
@@ -38,16 +37,7 @@ describe('serviceOptions', () => {
     // PROTEUS
     {
       protocol: CONVERSATION_PROTOCOL.PROTEUS,
-      isAppsEnabled: true,
-      hasWhitelistedServices: false,
-      isServicesRoom: false,
-      isGuestAndServicesRoom: false,
-      expectedToggleToBeVisible: false,
-    },
-    {
-      protocol: CONVERSATION_PROTOCOL.PROTEUS,
       isAppsEnabled: false,
-      hasWhitelistedServices: false,
       isServicesRoom: true,
       isGuestAndServicesRoom: false,
       expectedToggleToBeVisible: true,
@@ -55,7 +45,6 @@ describe('serviceOptions', () => {
     {
       protocol: CONVERSATION_PROTOCOL.PROTEUS,
       isAppsEnabled: false,
-      hasWhitelistedServices: false,
       isServicesRoom: false,
       isGuestAndServicesRoom: true,
       expectedToggleToBeVisible: true,
@@ -63,7 +52,6 @@ describe('serviceOptions', () => {
     {
       protocol: CONVERSATION_PROTOCOL.PROTEUS,
       isAppsEnabled: false,
-      hasWhitelistedServices: true,
       isServicesRoom: false,
       isGuestAndServicesRoom: false,
       expectedToggleToBeVisible: true,
@@ -71,7 +59,6 @@ describe('serviceOptions', () => {
     {
       protocol: CONVERSATION_PROTOCOL.PROTEUS,
       isAppsEnabled: false,
-      hasWhitelistedServices: true,
       isServicesRoom: true,
       isGuestAndServicesRoom: false,
       expectedToggleToBeVisible: true,
@@ -80,7 +67,6 @@ describe('serviceOptions', () => {
     {
       protocol: CONVERSATION_PROTOCOL.MLS,
       isAppsEnabled: false,
-      hasWhitelistedServices: true,
       isServicesRoom: false,
       isGuestAndServicesRoom: false,
       expectedToggleToBeVisible: false,
@@ -88,7 +74,6 @@ describe('serviceOptions', () => {
     {
       protocol: CONVERSATION_PROTOCOL.MLS,
       isAppsEnabled: false,
-      hasWhitelistedServices: false,
       isServicesRoom: true,
       isGuestAndServicesRoom: false,
       expectedToggleToBeVisible: true,
@@ -96,7 +81,6 @@ describe('serviceOptions', () => {
     {
       protocol: CONVERSATION_PROTOCOL.MLS,
       isAppsEnabled: true,
-      hasWhitelistedServices: false,
       isServicesRoom: false,
       isGuestAndServicesRoom: false,
       expectedToggleToBeVisible: true,
@@ -104,7 +88,6 @@ describe('serviceOptions', () => {
     {
       protocol: CONVERSATION_PROTOCOL.MLS,
       isAppsEnabled: true,
-      hasWhitelistedServices: false,
       isServicesRoom: true,
       isGuestAndServicesRoom: false,
       expectedToggleToBeVisible: true,
@@ -114,14 +97,12 @@ describe('serviceOptions', () => {
     ({
       protocol,
       isAppsEnabled,
-      hasWhitelistedServices,
       isServicesRoom,
       isGuestAndServicesRoom,
       expectedToggleToBeVisible,
     }) => {
       // Arrange
       const mockTeamState: Partial<TeamState> = {
-        hasWhitelistedServices: ko.observable(hasWhitelistedServices),
         isAppsEnabled: ko.pureComputed(() => isAppsEnabled),
       };
 

--- a/apps/webapp/src/script/page/RightSidebar/guestServicesOptions/components/servicesOptions/servicesOptions.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/guestServicesOptions/components/servicesOptions/servicesOptions.tsx
@@ -48,16 +48,12 @@ const ServicesOptions: FC<ServicesOptionsProps> = ({
     'isGuestAndServicesRoom',
   ]);
 
-  const {hasWhitelistedServices, isAppsEnabled} = useKoSubscribableChildren(teamState, [
-    'hasWhitelistedServices',
-    'isAppsEnabled',
-  ]);
+  const {isAppsEnabled} = useKoSubscribableChildren(teamState, ['isAppsEnabled']);
 
   const isServicesEnabled = isServicesRoom || isGuestAndServicesRoom;
 
   const isAppsFeatureEnabled = checkAppsFeatureAvailability({
     protocol: activeConversation.protocol,
-    hasWhitelistedServices: hasWhitelistedServices,
     isAppsEnabled: isAppsEnabled,
   });
 

--- a/apps/webapp/src/script/page/RightSidebar/guestServicesOptions/guestServicesOptions.test.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/guestServicesOptions/guestServicesOptions.test.tsx
@@ -83,6 +83,6 @@ describe('GuestServicesOptions', () => {
     const defaultProps = getDefaultParams(false);
     const {getByText} = render(<GuestServicesOptions {...defaultProps} activeConversation={conversation} />);
 
-    expect(getByText('servicesNotEnabledNoteTitle')).not.toBeNull();
+    expect(getByText('servicesRoomToggleInfo')).not.toBeNull();
   });
 });

--- a/apps/webapp/src/script/util/featureUtil.test.ts
+++ b/apps/webapp/src/script/util/featureUtil.test.ts
@@ -27,25 +27,21 @@ describe('featureUtil', () => {
     {
       protocol: CONVERSATION_PROTOCOL.PROTEUS,
       isAppsEnabled: false,
-      hasWhitelistedServices: true,
       expected: true,
     },
     {
       protocol: CONVERSATION_PROTOCOL.PROTEUS,
-      isAppsEnabled: false,
-      hasWhitelistedServices: false,
-      expected: false,
+      isAppsEnabled: true,
+      expected: true,
     },
     {
       protocol: CONVERSATION_PROTOCOL.MLS,
       isAppsEnabled: true,
-      hasWhitelistedServices: false,
       expected: true,
     },
     {
       protocol: CONVERSATION_PROTOCOL.MLS,
       isAppsEnabled: false,
-      hasWhitelistedServices: true,
       expected: false,
     },
   ])(

--- a/apps/webapp/src/script/util/featureUtil.ts
+++ b/apps/webapp/src/script/util/featureUtil.ts
@@ -22,15 +22,14 @@ import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team/feature/';
 export interface AppsFeatureOptions {
   protocol: CONVERSATION_PROTOCOL;
   isAppsEnabled: boolean;
-  hasWhitelistedServices: boolean;
 }
 
-export const checkAppsFeatureAvailability = ({protocol, isAppsEnabled, hasWhitelistedServices}: AppsFeatureOptions) => {
+export const checkAppsFeatureAvailability = ({protocol, isAppsEnabled}: AppsFeatureOptions) => {
   switch (protocol) {
     case CONVERSATION_PROTOCOL.MLS:
       return isAppsEnabled;
     case CONVERSATION_PROTOCOL.PROTEUS:
-      return hasWhitelistedServices;
+      return true;
     default:
       return false;
   }


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21440" title="WPB-21440" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-21440</a>  [Web] [Integration] Toggle Apps in Conversation Flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Summary

This commit was originally part of #21099

Apps / Services should always be enabled for Proteus conversations

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
