### PR TITLE
fix: allow apps to be enabled during channel creation [WPB-23669]

### DIFF
--- a/apps/webapp/src/script/components/Modals/CreateConversation/hooks/useCreateConversation.ts
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/hooks/useCreateConversation.ts
@@ -93,7 +93,7 @@ export const useCreateConversation = () => {
       access = toggleFeature(ACCESS_MODES.LINK, access);
     }
 
-    if (isServicesEnabled && conversationType !== ConversationType.Channel) {
+    if (isServicesEnabled) {
       access = toggleFeature(ACCESS_TYPES.SERVICE, access);
     }
 


### PR DESCRIPTION



<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23669" title="WPB-23669" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-23669</a>  [Web][Integrations] Toggle app slider at conversation creation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->



## Summary

During testing we noticed that Apps can't be enabled for channels during their creation. Even if the switch was set to on during creation the created channel would have them disabled. It looks like there was previously a condition during permission checks which only allowed apps to be enabled during group creation but not for channels.
Please let me know if there's some reason behind this I'm unaware of, but since the feature exists the state of the switch during creation should actually reflect the state of the created channel.
I also don't see any issue regarding permissions since after the channel was created it's already possible to enable Apps.

Execution of all e2e tests to verify this shouldn't break anything: https://github.com/wireapp/wire-webapp/actions/runs/24833106189/job/72688913366?pr=21110
(The two failing app lock tests are expected since this branch doesn't contain the fix already merged to dev yet)

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)
<img width="757" height="523" alt="image" src="https://github.com/user-attachments/assets/c0b12f42-aa8e-40c7-a698-b20936cffbc2" />
<img width="318" height="284" alt="image" src="https://github.com/user-attachments/assets/07c27c1f-ddc1-4641-8d83-b6c582a77d57" />

## Notes for reviewers

- 
