### PR TITLE
fix: display system message warning about apps when they are added [WPB-20363]

### DIFF
--- a/apps/webapp/src/script/repositories/event/preprocessor/ServiceMiddleware.test.ts
+++ b/apps/webapp/src/script/repositories/event/preprocessor/ServiceMiddleware.test.ts
@@ -25,6 +25,7 @@ import {UserRepository} from 'Repositories/user/UserRepository';
 import {createUuid} from 'Util/uuid';
 
 import {ServiceMiddleware} from './ServiceMiddleware';
+import {UserType} from '@wireapp/api-client/lib/user';
 
 function buildServiceMiddleware() {
   const selfUser = new User(createUuid());
@@ -42,12 +43,14 @@ describe('ServiceMiddleware', () => {
 
   describe('processEvent', () => {
     describe('conversation.member-join events', () => {
-      it('adds meta when services are present in the event', async () => {
+      it.each(['services', 'apps'] as const)('adds meta when %s are present in the event', async serviceType => {
         const [serviceMiddleware, {userRepository, selfUser}] = buildServiceMiddleware();
         const event = EventBuilder.buildMemberJoin(conversation, selfUser.qualifiedId, []);
 
         const service = new User();
-        service.isService = true;
+        if (serviceType === 'services') service.isService = true;
+        else service.type = UserType.APP;
+
         const userEntities = [new User(), service];
         userRepository.getUsersById.mockResolvedValue(userEntities);
 
@@ -94,12 +97,14 @@ describe('ServiceMiddleware', () => {
     });
 
     describe('conversation.one2one-creation events', () => {
-      it('adds meta when services are present in the event', async () => {
+      it.each(['services', 'apps'] as const)('adds meta when %s are present in the event', async serviceType => {
         const [serviceMiddleware, {userRepository, selfUser}] = buildServiceMiddleware();
         const event = EventBuilder.buildMemberJoin(conversation, selfUser.qualifiedId, []);
 
         const service = new User();
-        service.isService = true;
+        if (serviceType === 'services') service.isService = true;
+        else if (serviceType === 'apps') service.type = UserType.APP;
+
         const userEntities = [new User(), service];
         userRepository.getUsersById.mockResolvedValue(userEntities);
 

--- a/apps/webapp/src/script/repositories/event/preprocessor/ServiceMiddleware.ts
+++ b/apps/webapp/src/script/repositories/event/preprocessor/ServiceMiddleware.ts
@@ -18,7 +18,7 @@
  */
 
 import {CONVERSATION_EVENT, ConversationMemberJoinEvent} from '@wireapp/api-client/lib/event/';
-import type {QualifiedId} from '@wireapp/api-client/lib/user/';
+import {UserType, type QualifiedId} from '@wireapp/api-client/lib/user/';
 
 import type {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {MemberJoinEvent, OneToOneCreationEvent} from 'Repositories/conversation/EventBuilder';
@@ -91,7 +91,7 @@ export class ServiceMiddleware implements EventMiddleware {
 
   private async containsService(users: QualifiedId[]) {
     const userEntities = await this.userRepository.getUsersById(users);
-    return userEntities.some(userEntity => userEntity.isService);
+    return userEntities.some(userEntity => userEntity.isService || userEntity.type === UserType.APP);
   }
 
   private decorateWithHasServiceFlag(event: MemberJoinEvent | ConversationMemberJoinEvent | OneToOneCreationEvent) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20363" title="WPB-20363" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20363</a>  [Web] [Integration] - Searching for Apps specifically
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Previously a warning about apps being able to see the contents of the chat was only shown when legacy services were added to it. This expands the check to also show this warning when Apps are added.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)
<img width="384" height="104" alt="image" src="https://github.com/user-attachments/assets/ef697595-c6af-499c-a8e7-c2311cf2214e" />

## Notes for reviewers

- 
