### PR TITLE
fix: don't show apps when adding participants if the feature was disabled [WPB-20363]

### DIFF
--- a/apps/webapp/src/script/page/RightSidebar/addParticipants/addParticipants.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/addParticipants/addParticipants.tsx
@@ -50,6 +50,7 @@ import {compareTransliteration, sortByPriority, sortUsersByPriority} from 'Util/
 import {getManageServicesUrl} from '../../../externalRoute';
 import {PanelHeader} from '../panelHeader';
 import {PanelEntity, PanelState} from '../RightSidebar';
+import {checkAppsFeatureAvailability} from 'Util/featureUtil';
 
 const ENABLE_ADD_ACTIONS_LENGTH = 0;
 const ENABLE_IS_SEARCHING_LENGTH = 0;
@@ -102,7 +103,12 @@ const AddParticipants: FC<AddParticipantsProps> = ({
     'isTeamOnly',
     'participating_user_ids',
   ]);
-  const {isTeam, teamMembers, teamUsers} = useKoSubscribableChildren(teamState, ['isTeam', 'teamMembers', 'teamUsers']);
+  const {isTeam, teamMembers, teamUsers, isAppsEnabled} = useKoSubscribableChildren(teamState, [
+    'isTeam',
+    'teamMembers',
+    'teamUsers',
+    'isAppsEnabled',
+  ]);
   const {connectedUsers} = useKoSubscribableChildren(userState, ['connectedUsers']);
   const {teamRole} = useKoSubscribableChildren(selfUser, ['teamRole']);
   const {services} = useKoSubscribableChildren(integrationRepository, ['services']);
@@ -149,7 +155,13 @@ const AddParticipants: FC<AddParticipantsProps> = ({
     const isService = !!firstUserEntity?.isService;
     const allowIntegrations = isGroupOrChannel || isService;
 
-    return isTeam && allowIntegrations && inTeam && !isTeamOnly && isServicesEnabled;
+    // Don't allow new apps to be added if the feature has been disabled
+    const isAppFeatureEnabled = checkAppsFeatureAvailability({
+      protocol: activeConversation.protocol,
+      isAppsEnabled: isAppsEnabled,
+    });
+
+    return isTeam && allowIntegrations && inTeam && !isTeamOnly && isServicesEnabled && isAppFeatureEnabled;
   }, [
     firstUserEntity?.isService,
     inTeam,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20363" title="WPB-20363" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20363</a>  [Web] [Integration] - Searching for Apps specifically
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

When a conversation was created with Apps enabled it was still possible to search for and try to add apps to it even though the feature was disabled for the team. This adds a check to really only show the tab for searching for apps / services if the feature is still enabled.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- 