### PR TITLE
test: add verification step for Terms of Use link in settings [WPB-24830]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/index.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/index.ts
@@ -75,6 +75,7 @@ import {ConversationJoinPage} from './webapp/pages/conversationJoin.page';
 import {CreateConversationModal} from './webapp/modals/createConversation';
 import {InviteModal} from './webapp/modals/invite.modal';
 import {JoinGuestLinkPasswordModal} from './webapp/modals/joinGuestLinkPassword.modal';
+import {AboutPage} from './webapp/pages/about.page';
 
 export const webAppPath = process.env.WEBAPP_URL ?? '';
 
@@ -173,6 +174,7 @@ export class PageManager {
       options: () => this.getOrCreate('webapp.pages.options', () => new OptionsPage(this.page)),
       audioVideoSettings: () =>
         this.getOrCreate('webapp.pages.audioVideoSettings', () => new AudioVideoSettingsPage(this.page)),
+      about: () => this.getOrCreate('webapp.pages.about', () => new AboutPage(this.page)),
       outgoingConnection: () =>
         this.getOrCreate('webapp.pages.outgoingConnection', () => new OutgoingConnectionPage(this.page)),
       guestOptions: () => this.getOrCreate('webapp.pages.guestOptions', () => GuestOptionsPage(this.page)),

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/about.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/about.page.ts
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+export class AboutPage {
+  private readonly page: Page;
+  readonly wireSection: Locator;
+  readonly termsOfUseLink: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.wireSection = this.page.getByRole('group', {name: 'Wire'});
+    this.termsOfUseLink = this.wireSection.getByRole('link', {name: 'Terms of Use'});
+  }
+
+  async clickTermsOfUseLink() {
+    await this.termsOfUseLink.click();
+  }
+}

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/settings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/settings.page.ts
@@ -24,6 +24,7 @@ export class SettingsPage {
   readonly devicesButton: Locator;
   readonly optionsButton: Locator;
   readonly audioVideoButton: Locator;
+  readonly aboutButton: Locator;
   readonly copyProfileLinkButton: Locator;
   readonly profileLink: Locator;
 
@@ -32,6 +33,7 @@ export class SettingsPage {
     this.devicesButton = page.getByRole('button', {name: 'Devices'});
     this.optionsButton = page.getByRole('button', {name: 'Options'});
     this.audioVideoButton = page.getByRole('button', {name: 'Audio / Video'});
+    this.aboutButton = page.getByRole('button', {name: 'About'});
     this.copyProfileLinkButton = page.getByRole('button', {name: 'Copy Profile Link'});
     this.profileLink = page.getByTestId('element-profile-link');
   }
@@ -46,5 +48,9 @@ export class SettingsPage {
 
   async clickOptionsButton() {
     await this.optionsButton.click();
+  }
+
+  async clickAboutButton() {
+    await this.aboutButton.click();
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
@@ -161,6 +161,19 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
     ).toBeVisible();
   });
 
+  await test.step('Personal user A opens About -> terms of use link in settings', async () => {
+    const {pages, components} = pageManagerA.webapp;
+
+    await components.conversationSidebar().clickPreferencesButton();
+    await pages.settings().clickAboutButton();
+
+    const [newTab] = await Promise.all([pageManagerA.page.waitForEvent('popup'), pages.about().clickTermsOfUseLink()]);
+
+    await expect(newTab).toHaveURL(/legal#terms/);
+
+    await newTab.close();
+  });
+
   await test.step('Personal User A deletes their account', async () => {
     const {pages, modals, components} = pageManagerA.webapp;
     await components.conversationSidebar().clickPreferencesButton();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24830" title="WPB-24830" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24830</a>  [Web][QA] Add missing step for opening terms of use in Critical Flow test TC-8638 Personal account lifecycle
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Summary:
This PR adds a validation step to TC-8638 (Personal Account Lifecycle) to verify the "Terms of Use" navigation.

Changes:

- Added logic to handle the popup window when the Terms of Use link is clicked.
- Verified the destination URL matches the expected legal path.