### PR TITLE
fix(webapp): skip MLS init join for past-member conversations [WPB-25087]

### DIFF
--- a/apps/webapp/src/script/mls/MLSConversations.test.ts
+++ b/apps/webapp/src/script/mls/MLSConversations.test.ts
@@ -25,6 +25,7 @@ import {randomUUID} from 'crypto';
 import {Account} from '@wireapp/core';
 
 import {MLSConversation} from 'Repositories/conversation/ConversationSelectors';
+import {ConversationStatus} from 'Repositories/conversation/ConversationStatus';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {Core} from 'src/script/service/CoreSingleton';
@@ -70,6 +71,21 @@ describe('MLSConversations', () => {
       for (const conversation of mlsConversations) {
         expect(joinSpy).toHaveBeenCalledWith(conversation.qualifiedId);
       }
+    });
+
+    it('does not join MLS groups for past member conversations', async () => {
+      const mlsConversation = createMLSConversation(CONVERSATION_TYPE.REGULAR, 1);
+      mlsConversation.status(ConversationStatus.PAST_MEMBER);
+
+      const conversationRepository = await testFactory.exposeConversationActors();
+      const repositoryCore = (conversationRepository as any).core as Core;
+
+      jest.spyOn(repositoryCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
+      const joinSpy = jest.spyOn(repositoryCore.service!.conversation, 'joinByExternalCommit');
+
+      await initMLSGroupConversations([mlsConversation], conversationRepository, {core: repositoryCore});
+
+      expect(joinSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/webapp/src/script/mls/MLSConversations.ts
+++ b/apps/webapp/src/script/mls/MLSConversations.ts
@@ -60,7 +60,7 @@ export async function initMLSGroupConversations(
 
   const mlsGroupConversations = conversations.filter(
     (conversation): conversation is MLSCapableConversation =>
-      conversation.isGroupOrChannel() && isMLSCapableConversation(conversation),
+      conversation.isGroupOrChannel() && isMLSCapableConversation(conversation) && !conversation.isSelfUserRemoved(),
   );
 
   for (const mlsConversation of mlsGroupConversations) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25087" title="WPB-25087" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25087</a>  [Web] Skip MLS external-commit init for PAST_MEMBER conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Avoids attempting external-commit joins for conversations the user has already left (PAST_MEMBER) during app initialization.

- Filters out past-member conversations at the MLS init flow entry (initMLSGroupConversations), so they never enter the join path.
- Adds a regression test to verify left conversations do not trigger joinByExternalCommit.
- Prevents noisy 404 /groupinfo errors caused by stale local conversations on older clients.


