### PR TITLE
Use fire-and-forget invoker for auth index auto-login and React components [WPB-22420]

### DIFF
--- a/apps/webapp/project.json
+++ b/apps/webapp/project.json
@@ -55,7 +55,7 @@
       "executor": "nx:run-commands",
       "dependsOn": ["webapp:stylelint", "webapp:type-check"],
       "options": {
-        "command": "eslint --max-warnings=1289 --ext .js,.ts,.tsx {projectRoot}"
+        "command": "eslint --max-warnings=1036 --ext .js,.ts,.tsx {projectRoot}"
       }
     },
     "stylelint": {

--- a/apps/webapp/src/script/auth/util/test/TestUtil.tsx
+++ b/apps/webapp/src/script/auth/util/test/TestUtil.tsx
@@ -64,6 +64,10 @@ import {User} from 'Repositories/entity/User';
 import {BackgroundEffectsController} from 'Repositories/media/backgroundEffects/effects/backgroundEffectsController';
 import {BackgroundEffectsHandler} from 'Repositories/media/backgroundEffectsHandler';
 import {MediaDevicesHandler} from 'Repositories/media/MediaDevicesHandler';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
 import {setStrings} from 'Util/localizerUtil';
 import {createUuid} from 'Util/uuid';
 
@@ -105,6 +109,9 @@ const withRouter = (component: React.ReactNode) => (
   <Router future={{v7_relativeSplatPath: true, v7_startTransition: true}}>{component}</Router>
 );
 
+const rootContextValue = createRootContextValueForTest({});
+const rootProviderWrapper = createRootProviderWrapperForTest(rootContextValue);
+
 const loadLanguage = (language: string) => {
   return require(`I18n/${mapLanguage(language)}.json`);
 };
@@ -119,7 +126,9 @@ export const withIntl = (component: React.ReactNode) => {
   );
 };
 
