### PR TITLE
feat: make unread marker readable for screen readers [WPB-22778]

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -160,6 +160,7 @@
   "accessibility.rightPanel.close": "Close conversation info",
   "accessibility.searchInput.cancel": "Delete entry",
   "accessibility.selfDeletingMessage.timer": "Self-deleting message, timer is counting down.",
+  "accessibility.unreadMessagesSeparator": "Following messages are unread",
   "accessibility.userProfileDeleteEntry": "Delete entry",
   "accountAlreadyExistsModal.changeEmailLink": "Change your email address",
   "accountAlreadyExistsModal.content": "This email's domain belongs to an on-premises backend. Please change your email in the account settings or delete your account. If you are part of a team please contact your team admin.",

--- a/apps/webapp/src/script/components/MessagesList/Message/Marker/Marker.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/Marker/Marker.tsx
@@ -23,6 +23,7 @@ import {SerializedStyles, css} from '@emotion/react';
 
 import {ScrollToElement} from 'Components/MessagesList/Message/types';
 import {useRelativeTimestamp} from 'src/script/hooks/useRelativeTimestamp';
+import {t} from 'Util/localizerUtil';
 
 import {dayMarkerStyle, baseMarkerStyle, notVirtualizedMarkerStyle} from './Marker.styles';
 import {getMessagesGroupLabel} from './Marker.utils';
@@ -30,6 +31,7 @@ import {getMessagesGroupLabel} from './Marker.utils';
 import {Config} from '../../../../Config';
 import {Marker} from '../../utils/messagesGroup';
 import {MessageTime} from '../MessageTime';
+import {TabIndex} from '@wireapp/react-ui-kit';
 
 const markerStyles: Partial<Record<Marker['type'], SerializedStyles>> = {
   day: dayMarkerStyle,
@@ -71,7 +73,15 @@ export const MarkerComponent = ({marker, scrollTo, measureElement, index}: Props
       }}
     >
       <div className="message-header-icon">
-        {marker.type === 'unread' && <span className="message-unread-dot dot-md" />}
+        {marker.type === 'unread' && (
+          <span
+            className="message-unread-dot dot-md"
+            role="img"
+            aria-label={t('accessibility.unreadMessagesSeparator')}
+            tabIndex={TabIndex.FOCUSABLE}
+            title={t('accessibility.unreadMessagesSeparator')}
+          />
+        )}
       </div>
 
       <h3 className="message-header-label">

--- a/apps/webapp/src/script/components/MessagesList/Message/Marker/Marker.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/Marker/Marker.tsx
@@ -21,6 +21,8 @@ import {useLayoutEffect, useRef} from 'react';
 
 import {SerializedStyles, css} from '@emotion/react';
 
+import {TabIndex} from '@wireapp/react-ui-kit';
+
 import {ScrollToElement} from 'Components/MessagesList/Message/types';
 import {useRelativeTimestamp} from 'src/script/hooks/useRelativeTimestamp';
 import {t} from 'Util/localizerUtil';
@@ -31,7 +33,6 @@ import {getMessagesGroupLabel} from './Marker.utils';
 import {Config} from '../../../../Config';
 import {Marker} from '../../utils/messagesGroup';
 import {MessageTime} from '../MessageTime';
-import {TabIndex} from '@wireapp/react-ui-kit';
 
 const markerStyles: Partial<Record<Marker['type'], SerializedStyles>> = {
   day: dayMarkerStyle,

--- a/apps/webapp/src/types/i18n.d.ts
+++ b/apps/webapp/src/types/i18n.d.ts
@@ -164,6 +164,7 @@ declare module 'I18n/en-US.json' {
     'accessibility.rightPanel.close': `Close conversation info`;
     'accessibility.searchInput.cancel': `Delete entry`;
     'accessibility.selfDeletingMessage.timer': `Self-deleting message, timer is counting down.`;
+    'accessibility.unreadMessagesSeparator': `Following messages are unread`;
     'accessibility.userProfileDeleteEntry': `Delete entry`;
     'accountAlreadyExistsModal.changeEmailLink': `Change your email address`;
     'accountAlreadyExistsModal.content': `This email\'s domain belongs to an on-premises backend. Please change your email in the account settings or delete your account. If you are part of a team please contact your team admin.`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22778" title="WPB-22778" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22778</a>  [Web] Unread messages element needs alt text for screen reader
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Enabled unread messages marker to be readable by screen readers

https://github.com/user-attachments/assets/18d8c140-fc7a-4aa9-9d88-fd84af97e5c8

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
