### PR TITLE
fix: add aria-label for restore button [WPB-22743]

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -322,6 +322,7 @@
   "backupImportPasswordErrorSecondary": "Please verify your input and try again",
   "backupImportProgressHeadline": "Preparing…",
   "backupImportProgressSecondary": "Restoring history · {processed} of {total} — {progress}%",
+  "backupImportRestoreHistory": "Restore history",
   "backupImportSuccessHeadline": "History restored.",
   "backupImportVersionErrorHeadline": "Incompatible backup",
   "backupImportVersionErrorSecondary": "This backup was created by a newer or outdated version of {brandName} and cannot be restored here.",

--- a/apps/webapp/src/script/components/HistoryImport/BackupFileUpload.tsx
+++ b/apps/webapp/src/script/components/HistoryImport/BackupFileUpload.tsx
@@ -23,6 +23,7 @@ import {TabIndex, Button, ButtonVariant} from '@wireapp/react-ui-kit';
 
 import {CONFIG as HistoryExportConfig} from 'Components/HistoryExport';
 import {handleKeyDown, KEY} from 'Util/keyboardUtil';
+import {t} from 'Util/localizerUtil';
 
 interface BackupFileUploadProps {
   onFileChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -84,7 +85,7 @@ const BackupFileUpload = ({
         tabIndex={TabIndex.FOCUSABLE}
         onKeyDown={event => handleKeyDown({event, callback: fileInputClick, keys: [KEY.ENTER, KEY.SPACE]})}
         onClick={() => fileInputRef.current?.click()}
-        aria-labelledby="do-backup-import"
+        aria-label={t('backupImportRestoreHistory')}
       >
         <span>{backupImportHeadLine}</span>
       </Button>

--- a/apps/webapp/src/types/i18n.d.ts
+++ b/apps/webapp/src/types/i18n.d.ts
@@ -326,6 +326,7 @@ declare module 'I18n/en-US.json' {
     'backupImportPasswordErrorSecondary': `Please verify your input and try again`;
     'backupImportProgressHeadline': `Preparing…`;
     'backupImportProgressSecondary': `Restoring history · {processed} of {total} — {progress}%`;
+    'backupImportRestoreHistory': `Restore history`;
     'backupImportSuccessHeadline': `History restored.`;
     'backupImportVersionErrorHeadline': `Incompatible backup`;
     'backupImportVersionErrorSecondary': `This backup was created by a newer or outdated version of {brandName} and cannot be restored here.`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22743" title="WPB-22743" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22743</a>  [Web] The visible name of the backup restore button is not part of the accessible name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Add aria-label for restore backup button.

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-webapp/blob/dev/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-webapp/blob/dev/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
