### PR TITLE
Fix TC-141 test user cross dependency [WPB-25032]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -155,13 +155,13 @@ test.describe('User Blocking', () => {
       'Verify you still receive messages from blocked person in a group chat',
       {tag: ['@TC-141', '@regression']},
       async ({createPage}) => {
+        const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
         const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectionRequest(userB)));
         const userAPages = userAPageManager.webapp.pages;
 
         const conversationName = 'GroupConversation';
 
         // Preconditions: User B accepts the connection request
-        const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
         await userBPages.connectRequest().clickConnectButton();
 
         await expect(userAPages.conversationList().getConversationLocator(userB.fullName)).toBeAttached();

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -162,6 +162,7 @@ test.describe('User Blocking', () => {
         const conversationName = 'GroupConversation';
 
         // Preconditions: User B accepts the connection request
+        await userBPages.conversationList().openPendingConnectionRequest();
         await userBPages.connectRequest().clickConnectButton();
 
         await expect(userAPages.conversationList().getConversationLocator(userB.fullName)).toBeAttached();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25032" title="WPB-25032" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25032</a>  [Web][QA] Fix TC-141 test that is failing because of user cross-dependency
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

https://wearezeta.atlassian.net/browse/WPB-25032

- What did I change and why?

Changed order of creating pre-requisites for TC-141 test and added explicit opening of connect request.

- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
