### PR TITLE
Remove node20 variable-mapper and inline branch/tag mappings [WPB-22420]

### DIFF
--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -77,20 +77,14 @@ jobs:
           name: 'build-artifact'
           path: '${{env.BUILD_DIR}}${{env.BUILD_ARTIFACT}}'
 
-      - uses: kanga333/variable-mapper@3681b75f5c6c00162721168fb91ab74925eaebcb
-        id: changelog
-        with:
-          key: '${{github.ref}}'
-          map: |
-            {
-              "production": {
-                "changelog_type": "production"
-              },
-              "staging": {
-                "changelog_type": "staging"
-              }
-            }
-          export_to: env
+      - name: Define changelog type
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == *production* ]]; then
+            echo "changelog_type=production" >> "$GITHUB_ENV"
+          elif [[ "${GITHUB_REF}" == *staging* ]]; then
+            echo "changelog_type=staging" >> "$GITHUB_ENV"
+          fi
 
       - name: Generate changelog
         id: generate_changelog
@@ -157,30 +151,26 @@ jobs:
 
       # generates a mapping between branches/tag to wire-build branches
       - name: Define target branches in wireapp/wire-builds to bump
-        uses: kanga333/variable-mapper@3681b75f5c6c00162721168fb91ab74925eaebcb
         id: output_target_branches
-        with:
-          key: '${{github.ref}}'
-          # TODO  Add staging if we ever use a wire-builds as a source for staging (we use k8s)
-          # "staging": {
-          #   "targets": "[\"TBD\"]"
-          # },
-          map: |
-            {
-              "production": {
-                "targets": "[\"main\"]"
-              },
-              "dev": {
-                "targets": "[\"dev\"]"
-              },
-              "q1-2024": {
-                "targets": "[\"q1-2024\"]"
-              },
-              "q2-2025": {
-                "targets": "[\"q2-2025\"]"
-              }
-            }
-          export_to: log,output
+        shell: bash
+        run: |
+          set -eo pipefail
+
+          wire_build_target_branches_json=""
+
+          if [[ "${GITHUB_REF}" == *production* ]]; then
+            wire_build_target_branches_json='["main"]'
+          elif [[ "${GITHUB_REF}" == *dev* ]]; then
+            wire_build_target_branches_json='["dev"]'
+          elif [[ "${GITHUB_REF}" == *q1-2024* ]]; then
+            wire_build_target_branches_json='["q1-2024"]'
+          elif [[ "${GITHUB_REF}" == *q2-2025* ]]; then
+            wire_build_target_branches_json='["q2-2025"]'
+          fi
+
+          if [[ -n "${wire_build_target_branches_json}" ]]; then
+            echo "targets=${wire_build_target_branches_json}" >> "$GITHUB_OUTPUT"
+          fi
 
   publish_wire_builds:
     name: Bump webapp chart in wire-builds
@@ -262,26 +252,24 @@ jobs:
 
     steps:
       # generates a mapping between branches/tag to aws envs to deploy to
-      - uses: kanga333/variable-mapper@3681b75f5c6c00162721168fb91ab74925eaebcb
-        id: targets
-        with:
-          key: '${{github.ref}}'
-          map: |
-            {
-              "dev": {
-                "targets": "[\"wire-webapp-dev\", \"wire-webapp-edge\"]"
-              },
-              "master": {
-                "targets": "[\"wire-webapp-main\"]"
-              },
-              "production": {
-                "targets": "[\"wire-webapp-prod\"]"
-              },
-              "staging": {
-                "targets": "[\"wire-webapp-staging\"]"
-              }
-            }
-          export_to: env
+      - name: Define deployment targets
+        shell: bash
+        run: |
+          deployment_targets_json=""
+
+          if [[ "${GITHUB_REF}" == *dev* ]]; then
+            deployment_targets_json='["wire-webapp-dev", "wire-webapp-edge"]'
+          elif [[ "${GITHUB_REF}" == *master* ]]; then
+            deployment_targets_json='["wire-webapp-main"]'
+          elif [[ "${GITHUB_REF}" == *production* ]]; then
+            deployment_targets_json='["wire-webapp-prod"]'
+          elif [[ "${GITHUB_REF}" == *staging* ]]; then
+            deployment_targets_json='["wire-webapp-staging"]'
+          fi
+
+          if [[ -n "${deployment_targets_json}" ]]; then
+            echo "targets=${deployment_targets_json}" >> "$GITHUB_ENV"
+          fi
 
   deploy_to_aws:
     name: 'Deploy to live environments'


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Replaces `kanga333/variable-mapper` (Node.js 20 action) with native bash mapping steps in `publish-and-deploy-webapp.yml` to eliminate upcoming GitHub Actions runtime deprecation risk.

We [already have this](https://github.com/wireapp/wire-webapp/actions/runs/25310306045) warning in our pipelines:

<img width="3017" height="479" alt="2026-05-04 11 12 16 github com da2e903727e0" src="https://github.com/user-attachments/assets/53cf293b-2d59-4791-b476-f35cdebab8aa" />
