### PR TITLE
fix: handle group creation with with no initial user defined [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -145,12 +145,14 @@ const GroupCreationModal = ({
   const rootContext = useContext(RootContext);
 
   useEffect(() => {
-    const showCreateGroup = (_: string, userEntity: User) => {
+    const showCreateGroup = (_: string, userEntity?: User) => {
       setEnableReadReceipts(isTeam);
       setIsShown(true);
       setGroupCreationState(GroupCreationModalState.PREFERENCES);
 
-      setSelectedContacts([...selectedContacts, userEntity]);
+      if (userEntity !== undefined) {
+        setSelectedContacts([...selectedContacts, userEntity]);
+      }
     };
 
     amplify.subscribe(WebAppEvents.CONVERSATION.CREATE_GROUP, showCreateGroup);


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Fixes a regression introduced by #21261 (see: https://github.com/wireapp/wire-webapp/pull/21261/changes#diff-8281ed38529155e2d33324b95edc9456816de03d1d264fbe4313fe644dbacfbfL153)