### PR TITLE
test: remove page plugin "withConnectionRequest" to prevent race conditions during login [WPB-25038]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -19,9 +19,9 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withLogin, withConnectionRequest, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
 
-import {createGroup} from '../../utils/userActions';
+import {createGroup, sendConnectionRequest} from '../../utils/userActions';
 
 /* ========== Block Utils ========== */
 /**
@@ -83,9 +83,9 @@ test.describe('User Blocking', () => {
       'I want to cancel blocking a 1:1 conversation from conversation list',
       {tag: ['@TC-137', '@regression']},
       async ({createPage}) => {
-        const userAPageManager = (await PageManager.from(createPage(withLogin(userA), withConnectionRequest(userB))))
-          .webapp;
-        const {pages: userAPages, modals: userAModals} = userAPageManager;
+        const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+        await sendConnectionRequest(userAPageManager, userB);
+        const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
 
         // Preconditions: User B accepts the connection request
         const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
@@ -113,9 +113,9 @@ test.describe('User Blocking', () => {
       'Verify you can block a user who is not in your team',
       {tag: ['@TC-140', '@regression']},
       async ({createPage}) => {
-        const userAPageManager = (await PageManager.from(createPage(withLogin(userA), withConnectionRequest(userB))))
-          .webapp;
-        const {pages: userAPages, modals: userAModals} = userAPageManager;
+        const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+        await sendConnectionRequest(userAPageManager, userB);
+        const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
 
         // Preconditions: User B accepts the connection request
         const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
@@ -155,14 +155,18 @@ test.describe('User Blocking', () => {
       'Verify you still receive messages from blocked person in a group chat',
       {tag: ['@TC-141', '@regression']},
       async ({createPage}) => {
-        const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectionRequest(userB)));
-        const userAPages = userAPageManager.webapp.pages;
-
-        const conversationName = 'GroupConversation';
+        const [userAPageManager, userBPageManager] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))),
+          PageManager.from(createPage(withLogin(userB))),
+        ]);
+        const [userAPages, userBPages] = [userAPageManager, userBPageManager].map(pm => pm.webapp.pages);
 
         // Preconditions: User B accepts the connection request
-        const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
+        await sendConnectionRequest(userAPageManager, userB);
+        await userBPages.conversationList().openPendingConnectionRequest();
         await userBPages.connectRequest().clickConnectButton();
+
+        const conversationName = 'GroupConversation';
 
         await expect(userAPages.conversationList().getConversationLocator(userB.fullName)).toBeAttached();
         await createGroup(userAPages, conversationName, [userB]);
@@ -195,11 +199,9 @@ test.describe('User Blocking', () => {
       {tag: ['@TC-142', '@regression']},
 
       async ({createPage}) => {
-        const userAPageManagerInstance = await PageManager.from(
-          createPage(withLogin(userA), withConnectionRequest(userB)),
-        );
-        const userAPageManager = userAPageManagerInstance.webapp;
-        const {pages: userAPages, modals: userAModals} = userAPageManager;
+        const userAPageManagerInstance = await PageManager.from(createPage(withLogin(userA)));
+        await sendConnectionRequest(userAPageManagerInstance, userB);
+        const {pages: userAPages, modals: userAModals} = userAPageManagerInstance.webapp;
 
         // Preconditions: User B accepts the connection request
         const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
@@ -236,11 +238,9 @@ test.describe('User Blocking', () => {
       'Verify you cannot add a person who blocked you to a group chat',
       {tag: ['@TC-143', '@regression']},
       async ({createPage}) => {
-        const userAPageManagerInstance = await PageManager.from(
-          createPage(withLogin(userA), withConnectedUser(userC), withConnectionRequest(userB)),
-        );
-        const userAPageManager = userAPageManagerInstance.webapp;
-        const {pages: userAPages, modals: userAModals} = userAPageManager;
+        const userAPageManagerInstance = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userC)));
+        await sendConnectionRequest(userAPageManagerInstance, userB);
+        const {pages: userAPages, modals: userAModals} = userAPageManagerInstance.webapp;
 
         const conversationName = 'Group Conversation';
 
@@ -276,9 +276,8 @@ test.describe('User Blocking', () => {
       'Verify you can block a user you sent a connection request from conversation list',
       {tag: ['@TC-144', '@regression']},
       async ({createPage}) => {
-        const userAPageManagerInstance = await PageManager.from(
-          createPage(withLogin(userA), withConnectionRequest(userB)),
-        );
+        const userAPageManagerInstance = await PageManager.from(createPage(withLogin(userA)));
+        await sendConnectionRequest(userAPageManagerInstance, userB);
 
         // Preconditions: User B does not accept connection request
         const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
@@ -294,11 +293,9 @@ test.describe('User Blocking', () => {
       'Verify you can unblock someone from conversation list options',
       {tag: ['@TC-148', '@regression']},
       async ({createPage}) => {
-        const userAPageManagerInstance = await PageManager.from(
-          createPage(withLogin(userA), withConnectedUser(userC), withConnectionRequest(userB)),
-        );
-        const userAPageManager = userAPageManagerInstance.webapp;
-        const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager;
+        const userAPageManagerInstance = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userC)));
+        await sendConnectionRequest(userAPageManagerInstance, userB);
+        const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManagerInstance.webapp;
 
         // Preconditions: User B accepts the connection request
         const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -20,9 +20,9 @@
 import {AudioType} from 'Repositories/audio/audioType';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, withConnectedUser, withLogin, expect, Team, withConnectionRequest} from 'test/e2e_tests/test.fixtures';
+import {test, withConnectedUser, withLogin, expect, Team} from 'test/e2e_tests/test.fixtures';
 import {isPlayingAudio} from 'test/e2e_tests/utils/audio.util';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Calling', () => {
   let userA: User;
@@ -477,13 +477,14 @@ test.describe('Calling', () => {
     {tag: ['@TC-2844', '@regression']},
     async ({createPage, createUser}) => {
       const guestUser = await createUser();
-      const [userAPages, userBPages, guestPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectionRequest(guestUser))).then(
-          pm => pm.webapp.pages,
-        ),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(guestUser))).then(pm => pm.webapp.pages),
+      const [userAPage, userBPage, guestPage] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userB))),
+        PageManager.from(createPage(withLogin(guestUser))),
       ]);
+      await sendConnectionRequest(userAPage, guestUser);
+
+      const [userAPages, userBPages, guestPages] = [userAPage, userBPage, guestPage].map(pm => pm.webapp.pages);
 
       // --- Setup and Call Initialization ---
       await test.step('Setup: Accept connection and start group call', async () => {

--- a/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
@@ -20,8 +20,8 @@
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 
-import {test, expect, withLogin, withConnectionRequest} from '../../test.fixtures';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {test, expect, withLogin} from '../../test.fixtures';
+import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Connections', () => {
   let memberA: User;
@@ -35,10 +35,11 @@ test.describe('Connections', () => {
     'Verify 1on1 conversation is not created on the second end after you ignore connection request',
     {tag: ['@TC-365', '@regression']},
     async ({createPage}) => {
-      const [memberBPages] = await Promise.all([
+      const [memberBPages, memberAPageManager] = await Promise.all([
         PageManager.from(createPage(withLogin(memberB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(memberA), withConnectionRequest(memberB))),
+        PageManager.from(createPage(withLogin(memberA))),
       ]);
+      await sendConnectionRequest(memberAPageManager, memberB);
 
       await memberBPages.conversationList().pendingConnectionRequest.click();
       await memberBPages.conversation().clickIgnoreButton();
@@ -52,13 +53,17 @@ test.describe('Connections', () => {
     {tag: ['@TC-369', '@regression']},
     async ({createPage, createUser}) => {
       const memberC = await createUser();
-      const [memberAPages, memberBPages, memberCPages] = await Promise.all([
-        PageManager.from(
-          createPage(withLogin(memberA), withConnectionRequest(memberB), withConnectionRequest(memberC)),
-        ).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(memberB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(memberC))).then(pm => pm.webapp.pages),
+      const [memberAPage, memberBPage, memberCPage] = await Promise.all([
+        PageManager.from(createPage(withLogin(memberA))),
+        PageManager.from(createPage(withLogin(memberB))),
+        PageManager.from(createPage(withLogin(memberC))),
       ]);
+      await sendConnectionRequest(memberAPage, memberB);
+      await sendConnectionRequest(memberAPage, memberC);
+
+      const [memberAPages, memberBPages, memberCPages] = [memberAPage, memberBPage, memberCPage].map(
+        page => page.webapp.pages,
+      );
 
       await test.step('B & C accept connection requests from A', async () => {
         for (const pages of [memberBPages, memberCPages]) {
@@ -91,10 +96,11 @@ test.describe('Connections', () => {
     'I want to cancel a pending request from conversation list',
     {tag: ['@TC-370', '@regression']},
     async ({createPage}) => {
-      const [memberBPages] = await Promise.all([
+      const [memberBPages, memberAPageManager] = await Promise.all([
         PageManager.from(createPage(withLogin(memberB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(memberA), withConnectionRequest(memberB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(memberA))),
       ]);
+      await sendConnectionRequest(memberAPageManager, memberB);
 
       await memberBPages.conversationList().pendingConnectionRequest.click();
       await memberBPages.conversation().ignoreButton.click();
@@ -107,8 +113,10 @@ test.describe('Connections', () => {
     'I want to archive a pending request from conversation list',
     {tag: ['@TC-371', '@regression']},
     async ({createPage}) => {
-      const {pages} = PageManager.from(await createPage(withLogin(memberA), withConnectionRequest(memberB))).webapp;
+      const pageManager = PageManager.from(await createPage(withLogin(memberA)));
+      await sendConnectionRequest(pageManager, memberB);
 
+      const {pages} = pageManager.webapp;
       const contextMenu = await pages.conversationList().getConversationLocator(memberB.fullName).openContextMenu();
       await contextMenu.archiveButton.click();
 

--- a/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
@@ -19,17 +19,9 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {
-  test,
-  expect,
-  withConnectedUser,
-  withLogin,
-  Team,
-  withConnectionRequest,
-  LOGIN_TIMEOUT,
-} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withConnectedUser, withLogin, Team, LOGIN_TIMEOUT} from 'test/e2e_tests/test.fixtures';
 import {interceptNotifications} from 'test/e2e_tests/utils/mockNotifications.util';
-import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
+import {connectWithUser, createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Conversations', () => {
   let team: Team;
@@ -135,20 +127,23 @@ test.describe('Conversations', () => {
     {tag: ['@TC-421', '@regression']},
     async ({createPage, createUser}) => {
       const guestUser = await createUser();
-      const [adminPage, guestPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectionRequest(guestUser))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(guestUser))).then(pm => pm.webapp.pages),
+      const [adminPage, guestPage] = await Promise.all([
+        createPage(withLogin(userA)),
+        createPage(withLogin(guestUser)),
       ]);
+      await sendConnectionRequest(adminPage, guestUser);
+
+      const [adminPages, guestPages] = [adminPage, guestPage].map(page => PageManager.from(page).webapp.pages);
 
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();
-      await expect(adminPage.conversationList().getConversationLocator(guestUser.fullName)).toBeAttached();
+      await expect(adminPages.conversationList().getConversationLocator(guestUser.fullName)).toBeAttached();
 
-      await createGroup(adminPage, groupName, [userB, guestUser]);
+      await createGroup(adminPages, groupName, [userB, guestUser]);
 
-      await adminPage.conversationList().openConversation(groupName);
-      await adminPage.conversation().clickConversationInfoButton();
-      await expect(adminPage.conversationDetails().getUserRoleIcon(guestUser.fullName)).toHaveAttribute(
+      await adminPages.conversationList().openConversation(groupName);
+      await adminPages.conversation().clickConversationInfoButton();
+      await expect(adminPages.conversationDetails().getUserRoleIcon(guestUser.fullName)).toHaveAttribute(
         'data-uie-name',
         'status-guest',
       );
@@ -161,21 +156,24 @@ test.describe('Conversations', () => {
     async ({createPage, createUser}) => {
       const guestUser = await createUser();
 
-      const [adminPage, guestPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectionRequest(guestUser))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(guestUser))).then(pm => pm.webapp.pages),
+      const [adminPage, guestPage] = await Promise.all([
+        createPage(withLogin(userA)),
+        createPage(withLogin(guestUser)),
       ]);
+      await sendConnectionRequest(adminPage, guestUser);
+
+      const [adminPages, guestPages] = [adminPage, guestPage].map(page => PageManager.from(page).webapp.pages);
 
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();
-      await expect(adminPage.conversationList().getConversationLocator(guestUser.fullName)).toBeAttached();
+      await expect(adminPages.conversationList().getConversationLocator(guestUser.fullName)).toBeAttached();
 
-      await createGroup(adminPage, groupName, [userB, guestUser]);
+      await createGroup(adminPages, groupName, [userB, guestUser]);
 
-      await adminPage.conversationList().openConversation(groupName);
-      await adminPage.conversation().clickConversationInfoButton();
+      await adminPages.conversationList().openConversation(groupName);
+      await adminPages.conversation().clickConversationInfoButton();
 
-      await expect(adminPage.conversation().membersList.filter({hasText: guestUser.fullName})).toBeVisible();
+      await expect(adminPages.conversation().membersList.filter({hasText: guestUser.fullName})).toBeVisible();
     },
   );
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
@@ -18,8 +18,8 @@
  */
 
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withLogin, withConnectionRequest} from '../../test.fixtures';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {test, expect, withLogin} from '../../test.fixtures';
+import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 test('Group Video call', {tag: ['@TC-8637', '@crit-flow-web']}, async ({createTeam, createUser, createPage, api}) => {
   test.setTimeout(150_000);
@@ -32,9 +32,10 @@ test('Group Video call', {tag: ['@TC-8637', '@crit-flow-web']}, async ({createTe
   const teamOwner = team.owner;
 
   const [ownerPageManager, guestPageManager] = await Promise.all([
-    PageManager.from(createPage(withLogin(teamOwner), withConnectionRequest(guestUser))),
+    PageManager.from(createPage(withLogin(teamOwner))),
     PageManager.from(createPage(withLogin(guestUser))),
   ]);
+  await sendConnectionRequest(ownerPageManager, guestUser);
 
   const ownerPages = ownerPageManager.webapp.pages;
   const guestPages = guestPageManager.webapp.pages;

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -21,7 +21,8 @@ import {PageManager} from 'test/e2e_tests/pageManager';
 import {getVideoFilePath, getAudioFilePath, getTextFilePath, isAssetDownloaded} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath, getLocalQRCodeValue, getQRCodeValueFromScreenshot} from 'test/e2e_tests/utils/sendImage.util';
 
-import {test, expect, withLogin, withConnectionRequest} from '../../test.fixtures';
+import {test, expect, withLogin} from '../../test.fixtures';
+import {sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 const imageFilePath = getImageFilePath();
 const videoFilePath = getVideoFilePath();
@@ -36,9 +37,11 @@ test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTea
 
   // Create page managers - User A sends connection request to User B
   const [memberAPage, memberBPage] = await Promise.all([
-    createPage(withLogin(memberA), withConnectionRequest(memberB)),
+    createPage(withLogin(memberA)),
     createPage(withLogin(memberB)),
   ]);
+  await sendConnectionRequest(memberAPage, memberB);
+
   const [memberAPageManager, memberBPageManager] = [PageManager.from(memberAPage), PageManager.from(memberBPage)];
 
   // Step 1-1: Preconditions

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/oneOnOneCall-TC-8754.spec.ts
@@ -19,7 +19,8 @@
 
 import {PageManager} from 'test/e2e_tests/pageManager';
 
-import {test, expect, withLogin, withConnectionRequest} from '../../test.fixtures';
+import {test, expect, withLogin} from '../../test.fixtures';
+import {sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 test(
   '1:1 Video call with device switch and screenshare',
@@ -30,9 +31,10 @@ test(
     const [{owner: userA}, {owner: userB}] = await Promise.all([createTeam('User A Team'), createTeam('User B Team')]);
     const {id: callingServiceInstanceId} = await api.callingService.createInstance(userB.password, userB.email);
     const [userAPageManager, userBPageManager] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectionRequest(userB))),
+      PageManager.from(createPage(withLogin(userA))),
       PageManager.from(createPage(withLogin(userB, {confirmNewHistory: true}))),
     ]);
+    await sendConnectionRequest(userAPageManager, userB);
 
     await test.step('User B accepts connection request from User A', async () => {
       const {pages} = userBPageManager.webapp;

--- a/apps/webapp/test/e2e_tests/specs/DeepLinks/deepLinks.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/DeepLinks/deepLinks.spec.ts
@@ -19,8 +19,8 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {expect, test, Team, withConnectedUser, withConnectionRequest, withLogin} from 'test/e2e_tests/test.fixtures';
-import {createGroup} from '../../utils/userActions';
+import {expect, test, Team, withConnectedUser, withLogin} from 'test/e2e_tests/test.fixtures';
+import {createGroup, sendConnectionRequest} from '../../utils/userActions';
 import {UserProfileModal} from '../../pageManager/webapp/modals/userProfile.modal';
 
 type ProfileModalOptions = {
@@ -117,11 +117,13 @@ test.describe('Deep Links', () => {
       }
 
       const [userAPage, userBPage, userCPage, userDPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectionRequest(userC)),
-        createPage(withLogin(userB), withConnectedUser(userA), withConnectionRequest(userD)),
+        createPage(withLogin(userA)),
+        createPage(withLogin(userB), withConnectedUser(userA)),
         createPage(withLogin(userC)),
         createPage(withLogin(userD)),
       ]);
+      await sendConnectionRequest(userAPage, userC);
+      await sendConnectionRequest(userBPage, userD);
 
       const userAPageManager = PageManager.from(userAPage);
       const userBPageManager = PageManager.from(userBPage);

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -1,16 +1,8 @@
 import {Page} from 'playwright/test';
 import {getUser, User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {
-  test,
-  expect,
-  withLogin,
-  Team,
-  LOGIN_TIMEOUT,
-  withGuestUser,
-  withConnectionRequest,
-} from 'test/e2e_tests/test.fixtures';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {test, expect, withLogin, Team, LOGIN_TIMEOUT, withGuestUser} from 'test/e2e_tests/test.fixtures';
+import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 /**
  * Navigates through the UI to generate a guest invitation link for a specific group.
@@ -177,12 +169,13 @@ test.describe('Guestroom', () => {
     'I should not see guests when adding people to existing conversation when guest toggle is OFF',
     {tag: ['@TC-3318', '@regression']},
     async ({createPage}) => {
-      const [ownerPages, guestPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectionRequest(guestUser))).then(
-          ({webapp}) => webapp.pages,
-        ),
-        PageManager.from(createPage(withLogin(guestUser))).then(({webapp}) => webapp.pages),
+      const [ownerPage, guestPage] = await Promise.all([
+        createPage(withLogin(userA)),
+        createPage(withLogin(guestUser)),
       ]);
+      await sendConnectionRequest(ownerPage, guestUser);
+
+      const [ownerPages, guestPages] = [ownerPage, guestPage].map(page => PageManager.from(page).webapp.pages);
 
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();

--- a/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
@@ -1,15 +1,7 @@
-import {
-  test,
-  expect,
-  withLogin,
-  withConnectedUser,
-  Team,
-  withGuestUser,
-  withConnectionRequest,
-} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin, withConnectedUser, Team, withGuestUser} from 'test/e2e_tests/test.fixtures';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Mention', () => {
   let team: Team;
@@ -517,10 +509,10 @@ test.describe('Mention', () => {
       const otherUser = await createUser();
       const otherUserPages = await PageManager.from(createPage(withLogin(otherUser))).then(pm => pm.webapp.pages);
 
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectionRequest(otherUser))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await sendConnectionRequest(userAPage, otherUser);
+
+      const [userAPages, userBPages] = [userAPage, userBPage].map(page => PageManager.from(page).webapp.pages);
 
       await otherUserPages.conversationList().pendingConnectionRequest.click();
       await otherUserPages.connectRequest().connectButton.click();

--- a/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
@@ -19,9 +19,9 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
-import {test, expect, withConnectedUser, withLogin, withConnectionRequest, Team} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withConnectedUser, withLogin, Team} from 'test/e2e_tests/test.fixtures';
 
 async function openParticipantDetailsFromGroup(
   pages: PageManager['webapp']['pages'],
@@ -56,11 +56,10 @@ test.describe('Participant Profile', () => {
     {tag: ['@TC-1474', '@regression']},
     async ({createPage, createUser}) => {
       const userC = await createUser();
-      const [userAPages, userCPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectionRequest(userC))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userCPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userC))]);
+      const [userAPages, userCPages] = [userAPage, userCPage].map(page => PageManager.from(page).webapp.pages);
 
+      await sendConnectionRequest(userAPage, userC);
       await acceptConnectionRequest(userCPages);
 
       await test.step('Go to any 1:1 conversation', async () => {
@@ -92,12 +91,16 @@ test.describe('Participant Profile', () => {
     {tag: ['@TC-1477', '@regression']},
     async ({createPage, createUser}) => {
       const userC = await createUser();
-      const [userAPages, userBPages, userCPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectionRequest(userC))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+      const [userAPage, userBPage, userCPage] = await Promise.all([
+        createPage(withLogin(userA)),
+        createPage(withLogin(userB), withConnectedUser(userA)),
+        createPage(withLogin(userC)),
       ]);
+      const [userAPages, userBPages, userCPages] = [userAPage, userBPage, userCPage].map(
+        page => PageManager.from(page).webapp.pages,
+      );
 
+      await sendConnectionRequest(userAPage, userC);
       await acceptConnectionRequest(userCPages);
       await expect(userAPages.conversationList().getConversationLocator(userC.fullName)).toBeAttached();
 
@@ -133,13 +136,14 @@ test.describe('Participant Profile', () => {
     {tag: ['@TC-1479', '@regression']},
     async ({createPage, createUser}) => {
       const userC = await createUser();
-      const [userAPageManager, userCPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectionRequest(userC))),
-        PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+      const [userAPageManager, userCPageManager] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA))),
+        PageManager.from(createPage(withLogin(userC))),
       ]);
-
       const {pages, modals} = userAPageManager.webapp;
-      await acceptConnectionRequest(userCPages);
+
+      await sendConnectionRequest(userAPageManager, userC);
+      await acceptConnectionRequest(userCPageManager.webapp.pages);
       await expect(pages.conversationList().getConversationLocator(userC.fullName)).toBeAttached();
 
       await createGroup(pages, groupName, [userB, userC]);

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -22,7 +22,7 @@ import {test as baseTest, type BrowserContext, type Page} from '@playwright/test
 import {ApiManagerE2E} from './backend/apiManager.e2e';
 import {getUser, User} from './data/user';
 import {PageManager} from './pageManager';
-import {connectWithUser, sendConnectionRequest} from './utils/userActions';
+import {connectWithUser} from './utils/userActions';
 import {mockAudioAndVideoDevices} from './utils/mockVideoDevice.util';
 import {Role} from '@wireapp/api-client/lib/team';
 import {FEATURE_KEY} from '@wireapp/api-client/lib/team/feature';
@@ -237,17 +237,6 @@ export const withConnectedUser =
   async page => {
     const pageManager = PageManager.from(page);
     await connectWithUser(pageManager, await user);
-  };
-
-/**
- * PagePlugin to connect with the given user
- * Note: This plugin only works if the users are NOT in the same team
- */
-export const withConnectionRequest =
-  (user: User | Promise<User>): PagePlugin =>
-  async page => {
-    const pageManager = PageManager.from(page);
-    await sendConnectionRequest(pageManager, await user);
   };
 
 /** PagePlugin to open a guest user link and join the group chat as temporary member */

--- a/apps/webapp/test/e2e_tests/utils/userActions.ts
+++ b/apps/webapp/test/e2e_tests/utils/userActions.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {expect, TestInfo} from 'playwright/test';
+import {expect, Page, TestInfo} from 'playwright/test';
 
 import {ApiManagerE2E} from '../backend/apiManager.e2e';
 import {User} from '../data/user';
@@ -97,8 +97,8 @@ export async function connectWithUser(senderPageManager: PageManager, receiver: 
  * Opens the connections tab, searches for the given user and sends a connection request
  * Note: This util only works if both users are NOT in the same team
  */
-export async function sendConnectionRequest(senderPageManager: PageManager, receiver: User) {
-  const {pages, modals, components} = senderPageManager.webapp;
+export async function sendConnectionRequest(sender: Page | PageManager, receiver: User) {
+  const {pages, modals, components} = ('webapp' in sender ? sender : PageManager.from(sender)).webapp;
   await components.conversationSidebar().clickConnectButton();
   await pages.startUI().searchInput.fill(receiver.username);
   await pages.startUI().selectUsers(receiver.username);

--- a/apps/webapp/test/e2e_tests/utils/userActions.ts
+++ b/apps/webapp/test/e2e_tests/utils/userActions.ts
@@ -85,8 +85,8 @@ export const createGroup = async (
  * Opens the connections tab, searches for the given user and starts a conversation with him
  * Note: This util only works if both users are part of the same team.
  */
-export async function connectWithUser(senderPageManager: PageManager, receiver: Pick<User, 'username'>) {
-  const {pages, modals, components} = senderPageManager.webapp;
+export async function connectWithUser(sender: Page | PageManager, receiver: Pick<User, 'username'>) {
+  const {pages, modals, components} = ('webapp' in sender ? sender : PageManager.from(sender)).webapp;
   await components.conversationSidebar().clickConnectButton();
   await pages.startUI().searchInput.fill(receiver.username);
   await pages.startUI().selectUsers(receiver.username);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25038" title="WPB-25038" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25038</a>  [Web][QA] Investigate race condition caused by parallel connection requests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is the first of two PRs to improve our E2E Tests and prevent race conditions sometimes occurring during login.
The `withConnectionRequest` page plugin could cause a situation where a connection request is sent to a user which doesn't have a device yet.