### PR TITLE
feat: add capability polling and move it behind feature flag [WPB-24520]

### DIFF
--- a/apps/webapp/jest.config.ts
+++ b/apps/webapp/jest.config.ts
@@ -50,7 +50,7 @@ const config: Config = {
   },
   testPathIgnorePatterns: ['<rootDir>/server', '<rootDir>/.yalc', '<rootDir>/test/e2e_tests'],
   testRunner: 'jest-jasmine2',
-  transformIgnorePatterns: ['/node_modules/(?!(true-myth|p-timeout|p-cancelable|noop-esm|uuid)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth|p-timeout|p-cancelable|noop-esm|uuid|@enormora/objectory)/)'],
   // Override transform to use babel-jest for webapp (uses React automatic runtime with Emotion)
   transform: {
     '^.+\\.[tj]sx?$': 'babel-jest',

--- a/apps/webapp/jest.report.config.cjs
+++ b/apps/webapp/jest.report.config.cjs
@@ -41,7 +41,7 @@ module.exports = {
   },
   testPathIgnorePatterns: ['<rootDir>/server', '<rootDir>/.yalc', '<rootDir>/test/e2e_tests'],
   testRunner: 'jest-jasmine2',
-  transformIgnorePatterns: ['/node_modules/(?!(true-myth|p-timeout|p-cancelable|noop-esm|uuid)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth|p-timeout|p-cancelable|noop-esm|uuid|@enormora/objectory)/)'],
   transform: {
     '^.+\\.[tj]sx?$': 'babel-jest',
   },

--- a/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/capabilityInformationValidator.test.ts
+++ b/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/capabilityInformationValidator.test.ts
@@ -27,9 +27,88 @@ describe('areCapabilityInfosEqual', () => {
     expect(areCapabilityInfosEqual(initialCapabilityInfo, futureCapabilityInfo)).toBe(false);
   });
 
-  it('returns false when webgl2 is not equal', () => {
-    const initialCapabilityInfo = Maybe.just(capabilityInfoFactory.build({webgl2: false}));
-    const futureCapabilityInfo = Maybe.just(capabilityInfoFactory.build({webgl2: true}));
+  it('returns false when both capability infos are Nothing', () => {
+    const initialCapabilityInfo = Maybe.nothing<CapabilityInfo>();
+    const futureCapabilityInfo = Maybe.nothing<CapabilityInfo>();
+
+    expect(areCapabilityInfosEqual(initialCapabilityInfo, futureCapabilityInfo)).toBe(false);
+  });
+
+  it.each`
+    property                       | initialValue | futureValue
+    ${'webgl2'}                    | ${false}     | ${true}
+    ${'webgl2'}                    | ${true}      | ${false}
+    ${'worker'}                    | ${false}     | ${true}
+    ${'worker'}                    | ${true}      | ${false}
+    ${'offscreenCanvas'}           | ${false}     | ${true}
+    ${'offscreenCanvas'}           | ${true}      | ${false}
+    ${'requestVideoFrameCallback'} | ${false}     | ${true}
+    ${'requestVideoFrameCallback'} | ${true}      | ${false}
+  `(
+    'returns false when $property changes from $initialValue to $futureValue',
+    ({property, initialValue, futureValue}) => {
+      const initialCapabilityInfo = Maybe.just(
+        capabilityInfoFactory.build({
+          [property]: initialValue,
+        }),
+      );
+
+      const futureCapabilityInfo = Maybe.just(
+        capabilityInfoFactory.build({
+          [property]: futureValue,
+        }),
+      );
+
+      expect(areCapabilityInfosEqual(initialCapabilityInfo, futureCapabilityInfo)).toBe(false);
+    },
+  );
+
+  it.each`
+    capabilityInfo
+    ${capabilityInfoFactory.build()}
+    ${capabilityInfoFactory.build({
+  offscreenCanvas: true,
+  worker: true,
+  webgl2: true,
+  requestVideoFrameCallback: true,
+})}
+    ${capabilityInfoFactory.build({
+  offscreenCanvas: true,
+  worker: false,
+  webgl2: true,
+  requestVideoFrameCallback: false,
+})}
+    ${capabilityInfoFactory.build({
+  offscreenCanvas: false,
+  worker: true,
+  webgl2: false,
+  requestVideoFrameCallback: true,
+})}
+  `('returns true when all attributes are equal: $capabilityInfo', ({capabilityInfo}) => {
+    const initialCapabilityInfo = Maybe.just(capabilityInfo);
+    const futureCapabilityInfo = Maybe.just({...capabilityInfo});
+
+    expect(areCapabilityInfosEqual(initialCapabilityInfo, futureCapabilityInfo)).toBe(true);
+  });
+
+  it('returns false when multiple attributes are different', () => {
+    const initialCapabilityInfo = Maybe.just(
+      capabilityInfoFactory.build({
+        offscreenCanvas: false,
+        worker: false,
+        webgl2: false,
+        requestVideoFrameCallback: false,
+      }),
+    );
+
+    const futureCapabilityInfo = Maybe.just(
+      capabilityInfoFactory.build({
+        offscreenCanvas: true,
+        worker: true,
+        webgl2: true,
+        requestVideoFrameCallback: true,
+      }),
+    );
 
     expect(areCapabilityInfosEqual(initialCapabilityInfo, futureCapabilityInfo)).toBe(false);
   });

--- a/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/capabilityInformationValidator.test.ts
+++ b/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/capabilityInformationValidator.test.ts
@@ -1,0 +1,36 @@
+import {Maybe} from 'true-myth';
+import {areCapabilityInfosEqual} from 'Components/calling/VideoControls/videoBackgroundPerformancePanel/capabilityInformationValidator';
+import {createFactory} from '@enormora/objectory';
+import {CapabilityInfo} from 'Repositories/media/backgroundEffects/backgroundEffectsWorkerTypes';
+
+const capabilityInfoFactory = createFactory<CapabilityInfo>(() => {
+  return {
+    offscreenCanvas: false,
+    worker: false,
+    webgl2: false,
+    requestVideoFrameCallback: false,
+  };
+});
+
+describe('areCapabilityInfosEqual', () => {
+  it('returns false when initialCapabilityInfo is a Nothing', () => {
+    const initialCapabilityInfo = Maybe.nothing<CapabilityInfo>();
+    const futureCapabilityInfo = Maybe.just(capabilityInfoFactory.build());
+
+    expect(areCapabilityInfosEqual(initialCapabilityInfo, futureCapabilityInfo)).toBe(false);
+  });
+
+  it('returns false when futureCapabilityInfo is a Nothing', () => {
+    const initialCapabilityInfo = Maybe.just(capabilityInfoFactory.build());
+    const futureCapabilityInfo = Maybe.nothing<CapabilityInfo>();
+
+    expect(areCapabilityInfosEqual(initialCapabilityInfo, futureCapabilityInfo)).toBe(false);
+  });
+
+  it('returns false when webgl2 is not equal', () => {
+    const initialCapabilityInfo = Maybe.just(capabilityInfoFactory.build({webgl2: false}));
+    const futureCapabilityInfo = Maybe.just(capabilityInfoFactory.build({webgl2: true}));
+
+    expect(areCapabilityInfosEqual(initialCapabilityInfo, futureCapabilityInfo)).toBe(false);
+  });
+});

--- a/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/capabilityInformationValidator.ts
+++ b/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/capabilityInformationValidator.ts
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe} from 'true-myth';
+
+import {CapabilityInfo} from 'Repositories/media/backgroundEffects/backgroundEffectsWorkerTypes';
+
+// Business logic for checking if the capability info has changed
+const capabilityComparator = (initialCapabilityInfo: CapabilityInfo) => (futureCapabilityInfo: CapabilityInfo) => {
+  return (
+    initialCapabilityInfo.webgl2 === futureCapabilityInfo.webgl2 &&
+    initialCapabilityInfo.worker === futureCapabilityInfo.worker &&
+    initialCapabilityInfo.offscreenCanvas === futureCapabilityInfo.offscreenCanvas &&
+    initialCapabilityInfo.requestVideoFrameCallback === futureCapabilityInfo.requestVideoFrameCallback
+  );
+};
+
+// Guard for checking if the capability info has changed
+export const areCapabilityInfosEqual = (
+  initialCapabilityInfo: Maybe<CapabilityInfo>,
+  futureCapabilityInfo: Maybe<CapabilityInfo>,
+): boolean => {
+  return Maybe.just(capabilityComparator).ap(initialCapabilityInfo).ap(futureCapabilityInfo).unwrapOr(false);
+};

--- a/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.tsx
@@ -23,6 +23,7 @@ import {Maybe} from 'true-myth';
 
 import {Button, ButtonVariant, CloseIcon, Option, Select} from '@wireapp/react-ui-kit';
 
+import {areCapabilityInfosEqual} from 'Components/calling/VideoControls/videoBackgroundPerformancePanel/capabilityInformationValidator';
 import {
   buttonBaseStyles,
   buttonNeutralStyles,
@@ -92,27 +93,6 @@ const getCapabilityRows = (capabilityInfo: CapabilityInfo | null | undefined) =>
       {label: 'VideoFrameCallback', value: info.requestVideoFrameCallback ? '✔' : '✖'},
     ])
     .unwrapOr([]);
-};
-
-const areCapabilityInfosEqual = (
-  prev: CapabilityInfo | null | undefined,
-  current: CapabilityInfo | null | undefined,
-): boolean => {
-  if (prev == null || current == null) {
-    return prev === current;
-  }
-
-  return Maybe.of(prev)
-    .andThen(prevValue =>
-      Maybe.of(current).map(
-        currentValue =>
-          prevValue.webgl2 === currentValue.webgl2 &&
-          prevValue.worker === currentValue.worker &&
-          prevValue.offscreenCanvas === currentValue.offscreenCanvas &&
-          prevValue.requestVideoFrameCallback === currentValue.requestVideoFrameCallback,
-      ),
-    )
-    .unwrapOr(false);
 };
 
 type MetricRowProps = {
@@ -206,7 +186,7 @@ export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: Perf
 
     const syncCapabilities = () => {
       const current = backgroundEffectsHandler.getCapabilityInfo();
-      setCapabilityInfo(prev => (areCapabilityInfosEqual(prev, current) ? prev : current));
+      setCapabilityInfo(prev => (areCapabilityInfosEqual(Maybe.of(prev), Maybe.of(current)) ? prev : current));
     };
 
     syncCapabilities();

--- a/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.tsx
@@ -94,6 +94,27 @@ const getCapabilityRows = (capabilityInfo: CapabilityInfo | null | undefined) =>
     .unwrapOr([]);
 };
 
