### PR TITLE
ci: only run crit flow e2e tests in PRs & move reporting to nightly runs [WPB-24893]

### DIFF
--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -22,8 +22,8 @@ jobs:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       WIRE_E2E_TEST_BOT_WEBHOOK_URL: ${{ secrets.WIRE_E2E_TEST_BOT_WEBHOOK_URL }}
 
-  report-to-testiny:
-    name: Upload test report to Testiny
+  report:
+    name: Report test results
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     needs: e2e_tests
@@ -44,7 +44,27 @@ jobs:
           artifact-ids: ${{ needs.e2e_tests.outputs.reportArtifactId }}
           path: apps/webapp/playwright-report
 
+      - name: Extract test results
+        id: test-results
+        run: |
+          REPORT="apps/webapp/playwright-report/report.json"
+          if [ ! -f "$REPORT" ]; then
+            echo "::error::Report file not found at $REPORT"
+            exit 1
+          fi
+          PASSED=$(jq '.stats.expected' "$REPORT")
+          FAILED=$(jq '.stats.unexpected' "$REPORT")
+          SKIPPED=$(jq '.stats.skipped' "$REPORT")
+          FLAKY=$(jq '.stats.flaky' "$REPORT")
+          TOTAL=$((PASSED + FAILED + SKIPPED + FLAKY))
+          echo "passed=$PASSED" >> $GITHUB_OUTPUT
+          echo "failed=$FAILED" >> $GITHUB_OUTPUT
+          echo "skipped=$SKIPPED" >> $GITHUB_OUTPUT
+          echo "flaky=$FLAKY" >> $GITHUB_OUTPUT
+          echo "total=$TOTAL" >> $GITHUB_OUTPUT
+
       - name: Upload report to Testiny
+        continue-on-error: true
         env:
           TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
           TESTINY_TEST_PLAN_ID: 105 # 105 is the id of the "Regression" test plan within Testiny
@@ -56,3 +76,16 @@ jobs:
           --testPlanId="$TESTINY_TEST_PLAN_ID" \
           --description="$DESCRIPTION" \
           --reportPath="./apps/webapp/playwright-report/report.json"
