### PR TITLE
fix: don't show apps which have already been added to the conversation when adding [WPB-20363]

### DIFF
--- a/apps/webapp/src/script/page/RightSidebar/addParticipants/addParticipants.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/addParticipants/addParticipants.tsx
@@ -135,8 +135,9 @@ const AddParticipants: FC<AddParticipantsProps> = ({
   }, [contacts, integrationRepository, searchInput]);
 
   const servicesList = useMemo(() => {
-    return activeConversation.protocol === CONVERSATION_PROTOCOL.MLS ? apps : services;
-  }, [activeConversation.protocol, apps, services]);
+    const allApps = activeConversation.protocol === CONVERSATION_PROTOCOL.MLS ? apps : services;
+    return allApps.filter(app => !participatingUserIds.some(id => id.id === app.id)); // Make sure apps already added to the conversation don't show up again
+  }, [activeConversation.protocol, apps, services, participatingUserIds]);
 
   const enabledAddAction = selectedContacts.length > ENABLE_ADD_ACTIONS_LENGTH;
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20363" title="WPB-20363" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20363</a>  [Web] [Integration] - Searching for Apps specifically
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

So far Apps / Services have not been filtered like the Users to not show ones which are already part of the current conversation. This change filters out the apps / services where the ID is already part of the conversation.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

-
