### PR TITLE
test: write missing History Backup test [WPB-24920]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -27,6 +27,8 @@ import {RequestResetPasswordPage} from '../../pageManager/webapp/pages/requestRe
 test.describe('History Backup', () => {
   let userA: User;
   let userB: User;
+  const conversationName = 'Test group';
+
   test.beforeEach(async ({createTeam, createUser}) => {
     userB = await createUser();
     const team = await createTeam('Test Team', {users: [userB]});
@@ -45,7 +47,6 @@ test.describe('History Backup', () => {
       const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages} = userBPageManager.webapp;
 
-      const conversationName = 'Test group';
       await createGroup(userAPages, conversationName, [userB]);
 
       const messageUserA = 'Message from User A';
@@ -168,7 +169,6 @@ test.describe('History Backup', () => {
       const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages} = userBPageManager.webapp;
 
-      const conversationName = 'Test group';
       await createGroup(userBPages, conversationName, [userA]);
 
       const messageUserA = 'Message from User A';
@@ -228,7 +228,6 @@ test.describe('History Backup', () => {
       const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages} = userBPageManager.webapp;
 
-      const conversationName = 'Test group';
       await createGroup(userAPages, conversationName, [userB]);
 
       const messageUserA = 'Message from User A';
@@ -343,7 +342,6 @@ test.describe('History Backup', () => {
       const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages} = userBPageManager.webapp;
 
-      const conversationName = 'Test group';
       await createGroup(userAPages, conversationName, [userB]);
 
       const messageUserA = 'Message from User A';
@@ -377,6 +375,57 @@ test.describe('History Backup', () => {
       await test.step('Validate deleted group conversation is no longer visible', async () => {
         await userAComponents.conversationSidebar().allConversationsButton.click();
         await expect(userAPages.conversationList().getConversationLocator(conversationName)).not.toBeVisible();
+      });
+    },
+  );
+
+  test(
+    'I shouldn`t be able to send messages in the group conversation that I previously left after backup',
+    {tag: ['@TC-10549', '@regression']},
+    async ({createPage}, testInfo) => {
+      const [userAPageManager, userBPageManager] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userB))),
+      ]);
+      const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
+      const {pages: userBPages} = userBPageManager.webapp;
+
+      await createGroup(userBPages, conversationName, [userA]);
+
+      await test.step('User A and User B write messages to each other', async () => {
+        await userAPages.conversationList().openConversation(conversationName);
+        await userAPages.conversation().sendMessage('Message from User A');
+        await userBPages.conversationList().openConversation(conversationName);
+        await userBPages.conversation().sendMessage('Message from User B');
+        await expect(userAPages.conversation().messageItems).toHaveCount(2);
+      });
+
+      await test.step('User A leaves the group', async () => {
+        await userAPages.conversation().toggleGroupInformation();
+        await userAPages.conversation().leaveConversation();
+        await userAModals.leaveConversation().clickConfirm();
+        await expect(userAPages.conversation().systemMessages.filter({hasText: 'You left'})).toBeVisible();
+      });
+
+      const backupName = await test.step('User A creates History Backup', async () => {
+        await userAComponents.conversationSidebar().clickPreferencesButton();
+        return await createAndSaveBackup(testInfo, userAPageManager);
+      });
+
+      await test.step('User A restores backup', async () => {
+        await logOutUser(userAPageManager, true);
+        await loginUser(userA, userAPageManager);
+
+        await userAPages.historyInfo().clickConfirmButton();
+        await userAComponents.conversationSidebar().clickPreferencesButton();
+        await userAPages.account().backupFileInput.setInputFiles(backupName);
+      });
+
+      await test.step('Validate user A cannot send messages in the left group', async () => {
+        await userAComponents.conversationSidebar().allConversationsButton.click();
+        await userAPages.conversationList().openConversation(conversationName);
+        await expect(userAPages.conversation().systemMessages.filter({hasText: 'You left'})).toBeVisible();
+        await expect(userAPages.conversation().messageInput).toBeHidden();
       });
     },
   );

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -19,7 +19,7 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin, withConnectedUser, LOGIN_TIMEOUT} from 'test/e2e_tests/test.fixtures';
 import {createAndSaveBackup, createGroup, loginUser, logOutUser} from 'test/e2e_tests/utils/userActions';
 import {generateSecurePassword, generateWireEmail} from '../../utils/userDataGenerator';
 import {RequestResetPasswordPage} from '../../pageManager/webapp/pages/requestResetPassword.page';
@@ -417,7 +417,7 @@ test.describe('History Backup', () => {
         await loginUser(userA, userAPageManager);
 
         await userAPages.historyInfo().clickConfirmButton();
-        await userAComponents.conversationSidebar().clickPreferencesButton();
+        await userAComponents.conversationSidebar().preferencesButton.click({timeout: LOGIN_TIMEOUT});
         await userAPages.account().backupFileInput.setInputFiles(backupName);
       });
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24920" title="WPB-24920" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24920</a>  [Web][QA] Write missing History Backup test
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Summary

This PR adds a new automated regression test to History Backup test suites to verify that a user remains restricted from sending messages in a group they have left, even after performing a History Backup and Restore.

Changes

Added test case TC-10549 to the regression suite.