### PR TITLE
test: improve reliability of history backup test [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -357,6 +357,9 @@ test.describe('History Backup', () => {
         await userAPages.conversationDetails().deleteGroupButton.click();
         await expect(userAModals.confirm().modalTitle).toContainText('Delete group conversation?');
         await userAModals.confirm().clickAction();
+
+        // Verify conversation is gone before creating backup
+        await expect(userAPages.conversationList().getConversation(conversationName)).not.toBeVisible();
       });
 
       await test.step('User A creates History Backup', async () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If the deletion of the group conversation in TC-1097 took too long it could happen that it was still included within the created backup.

### Solutions

This PR waits for the conversation to be no longer visible before creating the backup to make it more reliable.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
