### PR TITLE
Enforce strict-boolean-expressions outside webapp [WPB-22420]

### DIFF
--- a/apps/server/Server.ts
+++ b/apps/server/Server.ts
@@ -109,7 +109,7 @@ class Server {
     } else {
       this.app.use((req, res, next) => {
         // If the user agent adds a v param, it means that its requesting a particular version of the file and that could be cached forever since the file will never change.
-        const hasCacheVersionParam = req.query.v && typeof req.query.v === 'string';
+        const hasCacheVersionParam = typeof req.query.v === 'string';
         const oneYear = 31536000;
         const maxAge = hasCacheVersionParam ? oneYear : this.config.CACHE_DURATION_SECONDS;
         const milliSeconds = 1000;
@@ -122,7 +122,7 @@ class Server {
 
   private initForceSSL(): void {
     const SSLMiddleware: express.RequestHandler = (req, res, next) => {
-      const shouldEnforceHTTPS = !this.config.ENFORCE_HTTPS || req.url.match(/_health\/?/);
+      const shouldEnforceHTTPS = !this.config.ENFORCE_HTTPS || req.url.match(/_health\/?/) !== null;
       const isInsecure = !req.secure || req.get('X-Forwarded-Proto') !== 'https';
 
       if (isInsecure && !shouldEnforceHTTPS) {

--- a/apps/server/routes/error/errorRoutes.ts
+++ b/apps/server/routes/error/errorRoutes.ts
@@ -43,7 +43,7 @@ const InternalErrorRoute = (): express.ErrorRequestHandler => (err, req, res, ne
     ip: req.ip,
     url: req.url,
   };
-  if (req.headers?.date) {
+  if (req.headers?.date !== undefined) {
     request.date = req.headers.date;
   }
   req.app.locals.error = error;

--- a/apps/server/util/browserUtil.ts
+++ b/apps/server/util/browserUtil.ts
@@ -65,7 +65,7 @@ interface ParsedUserAgent {
 }
 
 function parseUserAgent(userAgent?: string): ParsedUserAgent | null {
-  if (!userAgent) {
+  if (userAgent === undefined || userAgent.length === 0) {
     return null;
   }
 
@@ -82,12 +82,12 @@ function parseUserAgent(userAgent?: string): ParsedUserAgent | null {
   const isBingBot = userAgent.includes('bingbot');
   const isBingbot = userAgent.includes('bingbot');
   const isBlackberryTablet = agent.isBlackberry && userAgent.includes('tablet');
-  const isElectron = !!electronVersion;
-  const isFranz = !!franzVersion;
+  const isElectron = electronVersion !== undefined;
+  const isFranz = franzVersion !== undefined;
   const isGoogleBot = userAgent.includes('googlebot');
   const isIOS = /ipad|iphone|ipod/i.test(agent.platform);
   const isOSX = agent.platform.toLowerCase().includes('mac');
-  const isWire = !!wireVersion;
+  const isWire = wireVersion !== undefined;
   const isYahooBot = userAgent.includes('yahoo');
 
   const isCrawler = isBingBot || isGoogleBot || isYahooBot;

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -551,7 +551,13 @@ export class CallingRepository {
       this.videoStateChanged, // `vstateh`,
     );
     const tenSeconds = 10;
-    wCall.setNetworkQualityHandler(wUser, this.updateCallQuality, tenSeconds);
+    wCall.setNetworkQualityHandler(
+      wUser,
+      (conversationId, userId, clientId, quality) => {
+        this.updateCallQuality(conversationId, userId, clientId, JSON.stringify({quality}));
+      },
+      tenSeconds,
+    );
     wCall.setMuteHandler(wUser, this.updateMuteState);
     wCall.setStateHandler(wUser, this.updateCallState);
     wCall.setParticipantChangedHandler(wUser, this.handleCallParticipantChanges);
@@ -643,12 +649,11 @@ export class CallingRepository {
       return;
     }
 
-    const {quality} = qualityInfo;
-
     const call = this.findCall(this.parseQualifiedId(conversationId));
     if (!call) {
       return;
     }
+    const {quality} = qualityInfo;
     if (!this.poorCallQualityUsers[conversationId]) {
       this.poorCallQualityUsers[conversationId] = [];
     }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -165,6 +165,7 @@ const config: Linter.Config[] = [
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/no-var-requires': 'off',
       '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/strict-boolean-expressions': 'error',
       '@typescript-eslint/no-floating-promises': 'warn',
       '@typescript-eslint/no-unused-vars': [
         'warn',
@@ -214,6 +215,12 @@ const config: Linter.Config[] = [
     rules: {
       'no-magic-numbers': 'off',
       'id-length': 'off',
+    },
+  },
+  {
+    files: ['apps/webapp/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/strict-boolean-expressions': 'off',
     },
   },
 ];

--- a/libraries/api-client/src/apiClient.ts
+++ b/libraries/api-client/src/apiClient.ts
@@ -272,7 +272,7 @@ export class APIClient extends EventEmitter {
       version: backendVersion,
       domain: responsePayload?.domain ?? '',
       federationEndpoints: backendVersion > 0,
-      isFederated: responsePayload?.federation || false,
+      isFederated: responsePayload?.federation ?? false,
       supportsMLS: backendVersion >= 5,
       supportsGuestLinksWithPassword: backendVersion >= 4,
     };
@@ -427,20 +427,20 @@ export class APIClient extends EventEmitter {
   }
 
   public get clientId(): string | undefined {
-    return this.context?.clientId || undefined;
+    return this.context?.clientId;
   }
 
   public get userId(): string | undefined {
-    return this.context?.userId || undefined;
+    return this.context?.userId;
   }
 
   public get domain(): string | undefined {
-    return this.context?.domain || undefined;
+    return this.context?.domain;
   }
 
   /** Should be used in cases where the user ID is MANDATORY. */
   public get validatedUserId(): string {
-    if (this.userId) {
+    if (this.userId !== undefined && this.userId.length > 0) {
       return this.userId;
     }
     throw new Error('No valid user ID.');
@@ -448,7 +448,7 @@ export class APIClient extends EventEmitter {
 
   /** Should be used in cases where the client ID is MANDATORY. */
   public get validatedClientId(): string {
-    if (this.clientId) {
+    if (this.clientId !== undefined && this.clientId.length > 0) {
       return this.clientId;
     }
     throw new Error('No valid client ID.');
@@ -466,7 +466,7 @@ export class APIClient extends EventEmitter {
 
     try {
       const backendRemovalKey = (await this.api.client.getPublicKeys()).removal;
-      return !!backendRemovalKey;
+      return backendRemovalKey !== undefined;
     } catch {
       // Ignore errors, backend might not support removal keys
     }

--- a/libraries/api-client/src/asset/assetApi.ts
+++ b/libraries/api-client/src/asset/assetApi.ts
@@ -85,7 +85,7 @@ export class AssetAPI {
     forceCaching: boolean = false,
     progressCallback?: ProgressCallback,
   ): RequestCancelable<AssetResponse> {
-    if (token && !isValidToken(token)) {
+    if (token !== null && token !== undefined && token.length > 0 && !isValidToken(token)) {
       throw new TypeError(`Expected token "${token.substr(0, 5)}..." (redacted) to be base64 encoded string.`);
     }
 
@@ -100,7 +100,7 @@ export class AssetAPI {
       url: assetUrl,
     };
 
-    if (token) {
+    if (token !== null && token !== undefined && token.length > 0) {
       config.params.asset_token = token;
     }
 
@@ -146,7 +146,7 @@ export class AssetAPI {
       filetype?: string;
     } = {
       public: options?.public ?? true,
-      retention: options?.retention || AssetRetentionPolicy.PERSISTENT,
+      retention: options?.retention ?? AssetRetentionPolicy.PERSISTENT,
       domain: options?.domain,
     };
 

--- a/libraries/api-client/src/auth/accessTokenStore.ts
+++ b/libraries/api-client/src/auth/accessTokenStore.ts
@@ -85,7 +85,11 @@ export class AccessTokenStore extends EventEmitter {
   };
 
   public getAccessToken = (): string | undefined => {
-    if (this.accessTokenData && this.tokenExpirationDate && this.tokenExpirationDate > Date.now()) {
+    if (
+      this.accessTokenData !== undefined &&
+      this.tokenExpirationDate !== undefined &&
+      this.tokenExpirationDate > Date.now()
+    ) {
       return this.accessTokenData.access_token;
     }
     this.logger.warn('Access token is not set or has expired');

--- a/libraries/api-client/src/auth/authApi.ts
+++ b/libraries/api-client/src/auth/authApi.ts
@@ -78,9 +78,9 @@ export class AuthAPI {
     const {verificationCode, ...rest} = loginData;
     const login = {
       ...rest,
-      ...(verificationCode && {verification_code: verificationCode}),
+      ...(verificationCode !== undefined && verificationCode.length > 0 && {verification_code: verificationCode}),
       clientType: undefined as any,
-      password: loginData.password ? String(loginData.password) : undefined,
+      password: loginData.password !== undefined ? String(loginData.password) : undefined,
     };
 
     const config: AxiosRequestConfig = {

--- a/libraries/api-client/src/cells/cellsApi.ts
+++ b/libraries/api-client/src/cells/cellsApi.ts
@@ -117,7 +117,7 @@ export class CellsAPI {
       headers: {...this.httpClientConfig.headers},
     };
 
-    if (cellsConfig.pydio.apiKey) {
+    if (cellsConfig.pydio.apiKey !== undefined && cellsConfig.pydio.apiKey.length > 0) {
       return new HttpClient(
         {
           ...baseHttpClientConfig,
@@ -133,7 +133,7 @@ export class CellsAPI {
     // Althouht the HttpClient handles the authorization already (see _sendRequest), as we pass a custom axios instance to the NodeServiceApi, we need to add it manually
     http.client.interceptors.request.use(config => {
       const accessToken = this.accessTokenStore.getAccessToken();
-      if (accessToken) {
+      if (accessToken !== undefined && accessToken.length > 0) {
         const requestHeaders = AxiosHeaders.from(config.headers);
         requestHeaders.set('Authorization', `Bearer ${accessToken}`);
         config.headers = requestHeaders;
@@ -177,8 +177,8 @@ export class CellsAPI {
 
     const firstCreateCheckResult = result.data.Results?.[0];
 
-    if (autoRename && firstCreateCheckResult?.Exists) {
-      filePath = firstCreateCheckResult.NextPath || filePath;
+    if (autoRename === true && firstCreateCheckResult?.Exists === true) {
+      filePath = firstCreateCheckResult.NextPath ?? filePath;
     }
 
     const metadata = {
@@ -400,9 +400,9 @@ export class CellsAPI {
       Limit: `${limit}`,
       Offset: `${offset}`,
       Filters: {
-        Type: type || 'UNKNOWN',
+        Type: type ?? 'UNKNOWN',
         Status: {
-          Deleted: deleted ? 'Only' : 'Not',
+          Deleted: deleted === true ? 'Only' : 'Not',
         },
       },
       SortField: sortBy,
@@ -447,13 +447,16 @@ export class CellsAPI {
         Status: {
           Deleted: deleted ? 'Only' : 'Not',
         },
-        Metadata: tags?.length ? [{Namespace: USER_META_TAGS_NAMESPACE, Term: this.transformTagsToJson(tags)}] : [],
+        Metadata:
+          tags !== undefined && tags.length > 0
+            ? [{Namespace: USER_META_TAGS_NAMESPACE, Term: this.transformTagsToJson(tags)}]
+            : [],
       },
       Flags: ['WithPreSignedURLs'],
       Limit: `${limit}`,
       Offset: `${offset}`,
       SortField: sortBy,
-      SortDirDesc: sortDirection ? sortDirection === 'desc' : undefined,
+      SortDirDesc: sortDirection !== undefined ? sortDirection === 'desc' : undefined,
     };
 
     const result = await this.client.lookup(request);
@@ -485,7 +488,7 @@ export class CellsAPI {
           Locator: {Path: path.normalize('NFC')},
           ResourceUuid: uuid,
           VersionId: versionId,
-          ...(templateUuid ? {TemplateUuid: templateUuid} : {}),
+          ...(templateUuid !== undefined ? {TemplateUuid: templateUuid} : {}),
         },
       ],
     });
@@ -573,7 +576,7 @@ export class CellsAPI {
       },
     };
 
-    if (createPassword && passwordEnabled) {
+    if (createPassword !== undefined && createPassword.length > 0 && passwordEnabled === true) {
       requestBody.Link.PasswordRequired = true;
       requestBody.CreatePassword = createPassword;
       requestBody.PasswordEnabled = passwordEnabled;
@@ -635,11 +638,11 @@ export class CellsAPI {
       requestBody.Link.PasswordRequired = passwordEnabled;
     }
 
-    if (createPassword) {
+    if (createPassword !== undefined && createPassword.length > 0) {
       requestBody.CreatePassword = createPassword;
     }
 
-    if (updatePassword) {
+    if (updatePassword !== undefined && updatePassword.length > 0) {
       requestBody.UpdatePassword = updatePassword;
     }
 

--- a/libraries/api-client/src/cells/cellsStorage/s3Service.ts
+++ b/libraries/api-client/src/cells/cellsStorage/s3Service.ts
@@ -81,9 +81,14 @@ export class S3Service implements CellsStorage {
       abortController,
     });
 
-    if (progressCallback) {
+    if (progressCallback !== undefined) {
       upload.on('httpUploadProgress', progress => {
-        if (!progress?.loaded || !progress?.total) {
+        if (
+          progress?.loaded === undefined ||
+          progress?.loaded <= 0 ||
+          progress?.total === undefined ||
+          progress?.total <= 0
+        ) {
           return;
         }
         progressCallback(progress.loaded / progress.total);
@@ -109,7 +114,7 @@ export class S3Service implements CellsStorage {
   }
 
   private getS3Client(): S3Client {
-    if (this.config.apiKey) {
+    if (this.config.apiKey !== undefined && this.config.apiKey.length > 0) {
       return this.client;
     }
 
@@ -118,7 +123,7 @@ export class S3Service implements CellsStorage {
 
     // Recreate the client if the access token has changed or expired
     const shouldRecreate =
-      this.currentAccessToken !== currentAccessToken || !tokenExpiration || tokenExpiration <= Date.now();
+      this.currentAccessToken !== currentAccessToken || tokenExpiration === undefined || tokenExpiration <= Date.now();
 
     if (shouldRecreate) {
       const newClient = this.createS3Client({accessToken: currentAccessToken});
@@ -136,14 +141,14 @@ export class S3Service implements CellsStorage {
       forcePathStyle: true,
       region: this.config.region,
       credentials: async () => {
-        if (this.config.apiKey) {
+        if (this.config.apiKey !== undefined && this.config.apiKey.length > 0) {
           return {
             accessKeyId: this.config.apiKey,
             secretAccessKey: 'gatewaysecret',
           };
         }
 
-        if (!accessToken) {
+        if (accessToken === undefined || accessToken.length === 0) {
           throw new Error('No access token available for S3 authentication');
         }
 

--- a/libraries/api-client/src/client/clientApi.ts
+++ b/libraries/api-client/src/client/clientApi.ts
@@ -231,7 +231,7 @@ export class ClientAPI {
     const config: AxiosRequestConfig = {
       method: 'POST',
       url: `/${ClientAPI.URL.MLS_CLIENTS}/${ClientAPI.URL.MLS_KEY_PACKAGES}/claim/${userDomain}/${userId}${
-        skipOwn ? `?skip_own=${skipOwn}` : ''
+        skipOwn !== undefined && skipOwn.length > 0 ? `?skip_own=${skipOwn}` : ''
       }`,
       params: {
         ciphersuite,

--- a/libraries/api-client/src/connection/connectionApi.ts
+++ b/libraries/api-client/src/connection/connectionApi.ts
@@ -99,7 +99,7 @@ export class ConnectionAPI {
         allConnections = allConnections.concat(connections);
       }
 
-      if (has_more) {
+      if (has_more === true) {
         return getConnectionChunks(paging_state);
       }
 

--- a/libraries/api-client/src/conversation/conversationApi/conversationApi.ts
+++ b/libraries/api-client/src/conversation/conversationApi/conversationApi.ts
@@ -316,7 +316,7 @@ export class ConversationAPI {
     const allConversations: QualifiedId[] = [];
 
     const getConversationChunks = async (pagingState?: string): Promise<QualifiedId[]> => {
-      if (pagingState) {
+      if (pagingState !== undefined && pagingState.length > 0) {
         config.data.paging_state = pagingState;
       }
       const {data} = await this.client.sendJSON<QualifiedConversationIds>(config);
@@ -556,7 +556,7 @@ export class ConversationAPI {
       data: {},
     };
 
-    if (password) {
+    if (password !== undefined && password.length > 0) {
       config.data = {password};
     }
 

--- a/libraries/api-client/src/conversation/federatedBackendsError.ts
+++ b/libraries/api-client/src/conversation/federatedBackendsError.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import is from '@sindresorhus/is';
 import {AxiosError} from 'axios';
 
 export enum FederatedBackendsErrorLabel {
@@ -40,7 +41,11 @@ export class FederatedBackendsError extends Error {
 }
 
 export function isFederatedBackendsError(error: unknown): error is FederatedBackendsError {
-  return !!error && typeof error === 'object' && 'name' in error && error.name === 'FederatedBackendsError';
+  if (!is.object(error) || !('name' in error)) {
+    return false;
+  }
+
+  return is.string(error.name) && error.name === 'FederatedBackendsError';
 }
 
 export function handleFederationErrors(error: AxiosError<any>) {

--- a/libraries/api-client/src/http/abortableWait.ts
+++ b/libraries/api-client/src/http/abortableWait.ts
@@ -50,7 +50,7 @@ export function createAbortableWait(dependencies: AbortableWaitDependencies): Ab
           resolve();
         }, durationInMilliseconds);
 
-        if (abortSignalOrUndefined?.aborted) {
+        if (abortSignalOrUndefined?.aborted === true) {
           handleAbort();
 
           return;

--- a/libraries/api-client/src/http/httpClient.ts
+++ b/libraries/api-client/src/http/httpClient.ts
@@ -118,7 +118,7 @@ export class HttpClient extends EventEmitter {
       retryDelay: exponentialDelay,
       retryCondition: (error: AxiosError) => {
         const {response, request} = error;
-        const isNetworkError = !response && request && !Object.keys(request).length;
+        const isNetworkError = response === undefined && request !== undefined && Object.keys(request).length === 0;
         if (isNetworkError) {
           this.logger.warn('Disconnected from backend');
           this.updateConnectionState(ConnectionState.DISCONNECTED);
@@ -238,7 +238,10 @@ export class HttpClient extends EventEmitter {
         ...config,
         signal: abortController?.signal,
         // We want to prefix all urls, except for the "access" endpoint
-        url: config.url?.startsWith(AuthAPI.URL.ACCESS) ? config.url : `${this.versionPrefix}${config.url}`,
+        url:
+          config.url !== undefined && config.url.startsWith(AuthAPI.URL.ACCESS)
+            ? config.url
+            : `${this.versionPrefix}${config.url}`,
         maxBodyLength: FILE_SIZE_100_MB,
         maxContentLength: FILE_SIZE_100_MB,
       });
@@ -256,7 +259,7 @@ export class HttpClient extends EventEmitter {
         return this._sendRequest<T>({config, isFirstTry: false, abortController});
       };
 
-      const hasAccessToken = !!this.accessTokenStore?.accessTokenData;
+      const hasAccessToken = this.accessTokenStore?.accessTokenData !== undefined;
 
       if (axios.isAxiosError(error) && error.response?.status === StatusCode.UNAUTHORIZED) {
         return retryWithTokenRefresh();
@@ -300,9 +303,9 @@ export class HttpClient extends EventEmitter {
   }
 
   static isBackendError(errorCandidate: any): errorCandidate is AxiosError<BackendError> & {response: BackendError} {
-    if (errorCandidate.response) {
+    if (errorCandidate.response !== undefined) {
       const {data} = errorCandidate.response;
-      return !!data?.code && !!data?.label && !!data?.message;
+      return data?.code !== undefined && data?.label !== undefined && data?.message !== undefined;
     }
     return false;
   }
@@ -312,7 +315,7 @@ export class HttpClient extends EventEmitter {
    * @param  {number} errorMargin - Since the expiration date is subject to time shift between client and server, an error margin can be used. Defaults to 10s
    */
   public hasValidAccessToken(errorMargin: number = 10000): boolean {
-    if (this.accessTokenStore.tokenExpirationDate) {
+    if (this.accessTokenStore.tokenExpirationDate !== undefined) {
       const now = Date.now();
       const expirationDate = this.accessTokenStore.tokenExpirationDate;
       return expirationDate - errorMargin >= now;
@@ -322,7 +325,10 @@ export class HttpClient extends EventEmitter {
 
   public async refreshAccessToken(): Promise<AccessTokenData> {
     let expiredAccessToken: AccessTokenData | undefined;
-    if (this.accessTokenStore.accessTokenData?.access_token) {
+    if (
+      this.accessTokenStore.accessTokenData?.access_token !== undefined &&
+      this.accessTokenStore.accessTokenData.access_token.length > 0
+    ) {
       expiredAccessToken = this.accessTokenStore.accessTokenData;
     }
 
@@ -340,9 +346,13 @@ export class HttpClient extends EventEmitter {
       method: 'post',
       url: `${AuthAPI.URL.ACCESS}`,
       withCredentials: true,
-      params: clientId && {client_id: clientId},
+      params: clientId !== undefined && clientId.length > 0 ? {client_id: clientId} : undefined,
     };
-    if (expiredAccessToken?.access_token && config?.headers) {
+    if (
+      expiredAccessToken?.access_token !== undefined &&
+      expiredAccessToken.access_token.length > 0 &&
+      config.headers !== undefined
+    ) {
       config.headers = new AxiosHeaders(config.headers as AxiosHeaders);
       config.headers.set(
         'Authorization',
@@ -412,7 +422,7 @@ export class HttpClient extends EventEmitter {
     const shouldGzipData =
       this.enableGzip &&
       process.env.NODE_ENV !== 'test' &&
-      !!config.data &&
+      config.data !== undefined &&
       ['post', 'put', 'patch'].includes(config.method?.toLowerCase() ?? '');
 
     if (shouldGzipData) {

--- a/libraries/api-client/src/http/requestProgressHandler.ts
+++ b/libraries/api-client/src/http/requestProgressHandler.ts
@@ -22,12 +22,13 @@ import {AxiosProgressEvent} from 'axios';
 export type ProgressCallback = (progress: number) => void;
 
 export const handleProgressEvent = (progressCallback?: ProgressCallback) => {
-  return (
-    progressCallback &&
-    ((progressEvent: AxiosProgressEvent) => {
-      if (progressEvent.total) {
-        progressCallback(progressEvent.loaded / progressEvent.total);
-      }
-    })
-  );
+  if (progressCallback === undefined) {
+    return undefined;
+  }
+
+  return (progressEvent: AxiosProgressEvent) => {
+    if (progressEvent.total !== undefined && progressEvent.total > 0) {
+      progressCallback(progressEvent.loaded / progressEvent.total);
+    }
+  };
 };

--- a/libraries/api-client/src/notification/notificationApi/notificationApi.ts
+++ b/libraries/api-client/src/notification/notificationApi/notificationApi.ts
@@ -116,7 +116,10 @@ export class NotificationAPI {
         const isAxiosError = axios.isAxiosError(error);
 
         //error with response body (before v3 API)
-        const isErrorWithNotifications = isAxiosError && error.response?.data?.notifications;
+        const isErrorWithNotifications =
+          isAxiosError &&
+          Array.isArray(error.response?.data?.notifications) &&
+          error.response.data.notifications.length > 0;
 
         //uuid parsing error
         const isBadRequestError = isAxiosError && error.response?.status === StatusCode.BAD_REQUEST;

--- a/libraries/api-client/src/oauth/oAuthApi.ts
+++ b/libraries/api-client/src/oauth/oAuthApi.ts
@@ -55,7 +55,7 @@ export class OAuthAPI {
    */
   public async deleteApplication(applicationId: string, password?: string): Promise<void> {
     const config: AxiosRequestConfig = {
-      ...(password && {data: {password}}),
+      ...(password !== undefined && password.length > 0 && {data: {password}}),
       method: 'delete',
       url: `${OAuthAPI.URL.OAUTH}/${OAuthAPI.URL.APPLICATIONS}/${applicationId}/sessions`,
     };

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -97,7 +97,7 @@ export class ReconnectingWebsocket {
   ) {
     this.logger = LogFactory.getLogger('@wireapp/api-client/tcp/ReconnectingWebsocket');
 
-    if (options.pingInterval) {
+    if (options.pingInterval !== undefined) {
       this.PING_INTERVAL = options.pingInterval;
     }
 

--- a/libraries/api-client/src/tcp/webSocketClient.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.ts
@@ -208,7 +208,7 @@ export class WebSocketClient extends EventEmitter {
   }
 
   public disconnect(reason?: string): void {
-    if (this.socket) {
+    if (this.socket !== undefined) {
       this.socket.disconnect(reason);
     }
   }
@@ -247,9 +247,9 @@ export class WebSocketClient extends EventEmitter {
       accessTokenStore: {getAccessToken, getNextMarkerToken},
     } = this.client;
     const accessToken = getAccessToken?.() ?? '';
-    const markerToken = getNextMarkerToken?.();
+    const markerToken = getNextMarkerToken?.() ?? '';
 
-    if (!accessToken) {
+    if (accessToken.length === 0) {
       this.logger.warn('Reconnecting WebSocket with unset token');
     }
 
@@ -261,7 +261,7 @@ export class WebSocketClient extends EventEmitter {
       access_token: accessToken,
     });
 
-    if (markerToken && !this.useLegacySocket) {
+    if (markerToken.length > 0 && !this.useLegacySocket) {
       queryParams.append('sync_marker', markerToken);
     }
 
@@ -269,7 +269,7 @@ export class WebSocketClient extends EventEmitter {
      * @note If no client ID is given, then the WebSocket connection
      * will receive all notifications for all clients of the connected user
      */
-    if (this.clientId) {
+    if (this.clientId !== undefined && this.clientId.length > 0) {
       queryParams.append('client', this.clientId);
     }
 

--- a/libraries/api-client/src/team/identityprovider/identityProviderApi.ts
+++ b/libraries/api-client/src/team/identityprovider/identityProviderApi.ts
@@ -59,7 +59,7 @@ export class IdentityProviderAPI {
       url: `${IdentityProviderAPI.URL.PROVIDER}/${identityProviderId}`,
     };
 
-    if (purge) {
+    if (purge === true) {
       config.params = {purge};
     }
 
@@ -73,7 +73,7 @@ export class IdentityProviderAPI {
       url: `${IdentityProviderAPI.URL.PROVIDER}`,
     };
 
-    if (replaceProviderId) {
+    if (replaceProviderId !== undefined && replaceProviderId.length > 0) {
       config.params = {replaces: replaceProviderId};
     }
 

--- a/libraries/api-client/src/team/invitation/teamInvitationApi.ts
+++ b/libraries/api-client/src/team/invitation/teamInvitationApi.ts
@@ -109,7 +109,7 @@ export class TeamInvitationAPI {
     try {
       await this.client.sendJSON(config);
     } catch (error: unknown) {
-      if (axios.isAxiosError(error) && error.response?.status) {
+      if (axios.isAxiosError(error) && error.response?.status !== undefined) {
         const status = error.response?.status;
         switch (status) {
           case StatusCode.NOT_FOUND: {

--- a/libraries/api-client/src/team/member/role.ts
+++ b/libraries/api-client/src/team/member/role.ts
@@ -82,19 +82,19 @@ export const permissionsToRole = (permissions: PermissionsData): Role | undefine
 };
 
 export const isPartner = (permissions: PermissionsData): boolean => {
-  return !!(permissions && permissionsToRole(permissions) === Role.EXTERNAL);
+  return permissions !== undefined && permissionsToRole(permissions) === Role.EXTERNAL;
 };
 
 export const isMember = (permissions: PermissionsData): boolean => {
-  return !!(permissions && permissionsToRole(permissions) === Role.MEMBER);
+  return permissions !== undefined && permissionsToRole(permissions) === Role.MEMBER;
 };
 
 export const isAdmin = (permissions: PermissionsData): boolean => {
-  return !!(permissions && permissionsToRole(permissions) === Role.ADMIN);
+  return permissions !== undefined && permissionsToRole(permissions) === Role.ADMIN;
 };
 
 export const isOwner = (permissions: PermissionsData): boolean => {
-  return !!(permissions && permissionsToRole(permissions) === Role.OWNER);
+  return permissions !== undefined && permissionsToRole(permissions) === Role.OWNER;
 };
 
 export const isAtLeastPartner = (permissions: PermissionsData): boolean => {

--- a/libraries/api-client/src/team/scim/scimApi.ts
+++ b/libraries/api-client/src/team/scim/scimApi.ts
@@ -63,9 +63,9 @@ export class ScimAPI {
       data: {
         description,
         password,
-        ...(idp && {idp}),
-        ...(name && {name}),
-        ...(verificationCode && {verification_code: verificationCode}),
+        ...(idp !== undefined && idp.length > 0 && {idp}),
+        ...(name !== undefined && name.length > 0 && {name}),
+        ...(verificationCode !== undefined && verificationCode.length > 0 && {verification_code: verificationCode}),
       },
       method: 'post',
       url: `${ScimAPI.URL.SCIM}/${ScimAPI.URL.AUTH_TOKENS}`,

--- a/libraries/api-client/src/team/team/teamApi.ts
+++ b/libraries/api-client/src/team/team/teamApi.ts
@@ -86,7 +86,7 @@ export class TeamAPI {
     const config: AxiosRequestConfig = {
       data: {
         password,
-        ...(verificationCode && {verification_code: verificationCode}),
+        ...(verificationCode !== undefined && verificationCode.length > 0 && {verification_code: verificationCode}),
       },
       method: 'delete',
       url: `${TeamAPI.URL.TEAMS}/${teamId}`,

--- a/libraries/api-client/src/user/userApi.ts
+++ b/libraries/api-client/src/user/userApi.ts
@@ -63,7 +63,7 @@ type UsersReponse = {
   not_found?: QualifiedId[];
 };
 function isUsersResponse(object: any): object is UsersReponse {
-  return object.found || object.failed || object.not_found;
+  return object.found !== undefined || object.failed !== undefined || object.not_found !== undefined;
 }
 
 const apiBreakpoint = {
@@ -290,10 +290,10 @@ export class UserAPI {
       url: `/${UserAPI.URL.SEARCH}/${UserAPI.URL.CONTACTS}`,
     };
 
-    if (domain) {
+    if (domain !== undefined && domain.length > 0) {
       config.params.domain = domain;
     }
-    if (limit) {
+    if (limit !== undefined && limit > 0) {
       config.params.size = limit;
     }
 

--- a/libraries/core/src/account.ts
+++ b/libraries/core/src/account.ts
@@ -287,7 +287,7 @@ export class Account extends TypedEventEmitter<Events> {
       throw new Error('Client has not been initialized - please login first');
     }
 
-    if (!this.service?.mls?.isEnabled || !this.service?.e2eIdentity) {
+    if (this.service?.mls?.isEnabled !== true || this.service?.e2eIdentity === undefined) {
       throw new Error('MLS not initialized, unable to enroll E2EI');
     }
 
@@ -446,7 +446,7 @@ export class Account extends TypedEventEmitter<Events> {
       },
     };
 
-    if (this.options.coreCryptoConfig?.enabled) {
+    if (this.options.coreCryptoConfig?.enabled === true) {
       const {buildClient} = await import('./messagingProtocols/proteus/proteusService/cryptoClient/coreCryptoWrapper');
       const client = await buildClient(
         storeEngine,
@@ -572,9 +572,9 @@ export class Account extends TypedEventEmitter<Events> {
     this.db?.close();
     this.encryptedDb?.close();
 
-    if (data?.clearAllData) {
+    if (data?.clearAllData === true) {
       await this.wipeAllData();
-    } else if (data?.clearCryptoData) {
+    } else if (data?.clearCryptoData === true) {
       await this.wipeCryptoData();
     }
 
@@ -648,7 +648,7 @@ export class Account extends TypedEventEmitter<Events> {
    * return true if the current user has a MLS device that is initialized and ready to use
    */
   public get hasMLSDevice(): boolean {
-    return !!this.service?.mls?.isEnabled;
+    return this.service?.mls?.isEnabled === true;
   }
 
   /**
@@ -867,7 +867,7 @@ export class Account extends TypedEventEmitter<Events> {
             this.logger.info(`Processing legacy notification "${notification.id}" at ${notificationTime}`);
             this.logger.info(`Total notifications queue length: ${this.notificationProcessingQueue.getLength()}`);
             this.logger.info(`Total pending proposals queue length: ${getProposalQueueLength()}`);
-            if (notificationTime) {
+            if (notificationTime !== null && notificationTime.length > 0) {
               onNotificationStreamProgress(notificationTime);
             }
 
@@ -976,7 +976,7 @@ export class Account extends TypedEventEmitter<Events> {
 
       const firstEventPayload = notification.data.event.payload[0];
       const notificationTime = firstEventPayload ? this.getNotificationEventTime(firstEventPayload) : null;
-      if (this.connectionState !== ConnectionState.LIVE && notificationTime) {
+      if (this.connectionState !== ConnectionState.LIVE && notificationTime !== null && notificationTime.length > 0) {
         onNotificationStreamProgress(notificationTime);
       }
 
@@ -1140,7 +1140,7 @@ export class Account extends TypedEventEmitter<Events> {
         }
       }
 
-      if (connectionState) {
+      if (connectionState !== undefined) {
         onConnectionStateChanged(connectionState);
       }
     });
@@ -1172,7 +1172,7 @@ export class Account extends TypedEventEmitter<Events> {
     const localStorageKey = 'has_missing_notification';
 
     // First-time handling: set flag and reload to trigger full re-fetch of state.
-    if (!AccountLocalStorageStore.has(localStorageKey)) {
+    if (AccountLocalStorageStore.has(localStorageKey) === false) {
       this.logger.info('First missed notification detected, reloading to recover state');
       AccountLocalStorageStore.add(localStorageKey, 'true');
       window.location.reload();
@@ -1241,7 +1241,7 @@ export class Account extends TypedEventEmitter<Events> {
     conversationId: QualifiedId,
     subconversationId?: SUBCONVERSATION_ID,
   ): Promise<string | undefined> => {
-    if (!subconversationId) {
+    if (subconversationId === undefined) {
       return this.coreCallbacks?.groupIdFromConversationId(conversationId);
     }
 
@@ -1250,7 +1250,7 @@ export class Account extends TypedEventEmitter<Events> {
 
   public isMLSActiveForClient = async (): Promise<boolean> => {
     // Check for CoreCrypto library, it is required for MLS
-    if (!this.options.coreCryptoConfig?.enabled) {
+    if (this.options.coreCryptoConfig?.enabled !== true) {
       return false;
     }
 

--- a/libraries/core/src/auth/loginSanitizer.ts
+++ b/libraries/core/src/auth/loginSanitizer.ts
@@ -25,15 +25,15 @@ export class LoginSanitizer {
   public static removeNonPrintableCharacters(loginData: LoginData): void {
     const nonPrintableCharacters = /\s/gm;
 
-    if (loginData.email) {
+    if (loginData.email !== undefined && loginData.email.length > 0) {
       loginData.email = loginData.email.replace(nonPrintableCharacters, '');
     }
 
-    if (loginData.handle) {
+    if (loginData.handle !== undefined && loginData.handle.length > 0) {
       loginData.handle = loginData.handle.replace(nonPrintableCharacters, '');
     }
 
-    if (loginData.password) {
+    if (loginData.password !== undefined) {
       loginData.password = loginData.password.toString();
     }
   }

--- a/libraries/core/src/client/clientService.ts
+++ b/libraries/core/src/client/clientService.ts
@@ -74,7 +74,7 @@ export class ClientService {
    * @param password? Password of the owning user. Can be omitted for temporary devices
    */
   public async deleteClient(clientId: string, password?: string): Promise<unknown> {
-    const userId: QualifiedId = {id: this.apiClient.userId as string, domain: this.apiClient.domain || ''};
+    const userId: QualifiedId = {id: this.apiClient.userId as string, domain: this.apiClient.domain ?? ''};
     await this.backend.deleteClient(clientId, password);
     return this.database.deleteClient(this.proteusService.constructSessionId(userId, clientId));
   }
@@ -85,7 +85,7 @@ export class ClientService {
    */
   public async deleteLocalClient(password?: string): Promise<string> {
     const localClientId = this.apiClient.context?.clientId;
-    if (!localClientId) {
+    if (localClientId === undefined || localClientId.length === 0) {
       // No client in context -> there's nothing to delete on backend, just drop local state
       this.logger.warn('No local client id in context; deleting local client data from DB only.');
       return this.database.deleteLocalClient();
@@ -117,7 +117,7 @@ export class ClientService {
   public async loadClient(): Promise<MetaClient | undefined> {
     const loadedClient = await this.getLocalClient();
 
-    if (!loadedClient) {
+    if (loadedClient === undefined) {
       return undefined;
     }
 
@@ -126,7 +126,7 @@ export class ClientService {
       return this.database.updateLocalClient(remoteClient);
     } catch (error: unknown) {
       const notFoundOnBackend = axios.isAxiosError(error) ? error.response?.status === StatusCodes.NOT_FOUND : false;
-      if (notFoundOnBackend && this.storeEngine) {
+      if (notFoundOnBackend && this.storeEngine !== undefined) {
         const shouldDeleteWholeDatabase = loadedClient.type === ClientType.TEMPORARY;
         await this.proteusService.wipe();
         if (shouldDeleteWholeDatabase) {
@@ -188,7 +188,7 @@ export class ClientService {
       lastkey: lastPrekey,
       location: clientInfo.location,
       model: clientInfo.model,
-      password: loginData.password ? String(loginData.password) : undefined,
+      password: loginData.password !== undefined ? String(loginData.password) : undefined,
       verification_code: loginData.verificationCode,
       prekeys: prekeys,
       type: loginData.clientType,

--- a/libraries/core/src/conversation/content/contentType.guards.ts
+++ b/libraries/core/src/conversation/content/contentType.guards.ts
@@ -42,19 +42,19 @@ import {
 } from '.';
 
 export function isAbortedAssetContent(content: ConversationContent): content is AssetContent {
-  return !!(content as AssetContent).abortReason;
+  return (content as AssetContent).abortReason !== undefined;
 }
 
 export function isAssetContent(content: ConversationContent): content is AssetContent {
-  return !!((content as AssetContent).uploaded || (content as AssetContent).preview);
+  return (content as AssetContent).uploaded !== undefined || (content as AssetContent).preview !== undefined;
 }
 
 export function isClearedContent(content: ConversationContent): content is ClearedContent {
-  return !!(content as ClearedContent).clearedTimestamp;
+  return (content as ClearedContent).clearedTimestamp !== undefined;
 }
 
 export function isClientActionContent(content: ConversationContent): content is ClientActionContent {
-  return !!(content as ClientActionContent).clientAction;
+  return (content as ClientActionContent).clientAction !== undefined;
 }
 
 export function isClientActionType(content: ConversationContent): content is ClientActionType {
@@ -62,57 +62,61 @@ export function isClientActionType(content: ConversationContent): content is Cli
 }
 
 export function isConfirmationContent(content: ConversationContent): content is ConfirmationContent {
-  return !!(content as ConfirmationContent).firstMessageId;
+  return (content as ConfirmationContent).firstMessageId !== undefined;
 }
 
 export function isConnection(content: ConversationContent): content is Connection {
-  return !!(content as Connection).from && !!(content as Connection).to;
+  return (content as Connection).from !== undefined && (content as Connection).to !== undefined;
 }
 
 export function isDeletedContent(content: ConversationContent): content is DeletedContent {
-  return !!(content as DeletedContent).messageId && !(content as any).text;
+  return (content as DeletedContent).messageId !== undefined && (content as any).text === undefined;
 }
 
 export function isEditedTextContent(content: ConversationContent): content is EditedTextContent {
-  return !!(content as EditedTextContent).text && !!(content as EditedTextContent).originalMessageId;
+  return (
+    (content as EditedTextContent).text !== undefined && (content as EditedTextContent).originalMessageId !== undefined
+  );
 }
 
 export function isFileAssetAbortContent(content: ConversationContent): content is FileAssetAbortContent {
-  return !!(content as FileAssetAbortContent).reason;
+  return (content as FileAssetAbortContent).reason !== undefined;
 }
 
 export function isFileAssetContent(content: ConversationContent): content is FileAssetContent {
-  return !!(content as FileAssetContent).asset && !!(content as FileAssetContent).file;
+  return (content as FileAssetContent).asset !== undefined && (content as FileAssetContent).file !== undefined;
 }
 
 export function isFileAssetMetaDataContent(content: ConversationContent): content is FileAssetMetaDataContent {
-  return !!(content as FileAssetMetaDataContent).metaData;
+  return (content as FileAssetMetaDataContent).metaData !== undefined;
 }
 
 export function isHiddenContent(content: ConversationContent): content is HiddenContent {
-  return !!(content as HiddenContent).conversationId;
+  return (content as HiddenContent).conversationId !== undefined;
 }
 
 export function isImageAssetContent(content: ConversationContent): content is ImageAssetContent {
-  return !!(content as ImageAssetContent).asset && !!(content as ImageAssetContent).image;
+  return (content as ImageAssetContent).asset !== undefined && (content as ImageAssetContent).image !== undefined;
 }
 
 export function isImageContent(content: ConversationContent): content is ImageContent {
-  return !!(content as ImageContent).data && !!(content as ImageContent).type;
+  return (content as ImageContent).data !== undefined && (content as ImageContent).type !== undefined;
 }
 
 export function isLocationContent(content: ConversationContent): content is LocationContent {
-  return !!(content as LocationContent).latitude && !!(content as LocationContent).longitude;
+  return (content as LocationContent).latitude !== undefined && (content as LocationContent).longitude !== undefined;
 }
 
 export function isReactionContent(content: ConversationContent): content is ReactionContent {
-  return !!(content as ReactionContent).type && !!(content as ReactionContent).originalMessageId;
+  return (
+    (content as ReactionContent).type !== undefined && (content as ReactionContent).originalMessageId !== undefined
+  );
 }
 
 export function isTextContent(content: ConversationContent): content is TextContent {
-  return !!(content as TextContent).text;
+  return (content as TextContent).text !== undefined;
 }
 
 export function isMultiPartContent(content: ConversationContent): content is MultiPartContent {
-  return !!(content as MultiPartContent).text && !!(content as MultiPartContent).attachments;
+  return (content as MultiPartContent).text !== undefined && (content as MultiPartContent).attachments !== undefined;
 }

--- a/libraries/core/src/conversation/conversationService/conversationService.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.ts
@@ -331,7 +331,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
     const {group_id: groupId, qualified_id: qualifiedId} = newConversation;
 
-    if (!groupId) {
+    if (groupId === undefined || groupId.length === 0) {
       throw new Error('No group_id found in response which is required for creating MLS conversations.');
     }
 
@@ -355,7 +355,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     const {
       conversation: {group_id: newGroupId},
     } = await this.resetMLSConversation(conversationId);
-    if (!newGroupId) {
+    if (newGroupId === undefined || newGroupId.length === 0) {
       const errorMessage = 'Tried to reset MLS conversation but no group_id found in response';
       this.logger.error(errorMessage, {conversationId});
       throw new Error(errorMessage);
@@ -600,8 +600,8 @@ export class ConversationService extends TypedEventEmitter<Events> {
   private async refreshGroupIdConversationMap(): Promise<void> {
     const conversations = await this.apiClient.api.conversation.getConversationList();
     this.groupIdConversationMap.clear();
-    for (const conversation of conversations.found || []) {
-      if (conversation.group_id) {
+    for (const conversation of conversations.found ?? []) {
+      if (conversation.group_id !== undefined && conversation.group_id.length > 0) {
         this.groupIdConversationMap.set(conversation.group_id, conversation);
       }
     }
@@ -657,7 +657,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     );
     const {validatedClientId: clientId, userId, domain: selfUserDomain} = this.apiClient;
 
-    if (!selfUserDomain) {
+    if (selfUserDomain === undefined || selfUserDomain.length === 0) {
       const errorMessage = 'Could not find domain of the self user';
       this.logger.error(errorMessage, {conversationId});
       throw new Error(errorMessage);
@@ -673,7 +673,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
     this.validateDomainMatch(selfUserDomain, conversationDomain);
 
-    if (!groupId || !epoch) {
+    if (groupId === undefined || groupId.length === 0 || epoch === undefined) {
       const errorMessage = 'Could not find group id or epoch for the conversation';
       this.logger.error(errorMessage, {conversationId});
       throw new Error(errorMessage);
@@ -686,7 +686,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
       groupId,
     });
 
-    if (!userId || !selfUserDomain) {
+    if (userId === undefined || userId.length === 0 || selfUserDomain.length === 0) {
       const errorMessage = 'Could not find userId or domain of the self user';
       this.logger.error(errorMessage, {conversationId});
       throw new Error(errorMessage);
@@ -702,11 +702,11 @@ export class ConversationService extends TypedEventEmitter<Events> {
       newGroupId,
     });
 
-    if (!newGroupId || !clientId) {
+    if (newGroupId === undefined || newGroupId.length === 0 || clientId.length === 0) {
       throw new Error(`Failed to recover MLS conversation: missing groupId (${newGroupId}), or clientId (${clientId})`);
     }
 
-    const usersToReAdd = members.others.map(member => member.qualified_id).filter(userId => !!userId);
+    const usersToReAdd = members.others.map(member => member.qualified_id).filter(userId => userId !== undefined);
 
     // STEP 5: Re-establish the conversation by re-adding all members
     return await this.establishMLSGroupConversation(
@@ -1026,14 +1026,14 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
   private async recoverMLSGroupFromEpochMismatch(conversationId: QualifiedId, subconversationId?: SUBCONVERSATION_ID) {
     this.logger.info(`Recovering MLS group from epoch mismatch`, {conversationId, subconversationId});
-    if (subconversationId) {
+    if (subconversationId !== undefined) {
       const parentGroupId = await this.groupIdFromConversationId(conversationId);
       const subconversation = await this.apiClient.api.conversation.getSubconversation(
         conversationId,
         subconversationId,
       );
 
-      if (!parentGroupId) {
+      if (parentGroupId === undefined || parentGroupId.length === 0) {
         throw new Error('Could not find parent group id for the subconversation');
       }
       return this.handleSubconversationEpochMismatch(subconversation, parentGroupId);

--- a/libraries/core/src/conversation/message/messageService.ts
+++ b/libraries/core/src/conversation/message/messageService.ts
@@ -77,11 +77,12 @@ export class MessageService {
     try {
       return await send(encryptionResults);
     } catch (error: unknown) {
-      if (!this.isClientMismatchError(error)) {
+      if (this.isClientMismatchError(error) === false) {
         throw error;
       }
       const mismatch = error.response!.data as MessageSendingStatus;
-      const shouldStopSending = options.onClientMismatch && (await options.onClientMismatch(mismatch)) === false;
+      const shouldStopSending =
+        options.onClientMismatch !== undefined && (await options.onClientMismatch(mismatch)) === false;
       if (shouldStopSending) {
         return {...mismatch, canceled: true};
       }
@@ -132,11 +133,11 @@ export class MessageService {
       nativePush: options.nativePush,
     });
 
-    if (options.assetData) {
+    if (options.assetData !== undefined) {
       protoMessage.blob = options.assetData;
     }
 
-    if (options.reportMissing) {
+    if (options.reportMissing !== undefined && options.reportMissing !== false) {
       if (isQualifiedIdArray(options.reportMissing)) {
         protoMessage.reportOnly = {userIds: options.reportMissing};
       } else {
@@ -146,7 +147,7 @@ export class MessageService {
       protoMessage.ignoreAll = true;
     }
 
-    if (!options.conversationId) {
+    if (options.conversationId === undefined) {
       return this.apiClient.api.broadcast.postBroadcastMessage(sendingClientId, protoMessage);
     }
 

--- a/libraries/core/src/conversation/message/messageToProtoMapper.ts
+++ b/libraries/core/src/conversation/message/messageToProtoMapper.ts
@@ -95,11 +95,11 @@ export class MessageToProtoMapper {
       legalHoldStatus,
     });
 
-    if (linkPreviews?.length) {
+    if (linkPreviews !== undefined && linkPreviews.length > 0) {
       textMessage.linkPreview = MessageToProtoMapper.mapLinkPreviews(linkPreviews);
     }
 
-    if (mentions?.length) {
+    if (mentions !== undefined && mentions.length > 0) {
       textMessage.mentions = mentions.map(mention => Mention.create(mention));
     }
 

--- a/libraries/core/src/conversation/message/textContentBuilder.ts
+++ b/libraries/core/src/conversation/message/textContentBuilder.ts
@@ -38,7 +38,7 @@ export class TextContentBuilder<T extends TextContent | EditedTextContent> {
   }
 
   withLinkPreviews(linkPreviews?: LinkPreviewUploadedContent[]) {
-    if (linkPreviews?.length) {
+    if (linkPreviews !== undefined && linkPreviews.length > 0) {
       this.content.linkPreviews = linkPreviews;
     }
 
@@ -46,7 +46,7 @@ export class TextContentBuilder<T extends TextContent | EditedTextContent> {
   }
 
   withMentions(mentions?: MentionContent[]) {
-    if (mentions?.length) {
+    if (mentions !== undefined && mentions.length > 0) {
       this.content.mentions = mentions;
     }
 

--- a/libraries/core/src/conversation/messageTimer/messageTimer.ts
+++ b/libraries/core/src/conversation/messageTimer/messageTimer.ts
@@ -27,15 +27,19 @@ export class MessageTimer {
   }
 
   public getConversationLevelTimer(conversationId: string): number {
-    return this.conversationLevelTimers.get(conversationId) || 0;
+    return this.conversationLevelTimers.get(conversationId) ?? 0;
   }
 
   public getMessageLevelTimer(conversationId: string): number {
-    return this.messageLevelTimers.get(conversationId) || 0;
+    return this.messageLevelTimers.get(conversationId) ?? 0;
   }
 
   public getMessageTimer(conversationId: string): number {
-    return this.getConversationLevelTimer(conversationId) || this.getMessageLevelTimer(conversationId);
+    const conversationLevelTimer = this.getConversationLevelTimer(conversationId);
+    if (conversationLevelTimer > 0) {
+      return conversationLevelTimer;
+    }
+    return this.getMessageLevelTimer(conversationId);
   }
 
   public setConversationLevelTimer(conversationId: string, messageTimer: number): void {

--- a/libraries/core/src/conversation/subconversationService/subconversationService.ts
+++ b/libraries/core/src/conversation/subconversationService/subconversationService.ts
@@ -131,7 +131,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
     this.logger.info('Leaving conference subconversation', {conversationId});
     const subconversationGroupId = await this.getSubconversationGroupId(conversationId, SUBCONVERSATION_ID.CONFERENCE);
 
-    if (!subconversationGroupId) {
+    if (subconversationGroupId === undefined || subconversationGroupId.length === 0) {
       this.logger.warn('No subconversation groupId found when leaving conference subconversation', {conversationId});
       return;
     }
@@ -202,7 +202,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
     );
 
     // this method should not be called if the subconversation (and its parent conversation) is not established
-    if (!subconversationGroupId) {
+    if (subconversationGroupId === undefined || subconversationGroupId.length === 0) {
       this.logger.error('Could not obtain epoch info for conference subconversation: missing groupId', {
         parentConversationId,
       });
@@ -333,7 +333,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
     });
     const subconversationGroupId = await this.getSubconversationGroupId(conversationId, SUBCONVERSATION_ID.CONFERENCE);
 
-    if (!subconversationGroupId) {
+    if (subconversationGroupId === undefined || subconversationGroupId.length === 0) {
       this.logger.warn('Cannot remove client: subconversation groupId missing', {conversationId});
       return;
     }

--- a/libraries/core/src/cryptography/assetCryptography/crypto.browser.ts
+++ b/libraries/core/src/cryptography/assetCryptography/crypto.browser.ts
@@ -24,7 +24,7 @@ import {toBufferSource} from '../../util/bufferUtils';
 function getBrowserCrypto(): globalThis.Crypto {
   const browserCrypto = globalThis.crypto;
 
-  if (!browserCrypto?.subtle) {
+  if (browserCrypto?.subtle === undefined) {
     throw new Error('Web Crypto API is unavailable');
   }
 

--- a/libraries/core/src/cryptography/genericMessageMapper.ts
+++ b/libraries/core/src/cryptography/genericMessageMapper.ts
@@ -72,15 +72,15 @@ export class GenericMessageMapper {
 
         const content: TextContent = {expectsReadConfirmation, legalHoldStatus, text};
 
-        if (linkPreviews?.length) {
+        if (linkPreviews !== undefined && linkPreviews.length > 0) {
           content.linkPreviews = linkPreviews;
         }
 
-        if (mentions?.length) {
+        if (mentions !== undefined && mentions.length > 0) {
           content.mentions = mentions;
         }
 
-        if (quote) {
+        if (quote !== undefined) {
           content.quote = quote;
         }
 
@@ -159,15 +159,15 @@ export class GenericMessageMapper {
           text: editedText,
         };
 
-        if (editedLinkPreviews?.length) {
+        if (editedLinkPreviews !== undefined && editedLinkPreviews.length > 0) {
           content.linkPreviews = editedLinkPreviews;
         }
 
-        if (editedMentions?.length) {
+        if (editedMentions !== undefined && editedMentions.length > 0) {
           content.mentions = editedMentions;
         }
 
-        if (editedQuote) {
+        if (editedQuote !== undefined) {
           content.quote = editedQuote;
         }
 
@@ -223,7 +223,7 @@ export class GenericMessageMapper {
       case GenericMessageType.ASSET: {
         const {expectsReadConfirmation, legalHoldStatus, notUploaded, original, preview, status, uploaded} =
           genericMessage[GenericMessageType.ASSET];
-        const isImage = !!uploaded?.assetId && !!original?.image;
+        const isImage = uploaded?.assetId !== undefined && original?.image !== undefined;
 
         const content: AssetContent = {
           abortReason: notUploaded,

--- a/libraries/core/src/errors/federatedBackendsError.ts
+++ b/libraries/core/src/errors/federatedBackendsError.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import is from '@sindresorhus/is';
+
 /**
  * This error means we are trying to add users that are parts of 2 backends that are not federating with each other to a new conversation.
  */
@@ -28,5 +30,10 @@ export class NonFederatingBackendsError extends Error {
 }
 
 export function isNonFederatingBackendsError(error: unknown): error is NonFederatingBackendsError {
-  return !!error && typeof error === 'object' && 'name' in error && error.name === 'NonFederatingBackendError';
+  if (typeof error !== 'object' || error === null || 'name' in error === false) {
+    return false;
+  }
+
+  const errorName = (error as {name: unknown}).name;
+  return is.string(errorName) && errorName === 'NonFederatingBackendError';
 }

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/e2eiServiceExternal.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/e2eiServiceExternal.ts
@@ -324,7 +324,8 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
       cx.e2eiRegisterCRL(url, crl),
     );
 
-    const expirationTimestamp = expirationTimestampSeconds && expirationTimestampSeconds * TimeInMillis.SECOND;
+    const expirationTimestamp =
+      expirationTimestampSeconds !== undefined ? expirationTimestampSeconds * TimeInMillis.SECOND : undefined;
 
     await this.cancelCrlDistributionTimer(url);
 
@@ -334,7 +335,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
     }
 
     //if it was dirty, trigger e2eiconversationstate for every conversation
-    if (dirty) {
+    if (dirty === true) {
       onDirty();
     }
   }

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/e2eiServiceInternal.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/e2eiServiceInternal.ts
@@ -77,10 +77,10 @@ export class E2EIServiceInternal {
   ) {
     const stashedEnrollmentData = await this.enrollmentStorage.getPendingEnrollmentData();
 
-    if (stashedEnrollmentData) {
+    if (stashedEnrollmentData !== undefined) {
       // In case we have stashed data, we continue the enrollment flow (we are coming back from a redirect)
       const oAuthToken = await getOAuthToken();
-      if (!oAuthToken) {
+      if (oAuthToken === undefined || oAuthToken.length === 0) {
         throw new Error('No OAuthToken received for in progress enrollment process');
       }
       return this.continueCertificateGeneration(oAuthToken, stashedEnrollmentData, getAllConversations, ciphersuite);
@@ -103,7 +103,7 @@ export class E2EIServiceInternal {
 
     // At this point we might be redirected to the identity provider. We have
     const oAuthToken = await getOAuthToken(challengeData);
-    if (!oAuthToken) {
+    if (oAuthToken === undefined || oAuthToken.length === 0) {
       throw new Error('No OAuthToken received for in initial enrollment process');
     }
     return this.continueCertificateGeneration(oAuthToken, enrollmentData, getAllConversations, ciphersuite);
@@ -137,7 +137,7 @@ export class E2EIServiceInternal {
   private async getDirectory(identity: E2eiEnrollment, connection: AcmeService): Promise<AcmeDirectory | undefined> {
     const directory = await connection.getDirectory();
 
-    if (directory) {
+    if (directory !== undefined) {
       const parsedDirectory = identity.directoryResponse(directory);
       return parsedDirectory;
     }
@@ -146,7 +146,7 @@ export class E2EIServiceInternal {
 
   private async getInitialNonce(directory: AcmeDirectory, connection: AcmeService): Promise<string> {
     const nonce = await connection.getInitialNonce(directory.newNonce);
-    if (!nonce) {
+    if (nonce === undefined || nonce.length === 0) {
       throw new Error('No initial-nonce received');
     }
     return nonce;
@@ -162,13 +162,13 @@ export class E2EIServiceInternal {
     // Get the directory
     const {acmeService: acmeService} = this;
     const directory = await this.getDirectory(identity, acmeService);
-    if (!directory) {
+    if (directory === undefined) {
       throw new Error('Error while trying to start OAuth flow. No directory received');
     }
 
     // Step 1: Get a new nonce from ACME server
     const nonce = await this.getInitialNonce(directory, acmeService);
-    if (!nonce) {
+    if (nonce.length === 0) {
       throw new Error('Error while trying to start OAuth flow. No nonce received');
     }
 
@@ -224,7 +224,7 @@ export class E2EIServiceInternal {
     });
     this.logger.debug('oidc data', oidcData);
 
-    if (!oidcData.data.validated) {
+    if (oidcData.data.validated !== 'valid') {
       throw new Error('Error while trying to continue OAuth flow. OIDC challenge not validated');
     }
 

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/helper/index.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/helper/index.ts
@@ -77,7 +77,12 @@ export const getMLSDeviceStatus = (
   const signatureAlogrithm = getSignatureAlgorithmForCiphersuite(ciphersuite);
   const signature = mls_public_keys[signatureAlogrithm];
 
-  if (!signature || !existingClientSignature) {
+  if (
+    signature === undefined ||
+    signature.length === 0 ||
+    existingClientSignature === undefined ||
+    existingClientSignature.length === 0
+  ) {
     return MLSDeviceStatus.FRESH;
   }
   if (signature !== existingClientSignature) {
@@ -86,4 +91,5 @@ export const getMLSDeviceStatus = (
   return MLSDeviceStatus.REGISTERED;
 };
 
-export const isResponseStatusValid = (status: string | undefined) => status && status === 'valid';
+export const isResponseStatusValid = (status: string | undefined) =>
+  status !== undefined && status.length > 0 && status === 'valid';

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/account.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/account.ts
@@ -38,7 +38,7 @@ export const createNewAccount = async ({
   const reqBody = await identity.newAccountRequest(nonce);
   const response = await connection.createNewAccount(directory.newAccount, reqBody);
 
-  if (response?.data && !!response.data.status.length && !!response.nonce.length) {
+  if (response?.data !== undefined && response.data.status.length > 0 && response.nonce.length > 0) {
     await identity.newAccountResponse(jsonToByteArray(response.data));
     return response.nonce;
   }

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/dpopChallenge/dpopChallenge.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/dpopChallenge/dpopChallenge.ts
@@ -43,7 +43,7 @@ export const doWireDpopChallenge = async ({
   expirySecs,
 }: DoWireDpopChallengeParams) => {
   const {dpopChallenge} = authData.authorization;
-  if (!dpopChallenge) {
+  if (dpopChallenge === undefined) {
     throw new Error('No wireDpopChallenge defined');
   }
 
@@ -55,7 +55,7 @@ export const doWireDpopChallenge = async ({
   const reqBody = await identity.newDpopChallengeRequest(clientAccessTokenData.token, nonce);
 
   const dpopChallengeResponse = await connection.validateDpopChallenge(dpopChallenge.url, reqBody);
-  if (!dpopChallengeResponse) {
+  if (dpopChallengeResponse === undefined) {
     throw new Error('No response received while validating DPOP challenge');
   }
 

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/oidcChallenge.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/oidcChallenge.ts
@@ -39,14 +39,14 @@ export const doWireOidcChallenge = async ({
   oAuthIdToken,
 }: DoWireOidcChallengeParams) => {
   const {oidcChallenge} = authData.authorization;
-  if (!oidcChallenge) {
+  if (oidcChallenge === undefined) {
     throw new Error('No wireOIDCChallenge defined');
   }
 
   const reqBody = await identity.newOidcChallengeRequest(oAuthIdToken, nonce);
 
   const oidcChallengeResponse = await connection.validateOidcChallenge(oidcChallenge.url, reqBody);
-  if (!oidcChallengeResponse) {
+  if (oidcChallengeResponse === undefined) {
     throw new Error('No response received while validating OIDC challenge');
   }
   await identity.newOidcChallengeResponse(

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/order.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/order.ts
@@ -44,7 +44,7 @@ export const createNewOrder = async ({
 }: CreateNewOrderParams): Promise<CreateNewOrderReturnValue> => {
   const reqBody = await identity.newOrderRequest(nonce);
   const {data, nonce: responseNonce, location} = await connection.createNewOrder(directory.newOrder, reqBody);
-  if (!location) {
+  if (location === undefined || location.length === 0) {
     throw new Error('No location header from API received for order creation');
   }
   return {
@@ -65,12 +65,16 @@ export const finalizeOrder = async ({identity, nonce, orderUrl, connection}: Fin
   const statusReqBody = await identity.checkOrderRequest(orderUrl, nonce);
   const statusResponse = await connection.checkStatusOfOrder(orderUrl, statusReqBody);
 
-  if (statusResponse?.data && !!statusResponse.data.status.length && !!statusResponse.nonce.length) {
+  if (statusResponse?.data !== undefined && statusResponse.data.status.length > 0 && statusResponse.nonce.length > 0) {
     const finalizeUrl = await identity.checkOrderResponse(jsonToByteArray(statusResponse.data));
     const finalizeReqBody = await identity.finalizeRequest(statusResponse.nonce);
     const finalizeResponse = await connection.finalizeOrder(finalizeUrl, finalizeReqBody);
 
-    if (finalizeResponse?.data && !!finalizeResponse.data.status.length && !!finalizeResponse.nonce.length) {
+    if (
+      finalizeResponse?.data !== undefined &&
+      finalizeResponse.data.status.length > 0 &&
+      finalizeResponse.nonce.length > 0
+    ) {
       const certificateUrl = await identity.finalizeResponse(jsonToByteArray(finalizeResponse.data));
 
       return {

--- a/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.ts
+++ b/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.ts
@@ -217,7 +217,7 @@ export class MLSService extends TypedEventEmitter<Events> {
 
       switch (mlsDeviceStatus) {
         case MLSDeviceStatus.REGISTERED:
-          if (!skipInitIdentity) {
+          if (skipInitIdentity !== true) {
             await this.verifyRemoteMLSKeyPackagesAmount(client.id);
           } else {
             this.logger.info(`Blocked initial key package upload for client ${client.id} as E2EI is enabled`);
@@ -228,7 +228,7 @@ export class MLSService extends TypedEventEmitter<Events> {
           this.emit(MLSServiceEvents.MLS_CLIENT_MISMATCH);
           break;
         case MLSDeviceStatus.FRESH:
-          if (!skipInitIdentity) {
+          if (skipInitIdentity !== true) {
             await this.uploadMLSPublicKeys(client);
           } else {
             this.logger.info(`Blocked initial key package upload for client ${client.id} as E2EI is enabled`);
@@ -379,7 +379,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       const clientIdParts = fullClientId?.split(':');
       const groupClientId = clientIdParts?.[1];
 
-      if (groupClientId) {
+      if (groupClientId !== undefined && groupClientId.length > 0) {
         currentClientIdsInGroup.push(groupClientId);
       }
     }
@@ -483,7 +483,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       await this.dispatchNewCrlDistributionPoints(welcomeBundle.crlNewDistributionPoints);
 
       this.logger.info('welcome bundle after joining via external commit');
-      if (welcomeBundle.id) {
+      if (welcomeBundle.id !== undefined) {
         //after we've successfully joined via external commit, we schedule periodic key material renewal
         const groupIdStr = Encoder.toBase64(welcomeBundle.id.copyBytes()).asString;
         const newEpoch = await this.getEpoch(groupIdStr);
@@ -600,7 +600,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
 
     let externalSenders: ExternalSenderKey[] = [];
-    if (parentGroupId) {
+    if (parentGroupId !== undefined && parentGroupId.length > 0) {
       const parentGroupIdBytes = Decoder.fromBase64(parentGroupId).asBytes;
       externalSenders = [
         new ExternalSenderKey(await this.coreCryptoClient.getExternalSender(new ConversationId(parentGroupIdBytes))),
@@ -609,7 +609,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       const ciphersuiteSignature = getSignatureAlgorithmForCiphersuite(this.config.defaultCiphersuite);
       const removalKeyForSignature =
         removalKeyFor1to1Signature?.[ciphersuiteSignature] ?? mlsPublicRemovalKeys[ciphersuiteSignature];
-      if (!removalKeyForSignature) {
+      if (removalKeyForSignature === undefined || removalKeyForSignature.length === 0) {
         throw new Error(
           `Cannot create conversation: No backend removal key found for the signature ${ciphersuiteSignature}`,
         );
@@ -943,7 +943,7 @@ export class MLSService extends TypedEventEmitter<Events> {
   private async getCCClientSignatureString(): Promise<string> {
     const credentialType = await this.getCredentialType();
     const publicKey = await this.coreCryptoClient.clientPublicKey(this.config.defaultCiphersuite, credentialType);
-    if (!publicKey) {
+    if (publicKey === undefined) {
       throw new Error('No public key found for client');
     }
     return btoa(Converter.arrayBufferViewToBaselineString(publicKey));
@@ -1143,9 +1143,11 @@ export class MLSService extends TypedEventEmitter<Events> {
     const groupId = await groupIdFromConversationId(qualifiedConversationId, event.subconv);
 
     // We should not receive a message for a group the client is not aware of
-    if (!groupId) {
+    if (groupId === undefined || groupId.length === 0) {
       throw new Error(
-        `Could not find a group_id for conversation ${qualifiedConversationId.id}@${qualifiedConversationId.domain}${event.subconv ? `/subconversation:${event.subconv}` : ''}`,
+        `Could not find a group_id for conversation ${qualifiedConversationId.id}@${qualifiedConversationId.domain}${
+          event.subconv !== undefined ? `/subconversation:${event.subconv}` : ''
+        }`,
       );
     }
 

--- a/libraries/core/src/messagingProtocols/mls/recovery/mlsErrorMapper.ts
+++ b/libraries/core/src/messagingProtocols/mls/recovery/mlsErrorMapper.ts
@@ -112,7 +112,7 @@ export class ChainedMlsErrorMapper implements MlsErrorMapper {
     for (const handler of this.handlers) {
       if (handler.canHandle(error, context)) {
         const mapped = handler.map(error, context);
-        if (mapped) {
+        if (mapped !== undefined) {
           return mapped;
         }
       }
@@ -241,7 +241,7 @@ function tryExtractGroupIdFromCoreCryptoError(err: ConversationAlreadyExistsErro
   try {
     // core-crypto error.context?.context?.conversationId is a byte array (number[])
     const conversationIdArray = err?.context?.context?.conversationId;
-    if (!conversationIdArray) {
+    if (conversationIdArray === undefined) {
       return undefined;
     }
     return Encoder.toBase64(new Uint8Array(conversationIdArray)).asString;

--- a/libraries/core/src/messagingProtocols/mls/recovery/mlsRecoveryOrchestrator.ts
+++ b/libraries/core/src/messagingProtocols/mls/recovery/mlsRecoveryOrchestrator.ts
@@ -196,7 +196,7 @@ export class MlsRecoveryOrchestratorImpl implements MlsRecoveryOrchestrator {
       const policy = this.getPolicyFor(normalizedError, context);
       this.logger.info(`Resolved recovery policy: action=${policy.action}`, {policy});
 
-      if (policy.action === 'Unknown' || !retry) {
+      if (policy.action === 'Unknown' || retry === false) {
         this.logger.info('No recovery action configured or retry disabled, re-throwing original error');
         throw rawError;
       }
@@ -205,7 +205,7 @@ export class MlsRecoveryOrchestratorImpl implements MlsRecoveryOrchestrator {
       await this.performRecovery(context, normalizedError, policy, key);
       await this.maybeDelay(policy.retryConfig);
 
-      if (policy.retryConfig.reRunOriginalOperation) {
+      if (policy.retryConfig.reRunOriginalOperation === true) {
         this.logger.info(`Re-running original operation after recovery for key ${key}`);
         return this.execute({context, callBack, retry: false});
       }
@@ -260,10 +260,10 @@ export class MlsRecoveryOrchestratorImpl implements MlsRecoveryOrchestrator {
       case 'AddMissingUsers': {
         const groupId = context.groupId;
         const missing = err.context?.missingUsers;
-        if (!missing || missing.length === 0) {
+        if (missing === undefined || missing.length === 0) {
           throw new Error('No missing users reported in error context for AddMissingUsers');
         }
-        if (!groupId) {
+        if (groupId === undefined || groupId.length === 0) {
           throw new Error('Missing groupId for AddMissingUsers');
         }
         await this.runOnceWithKey(recoveryKey, () => this.deps.addMissingUsers(id, groupId, missing));
@@ -272,7 +272,7 @@ export class MlsRecoveryOrchestratorImpl implements MlsRecoveryOrchestrator {
       case 'WipeAndReprocessWelcome': {
         // We rely on either the operation context groupId (preferred) or any mapped error context
         const groupId = context.groupId ?? err.context?.groupId;
-        if (!groupId) {
+        if (groupId === undefined || groupId.length === 0) {
           this.logger.warn('Could not determine groupId for WipeAndReprocessWelcome; skipping wipe');
           break;
         }
@@ -320,7 +320,7 @@ export class MlsRecoveryOrchestratorImpl implements MlsRecoveryOrchestrator {
 
   /** Optionally wait before re-invoking the original operation. */
   private async maybeDelay(retry: RetryPolicy): Promise<void> {
-    if (retry.delayMs) {
+    if (retry.delayMs !== undefined && retry.delayMs > 0) {
       this.logger.info(`Waiting for ${retry.delayMs}ms before retrying original operation`);
       await this.sleep(retry.delayMs);
     }

--- a/libraries/core/src/messagingProtocols/proteus/proteusService/cryptoClient/coreCryptoWrapper/coreCryptoWrapper.ts
+++ b/libraries/core/src/messagingProtocols/proteus/proteusService/cryptoClient/coreCryptoWrapper/coreCryptoWrapper.ts
@@ -87,7 +87,7 @@ const migrateOnceAndGetKey = async (
   // We retrieve the new key if it exists or generate a new one
   const keyNew = await getKey(generateSecretKey, coreCryptoNewKeyId, 32);
 
-  if (!keyNew || !keyOld) {
+  if (keyNew === undefined || keyOld === undefined) {
     // If we dont retreive any key, we throw an error
     // This should not happen since we generate a new key if it does not exist
     throw new Error('Key not found and could not be generated');
@@ -99,7 +99,7 @@ const migrateOnceAndGetKey = async (
    * - If `keyNew` is freshly generated and `keyOld` is not freshly generated:
    *     - Migrate data from `keyOld` to `keyNew`
    */
-  if (keyNew.freshlyGenerated && !keyOld.freshlyGenerated) {
+  if (keyNew.freshlyGenerated === true && keyOld.freshlyGenerated === false) {
     const databaseKey = new DatabaseKey(keyNew.key);
     await migrateDatabaseKeyTypeToBytes(coreCryptoDbName, Encoder.toBase64(keyOld.key).asString, databaseKey);
   }
@@ -202,7 +202,7 @@ export class CoreCryptoWrapper implements CryptoClient {
   }
 
   init(nbInitialPrekeys?: number) {
-    if (nbInitialPrekeys) {
+    if (nbInitialPrekeys !== undefined) {
       this.prekeyTracker.setInitialState(nbInitialPrekeys);
     }
     return this.coreCrypto.transaction(cx => cx.proteusInit());

--- a/libraries/core/src/messagingProtocols/proteus/proteusService/cryptoClient/cryptoboxWrapper.ts
+++ b/libraries/core/src/messagingProtocols/proteus/proteusService/cryptoClient/cryptoboxWrapper.ts
@@ -110,7 +110,7 @@ export class CryptoboxWrapper implements CryptoClient {
 
   async sessionExists(sessionId: string) {
     try {
-      return !!(await this.cryptobox.session_load(sessionId));
+      return (await this.cryptobox.session_load(sessionId)) !== undefined;
     } catch {
       return false;
     }

--- a/libraries/core/src/messagingProtocols/proteus/proteusService/cryptoMigrationStateStore.ts
+++ b/libraries/core/src/messagingProtocols/proteus/proteusService/cryptoMigrationStateStore.ts
@@ -39,7 +39,7 @@ const isMigrationReady = (getKey: (dbName: string) => string) => (dbName: string
   const key = getKey(dbName);
   const localStorage = getLocalStorage();
   const value = localStorage.getItem(key);
-  return !!value && value === MIGRATION_READY_STATE;
+  return value !== null && value === MIGRATION_READY_STATE;
 };
 
 export const cryptoMigrationStore = {

--- a/libraries/core/src/messagingProtocols/proteus/proteusService/proteusService.ts
+++ b/libraries/core/src/messagingProtocols/proteus/proteusService/proteusService.ts
@@ -97,7 +97,7 @@ export class ProteusService {
   }
 
   public async initClient(context: Context) {
-    if (context.domain) {
+    if (context.domain !== undefined && context.domain.length > 0) {
       // We want sessions to be fully qualified from now on
       if (!cryptoMigrationStore.qualifiedSessions.isReady(this.dbName)) {
         this.logger.info(`Migrating existing session ids to qualified ids.`);
@@ -267,7 +267,7 @@ export class ProteusService {
       onClientMismatch: mismatch => onClientMismatch?.(mismatch, false),
     });
 
-    if (!response.canceled) {
+    if (response.canceled !== true) {
       if (!isClearFromMismatch(response)) {
         // We warn the consumer that there is a mismatch that did not prevent message sending
         await onClientMismatch?.(response, true);
@@ -275,10 +275,10 @@ export class ProteusService {
       this.logger.log(`Successfully sent Proteus message to conversation '${conversationId.id}'`);
     }
 
-    const sendingState = response.canceled ? MessageSendingState.CANCELED : MessageSendingState.OUTGOING_SENT;
+    const sendingState = response.canceled === true ? MessageSendingState.CANCELED : MessageSendingState.OUTGOING_SENT;
 
     const failedToSend =
-      response.failed || Object.keys(response.failed_to_confirm_clients ?? {}).length > 0
+      response.failed !== undefined || Object.keys(response.failed_to_confirm_clients ?? {}).length > 0
         ? {
             queued: response.failed_to_confirm_clients,
             failed: response.failed,

--- a/libraries/core/src/messagingProtocols/proteus/utility/isClearFromMismatch.ts
+++ b/libraries/core/src/messagingProtocols/proteus/utility/isClearFromMismatch.ts
@@ -20,10 +20,10 @@
 import {MessageSendingStatus} from '@wireapp/api-client/lib/conversation';
 
 const isClearFromMismatch = (mismatch: MessageSendingStatus): boolean => {
-  const hasMissing = Object.keys(mismatch.missing || {}).length > 0;
-  const hasDeleted = Object.keys(mismatch.deleted || {}).length > 0;
-  const hasRedundant = Object.keys(mismatch.redundant || {}).length > 0;
-  const hasFailed = Object.keys((mismatch as MessageSendingStatus).failed_to_send || {}).length > 0;
+  const hasMissing = Object.keys(mismatch.missing ?? {}).length > 0;
+  const hasDeleted = Object.keys(mismatch.deleted ?? {}).length > 0;
+  const hasRedundant = Object.keys(mismatch.redundant ?? {}).length > 0;
+  const hasFailed = Object.keys((mismatch as MessageSendingStatus).failed_to_send ?? {}).length > 0;
   return !hasMissing && !hasDeleted && !hasRedundant && !hasFailed;
 };
 

--- a/libraries/core/src/messagingProtocols/proteus/utility/recipients.ts
+++ b/libraries/core/src/messagingProtocols/proteus/utility/recipients.ts
@@ -49,7 +49,7 @@ const getRecipientsForConversation = async ({
     return userIds;
   }
 
-  const hasTargetUsers = userIds && Object.keys(userIds).length > 0;
+  const hasTargetUsers = userIds !== undefined && Object.keys(userIds).length > 0;
   const recipientIds = hasTargetUsers
     ? userIds
     : await getConversationQualifiedMembers({apiClient: apiClient, conversationId});

--- a/libraries/core/src/messagingProtocols/proteus/utility/sessionHandler/sessionHandler.ts
+++ b/libraries/core/src/messagingProtocols/proteus/utility/sessionHandler/sessionHandler.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import is from '@sindresorhus/is';
 import {PreKey} from '@wireapp/api-client/lib/auth';
 import {QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId, QualifiedUserPreKeyBundleMap} from '@wireapp/api-client/lib/user';
@@ -48,11 +49,16 @@ type InitSessionsResult = {
 const constructSessionId = ({userId, clientId}: ConstructSessionIdParams): string => {
   const {id, domain} = userId;
   const baseId = `${id}@${clientId}`;
-  return domain ? `${domain}@${baseId}` : baseId;
+  return is.nonEmptyString(domain) ? `${domain}@${baseId}` : baseId;
 };
 
-const isSessionId = (object: any): object is SessionId => {
-  return object.userId && object.clientId;
+const isSessionId = (value: unknown): value is SessionId => {
+  if (!is.object(value)) {
+    return false;
+  }
+
+  const sessionIdCandidate = value as {userId?: unknown; clientId?: unknown};
+  return is.nonEmptyString(sessionIdCandidate.userId) && is.nonEmptyString(sessionIdCandidate.clientId);
 };
 
 /**
@@ -118,7 +124,7 @@ const createSessions = async ({recipients, apiClient, cryptoClient}: CreateSessi
 
   return {
     ...result,
-    failed: failed?.length ? failed : undefined,
+    failed: failed !== undefined && failed.length > 0 ? failed : undefined,
   };
 };
 
@@ -263,7 +269,7 @@ type EncryptedPayloads<T> = Record<string, Record<string, Record<string, T>>>;
 const buildEncryptedPayloads = <T>(payloads: Map<string, T>): EncryptedPayloads<T> => {
   return [...payloads].reduce((acc, [sessionId, payload]) => {
     const {userId, domain, clientId} = parseSessionId(sessionId);
-    if (!domain) {
+    if (domain === undefined || domain.length === 0) {
       throw new Error('Invalid session ID');
     }
     const domainPayloads = acc[domain] ?? {};

--- a/libraries/core/src/notification/notificationService.ts
+++ b/libraries/core/src/notification/notificationService.ts
@@ -126,7 +126,7 @@ export class NotificationService extends TypedEventEmitter<Events> {
       throw error;
     }
 
-    if (databaseLastEventDate && eventDate > databaseLastEventDate) {
+    if (databaseLastEventDate !== undefined && eventDate > databaseLastEventDate) {
       return this.database.updateLastEventDate(eventDate);
     }
 
@@ -154,7 +154,7 @@ export class NotificationService extends TypedEventEmitter<Events> {
   ): Promise<{total: number; error: number; success: number}> {
     const lastNotificationId = await this.database.getLastNotificationId();
     const {notifications, missedNotification} = await this.getAllNotifications(lastNotificationId, abortHandler);
-    if (missedNotification) {
+    if (missedNotification !== undefined && missedNotification.length > 0) {
       onMissedNotifications(missedNotification);
     }
 
@@ -165,7 +165,7 @@ export class NotificationService extends TypedEventEmitter<Events> {
         : `No notification to process from the stream`;
     this.logger.log(logMessage);
     for (const [index, notification] of notifications.entries()) {
-      if (abortHandler?.signal.aborted) {
+      if (abortHandler?.signal.aborted === true) {
         /* Stop handling notifications if the websocket has been disconnected.
          * Upon reconnecting we are going to restart handling the notification stream for where we left of
          */
@@ -197,7 +197,7 @@ export class NotificationService extends TypedEventEmitter<Events> {
    */
   private isOutdatedEvent(event: {time: string}, source: NotificationSource, lastEventDate?: Date) {
     const isFromNotificationStream = source === NotificationSource.NOTIFICATION_STREAM;
-    const shouldCheckEventDate = !!event.time && isFromNotificationStream && lastEventDate;
+    const shouldCheckEventDate = event.time.length > 0 && isFromNotificationStream && lastEventDate !== undefined;
 
     if (shouldCheckEventDate) {
       /** This check prevents duplicated "You joined" system messages. */
@@ -225,7 +225,7 @@ export class NotificationService extends TypedEventEmitter<Events> {
       }
       try {
         const handledEventResult = await this.handleEvent(event);
-        if (handledEventResult.status === 'handled' && handledEventResult.payload) {
+        if (handledEventResult.status === 'handled' && handledEventResult.payload !== null) {
           yield handledEventResult.payload;
         }
       } catch (error: unknown) {
@@ -241,7 +241,7 @@ export class NotificationService extends TypedEventEmitter<Events> {
         this.emit(NotificationService.TOPIC.NOTIFICATION_ERROR, notificationError);
       }
     }
-    if (!notification.transient) {
+    if (notification.transient !== true) {
       // keep track of the last handled notification for next time we fetch the notification stream
       await this.setLastNotificationId(notification);
     }

--- a/libraries/core/src/self/selfService.ts
+++ b/libraries/core/src/self/selfService.ts
@@ -30,7 +30,7 @@ export class SelfService {
 
   public async checkUsername(username: string): Promise<boolean> {
     const [availableUsername] = await this.checkUsernames([username]);
-    return !!availableUsername;
+    return availableUsername !== undefined;
   }
 
   public checkUsernames(usernames: string[]): Promise<string[]> {
@@ -72,7 +72,11 @@ export class SelfService {
       return;
     }
 
-    if (!supportedProtocols || supportedProtocols.length === 0) {
+    if (supportedProtocols === undefined) {
+      throw new Error('Supported protocols must be a non-empty protocols list');
+    }
+
+    if (supportedProtocols.length === 0) {
       throw new Error('Supported protocols must be a non-empty protocols list');
     }
 

--- a/libraries/core/src/util/fullyQualifiedClientIdUtils.ts
+++ b/libraries/core/src/util/fullyQualifiedClientIdUtils.ts
@@ -34,7 +34,7 @@ export const constructFullyQualifiedClientId = (
 export const parseFullQualifiedClientId = (qualifiedId: string): ParsedFullyQualifiedId => {
   const regexp = /([a-zA-Z0-9\-]+):([a-zA-Z0-9\-]+)@([a-zA-Z0-9\-.]+)/;
   const [, user, client, domain] = qualifiedId.match(regexp) ?? [];
-  if (!user || !client || !domain) {
+  if (user === undefined || client === undefined || domain === undefined) {
     throw new Error(`given client fully qualified ID is corrupted (${qualifiedId})`);
   }
   return {user, client, domain};

--- a/libraries/core/src/util/localStorageStore/index.ts
+++ b/libraries/core/src/util/localStorageStore/index.ts
@@ -22,7 +22,7 @@ const prependKey = (key: string, pKey: string) => `${pKey}_${key}`;
 export const LocalStorageStore = <T = string>(pKey: string) => ({
   get: (key: string): T | undefined => {
     const value = localStorage.getItem(prependKey(key, pKey));
-    if (value) {
+    if (value !== null) {
       if (!Number.isNaN(Number(value))) {
         return Number(value) as T;
       }
@@ -32,5 +32,5 @@ export const LocalStorageStore = <T = string>(pKey: string) => ({
   },
   add: (key: string, value: T) => localStorage.setItem(prependKey(key, pKey), String(value)),
   remove: (key: string) => localStorage.removeItem(prependKey(key, pKey)),
-  has: (key: string) => !!localStorage.getItem(prependKey(key, pKey)),
+  has: (key: string) => localStorage.getItem(prependKey(key, pKey)) !== null,
 });

--- a/libraries/core/src/util/lowPrecisionTaskScheduler/lowPrecisionTaskScheduler.ts
+++ b/libraries/core/src/util/lowPrecisionTaskScheduler/lowPrecisionTaskScheduler.ts
@@ -82,8 +82,8 @@ interface CancelLowPrecisionTaskParams {
 }
 
 const cancelTask = ({intervalDelay, key}: CancelLowPrecisionTaskParams) => {
-  if (intervals[intervalDelay]) {
-    const tasks = intervals[intervalDelay].tasks || {};
+  if (intervals[intervalDelay] !== undefined) {
+    const tasks = intervals[intervalDelay].tasks ?? {};
 
     const newTasks = {...tasks};
     delete newTasks[key];

--- a/libraries/core/src/util/qualifiedIdUtil.ts
+++ b/libraries/core/src/util/qualifiedIdUtil.ts
@@ -25,7 +25,7 @@ export const stringifyQualifiedId = (qualifiedId: QualifiedId): StringifiedQuali
 
 export const parseQualifiedId = (qualifiedId: string): QualifiedId => {
   const [id, domain] = qualifiedId.split('@');
-  if (!id || !domain) {
+  if (id === undefined || domain === undefined) {
     throw new Error(`given qualified ID is corrupted (${qualifiedId})`);
   }
   return {id, domain};

--- a/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.store.ts
+++ b/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.store.ts
@@ -19,7 +19,7 @@
 
 export const loadState = (key: string): number | undefined => {
   const storedState = localStorage.getItem(key);
-  return !storedState ? undefined : parseInt(storedState, 10);
+  return storedState === null ? undefined : parseInt(storedState, 10);
 };
 
 export const saveState = (key: string, firedAt: number) => {

--- a/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.ts
+++ b/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.ts
@@ -44,7 +44,7 @@ export class RecurringTaskScheduler {
     key,
     addTaskOnWindowFocusEvent = false,
   }: TaskParams): Promise<void> => {
-    const firingDate = (await this.storage.get(key)) || Date.now() + every;
+    const firingDate = (await this.storage.get(key)) ?? Date.now() + every;
     await this.storage.set(key, firingDate);
 
     const taskConfig = {
@@ -70,7 +70,7 @@ export class RecurringTaskScheduler {
 
     // If the task should be added on window focus event, we add it here
 
-    if (addTaskOnWindowFocusEvent && typeof window !== 'undefined') {
+    if (addTaskOnWindowFocusEvent === true && typeof window !== 'undefined') {
       window.addEventListener('focus', taskConfig.task);
     }
   };
@@ -82,6 +82,6 @@ export class RecurringTaskScheduler {
   };
 
   public readonly hasTask = async (taskKey: string): Promise<boolean> => {
-    return !!(await this.storage.get(taskKey));
+    return (await this.storage.get(taskKey)) !== undefined;
   };
 }

--- a/libraries/core/src/util/taskScheduler/taskScheduler.ts
+++ b/libraries/core/src/util/taskScheduler/taskScheduler.ts
@@ -91,12 +91,12 @@ const cancelTask = (key: string) => {
  */
 const continueTask = ({key, task}: Omit<ScheduleTaskParams, 'firingDate' | 'persist'>) => {
   const activeTaskEndTime = TaskSchedulerStore.get(key);
-  if (activeTaskEndTime) {
+  if (activeTaskEndTime !== undefined) {
     addTask({task, firingDate: activeTaskEndTime, key, persist: true});
   }
 };
 
-const hasActiveTask = (key: string) => !!activeTimeouts[key];
+const hasActiveTask = (key: string) => activeTimeouts[key] !== undefined;
 
 export const TaskScheduler = {
   addTask,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Keep `apps/webapp/**` explicitly excluded from strict-boolean-expressions for now.

Reason for webapp exclusion:

- apps/webapp currently has a very large existing backlog (about 1.5k strict-boolean violations).
- Enforcing the rule there in this change would create an oversized, high-risk migration diff.
- This commit intentionally scopes enforcement to non-webapp packages to keep reviewable, safe changes while preserving green lint/test.


