### PR TITLE
test: skip broken groupConversation tests due to backend regression [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -89,41 +89,47 @@ test.describe('Group Conversation', () => {
     },
   );
 
-  test('I want to delete a group as the Group Creator', {tag: ['@TC-1089', '@regression']}, async ({createPage}) => {
-    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
-    const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
-    const userBPages = PageManager.from(userBPage).webapp.pages;
+  // This test is currently broken due to the backend taking more than 20s to delete the conversation
+  test.skip(
+    'I want to delete a group as the Group Creator',
+    {tag: ['@TC-1089', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
-    await createGroup(userAPages, groupName, [userB, userC]);
-    const adminGroupLocator = await userAPages.conversationList().getConversation(groupName).open();
-    const memberGroupLocator = userBPages.conversationList().getConversation(groupName);
+      await createGroup(userAPages, groupName, [userB, userC]);
+      const adminGroupLocator = await userAPages.conversationList().getConversation(groupName).open();
+      const memberGroupLocator = userBPages.conversationList().getConversation(groupName);
 
-    // Pre-condition: Ensure the member can see the group before the creator deletes it
-    await expect(memberGroupLocator).toBeVisible();
+      // Pre-condition: Ensure the member can see the group before the creator deletes it
+      await expect(memberGroupLocator).toBeVisible();
 
-    // User A initiate group deletion
-    await userAPages.conversation().clickConversationInfoButton();
-    await userAPages.conversationDetails().deleteGroupButton.click();
+      // User A initiate group deletion
+      await userAPages.conversation().clickConversationInfoButton();
+      await userAPages.conversationDetails().deleteGroupButton.click();
 
-    // User sees a confirmation dialog with explanation when he initiates delete group
-    await expect(userAModals.confirm().modalText).toContainText(
-      'This will delete the conversation and all content for all participants on all devices',
-    );
+      // User sees a confirmation dialog with explanation when he initiates delete group
+      await expect(userAModals.confirm().modalText).toContainText(
+        'This will delete the conversation and all content for all participants on all devices',
+      );
 
-    // User can cancel the delete group from the confirmation dialog
-    await userAModals.confirm().cancelButton.click();
-    await expect(adminGroupLocator).toBeVisible();
+      // User can cancel the delete group from the confirmation dialog
+      await userAModals.confirm().cancelButton.click();
+      await expect(adminGroupLocator).toBeVisible();
 
-    // User can delete group as the group creator
-    await userAPages.conversationDetails().deleteGroupButton.click();
-    await userAModals.confirm().actionButton.click();
+      // User can delete group as the group creator
+      await userAPages.conversationDetails().deleteGroupButton.click();
+      await userAModals.confirm().actionButton.click();
 
-    // Verify the group no longer exists for any user
-    await expect(adminGroupLocator).toBeHidden({timeout: 20_000});
-    await expect(memberGroupLocator).toBeHidden({timeout: 20_000});
-  });
+      // Verify the group no longer exists for any user
+      await expect(adminGroupLocator).toBeHidden({timeout: 20_000});
+      await expect(memberGroupLocator).toBeHidden({timeout: 20_000});
+    },
+  );
 
-  test(
+  // This test is currently broken due to the backend taking more than 20s to delete the conversation
+  test.skip(
     'I want to be notified about the group deletion when app is in background',
     {tag: ['@TC-1093', '@regression']},
     async ({createPage}) => {
@@ -165,42 +171,47 @@ test.describe('Group Conversation', () => {
     },
   );
 
-  test('I should not be able to search for deleted group', {tag: ['@TC-1095', '@regression']}, async ({createPage}) => {
-    const [userAPageManager, userBPageManager, userCPageManager] = await Promise.all([
-      createPage(withLogin(userA)),
-      createPage(withLogin(userB)),
-      createPage(withLogin(userC), withConnectedUser(userA)),
-    ]);
+  // This test is currently broken due to the backend taking more than 20s to delete the conversation
+  test.skip(
+    'I should not be able to search for deleted group',
+    {tag: ['@TC-1095', '@regression']},
+    async ({createPage}) => {
+      const [userAPageManager, userBPageManager, userCPageManager] = await Promise.all([
+        createPage(withLogin(userA)),
+        createPage(withLogin(userB)),
+        createPage(withLogin(userC), withConnectedUser(userA)),
+      ]);
 
-    const userAPages = PageManager.from(userAPageManager).webapp.pages;
-    const userBPages = PageManager.from(userBPageManager).webapp.pages;
-    const userCPages = PageManager.from(userCPageManager).webapp.pages;
+      const userAPages = PageManager.from(userAPageManager).webapp.pages;
+      const userBPages = PageManager.from(userBPageManager).webapp.pages;
+      const userCPages = PageManager.from(userCPageManager).webapp.pages;
 
-    await createGroup(userAPages, 'Group A', [userB, userC]);
-    await createGroup(userBPages, 'Group B', [userA, userC]);
-    await expect(userCPages.conversationList().list.getByRole('listitem')).toHaveCount(3);
+      await createGroup(userAPages, 'Group A', [userB, userC]);
+      await createGroup(userBPages, 'Group B', [userA, userC]);
+      await expect(userCPages.conversationList().list.getByRole('listitem')).toHaveCount(3);
 
-    const groups = [
-      {name: 'Group A', owner: userAPageManager, members: [userB, userC]},
-      {name: 'Group B', owner: userBPageManager, members: [userA, userC]},
-    ];
+      const groups = [
+        {name: 'Group A', owner: userAPageManager, members: [userB, userC]},
+        {name: 'Group B', owner: userBPageManager, members: [userA, userC]},
+      ];
 
-    for (const group of groups) {
-      const {pages, modals} = PageManager.from(group.owner).webapp;
+      for (const group of groups) {
+        const {pages, modals} = PageManager.from(group.owner).webapp;
 
-      await pages.conversationList().getConversation(group.name).open();
-      await pages.conversation().clickConversationInfoButton();
-      await pages.conversationDetails().deleteGroupButton.click();
-      await modals.confirm().actionButton.click();
-      await expect(userCPages.conversationList().getConversation(group.name)).not.toBeAttached({
-        timeout: 20_000,
-      });
+        await pages.conversationList().getConversation(group.name).open();
+        await pages.conversation().clickConversationInfoButton();
+        await pages.conversationDetails().deleteGroupButton.click();
+        await modals.confirm().actionButton.click();
+        await expect(userCPages.conversationList().getConversation(group.name)).not.toBeAttached({
+          timeout: 20_000,
+        });
 
-      await userCPages.conversationList().searchConversationsInput.fill(group.name);
-      await expect(userCPages.conversationList().list).toContainText('No results found');
-      await userCPages.conversationList().searchConversationsInput.fill(''); // Clear search input for next iteration
-    }
-  });
+        await userCPages.conversationList().searchConversationsInput.fill(group.name);
+        await expect(userCPages.conversationList().list).toContainText('No results found');
+        await userCPages.conversationList().searchConversationsInput.fill(''); // Clear search input for next iteration
+      }
+    },
+  );
 
   test(
     'I want to leave a group conversation via conversation list dropdown options',

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -327,7 +327,6 @@ test.describe('History Backup', () => {
     },
   );
 
-  // TODO: unskip this test once https://github.com/wireapp/wire-server/pull/5205 is merged
   // This test is currently broken due to the backend taking more than 10s to delete the conversation
   test.skip(
     'I should not see the deleted group after restore from the backup',


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Sadly the backend regression seems to still be ongoing blocking all our tests which attempt to delete a conversation. Now even the tests which had a timeout of 20s for this are constantly failing.

Notes for reviewers:
- The changes look scary due to the new linebreak, but they actually just add the `.skip` to the broken tests