### PR TITLE
test: add test for terms of use before registration [WPB-24831]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Registration/registration.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Registration/registration.spec.ts
@@ -33,6 +33,30 @@ test.describe('Registration', () => {
     });
 
     test(
+      'I want to be informed about terms of personal account before registration',
+      {tag: ['@TC-1621', '@regression']},
+      async ({pageManager}) => {
+        const newUser = getUser();
+        const unregisteredEmail = newUser.email;
+
+        await pageManager.openMainPage();
+        const {pages} = pageManager.webapp;
+
+        await goToPersonalRegistration(pageManager, unregisteredEmail);
+
+        await expect(pages.registration().termsLabel).toBeVisible();
+
+        const pagePromise = pageManager.page.context().waitForEvent('page');
+
+        await pages.registration().termsLabel.click();
+
+        const newTab = await pagePromise;
+        await newTab.waitForLoadState();
+        await expect(newTab).toHaveURL(/legal#terms/);
+      },
+    );
+
+    test(
       'I want to be notified if the email address I entered during registration has already been registered',
       {tag: ['@TC-1623', '@TC-1640', '@regression']},
       async ({pageManager}) => {

--- a/apps/webapp/test/e2e_tests/specs/Registration/registration.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Registration/registration.spec.ts
@@ -46,12 +46,11 @@ test.describe('Registration', () => {
 
         await expect(pages.registration().termsLabel).toBeVisible();
 
-        const pagePromise = pageManager.page.context().waitForEvent('page');
+        const [newTab] = await Promise.all([
+          pageManager.page.waitForEvent('popup'),
+          pages.registration().termsLabel.click(),
+        ]);
 
-        await pages.registration().termsLabel.click();
-
-        const newTab = await pagePromise;
-        await newTab.waitForLoadState();
         await expect(newTab).toHaveURL(/legal#terms/);
       },
     );


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24831" title="WPB-24831" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24831</a>  [Web][QA] Write missing test in Regression -> Registration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->



#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The regression test suite was missing a test for the registration flow, specifically for TC-1621: I want to be informed about terms of personal account before registration.

### Solutions

This PR implements the missing automated test for `TC-1621`.

It ensures users are properly informed about the terms of use when creating a personal account via the SSO login flow. The implemented scenario verifies:
- Entering an unregistered email on the SSO sign-in page and navigating to the personal account registration page.
- The visibility of the Terms of Use link.
- Opening the link and validating the correct routing to the `/legal#terms` URL in a new tab.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.



