### PR TITLE
fix: display "apps are active badge" for conversations containing active apps [WPB-21440]

### DIFF
--- a/apps/webapp/src/script/components/TitleBar/TitleBar.test.tsx
+++ b/apps/webapp/src/script/components/TitleBar/TitleBar.test.tsx
@@ -281,6 +281,24 @@ describe('TitleBar', () => {
 
     expect(getByText('guestRoomConversationBadge')).toBeDefined();
   });
+
+  it.each([
+    {hasServices: false, hasApps: true},
+    {hasServices: true, hasApps: false},
+    {hasServices: true, hasApps: true},
+  ])(
+    "displays 'apps are active' badge when the conversation hasServices: $hasServices and hasApps: $hasApps",
+    ({hasServices, hasApps}) => {
+      const conversation = createConversationEntity({
+        hasService: ko.pureComputed(() => hasServices),
+        hasApps: ko.pureComputed(() => hasApps),
+      });
+
+      const {queryByText} = render(withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} />));
+
+      expect(queryByText('guestRoomConversationBadgeService')).toBeInTheDocument();
+    },
+  );
 });
 
 function createUser(activated: boolean = true) {

--- a/apps/webapp/src/script/components/TitleBar/TitleBar.tsx
+++ b/apps/webapp/src/script/components/TitleBar/TitleBar.tsx
@@ -83,6 +83,7 @@ export const TitleBar = ({
     hasExternal,
     hasDirectGuest,
     hasService,
+    hasApps,
     hasFederatedUsers,
     firstUserEntity,
     hasLegalHold,
@@ -95,6 +96,7 @@ export const TitleBar = ({
     'hasExternal',
     'hasDirectGuest',
     'hasService',
+    'hasApps',
     'hasFederatedUsers',
     'firstUserEntity',
     'hasLegalHold',
@@ -129,7 +131,7 @@ export const TitleBar = ({
       hasExternal,
       hasFederated: hasFederatedUsers,
       hasGuest: hasDirectGuest,
-      hasService,
+      hasService: hasService || hasApps,
     });
 
     if (translationKey) {
@@ -137,7 +139,7 @@ export const TitleBar = ({
     }
 
     return '';
-  }, [hasDirectGuest, hasExternal, hasFederatedUsers, hasService, is1to1, isRequest]);
+  }, [hasDirectGuest, hasExternal, hasFederatedUsers, hasService, hasApps, is1to1, isRequest]);
 
   const hasCall = useMemo(() => {
     const hasEntities = !!joinedCall;

--- a/apps/webapp/src/script/repositories/entity/Conversation.test.ts
+++ b/apps/webapp/src/script/repositories/entity/Conversation.test.ts
@@ -38,6 +38,7 @@ import {Text} from './message/Text';
 import {User} from './User';
 
 import {entities} from '../../../../test/api/payloads';
+import {UserType} from '@wireapp/api-client/lib/user';
 
 describe('Conversation', () => {
   let conversation_et: Conversation = null;
@@ -715,6 +716,23 @@ describe('Conversation', () => {
       conversation_et.type(CONVERSATION_TYPE.REGULAR);
 
       expect(conversation_et.hasService()).toBe(true);
+    });
+  });
+
+  describe('hasApps', () => {
+    it('detects conversations with apps', () => {
+      const userEntity = new User(createUuid(), null);
+
+      conversation_et = new Conversation(createUuid());
+      conversation_et.participating_user_ets.push(userEntity);
+
+      expect(conversation_et.hasApps()).toBe(false);
+
+      const secondUserEntity = new User(createUuid(), null);
+      secondUserEntity.type = UserType.APP;
+      conversation_et.participating_user_ets.push(secondUserEntity);
+
+      expect(conversation_et.hasApps()).toBe(true);
     });
   });
 

--- a/apps/webapp/src/script/repositories/entity/Conversation.ts
+++ b/apps/webapp/src/script/repositories/entity/Conversation.ts
@@ -29,7 +29,7 @@ import {
 } from '@wireapp/api-client/lib/conversation/';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
-import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {QualifiedId, UserType} from '@wireapp/api-client/lib/user';
 import {amplify} from 'amplify';
 import ko from 'knockout';
 import {container} from 'tsyringe';
@@ -127,6 +127,7 @@ export class Conversation {
   public readonly hasDirectGuest: ko.PureComputed<boolean>;
   public readonly hasLegalHold: ko.Computed<boolean>;
   public readonly hasService: ko.PureComputed<boolean>;
+  public readonly hasApps: ko.PureComputed<boolean>;
   public readonly hasUnread: ko.PureComputed<boolean>;
   public id: string;
   public readonly inTeam: ko.PureComputed<boolean>;
@@ -315,6 +316,9 @@ export class Conversation {
       return hasGuestUser && this.isGroupOrChannel();
     });
     this.hasService = ko.pureComputed(() => this.participating_user_ets().some(userEntity => userEntity.isService));
+    this.hasApps = ko.pureComputed(() =>
+      this.participating_user_ets().some(userEntity => userEntity.type === UserType.APP),
+    );
     this.hasExternal = ko.pureComputed(() => this.participating_user_ets().some(userEntity => userEntity.isExternal()));
     this.hasFederatedUsers = ko.pureComputed(() =>
       this.participating_user_ets().some(userEntity => userEntity.isFederated),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21440" title="WPB-21440" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-21440</a>  [Web] [Integration] Toggle Apps in Conversation Flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

The badge indicating that apps are active within a conversation so far only checked for the soon legacy services. Since Apps will replace those in the future this PR updates the logic to also display the banner if Apps are part of the conversation.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)
<img width="804" height="138" alt="image" src="https://github.com/user-attachments/assets/72e3defe-086f-4a4c-ac5f-35e246c4b24d" />

## Notes for reviewers

- 
