### PR TITLE
ci: prepare Playwright dependencies once per End-to-End run [WPB-22420]

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,6 +64,9 @@ jobs:
   bootstrap_smoke_test:
     name: Run bootstrap smoke test
     runs-on: ubuntu-24.04
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --ipc=host
 
     services:
       testservice:
@@ -80,8 +83,14 @@ jobs:
           cache: 'yarn'
 
       - run: yarn --immutable
-      - run: yarn playwright install --only-shell --with-deps chromium
-      - uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4
+
+      - name: Install 1Password CLI
+        run: |
+          curl --fail --silent --show-error --location \
+            --output /tmp/1password-cli.deb \
+            https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          dpkg -i /tmp/1password-cli.deb
+          op --version
 
       - name: Generate env file
         run: op inject -i apps/webapp/test/e2e_tests/.env.staging.tpl -o apps/webapp/test/e2e_tests/.env
@@ -92,7 +101,7 @@ jobs:
         env:
           WEBAPP_URL: ${{ inputs.webappUrl }}
           BACKEND_URL: ${{ inputs.backendUrl }}
-          TEST_SERVICE_URL: http://localhost:8080
+          TEST_SERVICE_URL: http://testservice:8080
         run: yarn playwright test -c apps/webapp/playwright.config.ts apps/webapp/test/e2e_tests/specs/CriticalFlow/startupHasNoConsoleErrors.spec.ts
 
   test:
@@ -125,7 +134,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
-
+      
       - run: yarn --immutable
       - name: Install 1Password CLI
         run: |


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Summary

This changes the reusable End-to-End workflow so JavaScript dependencies are prepared once per run and then reused by all Playwright shards.

The main goal is reliability: avoid repeated registry traffic and repeated environment setup in the 64-shard End-to-End fan-out, to avoid potential npmjs.com rate limiting.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