+
+      - name: Notify on Wire about failed tests
+        if: ${{ !cancelled() && steps.test-results.outputs.failed > 0 }}
+        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_E2E_TEST_BOT_WEBHOOK_URL }}
+        with:
+          status: custom
+          custom_payload: |
+            {
+              "text": "❌ Web E2E Tests failed ❌\n*Results:* ${{ steps.test-results.outputs.passed }}/${{ steps.test-results.outputs.total }} passed · ${{ steps.test-results.outputs.failed }} failed · ${{ steps.test-results.outputs.flaky }} flaky · ${{ steps.test-results.outputs.skipped }} skipped\n*Report:* ${{ needs.e2e_tests.outputs.reportUrl }}\n*Build log:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -45,41 +45,67 @@ jobs:
           path: apps/webapp/playwright-report
           pattern: '**/report.json'
 
-      - name: Extract test results
-        id: test-results
+      - name: Generate report description
+        id: generate-description
         run: |
-          REPORT="apps/webapp/playwright-report/report.json"
-          if [ ! -f "$REPORT" ]; then
-            echo "::error::Report file not found at $REPORT"
-            exit 1
+          REPORT_FILE="apps/webapp/playwright-report/report.json"
+          if [ ! -f "$REPORT_FILE" ]; then
+              echo "Error: File '$REPORT_FILE' not found!"
+              exit 1
           fi
-          PASSED=$(jq '.stats.expected' "$REPORT")
-          FAILED=$(jq '.stats.unexpected' "$REPORT")
-          SKIPPED=$(jq '.stats.skipped' "$REPORT")
-          FLAKY=$(jq '.stats.flaky' "$REPORT")
-          TOTAL=$((PASSED + FAILED + SKIPPED + FLAKY))
-          echo "passed=$PASSED" >> $GITHUB_OUTPUT
-          echo "failed=$FAILED" >> $GITHUB_OUTPUT
-          echo "skipped=$SKIPPED" >> $GITHUB_OUTPUT
-          echo "flaky=$FLAKY" >> $GITHUB_OUTPUT
-          echo "total=$TOTAL" >> $GITHUB_OUTPUT
+
+          FAILED=$(jq '.stats.unexpected' "$REPORT_FILE")
+          MESSAGE=$(jq -c '
+            # Recursively find all objects that have a non-empty "specs" array
+            # Capture the suite title and prepend it to the test title
+            [.. | objects | select(has("specs") and (.specs | length > 0)) | .title as $suite | .specs[] | .title as $title | .tests[] | {title: ($suite + " > " + $title), status: .status}] as $tests |
+            
+            # Calculate aggregates
+            ($tests | length) as $total |
+            ($tests | map(select(.status == "expected")) | length) as $passed |
+            ($tests | map(select(.status == "unexpected")) | length) as $failed |
+            ($tests | map(select(.status == "flaky")) | length) as $flaky |
+            ($tests | map(select(.status == "skipped")) | length) as $skipped |
+            
+            # Generate unique lists for failed and flaky tests
+            ($tests | map(select(.status == "unexpected")) | map("  ❌ " + .title) | unique | join("\n")) as $failed_list |
+            ($tests | map(select(.status == "flaky")) | map("  ⚠️ " + .title) | unique | join("\n")) as $flaky_list |
+            
+            # Construct the final formatted message
+            "📋 **Playwright Test Run Summary**\n" +
+            "Build URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n" +
+            "======================================\n" +
+            "**Total Tests:** \($total)\n" +
+            "✅ **Passed:** \($passed)\n" +
+            "❌ **Failed:** \($failed)\n" +
+            "⚠️ **Flaky:** \($flaky)\n" +
+            (if $skipped > 0 then "⏭️ **Skipped:** \($skipped)\n" else "" end) +
+            "======================================\n" +
+            (if $failed > 0 then "\n❌ **Failed Tests:**\n\($failed_list)\n" else "" end) +
+            (if $flaky > 0 then "\n⚠️ **Flaky Tests:**\n\($flaky_list)\n" else "" end)
+          ' $REPORT_FILE)
+
+          echo "failed_tests=$FAILED" >> $GITHUB_OUTPUT
+          echo "report_message=$MESSAGE" >> $GITHUB_OUTPUT
 
       - name: Upload report to Testiny
         continue-on-error: true
         env:
           TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
           TESTINY_TEST_PLAN_ID: 105 # 105 is the id of the "Regression" test plan within Testiny
-          DESCRIPTION: |
-            Build URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DESCRIPTION: ${{ steps.generate-description.outputs.report_message }}
         run: |
+          # Extract description from json format so it can be quoted correctly
+          RAW_DESCRIPTION=$(echo "$DESCRIPTION" | jq -r '.')
+
           node ./apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts \
           --runName="Regression $(date +'%m/%d/%Y - %H:%M')" \
           --testPlanId="$TESTINY_TEST_PLAN_ID" \
-          --description="$DESCRIPTION" \
+          --description="$RAW_DESCRIPTION" \
           --reportPath="./apps/webapp/playwright-report/report.json"
 
       - name: Notify on Wire about failed tests
-        if: ${{ !cancelled() && steps.test-results.outputs.failed > 0 }}
+        if: ${{ !cancelled() && steps.generate-description.outputs.failed_tests > 0 }}
         uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
         continue-on-error: true
         env:
@@ -88,5 +114,5 @@ jobs:
           status: custom
           custom_payload: |
             {
-              "text": "❌ Web E2E Tests failed ❌\n*Results:* ${{ steps.test-results.outputs.passed }}/${{ steps.test-results.outputs.total }} passed · ${{ steps.test-results.outputs.failed }} failed · ${{ steps.test-results.outputs.flaky }} flaky · ${{ steps.test-results.outputs.skipped }} skipped\n*Report:* ${{ needs.e2e_tests.outputs.reportUrl }}\n*Build log:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": ${{ steps.generate-description.outputs.report_message }},
             }

--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           artifact-ids: ${{ needs.e2e_tests.outputs.reportArtifactId }}
           path: apps/webapp/playwright-report
+          pattern: '**/report.json'
 
       - name: Extract test results
         id: test-results

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,14 +12,11 @@ on:
         options:
           - https://wire-webapp-dev.zinfra.io/
           - https://wire-webapp-master.zinfra.io/
-          - https://wire-webapp-edge.wire.com/
-          - https://wire-webapp-staging.wire.com/
       backendUrl:
         type: choice
-        description: Define which backend should be used (make sure this matches the one used by the stage set for webappUrl)
+        description: Define which backend should be used
         options:
           - https://staging-nginz-https.zinfra.io/
-          - https://prod-nginz-https.wire.com/
       grep:
         type: string
         description: Define which tests to run, the given value will be passed to the `--grep` flag of playwright

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -240,51 +240,6 @@ jobs:
           echo "reportUrl=${{ steps.upload_playwright_report.outputs.artifact-url }}" >> $GITHUB_OUTPUT
           echo "reportArtifactId=${{ steps.upload_playwright_report.outputs.artifact-id }}" >> $GITHUB_OUTPUT
 
-      - name: Extract test results
-        id: test-results
-        run: |
-          REPORT="${{ env.PLAYWRIGHT_REPORT_PATH }}/report.json"
-          if [ ! -f "$REPORT" ]; then
-            echo "::error::Report file not found at $REPORT"
-            exit 1
-          fi
-          PASSED=$(jq '.stats.expected' "$REPORT")
-          FAILED=$(jq '.stats.unexpected' "$REPORT")
-          SKIPPED=$(jq '.stats.skipped' "$REPORT")
-          FLAKY=$(jq '.stats.flaky' "$REPORT")
-          TOTAL=$((PASSED + FAILED + SKIPPED + FLAKY))
-          echo "passed=$PASSED" >> $GITHUB_OUTPUT
-          echo "failed=$FAILED" >> $GITHUB_OUTPUT
-          echo "skipped=$SKIPPED" >> $GITHUB_OUTPUT
-          echo "flaky=$FLAKY" >> $GITHUB_OUTPUT
-          echo "total=$TOTAL" >> $GITHUB_OUTPUT
-
-      - name: Notify on Wire if succeeded
-        if: needs.test.result == 'success' && env.SLACK_WEBHOOK_URL != ''
-        continue-on-error: true
-        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_E2E_TEST_BOT_WEBHOOK_URL }}
-        with:
-          status: custom
-          custom_payload: |
-            {
-              "text": "✅ Web E2E Tests succeeded ✅\n*Results:* ${{ steps.test-results.outputs.passed }}/${{ steps.test-results.outputs.total }} passed · ${{ steps.test-results.outputs.flaky }} flaky · ${{ steps.test-results.outputs.skipped }} skipped\n*Triggered by:* ${{ github.triggering_actor }}\n*Report:* ${{ steps.upload_playwright_report.outputs.artifact-url }}\n*Build log:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
-
-      - name: Notify on Wire if failed
-        if: needs.test.result == 'failure' && env.SLACK_WEBHOOK_URL != ''
-        continue-on-error: true
-        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_E2E_TEST_BOT_WEBHOOK_URL }}
-        with:
-          status: custom
-          custom_payload: |
-            {
-              "text": "❌ Web E2E Tests failed ❌\n*Results:* ${{ steps.test-results.outputs.passed }}/${{ steps.test-results.outputs.total }} passed · ${{ steps.test-results.outputs.failed }} failed · ${{ steps.test-results.outputs.flaky }} flaky · ${{ steps.test-results.outputs.skipped }} skipped\n*Triggered by:* ${{ github.triggering_actor }}\n*Report:* ${{ steps.upload_playwright_report.outputs.artifact-url }}\n*Build log:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
-
       - name: Update Testiny Run with results
         if: ${{ success() && inputs.testinyRunName }}
         env:

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -117,7 +117,7 @@ jobs:
     with:
       env_name: ${{ needs.build.outputs.env_name }}
       backendUrl: https://staging-nginz-https.zinfra.io/
-      grep: '@crit-flow-web'
+      grep: ${{ case(github.base_ref == "master", "", "@crit-flow-web") }} # Run all E2E tests when attempting to merge to master
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       WEBTEAM_AWS_ACCESS_KEY_ID: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -117,7 +117,8 @@ jobs:
     with:
       env_name: ${{ needs.build.outputs.env_name }}
       backendUrl: https://staging-nginz-https.zinfra.io/
-      grep: ${{ case(github.base_ref == "master", "", "@crit-flow-web") }} # Run all E2E tests when attempting to merge to master
+      # Run all E2E tests when attempting to merge to master when running for a PR as well as in the merge queue (base_ref contains the full ref name instead of the short name on merge_group)
+      grep: ${{ case(github.base_ref == 'master' || github.event.merge_group.base_ref == 'refs/heads/master', '', '@crit-flow-web') }}
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       WEBTEAM_AWS_ACCESS_KEY_ID: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -109,50 +109,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # An extra step is needed to see if the e2e_tests folder was touched as part of the PR
-  check_edits_to_e2e_tests:
-    name: Check if the PR touches e2e tests
-    if: ${{ github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    outputs:
-      tests_to_run: ${{ steps.check_e2e_tests.outputs.tests_to_run || steps.set_default_tests_for_merge_queue.outputs.tests_to_run }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          fetch-depth: 0
-
-      - name: Check for e2e tests changes
-        if: ${{ github.event_name == 'pull_request' }}
-        id: check_e2e_tests
-        run: |
-          git diff --exit-code origin/${{ github.base_ref }}...HEAD -- apps/webapp/test/e2e_tests/ || RESULT=$?
-
-          # If the e2e_tests folder was touched within the PR run all tests, otherwise just the critical flow ones
-          if [ $RESULT -eq 1 ]; then
-            echo "tests_to_run=" >> $GITHUB_OUTPUT
-            echo "E2E Tests have been modified, executing all tests"
-          else
-            echo "tests_to_run=@crit-flow-web" >> $GITHUB_OUTPUT
-            echo "E2E Tests have not been modified, executing critical flow tests only"
-          fi
-
-      - name: Use critical flow tests on merge queue
-        if: ${{ github.event_name == 'merge_group' }}
-        id: set_default_tests_for_merge_queue
-        run: |
-          echo "tests_to_run=@crit-flow-web" >> $GITHUB_OUTPUT
-          echo "Merge queue run detected, executing critical flow tests"
-
   deploy_and_run_e2e:
     name: Deploy to precommit and run E2E
     if: ${{ success() && github.repository == 'wireapp/wire-webapp' }}
-    needs: [build, check_edits_to_e2e_tests]
+    needs: [build]
     uses: ./.github/workflows/precommit-slot-run.yml
     with:
       env_name: ${{ needs.build.outputs.env_name }}
       backendUrl: https://staging-nginz-https.zinfra.io/
-      grep: ${{ needs.check_edits_to_e2e_tests.outputs.tests_to_run }}
+      grep: '@crit-flow-web'
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       WEBTEAM_AWS_ACCESS_KEY_ID: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}

--- a/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
+++ b/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
@@ -39,10 +39,6 @@ const {values: args} = parseArgs({
   },
 });
 
-if (!args.testinyApiKey) throw new Error('Missing required arg testinyApiKey');
-if (!args.reportPath) throw new Error('Missing required arg reportPath');
-if (!args.runName) throw new Error('Missing required arg runName');
-
 const getTests = (suite: JSONReportSuite): (JSONReportTest & Pick<JSONReportSpec, 'tags'>)[] => {
   return [
     ...(suite.specs.flatMap(spec => spec.tests.map(test => ({...test, tags: spec.tags}))) ?? []),
@@ -154,6 +150,10 @@ async function addTestResultsToRun(testCaseMappings: TestinyTestCaseMapping[]) {
 }
 
 async function main() {
+  if (!args.testinyApiKey) throw new Error('Missing required arg testinyApiKey');
+  if (!args.reportPath) throw new Error('Missing required arg reportPath');
+  if (!args.runName) throw new Error('Missing required arg runName');
+
   const reportAbsPath = path.resolve(args.reportPath);
   if (!fs.existsSync(reportAbsPath)) {
     throw new Error(`Report file not found: ${reportAbsPath}`);
@@ -161,7 +161,7 @@ async function main() {
 
   const report: JSONReport = JSON.parse(fs.readFileSync(reportAbsPath, 'utf-8'));
   const testRun = await createTestRun({
-    testPlanId: Number.isInteger(+args.testPlanId) ? +args.testPlanId : undefined,
+    testPlanId: args.testPlanId !== undefined && Number.isInteger(+args.testPlanId) ? +args.testPlanId : undefined,
     description: `<!--markdown-->\n${args.description}\n`,
   });
   console.log(`Created test run with id: ${testRun.id}`);


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24893" title="WPB-24893" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24893</a>  [Web][QA] Use E2E tests as monitoring instead of PR criteria
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

This PR attempts to unblock PRs by only running the crit flow E2E tests as part of them. Instead the nightly E2E test run will run all tests and report the results to Testiny as well as a chat group in case of failure.
Only when attempting to merge to master all E2E tests will be run to prevent regressions in releases.

The report published into the wire group will look like this:
<img width="753" height="617" alt="image" src="https://github.com/user-attachments/assets/b1ab5124-c462-4b23-9210-01265d32c9d8" />

The same results are also added to the description of the run in Testiny so e.g. information about the flaky tests is preserved.