### PR TITLE
test: increase timeout for TC-2752 [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -70,7 +70,10 @@ test.describe('AppLock', () => {
     ).forEach(({title, tag}) => {
       const shouldLock = tag === '@TC-2752';
 
-      test(title, {tag: [tag, '@regression']}, async ({createPage}) => {
+      test(title, {tag: [tag, '@regression']}, async ({createPage}, testInfo) => {
+        // Increase test timeout by 61s in case it needs to wait for the app to lock
+        if (shouldLock) test.setTimeout(testInfo.timeout + 61_000);
+
         const page = await createPage(withLogin(memberA));
         const pageManager = PageManager.from(page);
         await handleAppLockState(pageManager, appLockPassCode);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

The test waits 60s for the app lock modal to appear, this narrows the time left for the test itself to only 30s which is not enough in case the login takes a bit longer.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
