### PR TITLE
fix: ensure app author is always resolved [WPB-21440]

### DIFF
--- a/apps/webapp/src/script/page/RightSidebar/groupParticipantService/groupParticipantService.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/groupParticipantService/groupParticipantService.tsx
@@ -110,10 +110,11 @@ const GroupParticipantService: FC<GroupParticipantServiceProps> = ({
   }, [integrationRepository, serviceEntity]);
 
   useEffect(() => {
-    if (!is.nullOrUndefined(serviceUser?.teamId)) {
-      teamRepository.getTeamNameById(serviceUser.teamId).then(name => serviceEntity.author(name));
+    // Set the author of the Service / App to the name of the team the user is in
+    if (!is.nullOrUndefined(selfUser.teamId)) {
+      teamRepository.getTeamNameById(selfUser.teamId).then(name => serviceEntity.author(name));
     }
-  }, [teamRepository, serviceUser?.teamId]);
+  }, [teamRepository, selfUser.teamId]);
 
   return (
     <div id="group-participant-service" className="panel__page group-participant">


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21440" title="WPB-21440" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-21440</a>  [Web] [Integration] Toggle Apps in Conversation Flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Since the service user is only resolved if it's already added to the conversation the author was only shown for apps which have already been added. When searching for conversations it was missing. Since the name of the author of the app is supposed to be the name of the team this PR changes the lookup of the team name to use the teamId from the current user instead of the apps user. This works reliably since apps available to the user are part of the same team as the user himself.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

| Before | After |
|--------|------|
| <img width="318" height="577" alt="image" src="https://github.com/user-attachments/assets/20c9333e-7c57-414e-b973-f090391cb64c" /> | <img width="318" height="562" alt="image" src="https://github.com/user-attachments/assets/63d86277-f3ce-4256-be43-7363036fb569" /> |

## Notes for reviewers

- 
