### PR TITLE
test: Add missing regression test for editing replies [WPB-24828]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -62,6 +62,7 @@ export class ConversationPage {
   readonly mentionSuggestions: Locator;
   readonly invitePeopleButton: Locator;
   readonly guestsIndicator: Locator;
+  readonly replyQuoteBoxAboveMessageInputField: Locator;
 
   readonly getImageAltText = (user: User) => `Image from ${user.fullName}`;
 
@@ -110,6 +111,7 @@ export class ConversationPage {
     this.mentionSuggestions = page.getByRole('listbox').getByTestId('item-mention-suggestion');
     this.invitePeopleButton = page.getByRole('button', {name: 'Invite people'});
     this.guestsIndicator = page.getByTestId('status-indication-badge');
+    this.replyQuoteBoxAboveMessageInputField = page.getByTestId('input-bar-reply-box');
   }
 
   getImageLocator(user: User): Locator {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationList.page.ts
@@ -70,6 +70,7 @@ export class ConversationListPage {
       unreadIndicator: conversation.getByTitle('Unread message'),
       mutedIndicator: conversation.getByTitle('Muted conversation'),
       mentionIndicator: conversation.getByTitle('Unread mention'),
+      unreadReplyIndicator: conversation.getByTitle('Unread reply'),
       blockedIndicator: conversation.locator(`span[data-uie-name="status-label"] + span`),
       joinCallButton: conversation.getByRole('button', {name: 'Join'}),
 

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -355,8 +355,8 @@ test.describe('Reply', () => {
 
     await test.step('Prerequisites: Setup group and open conversations', async () => {
       await createGroup(userBPages, conversationName, [userA]);
-      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     });
 
     await test.step('User B sends a message to User A', async () => {
@@ -364,7 +364,7 @@ test.describe('Reply', () => {
     });
 
     await test.step('User B opens another conversation', async () => {
-      await userBPages.conversationList().openConversation(conversationName);
+      await userBPages.conversationList().getConversation(conversationName).open();
     });
 
     await test.step("User A replies to User B's message", async () => {
@@ -375,12 +375,12 @@ test.describe('Reply', () => {
 
       const unreadReplyIndicator = userBPages
         .conversationList()
-        .getConversationLocator(userA.fullName, {protocol: 'mls'}).unreadReplyIndicator;
+        .getConversation(userA.fullName, {protocol: 'mls'}).unreadReplyIndicator;
       await expect(unreadReplyIndicator).toBeVisible();
     });
 
     await test.step('User A edits the reply message', async () => {
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       const replyMessage = userAPages.conversation().getMessage({content: 'Reply'});
       await expect(userBPages.conversation().getMessage({content: 'Reply', sender: userA})).toBeVisible();
       await userAPages.conversation().editMessage(replyMessage);

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -341,4 +341,95 @@ test.describe('Reply', () => {
       await expect(pages.conversationDetails().conversationDetails).toBeVisible();
     },
   );
+
+  test('I want to edit my reply', {tag: ['@TC-3019', '@regression']}, async ({createPage}) => {
+    const [userAPageManager, userBPages] = await Promise.all([
+      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+    ]);
+
+    const {pages: userAPages} = userAPageManager.webapp;
+    const conversationName = 'Group Conversation';
+
+    await test.step('Prerequisites: Setup group and open conversations', async () => {
+      await createGroup(userBPages, conversationName, [userA]);
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+    });
+
+    await test.step('User B sends a message to User A', async () => {
+      await userBPages.conversation().sendMessage('Original Message');
+    });
+
+    await test.step('User B opens another conversation', async () => {
+      await userBPages.conversationList().openConversation(conversationName);
+    });
+
+    await test.step("User A replies to User B's message", async () => {
+      const messageToReplyTo = userAPages.conversation().getMessage({content: 'Original Message'});
+      await userAPages.conversation().replyToMessage(messageToReplyTo);
+      await userAPages.conversation().sendMessage('Reply');
+
+      const unreadReplyIndicator = userBPages
+        .conversationList()
+        .getConversationLocator(userA.fullName, {protocol: 'mls'}).unreadReplyIndicator;
+      await expect(unreadReplyIndicator).toBeVisible();
+    });
+
+    await test.step('User A edits the reply message', async () => {
+      const replyMessage = userAPages.conversation().getMessage({content: 'Reply'});
+      await userAPages.conversation().editMessage(replyMessage);
+      await expect(userAPages.conversation().replyQuoteBoxAboveMessageInputField).not.toBeVisible();
+      await userAPages.conversation().sendMessage('Edited Message');
+    });
+
+    await test.step('User B edits original message', async () => {
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+      const originalMessage = userBPages.conversation().getMessage({content: 'Original Message', sender: userB});
+      await userBPages.conversation().editMessage(originalMessage);
+      await userBPages.conversation().sendMessage('Edited Original Message');
+
+      // Check that quote in reply by User A is reflecting the changes to original message
+      const replyFromUserA = userBPages.conversation().getMessage({content: 'Edited Message', sender: userA});
+      await expect(replyFromUserA.getByTestId('quote-item')).toContainText('Edited Original Message');
+    });
+
+    const originalLink = 'www.lidl.de';
+
+    await test.step('User B sends another message with text and url', async () => {
+      await userBPages.conversation().sendMessage(`Here is a great link: ${originalLink}`);
+    });
+
+    await test.step('User A replies to the new message', async () => {
+      const linkMessageFromUserB = userAPages
+        .conversation()
+        .getMessage({content: `Here is a great link: ${originalLink}`});
+      await userAPages.conversation().replyToMessage(linkMessageFromUserB);
+      await userAPages.conversation().sendMessage('Reply to the link message');
+    });
+
+    await test.step('User B edits the url in the original message', async () => {
+      const linkMessage = userBPages.conversation().getMessage({content: `Here is a great link: ${originalLink}`});
+      await userBPages.conversation().editMessage(linkMessage);
+      await userBPages.conversation().sendMessage('Here is another great link: www.kaufland.de');
+
+      const linkFromUserB = userAPages
+        .conversation()
+        .getMessage({content: 'Here is another great link: www.kaufland.de', sender: userB});
+      await expect(linkFromUserB).toBeVisible();
+    });
+
+    await test.step('User A clicks on the url in the quotes message', async () => {
+      const replyMessageToLink = userAPages
+        .conversation()
+        .getMessage({content: 'Reply to the link message', sender: userA});
+
+      const [newTab] = await Promise.all([
+        userAPageManager.page.waitForEvent('popup'),
+        replyMessageToLink.getByTestId('quote-item').getByRole('link').click(),
+      ]);
+
+      await expect(newTab).toHaveURL(/www.kaufland.de/);
+    });
+  });
 });

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -402,8 +402,6 @@ test.describe('Reply', () => {
 
       // Check that quote in reply by User A is reflecting the changes to original message
       const replyFromUserA = userBPages.conversation().getMessage({content: 'Edited Reply', sender: userA});
-      // Wait for the transient "deleted" placeholder to disappear to prevent flakiness during the edit sync
-      await expect(replyFromUserA.getByTestId('quote-item')).not.toContainText('You cannot see this message');
       await expect(replyFromUserA.getByTestId('quote-item')).toContainText('Guava');
     });
 

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -435,7 +435,6 @@ test.describe('Reply', () => {
       const replyMessageToLink = userAPages
         .conversation()
         .getMessage({content: 'Reply to the link message', sender: userA});
-      await expect(replyMessageToLink.getByTestId('quote-item')).not.toContainText('You cannot see this message');
 
       const [newTab] = await Promise.all([
         userAPageManager.page.waitForEvent('popup'),

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -342,7 +342,8 @@ test.describe('Reply', () => {
     },
   );
 
-  test('I want to edit my reply', {tag: ['@TC-3019', '@regression']}, async ({createPage}) => {
+  // TODO: flaky due to Bug-Ticket [WPB-25411]
+  test.skip('I want to edit my reply', {tag: ['@TC-3019', '@regression']}, async ({createPage}) => {
     const [userAPageManager, userBPageManager] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
       PageManager.from(createPage(withLogin(userB))),

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -343,12 +343,14 @@ test.describe('Reply', () => {
   );
 
   test('I want to edit my reply', {tag: ['@TC-3019', '@regression']}, async ({createPage}) => {
-    const [userAPageManager, userBPages] = await Promise.all([
+    const [userAPageManager, userBPageManager] = await Promise.all([
       PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userB))),
     ]);
 
     const {pages: userAPages} = userAPageManager.webapp;
+    const {pages: userBPages} = userBPageManager.webapp;
+
     const conversationName = 'Group Conversation';
 
     await test.step('Prerequisites: Setup group and open conversations', async () => {
@@ -380,17 +382,24 @@ test.describe('Reply', () => {
       const replyMessage = userAPages.conversation().getMessage({content: 'Reply'});
       await userAPages.conversation().editMessage(replyMessage);
       await expect(userAPages.conversation().replyQuoteBoxAboveMessageInputField).not.toBeVisible();
-      await userAPages.conversation().sendMessage('Edited Message');
+      await userAPages.conversation().sendMessage('Edited Reply');
     });
 
     await test.step('User B edits original message', async () => {
       await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      const originalMessage = userBPages.conversation().getMessage({content: 'Original Message', sender: userB});
+      const originalMessage = userBPages.conversation().getMessage({content: 'Original Message'}).first();
+      await expect(originalMessage).toBeVisible();
       await userBPages.conversation().editMessage(originalMessage);
       await userBPages.conversation().sendMessage('Edited Original Message');
+      await expect(userBPages.conversation().getMessage({content: 'Edited Original Message'}).first()).toBeVisible();
+      await expect(
+        userAPages.conversation().getMessage({content: 'Edited Original Message', sender: userB}),
+      ).toBeVisible();
 
       // Check that quote in reply by User A is reflecting the changes to original message
-      const replyFromUserA = userBPages.conversation().getMessage({content: 'Edited Message', sender: userA});
+      const replyFromUserA = userBPages.conversation().getMessage({content: 'Edited Reply', sender: userA});
+      // Wait for the transient "deleted" placeholder to disappear to prevent flakiness during the edit sync
+      await expect(replyFromUserA.getByTestId('quote-item')).not.toContainText('You cannot see this message');
       await expect(replyFromUserA.getByTestId('quote-item')).toContainText('Edited Original Message');
     });
 

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -360,7 +360,7 @@ test.describe('Reply', () => {
     });
 
     await test.step('User B sends a message to User A', async () => {
-      await userBPages.conversation().sendMessage('Original Message');
+      await userBPages.conversation().sendMessage('Papaya');
     });
 
     await test.step('User B opens another conversation', async () => {
@@ -368,7 +368,8 @@ test.describe('Reply', () => {
     });
 
     await test.step("User A replies to User B's message", async () => {
-      const messageToReplyTo = userAPages.conversation().getMessage({content: 'Original Message'});
+      const messageToReplyTo = userAPages.conversation().getMessage({content: 'Papaya', sender: userB});
+      await expect(messageToReplyTo).toBeVisible();
       await userAPages.conversation().replyToMessage(messageToReplyTo);
       await userAPages.conversation().sendMessage('Reply');
 
@@ -379,28 +380,30 @@ test.describe('Reply', () => {
     });
 
     await test.step('User A edits the reply message', async () => {
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
       const replyMessage = userAPages.conversation().getMessage({content: 'Reply'});
+      await expect(userBPages.conversation().getMessage({content: 'Reply', sender: userA})).toBeVisible();
       await userAPages.conversation().editMessage(replyMessage);
       await expect(userAPages.conversation().replyQuoteBoxAboveMessageInputField).not.toBeVisible();
+      await expect(userAPages.conversation().messageInput).toContainText('Reply');
       await userAPages.conversation().sendMessage('Edited Reply');
+      await expect(userBPages.conversation().getMessage({content: 'Edited Reply', sender: userA})).toBeVisible();
     });
 
     await test.step('User B edits original message', async () => {
-      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
-      const originalMessage = userBPages.conversation().getMessage({content: 'Original Message'}).first();
+      const originalMessage = userBPages.conversation().getMessage({content: 'Papaya', sender: userB});
       await expect(originalMessage).toBeVisible();
       await userBPages.conversation().editMessage(originalMessage);
-      await userBPages.conversation().sendMessage('Edited Original Message');
-      await expect(userBPages.conversation().getMessage({content: 'Edited Original Message'}).first()).toBeVisible();
-      await expect(
-        userAPages.conversation().getMessage({content: 'Edited Original Message', sender: userB}),
-      ).toBeVisible();
+      await expect(userBPages.conversation().messageInput).toContainText('Papaya');
+      await userBPages.conversation().sendMessage('Guava');
+      await expect(userBPages.conversation().getMessage({content: 'Guava', sender: userB})).toBeVisible();
+      await expect(userAPages.conversation().getMessage({content: 'Guava', sender: userB})).toBeVisible();
 
       // Check that quote in reply by User A is reflecting the changes to original message
       const replyFromUserA = userBPages.conversation().getMessage({content: 'Edited Reply', sender: userA});
       // Wait for the transient "deleted" placeholder to disappear to prevent flakiness during the edit sync
       await expect(replyFromUserA.getByTestId('quote-item')).not.toContainText('You cannot see this message');
-      await expect(replyFromUserA.getByTestId('quote-item')).toContainText('Edited Original Message');
+      await expect(replyFromUserA.getByTestId('quote-item')).toContainText('Guava');
     });
 
     const originalLink = 'www.lidl.de';
@@ -420,6 +423,7 @@ test.describe('Reply', () => {
     await test.step('User B edits the url in the original message', async () => {
       const linkMessage = userBPages.conversation().getMessage({content: `Here is a great link: ${originalLink}`});
       await userBPages.conversation().editMessage(linkMessage);
+      await expect(userBPages.conversation().messageInput).toContainText(`Here is a great link: ${originalLink}`);
       await userBPages.conversation().sendMessage('Here is another great link: www.kaufland.de');
 
       const linkFromUserB = userAPages
@@ -432,6 +436,7 @@ test.describe('Reply', () => {
       const replyMessageToLink = userAPages
         .conversation()
         .getMessage({content: 'Reply to the link message', sender: userA});
+      await expect(replyMessageToLink.getByTestId('quote-item')).not.toContainText('You cannot see this message');
 
       const [newTab] = await Promise.all([
         userAPageManager.page.waitForEvent('popup'),


### PR DESCRIPTION




<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24828" title="WPB-24828" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24828</a>  [Web][QA] Write missing tests in Regression -> Reply folder
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->




#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The regression test suite was missing a test for the reply flow, specifically for TC-3019: I want to edit my reply.
NOTE: As discussed with @iskvortsov, the test is currently skipped due to flakiness. The underlying issue is tracked in [WPB-25411].

### Solutions

This PR implements the missing automated test for `TC-3019`.

It ensures users can successfully edit replies and that the UI accurately reflects edits to both replies and original quoted messages. The implemented scenario verifies:
- The unread reply indicator appears correctly in the conversation list.
- The quote box is not visible in the input field while editing a reply.
- Edits made to an original message are dynamically reflected in the quoted text of the reply.
- Updating a message containing a URL successfully syncs the new text and link to the recipient.
- Clicking a URL inside a quoted reply successfully opens the correct link in a new tab.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.

[WPB-25411]: https://wearezeta.atlassian.net/browse/WPB-25411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