### PR TITLE
test: increase timeout after manual login in TC-2763 [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -21,7 +21,7 @@ import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {handleAppLockState, loginUser} from 'test/e2e_tests/utils/userActions';
 
-import {test, expect, withLogin} from '../../test.fixtures';
+import {test, expect, withLogin, LOGIN_TIMEOUT} from '../../test.fixtures';
 
 test.describe('AppLock', () => {
   let owner: User;
@@ -182,7 +182,7 @@ test.describe('AppLock', () => {
         await loginUser(memberA, pageManager);
 
         // App lock setup modal should appear again (passcode was cleared on logout, session data is preserved)
-        await expect(modals.appLock().appLockModal).toBeVisible();
+        await expect(modals.appLock().appLockModal).toBeVisible({timeout: LOGIN_TIMEOUT});
         await expect(modals.appLock().lockPasscodeInput).toBeVisible();
 
         await expect.poll(() => page.evaluate(() => indexedDB.databases())).not.toHaveLength(0);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- The login can take up to 40s so the timeout after a manual login needs to be increased to stabilize the test

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