+const areCapabilityInfosEqual = (
+  prev: CapabilityInfo | null | undefined,
+  current: CapabilityInfo | null | undefined,
+): boolean => {
+  if (prev === current) {
+    return true;
+  }
+
+  return Maybe.of(prev)
+    .andThen(prevValue =>
+      Maybe.of(current).map(
+        currentValue =>
+          prevValue.webgl2 === currentValue.webgl2 &&
+          prevValue.worker === currentValue.worker &&
+          prevValue.offscreenCanvas === currentValue.offscreenCanvas &&
+          prevValue.requestVideoFrameCallback === currentValue.requestVideoFrameCallback,
+      ),
+    )
+    .unwrapOr(false);
+};
+
 type MetricRowProps = {
   label: string;
   value: ReactNode;
@@ -133,6 +154,11 @@ const MetricsDisplay = ({capabilityInfo}: MetricsDisplayProps) => {
   );
 };
 
+const qualitySelectOptions = QUALITY_OPTIONS.map(option => ({
+  label: option,
+  value: option,
+}));
+
 export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: PerformancePanelProps) => {
   const isFeatureEnabled = useBackgroundEffectsStore(state => state.isFeatureEnabled);
 
@@ -140,33 +166,52 @@ export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: Perf
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [capabilityInfo, setCapabilityInfo] = useState<CapabilityInfo | null>(null);
 
-  const qualitySelectOptions = useMemo(
-    () =>
-      QUALITY_OPTIONS.map(option => ({
-        label: option,
-        value: option,
-      })),
-    [],
-  );
-
   const selectedOption = useMemo(
     () => qualitySelectOptions.find(option => option.value === selectedQuality) ?? null,
-    [qualitySelectOptions, selectedQuality],
+    [selectedQuality],
   );
 
   useEffect(() => {
+    if (!isFeatureEnabled) {
+      setCapabilityInfo(null);
+      return undefined;
+    }
+
     setCapabilityInfo(backgroundEffectsHandler.getCapabilityInfo());
-  }, [backgroundEffectsHandler]);
+  }, [backgroundEffectsHandler, isFeatureEnabled]);
 
   // Quality polling (fallback for non-reactive quality)
   useEffect(() => {
+    if (!isFeatureEnabled) {
+      return undefined;
+    }
+
     const interval = setInterval(() => {
       const current = backgroundEffectsHandler.getQuality();
+
       setSelectedQuality(prev => (prev !== current ? current : prev));
     }, POLLING_INTERVAL);
 
     return () => clearInterval(interval);
-  }, [backgroundEffectsHandler]);
+  }, [backgroundEffectsHandler, isFeatureEnabled]);
+
+  // Capability polling (controller updates these after pipeline start)
+  useEffect(() => {
+    if (!isFeatureEnabled) {
+      setCapabilityInfo(null);
+      return undefined;
+    }
+
+    const syncCapabilities = () => {
+      const current = backgroundEffectsHandler.getCapabilityInfo();
+      setCapabilityInfo(prev => (areCapabilityInfosEqual(prev, current) ? prev : current));
+    };
+
+    syncCapabilities();
+
+    const interval = setInterval(syncCapabilities, POLLING_INTERVAL);
+    return () => clearInterval(interval);
+  }, [backgroundEffectsHandler, isFeatureEnabled]);
 
   // Auto close if disabled
   useEffect(() => {
@@ -175,21 +220,9 @@ export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: Perf
     }
   }, [isFeatureEnabled, isPanelOpen]);
 
