### PR TITLE
feat: archive collaboraNewDocumentCreationMenuFeatureToggleName ff [WPB-25086]

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsNewMenu/CellsNewMenu.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsNewMenu/CellsNewMenu.tsx
@@ -24,8 +24,6 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {Button, ButtonVariant, DropdownMenu, PlusIcon} from '@wireapp/react-ui-kit';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
-import {collaboraNewDocumentCreationMenuFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
-import {useApplicationContext} from 'src/script/page/RootProvider';
 import {t} from 'Util/localizerUtil';
 
 import {CellsNewFileModal} from './CellsNewFileModal/CellsNewFileModal';
@@ -43,13 +41,9 @@ interface CellsNewMenuProps {
 export type CellsNewFileType = 'document' | 'spreadsheet' | 'presentation';
 
 export const CellsNewMenu = ({cellsRepository, conversationQualifiedId, onRefresh}: CellsNewMenuProps) => {
-  const {isFeatureToggleEnabled} = useApplicationContext();
   const [isFolderModalOpen, setIsFolderModalOpen] = useState(false);
   const [isFileModalOpen, setIsFileModalOpen] = useState(false);
   const [fileType, setFileType] = useState<CellsNewFileType>('document');
-  const isCollaboraNewDocumentCreationMenuEnabled = isFeatureToggleEnabled(
-    collaboraNewDocumentCreationMenuFeatureToggleName,
-  );
 
   const openFolderModal = () => setIsFolderModalOpen(true);
 
@@ -75,22 +69,20 @@ export const CellsNewMenu = ({cellsRepository, conversationQualifiedId, onRefres
         </DropdownMenu.Trigger>
         <DropdownMenu.Content>
           <DropdownMenu.Item onClick={openFolderModal}>{t('cells.newItemMenu.folder')}</DropdownMenu.Item>
-          {isCollaboraNewDocumentCreationMenuEnabled && (
-            <DropdownMenu.Sub>
-              <DropdownMenu.SubTrigger>{t('cells.newItemMenu.file')}</DropdownMenu.SubTrigger>
-              <DropdownMenu.SubContent>
-                <DropdownMenu.Item onClick={() => openFileModal('document')}>
-                  {t('cells.newItemMenu.document')}
-                </DropdownMenu.Item>
-                <DropdownMenu.Item onClick={() => openFileModal('spreadsheet')}>
-                  {t('cells.newItemMenu.spreadsheet')}
-                </DropdownMenu.Item>
-                <DropdownMenu.Item onClick={() => openFileModal('presentation')}>
-                  {t('cells.newItemMenu.presentation')}
-                </DropdownMenu.Item>
-              </DropdownMenu.SubContent>
-            </DropdownMenu.Sub>
-          )}
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger>{t('cells.newItemMenu.file')}</DropdownMenu.SubTrigger>
+            <DropdownMenu.SubContent>
+              <DropdownMenu.Item onClick={() => openFileModal('document')}>
+                {t('cells.newItemMenu.document')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onClick={() => openFileModal('spreadsheet')}>
+                {t('cells.newItemMenu.spreadsheet')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onClick={() => openFileModal('presentation')}>
+                {t('cells.newItemMenu.presentation')}
+              </DropdownMenu.Item>
+            </DropdownMenu.SubContent>
+          </DropdownMenu.Sub>
         </DropdownMenu.Content>
       </DropdownMenu>
       <CellsNewFolderModal
@@ -102,18 +94,16 @@ export const CellsNewMenu = ({cellsRepository, conversationQualifiedId, onRefres
           setIsFolderModalOpen(false);
         }}
       />
-      {isCollaboraNewDocumentCreationMenuEnabled && (
-        <CellsNewFileModal
-          {...commonProps}
-          isOpen={isFileModalOpen}
-          fileType={fileType}
-          onClose={() => setIsFileModalOpen(false)}
-          onSuccess={() => {
-            onRefresh();
-            setIsFileModalOpen(false);
-          }}
-        />
-      )}
+      <CellsNewFileModal
+        {...commonProps}
+        isOpen={isFileModalOpen}
+        fileType={fileType}
+        onClose={() => setIsFileModalOpen(false)}
+        onSuccess={() => {
+          onRefresh();
+          setIsFileModalOpen(false);
+        }}
+      />
     </>
   );
 };

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -18,12 +18,10 @@
  */
 
 export const reliableWebsocketConnectionFeatureToggleName = 'reliable-websocket-connection';
-export const collaboraNewDocumentCreationMenuFeatureToggleName = 'collabora-new-document-creation-menu';
 export const applockRefactoredFeatureToggleName = 'applock-refactored';
 
 export const startupFeatureToggleNames = [
   reliableWebsocketConnectionFeatureToggleName,
-  collaboraNewDocumentCreationMenuFeatureToggleName,
   applockRefactoredFeatureToggleName,
 ] as const;
 

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -24,14 +24,12 @@ import {
 } from './startupFeatureToggles';
 import {
   applockRefactoredFeatureToggleName,
-  collaboraNewDocumentCreationMenuFeatureToggleName,
   reliableWebsocketConnectionFeatureToggleName,
   startupFeatureToggleNames,
 } from './startupFeatureToggleNames';
 
 const featureToggleNamesWithDedicatedExistenceTests = [
   reliableWebsocketConnectionFeatureToggleName,
-  collaboraNewDocumentCreationMenuFeatureToggleName,
   applockRefactoredFeatureToggleName,
 ] as const;
 
@@ -66,14 +64,6 @@ describe('startupFeatureToggles', function () {
     );
 
     expect(startupFeatureToggles.getEnabledFeatureToggleNames()).toEqual([]);
-  });
-
-  it('enables the collabora new document creation feature toggle when present in the query parameter', () => {
-    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=${collaboraNewDocumentCreationMenuFeatureToggleName}`,
-    );
-
-    expect(startupFeatureToggles.isFeatureToggleEnabled(collaboraNewDocumentCreationMenuFeatureToggleName)).toBe(true);
   });
 
   it('keeps only whitelisted feature toggles when known and unknown values are mixed', () => {
@@ -136,7 +126,6 @@ describe('startupFeatureToggles', function () {
   it('contains only whitelisted values in allowedStartupFeatureToggleNames', () => {
     expect(allowedStartupFeatureToggleNames).toEqual([
       reliableWebsocketConnectionFeatureToggleName,
-      collaboraNewDocumentCreationMenuFeatureToggleName,
       applockRefactoredFeatureToggleName,
     ]);
   });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25086" title="WPB-25086" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25086</a>  [Web] Archive isCollaboraNewDocumentCreationMenuEnabled feature flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This pull request removes the feature toggle for the "Collabora new document creation menu" from the codebase. The code related to this feature toggle has been deleted from both the implementation and the tests, resulting in the menu and modal for new document creation always being available (rather than being gated by the toggle). No other feature toggles are affected.

Feature toggle removal:

* Removed all references to `collaboraNewDocumentCreationMenuFeatureToggleName` from the codebase, including its definition in `startupFeatureToggleNames.ts`, its usage in `CellsNewMenu.tsx`, and all related test cases and imports in `startupFeatureToggles.test.ts`. 

UI behavior update:

* The "new document" menu and modal in `CellsNewMenu.tsx` are now always shown, simplifying the code and removing the need to check if the feature toggle is enabled.

