### PR TITLE
ci: enable yarn offline mode during install [WPB-22420]

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -80,6 +80,7 @@ jobs:
           cache: 'yarn'
 
       - run: yarn --immutable
+
       - run: yarn playwright install --only-shell --with-deps chromium
       - uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4
 
@@ -126,7 +127,12 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
-      - run: yarn --immutable
+      - name: Install dependencies
+        run: yarn --immutable
+        env:
+          # Installation from cache is preferred to avoid hitting rate limits from npm
+          YARN_ENABLE_OFFLINE_MODE: 1
+
       - name: Install 1Password CLI
         run: |
           curl --fail --silent --show-error --location \


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Yarns offline mode ([Docs](https://yarnpkg.com/configuration/yarnrc#enableOfflineMode)) makes it prefer the locale cache over always fetching via the network. This setting mimics the old "--prefer-offline" flag from classic yarn. Since we're running with an immutable lockfile in CI anyway there's no need to re-check for newer versions.

> Note: This won't bring a huge speed improvement since resolving and linking the dependencies from the global cache still takes some time. But it should help us avoid rate limiting due to the amount of requests we're making

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
