### PR TITLE
feat: hide wave img from screen reader [WPB-22173]

### DIFF
--- a/apps/webapp/src/script/auth/component/AccountRegistrationLayout.tsx
+++ b/apps/webapp/src/script/auth/component/AccountRegistrationLayout.tsx
@@ -73,7 +73,9 @@ export const AccountRegistrationLayout = ({children}: {children: ReactNode}) => 
             <Text css={registrationLayoutSubHeaderCss}>{t('registrationLayout.footer')}</Text>
           </div>
         </div>
-        <WavesPattern />
+        <span aria-hidden="true">
+          <WavesPattern />
+        </span>
       </div>
 
       <div css={contentContainerCss}>{children}</div>

--- a/apps/webapp/src/script/auth/component/Layout.tsx
+++ b/apps/webapp/src/script/auth/component/Layout.tsx
@@ -47,7 +47,9 @@ export const Layout = ({children}: {children: ReactNode}) => {
             </Link>
           </div>
         </div>
-        <WavesPattern />
+        <span aria-hidden="true">
+          <WavesPattern />
+        </span>
       </div>
 
       <div css={contentContainerCss}>{children}</div>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22173" title="WPB-22173" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22173</a>  [Web] Images in login process are just marked as "image"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Description
Hide wave image from screen readers.