### PR TITLE
test: verify link preview and media playback [WPB-24824]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {FrameLocator} from 'playwright/test';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {test, withLogin, expect, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+
+test.describe('Link Preview', () => {
+  test(
+    'I want to see preview for youtube, spotify, soundcloud or vimeo which was sent into a group conversation, on the second end',
+    {tag: ['@TC-1264', '@regression']},
+    async ({createPage, createUser, createTeam}) => {
+      const userB = await createUser();
+      const team = await createTeam('Test Team', {
+        users: [userB],
+      });
+      const userA = team.owner;
+
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      ]);
+
+      await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
+      await userBPages.conversationList().openConversation(userA.fullName, {protocol: 'mls'});
+
+      const linkConfigs = [
+        {
+          url: 'https://soundcloud.com/slacker2d/dresden-ischen-sou-geil-v2',
+          iframeSelector: 'iframe.soundcloud',
+          validate: async (frame: FrameLocator) => {
+            await frame.getByRole('application', {name: 'Play', exact: true}).click();
+            await expect(frame.getByRole('application', {name: 'Pause', exact: true})).toBeVisible();
+          },
+        },
+        {
+          url: 'https://www.youtube.com/watch?v=BMFsJiAcELY',
+          iframeSelector: 'iframe.youtube',
+          validate: async (frame: FrameLocator) => {
+            await frame.getByRole('button', {name: 'Play video', exact: true}).click();
+            // Video player might take some time to load, so here we aren't checking for the pause button
+            await expect(frame.getByLabel('Time elapsed 0:00')).toBeVisible();
+          },
+        },
+        {
+          url: 'https://play.spotify.com/album/7buEcyw6fJF3WPgr06BomH',
+          iframeSelector: 'iframe.spotify',
+          validate: async (frame: FrameLocator) => {
+            await frame.getByRole('button', {name: 'Play', exact: true}).click();
+            await expect(frame.getByRole('button', {name: 'Pause', exact: true})).toBeVisible();
+          },
+        },
+        {
+          url: 'https://vimeo.com/288344114',
+          iframeSelector: 'iframe.vimeo',
+          validate: async (frame: FrameLocator) => {
+            await frame.getByRole('button', {name: 'Play', exact: true}).click();
+            await expect(frame.getByRole('button', {name: 'Pause', exact: true})).toBeVisible();
+          },
+        },
+      ];
+
+      for (const link of linkConfigs) {
+        await userAPages.conversation().sendTypedMessage(link.url);
+
+        // Validating the link preview for both users
+        for (const pages of [userAPages, userBPages]) {
+          const message = pages.conversation().getMessage({content: link.url});
+          const frame = message.frameLocator(link.iframeSelector);
+
+          await expect(message.locator(link.iframeSelector)).toBeVisible();
+          await link.validate(frame);
+        }
+      }
+    },
+  );
+});

--- a/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
@@ -53,9 +53,10 @@ test.describe('Link Preview', () => {
           url: 'https://www.youtube.com/watch?v=BMFsJiAcELY',
           iframeSelector: 'iframe.youtube',
           validate: async (frame: FrameLocator) => {
+            await expect(frame.getByLabel('Time elapsed')).not.toBeVisible();
             await frame.getByRole('button', {name: 'Play video', exact: true}).click();
             // Video player might take some time to load, so here we aren't checking for the pause button
-            await expect(frame.getByLabel('Time elapsed 0:00')).toBeVisible();
+            await expect(frame.getByLabel('Time elapsed')).toBeVisible();
           },
         },
         {
@@ -77,7 +78,7 @@ test.describe('Link Preview', () => {
       ];
 
       for (const link of linkConfigs) {
-        await userAPages.conversation().sendTypedMessage(link.url);
+        await userAPages.conversation().sendMessage(link.url);
 
         // Validating the link preview for both users
         for (const pages of [userAPages, userBPages]) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24824" title="WPB-24824" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24824</a>  [Web][QA] Write test for Regression -> Link Preview
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR introduces automated test coverage for Link Previews within group conversations (TC-1264). 
The test verifies that when a user sends a link from supported providers (YouTube, SoundCloud, Spotify, and Vimeo), the application correctly renders a rich preview iframe and the media player is functional