### PR TITLE
test: write the calling regression tests 2 part [WPB-19943]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/index.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/index.ts
@@ -75,6 +75,7 @@ import {ConversationJoinPage} from './webapp/pages/conversationJoin.page';
 import {CreateConversationModal} from './webapp/modals/createConversation';
 import {InviteModal} from './webapp/modals/invite.modal';
 import {JoinGuestLinkPasswordModal} from './webapp/modals/joinGuestLinkPassword.modal';
+import {WithoutTitle} from './webapp/modals/withoutTitle.modal';
 import {AboutPage} from './webapp/pages/about.page';
 
 export const webAppPath = process.env.WEBAPP_URL ?? '';
@@ -225,6 +226,7 @@ export class PageManager {
       createConversation: () =>
         this.getOrCreate('webapp.modals.createConversation', () => CreateConversationModal(this.page)),
       invite: () => this.getOrCreate('webapp.modals.invite', () => InviteModal(this.page)),
+      withoutTitle: () => this.getOrCreate('webapp.modals.withoutTitle', () => new WithoutTitle(this.page)),
     },
     components: {
       contactList: () => this.getOrCreate('webapp.components.ContactList', () => new ContactList(this.page)),

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/withoutTitle.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/withoutTitle.modal.ts
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Page} from '@playwright/test';
+
+import {BaseModal} from './base.modal';
+
+export class WithoutTitle extends BaseModal {
+  constructor(page: Page) {
+    super(page, 'modal-without-title');
+  }
+}

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/calling.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/calling.page.ts
@@ -118,6 +118,10 @@ export class CallingPage {
 
   // ─── Mute Controls ──────────────────────────────────────────────────────
 
+  async toggleMute() {
+    await this.toggleMuteButton.click();
+  }
+
   async muteSelfInFullScreen() {
     return await this.fullScreenMuteButton.click();
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
@@ -90,6 +90,7 @@ export const FullScreenCallPage = (page: Page) => {
     toggleParticipantsBtn,
     toggleHandRaise,
     selfVideoThumbnail,
+    gridTiles,
     toggleParticipantsList,
     getSidebarParticipant,
     getGridTile,

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
@@ -60,6 +60,14 @@ export const FullScreenCallPage = (page: Page) => {
     await toggleParticipantsBtn.click();
   };
 
+  const goToNextPage = async () => {
+    await nextPageButton.click();
+  };
+
+  const goToPreviousPage = async () => {
+    await previousPageButton.click();
+  };
+
   // Sidebar list of participants in the call
   const getSidebarParticipant = (userName: string) => {
     const participant = participantListItems.filter({hasText: userName});
@@ -71,6 +79,7 @@ export const FullScreenCallPage = (page: Page) => {
       speakIcon: participant.getByTestId('status-active-speaking'),
       videoIcon: participant.getByTestId('status-video'),
       screenShareIcon: participant.getByTestId('status-screenshare'),
+      menuButton: participant.getByTestId('participant-menu-icon'),
     });
   };
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
@@ -30,6 +30,8 @@ export const FullScreenCallPage = (page: Page) => {
   const selfVideoThumbnail = page.getByTestId('self-video-thumbnail-wrapper');
   const participantListItems = component.getByTestId('list-call-ui-participants').getByRole('listitem');
   const gridTiles = component.getByTestId('item-grid');
+  const nextPageButton = component.getByRole('button', {name: 'Go to next page'});
+  const previousPageButton = component.getByRole('button', {name: 'Go to previous page'});
 
   /* Press the react button and click the given emoji within the opened toolbar */
   const sendReaction = async (emoji: '👍') => {
@@ -91,5 +93,7 @@ export const FullScreenCallPage = (page: Page) => {
     toggleParticipantsList,
     getSidebarParticipant,
     getGridTile,
+    goToNextPage,
+    goToPreviousPage,
   };
 };

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
@@ -76,7 +76,7 @@ export const FullScreenCallPage = (page: Page) => {
       muteIcon: participant.getByTestId('status-audio-off'),
       guestIcon: participant.getByTestId('status-guest'),
       // User is an active speaker
-      speakIcon: participant.getByTestId('status-active-speaking'),
+      activeSpeakerIcon: participant.getByTestId('status-active-speaking'),
       videoIcon: participant.getByTestId('status-video'),
       screenShareIcon: participant.getByTestId('status-screenshare'),
       menuButton: participant.getByTestId('participant-menu-icon'),

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
@@ -28,7 +28,7 @@ export const FullScreenCallPage = (page: Page) => {
   const raiseHandButton = component.getByTestId('do-toggle-hand-raise');
   const toggleParticipantsBtn = component.getByTestId('do-toggle-call-participants-list');
   const selfVideoThumbnail = page.getByTestId('self-video-thumbnail-wrapper');
-  const participantListItems = component.getByTestId('list-call-ui-participants').getByRole('listitem');
+  const callingParticipants = component.getByTestId('list-call-ui-participants').getByRole('listitem');
   const gridTiles = component.getByTestId('item-grid');
   const nextPageButton = component.getByRole('button', {name: 'Go to next page'});
   const previousPageButton = component.getByRole('button', {name: 'Go to previous page'});
@@ -69,8 +69,8 @@ export const FullScreenCallPage = (page: Page) => {
   };
 
   // Sidebar list of participants in the call
-  const getSidebarParticipant = (userName: string) => {
-    const participant = participantListItems.filter({hasText: userName});
+  const getCallingParticipant = (userName: string) => {
+    const participant = callingParticipants.filter({hasText: userName});
 
     return Object.assign(participant, {
       muteIcon: participant.getByTestId('status-audio-off'),
@@ -80,6 +80,15 @@ export const FullScreenCallPage = (page: Page) => {
       videoIcon: participant.getByTestId('status-video'),
       screenShareIcon: participant.getByTestId('status-screenshare'),
       menuButton: participant.getByTestId('participant-menu-icon'),
+      openContextMenu: async () => {
+        await participant.getByTestId('participant-menu-icon').click();
+        const contextMenu = page.getByRole('menu');
+
+        return Object.assign(contextMenu, {
+          muteButton: contextMenu.getByRole('button', {name: 'Mute', exact: true}),
+          muteOthersButton: contextMenu.getByRole('button', {name: 'Mute everyone else'}),
+        });
+      },
     });
   };
 
@@ -101,7 +110,7 @@ export const FullScreenCallPage = (page: Page) => {
     selfVideoThumbnail,
     gridTiles,
     toggleParticipantsList,
-    getSidebarParticipant,
+    getCallingParticipant,
     getGridTile,
     goToNextPage,
     goToPreviousPage,

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -32,6 +32,12 @@ import {
 import {isPlayingAudio} from 'test/e2e_tests/utils/audio.util';
 import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
+async function joinCall(userPages: PageManager['webapp']['pages']) {
+  await expect(userPages.calling().callCell).toBeVisible();
+  await userPages.calling().clickAcceptCallButton();
+  await expect(userPages.calling().goFullScreen).toBeVisible();
+}
+
 test.describe('Calling', () => {
   let userA: User;
   let userB: User;
@@ -94,10 +100,7 @@ test.describe('Calling', () => {
     await userAPages.conversationList().getConversation(groupName).open();
     await userAPages.conversation().clickCallButton();
 
-    await expect(userBPages.calling().callCell).toBeVisible();
-    await userBPages.calling().clickAcceptCallButton();
-
-    await expect(userBPages.calling().goFullScreen).toBeVisible();
+    await joinCall(userBPages);
 
     const userACall = await userAPages.calling().maximizeCell();
     await expect(userACall.selfVideoThumbnail).toBeVisible();
@@ -259,11 +262,7 @@ test.describe('Calling', () => {
       await userAPages.conversation().clickCallButton();
 
       await expect(userAPages.calling().callCell).toBeVisible();
-      await expect(userBPages.calling().callCell).toBeVisible();
-
-      await userBPages.calling().clickAcceptCallButton();
-      // Confirm the calls grid is visible
-      await expect(userBPages.calling().goFullScreen).toBeVisible();
+      await joinCall(userBPages);
 
       // // User C joins the ongoing call
       await userCPage.waitForTimeout(5000);
@@ -293,10 +292,7 @@ test.describe('Calling', () => {
     await userAPages.conversation().clickCallButton();
 
     await expect(userAPages.calling().callCell).toBeVisible();
-    await expect(userBPages.calling().callCell).toBeVisible();
-
-    await userBPages.calling().clickAcceptCallButton();
-    await expect(userBPages.calling().goFullScreen).toBeVisible();
+    await joinCall(userBPages);
 
     await userAPages.calling().maximizeCell();
     await expect(userAPages.calling().selfVideoThumbnail).toBeVisible();
@@ -316,10 +312,9 @@ test.describe('Calling', () => {
     await userAPages.conversation().clickCallButton();
 
     await expect(userAPages.calling().callCell).toBeVisible();
-    await expect(userBPages.calling().callCell).toBeVisible();
 
     // User B joins the call
-    await userBPages.calling().clickAcceptCallButton();
+    await joinCall(userBPages);
     await expect(userBPages.calling().goFullScreen).toBeVisible();
 
     // User B leaves the group call
@@ -373,10 +368,8 @@ test.describe('Calling', () => {
         await userAPages.conversation().clickCallButton();
 
         await expect(userAPages.calling().callCell).toBeVisible();
-        await expect(userBPages.calling().callCell).toBeVisible();
 
-        await userBPages.calling().clickAcceptCallButton();
-        await expect(userBPages.calling().goFullScreen).toBeVisible();
+        await joinCall(userBPages);
       });
 
       await test.step('User A joins then leaves the call from their second device', async () => {
@@ -424,9 +417,7 @@ test.describe('Calling', () => {
 
       // Ensure all invited members join the call
       for (const member of [userBPages, userCPages]) {
-        await expect(member.calling().callCell).toBeVisible();
-        await member.calling().clickAcceptCallButton();
-        await expect(member.calling().goFullScreen).toBeVisible();
+        await joinCall(member);
       }
 
       // User A removes User B from the group
@@ -525,9 +516,7 @@ test.describe('Calling', () => {
 
       await test.step('Join call with all participants', async () => {
         for (const member of [userBPages, guestPages]) {
-          await expect(member.calling().callCell).toBeVisible();
-          await member.calling().clickAcceptCallButton();
-          await expect(member.calling().goFullScreen).toBeVisible();
+          await joinCall(member);
         }
       });
 
@@ -690,8 +679,7 @@ test.describe('Calling', () => {
       await test.step('Action: All members accept the incoming call', async () => {
         await Promise.all(
           memberPages.map(async memberPage => {
-            await memberPage.calling().acceptCallButton.click({timeout: 30_000});
-            await expect(memberPage.calling().goFullScreen).toBeVisible();
+            await joinCall(memberPage);
           }),
         );
       });
@@ -702,4 +690,44 @@ test.describe('Calling', () => {
       });
     });
   });
+
+  test(
+    'As a moderator I want to mute another participant',
+    {tag: ['@TC-2928', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPages, userCPages] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+      ]);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+
+      await createGroup(userAPages, groupName, [userB, userC]);
+
+      // User A initiates the call
+      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversation().clickCallButton();
+
+      await expect(userAPages.calling().callCell).toBeVisible();
+      // Ensure all invited members join the call
+      for (const member of [userBPages, userCPages]) {
+        joinCall(member);
+      }
+
+      // User B un-mutes themselves
+      await userBPages.calling().toggleMute();
+
+      // User A mutes User B from the participants list
+      const userACall = await userAPages.calling().maximizeCell();
+      await userACall.toggleParticipantsList();
+      await expect(userACall.getCallParticipant(userB.fullName).muteIcon).not.toBeVisible();
+
+      await userACall.getCallParticipant(userB.fullName).menuButton.click();
+      await userAPage.getByRole('button', {name: 'Mute', exact: true}).click();
+
+      await expect(userACall.getCallParticipant(userB.fullName).muteIcon).toBeVisible();
+      await expect(userACall.getGridTile(userB.fullName).muteIcon).toBeVisible();
+    },
+  );
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -34,7 +34,7 @@ test.describe('Calling', () => {
   test.beforeEach(async ({createTeam, createUser}) => {
     userB = await createUser();
     userC = await createUser();
-    const team = await createTeam('Team Call Team', {
+    team = await createTeam('Team Call Team', {
       users: [userB, userC],
       features: {conferenceCalling: true},
     });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -630,10 +630,31 @@ test.describe('Calling', () => {
     },
   );
 
-  test(
-    'I want to navigate between call pages',
-    {tag: ['@TC-2924', '@regression']},
-    async ({createPage, createUser}) => {
+  [
+    {
+      description: 'I want to navigate between call pages',
+      tag: '@TC-2924',
+      verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>, localUser: string) => {
+        await expect(callScreen.getGridTile(localUser)).toBeVisible();
+        await callScreen.goToNextPage();
+        await expect(callScreen.getGridTile(localUser)).toBeHidden();
+        await callScreen.goToPreviousPage();
+        await expect(callScreen.getGridTile(localUser)).toBeVisible();
+      },
+    },
+    {
+      description: 'I want to see video tiles ordered alphabetically by user names',
+      tag: '@TC-2927',
+      verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>, localUser: string) => {
+        const displayedNames = await callScreen.gridTiles.getByTestId('call-participant-name').allInnerTexts();
+        const listToVerify = displayedNames.filter(name => name !== localUser);
+        const sortedNames = [...listToVerify].sort();
+
+        expect(listToVerify).toEqual(sortedNames);
+      },
+    },
+  ].forEach(({description, tag, verify}) => {
+    test(description, {tag: [tag, '@regression']}, async ({createPage, createUser}) => {
       const userAPage = await createPage(withLogin(userA));
       const userAPages = PageManager.from(userAPage).webapp.pages;
 
@@ -675,18 +696,10 @@ test.describe('Calling', () => {
         );
       });
 
-      await test.step('Verify: Pagination and Grid Visibility', async () => {
-        const userACall = await userAPages.calling().maximizeCell();
-        await expect(userACall.getGridTile(userA.fullName)).toBeVisible();
-
-        // Navigate and Verify disappearance
-        await userACall.goToNextPage();
-        await expect(userACall.getGridTile(userA.fullName)).toBeHidden();
-
-        // Return and Verify reappearance
-        await userACall.goToPreviousPage();
-        await expect(userACall.getGridTile(userA.fullName)).toBeVisible();
+      await test.step('Verify functionality', async () => {
+        const callScreen = await userAPages.calling().maximizeCell();
+        await verify(callScreen, userA.fullName);
       });
-    },
-  );
+    });
+  });
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -857,4 +857,34 @@ test.describe('Calling', () => {
       });
     },
   );
+
+  test('I want to see multiple active speakers in 1 call', {tag: ['@TC-2945', '@regression']}, async ({createPage}) => {
+    const [userAPages, userBPages, userCPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+    ]);
+
+    await test.step('Setup: Create group and start call', async () => {
+      await createGroup(userAPages, groupName, [userB, userC]);
+      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversation().clickCallButton();
+
+      await expect(userAPages.calling().callCell).toBeVisible();
+    });
+
+    await test.step('User B and User C join the call', async () => {
+      for (const member of [userBPages, userCPages]) {
+        await joinCall(member);
+      }
+    });
+
+    await test.step('Verify 2 speakers are active in the call', async () => {
+      const userACall = await userAPages.calling().maximizeCell();
+      await userBPages.calling().toggleMute();
+      await userACall.toggleParticipantsList();
+      await expect(userACall.getCallParticipant(userA.fullName).activeSpeakerIcon).toBeVisible();
+      await expect(userACall.getCallParticipant(userB.fullName).activeSpeakerIcon).toBeVisible();
+    });
+  });
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -755,4 +755,63 @@ test.describe('Calling', () => {
       });
     });
   });
+
+  [
+    {
+      description: 'I want to unmute myself after I got muted',
+      tag: '@TC-2931',
+      verify: async (userCallPage: Page) => {
+        const userCallPages = PageManager.from(userCallPage).webapp.pages;
+        await userCallPages.calling().fullScreenMuteButton.click();
+        await expect(userCallPages.calling().getGridTile(userB.fullName).muteIcon).not.toBeVisible();
+      },
+    },
+    {
+      description: 'I want to get notified when I got muted',
+      tag: '@TC-2932',
+      verify: async (userCallPage: Page) => {
+        await expect(userCallPage.getByText('You have been muted')).toBeVisible();
+      },
+    },
+  ].forEach(({description, tag, verify}) => {
+    test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userB)),
+      ]);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      await test.step('Setup: Create group and start call', async () => {
+        await createGroup(userAPages, groupName, [userB]);
+        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversation().clickCallButton();
+
+        await expect(userAPages.calling().callCell).toBeVisible();
+      });
+
+      await test.step('User B joins the call', async () => {
+        await joinCall(userBPages);
+        await userBPages.calling().toggleMute(); // Ensure active mic state
+        await userBPages.calling().maximizeCell();
+      });
+
+      await test.step('Moderator mutes User B', async () => {
+        const userACall = await userAPages.calling().maximizeCell();
+        await userACall.toggleParticipantsList();
+
+        await expect(userACall.getCallParticipant(userB.fullName).muteIcon).not.toBeVisible();
+
+        await userACall.getCallParticipant(userB.fullName).menuButton.click();
+        await userAPage.getByRole('button', {name: 'Mute', exact: true}).click();
+
+        await expect(userACall.getCallParticipant(userB.fullName).muteIcon).toBeVisible();
+      });
+
+      await test.step('Verify mute functionality', async () => {
+        verify(userBPage);
+      });
+    });
+  });
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -21,15 +21,7 @@ import {Page} from 'playwright/test';
 import {AudioType} from 'Repositories/audio/audioType';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {
-  test,
-  withConnectedUser,
-  withLogin,
-  expect,
-  Team,
-  withConnectionRequest,
-  LOGIN_TIMEOUT,
-} from 'test/e2e_tests/test.fixtures';
+import {test, withConnectedUser, withLogin, expect, Team, LOGIN_TIMEOUT} from 'test/e2e_tests/test.fixtures';
 import {isPlayingAudio} from 'test/e2e_tests/utils/audio.util';
 import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
@@ -578,7 +570,7 @@ test.describe('Calling', () => {
 
       const createdLink = await test.step('Owner: Create group and generate guest invitation link', async () => {
         await createGroup(ownerPages, groupName, []);
-        await ownerPages.conversationList().openConversation(groupName);
+        await ownerPages.conversationList().getConversation(groupName).open();
         await ownerPages.conversation().toggleGroupInformation();
         await ownerPages.conversationDetails().openGuestOptions();
         return await ownerPages.guestOptions().createLink();
@@ -609,7 +601,7 @@ test.describe('Calling', () => {
       });
 
       await test.step('Guest: Join the active call', async () => {
-        const {joinCallButton} = guestPages.conversationList().getConversationLocator(groupName);
+        const {joinCallButton} = guestPages.conversationList().getConversation(groupName);
 
         await expect(guestPages.calling().callCell).toBeVisible();
         await expect(joinCallButton).toBeVisible();
@@ -638,7 +630,7 @@ test.describe('Calling', () => {
       verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>, localUser: string) => {
         const displayedNames = await callScreen.gridTiles.getByTestId('call-participant-name').allInnerTexts();
         const listToVerify = displayedNames.filter(name => name !== localUser);
-        const sortedNames = [...listToVerify].sort();
+        const sortedNames = [...listToVerify].sort((a, b) => a.localeCompare(b));
 
         expect(listToVerify).toEqual(sortedNames);
       },
@@ -670,7 +662,7 @@ test.describe('Calling', () => {
 
       await test.step('Action: User A initiates the group call', async () => {
         await createGroup(userAPages, groupName, groupMembers);
-        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().clickCallButton();
         // Warning modal about large group call
         await userAPage.getByTestId('modal-without-title').getByRole('button', {name: 'Call', exact: true}).click();
@@ -699,7 +691,7 @@ test.describe('Calling', () => {
       verify: async (userPage: Page, callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
         await userPage.getByRole('button', {name: 'Mute', exact: true}).click();
 
-        await expect(callScreen.getCallParticipant(userB.fullName).muteIcon).toBeVisible();
+        await expect(callScreen.getSidebarParticipant(userB.fullName).muteIcon).toBeVisible();
         await expect(callScreen.getGridTile(userB.fullName).muteIcon).toBeVisible();
       },
     },
@@ -708,11 +700,11 @@ test.describe('Calling', () => {
       tag: '@TC-2929',
       verify: async (userPage: Page, callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
         await userPage.getByRole('button', {name: 'Mute', exact: true}).click();
-        await callScreen.getCallParticipant(userB.fullName).menuButton.click();
+        await callScreen.getSidebarParticipant(userB.fullName).menuButton.click();
         await userPage.getByRole('button', {name: 'Mute everyone else'}).click();
 
         for (const participant of [userB, userC]) {
-          await expect(callScreen.getCallParticipant(participant.fullName).muteIcon).toBeVisible();
+          await expect(callScreen.getSidebarParticipant(participant.fullName).muteIcon).toBeVisible();
           await expect(callScreen.getGridTile(participant.fullName).muteIcon).toBeVisible();
         }
       },
@@ -729,7 +721,7 @@ test.describe('Calling', () => {
 
       await test.step('Setup: Create group and start call', async () => {
         await createGroup(userAPages, groupName, [userB, userC]);
-        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().clickCallButton();
 
         await expect(userAPages.calling().callCell).toBeVisible();
@@ -746,10 +738,10 @@ test.describe('Calling', () => {
         const userACall = await userAPages.calling().maximizeCell();
         await userACall.toggleParticipantsList();
 
-        await expect(userACall.getCallParticipant(userB.fullName).muteIcon).not.toBeVisible();
-        await expect(userACall.getCallParticipant(userC.fullName).muteIcon).not.toBeVisible();
+        await expect(userACall.getSidebarParticipant(userB.fullName).muteIcon).not.toBeVisible();
+        await expect(userACall.getSidebarParticipant(userC.fullName).muteIcon).not.toBeVisible();
 
-        await userACall.getCallParticipant(userB.fullName).menuButton.click();
+        await userACall.getSidebarParticipant(userB.fullName).menuButton.click();
 
         verify(userAPage, userACall);
       });
@@ -785,7 +777,7 @@ test.describe('Calling', () => {
 
       await test.step('Setup: Create group and start call', async () => {
         await createGroup(userAPages, groupName, [userB]);
-        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().clickCallButton();
 
         await expect(userAPages.calling().callCell).toBeVisible();
@@ -801,12 +793,12 @@ test.describe('Calling', () => {
         const userACall = await userAPages.calling().maximizeCell();
         await userACall.toggleParticipantsList();
 
-        await expect(userACall.getCallParticipant(userB.fullName).muteIcon).not.toBeVisible();
+        await expect(userACall.getSidebarParticipant(userB.fullName).muteIcon).not.toBeVisible();
 
-        await userACall.getCallParticipant(userB.fullName).menuButton.click();
+        await userACall.getSidebarParticipant(userB.fullName).menuButton.click();
         await userAPage.getByRole('button', {name: 'Mute', exact: true}).click();
 
-        await expect(userACall.getCallParticipant(userB.fullName).muteIcon).toBeVisible();
+        await expect(userACall.getSidebarParticipant(userB.fullName).muteIcon).toBeVisible();
       });
 
       await test.step('Verify mute functionality', async () => {
@@ -814,6 +806,31 @@ test.describe('Calling', () => {
       });
     });
   });
+
+  test(
+    'I want to see a group call timing out after 300s if no one else joined',
+    {tag: ['@TC-2936', '@regression']},
+    async ({createPage}) => {
+      test.setTimeout(390_000);
+      const userAPages = await PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages);
+
+      await createGroup(userAPages, groupName, [userB, userC]);
+
+      // User A initiates the call
+      await userAPages.conversationList().getConversation(groupName).open();
+      await userAPages.conversation().clickCallButton();
+      await expect(userAPages.calling().callCell).toBeVisible();
+
+      await expect(
+        userAPages
+          .conversation()
+          .systemMessages.filter({hasText: 'Your call was ended because no other participant joined.'}),
+      ).toBeVisible({
+        timeout: 302_000,
+      });
+      await expect(userAPages.calling().callCell).not.toBeVisible();
+    },
+  );
 
   test(
     'I want to see a group call timing out after 30s if I`m the last one left in the call',
@@ -827,7 +844,7 @@ test.describe('Calling', () => {
 
       await test.step('Setup: Create group and start call', async () => {
         await createGroup(userAPages, groupName, [userB, userC]);
-        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().clickCallButton();
 
         await expect(userAPages.calling().callCell).toBeVisible();
@@ -867,7 +884,7 @@ test.describe('Calling', () => {
 
     await test.step('Setup: Create group and start call', async () => {
       await createGroup(userAPages, groupName, [userB, userC]);
-      await userAPages.conversationList().openConversation(groupName);
+      await userAPages.conversationList().getConversation(groupName).open();
       await userAPages.conversation().clickCallButton();
 
       await expect(userAPages.calling().callCell).toBeVisible();
@@ -881,10 +898,14 @@ test.describe('Calling', () => {
 
     await test.step('Verify 2 speakers are active in the call', async () => {
       const userACall = await userAPages.calling().maximizeCell();
-      await userBPages.calling().toggleMute();
       await userACall.toggleParticipantsList();
-      await expect(userACall.getCallParticipant(userA.fullName).activeSpeakerIcon).toBeVisible();
-      await expect(userACall.getCallParticipant(userB.fullName).activeSpeakerIcon).toBeVisible();
+
+      await userBPages.calling().maximizeCell();
+      await userBPages.calling().unmuteSelfInFullScreen();
+      await expect(userBPages.calling().getGridTile(userB.fullName).muteIcon).toBeHidden(); // Ensure active video state
+
+      await expect(userACall.getSidebarParticipant(userA.fullName).activeSpeakerIcon).toBeVisible();
+      await expect(userACall.getSidebarParticipant(userB.fullName).activeSpeakerIcon).toBeVisible();
     });
   });
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {Page} from 'playwright/test';
 import {AudioType} from 'Repositories/audio/audioType';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
@@ -691,10 +692,33 @@ test.describe('Calling', () => {
     });
   });
 
-  test(
-    'As a moderator I want to mute another participant',
-    {tag: ['@TC-2928', '@regression']},
-    async ({createPage}) => {
+  [
+    {
+      description: 'As a moderator I want to mute another participant',
+      tag: '@TC-2928',
+      verify: async (userPage: Page, callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
+        await userPage.getByRole('button', {name: 'Mute', exact: true}).click();
+
+        await expect(callScreen.getCallParticipant(userB.fullName).muteIcon).toBeVisible();
+        await expect(callScreen.getGridTile(userB.fullName).muteIcon).toBeVisible();
+      },
+    },
+    {
+      description: 'As moderator of a call I want to mute all other participants',
+      tag: '@TC-2929',
+      verify: async (userPage: Page, callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
+        await userPage.getByRole('button', {name: 'Mute', exact: true}).click();
+        await callScreen.getCallParticipant(userB.fullName).menuButton.click();
+        await userPage.getByRole('button', {name: 'Mute everyone else'}).click();
+
+        for (const participant of [userB, userC]) {
+          await expect(callScreen.getCallParticipant(participant.fullName).muteIcon).toBeVisible();
+          await expect(callScreen.getGridTile(participant.fullName).muteIcon).toBeVisible();
+        }
+      },
+    },
+  ].forEach(({description, tag, verify}) => {
+    test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
       const [userAPage, userBPages, userCPages] = await Promise.all([
         createPage(withLogin(userA), withConnectedUser(userB)),
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
@@ -703,31 +727,32 @@ test.describe('Calling', () => {
 
       const userAPages = PageManager.from(userAPage).webapp.pages;
 
-      await createGroup(userAPages, groupName, [userB, userC]);
+      await test.step('Setup: Create group and start call', async () => {
+        await createGroup(userAPages, groupName, [userB, userC]);
+        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversation().clickCallButton();
 
-      // User A initiates the call
-      await userAPages.conversationList().openConversation(groupName);
-      await userAPages.conversation().clickCallButton();
+        await expect(userAPages.calling().callCell).toBeVisible();
+      });
 
-      await expect(userAPages.calling().callCell).toBeVisible();
-      // Ensure all invited members join the call
-      for (const member of [userBPages, userCPages]) {
-        joinCall(member);
-      }
+      await test.step('All participants join the call', async () => {
+        for (const member of [userBPages, userCPages]) {
+          await joinCall(member);
+          await member.calling().toggleMute(); // Ensure active mic state
+        }
+      });
 
-      // User B un-mutes themselves
-      await userBPages.calling().toggleMute();
+      await test.step('Verify moderator can mute other participants', async () => {
+        const userACall = await userAPages.calling().maximizeCell();
+        await userACall.toggleParticipantsList();
 
-      // User A mutes User B from the participants list
-      const userACall = await userAPages.calling().maximizeCell();
-      await userACall.toggleParticipantsList();
-      await expect(userACall.getCallParticipant(userB.fullName).muteIcon).not.toBeVisible();
+        await expect(userACall.getCallParticipant(userB.fullName).muteIcon).not.toBeVisible();
+        await expect(userACall.getCallParticipant(userC.fullName).muteIcon).not.toBeVisible();
 
-      await userACall.getCallParticipant(userB.fullName).menuButton.click();
-      await userAPage.getByRole('button', {name: 'Mute', exact: true}).click();
+        await userACall.getCallParticipant(userB.fullName).menuButton.click();
 
-      await expect(userACall.getCallParticipant(userB.fullName).muteIcon).toBeVisible();
-      await expect(userACall.getGridTile(userB.fullName).muteIcon).toBeVisible();
-    },
-  );
+        verify(userAPage, userACall);
+      });
+    });
+  });
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -518,7 +518,7 @@ test.describe('Calling', () => {
 
       const userACall = await userAPages.calling().maximizeCell();
       await userACall.toggleParticipantsList();
-      await expect(userACall.getSidebarParticipant(guestUser.fullName).guestIcon).toBeVisible();
+      await expect(userACall.getCallingParticipant(guestUser.fullName).guestIcon).toBeVisible();
 
       const participants = [
         {pages: userBPages, name: userB.fullName, label: 'User B'},
@@ -530,7 +530,7 @@ test.describe('Calling', () => {
           name: 'Mute',
           action: (p: PageManager['webapp']['pages']) => p.calling().toggleMuteButton.click(),
           verify: async (name: string) => {
-            await expect(userACall.getSidebarParticipant(name).muteIcon).not.toBeVisible();
+            await expect(userACall.getCallingParticipant(name).muteIcon).not.toBeVisible();
             await expect(userACall.getGridTile(name).muteIcon).not.toBeVisible();
           },
         },
@@ -538,7 +538,7 @@ test.describe('Calling', () => {
           name: 'Screenshare',
           action: (p: PageManager['webapp']['pages']) => p.calling().clickToggleScreenShareButton(),
           verify: async (name: string) => {
-            await expect(userACall.getSidebarParticipant(name).screenShareIcon).toBeVisible();
+            await expect(userACall.getCallingParticipant(name).screenShareIcon).toBeVisible();
             await expect(userACall.getGridTile(name).videoElement).toBeVisible();
           },
         },
@@ -546,7 +546,7 @@ test.describe('Calling', () => {
           name: 'Video',
           action: (p: PageManager['webapp']['pages']) => p.calling().clickToggleVideoButton(),
           verify: async (name: string) => {
-            await expect(userACall.getSidebarParticipant(name).videoIcon).toBeVisible();
+            await expect(userACall.getCallingParticipant(name).videoIcon).toBeVisible();
             await expect(userACall.getGridTile(name).videoElement).toBeVisible();
           },
         },
@@ -689,36 +689,36 @@ test.describe('Calling', () => {
     {
       description: 'As a moderator I want to mute another participant',
       tag: '@TC-2928',
-      verify: async (userPage: Page, callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
-        await userPage.getByRole('button', {name: 'Mute', exact: true}).click();
+      verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
+        const contextMenu = await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
+        await contextMenu.muteButton.click();
 
-        await expect(callScreen.getSidebarParticipant(userB.fullName).muteIcon).toBeVisible();
+        await expect(callScreen.getCallingParticipant(userB.fullName).muteIcon).toBeVisible();
         await expect(callScreen.getGridTile(userB.fullName).muteIcon).toBeVisible();
       },
     },
     {
       description: 'As moderator of a call I want to mute all other participants',
       tag: '@TC-2929',
-      verify: async (userPage: Page, callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
-        await userPage.getByRole('button', {name: 'Mute', exact: true}).click();
-        await callScreen.getSidebarParticipant(userB.fullName).menuButton.click();
-        await userPage.getByRole('button', {name: 'Mute everyone else'}).click();
+      verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
+        const contextMenu = await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
+        await contextMenu.muteButton.click();
+        await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
+        await contextMenu.muteOthersButton.click();
 
         for (const participant of [userB, userC]) {
-          await expect(callScreen.getSidebarParticipant(participant.fullName).muteIcon).toBeVisible();
+          await expect(callScreen.getCallingParticipant(participant.fullName).muteIcon).toBeVisible();
           await expect(callScreen.getGridTile(participant.fullName).muteIcon).toBeVisible();
         }
       },
     },
   ].forEach(({description, tag, verify}) => {
     test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
-      const [userAPage, userBPages, userCPages] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
+      const [userAPages, userBPages, userCPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
         PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
       ]);
-
-      const userAPages = PageManager.from(userAPage).webapp.pages;
 
       await test.step('Setup: Create group and start call', async () => {
         await createGroup(userAPages, groupName, [userB, userC]);
@@ -739,12 +739,10 @@ test.describe('Calling', () => {
         const userACall = await userAPages.calling().maximizeCell();
         await userACall.toggleParticipantsList();
 
-        await expect(userACall.getSidebarParticipant(userB.fullName).muteIcon).not.toBeVisible();
-        await expect(userACall.getSidebarParticipant(userC.fullName).muteIcon).not.toBeVisible();
+        await expect(userACall.getCallingParticipant(userB.fullName).muteIcon).not.toBeVisible();
+        await expect(userACall.getCallingParticipant(userC.fullName).muteIcon).not.toBeVisible();
 
-        await userACall.getSidebarParticipant(userB.fullName).menuButton.click();
-
-        verify(userAPage, userACall);
+        verify(userACall);
       });
     });
   });
@@ -793,13 +791,14 @@ test.describe('Calling', () => {
       await test.step('Moderator mutes User B', async () => {
         const userACall = await userAPages.calling().maximizeCell();
         await userACall.toggleParticipantsList();
+        const userBParticipant = userACall.getCallingParticipant(userB.fullName);
 
-        await expect(userACall.getSidebarParticipant(userB.fullName).muteIcon).not.toBeVisible();
+        await expect(userBParticipant.muteIcon).not.toBeVisible();
 
-        await userACall.getSidebarParticipant(userB.fullName).menuButton.click();
-        await userAPage.getByRole('button', {name: 'Mute', exact: true}).click();
+        const contextMenu = await userBParticipant.openContextMenu();
+        await contextMenu.muteButton.click();
 
-        await expect(userACall.getSidebarParticipant(userB.fullName).muteIcon).toBeVisible();
+        await expect(userBParticipant.muteIcon).toBeVisible();
       });
 
       await test.step('Verify mute functionality', async () => {
@@ -905,8 +904,8 @@ test.describe('Calling', () => {
       await userBPages.calling().unmuteSelfInFullScreen();
       await expect(userBPages.calling().getGridTile(userB.fullName).muteIcon).toBeHidden(); // Ensure active video state
 
-      await expect(userACall.getSidebarParticipant(userA.fullName).activeSpeakerIcon).toBeVisible();
-      await expect(userACall.getSidebarParticipant(userB.fullName).activeSpeakerIcon).toBeVisible();
+      await expect(userACall.getCallingParticipant(userA.fullName).activeSpeakerIcon).toBeVisible();
+      await expect(userACall.getCallingParticipant(userB.fullName).activeSpeakerIcon).toBeVisible();
     });
   });
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -629,4 +629,64 @@ test.describe('Calling', () => {
       });
     },
   );
+
+  test(
+    'I want to navigate between call pages',
+    {tag: ['@TC-2924', '@regression']},
+    async ({createPage, createUser}) => {
+      const userAPage = await createPage(withLogin(userA));
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+
+      const {groupMembers, memberPages} =
+        await test.step('Setup: Create members and initialize all browser pages', async () => {
+          // Generate a large participant list to trigger pagination
+          const extraMembers = await Promise.all(Array.from({length: 7}, () => createUser()));
+          const groupMembers = [userB, userC, ...extraMembers];
+
+          const memberPages = await Promise.all(
+            groupMembers.map(async member => {
+              if (![userB, userC].includes(member)) {
+                await team.addTeamMember(member);
+              }
+
+              const page = await createPage(withLogin(member));
+              return PageManager.from(page).webapp.pages;
+            }),
+          );
+
+          return {groupMembers, memberPages};
+        });
+
+      await test.step('Action: User A initiates the group call', async () => {
+        await createGroup(userAPages, groupName, groupMembers);
+        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversation().clickCallButton();
+        // Warning modal about large group call
+        await userAPage.getByTestId('modal-without-title').getByRole('button', {name: 'Call', exact: true}).click();
+        await expect(userAPages.calling().goFullScreen).toBeVisible();
+      });
+
+      await test.step('Action: All members accept the incoming call', async () => {
+        await Promise.all(
+          memberPages.map(async memberPage => {
+            await memberPage.calling().acceptCallButton.click({timeout: 30_000});
+            await expect(memberPage.calling().goFullScreen).toBeVisible();
+          }),
+        );
+      });
+
+      await test.step('Verify: Pagination and Grid Visibility', async () => {
+        const userACall = await userAPages.calling().maximizeCell();
+        await expect(userACall.getGridTile(userA.fullName)).toBeVisible();
+
+        // Navigate and Verify disappearance
+        await userACall.goToNextPage();
+        await expect(userACall.getGridTile(userA.fullName)).toBeHidden();
+
+        // Return and Verify reappearance
+        await userACall.goToPreviousPage();
+        await expect(userACall.getGridTile(userA.fullName)).toBeVisible();
+      });
+    },
+  );
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -34,7 +34,7 @@ test.describe('Calling', () => {
   test.beforeEach(async ({createTeam, createUser}) => {
     userB = await createUser();
     userC = await createUser();
-    team = await createTeam('Team Call Team', {
+    const team = await createTeam('Team Call Team', {
       users: [userB, userC],
       features: {conferenceCalling: true},
     });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -257,6 +257,9 @@ test.describe('Calling', () => {
       await expect(userAPages.calling().callCell).toBeVisible();
       await joinCall(userBPages);
 
+      // User A starts screen sharing
+      await userAPages.calling().clickToggleScreenShareButton();
+
       // // User C joins the ongoing call
       await userCPage.waitForTimeout(5000);
       await userCPages.conversationList().getConversation(groupName).joinCallButton.click();
@@ -266,7 +269,6 @@ test.describe('Calling', () => {
       await expect(userCPages.calling().gridTiles).toHaveCount(3);
 
       if (verifyScreenShare) {
-        await userAPages.calling().clickToggleScreenShareButton();
         const userCCall = await userCPages.calling().maximizeCell();
         await expect(userCCall.getGridTile(userA.fullName).videoElement).toBeVisible();
       }
@@ -469,14 +471,15 @@ test.describe('Calling', () => {
       }
 
       const allMembers = [userB, userC, ...extraMembers];
-      const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
-      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const {pages: userAPages, modals: userAModals} = PageManager.from(
+        await createPage(withLogin(userA), withConnectedUser(userB)),
+      ).webapp;
 
       await createGroup(userAPages, groupName, allMembers);
       await userAPages.conversationList().getConversation(groupName).open();
       await userAPages.conversation().clickCallButton();
 
-      await expect(userAPage.getByTestId('modal-without-title')).toContainText(
+      await expect(userAModals.withoutTitle().modalText).toContainText(
         `Are you sure you want to call ${allMembers.length} people?`,
       );
     },
@@ -628,6 +631,7 @@ test.describe('Calling', () => {
       description: 'I want to see video tiles ordered alphabetically by user names',
       tag: '@TC-2927',
       verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>, localUser: string) => {
+        await expect(callScreen.gridTiles).toHaveCount(6); // Ensure first grid page is full
         const displayedNames = await callScreen.gridTiles.getByTestId('call-participant-name').allInnerTexts();
         const listToVerify = displayedNames.filter(name => name !== localUser);
         const sortedNames = [...listToVerify].sort((a, b) => a.localeCompare(b));
@@ -637,8 +641,7 @@ test.describe('Calling', () => {
     },
   ].forEach(({description, tag, verify}) => {
     test(description, {tag: [tag, '@regression']}, async ({createPage, createUser}) => {
-      const userAPage = await createPage(withLogin(userA));
-      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const {pages: userAPages, modals: userAModals} = PageManager.from(await createPage(withLogin(userA))).webapp;
 
       const {groupMembers, memberPages} =
         await test.step('Setup: Create members and initialize all browser pages', async () => {
@@ -646,12 +649,10 @@ test.describe('Calling', () => {
           const extraMembers = await Promise.all(Array.from({length: 7}, () => createUser()));
           const groupMembers = [userB, userC, ...extraMembers];
 
+          await Promise.all(extraMembers.map(member => team.addTeamMember(member)));
+
           const memberPages = await Promise.all(
             groupMembers.map(async member => {
-              if (![userB, userC].includes(member)) {
-                await team.addTeamMember(member);
-              }
-
               const page = await createPage(withLogin(member));
               return PageManager.from(page).webapp.pages;
             }),
@@ -665,7 +666,7 @@ test.describe('Calling', () => {
         await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().clickCallButton();
         // Warning modal about large group call
-        await userAPage.getByTestId('modal-without-title').getByRole('button', {name: 'Call', exact: true}).click();
+        await userAModals.withoutTitle().clickAction();
         await expect(userAPages.calling().goFullScreen).toBeVisible();
       });
 
@@ -812,7 +813,8 @@ test.describe('Calling', () => {
     {tag: ['@TC-2936', '@regression']},
     async ({createPage}) => {
       test.setTimeout(390_000);
-      const userAPages = await PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages);
+      const userAPage = await createPage(withLogin(userA));
+      const userAPages = PageManager.from(userAPage).webapp.pages;
 
       await createGroup(userAPages, groupName, [userB, userC]);
 
@@ -821,13 +823,12 @@ test.describe('Calling', () => {
       await userAPages.conversation().clickCallButton();
       await expect(userAPages.calling().callCell).toBeVisible();
 
+      await userAPage.waitForTimeout(300_000);
       await expect(
         userAPages
           .conversation()
           .systemMessages.filter({hasText: 'Your call was ended because no other participant joined.'}),
-      ).toBeVisible({
-        timeout: 302_000,
-      });
+      ).toBeVisible();
       await expect(userAPages.calling().callCell).not.toBeVisible();
     },
   );

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -814,4 +814,47 @@ test.describe('Calling', () => {
       });
     });
   });
+
+  test(
+    'I want to see a group call timing out after 30s if I`m the last one left in the call',
+    {tag: ['@TC-2937', '@regression']},
+    async ({createPage}) => {
+      const [userAPages, userBPages, userCPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+      ]);
+
+      await test.step('Setup: Create group and start call', async () => {
+        await createGroup(userAPages, groupName, [userB, userC]);
+        await userAPages.conversationList().openConversation(groupName);
+        await userAPages.conversation().clickCallButton();
+
+        await expect(userAPages.calling().callCell).toBeVisible();
+      });
+
+      await test.step('User B and User C join the call', async () => {
+        for (const member of [userBPages, userCPages]) {
+          await joinCall(member);
+        }
+        await expect(userAPages.calling().gridTiles).toHaveCount(3);
+      });
+
+      await test.step('User B and User C leave the call', async () => {
+        for (const member of [userBPages, userCPages]) {
+          await member.calling().clickLeaveCallButton();
+          await expect(member.calling().goFullScreen).toBeHidden();
+        }
+      });
+
+      await test.step('Verify call ends for User A after 30s of being the last one in the call', async () => {
+        await expect(userAPages.calling().goFullScreen).toBeHidden({timeout: 35_000});
+        await expect(
+          userAPages
+            .conversation()
+            .systemMessages.filter({hasText: 'Your call was ended because all other participants left'}),
+        ).toBeVisible();
+      });
+    },
+  );
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -20,7 +20,15 @@
 import {AudioType} from 'Repositories/audio/audioType';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, withConnectedUser, withLogin, expect, Team} from 'test/e2e_tests/test.fixtures';
+import {
+  test,
+  withConnectedUser,
+  withLogin,
+  expect,
+  Team,
+  withConnectionRequest,
+  LOGIN_TIMEOUT,
+} from 'test/e2e_tests/test.fixtures';
 import {isPlayingAudio} from 'test/e2e_tests/utils/audio.util';
 import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
@@ -549,6 +557,58 @@ test.describe('Calling', () => {
           });
         }
       }
+    },
+  );
+
+  test(
+    'I want to accept a group video call as a personal account guest',
+    {tag: ['@TC-2852', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage()]);
+      const {pages: ownerPages, modals: ownerModals} = PageManager.from(userAPage).webapp;
+      const guestPages = PageManager.from(guestPage).webapp.pages;
+
+      const createdLink = await test.step('Owner: Create group and generate guest invitation link', async () => {
+        await createGroup(ownerPages, groupName, []);
+        await ownerPages.conversationList().openConversation(groupName);
+        await ownerPages.conversation().toggleGroupInformation();
+        await ownerPages.conversationDetails().openGuestOptions();
+        return await ownerPages.guestOptions().createLink();
+      });
+
+      await test.step('Guest: Navigate to link and log in with personal account', async () => {
+        await guestPage.goto(createdLink.toString());
+        await guestPages.conversationJoin().joinBrowserButton.click();
+        await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
+
+        await guestPages.login().login(userB);
+        await guestPages.conversation().conversationTitle.waitFor({
+          state: 'visible',
+          timeout: LOGIN_TIMEOUT,
+        });
+      });
+
+      await test.step('Owner: Verify guest arrival and initiate video call', async () => {
+        await expect(
+          ownerPages.conversation().systemMessages.filter({hasText: `${userB.fullName} joined`}),
+        ).toBeVisible();
+
+        await ownerPages.conversation().toggleGroupInformation();
+        await ownerPages.conversation().clickCallButton();
+        // Warning modal that guest started using a new device
+        await ownerModals.confirm().clickAction();
+        await expect(ownerPages.calling().callCell).toBeVisible();
+      });
+
+      await test.step('Guest: Join the active call', async () => {
+        const {joinCallButton} = guestPages.conversationList().getConversationLocator(groupName);
+
+        await expect(guestPages.calling().callCell).toBeVisible();
+        await expect(joinCallButton).toBeVisible();
+
+        await joinCallButton.click();
+        await expect(ownerPages.calling().goFullScreen).toBeVisible();
+      });
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -234,33 +234,51 @@ test.describe('Calling', () => {
     },
   );
 
-  test('Verify able to join ongoing call', {tag: ['@TC-2820', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages, userCPage] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB), withConnectedUser(userC))).then(pm => pm.webapp.pages),
-      createPage(withLogin(userC)),
-    ]);
+  [
+    {
+      description: 'Verify able to join ongoing call',
+      tag: '@TC-2820',
+    },
+    {
+      description: 'Late joiner wants to see the ongoing screen sharing on group call',
+      tag: '@TC-2874',
+      verifyScreenShare: true,
+    },
+  ].forEach(({description, tag, verifyScreenShare}) => {
+    test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
+      const [userAPages, userBPages, userCPage] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB), withConnectedUser(userC))).then(pm => pm.webapp.pages),
+        createPage(withLogin(userC)),
+      ]);
 
-    const userCPages = PageManager.from(userCPage).webapp.pages;
-    await createGroup(userAPages, groupName, [userB, userC]);
+      const userCPages = PageManager.from(userCPage).webapp.pages;
+      await createGroup(userAPages, groupName, [userB, userC]);
 
-    await userAPages.conversationList().getConversation(groupName).open();
-    await userAPages.conversation().clickCallButton();
+      await userAPages.conversationList().getConversation(groupName).open();
+      await userAPages.conversation().clickCallButton();
 
-    await expect(userAPages.calling().callCell).toBeVisible();
-    await expect(userBPages.calling().callCell).toBeVisible();
+      await expect(userAPages.calling().callCell).toBeVisible();
+      await expect(userBPages.calling().callCell).toBeVisible();
 
-    await userBPages.calling().clickAcceptCallButton();
-    // Confirm the calls grid is visible
-    await expect(userBPages.calling().goFullScreen).toBeVisible();
+      await userBPages.calling().clickAcceptCallButton();
+      // Confirm the calls grid is visible
+      await expect(userBPages.calling().goFullScreen).toBeVisible();
 
-    // // User C joins the ongoing call
-    await userCPage.waitForTimeout(5000);
-    await userCPages.conversationList().getConversation(groupName).joinCallButton.click();
+      // // User C joins the ongoing call
+      await userCPage.waitForTimeout(5000);
+      await userCPages.conversationList().getConversation(groupName).joinCallButton.click();
 
-    // Confirm that user C joined the call
-    await expect(userCPages.calling().goFullScreen).toBeVisible();
-    await expect(userCPages.calling().gridTiles).toHaveCount(3);
+      // Confirm that user C joined the call
+      await expect(userCPages.calling().goFullScreen).toBeVisible();
+      await expect(userCPages.calling().gridTiles).toHaveCount(3);
+
+      if (verifyScreenShare) {
+        await userAPages.calling().clickToggleScreenShareButton();
+        const userCCall = await userCPages.calling().maximizeCell();
+        await expect(userCCall.getGridTile(userA.fullName).videoElement).toBeVisible();
+      }
+    });
   });
 
   test('Verify Call UI checks', {tag: ['@TC-8771', '@regression']}, async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -701,10 +701,11 @@ test.describe('Calling', () => {
       description: 'As moderator of a call I want to mute all other participants',
       tag: '@TC-2929',
       verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
-        const contextMenu = await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
-        await contextMenu.muteButton.click();
-        await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
-        await contextMenu.muteOthersButton.click();
+        const firstContextMenu = await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
+        await firstContextMenu.muteButton.click();
+
+        const secondContextMenu = await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
+        await secondContextMenu.muteOthersButton.click();
 
         for (const participant of [userB, userC]) {
           await expect(callScreen.getCallingParticipant(participant.fullName).muteIcon).toBeVisible();
@@ -742,7 +743,7 @@ test.describe('Calling', () => {
         await expect(userACall.getCallingParticipant(userB.fullName).muteIcon).not.toBeVisible();
         await expect(userACall.getCallingParticipant(userC.fullName).muteIcon).not.toBeVisible();
 
-        verify(userACall);
+        await verify(userACall);
       });
     });
   });
@@ -802,7 +803,7 @@ test.describe('Calling', () => {
       });
 
       await test.step('Verify mute functionality', async () => {
-        verify(userBPage);
+        await verify(userBPage);
       });
     });
   });
@@ -902,10 +903,11 @@ test.describe('Calling', () => {
 
       await userBPages.calling().maximizeCell();
       await userBPages.calling().unmuteSelfInFullScreen();
+
       await expect(userBPages.calling().getGridTile(userB.fullName).muteIcon).toBeHidden(); // Ensure active video state
 
       await expect(userACall.getCallingParticipant(userA.fullName).activeSpeakerIcon).toBeVisible();
-      await expect(userACall.getCallingParticipant(userB.fullName).activeSpeakerIcon).toBeVisible();
+      await expect(userACall.getCallingParticipant(userB.fullName).activeSpeakerIcon).toBeVisible({timeout: 30_000});
     });
   });
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19943" title="WPB-19943" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19943</a>  [Web/QA] Write the calling regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This PR introduces the second phase of the Calling regression E2E test suite. To ensure a manageable review process, the full suite has been split into two logical parts.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
