### PR TITLE
ci: enable type checking for e2e_tests folder [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/backend/inbucketClient.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/inbucketClient.e2e.ts
@@ -109,7 +109,7 @@ export class InbucketClientE2E {
       timeout++;
     }
 
-    if (this.isValidURL(matchingUrl) === false) {
+    if (matchingUrl === undefined || this.isValidURL(matchingUrl) === false) {
       throw new Error('Matching URL not found in the email body');
     }
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/createConversation.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/createConversation.ts
@@ -25,7 +25,7 @@ export const CreateConversationModal = (page: Page) => {
 
     await nextButton.click();
 
-    if (options.members) {
+    if (options?.members !== undefined) {
       await addMembers(options.members);
     }
 
@@ -40,7 +40,7 @@ export const CreateConversationModal = (page: Page) => {
     await nextButton.click();
     await nextButton.click();
 
-    if (options.members) {
+    if (options?.members !== undefined) {
       await addMembers(options.members);
     }
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/guestOptions.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/guestOptions.page.ts
@@ -52,7 +52,11 @@ export const GuestOptionsPage = (page: Page) => {
       await new ConfirmModal(page).actionButton.click();
     }
 
-    return await guestLink.textContent();
+    const guestLinkText = await guestLink.textContent();
+    if (guestLinkText === null || guestLinkText.length <= 0)
+      throw new Error("Can't copy guest link since it was empty");
+
+    return guestLinkText;
   };
 
   const revokeLink = async () => {

--- a/apps/webapp/test/e2e_tests/scripts/send-playwright-results-to-testiny.ts
+++ b/apps/webapp/test/e2e_tests/scripts/send-playwright-results-to-testiny.ts
@@ -137,6 +137,8 @@ const PROJECT = process.env.TESTINY_PROJECT ?? '3';
 const projectField = Number.isNaN(Number(PROJECT)) ? {project_key: PROJECT} : {project_id: Number(PROJECT)};
 
 async function testinyRequest<T>(method: string, endpoint: string, body?: Body): Promise<T> {
+  if (API_KEY === undefined) throw new Error("Can't make request to Testiny without TESTINY_API_KEY");
+
   const res = await fetch(`${BASE_URL}${endpoint}`, {
     method,
     headers: {'Content-Type': 'application/json', 'X-Api-Key': API_KEY},

--- a/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
+++ b/apps/webapp/test/e2e_tests/scripts/uploadTestReport.ts
@@ -150,9 +150,9 @@ async function addTestResultsToRun(testCaseMappings: TestinyTestCaseMapping[]) {
 }
 
 async function main() {
-  if (!args.testinyApiKey) throw new Error('Missing required arg testinyApiKey');
-  if (!args.reportPath) throw new Error('Missing required arg reportPath');
-  if (!args.runName) throw new Error('Missing required arg runName');
+  if (args.testinyApiKey === undefined) throw new Error('Missing required arg testinyApiKey');
+  if (args.reportPath === undefined) throw new Error('Missing required arg reportPath');
+  if (args.runName === undefined) throw new Error('Missing required arg runName');
 
   const reportAbsPath = path.resolve(args.reportPath);
   if (!fs.existsSync(reportAbsPath)) {

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -459,6 +459,7 @@ test.describe('Guestroom', () => {
       // WORKAROUND: The 'Join in Browser' button currently redirects to Production.
       // To maintain the existing logged-in session, we must force the invitation
       // URL to use the same environment as our current test session.
+      if (process.env.WEBAPP_URL === undefined) throw new Error(`Missing env var "WEBAPP_URL"`);
       const envUrl = new URL(process.env.WEBAPP_URL);
       const invitationLink = new URL(guestPage.url());
 
@@ -516,6 +517,7 @@ test.describe('Guestroom', () => {
       // WORKAROUND: The 'Join in Browser' button currently redirects to Production.
       // To maintain the existing logged-in session, we must force the invitation
       // URL to use the same environment as our current test session.
+      if (process.env.WEBAPP_URL === undefined) throw new Error(`Missing env var "WEBAPP_URL"`);
       const envUrl = new URL(process.env.WEBAPP_URL);
       const invitationLink = new URL(guestPage.url());
 

--- a/apps/webapp/tsconfig.build.json
+++ b/apps/webapp/tsconfig.build.json
@@ -5,6 +5,5 @@
     "declaration": false,
     "declarationMap": false
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "../server/", "src/sw.js", "src/worker/", "test/**/*", "**/*.test.*", "**/*.spec.*"]
+  "exclude": ["node_modules", "../server/", "src/sw.js", "src/worker/", "test/unit_tests/**", "test/helper/**", "**/*.test.*"]
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
I noticed that the e2e_tests folder was excluded from type checking on CI. Since we want to catch silly mistakes early I re-enabled it and fixed the few issues which were found.

> Note: All other `.test.*` files are still excluded from type checking, but changing that is out of scope for this PR