### PR TITLE
test: improve stability of tests sending connection requests [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -113,12 +113,14 @@ test.describe('User Blocking', () => {
       'Verify you can block a user who is not in your team',
       {tag: ['@TC-140', '@regression']},
       async ({createPage}) => {
-        const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
-        await sendConnectionRequest(userAPageManager, userB);
-        const {pages: userAPages, modals: userAModals} = userAPageManager.webapp;
+        const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+        await sendConnectionRequest(userAPage, userB);
+
+        const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+        const {pages: userBPages} = PageManager.from(userBPage).webapp;
 
         // Preconditions: User B accepts the connection request
-        const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
+        await userBPages.conversationList().openPendingConnectionRequest();
         await userBPages.connectRequest().clickConnectButton();
 
         // Step 1: User A and B have a 1:1 conversation
@@ -169,6 +171,7 @@ test.describe('User Blocking', () => {
         const conversationName = 'GroupConversation';
 
         await expect(userAPages.conversationList().getConversation(userB.fullName)).toBeAttached();
+        await expect(userBPages.conversationList().getConversation(userA.fullName)).toBeAttached();
         await createGroup(userAPages, conversationName, [userB]);
 
         await test.step('Step 1: User B sends message to group chat with User A', async () => {
@@ -199,12 +202,17 @@ test.describe('User Blocking', () => {
       {tag: ['@TC-142', '@regression']},
 
       async ({createPage}) => {
-        const userAPageManagerInstance = await PageManager.from(createPage(withLogin(userA)));
+        const [userAPageManagerInstance, userBPageManagerInstance] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))),
+          PageManager.from(createPage(withLogin(userB))),
+        ]);
         await sendConnectionRequest(userAPageManagerInstance, userB);
+
         const {pages: userAPages, modals: userAModals} = userAPageManagerInstance.webapp;
+        const {pages: userBPages} = userBPageManagerInstance.webapp;
 
         // Preconditions: User B accepts the connection request
-        const userBPages = (await PageManager.from(createPage(withLogin(userB)))).webapp.pages;
+        await userBPages.conversationList().openPendingConnectionRequest();
         await userBPages.connectRequest().clickConnectButton();
 
         // Step 1: User A and B have a 1:1 conversation

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -490,6 +490,8 @@ test.describe('Calling', () => {
       await test.step('Setup: Accept connection and start group call', async () => {
         await guestPages.conversationList().openPendingConnectionRequest();
         await guestPages.connectRequest().clickConnectButton();
+        await expect(userAPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
+        await expect(guestPages.conversationList().getConversation(userA.fullName)).toBeAttached();
 
         await createGroup(userAPages, groupName, [userB, guestUser]);
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
@@ -44,6 +44,7 @@ test('Group Video call', {tag: ['@TC-8637', '@crit-flow-web']}, async ({createTe
     await guestPages.conversationList().openPendingConnectionRequest();
     await guestPages.connectRequest().clickConnectButton();
     await expect(ownerPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
+    await expect(guestPages.conversationList().getConversation(teamOwner.fullName)).toBeAttached();
   });
 
   await test.step('Owner and team member are in a group conversation together', async () => {

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -55,8 +55,12 @@ test.describe('Guestroom', () => {
         await guestPages.conversationJoin().joinBrowserButton.click();
         await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
 
-        await guestPages.login().login(guestUser);
-        await expect(guestBModals.joinGuestLinkPassword().joinForm).toBeVisible({timeout: LOGIN_TIMEOUT});
+        // Allow the login to be retried if the modal doesn't show up automatically, this is a workaround since the login mask for guest links is out of our control
+        await expect(async () => {
+          await guestPages.login().login(guestUser);
+          await expect(guestBModals.joinGuestLinkPassword().joinForm).toBeVisible();
+        }).toPass({timeout: LOGIN_TIMEOUT});
+
         await guestBModals.joinGuestLinkPassword().joinConversation('WrongPassword');
         await expect(guestBModals.joinGuestLinkPassword().joinForm).toContainText(
           'Password is incorrect, please try again.',

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -180,6 +180,7 @@ test.describe('Guestroom', () => {
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();
       await expect(ownerPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
+      await expect(guestPages.conversationList().getConversation(userA.fullName)).toBeAttached();
 
       await test.step('Owner creates a group with guest', async () => {
         await createGroup(ownerPages, groupName, [guestUser]);

--- a/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
@@ -103,6 +103,7 @@ test.describe('Participant Profile', () => {
       await sendConnectionRequest(userAPage, userC);
       await acceptConnectionRequest(userCPages);
       await expect(userAPages.conversationList().getConversation(userC.fullName)).toBeAttached();
+      await expect(userCPages.conversationList().getConversation(userA.fullName)).toBeAttached();
 
       await test.step('User C is in group with User A and B. User C is not connected to user B', async () => {
         await createGroup(userAPages, groupName, [userB, userC]);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
In some cases it could happen that the 1on1 conversation was created after the group conversation causing the test to fail e.g. because the already typed message couldn't be sent


