### PR TITLE
test: improve TC-392 by waiting for all messages to arrive before deleting [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -331,6 +331,7 @@ test.describe('In Conversation Search', () => {
 
     await userAPages.conversationList().openConversation(userB.fullName, {protocol: 'mls'});
     await userAPages.conversation().sendMessage('User A message: Guava');
+    await expect(userBPages.conversation().messages).toHaveCount(2);
 
     const messageUserB = userBPages.conversation().getMessage({sender: userB});
     await userBPages.conversation().deleteMessage(messageUserB, 'Everyone');


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
If the message from A arrived late it could cause the deletion to fail since it tries to hover the message but the message would move in between.


