### PR TITLE
test: refactor deep link setup to use beforeEach

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/DeepLinks/deepLinks.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/DeepLinks/deepLinks.spec.ts
@@ -19,7 +19,7 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {expect, test, withConnectedUser, withConnectionRequest, withLogin} from 'test/e2e_tests/test.fixtures';
+import {expect, test, Team, withConnectedUser, withConnectionRequest, withLogin} from 'test/e2e_tests/test.fixtures';
 import {createGroup} from '../../utils/userActions';
 import {UserProfileModal} from '../../pageManager/webapp/modals/userProfile.modal';
 
@@ -76,56 +76,52 @@ async function verifyUserProfileModal(profileModal: UserProfileModal, user: User
 }
 
 test.describe('Deep Links', () => {
+  let team: Team;
+  let userA: User;
+  let userB: User;
+  let userC: User;
+  let userD: User;
+
+  const groupName = 'DeepLinksGroup';
+
+  test.beforeEach(async ({createUser}) => {
+    userC = await createUser();
+    userD = await createUser();
+  });
+
   const testCases = [
     {
       title: 'Opening profile deep links as a team member',
       tag: ['@TC-590', '@regression'],
-      setupUsers: async (createTeam: any, createUser: any, createPage: any) => {
-        const userB = await createUser();
-        const team = await createTeam('Test Team', {users: [userB]});
-        const userA = team.owner;
-        const userC = await createUser();
-        const userD = await createUser();
-
-        const [userAPage, userBPage, userCPage, userDPage] = await Promise.all([
-          createPage(withLogin(userA), withConnectedUser(userB), withConnectionRequest(userC)),
-          createPage(withLogin(userB), withConnectionRequest(userD)),
-          createPage(withLogin(userC)),
-          createPage(withLogin(userD)),
-        ]);
-
-        return {userA, userB, userC, userD, userAPage, userBPage, userCPage, userDPage};
-      },
+      isTeamMemberScenario: true,
     },
     {
       title: 'Opening profile deep links as a personal account',
       tag: ['@TC-591', '@regression'],
-      setupUsers: async (createTeam: any, createUser: any, createPage: any) => {
-        const userA = await createUser();
-        const team = await createTeam('Test Team', {users: [userA]});
-        const userB = team.owner;
-        const userC = await createUser();
-        const userD = await createUser();
-
-        const [userAPage, userBPage, userCPage, userDPage] = await Promise.all([
-          createPage(withLogin(userA), withConnectionRequest(userC)),
-          createPage(withLogin(userB), withConnectedUser(userA), withConnectionRequest(userD)),
-          createPage(withLogin(userC)),
-          createPage(withLogin(userD)),
-        ]);
-
-        return {userA, userB, userC, userD, userAPage, userBPage, userCPage, userDPage};
-      },
+      isTeamMemberScenario: false,
     },
   ];
 
   for (const testCase of testCases) {
     test(testCase.title, {tag: testCase.tag}, async ({createTeam, createUser, createPage}) => {
-      const {userA, userB, userC, userD, userAPage, userBPage, userCPage, userDPage} = await testCase.setupUsers(
-        createTeam,
-        createUser,
-        createPage,
-      );
+      if (testCase.isTeamMemberScenario) {
+        // Logic for TC-590
+        userB = await createUser();
+        team = await createTeam('Test Team', {users: [userB]});
+        userA = team.owner;
+      } else {
+        // Logic for TC-591
+        userA = await createUser();
+        team = await createTeam('Test Team', {users: [userA]});
+        userB = team.owner;
+      }
+
+      const [userAPage, userBPage, userCPage, userDPage] = await Promise.all([
+        createPage(withLogin(userA), withConnectionRequest(userC)),
+        createPage(withLogin(userB), withConnectedUser(userA), withConnectionRequest(userD)),
+        createPage(withLogin(userC)),
+        createPage(withLogin(userD)),
+      ]);
 
       const userAPageManager = PageManager.from(userAPage);
       const userBPageManager = PageManager.from(userBPage);
@@ -136,8 +132,6 @@ test.describe('Deep Links', () => {
       const {pages: userBPages} = userBPageManager.webapp;
       const {pages: userCPages} = userCPageManager.webapp;
       const {pages: userDPages} = userDPageManager.webapp;
-
-      const groupName = 'DeepLinksGroup';
 
       await userCPages.conversationList().openPendingConnectionRequest();
       await userCPages.connectRequest().connectButton.click();


### PR DESCRIPTION
## Summary

This suggested refactor streamlines the Deep Links suite by moving the complex setupUsers logic into a centralized beforeEach hook. 

I replaced the manual callbacks with a configuration flag and removed redundant : any type declarations to leverage Playwright’s native fixture types.

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
