### PR TITLE
fix: add self user to MLS conversation when joining via invite link [WPB-22305]

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -1582,7 +1582,7 @@ export class ConversationRepository {
               if (response) {
                 await this.onMemberJoin(conversationEntity, response);
               }
-              await this.joinMLSConversationViaInviteLink(conversationEntity);
+              await this.addOtherSelfUserClientsToMLSConversation(conversationEntity);
               amplify.publish(WebAppEvents.CONVERSATION.SHOW, conversationEntity, {});
             } catch (error: unknown) {
               if (!isBackendError(error)) {
@@ -1636,7 +1636,9 @@ export class ConversationRepository {
     }
   };
 
-  private readonly joinMLSConversationViaInviteLink = async (conversationEntity: Conversation): Promise<void> => {
+  private readonly addOtherSelfUserClientsToMLSConversation = async (
+    conversationEntity: Conversation,
+  ): Promise<void> => {
     if (!isMLSConversation(conversationEntity)) {
       return;
     }
@@ -1648,16 +1650,12 @@ export class ConversationRepository {
       throw new Error('Self user qualified ID is not available for MLS invite-link join');
     }
 
-    await this.ensureConversationExists({
-      conversationId: conversationEntity.qualifiedId,
-      groupId: conversationEntity.groupId,
-      epoch: conversationEntity.epoch,
-    });
-
-    await this.core.service?.conversation?.addOtherSelfUserClientToMLSConversationAfterExternalCommit({
+    await this.core.service?.conversation?.addUsersToMLSConversation({
       conversationId: conversationEntity.qualifiedId,
       groupId: conversationEntity.groupId,
       qualifiedUsers: [selfUserQualifiedId],
+      commitPendingFirst: true,
+      updateKeyingMaterialIfEmpty: true,
     });
   };
 

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -1654,7 +1654,7 @@ export class ConversationRepository {
       epoch: conversationEntity.epoch,
     });
 
-    await this.core.service?.conversation?.addSelfUserToMLSConversationAfterExternalCommit({
+    await this.core.service?.conversation?.addOtherSelfUserClientToMLSConversationAfterExternalCommit({
       conversationId: conversationEntity.qualifiedId,
       groupId: conversationEntity.groupId,
       qualifiedUsers: [selfUserQualifiedId],

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -1582,6 +1582,7 @@ export class ConversationRepository {
               if (response) {
                 await this.onMemberJoin(conversationEntity, response);
               }
+              await this.joinMLSConversationViaInviteLink(conversationEntity);
               amplify.publish(WebAppEvents.CONVERSATION.SHOW, conversationEntity, {});
             } catch (error: unknown) {
               if (!isBackendError(error)) {
@@ -1633,6 +1634,31 @@ export class ConversationRepository {
         }
       }
     }
+  };
+
+  private readonly joinMLSConversationViaInviteLink = async (conversationEntity: Conversation): Promise<void> => {
+    if (!isMLSConversation(conversationEntity)) {
+      return;
+    }
+
+    const selfUserQualifiedId = this.userState.self()?.qualifiedId;
+
+    if (!selfUserQualifiedId) {
+      this.logger.error('Self user qualified ID is not available for MLS invite-link join');
+      throw new Error('Self user qualified ID is not available for MLS invite-link join');
+    }
+
+    await this.ensureConversationExists({
+      conversationId: conversationEntity.qualifiedId,
+      groupId: conversationEntity.groupId,
+      epoch: conversationEntity.epoch,
+    });
+
+    await this.core.service?.conversation?.addSelfUserToMLSConversationAfterExternalCommit({
+      conversationId: conversationEntity.qualifiedId,
+      groupId: conversationEntity.groupId,
+      qualifiedUsers: [selfUserQualifiedId],
+    });
   };
 
   private readonly getProtocolFor1to1Conversation = async (

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -1640,6 +1640,9 @@ export class ConversationRepository {
     conversationEntity: Conversation,
   ): Promise<void> => {
     if (!isMLSConversation(conversationEntity)) {
+      this.logger.warn('Can not add other self user clients to non-MLS conversation', {
+        conversationId: conversationEntity.qualifiedId,
+      });
       return;
     }
 
@@ -1649,6 +1652,12 @@ export class ConversationRepository {
       this.logger.error('Self user qualified ID is not available for MLS invite-link join');
       throw new Error('Self user qualified ID is not available for MLS invite-link join');
     }
+
+    this.logger.info('Adding other self user clients to MLS conversation', {
+      conversationId: conversationEntity.qualifiedId,
+      groupId: conversationEntity.groupId,
+      qualifiedUsers: [selfUserQualifiedId],
+    });
 
     await this.core.service?.conversation?.addUsersToMLSConversation({
       conversationId: conversationEntity.qualifiedId,

--- a/libraries/core/src/conversation/conversationService/conversationService.test.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.test.ts
@@ -1108,7 +1108,7 @@ describe('ConversationService', () => {
     });
   });
 
-  describe('addSelfUserToMLSConversationAfterExternalCommit', () => {
+  describe('addOtherSelfUserClientToMLSConversationAfterExternalCommit', () => {
     it('commits pending proposals before claiming self key packages and adding them to the group', async () => {
       const [conversationService, {apiClient, mlsService}] = await buildConversationService();
 
@@ -1128,7 +1128,7 @@ describe('ConversationService', () => {
         group_id: mockGroupId,
       } as unknown as Conversation);
 
-      await conversationService.addSelfUserToMLSConversationAfterExternalCommit({
+      await conversationService.addOtherSelfUserClientToMLSConversationAfterExternalCommit({
         qualifiedUsers: [selfUserToAdd],
         groupId: mockGroupId,
         conversationId: mockConversationId,
@@ -1158,7 +1158,7 @@ describe('ConversationService', () => {
         group_id: mockGroupId,
       } as unknown as Conversation);
 
-      await conversationService.addSelfUserToMLSConversationAfterExternalCommit({
+      await conversationService.addOtherSelfUserClientToMLSConversationAfterExternalCommit({
         qualifiedUsers: [selfUserToAdd],
         groupId: mockGroupId,
         conversationId: mockConversationId,

--- a/libraries/core/src/conversation/conversationService/conversationService.test.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.test.ts
@@ -153,6 +153,7 @@ describe('ConversationService', () => {
       getClientIdsInGroup: jest.fn(),
       getKeyPackagesPayload: jest.fn(),
       addUsersToExistingConversation: jest.fn(),
+      updateKeyingMaterialForConversation: jest.fn(),
       removeClientsFromConversation: jest.fn(),
       resetKeyMaterialRenewal: jest.fn(),
       handleMLSWelcomeMessageEvent: jest.fn(),
@@ -1104,6 +1105,69 @@ describe('ConversationService', () => {
 
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mockConversationId);
       expect(mlsService.addUsersToExistingConversation).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('addSelfUserToMLSConversationAfterExternalCommit', () => {
+    it('commits pending proposals before claiming self key packages and adding them to the group', async () => {
+      const [conversationService, {apiClient, mlsService}] = await buildConversationService();
+
+      const mockGroupId = 'groupId';
+      const mockConversationId = {id: PayloadHelper.getUUID(), domain: 'local.wire.com'};
+      const selfUserToAdd = {id: 'self-user-id', domain: 'local.wire.com'};
+      const keyPackages = [new Uint8Array([1, 2, 3])];
+      const existingClientIds = ['self-client-id'];
+
+      jest.spyOn(mlsService, 'commitPendingProposals').mockResolvedValueOnce(undefined);
+      jest.spyOn(mlsService, 'getClientIdsInGroup').mockResolvedValueOnce(existingClientIds);
+      jest.spyOn(mlsService, 'getKeyPackagesPayload').mockResolvedValueOnce({keyPackages, failures: []});
+      jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
+        qualified_id: mockConversationId,
+        protocol: CONVERSATION_PROTOCOL.MLS,
+        epoch: 1,
+        group_id: mockGroupId,
+      } as unknown as Conversation);
+
+      await conversationService.addSelfUserToMLSConversationAfterExternalCommit({
+        qualifiedUsers: [selfUserToAdd],
+        groupId: mockGroupId,
+        conversationId: mockConversationId,
+      });
+
+      expect(mlsService.commitPendingProposals).toHaveBeenCalledWith(mockGroupId, true);
+      expect(mlsService.getKeyPackagesPayload).toHaveBeenCalledWith([selfUserToAdd], existingClientIds);
+      expect(mlsService.addUsersToExistingConversation).toHaveBeenCalledWith(mockGroupId, keyPackages);
+      expect(mlsService.updateKeyingMaterialForConversation).not.toHaveBeenCalled();
+      expect(mlsService.resetKeyMaterialRenewal).toHaveBeenCalledWith(mockGroupId);
+    });
+
+    it('updates keying material when self has no key packages to add', async () => {
+      const [conversationService, {apiClient, mlsService}] = await buildConversationService();
+
+      const mockGroupId = 'groupId';
+      const mockConversationId = {id: PayloadHelper.getUUID(), domain: 'local.wire.com'};
+      const selfUserToAdd = {id: 'self-user-id', domain: 'local.wire.com'};
+
+      jest.spyOn(mlsService, 'commitPendingProposals').mockResolvedValueOnce(undefined);
+      jest.spyOn(mlsService, 'getClientIdsInGroup').mockResolvedValueOnce([]);
+      jest.spyOn(mlsService, 'getKeyPackagesPayload').mockResolvedValueOnce({keyPackages: [], failures: []});
+      jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
+        qualified_id: mockConversationId,
+        protocol: CONVERSATION_PROTOCOL.MLS,
+        epoch: 1,
+        group_id: mockGroupId,
+      } as unknown as Conversation);
+
+      await conversationService.addSelfUserToMLSConversationAfterExternalCommit({
+        qualifiedUsers: [selfUserToAdd],
+        groupId: mockGroupId,
+        conversationId: mockConversationId,
+      });
+
+      expect(mlsService.commitPendingProposals).toHaveBeenCalledWith(mockGroupId, true);
+      expect(mlsService.addUsersToExistingConversation).not.toHaveBeenCalled();
+      expect(mlsService.updateKeyingMaterialForConversation).toHaveBeenCalledWith(mockGroupId);
+      expect(mlsService.resetKeyMaterialRenewal).toHaveBeenCalledWith(mockGroupId);
     });
   });
 

--- a/libraries/core/src/conversation/conversationService/conversationService.test.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.test.ts
@@ -1106,40 +1106,6 @@ describe('ConversationService', () => {
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mockConversationId);
       expect(mlsService.addUsersToExistingConversation).toHaveBeenCalledTimes(2);
     });
-  });
-
-  describe('addOtherSelfUserClientToMLSConversationAfterExternalCommit', () => {
-    it('commits pending proposals before claiming self key packages and adding them to the group', async () => {
-      const [conversationService, {apiClient, mlsService}] = await buildConversationService();
-
-      const mockGroupId = 'groupId';
-      const mockConversationId = {id: PayloadHelper.getUUID(), domain: 'local.wire.com'};
-      const selfUserToAdd = {id: 'self-user-id', domain: 'local.wire.com'};
-      const keyPackages = [new Uint8Array([1, 2, 3])];
-      const existingClientIds = ['self-client-id'];
-
-      jest.spyOn(mlsService, 'commitPendingProposals').mockResolvedValueOnce(undefined);
-      jest.spyOn(mlsService, 'getClientIdsInGroup').mockResolvedValueOnce(existingClientIds);
-      jest.spyOn(mlsService, 'getKeyPackagesPayload').mockResolvedValueOnce({keyPackages, failures: []});
-      jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
-        qualified_id: mockConversationId,
-        protocol: CONVERSATION_PROTOCOL.MLS,
-        epoch: 1,
-        group_id: mockGroupId,
-      } as unknown as Conversation);
-
-      await conversationService.addOtherSelfUserClientToMLSConversationAfterExternalCommit({
-        qualifiedUsers: [selfUserToAdd],
-        groupId: mockGroupId,
-        conversationId: mockConversationId,
-      });
-
-      expect(mlsService.commitPendingProposals).toHaveBeenCalledWith(mockGroupId, true);
-      expect(mlsService.getKeyPackagesPayload).toHaveBeenCalledWith([selfUserToAdd], existingClientIds);
-      expect(mlsService.addUsersToExistingConversation).toHaveBeenCalledWith(mockGroupId, keyPackages);
-      expect(mlsService.updateKeyingMaterialForConversation).not.toHaveBeenCalled();
-      expect(mlsService.resetKeyMaterialRenewal).toHaveBeenCalledWith(mockGroupId);
-    });
 
     it('updates keying material when self has no key packages to add', async () => {
       const [conversationService, {apiClient, mlsService}] = await buildConversationService();
@@ -1158,10 +1124,12 @@ describe('ConversationService', () => {
         group_id: mockGroupId,
       } as unknown as Conversation);
 
-      await conversationService.addOtherSelfUserClientToMLSConversationAfterExternalCommit({
+      await conversationService.addUsersToMLSConversation({
         qualifiedUsers: [selfUserToAdd],
         groupId: mockGroupId,
         conversationId: mockConversationId,
+        updateKeyingMaterialIfEmpty: true,
+        commitPendingFirst: true,
       });
 
       expect(mlsService.commitPendingProposals).toHaveBeenCalledWith(mockGroupId, true);

--- a/libraries/core/src/conversation/conversationService/conversationService.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.ts
@@ -486,36 +486,30 @@ export class ConversationService extends TypedEventEmitter<Events> {
     qualifiedUsers,
     groupId,
     conversationId,
-  }: Required<AddUsersParams> & {shouldRetry?: boolean}): Promise<BaseCreateConversationResponse> {
-    return this.MLSRecoveryOrchestrator.execute({
-      context: {operationName: OperationName.addUsers, qualifiedConversationId: conversationId, groupId},
-      callBack: () => this.performAddUsersToMLSConversationAPI({qualifiedUsers, groupId, conversationId}),
-    });
-  }
-
-  public async addOtherSelfUserClientToMLSConversationAfterExternalCommit({
-    qualifiedUsers,
-    groupId,
-    conversationId,
-  }: Required<AddUsersParams>): Promise<BaseCreateConversationResponse> {
+    commitPendingFirst = false,
+    updateKeyingMaterialIfEmpty = false,
+  }: AddUsersParams): Promise<BaseCreateConversationResponse> {
     return this.MLSRecoveryOrchestrator.execute({
       context: {operationName: OperationName.addUsers, qualifiedConversationId: conversationId, groupId},
       callBack: () =>
-        this.performAddUsersToMLSConversationAPI(
-          {qualifiedUsers, groupId, conversationId},
-          {commitPendingFirst: true, updateKeyingMaterialIfEmpty: true},
-        ),
+        this.performAddUsersToMLSConversationAPI({
+          qualifiedUsers,
+          groupId,
+          conversationId,
+          commitPendingFirst,
+          updateKeyingMaterialIfEmpty,
+        }),
     });
   }
 
   // Low-level API to add users without any recovery logic; used by orchestrator and direct callers
-  private async performAddUsersToMLSConversationAPI(
-    {qualifiedUsers, groupId, conversationId}: Required<AddUsersParams>,
-    {
-      commitPendingFirst = false,
-      updateKeyingMaterialIfEmpty = false,
-    }: {commitPendingFirst?: boolean; updateKeyingMaterialIfEmpty?: boolean} = {},
-  ): Promise<BaseCreateConversationResponse> {
+  private async performAddUsersToMLSConversationAPI({
+    qualifiedUsers,
+    groupId,
+    conversationId,
+    commitPendingFirst = false,
+    updateKeyingMaterialIfEmpty = false,
+  }: AddUsersParams): Promise<BaseCreateConversationResponse> {
     this.logger.info(`Adding users to MLS conversation`, {groupId, conversationId, qualifiedUsers});
 
     if (commitPendingFirst) {

--- a/libraries/core/src/conversation/conversationService/conversationService.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.ts
@@ -493,7 +493,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     });
   }
 
-  public async addSelfUserToMLSConversationAfterExternalCommit({
+  public async addOtherSelfUserClientToMLSConversationAfterExternalCommit({
     qualifiedUsers,
     groupId,
     conversationId,
@@ -501,17 +501,27 @@ export class ConversationService extends TypedEventEmitter<Events> {
     return this.MLSRecoveryOrchestrator.execute({
       context: {operationName: OperationName.addUsers, qualifiedConversationId: conversationId, groupId},
       callBack: () =>
-        this.performAddSelfUserToMLSConversationAfterExternalCommitAPI({qualifiedUsers, groupId, conversationId}),
+        this.performAddUsersToMLSConversationAPI(
+          {qualifiedUsers, groupId, conversationId},
+          {commitPendingFirst: true, updateKeyingMaterialIfEmpty: true},
+        ),
     });
   }
 
   // Low-level API to add users without any recovery logic; used by orchestrator and direct callers
-  private async performAddUsersToMLSConversationAPI({
-    qualifiedUsers,
-    groupId,
-    conversationId,
-  }: Required<AddUsersParams>): Promise<BaseCreateConversationResponse> {
+  private async performAddUsersToMLSConversationAPI(
+    {qualifiedUsers, groupId, conversationId}: Required<AddUsersParams>,
+    {
+      commitPendingFirst = false,
+      updateKeyingMaterialIfEmpty = false,
+    }: {commitPendingFirst?: boolean; updateKeyingMaterialIfEmpty?: boolean} = {},
+  ): Promise<BaseCreateConversationResponse> {
     this.logger.info(`Adding users to MLS conversation`, {groupId, conversationId, qualifiedUsers});
+
+    if (commitPendingFirst) {
+      await this.mlsService.commitPendingProposals(groupId, true);
+    }
+
     const existingClientIdsInGroup = await this.mlsService.getClientIdsInGroup(groupId);
     const conversation = await this.getConversation(conversationId);
 
@@ -521,47 +531,16 @@ export class ConversationService extends TypedEventEmitter<Events> {
     );
 
     // We had cases where did not get any key packages, but still used core-crypto to call the backend (which results in failure).
-    if (keyPackages && keyPackages?.length > 0) {
-      await this.mlsService.addUsersToExistingConversation(groupId, keyPackages);
-
-      // We store the info when user was added (and key material was created), so we will know when to renew it
-      await this.mlsService.resetKeyMaterialRenewal(groupId);
-    }
-
-    return {
-      conversation,
-      failedToAdd: keysClaimingFailures,
-    };
-  }
-
-  private async performAddSelfUserToMLSConversationAfterExternalCommitAPI({
-    qualifiedUsers,
-    groupId,
-    conversationId,
-  }: Required<AddUsersParams>): Promise<BaseCreateConversationResponse> {
-    this.logger.info(`Adding self user to MLS conversation after external commit`, {
-      groupId,
-      conversationId,
-      qualifiedUsers,
-    });
-
-    await this.mlsService.commitPendingProposals(groupId, true);
-
-    const existingClientIdsInGroup = await this.mlsService.getClientIdsInGroup(groupId);
-    const conversation = await this.getConversation(conversationId);
-
-    const {keyPackages, failures: keysClaimingFailures} = await this.mlsService.getKeyPackagesPayload(
-      qualifiedUsers,
-      existingClientIdsInGroup,
-    );
-
     if (keyPackages.length > 0) {
       await this.mlsService.addUsersToExistingConversation(groupId, keyPackages);
-    } else {
+      // We store the info when user was added (and key material was created), so we will know when to renew it
+      await this.mlsService.resetKeyMaterialRenewal(groupId);
+    } else if (updateKeyingMaterialIfEmpty) {
+      // After an external commit the self client must publish fresh keying material
+      // even when no peer key packages were claimed.
       await this.mlsService.updateKeyingMaterialForConversation(groupId);
+      await this.mlsService.resetKeyMaterialRenewal(groupId);
     }
-
-    await this.mlsService.resetKeyMaterialRenewal(groupId);
 
     return {
       conversation,

--- a/libraries/core/src/conversation/conversationService/conversationService.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.ts
@@ -493,6 +493,18 @@ export class ConversationService extends TypedEventEmitter<Events> {
     });
   }
 
+  public async addSelfUserToMLSConversationAfterExternalCommit({
+    qualifiedUsers,
+    groupId,
+    conversationId,
+  }: Required<AddUsersParams>): Promise<BaseCreateConversationResponse> {
+    return this.MLSRecoveryOrchestrator.execute({
+      context: {operationName: OperationName.addUsers, qualifiedConversationId: conversationId, groupId},
+      callBack: () =>
+        this.performAddSelfUserToMLSConversationAfterExternalCommitAPI({qualifiedUsers, groupId, conversationId}),
+    });
+  }
+
   // Low-level API to add users without any recovery logic; used by orchestrator and direct callers
   private async performAddUsersToMLSConversationAPI({
     qualifiedUsers,
@@ -500,12 +512,12 @@ export class ConversationService extends TypedEventEmitter<Events> {
     conversationId,
   }: Required<AddUsersParams>): Promise<BaseCreateConversationResponse> {
     this.logger.info(`Adding users to MLS conversation`, {groupId, conversationId, qualifiedUsers});
-    const exisitingClientIdsInGroup = await this.mlsService.getClientIdsInGroup(groupId);
+    const existingClientIdsInGroup = await this.mlsService.getClientIdsInGroup(groupId);
     const conversation = await this.getConversation(conversationId);
 
     const {keyPackages, failures: keysClaimingFailures} = await this.mlsService.getKeyPackagesPayload(
       qualifiedUsers,
-      exisitingClientIdsInGroup,
+      existingClientIdsInGroup,
     );
 
     // We had cases where did not get any key packages, but still used core-crypto to call the backend (which results in failure).
@@ -515,6 +527,41 @@ export class ConversationService extends TypedEventEmitter<Events> {
       // We store the info when user was added (and key material was created), so we will know when to renew it
       await this.mlsService.resetKeyMaterialRenewal(groupId);
     }
+
+    return {
+      conversation,
+      failedToAdd: keysClaimingFailures,
+    };
+  }
+
+  private async performAddSelfUserToMLSConversationAfterExternalCommitAPI({
+    qualifiedUsers,
+    groupId,
+    conversationId,
+  }: Required<AddUsersParams>): Promise<BaseCreateConversationResponse> {
+    this.logger.info(`Adding self user to MLS conversation after external commit`, {
+      groupId,
+      conversationId,
+      qualifiedUsers,
+    });
+
+    await this.mlsService.commitPendingProposals(groupId, true);
+
+    const existingClientIdsInGroup = await this.mlsService.getClientIdsInGroup(groupId);
+    const conversation = await this.getConversation(conversationId);
+
+    const {keyPackages, failures: keysClaimingFailures} = await this.mlsService.getKeyPackagesPayload(
+      qualifiedUsers,
+      existingClientIdsInGroup,
+    );
+
+    if (keyPackages.length > 0) {
+      await this.mlsService.addUsersToExistingConversation(groupId, keyPackages);
+    } else {
+      await this.mlsService.updateKeyingMaterialForConversation(groupId);
+    }
+
+    await this.mlsService.resetKeyMaterialRenewal(groupId);
 
     return {
       conversation,

--- a/libraries/core/src/conversation/conversationService/conversationService.types.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.types.ts
@@ -102,7 +102,9 @@ export type KeyPackageClaimUser = QualifiedId & {skipOwnClientId?: string};
 export type AddUsersParams = {
   conversationId: QualifiedId;
   qualifiedUsers: KeyPackageClaimUser[];
-  groupId?: string;
+  groupId: string;
+  commitPendingFirst?: boolean;
+  updateKeyingMaterialIfEmpty?: boolean;
 };
 
 export type RemoveUsersParams = {

--- a/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.test.ts
+++ b/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.test.ts
@@ -735,6 +735,17 @@ describe('MLSService', () => {
     });
   });
 
+  describe('updateKeyingMaterialForConversation', () => {
+    it('updates keying material in a core crypto transaction', async () => {
+      const [mlsService, {transactionContext}] = await createMLSService();
+      const groupId = 'mXOagqRIX/RFd7QyXJA8/Ed8X+hvQgLXIiwYHm4OQFc=';
+
+      await mlsService.updateKeyingMaterialForConversation(groupId);
+
+      expect(transactionContext.updateKeyingMaterial).toHaveBeenCalledWith(expect.any(ConversationId));
+    });
+  });
+
   describe('handleMLSWelcomeMessageEvent', () => {
     it("before processing welcome it verifies that there's enough key packages locally", async () => {
       const [mlsService, {apiClient, transactionContext}] = await createMLSService();

--- a/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.ts
+++ b/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.ts
@@ -581,6 +581,10 @@ export class MLSService extends TypedEventEmitter<Events> {
     }
   }
 
+  public async updateKeyingMaterialForConversation(groupId: string) {
+    await this.coreCryptoClient.transaction(context => this.updateKeyingMaterial(groupId, context));
+  }
+
   /**
    * Will create an empty conversation inside of coreCrypto.
    * @param groupId the id of the group to create inside of coreCrypto


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22305" title="WPB-22305" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-22305</a>  [Web] Joining MLS conversation by guest link doesn't produce welcome message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


when joining a conv via invite link the web app was not sending welcome message to invite self user other clients to the conv

to test the fix you must have user A on web and mobile, and user B does not matter 
1.  B create a new empty MLS group
2. B create an invite link and send it to A in 1:1
3. A open the link from their web client 
4. B send a message in that group

expected:
A should see this message on web and mobile
actual:
A sees the message only on web

to fix it i used codex with GPT-5.5 using this prompt  

-------

join an MLS conv via invite link is broken for other self clients when joining from this web app
my theory is the app is not doing step 8 from what the android app is doing 

Here’s the Android/Kalium flow for “join MLS conversation via invite link”, with the CoreCrypto calls called out.

**Flow**
1. Public API: [JoinConversationViaCodeUseCase](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/JoinConversationViaCodeUseCase.kt:44)
   calls `conversationGroupRepository.joinViaInviteCode(code, key, null, password)`.

2. Backend invite join: [ConversationGroupRepository](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt:560)
   calls:
   ```kotlin
   conversationApi.joinConversation(code, key, uri, password)
   ```
   Network side is `POST /conversations/join`.

3. If backend returns `Changed`, Kalium emits the local member-join event, reads the conversation protocol, and if it is MLS-capable starts crypto transaction `joinViaInviteCode`.

4. Inside that transaction, Kalium first joins the MLS group:
   [JoinExistingMLSConversationUseCase](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt:227)
   fetches group info:
   ```http
   GET /conversations/{domain}/{conversationId}/groupinfo
   ```
   implemented at [ConversationApiV5](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/ConversationApiV5.kt:49).

5. Then Kalium calls:
   ```kotlin
   mlsConversationRepository.joinGroupByExternalCommit(mlsContext, groupId, groupInfo)
   ```
   which calls CoreCrypto:
   ```kotlin
   mlsContext.joinByExternalCommit(groupInfo)
   ```
   at [MLSConversationRepository](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt:389).

6. The actual CoreCrypto binding call is:
   ```kotlin
   context.joinByExternalCommit(
       groupInfo = publicGroupState.toGroupInfo(),
       customConfiguration = CUSTOM_CONFIGURATION_DEFAULT,
       credentialType = DEFAULT or X509,
   )
   ```
   at [MLSClientImpl](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt:103).

7. After that succeeds, Kalium reads the local epoch:
   ```kotlin
   mlsContext.conversationEpoch(groupId)
   ```
   and marks the local DB group state as `ESTABLISHED`.

8. Important second step: after external commit succeeds, invite-link join also calls:
   ```kotlin
   mlsConversationRepository.addMemberToMLSGroup(
       mlsContext,
       groupId,
       listOf(selfUserId),
       cipherSuite
   )
   ```
   See [ConversationGroupRepository](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt:584).

9. `addMemberToMLSGroup` first commits pending proposals:
   ```kotlin
   mlsContext.commitPendingProposals(groupId)
   ```
   then claims key packages for `selfUserId`, then calls either:
   ```kotlin
   mlsContext.addMember(groupId, clientKeyPackageList)
   ```
   or, if there are no key packages:
   ```kotlin
   mlsContext.updateKeyingMaterial(groupId)
   ```
   See [MLSConversationRepository](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt:513) and [MLSConversationRepository](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt:546).

10. CoreCrypto implementations for those are:
   ```kotlin
   context.commitPendingProposals(groupId.toCrypto())
   context.addClientsToConversation(groupId.toCrypto(), keyPackages)
   context.updateKeyingMaterial(groupId.toCrypto())
   ```
   See [MLSClientImpl](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt:149) and [MLSClientImpl](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt:199).

**Transport detail web may be missing**
Kalium does not manually POST every generated MLS commit from the repository. The MLS client is created with an `MLSTransporter`; CoreCrypto uses that transport to send commit bundles. The transport calls:
```kotlin
mlsMessageApi.sendCommitBundle(...)
```
which posts:
```http
POST /mls/commit-bundles
Content-Type: message/mls
```
See [MLSTransportProvider](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/MLSTransportProvider.kt:70) and [MLSMessageApiV5](/Users/mohamadjaara/Desktop/wire/main/wire-android/kalium/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/MLSMessageApiV5.kt:46).

So the short version to send web is:

```text
After POST /conversations/join succeeds for an MLS conversation:
1. Fetch /conversations/{domain}/{conv}/groupinfo.
2. Call CoreCrypto joinByExternalCommit(groupInfo, config, credentialType).
3. Let CoreCrypto/MLS transport send the produced commit bundle to POST /mls/commit-bundles.
4. Read local conversationEpoch and mark local group established.
5. Then add the current user/self clients to the MLS group:
   - commitPendingProposals(groupId)
   - claim self key packages
   - addClientsToConversation(groupId, keyPackages)
     OR updateKeyingMaterial(groupId) if no key packages
6. Those commit-producing calls also need their commit bundles sent via POST /mls/commit-bundles.
```
