### PR TITLE
fix(core): skip stale MLS pending proposal commits [WPB-24984]

### DIFF
--- a/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.test.ts
+++ b/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.test.ts
@@ -111,7 +111,10 @@ const createMLSService = async () => {
   const mlsService = new MLSService(apiClient, mockCoreCrypto, mockedDb, recurringTaskScheduler);
 
   mlsService['_config'] = {...defaultMLSInitConfig, nbKeyPackages: 100, keyingMaterialUpdateThreshold: 1};
-  return [mlsService, {apiClient, coreCrypto: mockCoreCrypto, recurringTaskScheduler, transactionContext}] as const;
+  return [
+    mlsService,
+    {apiClient, coreCrypto: mockCoreCrypto, recurringTaskScheduler, transactionContext, coreDatabase: mockedDb},
+  ] as const;
 };
 
 afterAll(() => {
@@ -581,6 +584,58 @@ describe('MLSService', () => {
       expect(recurringTaskScheduler.cancelTask).toHaveBeenCalledWith(expect.stringContaining(groupId));
       expect(TaskScheduler.cancelTask).toHaveBeenCalledWith(expect.stringContaining(groupId));
       expect(transactionContext.wipeConversation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pending proposals lifecycle', () => {
+    it('skips commit and clears pending task when local conversation is missing', async () => {
+      const [mlsService, {coreCrypto, transactionContext}] = await createMLSService();
+      const groupId = 'mXOagqRIX/RFd7QyXJA8/Ed8X+hvQgLXIiwYHm4OQFc=';
+
+      coreCrypto.conversationExists = jest.fn().mockResolvedValue(false);
+
+      jest.spyOn(TaskScheduler, 'cancelTask');
+
+      await mlsService.commitPendingProposals(groupId);
+
+      expect(coreCrypto.transaction).not.toHaveBeenCalled();
+      expect(transactionContext.commitPendingProposals).not.toHaveBeenCalled();
+      expect(TaskScheduler.cancelTask).toHaveBeenCalledWith(expect.stringContaining(groupId));
+    });
+
+    it('prunes stale pending proposal tasks on startup rehydration', async () => {
+      const [mlsService, {coreCrypto, coreDatabase}] = await createMLSService();
+      const groupId = 'mXOagqRIX/RFd7QyXJA8/Ed8X+hvQgLXIiwYHm4OQFc=';
+
+      await coreDatabase.put('pendingProposals', {groupId, firingDate: Date.now() - 1_000}, groupId);
+      coreCrypto.conversationExists = jest.fn().mockResolvedValue(false);
+
+      jest.spyOn(TaskScheduler, 'addTask');
+
+      await mlsService.initialisePendingProposalsTasks();
+
+      expect(TaskScheduler.addTask).not.toHaveBeenCalled();
+      await expect(coreDatabase.get('pendingProposals', groupId)).resolves.toBeUndefined();
+    });
+
+    it('rehydrates pending proposal task when local conversation exists', async () => {
+      const [mlsService, {coreCrypto, coreDatabase}] = await createMLSService();
+      const groupId = 'mXOagqRIX/RFd7QyXJA8/Ed8X+hvQgLXIiwYHm4OQFc=';
+      const firingDate = Date.now() + 5_000;
+
+      await coreDatabase.put('pendingProposals', {groupId, firingDate}, groupId);
+      coreCrypto.conversationExists = jest.fn().mockResolvedValue(true);
+
+      jest.spyOn(TaskScheduler, 'addTask');
+
+      await mlsService.initialisePendingProposalsTasks();
+
+      expect(TaskScheduler.addTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          firingDate,
+          key: expect.stringContaining(groupId),
+        }),
+      );
     });
   });
 

--- a/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.ts
+++ b/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.ts
@@ -1043,7 +1043,7 @@ export class MLSService extends TypedEventEmitter<Events> {
 
     const doesConversationExist = await this.conversationExists(groupId);
     if (!doesConversationExist) {
-      this.logger.warn('Skipping pending proposals commit because local MLS conversation is missing', {
+      this.logger.info('Skipping pending proposals commit because local MLS conversation is missing', {
         groupId,
         shouldRetry,
       });
@@ -1092,7 +1092,7 @@ export class MLSService extends TypedEventEmitter<Events> {
           pendingProposals.map(async ({groupId, firingDate}) => {
             const doesConversationExist = await this.conversationExists(groupId);
             if (!doesConversationExist) {
-              this.logger.warn('Pruning stale pending proposals task for missing local MLS conversation', {groupId});
+              this.logger.info('Pruning stale pending proposals task for missing local MLS conversation', {groupId});
               await this.cancelPendingProposalsTask(groupId);
               return;
             }

--- a/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.ts
+++ b/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.ts
@@ -1040,6 +1040,17 @@ export class MLSService extends TypedEventEmitter<Events> {
    */
   public async commitPendingProposals(groupId: string, shouldRetry = true): Promise<void> {
     this.logger.info(`Committing pending proposals for groupId ${groupId}`, {shouldRetry});
+
+    const doesConversationExist = await this.conversationExists(groupId);
+    if (!doesConversationExist) {
+      this.logger.warn('Skipping pending proposals commit because local MLS conversation is missing', {
+        groupId,
+        shouldRetry,
+      });
+      await this.cancelPendingProposalsTask(groupId);
+      return;
+    }
+
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
 
     try {
@@ -1077,11 +1088,20 @@ export class MLSService extends TypedEventEmitter<Events> {
     try {
       const pendingProposals = await this.coreDatabase.getAll('pendingProposals');
       if (pendingProposals.length > 0) {
-        pendingProposals.forEach(({groupId, firingDate}) =>
-          TaskScheduler.addTask({
-            task: () => this.commitPendingProposals(groupId),
-            firingDate,
-            key: this.createPendingProposalsTaskKey(groupId),
+        await Promise.all(
+          pendingProposals.map(async ({groupId, firingDate}) => {
+            const doesConversationExist = await this.conversationExists(groupId);
+            if (!doesConversationExist) {
+              this.logger.warn('Pruning stale pending proposals task for missing local MLS conversation', {groupId});
+              await this.cancelPendingProposalsTask(groupId);
+              return;
+            }
+
+            TaskScheduler.addTask({
+              task: () => this.commitPendingProposals(groupId),
+              firingDate,
+              key: this.createPendingProposalsTaskKey(groupId),
+            });
           }),
         );
       }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24984" title="WPB-24984" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24984</a>  [Web]  "Couldnt find conversation" error 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Guard pending proposal commits behind local conversation existence and prune stale rehydrated pending proposal tasks when the local MLS group is missing. This prevents deterministic "Couldn't find conversation" retries and startup log storms while preserving normal proposal handling for valid groups.
