### PR TITLE
test: add e2e test for proteus to MLS protocol migration [WPB-24851]

### DIFF
--- a/apps/webapp/src/script/components/panel/ConversationProtocolDetails/ConversationProtocolDetails.tsx
+++ b/apps/webapp/src/script/components/panel/ConversationProtocolDetails/ConversationProtocolDetails.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import {useId} from 'react';
+
 import {CSSObject} from '@emotion/react';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 
@@ -48,25 +50,34 @@ const wrapperStyles: CSSObject = {
   paddingTop: 4,
 };
 
-export const ConversationProtocolDetails = ({protocol, cipherSuite}: ConversationProtocolDetailsProps) => (
-  <div>
-    <h3 className="conversation-details__list-head">{t('conversationDetailsProtocolDetails')}</h3>
+export const ConversationProtocolDetails = ({protocol, cipherSuite}: ConversationProtocolDetailsProps) => {
+  const protocolLabelId = useId();
+  const cipherSuiteLabelId = useId();
 
-    <div css={wrapperStyles}>
-      <div css={titleStyles}>Protocol</div>
+  return (
+    <div>
+      <h3 className="conversation-details__list-head">{t('conversationDetailsProtocolDetails')}</h3>
 
-      <p css={subTitleStyles} data-uie-name="protocol-name">
-        {protocol.toUpperCase()}
-      </p>
+      <div css={wrapperStyles}>
+        <div id={protocolLabelId} css={titleStyles}>
+          Protocol
+        </div>
 
-      {protocol === CONVERSATION_PROTOCOL.MLS && cipherSuite != null && (
-        <>
-          <div css={titleStyles}>Cipher Suite</div>
-          <p css={subTitleStyles} data-uie-name="cipher-suite">
-            {Ciphersuite[cipherSuite]}
-          </p>
-        </>
-      )}
+        <div aria-labelledby={protocolLabelId} css={subTitleStyles} data-uie-name="protocol-name">
+          {protocol.toUpperCase()}
+        </div>
+
+        {protocol === CONVERSATION_PROTOCOL.MLS && cipherSuite != null && (
+          <>
+            <div id={cipherSuiteLabelId} css={titleStyles}>
+              Cipher Suite
+            </div>
+            <div aria-labelledby={cipherSuiteLabelId} css={subTitleStyles} data-uie-name="cipher-suite">
+              {Ciphersuite[cipherSuite]}
+            </div>
+          </>
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/apps/webapp/test/e2e_tests/backend/brigRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/brigRepository.e2e.ts
@@ -135,7 +135,10 @@ export class BrigRepositoryE2E {
     );
   }
 
-  public async enableMLSFeature(teamId: string) {
+  public async enableMLSFeature(
+    teamId: string,
+    config: {defaultProtocol: 'mls' | 'proteus'; supportedProtocols: ('mls' | 'proteus')[]},
+  ) {
     await this.axiosInstance.patch(
       `i/teams/${teamId}/features/mls`,
       {
@@ -143,9 +146,9 @@ export class BrigRepositoryE2E {
         config: {
           protocolToggleUsers: [],
           allowedCipherSuites: [2],
-          defaultProtocol: 'mls',
+          defaultProtocol: config?.defaultProtocol ?? 'mls',
           defaultCipherSuite: 2,
-          supportedProtocols: ['mls', 'proteus'],
+          supportedProtocols: config?.supportedProtocols ?? ['mls', 'proteus'],
         },
       },
       {

--- a/apps/webapp/test/e2e_tests/backend/brigRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/brigRepository.e2e.ts
@@ -135,14 +135,18 @@ export class BrigRepositoryE2E {
     );
   }
 
-  public async enableMLSFeature(
+  public async configureMLSFeature(
     teamId: string,
-    config: {defaultProtocol: 'mls' | 'proteus'; supportedProtocols: ('mls' | 'proteus')[]},
+    config: {
+      status?: 'enabled' | 'disabled';
+      defaultProtocol: 'mls' | 'proteus';
+      supportedProtocols: ('mls' | 'proteus')[];
+    },
   ) {
     await this.axiosInstance.patch(
       `i/teams/${teamId}/features/mls`,
       {
-        status: 'enabled',
+        status: config.status ?? 'enabled',
         config: {
           protocolToggleUsers: [],
           allowedCipherSuites: [2],

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
@@ -43,6 +43,8 @@ export class ConversationDetailsPage {
   readonly editConversationNameButton: Locator;
   readonly textFieldForConversationName: Locator;
 
+  readonly protocol: Locator;
+
   constructor(page: Page) {
     this.page = page;
     this.conversationDetails = page.locator('#conversation-details');
@@ -63,6 +65,8 @@ export class ConversationDetailsPage {
     this.notificationsButton = this.page.getByRole('button', {name: 'Notifications'});
     this.editConversationNameButton = this.page.getByRole('button', {name: 'Change conversation name'});
     this.textFieldForConversationName = this.page.locator('textarea[data-uie-name="enter-name"]');
+
+    this.protocol = this.conversationDetails.getByLabel('Protocol');
   }
 
   async waitForSidebar() {

--- a/apps/webapp/test/e2e_tests/specs/Encryption/encryption.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Encryption/encryption.spec.ts
@@ -1,0 +1,69 @@
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
+import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
+
+test.describe('Encryption', () => {
+  test(
+    'Migrate 1:1 conversations',
+    {tag: ['@TC-8736', '@regression']},
+    async ({createTeam, createUser, createPage, api}) => {
+      const userA = await createUser();
+      const userB = await createUser();
+      const proteusTeam = await createTeam('Proteus Team', {
+        users: [userA, userB],
+        features: {
+          mls: {status: 'disabled', defaultProtocol: 'proteus', supportedProtocols: ['proteus']},
+        },
+      });
+
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
+
+      const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+      const {pages: userBPages, modals: userBModals} = PageManager.from(userBPage).webapp;
+
+      await createGroup(userAPages, 'Distraction Group', []);
+      await userAPages.conversationList().getConversation('Distraction Group').open();
+      await userBPages.conversationList().getConversation(userA.fullName).open();
+
+      await test.step('Send messages & verify the conversation uses proteus', async () => {
+        await userBPages.conversation().sendMessage('Message before migration');
+        await userBPages.conversation().clickConversationInfoButton();
+        await expect(userBPages.conversationDetails().protocol).toHaveText('PROTEUS');
+      });
+
+      await test.step('Migrate team to MLS', async () => {
+        await api.brig.configureMLSFeature(proteusTeam.teamId, {
+          status: 'enabled',
+          defaultProtocol: 'mls',
+          supportedProtocols: ['mls', 'proteus'],
+        });
+      });
+
+      await test.step('Both users reload the app via the MLS modal', async () => {
+        for (const modal of [userAModals, userBModals]) {
+          await expect(modal.confirm().modal).toBeVisible();
+          await expect(modal.confirm().modalTitle).toContainText('New messaging protocol');
+          await modal.confirm().actionButton.click();
+        }
+      });
+
+      await test.step('User A still sees the correct unread count after migration', async () => {
+        const mlsConversation = userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'});
+        await expect(mlsConversation).toBeVisible();
+        await expect(mlsConversation.unreadIndicator).toBeVisible();
+        await expect(mlsConversation.unreadIndicator).toContainText('1'); // There should be one unread message
+      });
+
+      await test.step('Both users see MLS as protocol in the conversation details', async () => {
+        await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+        await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
+
+        for (const pages of [userAPages, userBPages]) {
+          await pages.conversation().clickConversationInfoButton();
+          await expect(pages.conversationDetails().protocol).toHaveText('MLS');
+        }
+      });
+    },
+  );
+});

--- a/apps/webapp/test/e2e_tests/specs/Encryption/encryption.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Encryption/encryption.spec.ts
@@ -3,7 +3,8 @@ import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
 import {connectWithUser, createGroup} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Encryption', () => {
-  test(
+  // Test is skipped due to the unread messages being lost during migration (See: WPB-25346)
+  test.skip(
     'Migrate 1:1 conversations',
     {tag: ['@TC-8736', '@regression']},
     async ({createTeam, createUser, createPage, api}) => {

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -26,6 +26,7 @@ import {connectWithUser} from './utils/userActions';
 import {mockAudioAndVideoDevices} from './utils/mockVideoDevice.util';
 import {Role} from '@wireapp/api-client/lib/team';
 import {FEATURE_KEY} from '@wireapp/api-client/lib/team/feature';
+import {BrigRepositoryE2E} from './backend/brigRepository.e2e';
 
 export type PagePlugin = (page: Page) => void | Promise<void>;
 
@@ -55,8 +56,13 @@ type Fixtures = {
   createTeam: (
     teamName: string,
     options?: {
-      users: (User | {user: User; role?: keyof typeof Role})[];
-      features?: {conferenceCalling?: boolean; channels?: boolean; mls?: boolean; cells?: boolean};
+      users?: (User | {user: User; role?: keyof typeof Role})[];
+      features?: {
+        conferenceCalling?: boolean;
+        channels?: boolean;
+        mls?: boolean | Parameters<BrigRepositoryE2E['enableMLSFeature']>[1];
+        cells?: boolean;
+      };
     },
   ) => Promise<Team>;
 };
@@ -154,7 +160,7 @@ export const test = baseTest.extend<Fixtures>({
         );
       }
 
-      if (options?.features && Object.values(options.features).every(Boolean)) {
+      if (options?.features && Object.values(options.features).some(Boolean)) {
         // The team will be reset right after initialization, so we need to wait a short time for it to finish
         // before changing feature configs since they would otherwise be overwritten (See WPB-23698)
         await new Promise(resolve => setTimeout(resolve, 5000));
@@ -164,13 +170,24 @@ export const test = baseTest.extend<Fixtures>({
           await api.waitForFeatureToBeEnabled(FEATURE_KEY.CONFERENCE_CALLING, teamId, owner.token);
         }
 
-        // Creating channels depends on MLS to be enabled
-        if (options.features.mls || options.features.channels) {
-          await api.brig.enableMLSFeature(owner.teamId);
+        if (options.features.mls) {
+          await api.brig.enableMLSFeature(
+            owner.teamId,
+            options.features.mls === true
+              ? {defaultProtocol: 'mls', supportedProtocols: ['mls', 'proteus']}
+              : options.features.mls,
+          );
           await api.waitForFeatureToBeEnabled(FEATURE_KEY.MLS, teamId, owner.token);
         }
 
         if (options.features.channels) {
+          // Creating channels depends on MLS to be enabled
+          await api.brig.enableMLSFeature(owner.teamId, {
+            defaultProtocol: 'mls',
+            supportedProtocols: ['mls', 'proteus'],
+          });
+          await api.waitForFeatureToBeEnabled(FEATURE_KEY.MLS, teamId, owner.token);
+
           await api.brig.unlockChannelFeature(teamId);
           await api.brig.enableChannelsFeature(teamId);
           await api.waitForFeatureToBeEnabled(FEATURE_KEY.CHANNELS, teamId, owner.token);

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -60,7 +60,7 @@ type Fixtures = {
       features?: {
         conferenceCalling?: boolean;
         channels?: boolean;
-        mls?: boolean | Parameters<BrigRepositoryE2E['enableMLSFeature']>[1];
+        mls?: boolean | Parameters<BrigRepositoryE2E['configureMLSFeature']>[1];
         cells?: boolean;
       };
     },
@@ -171,18 +171,17 @@ export const test = baseTest.extend<Fixtures>({
         }
 
         if (options.features.mls) {
-          await api.brig.enableMLSFeature(
+          await api.brig.configureMLSFeature(
             owner.teamId,
             options.features.mls === true
-              ? {defaultProtocol: 'mls', supportedProtocols: ['mls', 'proteus']}
+              ? {status: 'enabled', defaultProtocol: 'mls', supportedProtocols: ['mls', 'proteus']}
               : options.features.mls,
           );
-          await api.waitForFeatureToBeEnabled(FEATURE_KEY.MLS, teamId, owner.token);
         }
 
         if (options.features.channels) {
           // Creating channels depends on MLS to be enabled
-          await api.brig.enableMLSFeature(owner.teamId, {
+          await api.brig.configureMLSFeature(owner.teamId, {
             defaultProtocol: 'mls',
             supportedProtocols: ['mls', 'proteus'],
           });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24851" title="WPB-24851" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24851</a>  [Web][QA] Write test for Migrating from Proteus to MLS protocol
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This add the test case TC-8736 checking that conversations keep their state as expected during migration from proteus to MLS. The test is currently skipped due to a bug discovered where unread messages are marked as read after the migration (see [WPB-25346](https://wearezeta.atlassian.net/browse/WPB-25346)).
This decision was made in alignment with @iskvortsov (see: https://wearezeta.atlassian.net/browse/WPB-24851?focusedCommentId=159822)

[WPB-25346]: https://wearezeta.atlassian.net/browse/WPB-25346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