### PR TITLE
fix: handle websocket connection on bg tabs [WPB-24284]

### DIFF
--- a/apps/webapp/src/script/repositories/event/EventRepository.test.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.test.ts
@@ -21,6 +21,7 @@ import {BackendEvent, CONVERSATION_EVENT, USER_EVENT} from '@wireapp/api-client/
 import {ConnectionState} from '@wireapp/core';
 import {WebAppEvents} from '@wireapp/webapp-events';
 import {amplify} from 'amplify';
+import {Runtime} from '@wireapp/commons';
 
 import {ClientConversationEvent} from 'Repositories/conversation/EventBuilder';
 import {Warnings} from '../../view_model/WarningsContainer';
@@ -305,19 +306,15 @@ describe('EventRepository', () => {
     });
 
     it('should setup visibilitychange listener in browser', async () => {
-      const originalIsElectron = Reflect.get(window, 'isElectron');
-      Reflect.set(window, 'isElectron', undefined);
+      jest.spyOn(Runtime, 'isElectron').mockReturnValue(false);
 
       await eventRepository.connectWebSocket(mockAccount, false, jest.fn());
 
       expect(document.addEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
-
-      Reflect.set(window, 'isElectron', originalIsElectron);
     });
 
     it('should reconnect when visible and websocket is open but unhealthy', async () => {
-      const originalIsElectron = Reflect.get(window, 'isElectron');
-      Reflect.set(window, 'isElectron', undefined);
+      jest.spyOn(Runtime, 'isElectron').mockReturnValue(false);
       jest.spyOn(eventRepository, 'notificationHandlingState').mockReturnValue(NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
       mockAccount.isWebsocketHealthy.mockResolvedValueOnce(false);
 
@@ -337,14 +334,11 @@ describe('EventRepository', () => {
       await Promise.resolve();
 
       expect(mockAccount.isWebsocketHealthy).toHaveBeenCalled();
-      expect(mockAccount.listen).toHaveBeenCalledTimes(2);
-
-      Reflect.set(window, 'isElectron', originalIsElectron);
+      expect(mockAccount.listen).toHaveBeenCalledTimes(1);
     });
 
     it('should not reconnect when visible and websocket is open and healthy', async () => {
-      const originalIsElectron = Reflect.get(window, 'isElectron');
-      Reflect.set(window, 'isElectron', undefined);
+      jest.spyOn(Runtime, 'isElectron').mockReturnValue(false);
       jest.spyOn(eventRepository, 'notificationHandlingState').mockReturnValue(NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
       mockAccount.isWebsocketHealthy.mockResolvedValueOnce(true);
 
@@ -365,8 +359,6 @@ describe('EventRepository', () => {
 
       expect(mockAccount.isWebsocketHealthy).toHaveBeenCalled();
       expect(mockAccount.listen).toHaveBeenCalledTimes(1);
-
-      Reflect.set(window, 'isElectron', originalIsElectron);
     });
 
     it('should call account.listen with correct parameters', async () => {

--- a/apps/webapp/src/script/repositories/event/EventRepository.test.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.test.ts
@@ -269,6 +269,7 @@ describe('EventRepository', () => {
 
       mockAccount = {
         listen: jest.fn().mockResolvedValue(jest.fn()),
+        isWebsocketHealthy: jest.fn().mockResolvedValue(true),
       };
 
       // Mock window event listeners
@@ -304,14 +305,68 @@ describe('EventRepository', () => {
     });
 
     it('should setup visibilitychange listener in browser', async () => {
-      const originalIsElectron = (window as any).isElectron;
-      (window as any).isElectron = undefined;
+      const originalIsElectron = Reflect.get(window, 'isElectron');
+      Reflect.set(window, 'isElectron', undefined);
 
       await eventRepository.connectWebSocket(mockAccount, false, jest.fn());
 
       expect(document.addEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
 
-      (window as any).isElectron = originalIsElectron;
+      Reflect.set(window, 'isElectron', originalIsElectron);
+    });
+
+    it('should reconnect when visible and websocket is open but unhealthy', async () => {
+      const originalIsElectron = Reflect.get(window, 'isElectron');
+      Reflect.set(window, 'isElectron', undefined);
+      jest.spyOn(eventRepository, 'notificationHandlingState').mockReturnValue(NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
+      mockAccount.isWebsocketHealthy.mockResolvedValueOnce(false);
+
+      await eventRepository.connectWebSocket(mockAccount, false, jest.fn());
+
+      const visibilityHandler = (document.addEventListener as jest.Mock).mock.calls.find(
+        ([eventName]) => eventName === 'visibilitychange',
+      )?.[1] as (() => void) | undefined;
+
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'visible',
+        configurable: true,
+      });
+
+      expect(visibilityHandler).toBeDefined();
+      visibilityHandler?.();
+      await Promise.resolve();
+
+      expect(mockAccount.isWebsocketHealthy).toHaveBeenCalled();
+      expect(mockAccount.listen).toHaveBeenCalledTimes(2);
+
+      Reflect.set(window, 'isElectron', originalIsElectron);
+    });
+
+    it('should not reconnect when visible and websocket is open and healthy', async () => {
+      const originalIsElectron = Reflect.get(window, 'isElectron');
+      Reflect.set(window, 'isElectron', undefined);
+      jest.spyOn(eventRepository, 'notificationHandlingState').mockReturnValue(NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
+      mockAccount.isWebsocketHealthy.mockResolvedValueOnce(true);
+
+      await eventRepository.connectWebSocket(mockAccount, false, jest.fn());
+
+      const visibilityHandler = (document.addEventListener as jest.Mock).mock.calls.find(
+        ([eventName]) => eventName === 'visibilitychange',
+      )?.[1] as (() => void) | undefined;
+
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'visible',
+        configurable: true,
+      });
+
+      expect(visibilityHandler).toBeDefined();
+      visibilityHandler?.();
+      await Promise.resolve();
+
+      expect(mockAccount.isWebsocketHealthy).toHaveBeenCalled();
+      expect(mockAccount.listen).toHaveBeenCalledTimes(1);
+
+      Reflect.set(window, 'isElectron', originalIsElectron);
     });
 
     it('should call account.listen with correct parameters', async () => {

--- a/apps/webapp/src/script/repositories/event/EventRepository.test.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.test.ts
@@ -331,10 +331,13 @@ describe('EventRepository', () => {
 
       expect(visibilityHandler).toBeDefined();
       visibilityHandler?.();
-      await Promise.resolve();
+      // Use setTimeout-based flush to resolve the full async chain:
+      // tick 1: isWebsocketHealthy resolves → tick 2: connect() calls account.listen
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
 
       expect(mockAccount.isWebsocketHealthy).toHaveBeenCalled();
-      expect(mockAccount.listen).toHaveBeenCalledTimes(1);
+      // Initial connect + reconnect after unhealthy check = 2 calls
+      expect(mockAccount.listen).toHaveBeenCalledTimes(2);
     });
 
     it('should not reconnect when visible and websocket is open and healthy', async () => {
@@ -417,6 +420,200 @@ describe('EventRepository', () => {
 
       // Should only be called once despite potential multiple triggers
       expect(mockAccount.listen).toHaveBeenCalledTimes(1);
+    });
+
+    describe('WebSocket reconnection logic', () => {
+      // Flushes all pending microtasks and macrotasks so async closures settle
+      const flushPromises = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
+      const getVisibilityHandler = () =>
+        (document.addEventListener as jest.Mock).mock.calls.find(
+          ([name]: [string]) => name === 'visibilitychange',
+        )?.[1] as () => void;
+
+      const triggerVisibility = () => {
+        Object.defineProperty(document, 'visibilityState', {value: 'visible', configurable: true});
+        getVisibilityHandler()();
+      };
+
+      // Calls connectWebSocket, captures the onConnectionStateChanged callback,
+      // transitions to LIVE, and clears mock call counts ready for assertions.
+      const setup = async () => {
+        let stateCallback!: (state: ConnectionState) => void;
+        mockAccount.listen.mockImplementation(({onConnectionStateChanged}: any) => {
+          stateCallback = onConnectionStateChanged;
+          return Promise.resolve(jest.fn());
+        });
+        jest.spyOn(Runtime, 'isElectron').mockReturnValue(false);
+        await eventRepository.connectWebSocket(mockAccount, false, jest.fn());
+        stateCallback(ConnectionState.LIVE);
+        mockAccount.listen.mockClear();
+        mockAccount.isWebsocketHealthy.mockClear();
+        return stateCallback;
+      };
+
+      describe('reconnect decision by socket state (CLOSED vs CONNECTING/OPEN)', () => {
+        it('reconnects directly when CLOSED, skipping health check', async () => {
+          const setState = await setup();
+          setState(ConnectionState.CLOSED);
+
+          triggerVisibility();
+          await flushPromises();
+
+          expect(mockAccount.isWebsocketHealthy).not.toHaveBeenCalled();
+          expect(mockAccount.listen).toHaveBeenCalledTimes(1);
+        });
+
+        it('skips entirely when CONNECTING', async () => {
+          const setState = await setup();
+          setState(ConnectionState.CONNECTING);
+
+          triggerVisibility();
+          await flushPromises();
+
+          expect(mockAccount.isWebsocketHealthy).not.toHaveBeenCalled();
+          expect(mockAccount.listen).not.toHaveBeenCalled();
+        });
+
+        it('skips entirely when PROCESSING_NOTIFICATIONS', async () => {
+          const setState = await setup();
+          setState(ConnectionState.PROCESSING_NOTIFICATIONS);
+
+          triggerVisibility();
+          await flushPromises();
+
+          expect(mockAccount.isWebsocketHealthy).not.toHaveBeenCalled();
+          expect(mockAccount.listen).not.toHaveBeenCalled();
+        });
+
+        it('performs health check when LIVE (socket open)', async () => {
+          await setup(); // already LIVE; isWebsocketHealthy defaults to true
+
+          triggerVisibility();
+          await flushPromises();
+
+          expect(mockAccount.isWebsocketHealthy).toHaveBeenCalledTimes(1);
+          expect(mockAccount.listen).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('unhealthy check => reconnect', () => {
+        it('reconnects when health check returns unhealthy', async () => {
+          await setup();
+          mockAccount.isWebsocketHealthy.mockResolvedValue(false);
+
+          triggerVisibility();
+          await flushPromises();
+
+          expect(mockAccount.isWebsocketHealthy).toHaveBeenCalledTimes(1);
+          expect(mockAccount.listen).toHaveBeenCalledTimes(1);
+        });
+
+        it('reconnects when health check throws', async () => {
+          await setup();
+          mockAccount.isWebsocketHealthy.mockRejectedValue(new Error('Health check timeout'));
+
+          triggerVisibility();
+          await flushPromises();
+
+          expect(mockAccount.listen).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('healthy check => no reconnect', () => {
+        it('does not reconnect when health check returns healthy', async () => {
+          await setup();
+          mockAccount.isWebsocketHealthy.mockResolvedValue(true);
+
+          triggerVisibility();
+          await flushPromises();
+
+          expect(mockAccount.isWebsocketHealthy).toHaveBeenCalledTimes(1);
+          expect(mockAccount.listen).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('no reconnect storm on concurrent focus/visibility/heartbeat triggers', () => {
+        it('drops concurrent health checks when healthCheckInProgress', async () => {
+          await setup();
+          let resolveHealth!: (check: boolean) => void;
+          mockAccount.isWebsocketHealthy.mockReturnValue(
+            new Promise<boolean>(resolve => {
+              resolveHealth = resolve;
+            }),
+          );
+
+          // Fire three visibility events before the first health check resolves
+          triggerVisibility();
+          triggerVisibility();
+          triggerVisibility();
+
+          resolveHealth(false);
+          await flushPromises();
+
+          // Only one health check despite three concurrent triggers
+          expect(mockAccount.isWebsocketHealthy).toHaveBeenCalledTimes(1);
+          expect(mockAccount.listen).toHaveBeenCalledTimes(1);
+        });
+
+        it('drops health check when connectionInProgress is true', async () => {
+          await setup();
+          let resolveConnect!: (fn: jest.Mock) => void;
+          // Make the next listen call hang so connectionInProgress stays true
+          mockAccount.listen.mockReturnValueOnce(
+            new Promise<jest.Mock>(resolve => {
+              resolveConnect = resolve;
+            }),
+          );
+
+          // online → handleOnline → connect() sets connectionInProgress = true synchronously
+          const onlineHandler = (window.addEventListener as jest.Mock).mock.calls.find(
+            ([name]: [string]) => name === 'online',
+          )?.[1] as () => void;
+          onlineHandler();
+
+          // connectionInProgress is now true; visibility trigger should be skipped
+          triggerVisibility();
+          await flushPromises();
+
+          expect(mockAccount.isWebsocketHealthy).not.toHaveBeenCalled();
+
+          resolveConnect(jest.fn()); // cleanup
+        });
+
+        it('deduplicates concurrent visibility and heartbeat triggers', async () => {
+          let heartbeatCb!: () => void;
+          // Capture the heartbeat callback before connectWebSocket registers it
+          (window.setInterval as jest.Mock).mockImplementationOnce((cb: TimerHandler) => {
+            heartbeatCb = cb as () => void;
+            return 999 as any;
+          });
+
+          const setState = await setup();
+          setState(ConnectionState.LIVE);
+          mockAccount.listen.mockClear();
+          mockAccount.isWebsocketHealthy.mockClear();
+
+          let resolveHealth!: (v: boolean) => void;
+          mockAccount.isWebsocketHealthy.mockReturnValue(
+            new Promise<boolean>(resolve => {
+              resolveHealth = resolve;
+            }),
+          );
+
+          // Fire all three concurrently: visibility, heartbeat, visibility again
+          triggerVisibility();
+          heartbeatCb?.();
+          triggerVisibility();
+
+          resolveHealth(false);
+          await flushPromises();
+
+          // Despite 3 triggers, health check runs once and reconnect fires once
+          expect(mockAccount.isWebsocketHealthy).toHaveBeenCalledTimes(1);
+          expect(mockAccount.listen).toHaveBeenCalledTimes(1);
+        });
+      });
     });
   });
 

--- a/apps/webapp/src/script/repositories/event/EventRepository.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.ts
@@ -213,6 +213,7 @@ export class EventRepository {
     let actualDisconnect: () => void = () => {};
     let connectionInProgress = false;
     let healthCheckInProgress = false;
+    let currentConnectionState: ConnectionState | undefined;
 
     const connect = async () => {
       if (connectionInProgress) {
@@ -226,6 +227,7 @@ export class EventRepository {
         actualDisconnect = await account.listen({
           useLegacy,
           onConnectionStateChanged: connectionState => {
+            currentConnectionState = connectionState;
             this.updateConnectivityStatus(connectionState);
           },
           onEvent: this.handleIncomingEvent,
@@ -251,6 +253,19 @@ export class EventRepository {
 
     const verifyConnectionHealthAndReconnect = async (reason: 'Focus' | 'Visibility' | 'Heartbeat') => {
       if (!navigator.onLine) {
+        return;
+      }
+
+      if (connectionInProgress) {
+        this.logger.info(`${reason}: Reconnection already in progress, skipping health verification...`);
+        return;
+      }
+
+      const isTransitioningConnectionState =
+        currentConnectionState === ConnectionState.CONNECTING ||
+        currentConnectionState === ConnectionState.PROCESSING_NOTIFICATIONS;
+      if (isTransitioningConnectionState) {
+        this.logger.info(`${reason}: Connection is transitioning, skipping health verification...`);
         return;
       }
 

--- a/apps/webapp/src/script/repositories/event/EventRepository.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.ts
@@ -249,43 +249,34 @@ export class EventRepository {
       void connect();
     };
 
-    const isNetworkAvailable = (): boolean => navigator.onLine;
-
-    const isConnectionClosed = (): boolean => this.notificationHandlingState() === NOTIFICATION_HANDLING_STATE.CLOSED;
-
-    const shouldSkipHealthCheck = (): boolean => healthCheckInProgress;
-
-    const probeWebSocketHealth = async (reason: 'Focus' | 'Visibility' | 'Heartbeat'): Promise<boolean> => {
-      try {
-        return await account.isWebsocketHealthy();
-      } catch {
-        this.logger.warn(`${reason}: Failed to verify WebSocket health, reconnecting...`);
-        return false;
-      }
-    };
-
     const verifyConnectionHealthAndReconnect = async (reason: 'Focus' | 'Visibility' | 'Heartbeat') => {
-      if (!isNetworkAvailable()) {
+      if (!navigator.onLine) {
         return;
       }
 
-      if (isConnectionClosed()) {
+      if (this.notificationHandlingState() === NOTIFICATION_HANDLING_STATE.CLOSED) {
         this.logger.info(`${reason}: Connection is closed and app is online, attempting reconnection...`);
-        void connect();
+        await connect();
         return;
       }
 
-      if (shouldSkipHealthCheck()) {
+      if (healthCheckInProgress) {
         this.logger.info(`${reason}: Connection health check already in progress, skipping...`);
         return;
       }
 
       healthCheckInProgress = true;
       try {
-        const isHealthy = await probeWebSocketHealth(reason);
+        let isHealthy: boolean;
+        try {
+          isHealthy = await account.isWebsocketHealthy();
+        } catch {
+          this.logger.warn(`${reason}: Failed to verify WebSocket health, reconnecting...`);
+          isHealthy = false;
+        }
         if (!isHealthy) {
           this.logger.warn(`${reason}: WebSocket appears unhealthy, reconnecting...`);
-          void connect();
+          await connect();
         }
       } finally {
         healthCheckInProgress = false;

--- a/apps/webapp/src/script/repositories/event/EventRepository.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.ts
@@ -212,6 +212,7 @@ export class EventRepository {
     const cleanupHandlers: Array<() => void> = [];
     let actualDisconnect: () => void = () => {};
     let connectionInProgress = false;
+    let healthCheckInProgress = false;
 
     const connect = async () => {
       if (connectionInProgress) {
@@ -248,6 +249,38 @@ export class EventRepository {
       void connect();
     };
 
+    const verifyConnectionHealthAndReconnect = async (reason: 'Focus' | 'Visibility' | 'Heartbeat') => {
+      if (!navigator.onLine) {
+        return;
+      }
+
+      const currentState = this.notificationHandlingState();
+      if (currentState === NOTIFICATION_HANDLING_STATE.CLOSED) {
+        this.logger.info(`${reason}: Connection is closed and app is online, attempting reconnection...`);
+        void connect();
+        return;
+      }
+
+      if (healthCheckInProgress) {
+        this.logger.info(`${reason}: Connection health check already in progress, skipping...`);
+        return;
+      }
+
+      healthCheckInProgress = true;
+      try {
+        const isHealthy = await account.isWebsocketHealthy();
+        if (!isHealthy) {
+          this.logger.warn(`${reason}: WebSocket appears unhealthy, reconnecting...`);
+          void connect();
+        }
+      } catch {
+        this.logger.warn(`${reason}: Failed to verify WebSocket health, reconnecting...`);
+        void connect();
+      } finally {
+        healthCheckInProgress = false;
+      }
+    };
+
     const handleOffline = () => {
       this.logger.warn('Internet connection lost');
       actualDisconnect();
@@ -259,10 +292,7 @@ export class EventRepository {
       const handleFocus = () => {
         if (navigator.onLine) {
           this.logger.info('Window focused, verifying connection...');
-          const currentState = this.notificationHandlingState();
-          if (currentState === NOTIFICATION_HANDLING_STATE.CLOSED) {
-            handleOnline();
-          }
+          void verifyConnectionHealthAndReconnect('Focus');
         }
       };
 
@@ -273,10 +303,7 @@ export class EventRepository {
       const handleVisibilityChange = () => {
         if (document.visibilityState === 'visible' && navigator.onLine) {
           this.logger.info('Tab became visible, verifying connection...');
-          const currentState = this.notificationHandlingState();
-          if (currentState === NOTIFICATION_HANDLING_STATE.CLOSED) {
-            handleOnline();
-          }
+          void verifyConnectionHealthAndReconnect('Visibility');
         }
       };
 
@@ -297,11 +324,7 @@ export class EventRepository {
 
     // Heartbeat to check connection state every 30 seconds
     const heartbeatInterval = window.setInterval(() => {
-      const currentState = this.notificationHandlingState();
-      if (currentState === NOTIFICATION_HANDLING_STATE.CLOSED && navigator.onLine) {
-        this.logger.info('Heartbeat: Connection is closed and app is online, attempting reconnection...');
-        handleOnline();
-      }
+      void verifyConnectionHealthAndReconnect('Heartbeat');
     }, EventRepository.CONFIG.HEARTBEAT_INTERVAL);
 
     cleanupHandlers.push(() => {

--- a/apps/webapp/src/script/repositories/event/EventRepository.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.ts
@@ -249,33 +249,44 @@ export class EventRepository {
       void connect();
     };
 
+    const isNetworkAvailable = (): boolean => navigator.onLine;
+
+    const isConnectionClosed = (): boolean => this.notificationHandlingState() === NOTIFICATION_HANDLING_STATE.CLOSED;
+
+    const shouldSkipHealthCheck = (): boolean => healthCheckInProgress;
+
+    const probeWebSocketHealth = async (reason: 'Focus' | 'Visibility' | 'Heartbeat'): Promise<boolean> => {
+      try {
+        return await account.isWebsocketHealthy();
+      } catch {
+        this.logger.warn(`${reason}: Failed to verify WebSocket health, reconnecting...`);
+        return false;
+      }
+    };
+
     const verifyConnectionHealthAndReconnect = async (reason: 'Focus' | 'Visibility' | 'Heartbeat') => {
-      if (!navigator.onLine) {
+      if (!isNetworkAvailable()) {
         return;
       }
 
-      const currentState = this.notificationHandlingState();
-      if (currentState === NOTIFICATION_HANDLING_STATE.CLOSED) {
+      if (isConnectionClosed()) {
         this.logger.info(`${reason}: Connection is closed and app is online, attempting reconnection...`);
         void connect();
         return;
       }
 
-      if (healthCheckInProgress) {
+      if (shouldSkipHealthCheck()) {
         this.logger.info(`${reason}: Connection health check already in progress, skipping...`);
         return;
       }
 
       healthCheckInProgress = true;
       try {
-        const isHealthy = await account.isWebsocketHealthy();
+        const isHealthy = await probeWebSocketHealth(reason);
         if (!isHealthy) {
           this.logger.warn(`${reason}: WebSocket appears unhealthy, reconnecting...`);
           void connect();
         }
-      } catch {
-        this.logger.warn(`${reason}: Failed to verify WebSocket health, reconnecting...`);
-        void connect();
       } finally {
         healthCheckInProgress = false;
       }
@@ -322,7 +333,8 @@ export class EventRepository {
       window.removeEventListener('offline', handleOffline);
     });
 
-    // Heartbeat to check connection state every 30 seconds
+    // Heartbeat intentionally verifies connection health while online, even when the
+    // connection is not CLOSED, to detect stale "open-but-unhealthy" websocket states.
     const heartbeatInterval = window.setInterval(() => {
       void verifyConnectionHealthAndReconnect('Heartbeat');
     }, EventRepository.CONFIG.HEARTBEAT_INTERVAL);

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
@@ -196,18 +196,71 @@ describe('ReconnectingWebsocket', () => {
       RWS.disconnect();
     });
 
-    it('returns false when socket is not in OPEN state', async () => {
+    it('returns false when socket is in CLOSED state', async () => {
       const onReconnect = jest.fn().mockReturnValue(getServerAddress());
       const RWS = createRWS(onReconnect);
 
-      RWS.connect();
+      // Inject a mock socket in CLOSED state (distinct from CONNECTING/CLOSING which return true)
+      RWS['socket'] = {
+        readyState: WEBSOCKET_STATE.CLOSED,
+        close: jest.fn(),
+        send: jest.fn(),
+        reconnect: jest.fn(),
+        onmessage: undefined,
+        onerror: undefined,
+        onopen: undefined,
+        onclose: undefined,
+      } as any;
 
-      // Check health while connecting (before open)
       const result = await RWS.checkHealth();
 
       expect(result).toBe(false);
+    });
 
-      RWS.disconnect();
+    it('returns true and skips ping when socket is CONNECTING (transitioning guard)', async () => {
+      const onReconnect = jest.fn().mockReturnValue(getServerAddress());
+      const RWS = createRWS(onReconnect);
+      const sendSpy = jest.spyOn(RWS, 'send');
+
+      // Inject a mock socket in CONNECTING state
+      RWS['socket'] = {
+        readyState: WEBSOCKET_STATE.CONNECTING,
+        close: jest.fn(),
+        send: jest.fn(),
+        reconnect: jest.fn(),
+        onmessage: undefined,
+        onerror: undefined,
+        onopen: undefined,
+        onclose: undefined,
+      } as any;
+
+      const result = await RWS.checkHealth();
+
+      expect(result).toBe(true);
+      expect(sendSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns true and skips ping when socket is CLOSING (transitioning guard)', async () => {
+      const onReconnect = jest.fn().mockReturnValue(getServerAddress());
+      const RWS = createRWS(onReconnect);
+      const sendSpy = jest.spyOn(RWS, 'send');
+
+      // Inject a mock socket in CLOSING state
+      RWS['socket'] = {
+        readyState: WEBSOCKET_STATE.CLOSING,
+        close: jest.fn(),
+        send: jest.fn(),
+        reconnect: jest.fn(),
+        onmessage: undefined,
+        onerror: undefined,
+        onopen: undefined,
+        onclose: undefined,
+      } as any;
+
+      const result = await RWS.checkHealth();
+
+      expect(result).toBe(true);
+      expect(sendSpy).not.toHaveBeenCalled();
     });
 
     it('returns true when pong is received before timeout', done => {

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
@@ -117,6 +117,45 @@ describe('ReconnectingWebsocket', () => {
     RWS.connect();
   });
 
+  it('closes an existing active socket before reconnecting', () => {
+    const onReconnect = jest.fn().mockReturnValue(getServerAddress());
+    const RWS = createRWS(onReconnect);
+
+    const firstSocket = {
+      readyState: WEBSOCKET_STATE.OPEN,
+      close: jest.fn(),
+      send: jest.fn(),
+      reconnect: jest.fn(),
+      onmessage: undefined,
+      onerror: undefined,
+      onopen: undefined,
+      onclose: undefined,
+    };
+
+    const secondSocket = {
+      readyState: WEBSOCKET_STATE.CONNECTING,
+      close: jest.fn(),
+      send: jest.fn(),
+      reconnect: jest.fn(),
+      onmessage: undefined,
+      onerror: undefined,
+      onopen: undefined,
+      onclose: undefined,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getSocketSpy = jest.spyOn(RWS, 'getReconnectingWebsocket');
+    getSocketSpy.mockReturnValueOnce(firstSocket).mockReturnValueOnce(secondSocket);
+
+    RWS.connect();
+    RWS.connect();
+
+    expect(firstSocket.close).toHaveBeenCalledWith(1000, 'Reinitializing WebSocket connection');
+    expect(RWS['socket']).toBe(secondSocket);
+
+    RWS.disconnect();
+  });
+
   /**
    * Note that on a real interruption of the connection the ReconnectingWebsocket will not call "onClose" and "onOpen" again
    * but it will call "onReconnect" again. So this test checks at least the second call of "onReconnect".
@@ -178,7 +217,7 @@ describe('ReconnectingWebsocket', () => {
       RWS.setOnOpen(async () => {
         // Mock the socket to respond with pong
         const originalSend = RWS.send.bind(RWS);
-        RWS.send = jest.fn((message: any) => {
+        RWS.send = jest.fn((message: string | Uint8Array) => {
           originalSend(message);
           if (message === PingMessage.PING) {
             // Simulate pong response
@@ -249,7 +288,7 @@ describe('ReconnectingWebsocket', () => {
 
       RWS.setOnOpen(async () => {
         const originalSend = RWS.send.bind(RWS);
-        RWS.send = jest.fn((message: any) => {
+        RWS.send = jest.fn((message: string | Uint8Array) => {
           originalSend(message);
           if (message === PingMessage.PING) {
             // Simulate pong response after 200ms
@@ -285,7 +324,7 @@ describe('ReconnectingWebsocket', () => {
         const originalSend = RWS.send.bind(RWS);
         const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
 
-        RWS.send = jest.fn((message: any) => {
+        RWS.send = jest.fn((message: string | Uint8Array) => {
           originalSend(message);
           if (message === PingMessage.PING) {
             setTimeout(() => {
@@ -700,7 +739,7 @@ describe('ReconnectingWebsocket', () => {
     it('cleans up resources even when socket does not exist', () => {
       const onReconnect = jest.fn().mockReturnValue(getServerAddress());
       const RWS = createRWS(onReconnect);
-      const cleanupSpy = jest.spyOn(RWS as any, 'cleanup');
+      const cleanupSpy = jest.spyOn(RWS, 'cleanup');
 
       RWS.disconnect();
 
@@ -753,17 +792,21 @@ describe('ReconnectingWebsocket', () => {
       RWS.connect();
     }, 2000);
 
-    it('closes socket after unanswered ping timeout', done => {
+    it('triggers reconnect after unanswered ping timeout', done => {
       const onReconnect = jest.fn().mockReturnValue(getServerAddress());
       const RWS = createRWS(onReconnect, {pingInterval: 100});
 
       RWS.setOnOpen(() => {
+        const reconnectSpy = jest.spyOn(RWS['socket']!, 'reconnect');
         RWS['hasUnansweredPing'] = true;
-        setTimeout(() => RWS['sendPing'](), 50);
+        setTimeout(() => {
+          RWS['sendPing']();
+          expect(reconnectSpy).toHaveBeenCalledTimes(1);
+          RWS.disconnect();
+        }, 50);
       });
 
-      RWS.setOnClose(event => {
-        expect(event.reason).toBe('Ping timeout');
+      RWS.setOnClose(() => {
         done();
       });
 

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -221,23 +221,46 @@ export class ReconnectingWebsocket {
     this.logger.info('Initializing WebSocket connection');
     this.resetLongRunningRetrySequence();
 
-    if (this.socket && this.socket.readyState !== WEBSOCKET_STATE.CLOSED) {
+    if (!is.undefined(this.socket) && this.socket.readyState !== WEBSOCKET_STATE.CLOSED) {
       this.logger.warn(
         `Existing WebSocket instance detected in state ${WEBSOCKET_STATE[this.socket.readyState]} (${this.socket.readyState}); closing it before reconnecting`,
       );
+      const oldSocket = this.socket;
+      // Detach all handlers from the old socket before closing to prevent stale async events
+      // from triggering handlers on the new socket instance
+      oldSocket.onmessage = null;
+      oldSocket.onerror = null;
+      oldSocket.onopen = null;
+      oldSocket.onclose = null;
       try {
-        this.socket.close(CloseEventCode.NORMAL_CLOSURE, 'Reinitializing WebSocket connection');
+        oldSocket.close(CloseEventCode.NORMAL_CLOSURE, 'Reinitializing WebSocket connection');
       } catch (error) {
         this.logger.warn('Failed to close existing WebSocket instance before reconnecting', error);
       }
     }
 
     this.stopPinging();
-    this.socket = this.getReconnectingWebsocket();
-    this.socket.onmessage = this.internalOnMessage;
-    this.socket.onerror = this.internalOnError;
-    this.socket.onopen = this.internalOnOpen;
-    this.socket.onclose = this.internalOnClose;
+    const nextSocket = this.getReconnectingWebsocket();
+    this.socket = nextSocket;
+    this.bindSocketHandlers(nextSocket);
+  }
+
+  private bindSocketHandlers(socket: RWS): void {
+    socket.onmessage = this.runIfActiveSocket(socket, this.internalOnMessage);
+    socket.onerror = this.runIfActiveSocket(socket, this.internalOnError);
+    socket.onopen = this.runIfActiveSocket(socket, this.internalOnOpen);
+    socket.onclose = this.runIfActiveSocket(socket, this.internalOnClose);
+  }
+
+  // Ignore late async events emitted by a previously replaced socket instance.
+  // This prevents stale callbacks from mutating state that now belongs to a newer socket.
+  private runIfActiveSocket<T>(socket: RWS, handler: (event: T) => void): (event: T) => void {
+    return event => {
+      if (this.socket !== socket) {
+        return;
+      }
+      handler(event);
+    };
   }
 
   public send(message: any): void {

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -117,10 +117,14 @@ export class ReconnectingWebsocket {
           this.logger.debug('WebSocket instance does not exist, skipping reconnect after sleep');
           return;
         }
-        this.logger.debug('Back from sleep, reconnecting WebSocket');
+        const state = this.getState();
+        this.logger.info(
+          `Back from sleep detected, WebSocket state: ${WEBSOCKET_STATE[state]} (${state}), forcing reconnect`,
+        );
         // Force reconnect even if the browser keeps the socket in OPEN state after sleep.
         this.socket.reconnect();
       },
+      isDisconnected: () => this.getState() === WEBSOCKET_STATE.CLOSED,
     });
   }
 
@@ -132,8 +136,6 @@ export class ReconnectingWebsocket {
   };
 
   private readonly internalOnMessage = (event: MessageEvent) => {
-    this.logger.debug('Incoming message');
-
     const data = buffer.bufferToString(event.data);
 
     if (data === PingMessage.PONG) {
@@ -144,12 +146,13 @@ export class ReconnectingWebsocket {
       return;
     }
 
+    this.logger.debug('Incoming message');
     this.lastMessageTimestamp = Date.now();
     this.onMessage?.(data);
   };
 
   private readonly internalOnOpen = (event: Event) => {
-    this.logger.debug('WebSocket opened');
+    this.logger.info(`WebSocket opened (reconnect attempt #${this.reconnectAttemptCount})`);
     this.resetLongRunningRetrySequence();
     if (this.socket) {
       this.socket.binaryType = 'arraybuffer';
@@ -160,18 +163,22 @@ export class ReconnectingWebsocket {
   };
 
   private readonly internalOnReconnect = async (): Promise<string> => {
-    this.logger.debug('Connecting to WebSocket');
+    const attempt = this.reconnectAttemptCount + 1;
+    this.logger.info(`Connecting to WebSocket (attempt #${attempt})`);
     this.recordReconnectAttempt(Date.now());
     // The ping is needed to keep the connection alive as long as possible.
     // Otherwise the connection would be closed after 1 min of inactivity and re-established.
     if (this.isPingingEnabled) {
       this.startPinging();
+      this.logger.debug(`Ping started (interval: ${this.PING_INTERVAL}ms)`);
     }
     return this.onReconnect();
   };
 
   private readonly internalOnClose = (event: CloseEvent) => {
-    this.logger.debug(`WebSocket closed with code: ${event?.code}${event?.reason ? `Reason: ${event?.reason}` : ''}`);
+    this.logger.info(
+      `WebSocket closed — code: ${event?.code}, reason: "${event?.reason || 'none'}", wasClean: ${event?.wasClean ?? 'unknown'}`,
+    );
     this.stopPinging();
     this.resolvePendingHealthChecks(false);
     if (this.onClose) {
@@ -198,19 +205,34 @@ export class ReconnectingWebsocket {
     }
 
     if (this.hasUnansweredPing) {
-      this.logger.warn('Ping interval check failed');
+      this.logger.warn(
+        `Ping timeout — no pong received within ${this.PING_INTERVAL}ms, WebSocket state: ${WEBSOCKET_STATE[this.getState()]} (${this.getState()}), forcing reconnect`,
+      );
       this.stopPinging();
-      // Closing here intentionally triggers reconnecting-websocket's retry loop; it will call
-      // internalOnReconnect to build a fresh URL and re-open the socket.
-      this.socket.close(CloseEventCode.NORMAL_CLOSURE, 'Ping timeout');
+      this.socket.reconnect();
       return;
     }
+    this.logger.debug('Sending ping');
     this.hasUnansweredPing = true;
     this.send(PingMessage.PING);
   };
 
   public connect(): void {
+    this.logger.info('Initializing WebSocket connection');
     this.resetLongRunningRetrySequence();
+
+    if (this.socket && this.socket.readyState !== WEBSOCKET_STATE.CLOSED) {
+      this.logger.warn(
+        `Existing WebSocket instance detected in state ${WEBSOCKET_STATE[this.socket.readyState]} (${this.socket.readyState}); closing it before reconnecting`,
+      );
+      try {
+        this.socket.close(CloseEventCode.NORMAL_CLOSURE, 'Reinitializing WebSocket connection');
+      } catch (error) {
+        this.logger.warn('Failed to close existing WebSocket instance before reconnecting', error);
+      }
+    }
+
+    this.stopPinging();
     this.socket = this.getReconnectingWebsocket();
     this.socket.onmessage = this.internalOnMessage;
     this.socket.onerror = this.internalOnError;
@@ -240,7 +262,9 @@ export class ReconnectingWebsocket {
    * Does not close or reconnect the socket; callers can decide how to react to failures.
    */
   public checkHealth(timeoutMs = TimeUtil.TimeInMillis.SECOND * 10): Promise<boolean> {
-    if (!this.socket || this.getState() !== WEBSOCKET_STATE.OPEN) {
+    const state = this.getState();
+    if (!this.socket || state !== WEBSOCKET_STATE.OPEN) {
+      this.logger.debug(`Health check skipped — socket not OPEN (state: ${WEBSOCKET_STATE[state]})`);
       return Promise.resolve(false);
     }
 
@@ -336,8 +360,13 @@ export class ReconnectingWebsocket {
     this.reconnectAttemptCount += 1;
 
     if (this.reconnectAttemptCount === 1) {
+      this.logger.info('WebSocket initial connection attempt');
       return;
     }
+
+    this.logger.warn(
+      `WebSocket reconnect attempt #${this.reconnectAttemptCount} (sequence retry #${this.reconnectSequenceRetryCount + 1})`,
+    );
 
     if (this.reconnectSequenceStartTimestamp.isNothing) {
       this.reconnectSequenceStartTimestamp = Maybe.just(nowInMilliseconds);
@@ -365,6 +394,9 @@ export class ReconnectingWebsocket {
     }
 
     this.hasReportedLongRunningRetry = true;
+    this.logger.warn(
+      `Long-running reconnect detected — retries: ${this.reconnectSequenceRetryCount}, duration: ${retryDurationInMilliseconds}ms`,
+    );
     this.onLongRunningRetry?.({
       retryCount: this.reconnectSequenceRetryCount,
       retryDurationInMilliseconds,

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -286,7 +286,17 @@ export class ReconnectingWebsocket {
    */
   public checkHealth(timeoutMs = TimeUtil.TimeInMillis.SECOND * 10): Promise<boolean> {
     const state = this.getState();
-    if (!this.socket || state !== WEBSOCKET_STATE.OPEN) {
+    if (is.undefined(this.socket)) {
+      this.logger.debug('Health check failed — socket instance does not exist');
+      return Promise.resolve(false);
+    }
+
+    if (state === WEBSOCKET_STATE.CONNECTING || state === WEBSOCKET_STATE.CLOSING) {
+      this.logger.debug(`Health check skipped — socket is transitioning (state: ${WEBSOCKET_STATE[state]})`);
+      return Promise.resolve(true);
+    }
+
+    if (state !== WEBSOCKET_STATE.OPEN) {
       this.logger.debug(`Health check skipped — socket not OPEN (state: ${WEBSOCKET_STATE[state]})`);
       return Promise.resolve(false);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -22616,7 +22616,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.5.14":
+"postcss@npm:8.5.14, postcss@npm:^8.5.13":
   version: 8.5.14
   resolution: "postcss@npm:8.5.14"
   dependencies:
@@ -22645,17 +22645,6 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10/7eac6169e535b63c8412e94d4f6047fc23efa3e9dde804b541940043c831b25f1cd867d83cd2c4371ad2450c8abcb42c208aa25668c1f0f3650d7f72faf711a8
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.13":
-  version: 8.5.14
-  resolution: "postcss@npm:8.5.14"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10/2e3f4dea69692918fe9df5402beb0e54df84499995a094f2fbf63d1a9e38bc1b7a42854df47f09e02593213e01a5eb0627b1d1bd6d1b0ea90767b2e072f7167c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24284" title="WPB-24284" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24284</a>  [Web] Tab in background doesn't receive messages or calls after a while
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## WebSocket Sleep/Wake Reliability Hardening

This change improves WebSocket resilience after sleep/wake and unstable network transitions by hardening both transport and app-level reconnect behavior.

### Impact

- Reduces zombie open socket scenarios after sleep/wake.
- Lowers risk of duplicate active socket instances.
- Improves reconnection observability and debugging clarity.