### PR TITLE
test: skip TC-1097 since it's currently broken by the backend [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -330,7 +330,9 @@ test.describe('History Backup', () => {
     },
   );
 
-  test(
+  // TODO: unskip this test once https://github.com/wireapp/wire-server/pull/5205 is merged
+  // This test is currently broken due to the backend taking more than 10s to delete the conversation
+  test.skip(
     'I should not see the deleted group after restore from the backup',
     {tag: ['@TC-1097', '@regression']},
     async ({createPage}, testInfo) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This test is currently broken due to the dev backend taking more than 10s to delete the conversation. (See: https://github.com/wireapp/wire-server/pull/5205) Until this issue has been resolved it will be skipped to unblock CI.


