### PR TITLE
feat: update de-DE locale links [WPB-23924]

### DIFF
--- a/apps/webapp/src/script/Config.ts
+++ b/apps/webapp/src/script/Config.ts
@@ -101,6 +101,8 @@ const config = {
 
   COUNTLY_SERVER_URL: 'https://wire.count.ly/',
   GET_WIRE_URL: 'https://wire.com/app-download',
+  PRIVACY_POLICY_URL_DE: 'https://wire.com/de/datenschutzerklaerung',
+  TERMS_OF_USE_URL_DE: 'https://wire.com/de/legal/teams',
 } as const;
 
 export type Configuration = typeof config;

--- a/apps/webapp/src/script/auth/localeConfig.ts
+++ b/apps/webapp/src/script/auth/localeConfig.ts
@@ -20,15 +20,15 @@
 import {UrlUtil} from '@wireapp/commons';
 
 import {QUERY_KEY} from './route';
-import {supportedLocales as Locales} from './supportedLocales';
+import {Locales, SupportedLocale} from './supportedLocales';
 
-const DEFAULT_LANGUAGE = 'en-US';
+const DEFAULT_LANGUAGE: SupportedLocale = 'en-US';
 
-function getLocale(): string {
+function getLocale(): SupportedLocale {
   return mapLanguage(navigator.languages?.length ? navigator.languages[0] : navigator.language);
 }
 
-export function currentLanguage(): string {
+export function currentLanguage(): SupportedLocale {
   return mapLanguage(UrlUtil.getURLParameter(QUERY_KEY.LANGUAGE) || getLocale());
 }
 
@@ -37,11 +37,11 @@ export function normalizeLanguage(language: string = DEFAULT_LANGUAGE): string {
   return language.substring(0, LANGUAGE_SHORTHAND_LENGTH);
 }
 
-export function findLanguage(language: string = DEFAULT_LANGUAGE): string {
+export function findLanguage(language: string = DEFAULT_LANGUAGE): SupportedLocale {
   language = normalizeLanguage(language);
   return Locales.find(locale => locale.startsWith(language)) ?? DEFAULT_LANGUAGE;
 }
 
-export function mapLanguage(language: string = DEFAULT_LANGUAGE): string {
+export function mapLanguage(language: string = DEFAULT_LANGUAGE): SupportedLocale {
   return findLanguage(language) || DEFAULT_LANGUAGE;
 }

--- a/apps/webapp/src/script/auth/supportedLocales.ts
+++ b/apps/webapp/src/script/auth/supportedLocales.ts
@@ -17,44 +17,7 @@
  *
  */
 
-export type SupportedLocale =
-  | 'ar-SA'
-  | 'cs-CZ'
-  | 'da-DK'
-  | 'de-DE'
-  | 'el-GR'
-  | 'en-US'
-  | 'es-ES'
-  | 'et-EE'
-  | 'fa-IR'
-  | 'fi-FI'
-  | 'fr-FR'
-  | 'hi-IN'
-  | 'hr-HR'
-  | 'hu-HU'
-  | 'id-ID'
-  | 'it-IT'
-  | 'ja-JP'
-  | 'lt-LT'
-  | 'lv-LV'
-  | 'nl-NL'
-  | 'no-NO'
-  | 'pl-PL'
-  | 'pt-PT'
-  | 'pt-BR'
-  | 'ro-RO'
-  | 'ru-RU'
-  | 'si-LK'
-  | 'sk-SK'
-  | 'sl-SI'
-  | 'sr-SP'
-  | 'sv-SE'
-  | 'tr-TR'
-  | 'uk-UA'
-  | 'zh-CN'
-  | 'zh-TW';
-
-export const Locales: readonly SupportedLocale[] = [
+export const Locales = [
   'ar-SA',
   'cs-CZ',
   'da-DK',
@@ -90,4 +53,6 @@ export const Locales: readonly SupportedLocale[] = [
   'uk-UA',
   'zh-CN',
   'zh-TW',
-];
+] as const;
+
+export type SupportedLocale = (typeof Locales)[number];

--- a/apps/webapp/src/script/auth/supportedLocales.ts
+++ b/apps/webapp/src/script/auth/supportedLocales.ts
@@ -17,7 +17,44 @@
  *
  */
 
-export const supportedLocales: string[] = [
+export type SupportedLocale =
+  | 'ar-SA'
+  | 'cs-CZ'
+  | 'da-DK'
+  | 'de-DE'
+  | 'el-GR'
+  | 'en-US'
+  | 'es-ES'
+  | 'et-EE'
+  | 'fa-IR'
+  | 'fi-FI'
+  | 'fr-FR'
+  | 'hi-IN'
+  | 'hr-HR'
+  | 'hu-HU'
+  | 'id-ID'
+  | 'it-IT'
+  | 'ja-JP'
+  | 'lt-LT'
+  | 'lv-LV'
+  | 'nl-NL'
+  | 'no-NO'
+  | 'pl-PL'
+  | 'pt-PT'
+  | 'pt-BR'
+  | 'ro-RO'
+  | 'ru-RU'
+  | 'si-LK'
+  | 'sk-SK'
+  | 'sl-SI'
+  | 'sr-SP'
+  | 'sv-SE'
+  | 'tr-TR'
+  | 'uk-UA'
+  | 'zh-CN'
+  | 'zh-TW';
+
+export const Locales: readonly SupportedLocale[] = [
   'ar-SA',
   'cs-CZ',
   'da-DK',

--- a/apps/webapp/src/script/externalRoute.ts
+++ b/apps/webapp/src/script/externalRoute.ts
@@ -20,7 +20,7 @@
 import {currentLanguage} from './auth/localeConfig';
 import {Config} from './Config';
 
-const URL = Config.getConfig().URL;
+const {URL, TERMS_OF_USE_URL_DE, PRIVACY_POLICY_URL_DE} = Config.getConfig();
 
 const isProductionWebsite = URL.WEBSITE_BASE && URL.WEBSITE_BASE === 'https://wire.com';
 
@@ -43,9 +43,21 @@ const getAccountPagesUrl = (path: string = ''): string | undefined => {
   return URL.ACCOUNT_BASE ? `${URL.ACCOUNT_BASE}${path}` : undefined;
 };
 
-const getPrivacyPolicyUrl = (): string | undefined => addLocaleToUrl(URL.PRIVACY_POLICY || undefined);
-const getTermsOfUsePersonalUrl = (): string | undefined => addLocaleToUrl(URL.TERMS_OF_USE_PERSONAL || undefined);
-const getTermsOfUseTeamUrl = (): string | undefined => addLocaleToUrl(URL.TERMS_OF_USE_TEAMS || undefined);
+const getPrivacyPolicyUrl = () => {
+  const language = currentLanguage();
+  if (language === 'de-DE') {
+    return PRIVACY_POLICY_URL_DE;
+  }
+  return URL.PRIVACY_POLICY;
+};
+
+const getTermsOfUseUrl = () => {
+  const language = currentLanguage();
+  if (language === 'de-DE') {
+    return TERMS_OF_USE_URL_DE;
+  }
+  return URL.TERMS_OF_USE_TEAMS;
+};
 
 /**
  * Retrieves the URL for managing services with optional UTM parameters.
@@ -86,7 +98,6 @@ export const externalUrl = {
   createTeam: getCreateTeamUrl(),
   passwordReset: getAccountPagesUrl(URL.URL_PATH?.PASSWORD_RESET),
   privacyPolicy: getPrivacyPolicyUrl(),
-  termsOfUsePersonnal: getTermsOfUsePersonalUrl(),
-  termsOfUseTeam: getTermsOfUseTeamUrl(),
+  termsOfUse: getTermsOfUseUrl(),
   website: getWebsiteUrl(),
 };

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/AboutPreferences.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/AboutPreferences.tsx
@@ -48,7 +48,7 @@ const AboutPreferences = ({selfUser, teamState = container.resolve(TeamState)}: 
 
   const termsOfUseUrl = useMemo(() => {
     if (selfUser) {
-      return inTeam ? externalUrl.termsOfUseTeam : externalUrl.termsOfUsePersonnal;
+      return externalUrl.termsOfUse;
     }
     return '';
   }, [selfUser, inTeam]);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/personalAccountLifecycle-TC-8638.spec.ts
@@ -169,7 +169,7 @@ test('Personal Account Lifecycle', {tag: ['@TC-8638', '@crit-flow-web']}, async 
 
     const [newTab] = await Promise.all([pageManagerA.page.waitForEvent('popup'), pages.about().clickTermsOfUseLink()]);
 
-    await expect(newTab).toHaveURL(/legal#terms/);
+    await expect(newTab).toHaveURL(/wire\.com\/en\/legal/);
 
     await newTab.close();
   });

--- a/apps/webapp/test/e2e_tests/specs/Registration/registration.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Registration/registration.spec.ts
@@ -43,7 +43,7 @@ test.describe('Registration', () => {
           pages.registration().termsLabel.click(),
         ]);
 
-        await expect(newTab).toHaveURL(/legal#terms/);
+        await expect(newTab).toHaveURL(/wire\.com\/en\/legal/);
       },
     );
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23924" title="WPB-23924" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23924</a>  [Web] Terms of use and privacy policy have wrong link in settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR strengthens locale handling and improves external legal URL management, with a particular focus on German users.

### **Key updates**

- Introduced a strongly typed SupportedLocale type to replace generic string locale usage, improving type safety and consistency across locale-related logic.
- Updated locale configuration utilities and selection functions to use the new locale type throughout the codebase.
- Added dedicated German legal document URLs (PRIVACY_POLICY_URL_DE and TERMS_OF_USE_URL_DE).
- Enhanced external route handling so users with the de-DE locale automatically receive German-specific privacy policy and terms of use links.
- Simplified external URL usage by consolidating terms-of-use handling into a single termsOfUse property that dynamically resolves the correct localized URL.