### PR TITLE
Isolate unit tests from network [WPB-22420]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: yarn nx run-many -t lint --all
 
       - name: Test
-        run: yarn nx run-many -t test --all --configuration=ci --detectOpenHandles=false
+        run: ./bin/run-with-network-isolation.sh yarn nx run-many -t test --all --configuration=ci --detectOpenHandles=false
 
       - name: Upload webapp coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/bin/run-with-network-isolation.sh
+++ b/bin/run-with-network-isolation.sh
@@ -21,6 +21,14 @@ original_home="${HOME}"
 original_path="${PATH}"
 
 if unshare --map-root-user -n true >/dev/null 2>&1; then
+  if command -v ip >/dev/null 2>&1; then
+    exec unshare --map-root-user -n bash -c '
+      set -euo pipefail
+      ip link set lo up
+      exec "$@"
+    ' bash "$@"
+  fi
+
   exec unshare --map-root-user -n "$@"
 fi
 
@@ -31,6 +39,14 @@ fi
 if command -v sudo >/dev/null 2>&1; then
   if sudo unshare -n true >/dev/null 2>&1; then
     if command -v runuser >/dev/null 2>&1; then
+      if command -v ip >/dev/null 2>&1; then
+        exec sudo unshare -n bash -c '
+          set -euo pipefail
+          ip link set lo up
+          exec runuser -u "$1" -- env HOME="$2" PATH="$3" "${@:4}"
+        ' bash "${original_user}" "${original_home}" "${original_path}" "$@"
+      fi
+
       exec sudo unshare -n runuser -u "${original_user}" -- env HOME="${original_home}" PATH="${original_path}" "$@"
     fi
 

--- a/bin/run-with-network-isolation.sh
+++ b/bin/run-with-network-isolation.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 <command> [arguments...]" >&2
+  exit 1
+fi
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  exec "$@"
+fi
+
+if ! command -v unshare >/dev/null 2>&1; then
+  echo "The 'unshare' command is required on Linux to isolate network access during tests." >&2
+  exit 1
+fi
+
+original_user="$(id -un)"
+original_home="${HOME}"
+original_path="${PATH}"
+
+if unshare --map-root-user -n true >/dev/null 2>&1; then
+  exec unshare --map-root-user -n "$@"
+fi
+
+if unshare -n true >/dev/null 2>&1; then
+  exec unshare -n "$@"
+fi
+
+if command -v sudo >/dev/null 2>&1; then
+  if sudo unshare -n true >/dev/null 2>&1; then
+    if command -v runuser >/dev/null 2>&1; then
+      exec sudo unshare -n runuser -u "${original_user}" -- env HOME="${original_home}" PATH="${original_path}" "$@"
+    fi
+
+    echo "The 'runuser' command is required for the privileged unshare fallback on this Linux runner." >&2
+    exit 1
+  fi
+fi
+
+echo "Unable to create a network-isolated namespace with unshare on this Linux runner." >&2
+exit 1


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Ensure no unit test can make network requests in continuous integration

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
