### PR TITLE
Preserve runtime body classes to keep conversation selection styling and text selection behavior stable [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/AppContainer/hooks/useAccentColor.ts
+++ b/apps/webapp/src/script/components/AppContainer/hooks/useAccentColor.ts
@@ -23,16 +23,21 @@ import ko from 'knockout';
 import {container} from 'tsyringe';
 
 import {UserState} from 'Repositories/user/UserState';
+import {ACCENT_ID} from 'src/script/Config';
 
 function setAccentColor(accentColor?: number) {
-  if (!accentColor) {
-    return;
-  }
-  const classes = document.body.className
-    .split(' ')
-    .filter(elementClass => !elementClass.startsWith('main-accent-color-'))
-    .concat(`main-accent-color-${accentColor}`);
-  document.body.className = classes.join(' ');
+  const accentColorClassId = accentColor ?? ACCENT_ID.BLUE;
+  const accentClassPrefix = 'main-accent-color-';
+  const bodyClassList = document.body.classList;
+  const accentClasses = Array.from(bodyClassList).filter(existingClassName => {
+    return existingClassName.startsWith(accentClassPrefix);
+  });
+
+  accentClasses.forEach(existingAccentClass => {
+    bodyClassList.remove(existingAccentClass);
+  });
+
+  bodyClassList.add(`${accentClassPrefix}${accentColorClassId}`);
 }
 
 export function useAccentColor() {
@@ -42,9 +47,12 @@ export function useAccentColor() {
       const selfUser = userState.self();
       return selfUser?.accent_id();
     });
-    const subscription = accentColor.subscribe(accent_color => {
-      setAccentColor(accent_color);
+    setAccentColor(accentColor());
+    const subscription = accentColor.subscribe(accentColorValue => {
+      setAccentColor(accentColorValue);
     });
-    return () => subscription.dispose();
+    return () => {
+      return subscription.dispose();
+    };
   }, []);
 }

--- a/apps/webapp/src/script/components/AppContainer/hooks/useTheme.ts
+++ b/apps/webapp/src/script/components/AppContainer/hooks/useTheme.ts
@@ -28,11 +28,16 @@ const THEMES_CLASS_PREFIX = 'theme-';
 export type Theme = WebappProperties['settings']['interface']['theme'];
 
 function setTheme(theme: Theme) {
-  const classes = document.body.className
-    .split(' ')
-    .filter(elementClass => !elementClass.startsWith(THEMES_CLASS_PREFIX))
-    .concat(`${THEMES_CLASS_PREFIX}${theme}`);
-  document.body.className = classes.join(' ');
+  const bodyClassList = document.body.classList;
+  const themeClasses = Array.from(bodyClassList).filter(existingClassName => {
+    return existingClassName.startsWith(THEMES_CLASS_PREFIX);
+  });
+
+  themeClasses.forEach(existingThemeClass => {
+    bodyClassList.remove(existingThemeClass);
+  });
+
+  bodyClassList.add(`${THEMES_CLASS_PREFIX}${theme}`);
 }
 
 export function useTheme(getTheme: () => Theme) {

--- a/apps/webapp/src/style/content/conversation/message-list.less
+++ b/apps/webapp/src/style/content/conversation/message-list.less
@@ -154,6 +154,7 @@
   display: flex;
   width: 100%;
   line-height: var(--avatar-diameter-xs);
+  user-select: text;
 
   & > .message-body-actions {
     top: 6px;
@@ -209,6 +210,7 @@
   align-items: center;
   font-size: var(--font-size-small);
   font-weight: var(--font-weight-regular);
+  user-select: text;
   white-space: normal;
 
   &:has(.delivered-message-icon) {
@@ -284,6 +286,7 @@
 .message-body {
   position: relative;
   width: 100%;
+  user-select: text;
 
   .text:has(> .iframe-container) {
     margin-right: 0;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Restore user interface state integrity by ensuring theme and accent updates only modify their own class namespaces instead of replacing the full body class list.

Right now no single text can be selected and not copied.