### PR TITLE
feat: enable high quality blur option and update related handlers [WPB-25492]

### DIFF
--- a/apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx
@@ -285,6 +285,7 @@ const FullscreenVideoCall = ({
   const backgroundEffectsHandler = callingRepository.getBackgroundEffectsHandler();
 
   const selectedBackgroundEffect = useBackgroundEffectsStore(state => state.preferredEffect);
+  const isHighQualityBlurEnabled = useBackgroundEffectsStore(state => state.isHighQualityBlurEnabled);
 
   const handleBackgroundSidebarSelect = (effect: BackgroundEffectSelection) => {
     void switchVideoBackgroundEffect(effect);
@@ -419,7 +420,7 @@ const FullscreenVideoCall = ({
               onSelectEffect={handleBackgroundSidebarSelect}
               onEnableHighQualityBlur={handleEnableHighQualityBlur}
               onClose={() => setIsBackgroundSidebarOpen(false)}
-              highQualityBlurAllowed={callingRepository.isSuperhighQualityTierAllowed()}
+              highQualityBlurAllowed={isHighQualityBlurEnabled}
             />
           )}
         </div>
@@ -501,7 +502,7 @@ const FullscreenVideoCall = ({
           onSelectEffect={handleBackgroundSidebarSelect}
           onEnableHighQualityBlur={handleEnableHighQualityBlur}
           onClose={() => setIsBackgroundSidebarOpen(false)}
-          highQualityBlurAllowed={callingRepository.isSuperhighQualityTierAllowed()}
+          highQualityBlurAllowed={isHighQualityBlurEnabled}
         />
       )}
       <ModalComponent

--- a/apps/webapp/src/script/components/calling/VideoControls/VideoBackgroundSettings/VideoBackgroundSettings.test.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/VideoBackgroundSettings/VideoBackgroundSettings.test.tsx
@@ -17,30 +17,194 @@
  *
  */
 
-import {render} from '@testing-library/react';
+import {fireEvent, render} from '@testing-library/react';
 
-import {VideoBackgroundSettings} from './VideoBackgroundSettings';
 import type {BuiltinBackground} from 'Repositories/media/VideoBackgroundEffects';
 import {withTheme} from '../../../../auth/util/test/TestUtil';
+
+import {VideoBackgroundSettings} from './VideoBackgroundSettings';
 
 jest.mock('Util/localizerUtil', () => ({
   t: (key: string) => key,
 }));
 
 describe('VideoBackgroundSettings', () => {
+  const backgrounds = [
+    {
+      id: 'office',
+      imageUrl: 'office.jpg',
+      previewGradient: 'linear-gradient(red, blue)',
+    },
+    {
+      id: 'beach',
+      imageUrl: 'beach.jpg',
+      previewGradient: 'linear-gradient(yellow, green)',
+    },
+  ] as BuiltinBackground[];
+
   const defaultProps = {
     selectedEffect: {type: 'none'} as const,
-    backgrounds: [] as BuiltinBackground[],
+    backgrounds,
     onSelectEffect: jest.fn(),
     onEnableHighQualityBlur: jest.fn(),
     onClose: jest.fn(),
     highQualityBlurAllowed: false,
   };
 
-  it('renders the high quality blur checkbox as disabled', async () => {
-    const {getByTestId} = render(withTheme(<VideoBackgroundSettings {...defaultProps} />));
-    const checkbox = getByTestId('enable-high-quality-blur') as HTMLButtonElement;
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
-    expect(checkbox).toBeDisabled();
+  const renderComponent = (props = {}) => render(withTheme(<VideoBackgroundSettings {...defaultProps} {...props} />));
+
+  it('renders video background settings wrapper', () => {
+    const {getByTestId} = renderComponent();
+
+    expect(getByTestId('video-background-settings')).toBeInTheDocument();
+  });
+
+  it('renders the high quality blur checkbox as unchecked', () => {
+    const {getByTestId} = renderComponent();
+
+    const checkbox = getByTestId('enable-high-quality-blur') as HTMLInputElement;
+
+    expect(checkbox).not.toBeChecked();
+    expect(checkbox).not.toBeDisabled();
+  });
+
+  it('renders the high quality blur checkbox as checked', () => {
+    const {getByTestId} = renderComponent({highQualityBlurAllowed: true});
+
+    expect(getByTestId('enable-high-quality-blur')).toBeChecked();
+  });
+
+  it('calls onEnableHighQualityBlur when high quality blur checkbox changes', () => {
+    const {getByTestId} = renderComponent();
+
+    fireEvent.click(getByTestId('enable-high-quality-blur'));
+
+    expect(defaultProps.onEnableHighQualityBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when close modal close button is clicked', () => {
+    const {getByTitle} = renderComponent();
+
+    fireEvent.click(getByTitle('modalCloseButton'));
+
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('selects low blur', () => {
+    const {getByText} = renderComponent();
+
+    fireEvent.click(getByText('videoCallBackgroundBlurLow'));
+
+    expect(defaultProps.onSelectEffect).toHaveBeenCalledWith({
+      type: 'blur',
+      level: 'low',
+    });
+  });
+
+  it('selects high blur', () => {
+    const {getByText} = renderComponent();
+
+    fireEvent.click(getByText('videoCallBackgroundBlurHigh'));
+
+    expect(defaultProps.onSelectEffect).toHaveBeenCalledWith({
+      type: 'blur',
+      level: 'high',
+    });
+  });
+
+  it('marks selected high blur tile as pressed', () => {
+    const {getByText} = renderComponent({
+      selectedEffect: {type: 'blur', level: 'high'},
+    });
+
+    expect(getByText('videoCallBackgroundBlurHigh').closest('button')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('selects a virtual background', () => {
+    const {getAllByRole} = renderComponent();
+
+    const firstVirtualBackgroundButton = getAllByRole('button')[4];
+
+    fireEvent.click(firstVirtualBackgroundButton);
+
+    expect(defaultProps.onSelectEffect).toHaveBeenCalledWith({
+      type: 'virtual',
+      backgroundId: 'office',
+    });
+  });
+
+  it('marks selected virtual background tile as pressed', () => {
+    const {getAllByRole} = renderComponent({
+      selectedEffect: {type: 'virtual', backgroundId: 'beach'},
+    });
+
+    const secondVirtualBackgroundButton = getAllByRole('button')[5];
+
+    expect(secondVirtualBackgroundButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('calls onSelectEffect with none when no effect tile is clicked', () => {
+    const {getByText} = renderComponent();
+
+    fireEvent.click(getByText('videoCallBackgroundNoEffect'));
+
+    expect(defaultProps.onSelectEffect).toHaveBeenCalledWith({
+      type: 'none',
+    });
+  });
+
+  it('marks no effect tile as pressed when none is selected', () => {
+    const {getByText} = renderComponent();
+
+    expect(getByText('videoCallBackgroundNoEffect').closest('button')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('marks selected low blur tile as pressed', () => {
+    const {getByText} = renderComponent({
+      selectedEffect: {type: 'blur', level: 'low'},
+    });
+
+    expect(getByText('videoCallBackgroundBlurLow').closest('button')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('does not render virtual background tiles when backgrounds list is empty', () => {
+    const {getAllByRole} = renderComponent({
+      backgrounds: [],
+    });
+
+    // close button + no effect + low blur + high blur
+    expect(getAllByRole('button')).toHaveLength(4);
+  });
+
+  it('renders virtual background preview image and fallback gradient', () => {
+    const {container} = renderComponent();
+
+    const preview = container.querySelectorAll('.bg-tile__preview')[3] as HTMLElement;
+
+    expect(preview).toHaveStyle({
+      backgroundImage: 'url(office.jpg), linear-gradient(red, blue)',
+    });
+  });
+
+  it('does not mark another blur level as pressed when high blur is selected', () => {
+    const {getByText} = renderComponent({
+      selectedEffect: {type: 'blur', level: 'high'},
+    });
+
+    expect(getByText('videoCallBackgroundBlurLow').closest('button')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('does not mark another virtual background as pressed when one virtual background is selected', () => {
+    const {getAllByRole} = renderComponent({
+      selectedEffect: {type: 'virtual', backgroundId: 'beach'},
+    });
+
+    const firstVirtualBackgroundButton = getAllByRole('button')[4];
+
+    expect(firstVirtualBackgroundButton).toHaveAttribute('aria-pressed', 'false');
   });
 });

--- a/apps/webapp/src/script/components/calling/VideoControls/VideoBackgroundSettings/VideoBackgroundSettings.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/VideoBackgroundSettings/VideoBackgroundSettings.tsx
@@ -157,7 +157,6 @@ export const VideoBackgroundSettings = ({
 
         <div>
           <Checkbox
-            disabled={true}
             id="enable-high-quality-blur"
             checked={highQualityBlurAllowed}
             data-uie-name="enable-high-quality-blur"

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -347,14 +347,8 @@ export class CallingRepository {
     await this.applyCurrentBackgroundEffectOnSelfParticipant(true);
   }
 
-  public allowSuperhighQualityTier(event: boolean) {
-    if (this.isSuperhighQualityTierAllowed()) {
-      this.backgroundEffectsHandler.enableSuperhighQualityTier(event);
-    }
-  }
-
-  public isSuperhighQualityTierAllowed() {
-    return this.backgroundEffectsHandler.isSuperhighQualityTierAllowed();
+  public allowSuperhighQualityTier(enable: boolean) {
+    this.backgroundEffectsHandler.enableSuperhighQualityTier(enable);
   }
 
   public getBackgroundEffectsHandler(): BackgroundEffectsHandler {

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/backgroundEffectsController.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/backgroundEffectsController.ts
@@ -216,6 +216,11 @@ export class BackgroundEffectsController {
     return this.maxQualityTier;
   }
 
+  public setModelPath(path: string): void {
+    this.options = {...this.options, modelPath: path};
+    this.pushOptionsUpdate();
+  }
+
   private applyImageBitmap(bitmap: ImageBitmap, url: string): void {
     const workerSource: WorkerBackgroundSource = {type: 'image', media: bitmap, url};
     // Record the url without the bitmap so the options object remains serialisable.

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/options.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/options.ts
@@ -72,6 +72,9 @@ export type WorkerProcessVideoTrackOptions = Omit<
   backgroundSource: WorkerBackgroundSource | null;
 };
 
+export const SELFIE_MULTICLASS_MODEL_PATH = '/assets/mediapipe-models/selfie_multiclass_256x256.tflite';
+export const SELFIE_SEGMENTER_MODEL_PATH = '/assets/mediapipe-models/selfie_segmenter_landscape.tflite';
+
 /**
  * Configuration options for the virtual background.
  */
@@ -79,7 +82,7 @@ export const defaultOpts = {
   // MediaPipe options.
   wasmLoaderPath: '/min/mediapipe/wasm/vision_wasm_internal.js',
   wasmBinaryPath: '/min/mediapipe/wasm/vision_wasm_internal.wasm',
-  modelPath: '/assets/mediapipe-models/selfie_multiclass_256x256.tflite',
+  modelPath: SELFIE_MULTICLASS_MODEL_PATH,
   useWorker: !Runtime.isFirefox(),
 
   // Virtual background options.

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/segmenter.test.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/segmenter.test.ts
@@ -1,0 +1,23 @@
+import {getSegmenterModelUpdatedOptions} from 'Repositories/media/backgroundEffects/pipe/segmenter';
+
+describe('getSegmenterModelUpdatedOptions', () => {
+  it('returns null when model path has not changed', () => {
+    expect(getSegmenterModelUpdatedOptions('model-a.tflite', 'model-a.tflite')).toBeNull();
+  });
+
+  it('returns updated options when model path changes', () => {
+    expect(getSegmenterModelUpdatedOptions('model-b.tflite', 'model-a.tflite')).toEqual({
+      baseOptions: {
+        modelAssetPath: 'model-b.tflite',
+      },
+    });
+  });
+
+  it('returns updated options when current model path is undefined', () => {
+    expect(getSegmenterModelUpdatedOptions('model-a.tflite', undefined)).toEqual({
+      baseOptions: {
+        modelAssetPath: 'model-a.tflite',
+      },
+    });
+  });
+});

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/segmenter.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/segmenter.ts
@@ -96,24 +96,29 @@ export async function runSegmenter(
   attachCanvasEvents();
 
   let segmenter = await createSegmenter(canvas);
+  let currentModelPath = segmenterOptions.modelPath;
+  let restartPending = false;
 
   function restartSegmenter() {
+    restartPending = true;
+    const targetModelPath = segmenterOptions.modelPath;
     createSegmenter(canvas)
       .then(newSegmenter => {
         const oldSegmenter = segmenter;
         segmenter = newSegmenter;
+        currentModelPath = targetModelPath;
+        restartPending = false;
         oldSegmenter.close();
       })
       .catch((e: unknown) => {
         logger.error('Error restarting segmenter:', e);
+        restartPending = false;
       });
   }
 
   // Filters.
   const effectsCanvas = new OffscreenCanvas(1, 1);
   const videoFilter = new VideoFilter(effectsCanvas);
-
-  const useSelfieModel = !!segmenterOptions.modelPath?.includes('selfie_segmenter');
 
   // Metrics
   const metricsWindow = createMetricsWindow(60);
@@ -153,6 +158,16 @@ export async function runSegmenter(
           videoFrame.close();
           return;
         }
+
+        if (
+          restartPending === false &&
+          segmenterOptions.modelPath !== undefined &&
+          segmenterOptions.modelPath !== currentModelPath
+        ) {
+          restartSegmenter();
+        }
+
+        const useSelfieModel = currentModelPath?.includes('selfie_segmenter');
 
         // start to process the frame
         const frameStart = performance.now();

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/segmenter.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/segmenter.ts
@@ -59,6 +59,21 @@ async function createSegmenter(canvas: OffscreenCanvas) {
   return segmenter;
 }
 
+export function getSegmenterModelUpdatedOptions(
+  targetModelPath: string | undefined,
+  currentModelPath: string | undefined,
+) {
+  if (targetModelPath === currentModelPath) {
+    return null;
+  }
+
+  return {
+    baseOptions: {
+      modelAssetPath: targetModelPath,
+    },
+  };
+}
+
 export async function runSegmenter(
   canvas: OffscreenCanvas,
   readable: ReadableStream,
@@ -82,6 +97,7 @@ export async function runSegmenter(
     logger.log(`[virtual-background] webglcontextrestored (${!!webGLRenderer})`);
     if (!webGLRenderer) {
       setTimeout(() => {
+        logger.log('[virtual-background] restart segmenter onContextRestored');
         webGLRenderer = new WebGLRenderer(canvas);
         restartSegmenter();
         attachCanvasEvents();
@@ -97,23 +113,36 @@ export async function runSegmenter(
 
   let segmenter = await createSegmenter(canvas);
   let currentModelPath = segmenterOptions.modelPath;
-  let restartPending = false;
 
   function restartSegmenter() {
-    restartPending = true;
     const targetModelPath = segmenterOptions.modelPath;
     createSegmenter(canvas)
       .then(newSegmenter => {
         const oldSegmenter = segmenter;
         segmenter = newSegmenter;
         currentModelPath = targetModelPath;
-        restartPending = false;
         oldSegmenter.close();
       })
-      .catch((e: unknown) => {
-        logger.error('Error restarting segmenter:', e);
-        restartPending = false;
+      .catch((error: unknown) => {
+        logger.error('Error restarting segmenter:', error);
       });
+  }
+
+  async function updateSegmenterModel() {
+    const targetModelPath = segmenterOptions.modelPath;
+    const nextOptions = getSegmenterModelUpdatedOptions(targetModelPath, currentModelPath);
+
+    if (nextOptions === null) {
+      return;
+    }
+
+    try {
+      logger.log(`[virtual-background] model is changed to ${nextOptions.baseOptions.modelAssetPath}`);
+      await segmenter.setOptions(nextOptions);
+      currentModelPath = targetModelPath;
+    } catch (error: unknown) {
+      logger.error('[virtual-background] Error updating segmenter model:', error);
+    }
   }
 
   // Filters.
@@ -159,13 +188,7 @@ export async function runSegmenter(
           return;
         }
 
-        if (
-          restartPending === false &&
-          segmenterOptions.modelPath !== undefined &&
-          segmenterOptions.modelPath !== currentModelPath
-        ) {
-          restartSegmenter();
-        }
+        await updateSegmenterModel();
 
         const useSelfieModel = currentModelPath?.includes('selfie_segmenter');
 
@@ -264,6 +287,7 @@ export async function runSegmenter(
 
         // Restart segmenter to avoid memory leaks.
         if (segmenterOptions.restartEvery && totalFrames % segmenterOptions.restartEvery === 0) {
+          logger.log('[virtual-background] restart segmenter to avoid memory leaks');
           restartSegmenter();
         }
       },

--- a/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.test.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.test.ts
@@ -20,6 +20,10 @@
 import {BackgroundEffectsHandler, ReleasableMediaStream} from './backgroundEffectsHandler';
 import {backgroundEffectsStore} from './useBackgroundEffectsStore';
 import {DEFAULT_BUILTIN_BACKGROUND_ID} from 'Repositories/media/VideoBackgroundEffects';
+import {
+  SELFIE_MULTICLASS_MODEL_PATH,
+  SELFIE_SEGMENTER_MODEL_PATH,
+} from 'Repositories/media/backgroundEffects/pipe/options';
 
 // Mocks
 jest.mock('Util/localStorage', () => ({
@@ -49,6 +53,7 @@ describe('BackgroundEffectsHandler', () => {
     backgroundEffectsStore.getState().setPreferredEffect({type: 'none'});
     backgroundEffectsStore.getState().setMetrics(undefined);
     backgroundEffectsStore.getState().setLastVirtualBackgroundId(DEFAULT_BUILTIN_BACKGROUND_ID);
+    backgroundEffectsStore.getState().setIsHighQualityBlurEnabled(true);
   });
 
   beforeEach(() => {
@@ -59,6 +64,7 @@ describe('BackgroundEffectsHandler', () => {
       setMode: jest.fn(),
       setBlurStrength: jest.fn(),
       setBackgroundSource: jest.fn(),
+      setModelPath: jest.fn(),
     };
 
     mockStorage = {
@@ -107,7 +113,7 @@ describe('BackgroundEffectsHandler', () => {
   it('applies blur effect successfully', async () => {
     const handler = new BackgroundEffectsHandler(mockController);
 
-    handler.setPreferredBackgroundEffect({type: 'blur', level: 'high'} as any);
+    handler.setPreferredBackgroundEffect({type: 'blur', level: 'high'});
 
     const outputTrack = {stop: jest.fn()};
 
@@ -169,7 +175,7 @@ describe('BackgroundEffectsHandler', () => {
   it('handles controller error gracefully', async () => {
     const handler = new BackgroundEffectsHandler(mockController);
 
-    handler.setPreferredBackgroundEffect({type: 'blur', level: 'high'} as any);
+    handler.setPreferredBackgroundEffect({type: 'blur', level: 'high'});
 
     mockController.start.mockRejectedValue(new Error('fail'));
 
@@ -184,7 +190,7 @@ describe('BackgroundEffectsHandler', () => {
   it('falls back to default virtual when custom has no source', () => {
     const handler = new BackgroundEffectsHandler(mockController);
 
-    handler.setPreferredBackgroundEffect({type: 'custom'} as any);
+    handler.setPreferredBackgroundEffect({type: 'custom'});
 
     expect(backgroundEffectsStore.getState().preferredEffect.type).toBe('virtual');
   });
@@ -208,7 +214,7 @@ describe('BackgroundEffectsHandler', () => {
 
   it('releases processed stream correctly', async () => {
     const handler = new BackgroundEffectsHandler(mockController);
-    handler.setPreferredBackgroundEffect({type: 'blur', level: 'high'} as any);
+    handler.setPreferredBackgroundEffect({type: 'blur', level: 'high'});
 
     const outputTrack = {stop: jest.fn()};
     const stop = jest.fn();
@@ -302,5 +308,23 @@ describe('BackgroundEffectsHandler', () => {
     );
     expect(virtualIdCalls).toHaveLength(1);
     expect(virtualIdCalls[0][1]).toBe('office-2');
+  });
+
+  it('enables super high quality tier by switching to multiclass model and updating store', () => {
+    const handler = new BackgroundEffectsHandler(mockController);
+
+    handler.enableSuperhighQualityTier(true);
+
+    expect(mockController.setModelPath).toHaveBeenCalledWith(SELFIE_MULTICLASS_MODEL_PATH);
+    expect(backgroundEffectsStore.getState().isHighQualityBlurEnabled).toBe(true);
+  });
+
+  it('disables super high quality tier by switching to segmenter model and updating store', () => {
+    const handler = new BackgroundEffectsHandler(mockController);
+
+    handler.enableSuperhighQualityTier(false);
+
+    expect(mockController.setModelPath).toHaveBeenCalledWith(SELFIE_SEGMENTER_MODEL_PATH);
+    expect(backgroundEffectsStore.getState().isHighQualityBlurEnabled).toBe(false);
   });
 });

--- a/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.ts
@@ -20,7 +20,11 @@
 import {Metrics, QualityMode} from 'Repositories/media/backgroundEffects';
 import {BackgroundEffectsController} from 'Repositories/media/backgroundEffects/backgroundEffectsController';
 import {CapabilityInfo} from 'Repositories/media/backgroundEffects/backgroundEffectsWorkerTypes';
-import {defaultOpts} from 'Repositories/media/backgroundEffects/pipe/options';
+import {
+  defaultOpts,
+  SELFIE_MULTICLASS_MODEL_PATH,
+  SELFIE_SEGMENTER_MODEL_PATH,
+} from 'Repositories/media/backgroundEffects/pipe/options';
 import {
   BackgroundEffectSelection,
   BackgroundSource,
@@ -235,7 +239,8 @@ export class BackgroundEffectsHandler {
   }
 
   public enableSuperhighQualityTier(enable: boolean): void {
-    this.controller.setMaxQualityTier(enable ? 'superhigh' : 'high');
+    this.controller.setModelPath(enable ? SELFIE_MULTICLASS_MODEL_PATH : SELFIE_SEGMENTER_MODEL_PATH);
+    backgroundEffectsStore.getState().setIsHighQualityBlurEnabled(enable);
   }
 
   public isSuperhighQualityTierAllowed(): boolean {

--- a/apps/webapp/src/script/repositories/media/useBackgroundEffectsStore.test.ts
+++ b/apps/webapp/src/script/repositories/media/useBackgroundEffectsStore.test.ts
@@ -22,4 +22,21 @@ describe('backgroundEffectsStore:lastVirtualBackgroundId', () => {
     expect(state.lastVirtualBackgroundId).toBeDefined();
     expect(typeof state.lastVirtualBackgroundId).toBe('string');
   });
+
+  it('initializes high quality blur as enabled', () => {
+    expect(backgroundEffectsStore.getState().isHighQualityBlurEnabled).toBe(true);
+  });
+
+  it('updates isHighQualityBlurEnabled when setIsHighQualityBlurEnabled is called', () => {
+    backgroundEffectsStore.getState().setIsHighQualityBlurEnabled(false);
+
+    expect(backgroundEffectsStore.getState().isHighQualityBlurEnabled).toBe(false);
+  });
+
+  it('can enable high quality blur again', () => {
+    backgroundEffectsStore.getState().setIsHighQualityBlurEnabled(false);
+    backgroundEffectsStore.getState().setIsHighQualityBlurEnabled(true);
+
+    expect(backgroundEffectsStore.getState().isHighQualityBlurEnabled).toBe(true);
+  });
 });

--- a/apps/webapp/src/script/repositories/media/useBackgroundEffectsStore.ts
+++ b/apps/webapp/src/script/repositories/media/useBackgroundEffectsStore.ts
@@ -43,12 +43,14 @@ export type BackgroundEffectsState = {
   metrics: RenderMetrics | undefined;
   model: string;
   lastVirtualBackgroundId: string;
+  isHighQualityBlurEnabled: boolean;
 
   setIsFeatureEnabled(value: boolean): void;
   setPreferredEffect(effect: BackgroundEffectSelection): void;
   setLastVirtualBackgroundId(backgroundId: string): void;
   setMetrics(metrics: RenderMetrics | undefined): void;
   setModel(model: string | undefined): void;
+  setIsHighQualityBlurEnabled(value: boolean): void;
 };
 
 export const backgroundEffectsStore = createStore<BackgroundEffectsState>()(
@@ -58,6 +60,7 @@ export const backgroundEffectsStore = createStore<BackgroundEffectsState>()(
     metrics: undefined,
     model: 'unknown',
     lastVirtualBackgroundId: DEFAULT_BUILTIN_BACKGROUND_ID,
+    isHighQualityBlurEnabled: true,
 
     setIsFeatureEnabled: value =>
       set(state => {
@@ -81,6 +84,11 @@ export const backgroundEffectsStore = createStore<BackgroundEffectsState>()(
     setModel: model =>
       set(state => {
         state.model = model ?? 'unknown';
+      }),
+
+    setIsHighQualityBlurEnabled: value =>
+      set(state => {
+        state.isHighQualityBlurEnabled = value;
       }),
   })),
 );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25492" title="WPB-25492" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25492</a>  [Web] - Make High quality blur checkbox work
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Enable the checkbox to switch between models.

By default selfie_multiclass model is used with checkbox enabled.

On disabling this checkbox it will use selfie_segmentation model.