### PR TITLE
ensure mls conversation is established when joining with guest link [WPB-22305]

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -1602,9 +1602,9 @@ export class ConversationRepository {
               });
               if (response) {
                 await this.onMemberJoin(conversationEntity, response);
+                await this.addOtherSelfUserClientsToMLSConversation(conversationEntity);
+                amplify.publish(WebAppEvents.CONVERSATION.SHOW, conversationEntity, {});
               }
-              await this.addOtherSelfUserClientsToMLSConversation(conversationEntity);
-              amplify.publish(WebAppEvents.CONVERSATION.SHOW, conversationEntity, {});
             } catch (error: unknown) {
               if (!isBackendError(error)) {
                 throw error;
@@ -1678,6 +1678,11 @@ export class ConversationRepository {
       conversationId: conversationEntity.qualifiedId,
       groupId: conversationEntity.groupId,
       qualifiedUsers: [selfUserQualifiedId],
+    });
+
+    await this.ensureConversationExists({
+      conversationId: conversationEntity.qualifiedId,
+      groupId: conversationEntity.groupId,
     });
 
     await this.core.service?.conversation?.addUsersToMLSConversation({


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22305" title="WPB-22305" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-22305</a>  [Web] Joining MLS conversation by guest link doesn't produce welcome message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Before trying to add other self clients to the MLS conversation upon joining with guest link we need to make sure the current self client joins the conversation by external commit first


