### PR TITLE
ci: use manual testrun import instead of testiny "automation" [WPB-24713]

### DIFF
--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -1,6 +1,7 @@
 name: E2E Tests Nightly
 
 on:
+  workflow_dispatch:
   schedule:
     # we want to run this nightly on dev
     - cron: '0 02 * * 1-5'

--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -52,7 +52,7 @@ jobs:
             Build URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           node ./apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts \
-          --runName="Regression $(date +'%m/%d/%Y')" \
+          --runName="Regression $(date +'%m/%d/%Y - %H:%M')" \
           --testPlan="$TESTINY_TEST_PLAN_ID" \
           --description="$DESCRIPTION" \
           --reportPath="./apps/webapp/playwright-report/report.json"

--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -51,4 +51,4 @@ jobs:
           jq 'walk(if type == "object" and .title and .tags then .title += ([.tags[]? | select(startswith("TC-")) | " @" + .] | join("")) else . end)' ./apps/webapp/playwright-report/report.json > ./apps/webapp/playwright-report/report-with-ids.json
 
           CURRENT_DATE=$(date +'%m/%d/%Y')
-          yarn dlx @testiny/cli testrun --project WEB --name "Regression $CURRENT_DATE" --testcases ignore --close --playwright ./apps/webapp/playwright-report/report-with-ids.json
+          yarn dlx @testiny/cli testrun -y --project WEB --name "Regression $CURRENT_DATE" --testcases ignore --close --playwright ./apps/webapp/playwright-report/report-with-ids.json

--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -47,4 +47,8 @@ jobs:
         env:
           TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
         run: |
-          yarn dlx @testiny/cli automation --project WEB --source "github" --playwright ./apps/webapp/playwright-report/report.json
+          # Create a modified version of the playwright json report where the test-ids e.g. @TC-1234 are appended to the test title so Testiny can pick them up
+          jq 'walk(if type == "object" and .title and .tags then .title += ([.tags[]? | select(startswith("TC-")) | " @" + .] | join("")) else . end)' ./apps/webapp/playwright-report/report.json > ./apps/webapp/playwright-report/report-with-ids.json
+
+          CURRENT_DATE=$(date +'%m/%d/%Y')
+          yarn dlx @testiny/cli testrun --project WEB --name "Regression $CURRENT_DATE" --testcases ignore --close --playwright ./apps/webapp/playwright-report/report-with-ids.json

--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -53,6 +53,6 @@ jobs:
         run: |
           node ./apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts \
           --runName="Regression $(date +'%m/%d/%Y - %H:%M')" \
-          --testPlan="$TESTINY_TEST_PLAN_ID" \
+          --testPlanId="$TESTINY_TEST_PLAN_ID" \
           --description="$DESCRIPTION" \
           --reportPath="./apps/webapp/playwright-report/report.json"

--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -47,10 +47,12 @@ jobs:
       - name: Upload report to Testiny
         env:
           TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
+          TESTINY_TEST_PLAN_ID: 105 # 105 is the id of the "Regression" test plan within Testiny
           DESCRIPTION: |
             Build URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           node ./apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts \
           --runName="Regression $(date +'%m/%d/%Y')" \
+          --testPlan="$TESTINY_TEST_PLAN_ID" \
           --description="$DESCRIPTION" \
           --reportPath="./apps/webapp/playwright-report/report.json"

--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -47,8 +47,10 @@ jobs:
       - name: Upload report to Testiny
         env:
           TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
+          DESCRIPTION: |
+            Build URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           node ./apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts \
           --runName="Regression $(date +'%m/%d/%Y')" \
-          --buildURL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          --description="$DESCRIPTION" \
           --reportPath="./apps/webapp/playwright-report/report.json"

--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -43,12 +43,11 @@ jobs:
           artifact-ids: ${{ needs.e2e_tests.outputs.reportArtifactId }}
           path: apps/webapp/playwright-report
 
