### PR TITLE
fix: check for null in AuthSelector [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/auth/module/selector/AuthSelector.ts
+++ b/apps/webapp/src/script/auth/module/selector/AuthSelector.ts
@@ -54,7 +54,7 @@ export const isFetchingSSOSettings = (state: RootState) => state.authState.fetch
 export const getDefaultSSOCode = (state: RootState) => state.authState.ssoSettings?.default_sso_code;
 export const hasDefaultSSOCode = (state: RootState) => {
   const defaultSSOCode = state.authState.ssoSettings?.default_sso_code;
-  return defaultSSOCode !== undefined && defaultSSOCode.length > 0;
+  return defaultSSOCode !== undefined && defaultSSOCode !== null && defaultSSOCode.length > 0;
 };
 export const getError = (state: RootState) => state.authState.error;
 export const getLoginData = (state: RootState) => state.authState.loginData;


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

<img width="932" height="307" alt="image" src="https://github.com/user-attachments/assets/a2126f05-6770-438f-87d5-40cda668b351" />

According to TS this variable should never be `null` but for some reason it is. This is a hotfix to have auth on the SSO page working again so we can investigate the cause of TS not matching reality later.


