### PR TITLE
Set ESLint max warnings to current baseline and remove quiet lint mode [WPB-22420]

### DIFF
--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -56,7 +56,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --quiet --ext .js,.ts {projectRoot}"
+        "command": "eslint --config eslint.config.ts --max-warnings=1289 --ext .js,.ts {projectRoot}"
       }
     },
     "type-check": {

--- a/apps/webapp/project.json
+++ b/apps/webapp/project.json
@@ -55,7 +55,7 @@
       "executor": "nx:run-commands",
       "dependsOn": ["webapp:stylelint", "webapp:type-check"],
       "options": {
-        "command": "eslint --quiet --ext .js,.ts,.tsx {projectRoot}"
+        "command": "eslint --max-warnings=1289 --ext .js,.ts,.tsx {projectRoot}"
       }
     },
     "stylelint": {

--- a/libraries/api-client/project.json
+++ b/libraries/api-client/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --quiet --ext .js,.ts {projectRoot}"
+        "command": "eslint --config eslint.config.ts --max-warnings=1289 --ext .js,.ts {projectRoot}"
       }
     },
     "type-check": {

--- a/libraries/config/project.json
+++ b/libraries/config/project.json
@@ -43,7 +43,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --quiet --ext .js,.ts {projectRoot}"
+        "command": "eslint --config eslint.config.ts --max-warnings=1289 --ext .js,.ts {projectRoot}"
       }
     }
   },

--- a/libraries/core/project.json
+++ b/libraries/core/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --quiet --ext .js,.ts {projectRoot}"
+        "command": "eslint --config eslint.config.ts --max-warnings=1289 --ext .js,.ts {projectRoot}"
       }
     },
     "type-check": {


### PR DESCRIPTION
Lint now shows warnings in runs and enforces a fixed warning budget based on the current baseline. Warnings were effectively being ignored because lint ran in quiet mode; this change makes them visible so new warnings are avoided instead of silently accumulating.


