### PR TITLE
ci: add dynamic sharding for E2E tests [WPB-24724]

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -122,6 +122,7 @@ jobs:
           NUMBER_OF_SHARDS=$(( $NUMBER_OF_TESTS > 64 ? 64 : $NUMBER_OF_TESTS )) # Limit the number of shards to 64
           MATRIX_SHARDS=$(jq -nc --argjson len "$NUMBER_OF_SHARDS" '[range(1; $len + 1)]')
           echo "matrixShards=$MATRIX_SHARDS" >> $GITHUB_OUTPUT
+          echo "$NUMBER_OF_TESTS tests will be run across $NUMBER_OF_SHARDS shards"
 
   test:
     name: Run E2E Tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -96,11 +96,38 @@ jobs:
           TEST_SERVICE_URL: http://localhost:8080
         run: yarn playwright test -c apps/webapp/playwright.config.ts apps/webapp/test/e2e_tests/specs/CriticalFlow/startupHasNoConsoleErrors.spec.ts
 
+  # Since not always all e2e tests are run the number of shards to start up is computed dynamically from the amount of tests which will run
+  compute_shards:
+    name: Compute number of shards to use
+    runs-on: ubuntu-24.04
+
+    outputs:
+      matrixShards: ${{ steps.computeShards.outputs.matrixShards }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - run: yarn --immutable
+
+      - name: Compute shards
+        id: computeShards
+        env:
+          GREP: ${{ inputs.grep }}
+        run: |
+          NUMBER_OF_TESTS=$(yarn nx run webapp:e2e --list --grep=\"$GREP\" | grep 'Total:' | awk '{print $2}')
+          NUMBER_OF_SHARDS=$(( $NUMBER_OF_TESTS > 64 ? 64 : $NUMBER_OF_TESTS )) # Limit the number of shards to 64
+          MATRIX_SHARDS=$(jq -nc --argjson len "$NUMBER_OF_SHARDS" '[range(1; $len + 1)]')
+          echo "matrixShards=$MATRIX_SHARDS" >> $GITHUB_OUTPUT
+
   test:
     name: Run E2E Tests
     runs-on: ubuntu-24.04
     timeout-minutes: 45
-    needs: [bootstrap_smoke_test]
+    needs: [bootstrap_smoke_test, compute_shards]
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-noble
       options: --ipc=host
@@ -108,8 +135,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # prettier-ignore
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64]
+        shard: ${{ needs.compute_shards.outputs.matrixShards }}
 
     services:
       # Run the kalium testservice as service container of the current job

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -135,7 +135,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ needs.compute_shards.outputs.matrixShards }}
+        shard: ${{ fromJSON(needs.compute_shards.outputs.matrixShards) }}
 
     services:
       # Run the kalium testservice as service container of the current job


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24724" title="WPB-24724" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24724</a>  [Web][QA] Investigate sharding for E2E tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
We don't want to always spin up 64 shards to run e2e tests. This PR makes the number of shards dynamic to only use as many shards as there are tests with a limit of up to 64 shards.