### PR TITLE
test: remove page plugin "withConnectedUser" [WPB-25038]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Accessibility/Accessibility.spec.ts
@@ -19,9 +19,9 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
 
-import {expect, test, withConnectedUser, withLogin} from '../../test.fixtures';
+import {expect, test, withLogin} from '../../test.fixtures';
 
 test.describe('Accessibility', () => {
   let userA: User;
@@ -86,7 +86,10 @@ test.describe('Accessibility', () => {
       'I should not lose a drafted message when switching between conversations in collapsed view',
       {tag: ['@TC-51', '@regression']},
       async ({createPage}) => {
-        const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
+        const page = await createPage(withLogin(userA));
+        await connectWithUser(page, userB);
+
+        const {pages} = PageManager.from(page).webapp;
 
         await createGroup(pages, 'Test Group', [userB]);
         await pages.conversation().messageInput.fill('Draft Message');

--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -19,9 +19,9 @@
 
 import {getUser, User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {loginUser, logOutUser} from 'test/e2e_tests/utils/userActions';
+import {connectWithUser, loginUser, logOutUser} from 'test/e2e_tests/utils/userActions';
 
-import {test, expect, LOGIN_TIMEOUT, withLogin, withConnectedUser} from '../../test.fixtures';
+import {test, expect, LOGIN_TIMEOUT, withLogin} from '../../test.fixtures';
 
 test.describe('account settings', () => {
   let owner: User;
@@ -181,9 +181,11 @@ test.describe('account settings', () => {
 
   test('Verify I can retrieve calling logs', {tag: ['@TC-1725', '@regression']}, async ({createPage}) => {
     const [memberAPage, memberBPage] = await Promise.all([
-      createPage(withLogin(memberA), withConnectedUser(memberB)),
+      createPage(withLogin(memberA)),
       createPage(withLogin(memberB)),
     ]);
+    await connectWithUser(memberAPage, memberB);
+
     const memberAPages = PageManager.from(memberAPage).webapp.pages;
     const memberBPages = PageManager.from(memberBPage).webapp.pages;
 

--- a/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Archive/archive.spec.ts
@@ -21,7 +21,7 @@ import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
 
-import {expect, test, withConnectedUser, withLogin} from '../../test.fixtures';
+import {expect, test, withLogin} from '../../test.fixtures';
 import {Locator} from 'playwright/test';
 
 test.describe('Archive', () => {
@@ -37,7 +37,8 @@ test.describe('Archive', () => {
     'I want to archive and unarchive conversation via conversation list',
     {tag: ['@TC-97', '@regression']},
     async ({createPage}) => {
-      const page = await createPage(withLogin(memberA), withConnectedUser(memberB));
+      const page = await createPage(withLogin(memberA));
+      await connectWithUser(page, memberB);
       const {pages, components} = PageManager.from(page).webapp;
 
       const conversation = pages.conversationList().getConversation(memberB.fullName);
@@ -61,10 +62,13 @@ test.describe('Archive', () => {
     'Verify the conversation is not unarchived when there are new messages in this conversation',
     {tag: ['@TC-99', '@regression']},
     async ({createPage}) => {
-      const [memberAPages, memberBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(memberA), withConnectedUser(memberB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(memberB))).then(pm => pm.webapp.pages),
+      const [memberAPage, memberBPage] = await Promise.all([
+        createPage(withLogin(memberA)),
+        createPage(withLogin(memberB)),
       ]);
+      await connectWithUser(memberAPage, memberB);
+
+      const [memberAPages, memberBPages] = [memberAPage, memberBPage].map(page => PageManager.from(page).webapp.pages);
 
       const memberAConversation = await memberAPages
         .conversationList()
@@ -96,7 +100,8 @@ test.describe('Archive', () => {
     ] as const
   ).forEach(({title, tag}) => {
     test(title, {tag: [tag, '@regression']}, async ({createPage}) => {
-      const page = await createPage(withLogin(memberA), withConnectedUser(memberB));
+      const page = await createPage(withLogin(memberA));
+      await connectWithUser(page, memberB);
       const {pages, components} = PageManager.from(page).webapp;
 
       const conversation = await pages.conversationList().getConversation(memberB.fullName).open();

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -19,9 +19,9 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
 
-import {createGroup, sendConnectionRequest} from '../../utils/userActions';
+import {connectWithUser, createGroup, sendConnectionRequest} from '../../utils/userActions';
 
 /* ========== Block Utils ========== */
 /**
@@ -245,8 +245,9 @@ test.describe('User Blocking', () => {
       'Verify you cannot add a person who blocked you to a group chat',
       {tag: ['@TC-143', '@regression']},
       async ({createPage}) => {
-        const userAPageManagerInstance = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userC)));
+        const userAPageManagerInstance = await PageManager.from(createPage(withLogin(userA)));
         await sendConnectionRequest(userAPageManagerInstance, userB);
+        await connectWithUser(userAPageManagerInstance, userC);
         const {pages: userAPages, modals: userAModals} = userAPageManagerInstance.webapp;
 
         const conversationName = 'Group Conversation';
@@ -300,8 +301,9 @@ test.describe('User Blocking', () => {
       'Verify you can unblock someone from conversation list options',
       {tag: ['@TC-148', '@regression']},
       async ({createPage}) => {
-        const userAPageManagerInstance = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userC)));
+        const userAPageManagerInstance = await PageManager.from(createPage(withLogin(userA)));
         await sendConnectionRequest(userAPageManagerInstance, userB);
+        await connectWithUser(userAPageManagerInstance, userC);
         const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManagerInstance.webapp;
 
         // Preconditions: User B accepts the connection request
@@ -350,8 +352,9 @@ test.describe('User Blocking', () => {
     });
 
     test('Verify you can not block a user from your team', {tag: ['@TC-8778', '@regression']}, async ({createPage}) => {
-      const userAPageManager = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp;
-      const userAPages = userAPageManager.pages;
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+      await connectWithUser(userAPageManager, userB);
+      const userAPages = userAPageManager.webapp.pages;
 
       // Step 1: User A opens conversation with User B
       const conversation = await userAPages.conversationList().getConversation(userB.fullName).open();

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -21,9 +21,9 @@ import {Page} from 'playwright/test';
 import {AudioType} from 'Repositories/audio/audioType';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, withConnectedUser, withLogin, expect, Team, LOGIN_TIMEOUT} from 'test/e2e_tests/test.fixtures';
+import {test, withLogin, expect, Team, LOGIN_TIMEOUT} from 'test/e2e_tests/test.fixtures';
 import {isPlayingAudio} from 'test/e2e_tests/utils/audio.util';
-import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
+import {connectWithUser, createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 async function joinCall(userPages: PageManager['webapp']['pages']) {
   await expect(userPages.calling().callCell).toBeVisible();
@@ -52,12 +52,12 @@ test.describe('Calling', () => {
     'Verify that current call is terminated if you want to call someone else (as caller)',
     {tag: ['@TC-2802', '@regression']},
     async ({createPage}) => {
-      const [{pages: userAPages, modals: userAModals}, {pages: userBPages}] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC))).then(
-          pm => pm.webapp,
-        ),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+      await connectWithUser(userAPage, userC);
+
+      const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+      const {pages: userBPages} = PageManager.from(userBPage).webapp;
 
       // User A has a call with user B
       await userAPages.conversationList().getConversation(userB.fullName).open();
@@ -79,10 +79,7 @@ test.describe('Calling', () => {
   );
 
   test('Verify Raise hand functionality', {tag: ['@TC-8773', '@regression']}, async ({createPage}) => {
-    const [userAPage, userBPage] = await Promise.all([
-      createPage(withLogin(userA), withConnectedUser(userB)),
-      createPage(withLogin(userB)),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
 
     const userAPages = PageManager.from(userAPage).webapp.pages;
     const userBPages = PageManager.from(userBPage).webapp.pages;
@@ -113,10 +110,11 @@ test.describe('Calling', () => {
   });
 
   test('Verify in call reactions', {tag: ['@TC-8774', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userAPages.conversationList().getConversation(userB.fullName).open();
     await userAPages.conversation().clickCallButton();
@@ -136,10 +134,11 @@ test.describe('Calling', () => {
     'I want to answer incoming call with Join button in conversation view',
     {tag: ['@TC-2826', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userAPages.conversation().clickCallButton();
@@ -166,10 +165,9 @@ test.describe('Calling', () => {
     },
   ].forEach(({description, tag, conversationType}) => {
     test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
-      const [userAPage, userBPage1] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage1] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBDevice1Pages = PageManager.from(userBPage1).webapp.pages;
 
@@ -209,10 +207,12 @@ test.describe('Calling', () => {
     'Verify I can make another call while current one is ignored',
     {tag: ['@TC-2803', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userC))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+      await connectWithUser(userBPage, userC);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       // User A calls user B
       await userAPages.conversationList().getConversation(userB.fullName).open();
@@ -243,8 +243,8 @@ test.describe('Calling', () => {
   ].forEach(({description, tag, verifyScreenShare}) => {
     test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
       const [userAPages, userBPages, userCPage] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userC))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
         createPage(withLogin(userC)),
       ]);
 
@@ -277,7 +277,7 @@ test.describe('Calling', () => {
 
   test('Verify Call UI checks', {tag: ['@TC-8771', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
     ]);
 
@@ -347,9 +347,10 @@ test.describe('Calling', () => {
     'Verify joining and leaving call from second client does not disconnect the first client',
     {tag: ['@TC-2827', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
-      const userAPages = PageManager.from(userAPage).webapp.pages;
-      const userBPages = PageManager.from(userBPage).webapp.pages;
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      ]);
 
       // Log in a second session/device for User A.
       const userAPage2 = await createPage(withLogin(userA, {confirmNewHistory: true}));
@@ -397,7 +398,7 @@ test.describe('Calling', () => {
     {tag: ['@TC-2837', '@regression']},
     async ({createPage}) => {
       const [userAPages, userBPages, userCPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
         PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
       ]);
@@ -432,7 +433,7 @@ test.describe('Calling', () => {
     {tag: ['@TC-2838', '@regression']},
     async ({createPage}) => {
       const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
@@ -471,9 +472,9 @@ test.describe('Calling', () => {
       }
 
       const allMembers = [userB, userC, ...extraMembers];
-      const {pages: userAPages, modals: userAModals} = PageManager.from(
-        await createPage(withLogin(userA), withConnectedUser(userB)),
-      ).webapp;
+      const userAPage = await createPage(withLogin(userA));
+
+      const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
 
       await createGroup(userAPages, groupName, allMembers);
       await userAPages.conversationList().getConversation(groupName).open();
@@ -491,11 +492,12 @@ test.describe('Calling', () => {
     async ({createPage, createUser}) => {
       const guestUser = await createUser();
       const [userAPage, userBPage, guestPage] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userA))),
         PageManager.from(createPage(withLogin(userB))),
         PageManager.from(createPage(withLogin(guestUser))),
       ]);
       await sendConnectionRequest(userAPage, guestUser);
+      await connectWithUser(userAPage, userB);
 
       const [userAPages, userBPages, guestPages] = [userAPage, userBPage, guestPage].map(pm => pm.webapp.pages);
 
@@ -769,10 +771,7 @@ test.describe('Calling', () => {
     },
   ].forEach(({description, tag, verify}) => {
     test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
 
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
@@ -887,7 +886,7 @@ test.describe('Calling', () => {
 
   test('I want to see multiple active speakers in 1 call', {tag: ['@TC-2945', '@regression']}, async ({createPage}) => {
     const [userAPages, userBPages, userCPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
+      PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
       PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
     ]);
@@ -925,10 +924,8 @@ test.describe('Calling', () => {
     {id: '@TC-2909', title: 'I want to have 1:1 CBR audio call when the receiver turned it on'} as const,
   ].forEach(({id, title}) => {
     test(title, {tag: [id, '@regression']}, async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA)),
-        createPage(withLogin(userB), withConnectedUser(userA)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
 
       const {pages: userAPages} = PageManager.from(userAPage).webapp;
       const {pages: userBPages} = PageManager.from(userBPage).webapp;

--- a/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -19,11 +19,11 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, withLogin, withConnectedUser, expect} from 'test/e2e_tests/test.fixtures';
+import {test, withLogin, expect} from 'test/e2e_tests/test.fixtures';
 
 import {getTextFilePath, shareAssetHelper} from '../../utils/asset.util';
 import {getImageFilePath} from '../../utils/sendImage.util';
-import {createGroup} from '../../utils/userActions';
+import {connectWithUser, createGroup} from '../../utils/userActions';
 import {ConversationListPage} from 'test/e2e_tests/pageManager/webapp/pages/conversationList.page';
 
 test.describe('Clear Conversation Content', () => {
@@ -108,7 +108,8 @@ test.describe('Clear Conversation Content', () => {
       {tag: [tag, '@regression']},
       async ({createPage}) => {
         const userBPageManager = PageManager.from(await createPage(withLogin(userB)));
-        const userAPageManager = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB)));
+        const userAPageManager = PageManager.from(await createPage(withLogin(userA)));
+        await connectWithUser(userAPageManager, userB);
 
         const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
         const userBPages = userBPageManager.webapp.pages;
@@ -157,17 +158,18 @@ test.describe('Clear Conversation Content', () => {
       `I want to see incoming picture, ping and call after I clear content of a ${conversationType} conversation via conversation list`,
       {tag: [tag, '@regression']},
       async ({createPage}) => {
-        const [userBPage, userCPage] = await Promise.all([createPage(withLogin(userB)), createPage(withLogin(userC))]);
+        const [userAPage, userBPage, userCPage] = await Promise.all([
+          createPage(withLogin(userA)),
+          createPage(withLogin(userB)),
+          createPage(withLogin(userC)),
+        ]);
 
-        const userAPage = await createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC));
+        await connectWithUser(userAPage, userB);
+        await connectWithUser(userAPage, userC);
 
-        const userAPageManager = PageManager.from(userAPage);
-        const userBPageManager = PageManager.from(userBPage);
-        const userCPageManager = PageManager.from(userCPage);
-
-        const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
-        const userBPages = userBPageManager.webapp.pages;
-        const userCPages = userCPageManager.webapp.pages;
+        const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+        const userBPages = PageManager.from(userBPage).webapp.pages;
+        const userCPages = PageManager.from(userCPage).webapp.pages;
 
         // Step 1: Create a group conversation with User A, B and C
         const conversationName = conversationType === 'group' ? 'Group conversation' : userB.fullName;
@@ -263,11 +265,11 @@ test.describe('Clear Conversation Content', () => {
       `I want to clear the ${conversationType} conversation content from conversation details options`,
       {tag: [tag, '@regression']},
       async ({createPage}) => {
-        const userBPageManager = PageManager.from(await createPage(withLogin(userB)));
-        const userAPageManager = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB)));
+        const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+        await connectWithUser(PageManager.from(userAPage), userB);
 
-        const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
-        const userBPages = userBPageManager.webapp.pages;
+        const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+        const {pages: userBPages} = PageManager.from(userBPage).webapp;
 
         const conversationName = 'Group conversation';
         let userAConversation: ReturnType<ConversationListPage['getConversation']>;

--- a/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
@@ -19,7 +19,7 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withConnectedUser, withLogin, Team, LOGIN_TIMEOUT} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin, Team, LOGIN_TIMEOUT} from 'test/e2e_tests/test.fixtures';
 import {interceptNotifications} from 'test/e2e_tests/utils/mockNotifications.util';
 import {connectWithUser, createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
@@ -57,10 +57,11 @@ test.describe('Conversations', () => {
     'I want to see a system message with all group members mentioned when someone else created a group',
     {tag: ['@TC-2966', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userAPages, groupName, [userB, userC]);
       userBPages.conversationList().getConversation(groupName).open();
@@ -77,9 +78,10 @@ test.describe('Conversations', () => {
     'I want to see "No matching results. Try entering a different name." when I search for non existent users',
     {tag: ['@TC-2987', '@regression']},
     async ({createPage}) => {
-      const userAPages = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(
-        pm => pm.webapp.pages,
-      );
+      const userAPage = await createPage(withLogin(userA));
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
 
       const noResultsMessage = 'No matching results. Try entering a different name.';
 
@@ -107,9 +109,10 @@ test.describe('Conversations', () => {
     'Verify the name of the group conversation can be edited',
     {tag: ['@TC-418', '@regression']},
     async ({createPage}) => {
-      const userAPages = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(
-        pm => pm.webapp.pages,
-      );
+      const userAPage = await createPage(withLogin(userA));
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
 
       await createGroup(userAPages, groupName, [userB, userC]);
 
@@ -263,16 +266,14 @@ test.describe('Conversations', () => {
       const externalUser = await createUser();
       await team.addTeamMember(externalUser, {role: 'EXTERNAL'});
 
-      const adminPage = await PageManager.from(createPage(withLogin(userA), withConnectedUser(externalUser))).then(
-        pm => pm.webapp.pages,
-      );
+      const adminPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
-      await createGroup(adminPage, groupName, [userB, externalUser]);
+      await createGroup(adminPages, groupName, [userB, externalUser]);
 
-      await adminPage.conversationList().getConversation(groupName).open();
-      await adminPage.conversation().clickConversationInfoButton();
-      await expect(adminPage.conversation().membersList).toBeVisible();
-      await expect(adminPage.conversationDetails().getUserRoleIcon(externalUser.fullName)).toHaveAttribute(
+      await adminPages.conversationList().getConversation(groupName).open();
+      await adminPages.conversation().clickConversationInfoButton();
+      await expect(adminPages.conversation().membersList).toBeVisible();
+      await expect(adminPages.conversationDetails().getUserRoleIcon(externalUser.fullName)).toHaveAttribute(
         'data-uie-name',
         'status-external',
       );
@@ -307,12 +308,13 @@ test.describe('Conversations', () => {
     'Verify conversation scrolls to first unread message when opening',
     {tag: ['@TC-487', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA), withConnectedUser(userC))),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userBPage, userA);
+      await connectWithUser(userBPage, userC);
 
-      const {pages, components} = userBPageManager.webapp;
+      const {pages: userAPages} = PageManager.from(userAPage).webapp;
+      const {pages, components} = PageManager.from(userBPage).webapp;
+
       const totalMessages = 20;
 
       await test.step('User B opens conversation with User A to mark previous history as read', async () => {
@@ -453,10 +455,10 @@ test.describe('Conversations', () => {
   );
 
   test('Verify emoji autocomplete', {tag: ['@TC-495', '@regression']}, async ({createPage}) => {
-    const userAPages = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(
-      pm => pm.webapp.pages,
-    );
+    const userAPage = await createPage(withLogin(userA));
+    await connectWithUser(userAPage, userB);
 
+    const userAPages = PageManager.from(userAPage).webapp.pages;
     await userAPages.conversationList().getConversation(userB.fullName).open();
 
     await userAPages.conversation().messageInput.pressSequentially(':) ', {delay: 100});
@@ -489,10 +491,8 @@ test.describe('Conversations', () => {
     'I should not see a (push) notification when the role of another person has changed',
     {tag: ['@TC-503', '@regression']},
     async ({createPage}) => {
-      const [adminPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [adminPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(adminPage, userB);
 
       const adminPages = PageManager.from(adminPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/backupRestoration-TC-8634.spec.ts
@@ -17,10 +17,16 @@
  *
  */
 
-import {createAndSaveBackup, createGroup, loginUser, logOutUser} from 'test/e2e_tests/utils/userActions';
+import {
+  connectWithUser,
+  createAndSaveBackup,
+  createGroup,
+  loginUser,
+  logOutUser,
+} from 'test/e2e_tests/utils/userActions';
 
 import {User} from '../../data/user';
-import {test, expect, withLogin, withConnectedUser, LOGIN_TIMEOUT} from '../../test.fixtures';
+import {test, expect, withLogin, LOGIN_TIMEOUT} from '../../test.fixtures';
 import {PageManager} from 'test/e2e_tests/pageManager';
 
 const groupName = 'Critical Group';
@@ -38,7 +44,8 @@ test.beforeEach(async ({createTeam, createUser}) => {
 });
 
 test('Setting up new device with a backup', {tag: ['@TC-8634', '@crit-flow-web']}, async ({createPage}, testInfo) => {
-  const pageManager = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB)));
+  const pageManager = PageManager.from(await createPage(withLogin(userA)));
+  await connectWithUser(pageManager, userB);
   const {pages, modals, components} = pageManager.webapp;
 
   const userBConversation = pages.conversationList().getConversation(userB.fullName);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/joinTeam-TC-8635.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/joinTeam-TC-8635.spec.ts
@@ -18,9 +18,9 @@
  */
 
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
 
-import {test, expect, withLogin, withConnectedUser} from '../../test.fixtures';
+import {test, expect, withLogin} from '../../test.fixtures';
 
 test(
   'New person joins team and sets up device',
@@ -41,7 +41,9 @@ test(
       await team.addTeamMember(userA);
     });
 
-    const userAPages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(owner))).webapp.pages;
+    const userAPage = await createPage(withLogin(userA));
+    await connectWithUser(userAPage, owner);
+    const userAPages = PageManager.from(userAPage).webapp.pages;
 
     await test.step('A sends text to owner', async () => {
       await userAPages.conversationList().getConversation(owner.fullName).open();

--- a/apps/webapp/test/e2e_tests/specs/DeepLinks/deepLinks.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/DeepLinks/deepLinks.spec.ts
@@ -19,8 +19,8 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {expect, test, Team, withConnectedUser, withLogin} from 'test/e2e_tests/test.fixtures';
-import {createGroup, sendConnectionRequest} from '../../utils/userActions';
+import {expect, test, Team, withLogin} from 'test/e2e_tests/test.fixtures';
+import {connectWithUser, createGroup, sendConnectionRequest} from '../../utils/userActions';
 import {UserProfileModal} from '../../pageManager/webapp/modals/userProfile.modal';
 
 type ProfileModalOptions = {
@@ -118,12 +118,13 @@ test.describe('Deep Links', () => {
 
       const [userAPage, userBPage, userCPage, userDPage] = await Promise.all([
         createPage(withLogin(userA)),
-        createPage(withLogin(userB), withConnectedUser(userA)),
+        createPage(withLogin(userB)),
         createPage(withLogin(userC)),
         createPage(withLogin(userD)),
       ]);
       await sendConnectionRequest(userAPage, userC);
       await sendConnectionRequest(userBPage, userD);
+      await connectWithUser(userBPage, userA);
 
       const userAPageManager = PageManager.from(userAPage);
       const userBPageManager = PageManager.from(userBPage);

--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -21,10 +21,10 @@ import {Locator, Page} from 'playwright/test';
 import {ApiManagerE2E} from 'test/e2e_tests/backend/apiManager.e2e';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withConnectedUser, withLogin} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Delete', () => {
   let userA: User;
@@ -40,9 +40,14 @@ test.describe('Delete', () => {
     'I can delete my message in 1:1 and from second device',
     {tag: ['@TC-569', '@regression']},
     async ({createPage}) => {
-      const deviceA = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+      const deviceAPage = await createPage(withLogin(userA));
+      const deviceBPage = await createPage(withLogin(userA, {confirmNewHistory: true}));
+      await connectWithUser(deviceAPage, userB);
 
-      const deviceB = (await PageManager.from(createPage(withLogin(userA, {confirmNewHistory: true})))).webapp.pages;
+      const deviceA = PageManager.from(deviceAPage).webapp.pages;
+      const deviceB = PageManager.from(deviceBPage).webapp.pages;
+
+      await deviceA.conversationList().getConversation(userB.fullName).open();
       await deviceB.conversationList().getConversation(userB.fullName).open();
 
       await deviceA.conversation().sendMessage('Test Message');
@@ -60,10 +65,11 @@ test.describe('Delete', () => {
   );
 
   test('I can delete messages in group from me and others', {tag: ['@TC-570', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await test.step('Create test group', async () => {
       await createGroup(userAPages, 'Test Group', [userB]);
@@ -96,10 +102,11 @@ test.describe('Delete', () => {
     'I cannot delete certain types of messages (system messages)',
     {tag: ['@TC-571', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userAPages, 'Test Group', [userB]);
       await userBPages.conversationList().getConversation('Test Group').open();
@@ -117,8 +124,10 @@ test.describe('Delete', () => {
     'Deleted messages remain deleted after I archive and unarchive the conversation',
     {tag: ['@TC-572', '@regression']},
     async ({createPage}) => {
-      const {components, pages} = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))))
-        .webapp;
+      const page = await createPage(withLogin(userA));
+      await connectWithUser(page, userB);
+
+      const {components, pages} = PageManager.from(page).webapp;
       const conversation = await pages.conversationList().getConversation(userB.fullName).open();
 
       let message: Locator;
@@ -156,9 +165,11 @@ test.describe('Delete', () => {
     {tag: ['@TC-573', '@regression']},
     async ({context, createPage}) => {
       const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
+        createPage(withLogin(userA)),
         createPage(context, withLogin(userB)),
       ]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       let userBPages = PageManager.from(userBPage).webapp.pages;
 
@@ -189,10 +200,11 @@ test.describe('Delete', () => {
     'I see "Deleted" status message if other user deletes their message "For Everyone" (1:1)',
     {tag: ['@TC-576', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -217,10 +229,11 @@ test.describe('Delete', () => {
     'I see "Deleted" status message if other user deletes their message "For Everyone" (group)',
     {tag: ['@TC-577', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await test.step('Create test group', async () => {
         await createGroup(userAPages, 'Test Group', [userB]);
@@ -321,8 +334,8 @@ test.describe('Delete', () => {
 
   testCases.forEach(({name, tc, sendAction}) => {
     test(`Delete "For Everyone" works for ${name}`, {tag: [tc, '@regression']}, async ({createPage, api}) => {
-      const pageB = await createPage(withLogin(userB));
-      const pageA = await createPage(withLogin(userA), withConnectedUser(userB));
+      const [pageA, pageB] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(pageA, userB);
 
       const userAPages = PageManager.from(pageA).webapp.pages;
       const userBPages = PageManager.from(pageB).webapp.pages;
@@ -359,10 +372,11 @@ test.describe('Delete', () => {
     'I see no unread count if a message was deleted from someone in a conversation',
     {tag: ['@TC-587', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await test.step('Create group as second conversation', async () => {
         // We need to create a second conversation in order to switch to it to ensure the unread marker can be shown on the not open conversation

--- a/apps/webapp/test/e2e_tests/specs/Drive/drive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Drive/drive.spec.ts
@@ -22,8 +22,8 @@ import {PageManager} from 'test/e2e_tests/pageManager';
 import {getImageFilePath, getLocalQRCodeValue, ImageQRCodeFileName} from 'test/e2e_tests/utils/sendImage.util';
 import {getVideoFilePath, VideoFileName} from 'test/e2e_tests/utils/asset.util';
 
-import {test, expect, withLogin, withConnectedUser} from '../../test.fixtures';
-import {createGroup} from '../../utils/userActions';
+import {test, expect, withLogin} from '../../test.fixtures';
+import {connectWithUser, createGroup} from '../../utils/userActions';
 import {ConversationPage} from '../../pageManager/webapp/pages/conversation.page';
 import {Locator} from '@playwright/test';
 
@@ -68,9 +68,10 @@ test.describe('Conversations', () => {
     {tag: ['@crit-flow-cells', '@regression', '@TC-8785']},
     async ({createPage}, testInfo) => {
       const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userA))),
         PageManager.from(createPage(withLogin(userB))),
       ]);
+      await connectWithUser(userAPageManager, userB);
 
       const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages, modals: userBModals} = userBPageManager.webapp;
@@ -115,9 +116,10 @@ test.describe('Conversations', () => {
     {tag: ['@crit-flow-cells', '@regression', '@TC-8786']},
     async ({createPage}) => {
       const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userA))),
         PageManager.from(createPage(withLogin(userB))),
       ]);
+      await connectWithUser(userAPageManager, userB);
 
       const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages} = userBPageManager.webapp;
@@ -156,9 +158,10 @@ test.describe('Conversations', () => {
     {tag: ['@crit-flow-cells', '@regression', '@TC-8787']},
     async ({createPage}) => {
       const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userA))),
         PageManager.from(createPage(withLogin(userB))),
       ]);
+      await connectWithUser(userAPageManager, userB);
 
       const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages, components: userBComponents} = userBPageManager.webapp;
@@ -196,9 +199,10 @@ test.describe('Conversations', () => {
     {tag: ['@crit-flow-cells', '@regression', '@TC-8788']},
     async ({createPage}) => {
       const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userA))),
         PageManager.from(createPage(withLogin(userB))),
       ]);
+      await connectWithUser(userAPageManager, userB);
 
       const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages} = userBPageManager.webapp;

--- a/apps/webapp/test/e2e_tests/specs/Edit/edit.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Edit/edit.spec.ts
@@ -19,8 +19,8 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withConnectedUser, withLogin} from 'test/e2e_tests/test.fixtures';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
+import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Edit', () => {
   let userA: User;
@@ -33,7 +33,10 @@ test.describe('Edit', () => {
   });
 
   test('I can edit my message in 1:1', {tag: ['@TC-679', '@regression']}, async ({createPage}) => {
-    const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+    const page = await createPage(withLogin(userA));
+    await connectWithUser(page, userB);
+
+    const {pages} = PageManager.from(page).webapp;
     await pages.conversation().sendMessage('Test Message');
 
     const message = pages.conversation().getMessage({sender: userA});
@@ -69,7 +72,10 @@ test.describe('Edit', () => {
     'I see changed message if message was edited from another device',
     {tag: ['@TC-682', '@regression']},
     async ({createPage}) => {
-      const deviceA = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+      const deviceAPage = await createPage(withLogin(userA));
+      await connectWithUser(deviceAPage, userB);
+
+      const deviceA = PageManager.from(deviceAPage).webapp.pages;
 
       // Device 2 is intentionally created after device 1 to ensure the history info warning is confirmed
       const deviceB = (await PageManager.from(createPage(withLogin(userA, {confirmNewHistory: true})))).webapp.pages;
@@ -92,10 +98,11 @@ test.describe('Edit', () => {
   );
 
   test('I cannot edit another users message', {tag: ['@TC-683', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -112,7 +119,10 @@ test.describe('Edit', () => {
     'I can edit my last message by pressing the up arrow key',
     {tag: ['@TC-686', '@regression']},
     async ({createPage}) => {
-      const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+      const page = await createPage(withLogin(userA));
+      await connectWithUser(page, userB);
+
+      const pages = PageManager.from(page).webapp.pages;
 
       await pages.conversation().sendMessage('Test Message');
       await expect(pages.conversation().getMessage({content: 'Test Message'})).toBeVisible();
@@ -126,10 +136,11 @@ test.describe('Edit', () => {
     'Editing a message does not create unread dot on receiver side',
     {tag: ['@TC-690', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await test.step('Create group as second conversation', async () => {
         // We need to create a second conversation in order to switch to it to ensure the unread marker can be shown on the not open conversation
@@ -177,10 +188,11 @@ test.describe('Edit', () => {
     'I can see the changed message was edited from another user',
     {tag: ['@TC-692', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -19,8 +19,8 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {withLogin, withConnectedUser, test, expect} from 'test/e2e_tests/test.fixtures';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {withLogin, test, expect} from 'test/e2e_tests/test.fixtures';
+import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
 
 /* ===== Helper Functions ===== */
 /**
@@ -68,7 +68,8 @@ test.describe('Folders', () => {
     'I want to move a 1:1 conversation to a new custom folder',
     {tag: ['@TC-545', '@regression']},
     async ({createPage}) => {
-      const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+      await connectWithUser(userAPageManager, userB);
       const userAPages = userAPageManager.webapp.pages;
 
       const customFolderName = 'Custom-Folder';
@@ -88,7 +89,8 @@ test.describe('Folders', () => {
     'I want to move a group conversation to a new custom folder',
     {tag: ['@TC-546', '@regression']},
     async ({createPage}) => {
-      const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+      await connectWithUser(userAPageManager, userB);
       const userAPages = userAPageManager.webapp.pages;
 
       const customFolderName = 'Custom-Folder';
@@ -111,7 +113,8 @@ test.describe('Folders', () => {
     'I want to move a 1:1 conversation to an existing custom folder',
     {tag: ['@TC-547', '@regression']},
     async ({createPage}) => {
-      const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+      await connectWithUser(userAPageManager, userB);
       const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
 
       const customFolderName = 'Custom-Folder';
@@ -136,7 +139,8 @@ test.describe('Folders', () => {
     'I want to move a group conversation to an existing custom folder',
     {tag: ['@TC-548', '@regression']},
     async ({createPage}) => {
-      const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+      await connectWithUser(userAPageManager, userB);
       const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
 
       const customFolderName = 'Custom-Folder';
@@ -162,7 +166,8 @@ test.describe('Folders', () => {
     'I want to see custom folder removed when last conversation is removed',
     {tag: ['@TC-553', '@regression']},
     async ({createPage}) => {
-      const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+      await connectWithUser(userAPageManager, userB);
       const userAPages = userAPageManager.webapp.pages;
 
       const customFolderName = 'Custom-Folder';
@@ -193,7 +198,8 @@ test.describe('Folders', () => {
     'I should not be able to create a custom folder without a name',
     {tag: ['@TC-560', '@regression']},
     async ({createPage}) => {
-      const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+      await connectWithUser(userAPageManager, userB);
       const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
 
       // Step 1: User A opens 1:1 conversation with User B
@@ -212,7 +218,8 @@ test.describe('Folders', () => {
     'I should not see any traces of a deleted custom folder',
     {tag: ['@TC-568', '@regression']},
     async ({createPage}) => {
-      const userAPageManager = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)));
+      const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
+      await connectWithUser(userAPageManager, userB);
       const userAPages = userAPageManager.webapp.pages;
 
       const customFolderName = 'Custom-Folder';
@@ -239,13 +246,11 @@ test.describe('Folders', () => {
     'I want to see 1:1 and group conversations in Favorites folder',
     {tag: ['@TC-742', '@regression']},
     async ({createPage}) => {
-      const [userAPageManager, userBPageManager] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
 
-      const {pages: userAPages, components: userAComponents} = PageManager.from(userAPageManager).webapp;
-      const userBPages = PageManager.from(userBPageManager).webapp.pages;
+      const {pages: userAPages, components: userAComponents} = PageManager.from(userAPage).webapp;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       const groupName = 'Group Name';
 

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -19,9 +19,9 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withConnectedUser, withLogin, Team} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin, Team} from 'test/e2e_tests/test.fixtures';
 import {interceptNotifications} from 'test/e2e_tests/utils/mockNotifications.util';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Group Conversation', () => {
   let team: Team;
@@ -71,9 +71,11 @@ test.describe('Group Conversation', () => {
     'I see count of participants increase and decrease when I select or unselect',
     {tag: ['@TC-516', '@regression']},
     async ({createPage}) => {
-      const userAPages = PageManager.from(
-        await createPage(withLogin(userA), withConnectedUser(userB), withConnectedUser(userC)),
-      ).webapp.pages;
+      const userAPage = await createPage(withLogin(userA));
+      await connectWithUser(userAPage, userB);
+      await connectWithUser(userAPage, userC);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
 
       await userAPages.conversationList().clickCreateGroup();
       await userAPages.groupCreation().setGroupName(groupName);
@@ -133,10 +135,8 @@ test.describe('Group Conversation', () => {
     'I want to be notified about the group deletion when app is in background',
     {tag: ['@TC-1093', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
 
       const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
       const userBPages = PageManager.from(userBPage).webapp.pages;
@@ -179,8 +179,9 @@ test.describe('Group Conversation', () => {
       const [userAPageManager, userBPageManager, userCPageManager] = await Promise.all([
         createPage(withLogin(userA)),
         createPage(withLogin(userB)),
-        createPage(withLogin(userC), withConnectedUser(userA)),
+        createPage(withLogin(userC)),
       ]);
+      await connectWithUser(userCPageManager, userA);
 
       const userAPages = PageManager.from(userAPageManager).webapp.pages;
       const userBPages = PageManager.from(userBPageManager).webapp.pages;

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -19,8 +19,14 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withLogin, withConnectedUser, LOGIN_TIMEOUT} from 'test/e2e_tests/test.fixtures';
-import {createAndSaveBackup, createGroup, loginUser, logOutUser} from 'test/e2e_tests/utils/userActions';
+import {test, expect, withLogin, LOGIN_TIMEOUT} from 'test/e2e_tests/test.fixtures';
+import {
+  connectWithUser,
+  createAndSaveBackup,
+  createGroup,
+  loginUser,
+  logOutUser,
+} from 'test/e2e_tests/utils/userActions';
 import {generateSecurePassword, generateWireEmail} from '../../utils/userDataGenerator';
 import {RequestResetPasswordPage} from '../../pageManager/webapp/pages/requestResetPassword.page';
 
@@ -40,9 +46,10 @@ test.describe('History Backup', () => {
     {tag: ['@TC-118', '@regression']},
     async ({createPage, api}, testInfo) => {
       const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userA))),
         PageManager.from(createPage(withLogin(userB))),
       ]);
+      await connectWithUser(userAPageManager, userB);
 
       const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages} = userBPageManager.webapp;
@@ -116,9 +123,10 @@ test.describe('History Backup', () => {
     {tag: ['@TC-125', '@regression']},
     async ({createPage}, testInfo) => {
       const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userA))),
         PageManager.from(createPage(withLogin(userB))),
       ]);
+      await connectWithUser(userAPageManager, userB);
 
       const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages, components: userBComponents} = userBPageManager.webapp;
@@ -163,9 +171,11 @@ test.describe('History Backup', () => {
     {tag: ['@TC-131', '@regression']},
     async ({createPage}, testInfo) => {
       const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userA))),
         PageManager.from(createPage(withLogin(userB))),
       ]);
+      await connectWithUser(userAPageManager, userB);
+
       const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages} = userBPageManager.webapp;
 
@@ -222,9 +232,11 @@ test.describe('History Backup', () => {
     {tag: ['@TC-133', '@regression']},
     async ({createPage}, testInfo) => {
       const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userA))),
         PageManager.from(createPage(withLogin(userB))),
       ]);
+      await connectWithUser(userAPageManager, userB);
+
       const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages} = userBPageManager.webapp;
 
@@ -286,9 +298,10 @@ test.describe('History Backup', () => {
     {tag: ['@TC-135', '@regression']},
     async ({createPage}, testInfo) => {
       const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userA))),
         PageManager.from(createPage(withLogin(userB))),
       ]);
+      await connectWithUser(userAPageManager, userB);
 
       const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages} = userBPageManager.webapp;
@@ -333,9 +346,11 @@ test.describe('History Backup', () => {
     {tag: ['@TC-1097', '@regression']},
     async ({createPage}, testInfo) => {
       const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userA))),
         PageManager.from(createPage(withLogin(userB))),
       ]);
+      await connectWithUser(userAPageManager, userB);
+
       const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages} = userBPageManager.webapp;
 
@@ -384,9 +399,11 @@ test.describe('History Backup', () => {
     {tag: ['@TC-10549', '@regression']},
     async ({createPage}, testInfo) => {
       const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+        PageManager.from(createPage(withLogin(userA))),
         PageManager.from(createPage(withLogin(userB))),
       ]);
+      await connectWithUser(userAPageManager, userB);
+
       const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
       const {pages: userBPages} = userBPageManager.webapp;
 

--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -19,10 +19,10 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
-import {createGroup} from '../../utils/userActions';
+import {connectWithUser, createGroup} from '../../utils/userActions';
 
 test.describe('In Conversation Search', () => {
   let userA: User;
@@ -39,8 +39,8 @@ test.describe('In Conversation Search', () => {
     'Verify main overview shows media from all categories',
     {tag: ['@TC-352', '@regression']},
     async ({createPage}) => {
-      const userBPage = await createPage(withLogin(userB));
-      const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
 
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
@@ -69,10 +69,8 @@ test.describe('In Conversation Search', () => {
     "Verify ephemeral messages aren't shown in collection after timeout",
     {tag: ['@TC-354', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
 
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
@@ -98,10 +96,8 @@ test.describe('In Conversation Search', () => {
     'Verify ephemeral messages show in collection before timeout',
     {tag: ['@TC-355', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
 
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
@@ -127,10 +123,8 @@ test.describe('In Conversation Search', () => {
     'Verify opening overview of all pictures from sender and receiver in group',
     {tag: ['@TC-356', '@regression']},
     async ({createPage}) => {
-      const [pageA, pageB] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [pageA, pageB] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(pageA, userB);
 
       const userAPages = PageManager.from(pageA).webapp.pages;
       const userBPages = PageManager.from(pageB).webapp.pages;
@@ -159,10 +153,8 @@ test.describe('In Conversation Search', () => {
     'Verify opening single picture from all shared media overview',
     {tag: ['@TC-357', '@regression']},
     async ({createPage}) => {
-      const [pageA, pageB] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [pageA, pageB] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(pageA, userB);
 
       const {pages: userAPages, modals: userAModals} = PageManager.from(pageA).webapp;
       const userBPages = PageManager.from(pageB).webapp.pages;
@@ -181,10 +173,11 @@ test.describe('In Conversation Search', () => {
 
   // TODO: links are not shown to the collection - this part of the test is blocked by [WPB-22484]
   test.skip('Verify opening overview of all links', {tag: ['@TC-358', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     // Step: User B sends several links
@@ -197,10 +190,8 @@ test.describe('In Conversation Search', () => {
   });
 
   test('Verify opening overview of all files', {tag: ['@TC-359', '@regression']}, async ({createPage}) => {
-    const [pageA, pageB] = await Promise.all([
-      createPage(withLogin(userA), withConnectedUser(userB)),
-      createPage(withLogin(userB)),
-    ]);
+    const [pageA, pageB] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(pageA, userB);
 
     const userAPages = PageManager.from(pageA).webapp.pages;
     const userBPages = PageManager.from(pageB).webapp.pages;
@@ -224,10 +215,8 @@ test.describe('In Conversation Search', () => {
     "Verify deleted media isn't in collection on other side",
     {tag: ['@TC-360', '@regression']},
     async ({createPage}) => {
-      const [pageA, pageB] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [pageA, pageB] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(pageA, userB);
 
       const userAPages = PageManager.from(pageA).webapp.pages;
       const userBPages = PageManager.from(pageB).webapp.pages;
@@ -250,10 +239,11 @@ test.describe('In Conversation Search', () => {
 
   // TODO: [WPB-23814] - search behavior is broken
   test.skip('Verify I can search my own message', {tag: ['@TC-385', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await userBPages.conversation().sendMessage('User B message');
@@ -278,10 +268,11 @@ test.describe('In Conversation Search', () => {
     'Verify I can search for text mixed with a link preview',
     {tag: ['@TC-388', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().sendMessage('User B message');
@@ -299,10 +290,11 @@ test.describe('In Conversation Search', () => {
   );
 
   test('Verify I can search for links without preview', {tag: ['@TC-391', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await userBPages.conversation().sendMessage('User B message');
@@ -321,10 +313,11 @@ test.describe('In Conversation Search', () => {
   });
 
   test('Verify I can not search for a deleted message', {tag: ['@TC-392', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await userBPages.conversation().sendMessage('User B message: Papaya');
@@ -346,10 +339,11 @@ test.describe('In Conversation Search', () => {
     'Verify results are sorted - latest message on top of list',
     {tag: ['@TC-398', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       // User B sends the first (older) message
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -372,10 +366,11 @@ test.describe('In Conversation Search', () => {
   );
 
   test('Verify I can find a message with special letters', {tag: ['@TC-403', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     const specialWord = 'Crème brûlée';
 
@@ -393,10 +388,11 @@ test.describe('In Conversation Search', () => {
   });
 
   test('Verify invisible characters in search are trimmed', {tag: ['@TC-405', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
     await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
@@ -415,10 +411,11 @@ test.describe('In Conversation Search', () => {
     'I want to see message is scrolled into view when tapping on search result',
     {tag: ['@TC-408', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
       await userBPages.conversation().sendMessage('Papaya');

--- a/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
@@ -19,7 +19,8 @@
 
 import {FrameLocator} from 'playwright/test';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, withLogin, expect, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+import {test, withLogin, expect} from 'test/e2e_tests/test.fixtures';
+import {connectWithUser} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Link Preview', () => {
   test(
@@ -27,15 +28,14 @@ test.describe('Link Preview', () => {
     {tag: ['@TC-1264', '@regression']},
     async ({createPage, createUser, createTeam}) => {
       const userB = await createUser();
-      const team = await createTeam('Test Team', {
-        users: [userB],
-      });
+      const team = await createTeam('Test Team', {users: [userB]});
       const userA = team.owner;
 
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();

--- a/apps/webapp/test/e2e_tests/specs/Logs/logs.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Logs/logs.spec.ts
@@ -1,6 +1,7 @@
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
+import {connectWithUser} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Logs', () => {
   let userA: User;
@@ -16,10 +17,8 @@ test.describe('Logs', () => {
     'Check that user messages are not being console logged',
     {tag: ['@TC-8794', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
 
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;

--- a/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Markdown/markdown.spec.ts
@@ -20,7 +20,8 @@
 import {Locator} from 'playwright-core';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withConnectedUser, withLogin} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
+import {connectWithUser} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Markdown', () => {
   let userA: User;
@@ -63,10 +64,11 @@ test.describe('Markdown', () => {
     },
   ].forEach(({description, tag, message, getSelector, expectedText}) => {
     test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -85,7 +87,9 @@ test.describe('Markdown', () => {
     {tag: ['@TC-9482', '@regression']},
     async ({createPage}) => {
       const targetUrl = 'https://example.com/test_path_with_underscores';
-      const userAPageManager = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB)));
+      const userAPageManager = PageManager.from(await createPage(withLogin(userA)));
+      await connectWithUser(userAPageManager, userB);
+
       const {pages, modals} = userAPageManager.webapp;
 
       await pages.conversationList().getConversation(userB.fullName).open();
@@ -106,10 +110,12 @@ test.describe('Markdown', () => {
   );
 
   test('I want to write a long code message', {tag: ['@TC-1316', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
+
     await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
@@ -124,10 +130,11 @@ test.describe('Markdown', () => {
   });
 
   test('I want to write a mixed markdown message', {tag: ['@TC-1317', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -143,10 +150,11 @@ test.describe('Markdown', () => {
   });
 
   test('I want to edit a markdown message', {tag: ['@TC-1318', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -174,10 +182,11 @@ test.describe('Markdown', () => {
     'I want to write a url with markdown (Mixed with text)',
     {tag: ['@TC-1319', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();

--- a/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
@@ -1,7 +1,7 @@
-import {test, expect, withLogin, withConnectedUser, Team, withGuestUser} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin, Team, withGuestUser} from 'test/e2e_tests/test.fixtures';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
+import {connectWithUser, createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Mention', () => {
   let team: Team;
@@ -117,10 +117,11 @@ test.describe('Mention', () => {
   );
 
   test('I want to be able to write a mention in a 1:1', {tag: ['@TC-3490', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -138,10 +139,9 @@ test.describe('Mention', () => {
     'I want to send an ephemeral message with a mention',
     {tag: ['@TC-3491', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
@@ -169,10 +169,11 @@ test.describe('Mention', () => {
     'I want to mention the same person twice in the same message',
     {tag: ['@TC-3492', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -198,7 +199,10 @@ test.describe('Mention', () => {
     'I want mention to be shown as a full name even if I searched by username',
     {tag: ['@TC-3493', '@regression']},
     async ({createPage}) => {
-      const userAPages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
+      const userAPage = await createPage(withLogin(userA));
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
       await userAPages.conversationList().getConversation(userB.fullName).open();
 
       const conversationPageA = userAPages.conversation();
@@ -219,10 +223,12 @@ test.describe('Mention', () => {
     'I want to see the mentions in my profile color in the input field',
     {tag: ['@TC-3494', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)).then(page => PageManager.from(page).webapp.pages),
-        createPage(withLogin(userB)).then(page => PageManager.from(page).webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
@@ -252,7 +258,10 @@ test.describe('Mention', () => {
     'I should not loose drafted text or mentions in input field',
     {tag: ['@TC-3498', '@regression']},
     async ({createPage}) => {
-      const userAPages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+      const userAPage = await createPage(withLogin(userA));
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
       await createGroup(userAPages, 'Draft Group', [userB]);
 
       const conversationPageA = userAPages.conversation();
@@ -283,10 +292,11 @@ test.describe('Mention', () => {
   );
 
   test('I want to receive a message containing a mention', {tag: ['@TC-3521', '@regression']}, async ({createPage}) => {
-    const userBPages = await PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages);
-    const userAPages = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(
-      pm => pm.webapp.pages,
-    );
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -306,10 +316,11 @@ test.describe('Mention', () => {
     'I want to see a subtitle in the conversation list when there is one or more unread mentions in the conversation',
     {tag: ['@TC-3528', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       // Create and open a group conversation for userB to ensure the message from A won't be read immediately
       await createGroup(userBPages, 'Distraction Group', [userC]);
@@ -330,10 +341,11 @@ test.describe('Mention', () => {
     'I want to see mention icon when I have unread mention, messages, pings and calls in a conversation',
     {tag: ['@TC-3529', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await test.step('Create and open a distraction group conversation for User B', async () => {
         // userA creates the group, userB opens it. This is the distraction.
@@ -371,10 +383,11 @@ test.describe('Mention', () => {
     'I should not see mention indicator in the conversation list if the sender recalls the mention message to me',
     {tag: ['@TC-3530', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userAPages, 'Test Group', [userB]);
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
@@ -393,10 +406,11 @@ test.describe('Mention', () => {
     'I want to see normal text message (without mention link) when I did not select someone from mention suggestion',
     {tag: ['@TC-3531', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -414,7 +428,10 @@ test.describe('Mention', () => {
     'I should not see mentions suggestion if I type @ with characters in front',
     {tag: ['@TC-3532', '@regression']},
     async ({createPage}) => {
-      const {pages} = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp;
+      const page = await createPage(withLogin(userA));
+      await connectWithUser(page, userB);
+
+      const {pages} = PageManager.from(page).webapp;
       await pages.conversationList().getConversation(userB.fullName).open();
 
       await pages.conversation().messageInput.pressSequentially(`test@${userB.firstName}`);

--- a/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Notifications/notifications.spec.ts
@@ -1,8 +1,8 @@
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {interceptNotifications} from 'test/e2e_tests/utils/mockNotifications.util';
-import {test, withLogin, withConnectedUser, expect} from 'test/e2e_tests/test.fixtures';
-import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
+import {test, withLogin, expect} from 'test/e2e_tests/test.fixtures';
+import {connectWithUser, createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
 
@@ -17,10 +17,8 @@ test.describe('Notifications', () => {
   });
 
   test('I want to receive notifications for mentions', {tag: ['@TC-3499', '@regression']}, async ({createPage}) => {
-    const [userAPage, userBPage] = await Promise.all([
-      createPage(withLogin(userA), withConnectedUser(userB)),
-      createPage(withLogin(userB)),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
     const userAPages = PageManager.from(userAPage).webapp.pages;
 
     // Start intercepting notifications
@@ -48,10 +46,9 @@ test.describe('Notifications', () => {
     'I should not receive notifications for archived conversations',
     {tag: ['@TC-8760', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const {pages: userBPages, components: userBComponents} = PageManager.from(userBPage).webapp;
 
@@ -84,7 +81,9 @@ test.describe('Notifications', () => {
     'I want to mute 1on1 conversations via recent view',
     {tag: ['@TC-1437', '@regression']},
     async ({createPage}) => {
-      const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
+      const page = await createPage(withLogin(userA));
+      await connectWithUser(page, userB);
+      const pages = PageManager.from(page).webapp.pages;
 
       const conversation = await pages.conversationList().getConversation(userB.fullName).open();
       const contextMenu = await conversation.openContextMenu();
@@ -99,7 +98,10 @@ test.describe('Notifications', () => {
     'I want to unmute 1on1 conversations via recent view',
     {tag: ['@TC-1438', '@regression']},
     async ({createPage}) => {
-      const pages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
+      const page = await createPage(withLogin(userA));
+      await connectWithUser(page, userB);
+      const pages = PageManager.from(page).webapp.pages;
+
       const conversation = pages.conversationList().getConversation(userB.fullName);
 
       await test.step('Mute conversation', async () => {
@@ -128,10 +130,9 @@ test.describe('Notifications', () => {
       `I want to mute the ${conversationType} conversation via conversation details`,
       {tag: [testId, '@regression']},
       async ({createPage}) => {
-        const [userAPage, userBPage] = await Promise.all([
-          createPage(withLogin(userA), withConnectedUser(userB)),
-          createPage(withLogin(userB)),
-        ]);
+        const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+        await connectWithUser(userAPage, userB);
+
         const userAPages = PageManager.from(userAPage).webapp.pages;
         const userBPages = PageManager.from(userBPage).webapp.pages;
         await createGroup(userAPages, 'Test Group', [userB]);
@@ -166,10 +167,11 @@ test.describe('Notifications', () => {
     'I want to see join button on muted conversation when someone is trying to call me',
     {tag: ['@TC-1443', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       // User B mutes the conversation with User A
       const conversation = await userBPages
@@ -193,10 +195,9 @@ test.describe('Notifications', () => {
     'I should not receive notifications for muted 1:1 conversations',
     {tag: ['@TC-1444', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
@@ -236,10 +237,9 @@ test.describe('Notifications', () => {
     "Verify notification for ephemeral messages does not contain the message, sender's name or image",
     {tag: ['@TC-1448', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
 
       // Start intercepting notifications for User B
@@ -325,10 +325,9 @@ test.describe('Notifications', () => {
     ] as const
   ).forEach(({testId, title, notificationPreference, getExpectedNotifications}) => {
     test(title, {tag: [testId, '@regression']}, async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const {pages: userAPages, components: userAComponents} = PageManager.from(userAPage).webapp;
       const {pages: userBPages, components: userBComponents} = PageManager.from(userBPage).webapp;
 
@@ -384,10 +383,9 @@ test.describe('Notifications', () => {
     'Verify I can click ping notification while other conversation is opened',
     {tag: ['@TC-1455', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
@@ -412,10 +410,9 @@ test.describe('Notifications', () => {
     'Verify I can click calling notification while other conversation is opened',
     {tag: ['@TC-1456', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
@@ -443,10 +440,9 @@ test.describe('Notifications', () => {
     'Verify clicking a notification of a group conversation opens this conversation',
     {tag: ['@TC-1458', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
@@ -471,12 +467,12 @@ test.describe('Notifications', () => {
     'Verify I see notification when someone creates a group',
     {tag: ['@TC-1459', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
+
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       const {getNotifications} = await interceptNotifications(userBPage);
@@ -502,12 +498,12 @@ test.describe('Notifications', () => {
     'Verify I see notification when group name is changed',
     {tag: ['@TC-1461', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
+
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
       // User A creates a group with User B
@@ -572,10 +568,9 @@ test.describe('Notifications', () => {
     'Verify I see notification when image is sent to group conversation',
     {tag: ['@TC-1464', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
@@ -607,10 +602,9 @@ test.describe('Notifications', () => {
     'Verify I see notification when someone changes the timer',
     {tag: ['@TC-1466', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 

--- a/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
@@ -21,7 +21,7 @@ import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
-import {test, expect, withConnectedUser, withLogin, Team} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin, Team} from 'test/e2e_tests/test.fixtures';
 
 async function openParticipantDetailsFromGroup(
   pages: PageManager['webapp']['pages'],
@@ -93,9 +93,10 @@ test.describe('Participant Profile', () => {
       const userC = await createUser();
       const [userAPage, userBPage, userCPage] = await Promise.all([
         createPage(withLogin(userA)),
-        createPage(withLogin(userB), withConnectedUser(userA)),
+        createPage(withLogin(userB)),
         createPage(withLogin(userC)),
       ]);
+
       const [userAPages, userBPages, userCPages] = [userAPage, userBPage, userCPage].map(
         page => PageManager.from(page).webapp.pages,
       );
@@ -180,12 +181,12 @@ test.describe('Participant Profile', () => {
     'Verify big profile picture and username are shown on participant popover',
     {tag: ['@TC-1480', '@regression']},
     async ({createPage}) => {
-      const [adminPage, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      const [adminPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await createGroup(adminPage, groupName, [userB]);
+      await createGroup(adminPages, groupName, [userB]);
       await openParticipantDetailsFromGroup(userBPages, groupName, userA.fullName);
 
       await expect(userBPages.participantDetails().userPicture).toBeVisible();
@@ -201,12 +202,12 @@ test.describe('Participant Profile', () => {
       const externalUser = await createUser();
       await team.addTeamMember(externalUser, {role: 'EXTERNAL'});
 
-      const [adminPage, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(externalUser))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      const [adminPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await createGroup(adminPage, groupName, [userB, externalUser]);
+      await createGroup(adminPages, groupName, [userB, externalUser]);
       await openParticipantDetailsFromGroup(userBPages, groupName, externalUser.fullName);
 
       await expect(userBPages.participantDetails().userStatus).toContainText('External');
@@ -217,12 +218,12 @@ test.describe('Participant Profile', () => {
     'I want to see the group admin icon as a member seeing the group admin profile',
     {tag: ['@TC-1485', '@regression']},
     async ({createPage}) => {
-      const [adminPage, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+      const [adminPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await createGroup(adminPage, groupName, [userB]);
+      await createGroup(adminPages, groupName, [userB]);
       await openParticipantDetailsFromGroup(userBPages, groupName, userA.fullName);
 
       await expect(userBPages.participantDetails().userStatus).toContainText('Group Admin');
@@ -233,17 +234,15 @@ test.describe('Participant Profile', () => {
     'I want to see the group admin icon as an admin seeing the group admin profile',
     {tag: ['@TC-1486', '@regression']},
     async ({createPage}) => {
-      const adminPage = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(
-        pm => pm.webapp.pages,
-      );
+      const adminPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
-      await createGroup(adminPage, groupName, [userB]);
+      await createGroup(adminPages, groupName, [userB]);
 
-      await adminPage.conversationList().getConversation(groupName).open();
-      await adminPage.conversation().clickConversationInfoButton();
+      await adminPages.conversationList().getConversation(groupName).open();
+      await adminPages.conversation().clickConversationInfoButton();
 
-      await adminPage.conversation().makeUserAdmin(userB.fullName);
-      await expect(adminPage.participantDetails().userStatus).toContainText('Group Admin');
+      await adminPages.conversation().makeUserAdmin(userB.fullName);
+      await expect(adminPages.participantDetails().userStatus).toContainText('Group Admin');
     },
   );
 
@@ -251,14 +250,12 @@ test.describe('Participant Profile', () => {
     'I want to see Remove from group as an admin seeing a participants profile',
     {tag: ['@TC-1487', '@regression']},
     async ({createPage}) => {
-      const adminPage = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(
-        pm => pm.webapp.pages,
-      );
+      const adminPages = PageManager.from(await createPage(withLogin(userA))).webapp.pages;
 
-      await createGroup(adminPage, groupName, [userB]);
-      await openParticipantDetailsFromGroup(adminPage, groupName, userB.fullName);
+      await createGroup(adminPages, groupName, [userB]);
+      await openParticipantDetailsFromGroup(adminPages, groupName, userB.fullName);
 
-      const removeFromGroup = adminPage.participantDetails().removeFromGroupButton;
+      const removeFromGroup = adminPages.participantDetails().removeFromGroupButton;
       await expect(removeFromGroup).toBeVisible();
       await expect(removeFromGroup).toHaveText('Remove from group…');
     },
@@ -270,12 +267,13 @@ test.describe('Participant Profile', () => {
     async ({createPage, createUser}) => {
       const userC = await createUser();
       await team.addTeamMember(userC);
-      const [adminPage, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))).then(pm => pm.webapp.pages),
+
+      const [adminPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
       ]);
 
-      await createGroup(adminPage, groupName, [userB, userC]);
+      await createGroup(adminPages, groupName, [userB, userC]);
       await openParticipantDetailsFromGroup(userBPages, groupName, userC.fullName);
 
       await expect(userBPages.participantDetails().removeFromGroupButton).not.toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/Ping/ping.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Ping/ping.spec.ts
@@ -102,7 +102,7 @@ test.describe('Ping', () => {
       await userAPages.conversation().sendPing();
 
       await expect(userAModals.confirm().modal).toBeVisible();
-      await expect(await userAModals.confirm().getModalTitle()).toContain('Are you sure you want to ping 5 people?');
+      await expect(userAModals.confirm().modalTitle).toContainText('Are you sure you want to ping 5 people?');
     },
   );
 });

--- a/apps/webapp/test/e2e_tests/specs/Ping/ping.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Ping/ping.spec.ts
@@ -19,8 +19,8 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withLogin, withConnectedUser, Team} from 'test/e2e_tests/test.fixtures';
-import {createGroup} from '../../utils/userActions';
+import {test, expect, withLogin, Team} from 'test/e2e_tests/test.fixtures';
+import {connectWithUser, createGroup} from '../../utils/userActions';
 
 test.describe('Ping', () => {
   let team: Team;
@@ -43,10 +43,11 @@ test.describe('Ping', () => {
       `Verify I can receive ping in ${scenario.name}`,
       {tag: [scenario.tag, '@regression']},
       async ({createPage}) => {
-        const [userAPages, userBPages] = await Promise.all([
-          PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-          PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-        ]);
+        const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+        await connectWithUser(userAPage, userB);
+
+        const userAPages = PageManager.from(userAPage).webapp.pages;
+        const userBPages = PageManager.from(userBPage).webapp.pages;
 
         const conversationName = 'Test Group';
 
@@ -67,10 +68,11 @@ test.describe('Ping', () => {
   }
 
   test('Verify I can receive ping several times in a row', {tag: ['@TC-1491', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userBPages.conversationList().getConversation(userA.fullName).open();
     await userBPages.conversation().sendPing();
@@ -92,7 +94,8 @@ test.describe('Ping', () => {
         usersForBigGroup.push(newMember);
       }
 
-      const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
+      const userAPage = await createPage(withLogin(userA));
+      await connectWithUser(userAPage, userB);
       const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
 
       const conversationName = 'Test Group';

--- a/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
@@ -20,9 +20,10 @@
 import {Page} from 'playwright/test';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
+import {connectWithUser} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Reactions', () => {
   let userA: User;
@@ -84,10 +85,8 @@ test.describe('Reactions', () => {
 
   for (const c of likeCases) {
     test(`Verify liking someone's ${c.title}`, {tag: [c.tc, '@regression']}, async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
 
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
@@ -106,9 +105,10 @@ test.describe('Reactions', () => {
   }
 
   test("Verify liking someone's location", {tag: ['@TC-1533', '@regression']}, async ({createPage, api}) => {
-    const userAPages = await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(
-      pm => pm.webapp.pages,
-    );
+    const userAPage = await createPage(withLogin(userA));
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
 
     await test.step('Prerequisite: Send location via TestService', async () => {
       const {instanceId} = await api.testService.createInstance(
@@ -135,7 +135,10 @@ test.describe('Reactions', () => {
   });
 
   test('Verify liking an own text message', {tag: ['@TC-1534', '@regression']}, async ({createPage}) => {
-    const userAPages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
+    const userAPage = await createPage(withLogin(userA));
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
 
     await userAPages.conversation().sendMessage('Message from User A');
     const messageUserA = userAPages.conversation().getMessage({sender: userA});
@@ -145,7 +148,10 @@ test.describe('Reactions', () => {
   });
 
   test('Verify you cannot like a system message', {tag: ['@TC-1535', '@regression']}, async ({createPage}) => {
-    const userAPages = PageManager.from(await createPage(withLogin(userA), withConnectedUser(userB))).webapp.pages;
+    const userAPage = await createPage(withLogin(userA));
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
 
     const systemMessage = userAPages.conversation().systemMessages;
     await systemMessage.hover();
@@ -155,10 +161,11 @@ test.describe('Reactions', () => {
   });
 
   test('Verify likes are reset if you edited message', {tag: ['@TC-1538', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
+    const userAPages = PageManager.from(userAPage).webapp.pages;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
     await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -182,10 +189,8 @@ test.describe('Reactions', () => {
     'Verify I can open like list by hovering the link in the tooltip of a reaction pill',
     {tag: ['@TC-1540', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
 
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
@@ -212,10 +217,11 @@ test.describe('Reactions', () => {
     'Verify locally deleted message can be liked by others',
     {tag: ['@TC-1543', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -236,10 +242,11 @@ test.describe('Reactions', () => {
     'Verify likes are reset if sender edits their message',
     {tag: ['@TC-1544', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -278,10 +285,11 @@ test.describe('Reactions', () => {
 
   for (const c of toggleReactionCases) {
     test(c.title, {tag: [c.tc, '@regression']}, async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -19,10 +19,10 @@
 
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Reply', () => {
   let userA: User;
@@ -35,7 +35,9 @@ test.describe('Reply', () => {
   });
 
   test('I should not be able to reply to a ping', {tag: ['@TC-8038', '@regression']}, async ({createPage}) => {
-    const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+    const page = await createPage(withLogin(userA));
+    await connectWithUser(page, userB);
+    const pages = PageManager.from(page).webapp.pages;
 
     await pages.conversation().sendPing();
     const ping = pages.conversation().systemMessages.last();
@@ -46,7 +48,9 @@ test.describe('Reply', () => {
   });
 
   test('I should not be able to reply to timed messages', {tag: ['@TC-8039', '@regression']}, async ({createPage}) => {
-    const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+    const page = await createPage(withLogin(userA));
+    await connectWithUser(page, userB);
+    const pages = PageManager.from(page).webapp.pages;
 
     await pages.conversation().enableSelfDeletingMessages();
     await pages.conversation().sendMessage('Gone in 10s');
@@ -60,10 +64,11 @@ test.describe('Reply', () => {
     'I want to see a placeholder text as quote when original message is not available anymore',
     {tag: ['@TC-2994', '@regression']},
     async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
@@ -87,7 +92,10 @@ test.describe('Reply', () => {
     'I should not see the quoted message when searching for original message in collections',
     {tag: ['@TC-2996', '@regression']},
     async ({createPage}) => {
-      const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+      const page = await createPage(withLogin(userA));
+      await connectWithUser(page, userB);
+      const pages = PageManager.from(page).webapp.pages;
+
       await pages.conversation().sendMessage('Test');
 
       const messageToReplyTo = pages.conversation().getMessage({content: 'Test'});
@@ -110,7 +118,10 @@ test.describe('Reply', () => {
       const longMessage =
         'This is a very long message which should be truncated within the UI since it is as already stated very long.';
 
-      const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+      const page = await createPage(withLogin(userA));
+      await connectWithUser(page, userB);
+      const pages = PageManager.from(page).webapp.pages;
+
       await pages.conversation().sendMessage(longMessage);
 
       const messageToReplyTo = pages.conversation().getMessage({content: longMessage});
@@ -124,8 +135,10 @@ test.describe('Reply', () => {
   );
 
   test('I want to reply to a picture', {tag: ['@TC-3002', '@regression']}, async ({createPage}) => {
-    const page = await createPage(withLogin(userA), withConnectedUser(userB));
+    const page = await createPage(withLogin(userA));
+    await connectWithUser(page, userB);
     const pages = PageManager.from(page).webapp.pages;
+
     await shareAssetHelper(getImageFilePath(), page, page.getByRole('button', {name: 'Add picture'}));
 
     const messageWithImage = pages.conversation().getMessage({sender: userA});
@@ -137,7 +150,8 @@ test.describe('Reply', () => {
   });
 
   test('I want to reply to an audio message', {tag: ['@TC-3003', '@regression']}, async ({createPage}) => {
-    const page = await createPage(withLogin(userA), withConnectedUser(userB));
+    const page = await createPage(withLogin(userA));
+    await connectWithUser(page, userB);
     const pages = PageManager.from(page).webapp.pages;
 
     await shareAssetHelper(getAudioFilePath(), page, page.getByRole('button', {name: 'Add file'}));
@@ -151,8 +165,10 @@ test.describe('Reply', () => {
   });
 
   test('I want to reply to a video message', {tag: ['@TC-3004', '@regression']}, async ({createPage}) => {
-    const page = await createPage(withLogin(userA), withConnectedUser(userB));
+    const page = await createPage(withLogin(userA));
+    await connectWithUser(page, userB);
     const pages = PageManager.from(page).webapp.pages;
+
     await shareAssetHelper(getVideoFilePath(), page, page.getByRole('button', {name: 'Add file'}));
 
     const messageWithVideo = pages.conversation().getMessage({sender: userA});
@@ -164,7 +180,10 @@ test.describe('Reply', () => {
   });
 
   test('I want to reply to a link', {tag: ['@TC-3005', '@regression']}, async ({createPage}) => {
-    const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+    const page = await createPage(withLogin(userA));
+    await connectWithUser(page, userB);
+    const pages = PageManager.from(page).webapp.pages;
+
     await pages.conversation().sendMessage('https://www.lidl.de/');
 
     const messageWithLink = pages.conversation().getMessage({sender: userA});
@@ -176,8 +195,10 @@ test.describe('Reply', () => {
   });
 
   test('I want to reply to a file', {tag: ['@TC-3006', '@regression']}, async ({createPage}) => {
-    const page = await createPage(withLogin(userA), withConnectedUser(userB));
+    const page = await createPage(withLogin(userA));
+    await connectWithUser(page, userB);
     const pages = PageManager.from(page).webapp.pages;
+
     await shareAssetHelper(getTextFilePath(), page, page.getByRole('button', {name: 'Add file'}));
 
     const messageWithFile = pages.conversation().getMessage({sender: userA});
@@ -189,7 +210,10 @@ test.describe('Reply', () => {
   });
 
   test('I want to reply to a reply', {tag: ['@TC-3007', '@regression']}, async ({createPage}) => {
-    const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+    const page = await createPage(withLogin(userA));
+    await connectWithUser(page, userB);
+    const pages = PageManager.from(page).webapp.pages;
+
     await pages.conversation().sendMessage('Message');
 
     const message = pages.conversation().getMessage({content: 'Message'});
@@ -205,7 +229,10 @@ test.describe('Reply', () => {
   });
 
   test('I want to reply to a link mixed with text', {tag: ['@TC-3008', '@regression']}, async ({createPage}) => {
-    const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+    const page = await createPage(withLogin(userA));
+    await connectWithUser(page, userB);
+    const pages = PageManager.from(page).webapp.pages;
+
     await pages.conversation().sendMessage('Link: https://www.lidl.de/');
 
     const messageWithLink = pages.conversation().getMessage({sender: userA});
@@ -218,7 +245,9 @@ test.describe('Reply', () => {
   });
 
   test('I want to reply to a location share', {tag: ['@TC-3009', '@regression']}, async ({createPage, api}) => {
-    const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+    const page = await createPage(withLogin(userA));
+    await connectWithUser(page, userB);
+    const pages = PageManager.from(page).webapp.pages;
 
     await test.step('Prerequisite: Send location via TestService', async () => {
       const {instanceId} = await api.testService.createInstance(
@@ -250,7 +279,10 @@ test.describe('Reply', () => {
     'I want to send a timed message as a reply to any type of a message',
     {tag: ['@TC-3011', '@regression']},
     async ({createPage}) => {
-      const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+      const page = await createPage(withLogin(userA));
+      await connectWithUser(page, userB);
+      const pages = PageManager.from(page).webapp.pages;
+
       await pages.conversation().sendMessage('Message');
 
       const message = pages.conversation().getMessage({sender: userA});
@@ -267,7 +299,10 @@ test.describe('Reply', () => {
     'I want to click the quoted message to jump to the original message',
     {tag: ['@TC-3013', '@regression']},
     async ({createPage}) => {
-      const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+      const page = await createPage(withLogin(userA));
+      await connectWithUser(page, userB);
+      const pages = PageManager.from(page).webapp.pages;
+
       await pages.conversation().sendMessage('Message');
       await pages.conversation().sendMessage('Line\n'.repeat(50)); // Send a message with a lot of lines to test the scrolling behavior
 
@@ -322,7 +357,9 @@ test.describe('Reply', () => {
     'I want to reply with mention and tap on the mention in the reply opens the user profile',
     {tag: ['@TC-3016', '@regression']},
     async ({createPage}) => {
-      const pages = (await PageManager.from(createPage(withLogin(userA), withConnectedUser(userB)))).webapp.pages;
+      const page = await createPage(withLogin(userA));
+      await connectWithUser(page, userB);
+      const pages = PageManager.from(page).webapp.pages;
 
       await pages.conversation().sendMessageWithUserMention(userB.fullName, 'Message');
       const message = pages.conversation().getMessage({content: 'Message'});
@@ -345,9 +382,10 @@ test.describe('Reply', () => {
   // TODO: flaky due to Bug-Ticket [WPB-25411]
   test.skip('I want to edit my reply', {tag: ['@TC-3019', '@regression']}, async ({createPage}) => {
     const [userAPageManager, userBPageManager] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))),
+      PageManager.from(createPage(withLogin(userA))),
       PageManager.from(createPage(withLogin(userB))),
     ]);
+    await connectWithUser(userAPageManager, userB);
 
     const {pages: userAPages} = userAPageManager.webapp;
     const {pages: userBPages} = userBPageManager.webapp;

--- a/apps/webapp/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -20,8 +20,8 @@
 import {Locator} from '@playwright/test';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withLogin, withConnectedUser} from 'test/e2e_tests/test.fixtures';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
+import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Self Deleting Messages', () => {
   let userA: User;
@@ -34,10 +34,9 @@ test.describe('Self Deleting Messages', () => {
   });
 
   test('Verify sending ephemeral text message in 1:1', {tag: ['@TC-657', '@regression']}, async ({createPage}) => {
-    const [userAPage, userBPage] = await Promise.all([
-      createPage(withLogin(userA), withConnectedUser(userB)),
-      createPage(withLogin(userB)),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
     const userAPages = PageManager.from(userAPage).webapp.pages;
     const userBPages = PageManager.from(userBPage).webapp.pages;
 
@@ -74,7 +73,8 @@ test.describe('Self Deleting Messages', () => {
     'Verify timer is applied to all messages until turning it off in 1:1',
     {tag: ['@TC-662', '@regression']},
     async ({createPage}) => {
-      const page = await createPage(withLogin(userA), withConnectedUser(userB));
+      const page = await createPage(withLogin(userA));
+      await connectWithUser(page, userB);
       const pages = PageManager.from(page).webapp.pages;
 
       await pages.conversation().enableSelfDeletingMessages();
@@ -102,7 +102,8 @@ test.describe('Self Deleting Messages', () => {
     'Verify that message with previous timer are deleted on start-up when the timeout passed in 1:1',
     {tag: ['@TC-664', '@regression']},
     async ({context, createPage}) => {
-      let page = await createPage(context, withLogin(userA), withConnectedUser(userB));
+      let page = await createPage(context, withLogin(userA));
+      await connectWithUser(page, userB);
       let pages = PageManager.from(page).webapp.pages;
 
       await pages.conversation().enableSelfDeletingMessages();
@@ -127,10 +128,9 @@ test.describe('Self Deleting Messages', () => {
     "Verify the message is not deleted for users that didn't read the message",
     {tag: ['@TC-675', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const [userAPages, userBPages] = [userAPage, userBPage].map(page => PageManager.from(page).webapp.pages);
       await createGroup(userAPages, 'Test Group', [userB]);
 
@@ -215,10 +215,11 @@ test.describe('Self Deleting Messages', () => {
     let searchResults: Locator;
 
     test.beforeEach(async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
       await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();

--- a/apps/webapp/test/e2e_tests/specs/SendingAssets/sendingAssets.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SendingAssets/sendingAssets.spec.ts
@@ -20,7 +20,7 @@
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 
-import {test, expect, withConnectedUser, withLogin} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, shareAssetHelper, TextFileName} from 'test/e2e_tests/utils/asset.util';
 import {Locator} from 'playwright/test';
 import {getImageFilePath, ImageQRCodeFileName} from 'test/e2e_tests/utils/sendImage.util';
@@ -28,7 +28,7 @@ import {Buffer} from 'node:buffer';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import {tmpdir} from 'node:os';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
 
 interface DragAndDropOptions {
   buffer: Buffer;
@@ -66,7 +66,8 @@ test.describe('Sending Assets', () => {
   });
 
   test('Verify you can delete an audio message', {tag: ['@TC-111', '@regression']}, async ({createPage}) => {
-    const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
+    const userAPage = await createPage(withLogin(userA));
+    await connectWithUser(userAPage, userB);
     const {pages} = PageManager.from(userAPage).webapp;
 
     await pages.conversationList().getConversation(userB.fullName).open();
@@ -79,7 +80,8 @@ test.describe('Sending Assets', () => {
   });
 
   test('I want to drag & drop a file into a conversation', {tag: ['@TC-497', '@regression']}, async ({createPage}) => {
-    const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
+    const userAPage = await createPage(withLogin(userA));
+    await connectWithUser(userAPage, userB);
     const {pages, modals} = PageManager.from(userAPage).webapp;
 
     const buffer = await fs.readFile(getTextFilePath());
@@ -113,7 +115,8 @@ test.describe('Sending Assets', () => {
     'I want to copy & paste an image into a conversation',
     {tag: ['@TC-498', '@regression']},
     async ({createPage}) => {
-      const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
+      const userAPage = await createPage(withLogin(userA));
+      await connectWithUser(userAPage, userB);
       const {pages} = PageManager.from(userAPage).webapp;
 
       const buffer = await fs.readFile(getImageFilePath());
@@ -159,7 +162,8 @@ test.describe('Sending Assets', () => {
   );
 
   test('I want to copy message via message option menu', {tag: ['@TC-500', '@regression']}, async ({createPage}) => {
-    const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
+    const userAPage = await createPage(withLogin(userA));
+    await connectWithUser(userAPage, userB);
     const userAPages = PageManager.from(userAPage).webapp.pages;
 
     await userAPages.conversationList().getConversation(userB.fullName).open();
@@ -189,7 +193,8 @@ test.describe('Sending Assets', () => {
       `Verify file can be uploaded and re-downloaded by sender himself in ${conversationType}`,
       {tag: [`${tag}`, '@regression']},
       async ({createPage}, testInfo) => {
-        const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
+        const userAPage = await createPage(withLogin(userA));
+        await connectWithUser(userAPage, userB);
         const {pages} = PageManager.from(userAPage).webapp;
 
         const sourcePath = getTextFilePath();
@@ -230,7 +235,8 @@ test.describe('Sending Assets', () => {
   });
 
   test('Verify warning is shown if file size is too big', {tag: ['@TC-767', '@regression']}, async ({createPage}) => {
-    const page = await createPage(withLogin(userA), withConnectedUser(userB));
+    const page = await createPage(withLogin(userA));
+    await connectWithUser(page, userB);
     const {pages, modals} = PageManager.from(page).webapp;
     await createGroup(pages, 'Test Group', [userB]);
 
@@ -263,10 +269,9 @@ test.describe('Sending Assets', () => {
   });
 
   test('Verify sender is able to cancel upload', {tag: ['@TC-773', '@regression']}, async ({createPage}) => {
-    const [userAPage, userBPage] = await Promise.all([
-      createPage(withLogin(userA), withConnectedUser(userB)),
-      createPage(withLogin(userB)),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
+
     const pages = PageManager.from(userAPage).webapp.pages;
     const userBPages = PageManager.from(userBPage).webapp.pages;
 
@@ -294,10 +299,9 @@ test.describe('Sending Assets', () => {
     'I should not be able to download files that were manipulated with wrong hash or invalid hash',
     {tag: ['@TC-777', '@regression']},
     async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
       const userAPages = PageManager.from(userAPage).webapp.pages;
       const userBPages = PageManager.from(userBPage).webapp.pages;
 
@@ -324,7 +328,8 @@ test.describe('Sending Assets', () => {
     'I should not be able to download sent files when they are obfuscated',
     {tag: ['@TC-3728', '@regression']},
     async ({createPage}) => {
-      const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
+      const userAPage = await createPage(withLogin(userA));
+      await connectWithUser(userAPage, userB);
       const {pages} = PageManager.from(userAPage).webapp;
 
       await pages.conversationList().getConversation(userB.fullName).open();
@@ -347,7 +352,8 @@ test.describe('Sending Assets', () => {
     'Verify you can see conversation images in fullscreen',
     {tag: ['@TC-1193', '@regression']},
     async ({createPage}) => {
-      const userAPage = await createPage(withLogin(userA), withConnectedUser(userB));
+      const userAPage = await createPage(withLogin(userA));
+      await connectWithUser(userAPage, userB);
       const {pages, modals} = PageManager.from(userAPage).webapp;
 
       await pages.conversationList().getConversation(userB.fullName).open();

--- a/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
@@ -21,11 +21,11 @@ import {Page} from 'playwright/test';
 import {ApiManagerE2E} from 'test/e2e_tests/backend/apiManager.e2e';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {test, expect, withConnectedUser, withLogin, Team} from 'test/e2e_tests/test.fixtures';
+import {test, expect, withLogin, Team} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
 import {interceptNotifications} from 'test/e2e_tests/utils/mockNotifications.util';
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
-import {createGroup} from 'test/e2e_tests/utils/userActions';
+import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
 
 enum UserStatus {
   Away = 'Away',
@@ -224,10 +224,9 @@ test.describe('Status', () => {
 
   for (const config of notificationConfigs) {
     test(config.title, {tag: config.tag}, async ({createPage, api}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB), withConnectedUser(userC)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+      await connectWithUser(userBPage, userC);
 
       const userAPageManager = PageManager.from(userAPage).webapp;
       const userBPageManager = PageManager.from(userBPage).webapp;
@@ -352,10 +351,8 @@ test.describe('Status', () => {
     'When I am available or have unset status, I want to get notifications for every message in non-muted conversations',
     {tag: ['@TC-3626', '@regression']},
     async ({createPage, api}) => {
-      const [userAPage, userBPage] = await Promise.all([
-        createPage(withLogin(userA), withConnectedUser(userB)),
-        createPage(withLogin(userB)),
-      ]);
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
 
       const userAPageManager = PageManager.from(userAPage).webapp;
       const userBPageManager = PageManager.from(userBPage).webapp;
@@ -425,13 +422,11 @@ test.describe('Status', () => {
   );
 
   test('I want to set my status on profile page', {tag: ['@TC-1766', '@regression']}, async ({createPage}) => {
-    const [userAPageManager, userBPageManager] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA))),
-      PageManager.from(createPage(withLogin(userB), withConnectedUser(userA))),
-    ]);
+    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    await connectWithUser(userAPage, userB);
 
-    const {pages, components, modals} = userAPageManager.webapp;
-    const userBPages = userBPageManager.webapp.pages;
+    const {pages, components, modals} = PageManager.from(userAPage).webapp;
+    const userBPages = PageManager.from(userBPage).webapp.pages;
 
     // User B verify no status is set in conversation list
     const conversation = await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -22,7 +22,6 @@ import {test as baseTest, type BrowserContext, type Page} from '@playwright/test
 import {ApiManagerE2E} from './backend/apiManager.e2e';
 import {getUser, User} from './data/user';
 import {PageManager} from './pageManager';
-import {connectWithUser} from './utils/userActions';
 import {mockAudioAndVideoDevices} from './utils/mockVideoDevice.util';
 import {Role} from '@wireapp/api-client/lib/team';
 import {FEATURE_KEY} from '@wireapp/api-client/lib/team/feature';
@@ -229,17 +228,6 @@ export const withLogin =
     await pageManager.webapp.components
       .conversationSidebar()
       .sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
-  };
-
-/**
- * PagePlugin to connect with the given user
- * Note: This plugin only works if the users are in the same team
- */
-export const withConnectedUser =
-  (user: User | Promise<User>): PagePlugin =>
-  async page => {
-    const pageManager = PageManager.from(page);
-    await connectWithUser(pageManager, await user);
   };
 
 /** PagePlugin to open a guest user link and join the group chat as temporary member */


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25038" title="WPB-25038" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25038</a>  [Web][QA] Investigate race condition caused by parallel connection requests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is the follow up for #21175 to improve our E2E Tests and prevent race conditions sometimes occurring during login.
The `withConnectedUser` page plugin could cause a situation where a connection request is sent to a user which doesn't have a device yet.