### PR TITLE
fix: show correct system message when disabling self deleting messages [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -3097,9 +3097,6 @@ export class ConversationRepository {
     messageTimer: number | null,
   ): Promise<ConversationMessageTimerUpdateEvent> {
     messageTimer = ConversationEphemeralHandler.validateTimer(messageTimer);
-    if (messageTimer === null) {
-      messageTimer = 0;
-    }
 
     const response = await this.conversationService.updateConversationMessageTimer(
       conversationEntity.qualifiedId,

--- a/apps/webapp/src/script/repositories/conversation/ConversationService.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationService.ts
@@ -199,7 +199,7 @@ export class ConversationService {
    */
   updateConversationMessageTimer(
     conversationId: QualifiedId,
-    message_timer: number,
+    message_timer: number | null,
   ): Promise<ConversationMessageTimerUpdateEvent> {
     return this.apiClient.api.conversation.putConversationMessageTimer(conversationId, {message_timer});
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This reverts a [change](https://github.com/wireapp/wire-webapp/pull/21203/changes#diff-6a7d2709a05a0aa3f0e20d913b37f6edd3449395be5bbb13e1673c585de4bda6R3100) made in #21203 which changed the behavior of this message type by passing `0` as empty value instead of `null` causing the wrong system message to be printed. This fixes the regression test TC-3720 for self deleting messages.