-  const handleOpenPanel = useCallback(() => {
-    setIsPanelOpen(true);
-  }, []);
-
-  const handleClosePanel = useCallback(() => {
-    setIsPanelOpen(false);
-  }, []);
-
-  const togglePerformancePanel = useCallback(() => {
-    if (isPanelOpen) {
-      handleClosePanel();
-    } else {
-      handleOpenPanel();
-    }
-  }, [handleClosePanel, handleOpenPanel, isPanelOpen]);
+  const togglePerformancePanel = () => {
+    setIsPanelOpen(prev => !prev);
+  };
 
   const handleQualityChange = useCallback(
     (quality: Option) => {
@@ -234,7 +267,7 @@ export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: Perf
               type="button"
               className="icon-button"
               css={performancePanelCloseButtonStyles}
-              onClick={handleClosePanel}
+              onClick={togglePerformancePanel}
               aria-label={t('modalCloseButton')}
             >
               <CloseIcon width={12} height={12} />

--- a/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/videoBackgroundPerformancePanel/videoBackgroundPerformancePanel.tsx
@@ -98,8 +98,8 @@ const areCapabilityInfosEqual = (
   prev: CapabilityInfo | null | undefined,
   current: CapabilityInfo | null | undefined,
 ): boolean => {
-  if (prev === current) {
-    return true;
+  if (prev == null || current == null) {
+    return prev === current;
   }
 
   return Maybe.of(prev)
@@ -172,18 +172,18 @@ export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: Perf
   );
 
   useEffect(() => {
-    if (!isFeatureEnabled) {
+    if (!isFeatureEnabled || !isPanelOpen) {
       setCapabilityInfo(null);
-      return undefined;
+      return;
     }
 
     setCapabilityInfo(backgroundEffectsHandler.getCapabilityInfo());
-  }, [backgroundEffectsHandler, isFeatureEnabled]);
+  }, [backgroundEffectsHandler, isFeatureEnabled, isPanelOpen]);
 
   // Quality polling (fallback for non-reactive quality)
-  useEffect(() => {
-    if (!isFeatureEnabled) {
-      return undefined;
+  useEffect((): void | (() => void) => {
+    if (!isFeatureEnabled || !isPanelOpen) {
+      return;
     }
 
     const interval = setInterval(() => {
@@ -192,14 +192,16 @@ export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: Perf
       setSelectedQuality(prev => (prev !== current ? current : prev));
     }, POLLING_INTERVAL);
 
-    return () => clearInterval(interval);
-  }, [backgroundEffectsHandler, isFeatureEnabled]);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [backgroundEffectsHandler, isFeatureEnabled, isPanelOpen]);
 
   // Capability polling (controller updates these after pipeline start)
-  useEffect(() => {
-    if (!isFeatureEnabled) {
+  useEffect((): void | (() => void) => {
+    if (!isFeatureEnabled || !isPanelOpen) {
       setCapabilityInfo(null);
-      return undefined;
+      return;
     }
 
     const syncCapabilities = () => {
@@ -210,8 +212,11 @@ export const VideoBackgroundPerformancePanel = ({backgroundEffectsHandler}: Perf
     syncCapabilities();
 
     const interval = setInterval(syncCapabilities, POLLING_INTERVAL);
-    return () => clearInterval(interval);
-  }, [backgroundEffectsHandler, isFeatureEnabled]);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [backgroundEffectsHandler, isFeatureEnabled, isPanelOpen]);
 
   // Auto close if disabled
   useEffect(() => {

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/backgroundEffectsWorkerTypes.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/backgroundEffectsWorkerTypes.ts
@@ -66,12 +66,12 @@ export type SegmentationModelByTier = Partial<Record<QualityTier, string>>;
 /**
  * Browser capability information detected at runtime.
  */
-export interface CapabilityInfo {
+export type CapabilityInfo = {
   offscreenCanvas: boolean;
   worker: boolean;
   webgl2: boolean;
   requestVideoFrameCallback: boolean;
-}
+};
 
 export type QualityPolicyMode = 'auto' | 'conservative' | 'aggressive';
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
+    "@enormora/objectory": "0.0.7",
     "@faker-js/faker": "9.9.0",
     "@ls-lint/ls-lint": "2.3.1",
     "@nx/jest": "22.6.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3418,6 +3418,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@enormora/objectory@npm:0.0.7":
+  version: 0.0.7
+  resolution: "@enormora/objectory@npm:0.0.7"
+  checksum: 10/ecf200672c95f26e2aae19788cffee701bd171d1b0cf00e99abf03d6868c1d421046665127093e57c525045946dbae1f0484dde15c482af2bdf2b7841cddf26b
+  languageName: node
+  linkType: hard
+
 "@epic-web/invariant@npm:^1.0.0":
   version: 1.0.0
   resolution: "@epic-web/invariant@npm:1.0.0"
@@ -27557,6 +27564,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wire-webapp@workspace:."
   dependencies:
+    "@enormora/objectory": "npm:0.0.7"
     "@faker-js/faker": "npm:9.9.0"
     "@ls-lint/ls-lint": "npm:2.3.1"
     "@nx/jest": "npm:22.6.5"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24520" title="WPB-24520" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24520</a>  Issue with System Capabilities Not Updating in Panel
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- What did I change and why?
Moved capability polling and Quality polling behind the feature flag.
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
