### PR TITLE
test: update TC-2937 to expect call to be closed after 90s instead of 30s [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -836,9 +836,11 @@ test.describe('Calling', () => {
   );
 
   test(
-    'I want to see a group call timing out after 30s if I`m the last one left in the call',
+    'I want to see a group call timing out after 90s if I`m the last one left in the call',
     {tag: ['@TC-2937', '@regression']},
-    async ({createPage}) => {
+    async ({createPage}, testInfo) => {
+      test.setTimeout(testInfo.timeout + 95_000);
+
       const [userAPages, userBPages, userCPages] = await Promise.all([
         PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
         PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
@@ -867,8 +869,8 @@ test.describe('Calling', () => {
         }
       });
 
-      await test.step('Verify call ends for User A after 30s of being the last one in the call', async () => {
-        await expect(userAPages.calling().goFullScreen).toBeHidden({timeout: 35_000});
+      await test.step('Verify call ends for User A after 90s of being the last one in the call', async () => {
+        await expect(userAPages.calling().goFullScreen).toBeHidden({timeout: 95_000});
         await expect(
           userAPages
             .conversation()

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -839,13 +839,17 @@ test.describe('Calling', () => {
     'I want to see a group call timing out after 90s if I`m the last one left in the call',
     {tag: ['@TC-2937', '@regression']},
     async ({createPage}, testInfo) => {
-      test.setTimeout(testInfo.timeout + 95_000);
+      test.setTimeout(testInfo.timeout + 90_000);
 
-      const [userAPages, userBPages, userCPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA), withConnectedUser(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+      const [userAPage, userBPage, userCPage] = await Promise.all([
+        createPage(withLogin(userA)),
+        createPage(withLogin(userB)),
+        createPage(withLogin(userC)),
       ]);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+      const userCPages = PageManager.from(userCPage).webapp.pages;
 
       await test.step('Setup: Create group and start call', async () => {
         await createGroup(userAPages, groupName, [userB, userC]);
@@ -870,7 +874,8 @@ test.describe('Calling', () => {
       });
 
       await test.step('Verify call ends for User A after 90s of being the last one in the call', async () => {
-        await expect(userAPages.calling().goFullScreen).toBeHidden({timeout: 95_000});
+        await userAPage.waitForTimeout(90_000);
+        await expect(userAPages.calling().goFullScreen).toBeHidden();
         await expect(
           userAPages
             .conversation()


### PR DESCRIPTION
This was an intentional change made by AVS. Therefore the test needs to be updated as well.