-export const withTheme = (component: React.ReactNode) => <StyledApp themeId={THEME_ID.DEFAULT}>{component}</StyledApp>;
+export function withTheme(component: React.ReactNode): React.ReactElement {
+  return <StyledApp themeId={THEME_ID.DEFAULT}>{rootProviderWrapper({children: component})}</StyledApp>;
+}
 
 const wrapComponent = (
   component: React.ReactNode,

--- a/apps/webapp/src/script/components/Badge/components/VerificationBadges/VerificationBadges.tsx
+++ b/apps/webapp/src/script/components/Badge/components/VerificationBadges/VerificationBadges.tsx
@@ -42,6 +42,7 @@ import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {UserState} from 'Repositories/user/UserState';
 import {MLSStatuses, WireIdentity} from 'src/script/E2EIdentity/E2EIdentityVerification';
+import {useApplicationContext} from 'src/script/page/RootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {t} from 'Util/localizerUtil';
 import {waitFor} from 'Util/waitFor';
@@ -133,13 +134,14 @@ export const DeviceVerificationBadges = ({
   isE2EIEnabled?: boolean;
 }) => {
   const userState = useRef(container.resolve(UserState));
+  const {fireAndForgetInvoker} = useApplicationContext();
   const identity = useMemo(() => getIdentity?.(device.id), [device, getIdentity]);
   const [user, setUser] = useState<User | undefined>(undefined);
 
   useEffect(() => {
     // using active flag in combination with the cleanup to prevent race conditions
     let active = true;
-    void loadUser();
+    fireAndForgetInvoker.fireAndForget(loadUser);
     return () => {
       active = false;
     };
@@ -158,7 +160,7 @@ export const DeviceVerificationBadges = ({
       }
       setUser(userEntity);
     }
-  }, [identity]);
+  }, [fireAndForgetInvoker, identity]);
 
   let status: MLSStatuses | undefined = undefined;
   if (isE2EIEnabled && identity && user) {

--- a/apps/webapp/src/script/components/Cells/common/useCellPublicLink/useCellPublicLink.test.ts
+++ b/apps/webapp/src/script/components/Cells/common/useCellPublicLink/useCellPublicLink.test.ts
@@ -20,6 +20,11 @@
 import {act, renderHook, waitFor} from '@testing-library/react';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {
+  createExecutingFireAndForgetInvokerForTest,
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
 import {CellNode, CellNodeType} from 'src/script/types/cellNode';
 
 import {useCellPublicLink} from './useCellPublicLink';
@@ -36,6 +41,10 @@ describe('useCellPublicLink', () => {
   let mockCellsRepository: jest.Mocked<CellsRepository>;
   let mockNode: CellNode | undefined;
   const mockSetPublicLink = jest.fn();
+  const rootContextValue = createRootContextValueForTest({
+    fireAndForgetInvoker: createExecutingFireAndForgetInvokerForTest(),
+  });
+  const rootProviderWrapper = createRootProviderWrapperForTest(rootContextValue);
 
   const createMockNode = (overrides: Partial<CellNode> = {}): CellNode => ({
     id: 'test-uuid',
@@ -75,7 +84,7 @@ describe('useCellPublicLink', () => {
           refreshLinkDataAfterUpdate,
           setStatusOnPublicLinkUrl,
         }),
-      {initialProps},
+      {initialProps, wrapper: rootProviderWrapper},
     );
 
     const rerenderWith = (props: Partial<typeof initialProps>) =>
@@ -397,7 +406,7 @@ describe('useCellPublicLink', () => {
       mockCellsRepository.createPublicLink.mockResolvedValue({
         Uuid: undefined,
         LinkUrl: undefined,
-      } as any);
+      } as unknown as Awaited<ReturnType<CellsRepository['createPublicLink']>>);
 
       const {result} = renderPublicLinkHook();
 
@@ -456,7 +465,9 @@ describe('useCellPublicLink', () => {
       };
 
       mockCellsRepository.getPublicLink.mockResolvedValue(existingLink);
-      mockCellsRepository.updatePublicLink.mockResolvedValue({} as any);
+      mockCellsRepository.updatePublicLink.mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<CellsRepository['updatePublicLink']>>,
+      );
 
       const {result} = renderPublicLinkHook({node: mockNode, refreshLinkDataAfterUpdate: true});
 

--- a/apps/webapp/src/script/components/Cells/common/useCellPublicLink/useCellPublicLink.ts
+++ b/apps/webapp/src/script/components/Cells/common/useCellPublicLink/useCellPublicLink.ts
@@ -24,6 +24,7 @@ import type {RestShareLink} from '@wireapp/api-client/lib/cells';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {Config} from 'src/script/Config';
+import {useApplicationContext} from 'src/script/page/RootProvider';
 import type {CellNode} from 'src/script/types/cellNode';
 
 type PublicLinkStatus = 'idle' | 'loading' | 'error' | 'success';
@@ -47,6 +48,7 @@ export const useCellPublicLink = ({
   setStatusOnPublicLinkUrl = false,
   includeNodePublicLinkInCallbacks = false,
 }: UseCellPublicLinkParams) => {
+  const {fireAndForgetInvoker} = useApplicationContext();
   const [isEnabled, setIsEnabled] = useState(node?.publicLink?.alreadyShared === true);
   const [status, setStatus] = useState<PublicLinkStatus>(node?.publicLink !== undefined ? 'success' : 'idle');
   const [linkData, setLinkData] = useState<RestShareLink | null>(null);
@@ -225,19 +227,19 @@ export const useCellPublicLink = ({
     const shouldGetLink = isEnabled === true && node?.publicLink?.alreadyShared === true;
 
     if (shouldGetLink) {
-      void getPublicLink();
+      fireAndForgetInvoker.fireAndForget(getPublicLink);
       return;
     }
 
     if (shouldDeleteLink) {
-      void deletePublicLink();
+      fireAndForgetInvoker.fireAndForget(deletePublicLink);
       return;
     }
 
     if (shouldCreateNewLink) {
-      void createPublicLink();
+      fireAndForgetInvoker.fireAndForget(createPublicLink);
     }
-  }, [isEnabled, node?.publicLink, createPublicLink, deletePublicLink, getPublicLink]);
+  }, [createPublicLink, deletePublicLink, fireAndForgetInvoker, getPublicLink, isEnabled, node?.publicLink]);
 
   useEffect(() => {
     if (!setStatusOnPublicLinkUrl) {

--- a/apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx
+++ b/apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx
@@ -27,11 +27,13 @@ import {Button, Input, Switch} from '@wireapp/react-ui-kit';
 import {ConversationState} from 'Repositories/conversation/ConversationState';
 import {Config, Configuration} from 'src/script/Config';
 import {useClickOutside} from 'src/script/hooks/useClickOutside';
+import {useApplicationContext} from 'src/script/page/RootProvider';
 import {CoreCryptoLogLevel} from 'Util/debugUtil';
 
 import {wrapperStyles} from './ConfigToolbar.styles';
 
 export function ConfigToolbar() {
+  const {fireAndForgetInvoker} = useApplicationContext();
   const [showConfig, setShowConfig] = useState(false);
   const [isResettingMLSConversation, setIsResettingMLSConversation] = useState(false);
   const [isGzipEnabled, setIsGzipEnabled] = useState(window.wire?.app.debug?.isGzippingEnabled() ?? false);
@@ -106,7 +108,7 @@ export function ConfigToolbar() {
       }
     };
 
-    void sendMessage();
+    fireAndForgetInvoker.fireAndForget(sendMessage);
 
     return () => {
       isActive = false;
@@ -114,7 +116,7 @@ export function ConfigToolbar() {
         clearTimeout(timeoutId);
       }
     };
-  }, [isMessageSendingActive, prefix, messageDelaySec]);
+  }, [fireAndForgetInvoker, isMessageSendingActive, prefix, messageDelaySec]);
 
   const startSendingMessages = () => {
     messageCountRef.current = 0;
@@ -285,7 +287,9 @@ export function ConfigToolbar() {
           onChange={event => {
             const val = Number(event.currentTarget.value) as CoreCryptoLogLevel;
             setCoreCryptoLevel(val);
-            void window.wire?.app?.debug?.setCoreCryptoMaxLogLevel(val);
+            fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+              await window.wire?.app?.debug?.setCoreCryptoMaxLogLevel(val);
+            });
           }}
           style={{padding: '6px 8px'}}
         >

--- a/apps/webapp/src/script/components/Conversation/Conversation.tsx
+++ b/apps/webapp/src/script/components/Conversation/Conversation.tsx
@@ -103,7 +103,7 @@ export const Conversation = ({
   const isVirtualizedMessagesListEnabled = CONFIG.FEATURE.ENABLE_VIRTUALIZED_MESSAGES_LIST;
 
   const mainViewModel = useMainViewModel();
-  const {isFeatureToggleEnabled} = useApplicationContext();
+  const {fireAndForgetInvoker, isFeatureToggleEnabled} = useApplicationContext();
   const {content: contentViewModel} = mainViewModel;
   const {conversationRepository, repositories} = contentViewModel;
   const isSharedDriveSearchAndFiltersEnabled = isFeatureToggleEnabled(sharedDriveSearchAndFiltersFeatureToggleName);
@@ -192,12 +192,14 @@ export const Conversation = ({
       if (!allowsAllFiles()) {
         for (const file of fileArray) {
           if (!hasAllowedExtension(file.name)) {
-            conversationRepository.injectFileTypeRestrictedMessage(
-              activeConversation,
-              selfUser,
-              false,
-              getFileExtensionOrName(file.name),
-            );
+            fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+              await conversationRepository.injectFileTypeRestrictedMessage(
+                activeConversation,
+                selfUser,
+                false,
+                getFileExtensionOrName(file.name),
+              );
+            });
 
             return;
           }
@@ -221,7 +223,15 @@ export const Conversation = ({
         repositories.message.uploadFiles(activeConversation, files);
       }
     },
-    [activeConversation, conversationRepository, inTeam, repositories.asset, repositories.message, selfUser],
+    [
+      activeConversation,
+      conversationRepository,
+      fireAndForgetInvoker,
+      inTeam,
+      repositories.asset,
+      repositories.message,
+      selfUser,
+    ],
   );
 
   const uploadDroppedFiles = useCallback(
@@ -261,7 +271,9 @@ export const Conversation = ({
   const clickOnCancelRequest = (messageEntity: MemberMessage): void => {
     if (activeConversation) {
       const nextConversationEntity = conversationRepository.getNextConversation(activeConversation);
-      mainViewModel.actions.cancelConnectionRequest(messageEntity.otherUser(), true, nextConversationEntity);
+      fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+        await mainViewModel.actions.cancelConnectionRequest(messageEntity.otherUser(), true, nextConversationEntity);
+      });
     }
   };
 
@@ -335,7 +347,9 @@ export const Conversation = ({
 
     if (parsed?.type === 'user-profile') {
       event.preventDefault();
-      void openUserProfile(parsed.id, parsed.domain);
+      fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+        await openUserProfile(parsed.id, parsed.domain);
+      });
       return false;
     }
 
@@ -372,16 +386,16 @@ export const Conversation = ({
     const domain = messageDetails.userDomain;
 
     if (userId !== undefined && userId.length > 0) {
-      (async () => {
+      fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
         try {
           const userEntity = await repositories.user.getUserById({domain: domain ?? '', id: userId});
-          showUserDetails(userEntity);
+          await showUserDetails(userEntity);
         } catch (error: unknown) {
           if (error instanceof UserError && error.type !== UserError.TYPE.USER_NOT_FOUND) {
             throw error;
           }
         }
-      })();
+      });
     }
   };
 
@@ -424,6 +438,7 @@ export const Conversation = ({
       assetRepository: repositories.asset,
       conversationRepository: repositories.conversation,
       currentMessageEntity: messageEntity,
+      fireAndForgetInvoker,
       messageRepository: repositories.message,
       selfUser,
     });
@@ -459,7 +474,9 @@ export const Conversation = ({
     // if no message provided it means we need to jump to the last message
     if (needsUpdate && (!messageEntity || isLastReceivedMessage(messageEntity, conversationEntity))) {
       conversationEntity.setTimestamp(lastKnownTimestamp, ConversationEntity.TIMESTAMP_TYPE.LAST_READ);
-      repositories.message.markAsRead(conversationEntity);
+      fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+        await repositories.message.markAsRead(conversationEntity);
+      });
     }
   };
 
@@ -472,7 +489,9 @@ export const Conversation = ({
       if (!messageEntity.isEphemeral()) {
         const isCreationMessage = messageEntity.isMember() && messageEntity.isCreation();
         if (conversationEntity.is1to1() && isCreationMessage) {
-          repositories.integration.addProviderNameToParticipant((messageEntity as MemberMessage).otherUser());
+          fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+            await repositories.integration.addProviderNameToParticipant((messageEntity as MemberMessage).otherUser());
+          });
         }
       }
 
@@ -525,7 +544,13 @@ export const Conversation = ({
         return document.hasFocus() ? trigger() : window.addEventListener('focus', () => trigger(), {once: true});
       };
     },
-    [addReadReceiptToBatch, repositories.conversation, repositories.integration, updateConversationLastRead],
+    [
+      addReadReceiptToBatch,
+      fireAndForgetInvoker,
+      repositories.conversation,
+      repositories.integration,
+      updateConversationLastRead,
+    ],
   );
 
   const isFileTabActive = activeTabIndex === 1;

--- a/apps/webapp/src/script/components/InputBar/InputBar.test.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBar.test.tsx
@@ -36,6 +36,10 @@ import {StorageRepository} from 'Repositories/storage';
 import {TeamState} from 'Repositories/team/TeamState';
 import {withTheme} from 'src/script/auth/util/test/TestUtil';
 import {Config} from 'src/script/Config';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
 import {createUuid} from 'Util/uuid';
 
 import {TestFactory} from '../../../../test/helper/TestFactory';
@@ -75,6 +79,8 @@ beforeAll(async () => {
 
 describe('InputBar', () => {
   let propertiesRepository: PropertiesRepository;
+  const rootContextValue = createRootContextValueForTest({});
+  const rootProviderWrapper = createRootProviderWrapperForTest(rootContextValue);
 
   const getDefaultProps = () => ({
     assetRepository: new AssetRepository(),
@@ -116,9 +122,15 @@ describe('InputBar', () => {
   const testMessage = 'text';
   const pngFile = new File(['(⌐□_□)'], 'wire-example-image.png', {type: 'image/png'});
 
+  function renderInputBar(properties: ReturnType<typeof getDefaultProps>): ReturnType<typeof render> {
+    return render(withTheme(<InputBar {...properties} />), {
+      wrapper: rootProviderWrapper,
+    });
+  }
+
   it('has passed value', async () => {
     const props = getDefaultProps();
-    const {getByTestId} = render(withTheme(<InputBar {...props} />));
+    const {getByTestId} = renderInputBar(props);
 
     await new Promise(resolve => setTimeout(resolve));
     const inputBar = getByTestId('input-message');
@@ -135,7 +147,7 @@ describe('InputBar', () => {
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('typing request is sent if the typing indicator mode is enabled and user is typing', async () => {
     const props = getDefaultProps();
-    const {getByTestId, container} = render(withTheme(<InputBar {...props} />));
+    const {getByTestId, container} = renderInputBar(props);
     const inputBar = getByTestId('input-message');
 
     fireEvent.keyDown(container, {key: 'Enter', code: 'Enter'});
@@ -157,7 +169,7 @@ describe('InputBar', () => {
 
   it('typing request is not sent when user is typing but the typing indicator mode is disabled', async () => {
     const props = getDefaultProps();
-    const {getByTestId} = render(withTheme(<InputBar {...props} />));
+    const {getByTestId} = renderInputBar(props);
     const inputBar = getByTestId('input-message');
     const property = PropertiesRepository.CONFIG.WIRE_TYPING_INDICATOR_MODE;
     const defaultValue = property.defaultValue;
@@ -182,7 +194,7 @@ describe('InputBar', () => {
   it('has pasted image', async () => {
     const promise = Promise.resolve();
     const props = getDefaultProps();
-    const {getByTestId, queryByTestId} = render(withTheme(<InputBar {...props} />));
+    const {getByTestId, queryByTestId} = renderInputBar(props);
     await promise;
 
     const textArea = getByTestId('input-message');

--- a/apps/webapp/src/script/components/InputBar/InputBar.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBar.tsx
@@ -65,6 +65,7 @@ import {usePing} from './usePing/usePing';
 import {useTypingIndicator} from './useTypingIndicator/useTypingIndicator';
 
 import {Config} from '../../Config';
+import {useApplicationContext} from '../../page/RootProvider';
 
 const CONFIG = {
   ...Config.getConfig(),
@@ -115,6 +116,7 @@ export const InputBar = ({
   onCellImageUpload,
   onCellAssetUpload,
 }: InputBarProps) => {
+  const {fireAndForgetInvoker} = useApplicationContext();
   const {classifiedDomains, isSelfDeletingMessagesEnabled, isFileSharingSendingEnabled} = useKoSubscribableChildren(
     teamState,
     ['classifiedDomains', 'isSelfDeletingMessagesEnabled', 'isFileSharingSendingEnabled'],
@@ -187,12 +189,16 @@ export const InputBar = ({
       isTyping => {
         isTypingRef.current = isTyping;
         if (isTyping) {
-          void conversationRepository.sendTypingStart(conversation);
+          fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+            await conversationRepository.sendTypingStart(conversation);
+          });
         } else {
-          void conversationRepository.sendTypingStop(conversation);
+          fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+            await conversationRepository.sendTypingStop(conversation);
+          });
         }
       },
-      [conversationRepository, conversation],
+      [conversationRepository, conversation, fireAndForgetInvoker],
     ),
   });
 
@@ -260,8 +266,8 @@ export const InputBar = ({
       return;
     }
 
-    void sendMessage();
-  }, [isSendingDisabled, sendMessage]);
+    fireAndForgetInvoker.fireAndForget(sendMessage);
+  }, [fireAndForgetInvoker, isSendingDisabled, sendMessage]);
 
   const showAvatar = !!messageContent.text.length;
 

--- a/apps/webapp/src/script/components/InputBar/usePing/usePing.ts
+++ b/apps/webapp/src/script/components/InputBar/usePing/usePing.ts
@@ -23,6 +23,7 @@ import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {MessageRepository} from 'Repositories/conversation/MessageRepository';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {Config} from 'src/script/Config';
+import {useApplicationContext} from 'src/script/page/RootProvider';
 import {t} from 'Util/localizerUtil';
 import {TIME_IN_MILLIS} from 'Util/timeUtil';
 
@@ -33,6 +34,7 @@ interface UsePingProps {
 }
 
 export const usePing = ({conversation, messageRepository, is1to1}: UsePingProps) => {
+  const {fireAndForgetInvoker} = useApplicationContext();
   const [isPingDisabled, setIsPingDisabled] = useState(false);
 
   const maxUsersWithoutAlert = Config.getConfig().FEATURE.MAX_USERS_TO_PING_WITHOUT_ALERT;
@@ -40,7 +42,8 @@ export const usePing = ({conversation, messageRepository, is1to1}: UsePingProps)
 
   const pingConversation = () => {
     setIsPingDisabled(true);
-    void messageRepository.sendPing(conversation).then(() => {
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await messageRepository.sendPing(conversation);
       window.setTimeout(() => setIsPingDisabled(false), TIME_IN_MILLIS.SECOND * 2);
     });
   };

--- a/apps/webapp/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -34,6 +34,7 @@ import {ContentMessage} from 'Repositories/entity/message/ContentMessage';
 import {Text} from 'Repositories/entity/message/Text';
 import {TeamState} from 'Repositories/team/TeamState';
 import {QuoteEntity} from 'src/script/message/QuoteEntity';
+import {useApplicationContext} from 'src/script/page/RootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {t} from 'Util/localizerUtil';
 
@@ -85,6 +86,7 @@ export const MessageWrapper = ({
   teamState = container.resolve(TeamState),
   isMsgElementsFocusable,
 }: MessageParams) => {
+  const {fireAndForgetInvoker} = useApplicationContext();
   const findMessage = async (conversation: Conversation, messageId: string) => {
     const eventFromId = await messageRepository.getMessageInConversationById(conversation, messageId);
     const event =
@@ -193,7 +195,9 @@ export const MessageWrapper = ({
     if (!message.isContent()) {
       return;
     }
-    return void messageRepository.toggleReaction(conversation, message, reaction, selfId);
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await messageRepository.toggleReaction(conversation, message, reaction, selfId);
+    });
   };
   if (message.isContent()) {
     return (

--- a/apps/webapp/src/script/components/MessagesList/utils/useLoadConversation.ts
+++ b/apps/webapp/src/script/components/MessagesList/utils/useLoadConversation.ts
@@ -22,6 +22,7 @@ import {MutableRefObject, useEffect} from 'react';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {Message as MessageEntity} from 'Repositories/entity/message/Message';
+import {useApplicationContext} from 'src/script/page/RootProvider';
 
 interface Props {
   conversation: Conversation;
@@ -36,6 +37,7 @@ export const useLoadConversation = ({
   conversationLastReadTimestamp,
   onLoading,
 }: Props) => {
+  const {fireAndForgetInvoker} = useApplicationContext();
   const loadConversation = async (conversationToLoad: Conversation): Promise<MessageEntity[]> => {
     onLoading(true);
     try {
@@ -53,13 +55,15 @@ export const useLoadConversation = ({
   };
 
   useEffect(() => {
-    void loadConversation(conversation);
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await loadConversation(conversation);
+    });
 
     return () => {
       conversation.release();
       onLoading(true);
     };
-  }, [conversation]);
+  }, [conversation, fireAndForgetInvoker]);
 
   return {loadConversation};
 };

--- a/apps/webapp/src/script/components/Modals/DetailViewModal/DetailViewModalFooter.tsx
+++ b/apps/webapp/src/script/components/Modals/DetailViewModal/DetailViewModalFooter.tsx
@@ -22,6 +22,7 @@ import {FC, useCallback, useRef, useState} from 'react';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {ReactionType} from '@wireapp/core/lib/conversation';
 
+import {FireAndForgetInvoker} from '@wireapp/core';
 import {TabIndex} from '@wireapp/react-ui-kit';
 
 import {DownloadButton} from 'Components/MessagesList/Message/ContentMessage/MessageActions/DownloadButton';
@@ -47,6 +48,7 @@ interface DetailViewModalFooterProps {
   onDownloadClick: (message: ContentMessage) => void;
   messageRepository: MessageRepository;
   selfId: QualifiedId;
+  fireAndForgetInvoker: FireAndForgetInvoker;
 }
 
 const MESSAGE_REPLY_ID = 'do-reply-fullscreen-picture';
@@ -59,6 +61,7 @@ const DetailViewModalFooter: FC<DetailViewModalFooterProps> = ({
   onDownloadClick,
   messageRepository,
   selfId,
+  fireAndForgetInvoker,
 }) => {
   const {isSelfUserRemoved} = useKoSubscribableChildren(conversationEntity, ['isSelfUserRemoved']);
   const [currentMsgActionName, setCurrentMsgAction] = useState('');
@@ -68,7 +71,9 @@ const DetailViewModalFooter: FC<DetailViewModalFooterProps> = ({
     if (!messageEntity.isContent()) {
       return;
     }
-    return void messageRepository.toggleReaction(conversationEntity, messageEntity, reaction, selfId);
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await messageRepository.toggleReaction(conversationEntity, messageEntity, reaction, selfId);
+    });
   };
   const {handleMenuOpen} = useMessageActionsState();
   const resetActionMenuStates = useCallback(() => {

--- a/apps/webapp/src/script/components/Modals/DetailViewModal/index.tsx
+++ b/apps/webapp/src/script/components/Modals/DetailViewModal/index.tsx
@@ -22,6 +22,7 @@ import {KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState} from '
 import {amplify} from 'amplify';
 import cx from 'classnames';
 
+import {FireAndForgetInvoker} from '@wireapp/core';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {ZoomableImage} from 'Components/ZoomableImage';
@@ -48,6 +49,7 @@ import {isOfCategory} from '../../../page/MainContent/panels/Collection/utils';
 interface DetailViewModalProps {
   readonly assetRepository: AssetRepository;
   readonly conversationRepository: ConversationRepository;
+  readonly fireAndForgetInvoker: FireAndForgetInvoker;
   readonly messageRepository: MessageRepository;
   currentMessageEntity: ContentMessage;
   onClose?: () => void;
@@ -57,6 +59,7 @@ interface DetailViewModalProps {
 export const DetailViewModal = ({
   assetRepository,
   conversationRepository,
+  fireAndForgetInvoker,
   messageRepository,
   currentMessageEntity,
   onClose,
@@ -279,6 +282,7 @@ export const DetailViewModal = ({
             messageEntity={messageEntity}
             conversationEntity={conversationEntity}
             messageRepository={messageRepository}
+            fireAndForgetInvoker={fireAndForgetInvoker}
             onReplyClick={onReplyClick}
             onDownloadClick={onDownloadClick}
             selfId={selfUser.qualifiedId}

--- a/apps/webapp/src/script/components/UserDevices/components/DeviceCard/DeviceCard.test.tsx
+++ b/apps/webapp/src/script/components/UserDevices/components/DeviceCard/DeviceCard.test.tsx
@@ -22,6 +22,10 @@ import {ClientClassification} from '@wireapp/api-client/lib/client/';
 import ko from 'knockout';
 
 import type {ClientEntity} from 'Repositories/client/ClientEntity';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
 
 import {DeviceCard} from './DeviceCard';
 
@@ -37,6 +41,9 @@ function createClientEntity(clientEntity: Partial<ClientEntity>): ClientEntity {
 }
 
 describe('DeviceCard', () => {
+  const rootContextValue = createRootContextValueForTest({});
+  const rootProviderWrapper = createRootProviderWrapperForTest(rootContextValue);
+
   it('shows disclose icon when component is clickable', async () => {
     const props = {
       click: jest.fn(),
@@ -49,7 +56,7 @@ describe('DeviceCard', () => {
       showIcon: true,
     };
 
-    const {getByTestId} = render(<DeviceCard {...props} />);
+    const {getByTestId} = render(<DeviceCard {...props} />, {wrapper: rootProviderWrapper});
     expect(getByTestId('disclose-icon')).not.toBeNull();
   });
 });

--- a/apps/webapp/src/script/components/UserSearchableList/UserSearchableList.tsx
+++ b/apps/webapp/src/script/components/UserSearchableList/UserSearchableList.tsx
@@ -29,6 +29,7 @@ import type {User} from 'Repositories/entity/User';
 import {SearchRepository} from 'Repositories/search/SearchRepository';
 import type {TeamRepository} from 'Repositories/team/TeamRepository';
 import {TeamState} from 'Repositories/team/TeamState';
+import {useApplicationContext} from 'src/script/page/RootProvider';
 import {partition} from 'Util/arrayUtil';
 import {t} from 'Util/localizerUtil';
 import {matchQualifiedIds} from 'Util/qualifiedId';
@@ -68,6 +69,7 @@ export const UserSearchableList = ({
   teamState = container.resolve(TeamState),
   ...props
 }: UserListProps) => {
+  const {fireAndForgetInvoker} = useApplicationContext();
   const {searchRepository, teamRepository, selfFirst, ...userListProps} = props;
   const {conversationState = container.resolve(ConversationState)} = props;
 
@@ -115,11 +117,15 @@ export const UserSearchableList = ({
       );
 
     if (normalizedQuery !== '' && selfInTeam && allowRemoteSearch === true) {
-      fetchMembersFromBackend(filter, results);
+      fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+        await fetchMembersFromBackend(filter, results);
+      });
     }
 
     if (selfFirst !== true) {
-      void setUsers(results);
+      fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+        await setUsers(results);
+      });
       return;
     }
 
@@ -127,8 +133,10 @@ export const UserSearchableList = ({
     const [selfUser, otherUsers] = partition(results, user => user.isMe);
 
     const concatUsers = selfUser.concat(otherUsers);
-    void setUsers(concatUsers);
-  }, [filter, users.length]);
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await setUsers(concatUsers);
+    });
+  }, [filter, fireAndForgetInvoker, users.length]);
 
   const foundUserEntities = () => {
     if (!remoteTeamMembers.length) {

--- a/apps/webapp/src/script/components/calling/CallingCell/CallingCell.test.tsx
+++ b/apps/webapp/src/script/components/calling/CallingCell/CallingCell.test.tsx
@@ -18,7 +18,7 @@
  */
 
 import {render, waitFor} from '@testing-library/react';
-import {act} from 'react';
+import {act, ReactNode} from 'react';
 
 import {CALL_TYPE, STATE as CALL_STATE} from '@wireapp/avs';
 
@@ -29,6 +29,10 @@ import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {PropertiesRepository} from 'Repositories/properties/PropertiesRepository';
 import {TeamState} from 'Repositories/team/TeamState';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
 import {CallActions} from 'src/script/view_model/CallingViewModel';
 import {createUuid} from 'Util/uuid';
 
@@ -37,7 +41,7 @@ import {CallingCell, CallingCellProps} from './CallingCell';
 import {buildMediaDevicesHandler} from '../../../auth/util/test/TestUtil';
 
 jest.mock('Components/InViewport', () => ({
-  InViewport: ({onVisible, children}: {onVisible: () => void; children: any}) => {
+  InViewport: ({onVisible, children}: {onVisible: () => void; children: ReactNode}) => {
     setTimeout(onVisible);
     return <div>{children}</div>;
   },
@@ -84,10 +88,13 @@ const createProps = async () => {
 };
 
 describe('ConversationListCallingCell', () => {
+  const rootContextValue = createRootContextValueForTest({});
+  const rootProviderWrapper = createRootProviderWrapperForTest(rootContextValue);
+
   it('displays an incoming ringing call', async () => {
     const props = await createProps();
     props.call.state(CALL_STATE.INCOMING);
-    const {container} = render(<CallingCell {...props} />);
+    const {container} = render(<CallingCell {...props} />, {wrapper: rootProviderWrapper});
 
     const acceptButton = container.querySelector('[data-uie-name="do-call-controls-call-accept"]');
     const declineButton = container.querySelector('[data-uie-name="do-call-controls-call-decline"]');
@@ -100,7 +107,7 @@ describe('ConversationListCallingCell', () => {
     const props = await createProps();
     props.call.state(CALL_STATE.OUTGOING);
 
-    const {getByTestId} = render(<CallingCell {...props} />);
+    const {getByTestId} = render(<CallingCell {...props} />, {wrapper: rootProviderWrapper});
 
     expect(getByTestId('call-label-outgoing')).not.toBeNull();
   });
@@ -109,7 +116,7 @@ describe('ConversationListCallingCell', () => {
     const props = await createProps();
     props.call.state(CALL_STATE.ANSWERED);
 
-    const {container} = render(<CallingCell {...props} />);
+    const {container} = render(<CallingCell {...props} />, {wrapper: rootProviderWrapper});
 
     const connectingLabel = container.querySelector('[data-uie-name="call-label-connecting"]');
     expect(connectingLabel).not.toBeNull();
@@ -119,7 +126,7 @@ describe('ConversationListCallingCell', () => {
     const props = await createProps();
     props.call.state(CALL_STATE.MEDIA_ESTAB);
 
-    const {getByText, rerender, container} = render(<CallingCell {...props} />);
+    const {getByText, rerender, container} = render(<CallingCell {...props} />, {wrapper: rootProviderWrapper});
 
     jest.useFakeTimers();
     const now = Date.now();

--- a/apps/webapp/src/script/components/calling/CallingCell/CallingCell.tsx
+++ b/apps/webapp/src/script/components/calling/CallingCell/CallingCell.tsx
@@ -45,6 +45,7 @@ import {PROPERTIES_TYPE} from 'Repositories/properties/PropertiesType';
 import {TeamState} from 'Repositories/team/TeamState';
 import {Config} from 'src/script/Config';
 import {useUserPropertyValue} from 'src/script/hooks/useUserProperty';
+import {useApplicationContext} from 'src/script/page/RootProvider';
 import {useAppMainState, ViewType} from 'src/script/page/state';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {isEnterKey, isSpaceOrEnterKey} from 'Util/keyboardUtil';
@@ -89,6 +90,7 @@ export const CallingCell = ({
   teamState = container.resolve(TeamState),
   callState = container.resolve(CallState),
 }: CallingCellProps) => {
+  const {fireAndForgetInvoker} = useApplicationContext();
   const {conversation} = call;
   const {reason, state, isCbrEnabled, startedAt, maximizedParticipant, muteState} = useKoSubscribableChildren(call, [
     'reason',
@@ -225,18 +227,22 @@ export const CallingCell = ({
         return;
       }
       if (isSpaceOrEnterKey(event.key)) {
-        void callingRepository.setViewModeFullScreen();
+        fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+          await callingRepository.setViewModeFullScreen();
+        });
       }
     },
-    [isOngoing, callingRepository],
+    [callingRepository, fireAndForgetInvoker, isOngoing],
   );
 
   const handleMaximizeClick = useCallback(() => {
     if (!isOngoing) {
       return;
     }
-    void callingRepository.setViewModeFullScreen();
-  }, [isOngoing, callingRepository]);
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await callingRepository.setViewModeFullScreen();
+    });
+  }, [callingRepository, fireAndForgetInvoker, isOngoing]);
 
   const {setCurrentView} = useAppMainState(state => state.responsiveView);
   const {showAlert, clearShowAlert} = useCallAlertState();
@@ -326,10 +332,14 @@ export const CallingCell = ({
 
   const toggleDetachedWindow = () => {
     if (isDetachedWindow) {
-      void callingRepository.setViewModeMinimized();
+      fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+        await callingRepository.setViewModeMinimized();
+      });
       return;
     }
-    void callingRepository.setViewModeDetached();
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await callingRepository.setViewModeDetached();
+    });
   };
 
   if (isFullScreen) {

--- a/apps/webapp/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/apps/webapp/src/script/components/calling/CallingOverlayContainer.tsx
@@ -31,6 +31,7 @@ import {useVideoGrid} from 'Repositories/calling/videoGridHandler';
 import {MediaDevicesHandler} from 'Repositories/media/MediaDevicesHandler';
 import {useMediaDevicesStore} from 'Repositories/media/useMediaDevicesStore';
 import {PropertiesRepository} from 'Repositories/properties/PropertiesRepository';
+import {useApplicationContext} from 'src/script/page/RootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 
 import {ChooseScreen} from './ChooseScreen';
@@ -51,6 +52,7 @@ const CallingContainer = ({
   callState = container.resolve(CallState),
   toggleScreenshare,
 }: CallingContainerProps) => {
+  const {fireAndForgetInvoker} = useApplicationContext();
   const mediaDevicesHandler = container.resolve(MediaDevicesHandler);
   const {activeCallViewTab, joinedCall, hasAvailableScreensToShare, desktopScreenShareMenu, viewMode} =
     useKoSubscribableChildren(callState, [
@@ -73,9 +75,11 @@ const CallingContainer = ({
 
   useEffect(() => {
     if (currentCallState === undefined) {
-      void callingRepository.setViewModeMinimized();
+      fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+        await callingRepository.setViewModeMinimized();
+      });
     }
-  }, [currentCallState]);
+  }, [callingRepository, currentCallState, fireAndForgetInvoker]);
 
   const videoGrid = useVideoGrid(joinedCall!);
 
@@ -110,12 +114,16 @@ const CallingContainer = ({
 
   const switchCameraInput = (deviceId: string) => {
     setVideoInputDeviceId(deviceId);
-    callingRepository.refreshVideoInput();
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await callingRepository.refreshVideoInput();
+    });
   };
 
   const switchMicrophoneInput = (deviceId: string) => {
     setAudioInputDeviceId(deviceId);
-    callingRepository.refreshAudioInput();
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await callingRepository.refreshAudioInput();
+    });
   };
 
   const switchSpeakerOutput = (deviceId: string) => {
@@ -124,11 +132,15 @@ const CallingContainer = ({
   };
 
   const sendEmoji = (emoji: string, call: Call) => {
-    void callingRepository.sendInCallEmoji(emoji, call);
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await callingRepository.sendInCallEmoji(emoji, call);
+    });
   };
 
   const sendHandRaised = (isHandUp: boolean, call: Call) => {
-    void callingRepository.sendInCallHandRaised(isHandUp, call);
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await callingRepository.sendInCallHandRaised(isHandUp, call);
+    });
   };
 
   const toggleCamera = (call: Call) => callingRepository.toggleCamera(call);

--- a/apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx
@@ -55,6 +55,7 @@ import {PropertiesRepository} from 'Repositories/properties/PropertiesRepository
 import {TeamState} from 'Repositories/team/TeamState';
 import {useActiveWindowMatchMedia} from 'src/script/hooks/useActiveWindowMatchMedia';
 import {useToggleState} from 'src/script/hooks/useToggleState';
+import {useApplicationContext} from 'src/script/page/RootProvider';
 import {CallViewTab} from 'src/script/view_model/CallingViewModel';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {isDetachedCallingFeatureEnabled} from 'Util/isDetachedCallingFeatureEnabled';
@@ -142,6 +143,7 @@ const FullscreenVideoCall = ({
   teamState = container.resolve(TeamState),
   callState = container.resolve(CallState),
 }: FullscreenVideoCallProps) => {
+  const {fireAndForgetInvoker} = useApplicationContext();
   const [isConfirmCloseModalOpen, setIsConfirmCloseModalOpen] = useState<boolean>(false);
   const selfParticipant = call.getSelfParticipant();
   const {sharesCamera: selfSharesCamera} = useKoSubscribableChildren(selfParticipant, ['sharesCamera']);
@@ -287,7 +289,9 @@ const FullscreenVideoCall = ({
   const selectedBackgroundEffect = useBackgroundEffectsStore(state => state.preferredEffect);
 
   const handleBackgroundSidebarSelect = (effect: BackgroundEffectSelection) => {
-    void switchVideoBackgroundEffect(effect);
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await switchVideoBackgroundEffect(effect);
+    });
   };
 
   const handleEnableHighQualityBlur = (event: ChangeEvent<HTMLInputElement>) => {

--- a/apps/webapp/src/script/page/MainContent/panels/Collection/Collection.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/Collection/Collection.tsx
@@ -34,6 +34,7 @@ import {Conversation} from 'Repositories/entity/Conversation';
 import {ContentMessage} from 'Repositories/entity/message/ContentMessage';
 import {User} from 'Repositories/entity/User';
 import {Config} from 'src/script/Config';
+import {useApplicationContext} from 'src/script/page/RootProvider';
 import {generateConversationUrl} from 'src/script/router/routeGenerator';
 import {createNavigate} from 'src/script/router/routerBindings';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
@@ -90,6 +91,7 @@ const Collection = ({
   messageRepository,
   selfUser,
 }: CollectionDetailsProps) => {
+  const {fireAndForgetInvoker} = useApplicationContext();
   const [searchTerm, setSearchTerm] = useState('');
   const {display_name, cellsState} = useKoSubscribableChildren(conversation, ['display_name', 'cellsState']);
   const [messages, setMessages] = useState<ContentMessage[]>([]);
@@ -136,6 +138,7 @@ const Collection = ({
       assetRepository,
       conversationRepository,
       currentMessageEntity: message,
+      fireAndForgetInvoker,
       messageRepository,
       selfUser,
     });

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.test.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/DevicesPreference.test.tsx
@@ -31,6 +31,10 @@ import {CryptographyRepository} from 'Repositories/cryptography/CryptographyRepo
 import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {withTheme} from 'src/script/auth/util/test/TestUtil';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
 import {Core} from 'src/script/service/CoreSingleton';
 import {createUuid} from 'Util/uuid';
 
@@ -56,6 +60,8 @@ function createConversation(protocol?: CONVERSATION_PROTOCOL, type?: CONVERSATIO
 }
 
 describe('DevicesPreferences', () => {
+  const rootContextValue = createRootContextValueForTest({});
+  const rootProviderWrapper = createRootProviderWrapperForTest(rootContextValue);
   const selfProteusConversation = createConversation(CONVERSATION_PROTOCOL.PROTEUS, CONVERSATION_TYPE.SELF);
   const selfMLSConversation = createConversation(CONVERSATION_PROTOCOL.MLS, CONVERSATION_TYPE.SELF);
   const regularConversation = createConversation();
@@ -84,7 +90,9 @@ describe('DevicesPreferences', () => {
   defaultParams.conversationState.conversations([selfProteusConversation, selfMLSConversation, regularConversation]);
 
   it('displays all devices', async () => {
-    const {getByText, getAllByText} = render(withTheme(<DevicesPreferences {...defaultParams} />));
+    const {getByText, getAllByText} = render(withTheme(<DevicesPreferences {...defaultParams} />), {
+      wrapper: rootProviderWrapper,
+    });
 
     await waitFor(() => getByText('preferencesDevicesCurrent'));
     expect(getByText('preferencesDevicesCurrent')).toBeDefined();

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.test.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/DevicesPreferences/components/DeviceDetailsPreferences/DeviceDetailsPreferences.test.tsx
@@ -21,11 +21,17 @@ import {act, render, waitFor} from '@testing-library/react';
 
 import {ClientEntity} from 'Repositories/client/ClientEntity';
 import {withTheme} from 'src/script/auth/util/test/TestUtil';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
 import {createUuid} from 'Util/uuid';
 
 import {DeviceDetailsPreferences} from './DeviceDetailsPreferences';
 
 describe('DeviceDetailsPreferences', () => {
+  const rootContextValue = createRootContextValueForTest({});
+  const rootProviderWrapper = createRootProviderWrapperForTest(rootContextValue);
   const device = new ClientEntity(true, '', createUuid());
   device.model = 'test';
   device.time = new Date().toISOString();
@@ -38,15 +44,21 @@ describe('DeviceDetailsPreferences', () => {
     onResetSession: jest.fn().mockResolvedValue(undefined),
     onVerify: jest.fn((_, isVerified) => device.meta?.isVerified(isVerified)),
   };
+  function renderDeviceDetailsPreferences(): ReturnType<typeof render> {
+    return render(withTheme(<DeviceDetailsPreferences {...defaultParams} />), {
+      wrapper: rootProviderWrapper,
+    });
+  }
+
   it('shows device details', async () => {
-    const {getByText, getAllByText} = render(withTheme(<DeviceDetailsPreferences {...defaultParams} />));
+    const {getByText, getAllByText} = renderDeviceDetailsPreferences();
     await waitFor(() => getAllByText('00'));
 
     expect(getByText(device.model)).toBeDefined();
   });
 
   it('resets session with device', async () => {
-    const {getByText, getAllByText, queryByText} = render(withTheme(<DeviceDetailsPreferences {...defaultParams} />));
+    const {getByText, getAllByText, queryByText} = renderDeviceDetailsPreferences();
     await waitFor(() => getAllByText('00'));
     jest.useFakeTimers();
     act(() => {
@@ -71,7 +83,7 @@ describe('DeviceDetailsPreferences', () => {
   });
 
   it('toggles verification', async () => {
-    const {getByText, getAllByText} = render(withTheme(<DeviceDetailsPreferences {...defaultParams} />));
+    const {getByText, getAllByText} = renderDeviceDetailsPreferences();
     await waitFor(() => getAllByText('00'));
 
     act(() => {

--- a/apps/webapp/src/script/page/testSupport/rootContextTestSupport.tsx
+++ b/apps/webapp/src/script/page/testSupport/rootContextTestSupport.tsx
@@ -21,7 +21,7 @@ import {ReactNode} from 'react';
 
 import {FireAndForgetInvoker} from '@wireapp/core';
 
-import {WallClock} from '../../clock/wallClock';
+import {WallClock, createWallClock} from '../../clock/wallClock';
 import {StartupFeatureToggleName} from '../../featureToggles/startupFeatureToggles';
 import {MainViewModel} from '../../view_model/MainViewModel';
 import {RootContextValue, RootProvider} from '../RootProvider';
@@ -30,8 +30,8 @@ type CreateRootContextValueForTestParameters = {
   readonly doesApplicationNeedForceReload?: boolean;
   readonly fireAndForgetInvoker?: FireAndForgetInvoker;
   readonly isFeatureToggleEnabled?: (featureName: StartupFeatureToggleName) => boolean;
-  readonly mainViewModel: MainViewModel;
-  readonly wallClock: WallClock;
+  readonly mainViewModel?: MainViewModel;
+  readonly wallClock?: WallClock;
 };
 
 type RootProviderWrapperProperties = {
@@ -42,11 +42,46 @@ function isFeatureToggleDisabledForTest(): boolean {
   return false;
 }
 
+function createMainViewModelForTest(): MainViewModel {
+  return {} as MainViewModel;
+}
+
 export function createFireAndForgetInvokerForTest(): FireAndForgetInvoker {
   return {
     fireAndForget: jest.fn(),
-    waitUntilAllSettled: jest.fn(async () => {}),
-  } as FireAndForgetInvoker;
+    waitUntilAllSettled: jest.fn(async (): Promise<void> => {
+      return undefined;
+    }),
+  };
+}
+
+export function createExecutingFireAndForgetInvokerForTest(): FireAndForgetInvoker {
+  const activePromises = new Set<Promise<unknown>>();
+
+  async function observePromise(activePromise: Promise<unknown>): Promise<void> {
+    try {
+      await activePromise;
+    } catch {
+      return undefined;
+    } finally {
+      activePromises.delete(activePromise);
+    }
+  }
+
+  function fireAndForget(asyncAction: () => Promise<unknown>): void {
+    const activePromise = asyncAction();
+    activePromises.add(activePromise);
+    observePromise(activePromise).catch(() => undefined);
+  }
+
+  async function waitUntilAllSettled(): Promise<void> {
+    await Promise.allSettled(activePromises);
+  }
+
+  return {
+    fireAndForget,
+    waitUntilAllSettled,
+  };
 }
 
 export function createRootContextValueForTest(parameters: CreateRootContextValueForTestParameters): RootContextValue {
@@ -54,8 +89,8 @@ export function createRootContextValueForTest(parameters: CreateRootContextValue
     doesApplicationNeedForceReload = false,
     fireAndForgetInvoker = createFireAndForgetInvokerForTest(),
     isFeatureToggleEnabled = isFeatureToggleDisabledForTest,
-    mainViewModel,
-    wallClock,
+    mainViewModel = createMainViewModelForTest(),
+    wallClock = createWallClock(),
   } = parameters;
 
   return {
@@ -67,7 +102,9 @@ export function createRootContextValueForTest(parameters: CreateRootContextValue
   };
 }
 
-export function createRootProviderWrapperForTest(rootContextValue: RootContextValue) {
+export function createRootProviderWrapperForTest(
+  rootContextValue: RootContextValue,
+): (properties: RootProviderWrapperProperties) => ReactNode {
   function wrapper(properties: RootProviderWrapperProperties): ReactNode {
     return <RootProvider value={rootContextValue}>{properties.children}</RootProvider>;
   }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -229,6 +229,27 @@ const config: Linter.Config[] = [
       '@typescript-eslint/strict-boolean-expressions': 'error',
     },
   },
+  {
+    files: [
+      'apps/webapp/src/script/components/Badge/components/VerificationBadges/VerificationBadges.tsx',
+      'apps/webapp/src/script/components/Cells/common/useCellPublicLink/useCellPublicLink.ts',
+      'apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx',
+      'apps/webapp/src/script/components/Conversation/Conversation.tsx',
+      'apps/webapp/src/script/components/InputBar/InputBar.tsx',
+      'apps/webapp/src/script/components/InputBar/usePing/usePing.ts',
+      'apps/webapp/src/script/components/MessagesList/Message/MessageWrapper.tsx',
+      'apps/webapp/src/script/components/MessagesList/utils/useLoadConversation.ts',
+      'apps/webapp/src/script/components/Modals/DetailViewModal/DetailViewModalFooter.tsx',
+      'apps/webapp/src/script/components/UserSearchableList/UserSearchableList.tsx',
+      'apps/webapp/src/script/components/calling/CallingCell/CallingCell.tsx',
+      'apps/webapp/src/script/components/calling/CallingOverlayContainer.tsx',
+      'apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx',
+    ],
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+      'no-void': 'error',
+    },
+  },
 ];
 
 export default config;

--- a/libraries/core/src/taskExecution/fireAndForgetInvoker/fireAndForgetInvoker.ts
+++ b/libraries/core/src/taskExecution/fireAndForgetInvoker/fireAndForgetInvoker.ts
@@ -43,9 +43,13 @@ export function createFireAndForgetInvoker(dependencies: FireAndForgetInvokerDep
     }
   }
 
+  function logUnexpectedObservationError(error: unknown): void {
+    logger.error(fireAndForgetErrorMessage, error);
+  }
+
   function trackPromise(trackedPromise: Promise<unknown>): void {
     activePromises.add(trackedPromise);
-    observePromise(trackedPromise);
+    observePromise(trackedPromise).catch(logUnexpectedObservationError);
   }
 
   function fireAndForget(asyncAction: () => Promise<unknown>): void {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Start the fire-and-forget migration with a small vertical slice.


