### PR TITLE
fix(webapp): prevent IndexedDB limit overflow in EventService message loading [WPB-25039]

### DIFF
--- a/apps/webapp/src/script/repositories/event/EventService.ts
+++ b/apps/webapp/src/script/repositories/event/EventService.ts
@@ -57,6 +57,7 @@ const compareEventsByConversation = (eventA: EventRecord, eventB: EventRecord) =
 const compareEventsById = (eventA: EventRecord, eventB: EventRecord) => eventA.id.localeCompare(eventB.id);
 const compareEventsByTime = (eventA: EventRecord, eventB: EventRecord) =>
   eventTimeToDate(eventA.time).getTime() - eventTimeToDate(eventB.time).getTime();
+const MAX_INDEXED_DB_LIMIT = 0xffffffff; // 4_294_967_295
 
 /** Handles all databases interactions related to events */
 export class EventService {
@@ -240,7 +241,7 @@ export class EventService {
     conversationId: string,
     fromDate = new Date(0),
     toDate = new Date(),
-    limit = Number.MAX_SAFE_INTEGER,
+    limit = MAX_INDEXED_DB_LIMIT,
   ): Promise<DBEvents> {
     const includeParams = {
       includeFrom: true,
@@ -270,7 +271,7 @@ export class EventService {
   async loadFollowingEvents(
     conversationId: string,
     fromDate: Date,
-    limit = Number.MAX_SAFE_INTEGER,
+    limit = MAX_INDEXED_DB_LIMIT,
     includeFrom = true,
   ): Promise<DBEvents> {
     const includeParams = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25039" title="WPB-25039" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25039</a>  [Web] Fix IndexedDB unsigned-long overflow in EventService default message loading limit
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
EventService used Number.MAX_SAFE_INTEGER as the default fetch limit for loadPrecedingEvents and loadFollowingEvents. In IndexedDB/Dexie paths, that value can exceed the browser’s unsigned-long range for count/limit parameters, causing runtime failures (outside the 'unsigned long' value range) and breaking message loading in affected conversations.

This change replaces the default sentinel with an IndexedDB-safe maximum (0xFFFFFFFF) so “unbounded/default” loading remains effectively large while staying within platform constraints. It keeps behavior explicit and minimal by removing the earlier sanitization layer and relying on safe defaults at the API boundary.

