### PR TITLE
Add shared core fire-and-forget invoker [WPB-22420]

### DIFF
--- a/libraries/core/jest.config.js
+++ b/libraries/core/jest.config.js
@@ -32,7 +32,7 @@ module.exports = {
     '^.+\\.(ts|tsx)$': '@swc/jest',
     '^.+\\.(js|jsx)$': '@swc/jest',
   },
-  transformIgnorePatterns: ['/node_modules/(?!(true-myth|uuid)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth|uuid|noop-esm)/)'],
   coverageDirectory: '../../coverage/libraries/core',
   testMatch: ['<rootDir>/src/**/__tests__/**/*.[jt]s?(x)', '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)'],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],

--- a/libraries/core/src/index.ts
+++ b/libraries/core/src/index.ts
@@ -22,6 +22,11 @@ export * as auth from './auth/';
 export * from './conversation/';
 export {CoreError} from './coreError';
 export * from './cryptography/';
+export {
+  createFireAndForgetInvoker,
+  type FireAndForgetInvoker,
+  type FireAndForgetInvokerDependencies,
+} from './taskExecution/fireAndForgetInvoker/fireAndForgetInvoker';
 export * from './util';
 export * as MessageBuilder from './conversation/message/messageBuilder';
 export * from './errors';

--- a/libraries/core/src/taskExecution/fireAndForgetInvoker/fireAndForgetInvoker.test.ts
+++ b/libraries/core/src/taskExecution/fireAndForgetInvoker/fireAndForgetInvoker.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createFireAndForgetInvoker} from './fireAndForgetInvoker';
+import {noop} from 'noop-esm';
+
+describe('createFireAndForgetInvoker', () => {
+  it('invokes action without waiting for completion', () => {
+    const logger = {error: jest.fn()};
+    const fireAndForgetInvoker = createFireAndForgetInvoker({logger});
+    const asyncAction = jest.fn(async () => {
+      return 'resolved';
+    });
+
+    fireAndForgetInvoker.fireAndForget(asyncAction);
+
+    expect(asyncAction).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('reports synchronous errors thrown by action', async () => {
+    const logger = {error: jest.fn()};
+    const expectedError = new Error('synchronous failure');
+    const fireAndForgetInvoker = createFireAndForgetInvoker({logger});
+
+    fireAndForgetInvoker.fireAndForget(() => {
+      throw expectedError;
+    });
+
+    await fireAndForgetInvoker.waitUntilAllSettled();
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith('failed to execute fire-and-forget action', expectedError);
+  });
+
+  it('reports rejected promise errors', async () => {
+    const logger = {error: jest.fn()};
+    const expectedError = new Error('asynchronous failure');
+    const fireAndForgetInvoker = createFireAndForgetInvoker({logger});
+
+    fireAndForgetInvoker.fireAndForget(async () => {
+      throw expectedError;
+    });
+
+    await fireAndForgetInvoker.waitUntilAllSettled();
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith('failed to execute fire-and-forget action', expectedError);
+  });
+
+  it('does not report errors when action resolves', async () => {
+    const logger = {error: jest.fn()};
+    const fireAndForgetInvoker = createFireAndForgetInvoker({logger});
+
+    fireAndForgetInvoker.fireAndForget(async () => {
+      return 'ok';
+    });
+
+    await fireAndForgetInvoker.waitUntilAllSettled();
+
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('waitUntilAllSettled waits for all active actions', async () => {
+    const logger = {error: jest.fn()};
+    const fireAndForgetInvoker = createFireAndForgetInvoker({logger});
+    let resolveFirstAction: (value: string) => void = noop;
+    let resolveSecondAction: (value: string) => void = noop;
+
+    fireAndForgetInvoker.fireAndForget(() => {
+      return new Promise(resolve => {
+        resolveFirstAction = resolve;
+      });
+    });
+
+    fireAndForgetInvoker.fireAndForget(() => {
+      return new Promise(resolve => {
+        resolveSecondAction = resolve;
+      });
+    });
+
+    const waitPromise = fireAndForgetInvoker.waitUntilAllSettled();
+    let hasWaitFinished = false;
+
+    waitPromise.then(() => {
+      hasWaitFinished = true;
+    });
+
+    await Promise.resolve();
+    expect(hasWaitFinished).toBe(false);
+
+    resolveFirstAction('first');
+    await Promise.resolve();
+    expect(hasWaitFinished).toBe(false);
+
+    resolveSecondAction('second');
+    await waitPromise;
+    expect(hasWaitFinished).toBe(true);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/libraries/core/src/taskExecution/fireAndForgetInvoker/fireAndForgetInvoker.ts
+++ b/libraries/core/src/taskExecution/fireAndForgetInvoker/fireAndForgetInvoker.ts
@@ -1,0 +1,68 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export type FireAndForgetInvokerDependencies = {
+  readonly logger: {
+    error: (message: string, error?: unknown) => void;
+  };
+};
+
+export type FireAndForgetInvoker = {
+  fireAndForget: (asyncAction: () => Promise<unknown>) => void;
+  waitUntilAllSettled: () => Promise<void>;
+};
+
+export function createFireAndForgetInvoker(dependencies: FireAndForgetInvokerDependencies): FireAndForgetInvoker {
+  const {logger} = dependencies;
+  const activePromises = new Set<Promise<unknown>>();
+  const fireAndForgetErrorMessage = 'failed to execute fire-and-forget action';
+
+  async function observePromise(trackedPromise: Promise<unknown>): Promise<void> {
+    try {
+      await trackedPromise;
+    } catch (error: unknown) {
+      logger.error(fireAndForgetErrorMessage, error);
+    } finally {
+      activePromises.delete(trackedPromise);
+    }
+  }
+
+  function trackPromise(trackedPromise: Promise<unknown>): void {
+    activePromises.add(trackedPromise);
+    observePromise(trackedPromise);
+  }
+
+  function fireAndForget(asyncAction: () => Promise<unknown>): void {
+    try {
+      const trackedPromise = asyncAction();
+      trackPromise(trackedPromise);
+    } catch (error: unknown) {
+      logger.error(fireAndForgetErrorMessage, error);
+    }
+  }
+
+  async function waitUntilAllSettled(): Promise<void> {
+    await Promise.allSettled(Array.from(activePromises));
+  }
+
+  return {
+    fireAndForget,
+    waitUntilAllSettled,
+  };
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Introduce a shared, dependency-injected fire-and-forget invoker in core so promise work can be dispatched without `void` call sites while still guaranteeing rejection visibility. This establishes a reusable, explicit primitive for safe background async execution.


