### PR TITLE
Expose fire-and-forget invoker through Root context [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/AppContainer/AppContainer.tsx
+++ b/apps/webapp/src/script/components/AppContainer/AppContainer.tsx
@@ -23,6 +23,7 @@ import {ClientType} from '@wireapp/api-client/lib/client/';
 import {amplify} from 'amplify';
 import {container} from 'tsyringe';
 
+import {FireAndForgetInvoker} from '@wireapp/core';
 import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
@@ -53,11 +54,13 @@ import {AppLoader} from '../AppLoader';
 type AppProps = {
   readonly config: Configuration;
   readonly clientType: ClientType;
+  readonly fireAndForgetInvoker: FireAndForgetInvoker;
   readonly isFeatureToggleEnabled: (featureName: StartupFeatureToggleName) => boolean;
   readonly wallClock: WallClock;
 };
 
-export const AppContainer = ({config, clientType, isFeatureToggleEnabled, wallClock}: AppProps) => {
+export const AppContainer = (properties: AppProps) => {
+  const {config, clientType, fireAndForgetInvoker, isFeatureToggleEnabled, wallClock} = properties;
   setAppLocale();
   const app = useMemo(() => {
     return new App(container.resolve(Core), container.resolve(APIClient), config);
@@ -123,6 +126,7 @@ export const AppContainer = ({config, clientType, isFeatureToggleEnabled, wallCl
               selfUser={selfUser}
               mainView={mainView}
               locked={softLockEnabled}
+              fireAndForgetInvoker={fireAndForgetInvoker}
               wallClock={wallClock}
             />
           );

--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.test.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.test.tsx
@@ -13,6 +13,8 @@ import {mockStoreFactory} from '../../../auth/util/test/mockStoreFactory';
 import {initialRootState} from '../../../auth/module/reducer';
 import {t} from 'Util/localizerUtil';
 import {TypeUtil} from '@wireapp/commons';
+import {createDeterministicWallClock} from 'src/script/clock/deterministicWallClock';
+import {createRootContextValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 
 type TeamStateDateSet = {
   isAppsEnabled: boolean;
@@ -92,10 +94,14 @@ describe('GroupCreationModal', () => {
           },
         },
       } as RootContextValue;
+      const rootContextValue = createRootContextValueForTest({
+        mainViewModel: mockRootContext.mainViewModel,
+        wallClock: createDeterministicWallClock(),
+      });
 
       // Act
       const {getByTestId} = mountComponent(
-        <RootContext.Provider value={mockRootContext}>
+        <RootContext.Provider value={rootContextValue}>
           <GroupCreationModal userState={mockUserState} teamState={mockTeamState as TeamState} />
         </RootContext.Provider>,
         mockStoreFactory()({

--- a/apps/webapp/src/script/main/index.tsx
+++ b/apps/webapp/src/script/main/index.tsx
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     createWallClock,
   });
   const {isFeatureToggleEnabled} = startupFeatureToggles;
-  const {wallClock} = applicationServices;
+  const {fireAndForgetInvoker, wallClock} = applicationServices;
   const apiClient = createAPIClient();
   const core = new Core(apiClient);
   const cleanupIncrementalHttpRetryBackoffReset = createIncrementalHttpRetryBackoffReset({
@@ -116,6 +116,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     <AppContainer
       config={config}
       clientType={shouldPersist ? ClientType.PERMANENT : ClientType.TEMPORARY}
+      fireAndForgetInvoker={fireAndForgetInvoker}
       isFeatureToggleEnabled={isFeatureToggleEnabled}
       wallClock={wallClock}
     />,

--- a/apps/webapp/src/script/page/AppMain.tsx
+++ b/apps/webapp/src/script/page/AppMain.tsx
@@ -25,6 +25,7 @@ import ky from 'ky';
 import {ErrorBoundary} from 'react-error-boundary';
 import {container} from 'tsyringe';
 
+import {FireAndForgetInvoker} from '@wireapp/core';
 import {QUERY, StyledApp, THEME_ID, useMatchMedia} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
@@ -84,6 +85,7 @@ export type RightSidebarParams = {
 
 type AppMainProps = {
   readonly app: App;
+  readonly fireAndForgetInvoker: FireAndForgetInvoker;
   readonly isFeatureToggleEnabled: (featureName: StartupFeatureToggleName) => boolean;
   readonly selfUser: User;
   readonly mainView: MainViewModel;
@@ -94,16 +96,18 @@ type AppMainProps = {
   readonly locked: boolean;
 };
 
-export const AppMain = ({
-  app,
-  isFeatureToggleEnabled,
-  mainView,
-  selfUser,
-  conversationState = container.resolve(ConversationState),
-  callState = container.resolve(CallState),
-  wallClock,
-  locked,
-}: AppMainProps) => {
+export const AppMain = (properties: AppMainProps) => {
+  const {
+    app,
+    fireAndForgetInvoker,
+    isFeatureToggleEnabled,
+    mainView,
+    selfUser,
+    conversationState = container.resolve(ConversationState),
+    callState = container.resolve(CallState),
+    wallClock,
+    locked,
+  } = properties;
   const [doesApplicationNeedForceReload, setDoesApplicationNeedForceReload] = useState(false);
   const clientVersion = Config.getConfig().VERSION;
   const runApplicationPeriodicCheck: () => void = useCallback(() => {
@@ -312,6 +316,7 @@ export const AppMain = ({
       {!locked && <WindowTitleUpdater />}
       <RootProvider
         value={{
+          fireAndForgetInvoker,
           mainViewModel: mainView,
           wallClock,
           doesApplicationNeedForceReload,

--- a/apps/webapp/src/script/page/MainContent/MainContent.test.tsx
+++ b/apps/webapp/src/script/page/MainContent/MainContent.test.tsx
@@ -28,6 +28,7 @@ import {MainContent} from './MainContent';
 import {withTheme} from '../../auth/util/test/TestUtil';
 import {MainViewModel} from '../../view_model/MainViewModel';
 import {createDeterministicWallClock} from '../../clock/deterministicWallClock';
+import {createRootContextValueForTest} from '../testSupport/rootContextTestSupport';
 import {RootProvider} from '../RootProvider';
 import {ContentState, useAppState} from '../useAppState';
 
@@ -80,12 +81,11 @@ describe('Preferences', () => {
     render(
       withTheme(
         <RootProvider
-          value={{
+          value={createRootContextValueForTest({
+            isFeatureToggleEnabled: isFeatureToggleDisabledForTest,
             mainViewModel,
             wallClock,
-            doesApplicationNeedForceReload: false,
-            isFeatureToggleEnabled: isFeatureToggleDisabledForTest,
-          }}
+          })}
         >
           <MainContent {...defaultParams} />
         </RootProvider>,

--- a/apps/webapp/src/script/page/RootProvider.test.tsx
+++ b/apps/webapp/src/script/page/RootProvider.test.tsx
@@ -25,6 +25,7 @@ import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles'
 import {createDeterministicWallClock} from '../clock/deterministicWallClock';
 import {reliableWebsocketConnectionFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
 import {MainViewModel} from '../view_model/MainViewModel';
+import {createRootContextValueForTest, createRootProviderWrapperForTest} from './testSupport/rootContextTestSupport';
 import {RootContext, RootContextValue, RootProvider, useApplicationContext, useMainViewModel} from './RootProvider';
 
 interface WrapperProperties {
@@ -35,6 +36,7 @@ interface RootProviderWrapper {
   wrapper: (properties: WrapperProperties) => ReactNode;
   isFeatureToggleEnabled: jest.Mock<boolean, [StartupFeatureToggleName]>;
   deterministicWallClock: ReturnType<typeof createDeterministicWallClock>;
+  rootContextValue: RootContextValue;
 }
 
 function createRootProviderWrapper(
@@ -50,25 +52,15 @@ function createRootProviderWrapper(
   }
 
   const isFeatureToggleEnabled = jest.fn(isFeatureToggleEnabledForTest);
+  const rootContextValue = createRootContextValueForTest({
+    doesApplicationNeedForceReload,
+    isFeatureToggleEnabled,
+    mainViewModel,
+    wallClock: deterministicWallClock,
+  });
+  const wrapper = createRootProviderWrapperForTest(rootContextValue);
 
-  function wrapper(properties: WrapperProperties): ReactNode {
-    const wrappedChildren = (
-      <RootProvider
-        value={{
-          mainViewModel,
-          wallClock: deterministicWallClock,
-          doesApplicationNeedForceReload,
-          isFeatureToggleEnabled,
-        }}
-      >
-        {properties.children}
-      </RootProvider>
-    );
-
-    return wrappedChildren;
-  }
-
-  return {wrapper, deterministicWallClock, isFeatureToggleEnabled};
+  return {wrapper, deterministicWallClock, isFeatureToggleEnabled, rootContextValue};
 }
 
 function getRootContextValue(): RootContextValue | null {
@@ -81,11 +73,12 @@ describe('RootProvider', () => {
   const mainViewModel = {} as MainViewModel;
 
   it('provides the injected wall clock through context', () => {
-    const {wrapper, deterministicWallClock} = createRootProviderWrapper(mainViewModel, 1_234, false);
+    const {wrapper, deterministicWallClock, rootContextValue} = createRootProviderWrapper(mainViewModel, 1_234, false);
 
     const {result} = renderHook(getRootContextValue, {wrapper});
 
     expect(result.current?.mainViewModel).toBe(mainViewModel);
+    expect(result.current?.fireAndForgetInvoker).toBe(rootContextValue.fireAndForgetInvoker);
     expect(result.current?.wallClock).toBe(deterministicWallClock);
     expect(result.current?.wallClock.currentTimestampInMilliseconds).toBe(1_234);
     expect(result.current?.doesApplicationNeedForceReload).toBe(false);

--- a/apps/webapp/src/script/page/RootProvider.tsx
+++ b/apps/webapp/src/script/page/RootProvider.tsx
@@ -19,11 +19,14 @@
 
 import {ReactNode, ReactElement, createContext, useContext, useMemo} from 'react';
 
+import {FireAndForgetInvoker} from '@wireapp/core';
+
 import {WallClock} from '../clock/wallClock';
 import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles';
 import {MainViewModel} from '../view_model/MainViewModel';
 
 export type RootContextValue = {
+  readonly fireAndForgetInvoker: FireAndForgetInvoker;
   readonly mainViewModel: MainViewModel;
   readonly wallClock: WallClock;
   readonly doesApplicationNeedForceReload: boolean;

--- a/apps/webapp/src/script/page/components/ForceReloadModal/ForceReloadModal.test.tsx
+++ b/apps/webapp/src/script/page/components/ForceReloadModal/ForceReloadModal.test.tsx
@@ -29,6 +29,7 @@ import {t} from 'Util/localizerUtil';
 import {TIME_IN_MILLIS} from 'Util/timeUtil';
 
 import {RootProvider} from '../../RootProvider';
+import {createRootContextValueForTest} from '../../testSupport/rootContextTestSupport';
 import {ForceReloadModal} from './ForceReloadModal';
 
 interface ForceReloadModalTestContextValue {
@@ -74,12 +75,12 @@ function createForceReloadModalTestElement(contextValue: ForceReloadModalTestCon
 
   return (
     <RootProvider
-      value={{
+      value={createRootContextValueForTest({
         doesApplicationNeedForceReload,
         isFeatureToggleEnabled: isFeatureToggleDisabledForTest,
         mainViewModel: createMainViewModelForTest(),
         wallClock,
-      }}
+      })}
     >
       <ForceReloadModal reloadApplication={reloadApplication} />
     </RootProvider>

--- a/apps/webapp/src/script/page/testSupport/rootContextTestSupport.tsx
+++ b/apps/webapp/src/script/page/testSupport/rootContextTestSupport.tsx
@@ -1,0 +1,76 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ReactNode} from 'react';
+
+import {FireAndForgetInvoker} from '@wireapp/core';
+
+import {WallClock} from '../../clock/wallClock';
+import {StartupFeatureToggleName} from '../../featureToggles/startupFeatureToggles';
+import {MainViewModel} from '../../view_model/MainViewModel';
+import {RootContextValue, RootProvider} from '../RootProvider';
+
+type CreateRootContextValueForTestParameters = {
+  readonly doesApplicationNeedForceReload?: boolean;
+  readonly fireAndForgetInvoker?: FireAndForgetInvoker;
+  readonly isFeatureToggleEnabled?: (featureName: StartupFeatureToggleName) => boolean;
+  readonly mainViewModel: MainViewModel;
+  readonly wallClock: WallClock;
+};
+
+type RootProviderWrapperProperties = {
+  readonly children: ReactNode;
+};
+
+function isFeatureToggleDisabledForTest(): boolean {
+  return false;
+}
+
+export function createFireAndForgetInvokerForTest(): FireAndForgetInvoker {
+  return {
+    fireAndForget: jest.fn(),
+    waitUntilAllSettled: jest.fn(async () => {}),
+  } as FireAndForgetInvoker;
+}
+
+export function createRootContextValueForTest(parameters: CreateRootContextValueForTestParameters): RootContextValue {
+  const {
+    doesApplicationNeedForceReload = false,
+    fireAndForgetInvoker = createFireAndForgetInvokerForTest(),
+    isFeatureToggleEnabled = isFeatureToggleDisabledForTest,
+    mainViewModel,
+    wallClock,
+  } = parameters;
+
+  return {
+    doesApplicationNeedForceReload,
+    fireAndForgetInvoker,
+    isFeatureToggleEnabled,
+    mainViewModel,
+    wallClock,
+  };
+}
+
+export function createRootProviderWrapperForTest(rootContextValue: RootContextValue) {
+  function wrapper(properties: RootProviderWrapperProperties): ReactNode {
+    return <RootProvider value={rootContextValue}>{properties.children}</RootProvider>;
+  }
+
+  return wrapper;
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This change wires the invoker from applicationServices through AppContainer and AppMain into RootProvider, extending RootContextValue so React consumers can use the same dependency injection managed fire-and-forget primitive created at the composition root.


