### PR TITLE
refactor: improve a11y for proteus ID in settings [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/ProteusDeviceDetails.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/ProteusDeviceDetails.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import {useId} from 'react';
+
 import {VerificationBadges} from 'Components/Badge';
 import {t} from 'Util/localizerUtil';
 import {splitFingerprint} from 'Util/stringUtil';
@@ -31,14 +33,18 @@ interface ProteusDeviceDetailsProps extends Omit<DeviceProps, 'getDeviceIdentity
 }
 
 export const ProteusDeviceDetails = ({device, fingerprint, isProteusVerified}: ProteusDeviceDetailsProps) => {
+  const proteusLabelId = useId();
+
   return (
     <div className="preferences-proteus-details">
       <h4>{t('proteusDeviceDetails')}</h4>
 
       <div>
-        <p className="label preferences-label preferences-devices-fingerprint-label">{t('proteusID')}</p>
+        <p id={proteusLabelId} className="label preferences-label preferences-devices-fingerprint-label">
+          {t('proteusID')}
+        </p>
 
-        <p className="preferences-devices-fingerprint" css={{width: '230px'}}>
+        <p className="preferences-devices-fingerprint" css={{width: '230px'}} aria-labelledby={proteusLabelId}>
           <FormattedId idSlices={splitFingerprint(device.id)} />
         </p>
       </div>

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/devices.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/devices.page.ts
@@ -24,8 +24,7 @@ export class DevicesPage {
   readonly activeDevices: Locator;
 
   constructor(page: Page) {
-    // The id is not using any label or similar but just multiple paragraphs beneath each other
-    this.proteusId = page.locator("p:text('Proteus ID') + p");
+    this.proteusId = page.getByLabel('Proteus ID');
     this.activeDevices = page.getByRole('group', {name: 'Active'}).getByRole('button', {name: /device details/});
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Authentication/authentication.spec.ts
@@ -87,13 +87,14 @@ test.describe('Authentication', () => {
         await components.conversationSidebar().sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
       });
 
-      let proteusId: string;
-      await test.step('Open device settings and get current proteus id', async () => {
+      const proteusId = await test.step('Open device settings and get current proteus id', async () => {
         await components.conversationSidebar().clickPreferencesButton();
         await pages.settings().devicesButton.click();
 
-        proteusId = (await pages.devices().proteusId.textContent()) ?? '';
-        expect(proteusId).toBeTruthy();
+        const proteusId = (await pages.devices().proteusId.textContent()) ?? '';
+        expect(proteusId).toBeDefined();
+
+        return proteusId;
       });
 
       await test.step('Log out of public computer', async () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
So far the label was just a paragraph above the actual value, this links them using aria attributes and improves the locator used within e2e tests by that.


