### PR TITLE
Inject fire-and-forget invoker into application services [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/main/createApplicationServices.test.ts
+++ b/apps/webapp/src/script/main/createApplicationServices.test.ts
@@ -17,21 +17,33 @@
  *
  */
 
+import {FireAndForgetInvoker} from '@wireapp/core';
+
 import {createDeterministicWallClock} from '../clock/deterministicWallClock';
 import {createApplicationServices} from './createApplicationServices';
 
 describe('createApplicationServices', () => {
   it('creates wall clock through injected dependency', () => {
     const deterministicWallClock = createDeterministicWallClock();
+    const fireAndForgetInvoker = {
+      fireAndForget: jest.fn(),
+      waitUntilAllSettled: jest.fn(async () => {}),
+    } as FireAndForgetInvoker;
+    const createFireAndForgetInvoker = jest.fn(() => {
+      return fireAndForgetInvoker;
+    });
     const createWallClock = jest.fn(() => {
       return deterministicWallClock;
     });
 
     const applicationServices = createApplicationServices({
+      createFireAndForgetInvoker,
       createWallClock,
     });
 
+    expect(applicationServices.fireAndForgetInvoker).toBe(fireAndForgetInvoker);
     expect(applicationServices.wallClock).toBe(deterministicWallClock);
+    expect(createFireAndForgetInvoker).toHaveBeenCalledTimes(1);
     expect(createWallClock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/webapp/src/script/main/createApplicationServices.test.ts
+++ b/apps/webapp/src/script/main/createApplicationServices.test.ts
@@ -23,7 +23,7 @@ import {createDeterministicWallClock} from '../clock/deterministicWallClock';
 import {createApplicationServices} from './createApplicationServices';
 
 describe('createApplicationServices', () => {
-  it('creates wall clock through injected dependency', () => {
+  it('creates wall clock and fire-and-forget invoker through injected dependencies', () => {
     const deterministicWallClock = createDeterministicWallClock();
     const fireAndForgetInvoker = {
       fireAndForget: jest.fn(),

--- a/apps/webapp/src/script/main/createApplicationServices.ts
+++ b/apps/webapp/src/script/main/createApplicationServices.ts
@@ -17,20 +17,25 @@
  *
  */
 
+import {FireAndForgetInvoker} from '@wireapp/core';
+
 import {WallClock} from '../clock/wallClock';
 
 export type ApplicationServices = {
+  readonly fireAndForgetInvoker: FireAndForgetInvoker;
   readonly wallClock: WallClock;
 };
 
 type CreateApplicationServicesDependencies = {
+  readonly createFireAndForgetInvoker: () => FireAndForgetInvoker;
   readonly createWallClock: () => WallClock;
 };
 
 export function createApplicationServices(dependencies: CreateApplicationServicesDependencies): ApplicationServices {
-  const {createWallClock} = dependencies;
+  const {createFireAndForgetInvoker, createWallClock} = dependencies;
 
   return {
+    fireAndForgetInvoker: createFireAndForgetInvoker(),
     wallClock: createWallClock(),
   };
 }

--- a/apps/webapp/src/script/main/index.tsx
+++ b/apps/webapp/src/script/main/index.tsx
@@ -27,10 +27,12 @@ import {createRoot} from 'react-dom/client';
 import {container} from 'tsyringe';
 
 import {Runtime} from '@wireapp/commons';
+import {createFireAndForgetInvoker} from '@wireapp/core';
 
 import {AppContainer} from 'Components/AppContainer/AppContainer';
 import {doSimpleRedirect} from 'Repositories/LifeCycleRepository/LifeCycleRepository';
 import {StorageKey} from 'Repositories/storage';
+import {getLogger} from 'Util/logger';
 import {enableLogging} from 'Util/loggerUtil';
 import {loadValue} from 'Util/storageUtil';
 import {exposeWrapperGlobals} from 'Util/wrapper';
@@ -73,7 +75,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(globalThis.location.search);
+  const fireAndForgetInvokerLogger = getLogger('FireAndForgetInvoker');
   const applicationServices = createApplicationServices({
+    createFireAndForgetInvoker: () => {
+      return createFireAndForgetInvoker({logger: fireAndForgetInvokerLogger});
+    },
     createWallClock,
   });
   const {isFeatureToggleEnabled} = startupFeatureToggles;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Extend the webapp composition root so fire-and-forget invocation is created via dependency injection. The intent is to establish a single, explicit construction point for runtime services and make fire-and-forget behavior injectable/testable before exposing it through React context and migrating call sites.


