### PR TITLE
test: improve TC-369 by sending connection requests sequentially [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
@@ -58,23 +58,28 @@ test.describe('Connections', () => {
         PageManager.from(createPage(withLogin(memberB))),
         PageManager.from(createPage(withLogin(memberC))),
       ]);
-      await sendConnectionRequest(memberAPage, memberB);
-      await sendConnectionRequest(memberAPage, memberC);
 
       const [memberAPages, memberBPages, memberCPages] = [memberAPage, memberBPage, memberCPage].map(
         page => page.webapp.pages,
       );
 
       await test.step('B & C accept connection requests from A', async () => {
-        for (const pages of [memberBPages, memberCPages]) {
-          await pages.conversationList().pendingConnectionRequest.click();
-          await pages.connectRequest().connectButton.click();
-        }
+        await sendConnectionRequest(memberAPage, memberB);
+        await memberBPages.conversationList().pendingConnectionRequest.click();
+        await memberBPages.connectRequest().connectButton.click();
+
+        await sendConnectionRequest(memberAPage, memberC);
+        await memberCPages.conversationList().pendingConnectionRequest.click();
+        await memberCPages.connectRequest().connectButton.click();
       });
 
       await test.step('A creates a group with B & C', async () => {
-        await expect(memberAPages.conversationList().getConversation(memberB.fullName)).toBeAttached();
-        await expect(memberAPages.conversationList().getConversation(memberC.fullName)).toBeAttached();
+        await expect(
+          memberAPages.conversationList().getConversation(memberB.fullName, {protocol: 'mls'}),
+        ).toBeAttached();
+        await expect(
+          memberAPages.conversationList().getConversation(memberC.fullName, {protocol: 'mls'}),
+        ).toBeAttached();
 
         await createGroup(memberAPages, 'Group', [memberB, memberC]);
       });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Previously it could happen that the second pending connection request causes strict mode violations