-      - name: Run Testiny CLI
+      - name: Upload report to Testiny
         env:
           TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
         run: |
-          # Create a modified version of the playwright json report where the test-ids e.g. @TC-1234 are appended to the test title so Testiny can pick them up
-          jq 'walk(if type == "object" and .title and .tags then .title += ([.tags[]? | select(startswith("TC-")) | " @" + .] | join("")) else . end)' ./apps/webapp/playwright-report/report.json > ./apps/webapp/playwright-report/report-with-ids.json
-
-          CURRENT_DATE=$(date +'%m/%d/%Y')
-          yarn dlx @testiny/cli testrun -y --project WEB --name "Regression $CURRENT_DATE" --testcases ignore --close --playwright ./apps/webapp/playwright-report/report-with-ids.json
+          node ./apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts \
+          --runName="Regression $(date +'%m/%d/%Y')" \
+          --buildURL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          --reportPath="./apps/webapp/playwright-report/report.json"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -221,43 +221,14 @@ jobs:
           pattern: blob-report-*
           merge-multiple: true
 
-      - name: Check for blob reports
-        id: check_blob_reports
-        run: |
-          if [ -d "${{ env.PLAYWRIGHT_REPORT_PATH }}/blob-reports" ]; then
-            echo "has_blob_reports=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_blob_reports=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      # Merge reports and delete blob reports and zip archives for traces, only keep resources to include within the artifact
       - name: Merge playwright reports
-        if: ${{ steps.check_blob_reports.outputs.has_blob_reports == 'true' }}
         working-directory: apps/webapp
         run: |
           yarn playwright merge-reports --config ./playwright.config.ts playwright-report/blob-reports
           rm -rf playwright-report/blob-reports
 
-      - name: Delete trace artifacts
-        if: ${{ !inputs.keep_traces && steps.check_blob_reports.outputs.has_blob_reports == 'true' }}
-        working-directory: apps/webapp
-        run: |
-          if [ -d "playwright-report/html/data" ]; then
-            DELETED_COUNT=$(find playwright-report/html/data -name "*.zip" -type f -delete -print)
-            echo "Deleted $DELETED_COUNT trace archive files"
-          else
-            echo "Trace data directory not found, skipping trace cleanup"
-          fi
-
-      - name: Delete blob report artifacts
-        if: ${{ always() && steps.check_blob_reports.outputs.has_blob_reports == 'true' }}
-        uses: geekyeggo/delete-artifact@d79b2442431e4adbc383d29a28e630374eceb303
-        with:
-          name: blob-report-*
-
       - name: Upload test report
         id: upload_playwright_report
