### PR TITLE
test: re-enable TC-1097 after the backend regression was fixed [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -327,9 +327,7 @@ test.describe('History Backup', () => {
     },
   );
 
-  // TODO: unskip this test once https://github.com/wireapp/wire-server/pull/5205 is merged
-  // This test is currently broken due to the backend taking more than 10s to delete the conversation
-  test.skip(
+  test(
     'I should not see the deleted group after restore from the backup',
     {tag: ['@TC-1097', '@regression']},
     async ({createPage}, testInfo) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Once the regression where the deletion of conversations took more than 10s is resolved this PR will re-enable the currently skipped test.