-        if: ${{ steps.check_blob_reports.outputs.has_blob_reports == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: playwright-report
@@ -271,7 +242,6 @@ jobs:
 
       - name: Extract test results
         id: test-results
-        if: ${{ steps.check_blob_reports.outputs.has_blob_reports == 'true' }}
         run: |
           REPORT="${{ env.PLAYWRIGHT_REPORT_PATH }}/report.json"
           if [ ! -f "$REPORT" ]; then

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -316,7 +316,7 @@ jobs:
             }
 
       - name: Update Testiny Run with results
-        if: ${{ inputs.testinyRunName }}
+        if: ${{ success() && inputs.testinyRunName }}
         env:
           TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
           TESTINY_RUN_NAME: ${{ inputs.testinyRunName }}

--- a/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
+++ b/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
@@ -153,6 +153,7 @@ async function main() {
   const report: JSONReport = JSON.parse(fs.readFileSync(reportAbsPath, 'utf-8'));
   const testRun = await createTestRun(`
     <!--markdown-->
+    
     Build URL: [${args.buildURL}](${args.buildURL})
   `);
 

--- a/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
+++ b/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
@@ -30,6 +30,11 @@ const {values: args} = parseArgs({
       alias: 'name',
       description: 'Name of the test run',
     },
+    testPlanId: {
+      type: 'string',
+      alias: 'testPlan',
+      description: 'ID of the test plan this run should be associated with',
+    },
     description: {
       type: 'string',
       description: 'Description to add to the run, supports markdown',
@@ -49,7 +54,7 @@ const getTests = (suite: JSONReportSuite): (JSONReportTest & Pick<JSONReportSpec
 };
 
 type TestRun = {id: number};
-async function createTestRun(description?: string): Promise<TestRun> {
+async function createTestRun(options?: {testPlanId?: number; description?: string}): Promise<TestRun> {
   const res = await fetch('https://app.testiny.io/api/v1/testrun', {
     method: 'POST',
     headers: {
@@ -59,7 +64,8 @@ async function createTestRun(description?: string): Promise<TestRun> {
     body: JSON.stringify({
       title: args.runName,
       project_id: TESTINY_PROJECT_ID,
-      description: description,
+      testplan_id: options?.testPlanId,
+      description: options?.description,
     }),
   });
 
@@ -153,7 +159,10 @@ async function main() {
   }
 
   const report: JSONReport = JSON.parse(fs.readFileSync(reportAbsPath, 'utf-8'));
-  const testRun = await createTestRun(`<!--markdown-->\n${args.description}\n`);
+  const testRun = await createTestRun({
+    testPlanId: Number.isInteger(+args.testPlanId) ? +args.testPlanId : undefined,
+    description: `<!--markdown-->\n${args.description}\n`,
+  });
 
   try {
     const testResults = transformReportToTestinyMappings(report, testRun.id);

--- a/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
+++ b/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
@@ -30,9 +30,9 @@ const {values: args} = parseArgs({
       alias: 'name',
       description: 'Name of the test run',
     },
-    buildURL: {
+    description: {
       type: 'string',
-      description: 'URL linking to the current run in github, this will be added to the run description',
+      description: 'Description to add to the run, supports markdown',
     },
   },
 });
@@ -59,7 +59,7 @@ async function createTestRun(description?: string): Promise<TestRun> {
     body: JSON.stringify({
       title: args.runName,
       project_id: TESTINY_PROJECT_ID,
-      description: args.buildURL ? description : undefined,
+      description: description,
     }),
   });
 
@@ -153,11 +153,7 @@ async function main() {
   }
 
   const report: JSONReport = JSON.parse(fs.readFileSync(reportAbsPath, 'utf-8'));
-  const testRun = await createTestRun(`
-    <!--markdown-->
-    
-    Build URL: [${args.buildURL}](${args.buildURL})
-  `);
+  const testRun = await createTestRun(`<!--markdown-->\n${args.description}\n`);
 
   try {
     const testResults = transformReportToTestinyMappings(report, testRun.id);

--- a/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
+++ b/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
@@ -22,17 +22,14 @@ const {values: args} = parseArgs({
     },
     reportPath: {
       type: 'string',
-      alias: 'report',
       description: 'Path to the playright report in json format',
     },
     runName: {
       type: 'string',
-      alias: 'name',
       description: 'Name of the test run',
     },
     testPlanId: {
       type: 'string',
-      alias: 'testPlan',
       description: 'ID of the test plan this run should be associated with',
     },
     description: {

--- a/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
+++ b/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
@@ -52,18 +52,21 @@ const getTests = (suite: JSONReportSuite): (JSONReportTest & Pick<JSONReportSpec
 
 type TestRun = {id: number};
 async function createTestRun(options?: {testPlanId?: number; description?: string}): Promise<TestRun> {
+  const body = {
+    title: args.runName,
+    project_id: TESTINY_PROJECT_ID,
+    testplan_id: options?.testPlanId,
+    description: options?.description,
+  };
+  console.log(`Creating test run with title: ${body.title}`, body);
+
   const res = await fetch('https://app.testiny.io/api/v1/testrun', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${args.testinyApiKey}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      title: args.runName,
-      project_id: TESTINY_PROJECT_ID,
-      testplan_id: options?.testPlanId,
-      description: options?.description,
-    }),
+    body: JSON.stringify(body),
   });
 
   if (!res.ok) {
@@ -161,14 +164,18 @@ async function main() {
     testPlanId: Number.isInteger(+args.testPlanId) ? +args.testPlanId : undefined,
     description: `<!--markdown-->\n${args.description}\n`,
   });
+  console.log(`Created test run with id: ${testRun.id}`);
 
   try {
     const testResults = transformReportToTestinyMappings(report, testRun.id);
-    await addTestResultsToRun(testResults);
-    await closeTestRun(testRun);
 
+    await addTestResultsToRun(testResults);
+    console.log(`Added ${testResults.length} test results to test run`);
+
+    await closeTestRun(testRun);
     console.log('Successfully imported test results');
   } catch (e) {
+    console.error('Failed to add test results to run, deleting test run');
     // In case adding the results failed delete the whole test run
     await deleteTestRun(testRun.id);
     throw e;

--- a/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
+++ b/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
@@ -47,12 +47,7 @@ const getTests = (suite: JSONReportSuite): (JSONReportTest & Pick<JSONReportSpec
 };
 
 type TestRun = {id: number};
-async function createTestRun(): Promise<TestRun> {
-  const description = `
-      <!--markdown-->
-      Build URL: [${args.buildURL}](${args.buildURL})
-      `;
-
+async function createTestRun(description?: string): Promise<TestRun> {
   const res = await fetch('https://app.testiny.io/api/v1/testrun', {
     method: 'POST',
     headers: {
@@ -156,7 +151,10 @@ async function main() {
   }
 
   const report: JSONReport = JSON.parse(fs.readFileSync(reportAbsPath, 'utf-8'));
-  const testRun = await createTestRun();
+  const testRun = await createTestRun(`
+    <!--markdown-->
+    Build URL: [${args.buildURL}](${args.buildURL})
+  `);
 
   try {
     const testResults = transformReportToTestinyMappings(report, testRun.id);

--- a/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
+++ b/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
@@ -10,6 +10,8 @@ import {parseArgs} from 'node:util';
 import * as fs from 'node:fs';
 import type {JSONReport, JSONReportSpec, JSONReportSuite, JSONReportTest} from '@playwright/test/reporter';
 
+const TESTINY_PROJECT_ID = 3; // 3 is the id of the WEB project in Testiny
+
 const {values: args} = parseArgs({
   args: process.argv.slice(2),
   options: {
@@ -56,7 +58,7 @@ async function createTestRun(description?: string): Promise<TestRun> {
     },
     body: JSON.stringify({
       title: args.runName,
-      project_id: 3, // The Webapp project in testiny is id 3
+      project_id: TESTINY_PROJECT_ID,
       description: args.buildURL ? description : undefined,
     }),
   });

--- a/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
+++ b/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
@@ -1,0 +1,173 @@
+/**
+ * Script to upload report the result of a playwright test run to testiny.
+ * It will create a new test run, add the results of the given report.json and close the report automatically.
+ *
+ * This is used instead of the cli published by Testiny since the CLI is limited by features.
+ */
+
+import path from 'node:path';
+import {parseArgs} from 'node:util';
+import * as fs from 'node:fs';
+import type {JSONReport, JSONReportSpec, JSONReportSuite, JSONReportTest} from '@playwright/test/reporter';
+
+const {values: args} = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    testinyApiKey: {
+      type: 'string',
+      description: 'API key to connect to testiny',
+      default: process.env.TESTINY_API_KEY,
+    },
+    reportPath: {
+      type: 'string',
+      alias: 'report',
+      description: 'Path to the playright report in json format',
+    },
+    runName: {
+      type: 'string',
+      alias: 'name',
+      description: 'Name of the test run',
+    },
+    buildURL: {
+      type: 'string',
+      description: 'URL linking to the current run in github, this will be added to the run description',
+    },
+  },
+});
+
+if (!args.testinyApiKey) throw new Error('Missing required arg testinyApiKey');
+if (!args.reportPath) throw new Error('Missing required arg reportPath');
+if (!args.runName) throw new Error('Missing required arg runName');
+
+const getTests = (suite: JSONReportSuite): (JSONReportTest & Pick<JSONReportSpec, 'tags'>)[] => {
+  return [
+    ...(suite.specs.flatMap(spec => spec.tests.map(test => ({...test, tags: spec.tags}))) ?? []),
+    ...(suite.suites?.flatMap(suite => getTests(suite)) ?? []),
+  ];
+};
+
+type TestRun = {id: number};
+async function createTestRun(): Promise<TestRun> {
+  const description = `
+      <!--markdown-->
+      Build URL: [${args.buildURL}](${args.buildURL})
+      `;
+
+  const res = await fetch('https://app.testiny.io/api/v1/testrun', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${args.testinyApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      title: args.runName,
+      project_id: 3, // The Webapp project in testiny is id 3
+      description: args.buildURL ? description : undefined,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to create test run ${JSON.stringify(await res.json(), undefined, 2)}`);
+  }
+
+  return await res.json();
+}
+
+async function closeTestRun(testRun: TestRun) {
+  const res = await fetch(`https://app.testiny.io/api/v1/testrun/${testRun.id}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${args.testinyApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({...testRun, is_closed: true}),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to close test run ${JSON.stringify(await res.json(), undefined, 2)}`);
+  }
+}
+
+async function deleteTestRun(runId: number) {
+  const res = await fetch(`https://app.testiny.io/api/v1/testrun/${runId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${args.testinyApiKey}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Couldn't delete test run ${runId}`);
+  }
+}
+
+type TestinyTestCaseMapping = {
+  ids: {testcase_id: number; testrun_id: number};
+  mapped: {assigned_to: 'ANY'; result_status: 'NOTRUN' | 'PASSED' | 'FAILED' | 'BLOCKED' | 'SKIPPED'};
+};
+
+function transformReportToTestinyMappings(report: JSONReport, runId: number) {
+  return report.suites
+    .flatMap(suite => getTests(suite))
+    .reduce<TestinyTestCaseMapping[]>((acc, test) => {
+      const testIds = test.tags
+        .filter(tag => tag.startsWith('TC-'))
+        .map(tag => Number(tag.replace('TC-', '')))
+        .filter(Number.isInteger);
+
+      const resultMap: Record<JSONReportTest['status'], TestinyTestCaseMapping['mapped']['result_status']> = {
+        expected: 'PASSED',
+        unexpected: 'FAILED',
+        flaky: 'PASSED',
+        skipped: 'SKIPPED',
+      };
+
+      for (const testId of testIds) {
+        acc.push({
+          ids: {testrun_id: runId, testcase_id: testId},
+          mapped: {assigned_to: 'ANY', result_status: resultMap[test.status]},
+        });
+      }
+
+      return acc;
+    }, []);
+}
+
+async function addTestResultsToRun(testCaseMappings: TestinyTestCaseMapping[]) {
+  const res = await fetch('https://app.testiny.io/api/v1/testrun/mapping/bulk/testcase:testrun?op=add', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${args.testinyApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(testCaseMappings),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to add test results to test run ${JSON.stringify(await res.json(), undefined, 2)}`);
+  }
+}
+
+async function main() {
+  const reportAbsPath = path.resolve(args.reportPath);
+  if (!fs.existsSync(reportAbsPath)) {
+    throw new Error(`Report file not found: ${reportAbsPath}`);
+  }
+
+  const report: JSONReport = JSON.parse(fs.readFileSync(reportAbsPath, 'utf-8'));
+  const testRun = await createTestRun();
+
+  try {
+    const testResults = transformReportToTestinyMappings(report, testRun.id);
+    await addTestResultsToRun(testResults);
+    await closeTestRun(testRun);
+
+    console.log('Successfully imported test results');
+  } catch (e) {
+    // In case adding the results failed delete the whole test run
+    await deleteTestRun(testRun.id);
+    throw e;
+  }
+}
+main();

--- a/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
+++ b/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
@@ -111,6 +111,14 @@ type TestinyTestCaseMapping = {
 };
 
 function transformReportToTestinyMappings(report: JSONReport, runId: number) {
+  // Mapping from playwrights status to the result expected by Testiny
+  const resultMap: Record<JSONReportTest['status'], TestinyTestCaseMapping['mapped']['result_status']> = {
+    expected: 'PASSED',
+    unexpected: 'FAILED',
+    flaky: 'PASSED',
+    skipped: 'SKIPPED',
+  };
+
   return report.suites
     .flatMap(suite => getTests(suite))
     .reduce<TestinyTestCaseMapping[]>((acc, test) => {
@@ -118,13 +126,6 @@ function transformReportToTestinyMappings(report: JSONReport, runId: number) {
         .filter(tag => tag.startsWith('TC-'))
         .map(tag => Number(tag.replace('TC-', '')))
         .filter(Number.isInteger);
-
-      const resultMap: Record<JSONReportTest['status'], TestinyTestCaseMapping['mapped']['result_status']> = {
-        expected: 'PASSED',
-        unexpected: 'FAILED',
-        flaky: 'PASSED',
-        skipped: 'SKIPPED',
-      };
 
       for (const testId of testIds) {
         acc.push({

--- a/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AppLock/AppLock.spec.ts
@@ -211,7 +211,7 @@ test.describe('AppLock', () => {
       },
     );
 
-    test('I want to switch off app lock', {tag: ['@TC-2771', '@TC-2772', '@regression']}, async ({api, createPage}) => {
+    test('I want to switch off app lock', {tag: ['@TC-2771', '@regression']}, async ({api, createPage}) => {
       await api.brig.toggleAppLock(owner.teamId, 'enabled', false);
 
       const page = await createPage(withLogin(memberA));

--- a/apps/webapp/test/e2e_tests/specs/SendingAssets/sendingAssets.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SendingAssets/sendingAssets.spec.ts
@@ -177,11 +177,11 @@ test.describe('Sending Assets', () => {
 
   [
     {
-      tag: ['@TC-764', '@regression'],
+      tag: '@TC-764',
       conversationType: '1on1',
     } as const,
     {
-      tag: ['@TC-765', '@regression'],
+      tag: '@TC-765',
       conversationType: 'group',
     } as const,
   ].forEach(({tag, conversationType}) => {

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -71,19 +71,6 @@ export type Team = {
 export {expect} from '@playwright/test';
 
 export const test = baseTest.extend<Fixtures>({
-  // Temporary workaround to add the test id as annotation instead of tag so Testiny can pick it up
-  // The following test suites need to be updated to be individual tests: AppLock, Connections, RegisterSpecs
-  _beforeEach: [
-    async ({}, use, testInfo) => {
-      const testid = testInfo.tags.find(tag => tag.startsWith('@TC'));
-      if (testid && !testInfo.annotations.some(annotation => annotation.type === 'testid')) {
-        testInfo.annotations.push({type: 'testid', description: testid.slice(1)});
-      }
-
-      await use();
-    },
-    {auto: true},
-  ],
   api: async ({}, use) => {
     // Create a new instance of ApiManager for each test
     await use(new ApiManagerE2E());


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24713" title="WPB-24713" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24713</a>  [Web/QA] Report nightly e2e test runs to Testiny as manual test runs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Since the way Testiny handles "automated" test runs is way more limited than the manual import of test runs, we decided to for now import the test results as if they were manual ones instead of using the automations feature.

Sadly using the Testiny CLI directly wasn't possible since it didn't have all features needed and would e.g. interpret flaky tests as failed so I decided to take full control using a custom ts script and the Testiny API directly.