### PR TITLE
fix: disable retry for 503 status code [WPB-25507]

### DIFF
--- a/libraries/api-client/src/http/httpClient.test.ts
+++ b/libraries/api-client/src/http/httpClient.test.ts
@@ -217,7 +217,11 @@ describe('HttpClient', () => {
       const client = new HttpClient(testConfig, mockedAccessTokenStore as AccessTokenStore, {
         dependencies: httpClientDependenciesForTest,
       });
-      const serviceUnavailableError = new BackendError('Service unavailable', undefined, StatusCode.SERVICE_UNAVAILABLE);
+      const serviceUnavailableError = new BackendError(
+        'Service unavailable',
+        undefined,
+        StatusCode.SERVICE_UNAVAILABLE,
+      );
 
       client._sendRequest = jest.fn().mockRejectedValueOnce(serviceUnavailableError);
 

--- a/libraries/api-client/src/http/httpClient.test.ts
+++ b/libraries/api-client/src/http/httpClient.test.ts
@@ -193,7 +193,7 @@ describe('HttpClient', () => {
       },
     );
 
-    it('retries retryable backend errors with incremental retry backoff', async () => {
+    it('retries 500 backend errors with incremental retry backoff', async () => {
       const httpClientDependenciesForTest = createHttpClientDependenciesForTest();
       const client = new HttpClient(testConfig, mockedAccessTokenStore as AccessTokenStore, {
         dependencies: httpClientDependenciesForTest,
@@ -202,7 +202,7 @@ describe('HttpClient', () => {
 
       client._sendRequest = jest
         .fn()
-        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.SERVICE_UNAVAILABLE))
+        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.INTERNAL_SERVER_ERROR))
         .mockResolvedValueOnce(response);
 
       const result = await client.sendRequest({method: 'GET', url: '/conversations'});
@@ -210,6 +210,20 @@ describe('HttpClient', () => {
       expect(result).toBe(response);
       expect(client._sendRequest).toHaveBeenCalledTimes(2);
       expect(httpClientDependenciesForTest.observedDelayInMilliseconds).toEqual([100]);
+    });
+
+    it('does not retry 503 Service Unavailable backend errors', async () => {
+      const httpClientDependenciesForTest = createHttpClientDependenciesForTest();
+      const client = new HttpClient(testConfig, mockedAccessTokenStore as AccessTokenStore, {
+        dependencies: httpClientDependenciesForTest,
+      });
+      const serviceUnavailableError = new BackendError('Service unavailable', undefined, StatusCode.SERVICE_UNAVAILABLE);
+
+      client._sendRequest = jest.fn().mockRejectedValueOnce(serviceUnavailableError);
+
+      await expect(client.sendRequest({method: 'GET', url: '/conversations'})).rejects.toBe(serviceUnavailableError);
+      expect(client._sendRequest).toHaveBeenCalledTimes(1);
+      expect(httpClientDependenciesForTest.observedDelayInMilliseconds).toEqual([]);
     });
 
     it('does not retry non-retryable backend errors with incremental retry backoff', async () => {
@@ -235,11 +249,11 @@ describe('HttpClient', () => {
 
       client._sendRequest = jest
         .fn()
-        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.SERVICE_UNAVAILABLE))
+        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.INTERNAL_SERVER_ERROR))
         .mockResolvedValueOnce(response)
-        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.SERVICE_UNAVAILABLE))
+        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.INTERNAL_SERVER_ERROR))
         .mockResolvedValueOnce(response)
-        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.SERVICE_UNAVAILABLE))
+        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.INTERNAL_SERVER_ERROR))
         .mockResolvedValueOnce(response);
 
       await client.sendRequest({method: 'GET', url: '/conversations'});
@@ -278,7 +292,7 @@ describe('HttpClient', () => {
 
       client._sendRequest = jest
         .fn()
-        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.SERVICE_UNAVAILABLE))
+        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.INTERNAL_SERVER_ERROR))
         .mockResolvedValueOnce(response);
 
       const responsePromise = client.sendRequest({method: 'GET', url: '/conversations'});
@@ -322,7 +336,7 @@ describe('HttpClient', () => {
 
       client._sendRequest = jest
         .fn()
-        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.SERVICE_UNAVAILABLE));
+        .mockRejectedValueOnce(createRetryableBackendError(StatusCode.INTERNAL_SERVER_ERROR));
 
       const responsePromise = client.sendRequest({method: 'GET', url: '/conversations'}, false, abortController);
       await waitWasScheduled;

--- a/libraries/api-client/src/http/incrementalRetryBackoff.test.ts
+++ b/libraries/api-client/src/http/incrementalRetryBackoff.test.ts
@@ -104,7 +104,7 @@ describe('IncrementalRetryBackoff', function () {
     expect(resetBackoffState.totalRetryDelayInMilliseconds).toBe(0);
   });
 
-  it('treats 420, 429, and 5xx statuses as retryable', () => {
+  it('treats 420, 429, and 5xx statuses (except 503) as retryable', () => {
     expect(incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.just(420))).toBe(true);
     expect(incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.just(tooManyRequestsStatusCode))).toBe(
       true,
@@ -115,9 +115,12 @@ describe('IncrementalRetryBackoff', function () {
     expect(incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.just(badGatewayStatusCode))).toBe(
       true,
     );
+  });
+
+  it('does not retry on 503 Service Unavailable', () => {
     expect(
       incrementalRetryBackoffPolicy.shouldRetryWithIncrementalBackoff(Maybe.just(serviceUnavailableStatusCode)),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('does not treat unrelated statuses as retryable', () => {

--- a/libraries/api-client/src/http/incrementalRetryBackoff.ts
+++ b/libraries/api-client/src/http/incrementalRetryBackoff.ts
@@ -34,9 +34,10 @@ export type IncrementalRetryBackoffPolicy = {
 
 const initialRetryDelayInMilliseconds = 100;
 const maximumRetryDelayInMilliseconds = 10 * 60 * 1000;
-const nonStandardRetryableStatusCode = StatusCodes.METHOD_FAILURE;
-const serverErrorStatusCodeRangeStart = StatusCodes.INTERNAL_SERVER_ERROR;
-const serverErrorStatusCodeRangeEnd = StatusCodes.NETWORK_AUTHENTICATION_REQUIRED;
+const nonStandardRetryableStatusCode = 420;
+const serverErrorStatusCodeRangeStart = 500;
+const serverErrorStatusCodeRangeEnd = 599;
+const serviceUnavailableStatusCode = 503;
 
 export function createIncrementalRetryBackoffPolicy(): IncrementalRetryBackoffPolicy {
   return {
@@ -72,7 +73,7 @@ export function createIncrementalRetryBackoffPolicy(): IncrementalRetryBackoffPo
           return (
             statusCodeValue >= serverErrorStatusCodeRangeStart &&
             statusCodeValue <= serverErrorStatusCodeRangeEnd &&
-            statusCodeValue !== StatusCodes.SERVICE_UNAVAILABLE
+            statusCodeValue !== serviceUnavailableStatusCode
           );
         })
         .unwrapOr(false);

--- a/libraries/api-client/src/http/incrementalRetryBackoff.ts
+++ b/libraries/api-client/src/http/incrementalRetryBackoff.ts
@@ -34,9 +34,9 @@ export type IncrementalRetryBackoffPolicy = {
 
 const initialRetryDelayInMilliseconds = 100;
 const maximumRetryDelayInMilliseconds = 10 * 60 * 1000;
-const nonStandardRetryableStatusCode = 420;
-const serverErrorStatusCodeRangeStart = 500;
-const serverErrorStatusCodeRangeEnd = 599;
+const nonStandardRetryableStatusCode = StatusCodes.METHOD_FAILURE;
+const serverErrorStatusCodeRangeStart = StatusCodes.INTERNAL_SERVER_ERROR;
+const serverErrorStatusCodeRangeEnd = StatusCodes.NETWORK_AUTHENTICATION_REQUIRED;
 
 export function createIncrementalRetryBackoffPolicy(): IncrementalRetryBackoffPolicy {
   return {

--- a/libraries/api-client/src/http/incrementalRetryBackoff.ts
+++ b/libraries/api-client/src/http/incrementalRetryBackoff.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {StatusCodes} from 'http-status-codes';
 import {Maybe} from 'true-myth';
 
 export type IncrementalRetryBackoffState = {
@@ -35,9 +34,10 @@ export type IncrementalRetryBackoffPolicy = {
 const initialRetryDelayInMilliseconds = 100;
 const maximumRetryDelayInMilliseconds = 10 * 60 * 1000;
 const nonStandardRetryableStatusCode = 420;
+const tooManyRequestsStatusCode = 429;
 const serverErrorStatusCodeRangeStart = 500;
-const serverErrorStatusCodeRangeEnd = 599;
 const serviceUnavailableStatusCode = 503;
+const serverErrorStatusCodeRangeEnd = 599;
 
 export function createIncrementalRetryBackoffPolicy(): IncrementalRetryBackoffPolicy {
   return {
@@ -66,7 +66,7 @@ export function createIncrementalRetryBackoffPolicy(): IncrementalRetryBackoffPo
     shouldRetryWithIncrementalBackoff(statusCode) {
       return statusCode
         .map((statusCodeValue): boolean => {
-          if (statusCodeValue === nonStandardRetryableStatusCode || statusCodeValue === StatusCodes.TOO_MANY_REQUESTS) {
+          if (statusCodeValue === nonStandardRetryableStatusCode || statusCodeValue === tooManyRequestsStatusCode) {
             return true;
           }
 

--- a/libraries/api-client/src/http/incrementalRetryBackoff.ts
+++ b/libraries/api-client/src/http/incrementalRetryBackoff.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {StatusCodes} from 'http-status-codes';
 import {Maybe} from 'true-myth';
 
 export type IncrementalRetryBackoffState = {
@@ -34,7 +35,6 @@ export type IncrementalRetryBackoffPolicy = {
 const initialRetryDelayInMilliseconds = 100;
 const maximumRetryDelayInMilliseconds = 10 * 60 * 1000;
 const nonStandardRetryableStatusCode = 420;
-const tooManyRequestsStatusCode = 429;
 const serverErrorStatusCodeRangeStart = 500;
 const serverErrorStatusCodeRangeEnd = 599;
 
@@ -65,11 +65,15 @@ export function createIncrementalRetryBackoffPolicy(): IncrementalRetryBackoffPo
     shouldRetryWithIncrementalBackoff(statusCode) {
       return statusCode
         .map((statusCodeValue): boolean => {
-          if (statusCodeValue === nonStandardRetryableStatusCode || statusCodeValue === tooManyRequestsStatusCode) {
+          if (statusCodeValue === nonStandardRetryableStatusCode || statusCodeValue === StatusCodes.TOO_MANY_REQUESTS) {
             return true;
           }
 
-          return statusCodeValue >= serverErrorStatusCodeRangeStart && statusCodeValue <= serverErrorStatusCodeRangeEnd;
+          return (
+            statusCodeValue >= serverErrorStatusCodeRangeStart &&
+            statusCodeValue <= serverErrorStatusCodeRangeEnd &&
+            statusCodeValue !== StatusCodes.SERVICE_UNAVAILABLE
+          );
         })
         .unwrapOr(false);
     },

--- a/libraries/api-client/src/http/incrementalRetryBackoffRunner.test.ts
+++ b/libraries/api-client/src/http/incrementalRetryBackoffRunner.test.ts
@@ -97,7 +97,7 @@ describe('IncrementalRetryBackoffRunner', () => {
     let incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
     const runRequestAttempt = jest
       .fn<Promise<string>, []>()
-      .mockRejectedValueOnce({statusCode: 503})
+      .mockRejectedValueOnce({statusCode: 500})
       .mockResolvedValueOnce('response');
 
     const response = await incrementalRetryBackoffRunner.runWithIncrementalRetryBackoff({
@@ -138,8 +138,8 @@ describe('IncrementalRetryBackoffRunner', () => {
     let incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
     const runRequestAttempt = jest
       .fn<Promise<string>, []>()
-      .mockRejectedValueOnce({statusCode: 503})
-      .mockRejectedValueOnce({statusCode: 503})
+      .mockRejectedValueOnce({statusCode: 500})
+      .mockRejectedValueOnce({statusCode: 500})
       .mockResolvedValueOnce('response');
 
     const response = await incrementalRetryBackoffRunner.runWithIncrementalRetryBackoff({
@@ -168,7 +168,10 @@ describe('IncrementalRetryBackoffRunner', () => {
     expect(incrementalRetryBackoffState.delayInMilliseconds).toBe(200);
   });
 
-  it('rethrows non-retryable failures without waiting', async () => {
+  it.each([
+    {expectedDescription: '400 Bad Request', statusCode: 400},
+    {expectedDescription: '503 Service Unavailable', statusCode: 503},
+  ] as const)('rethrows $expectedDescription immediately without waiting', async ({statusCode}) => {
     const {abortableWait, waitForDurationInMilliseconds} = createIncrementalRetryBackoffRunnerDependenciesForTest();
     const incrementalRetryBackoffPolicy = createIncrementalRetryBackoffPolicy();
     const incrementalRetryBackoffRunner = createIncrementalRetryBackoffRunner({
@@ -179,7 +182,7 @@ describe('IncrementalRetryBackoffRunner', () => {
       incrementalRetryBackoffPolicy,
     });
     let incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
-    const nonRetryableError = {statusCode: 400};
+    const nonRetryableError = {statusCode};
     const runRequestAttempt = jest.fn<Promise<string>, []>().mockRejectedValue(nonRetryableError);
 
     await expect(
@@ -224,7 +227,7 @@ describe('IncrementalRetryBackoffRunner', () => {
     const resetAbortController = new AbortController();
     const runRequestAttempt = jest
       .fn<Promise<string>, []>()
-      .mockRejectedValueOnce({statusCode: 503})
+      .mockRejectedValueOnce({statusCode: 500})
       .mockResolvedValueOnce('response');
 
     waitForDurationInMilliseconds.mockImplementationOnce(async (_durationInMilliseconds, abortSignal) => {
@@ -272,7 +275,7 @@ describe('IncrementalRetryBackoffRunner', () => {
     });
     let incrementalRetryBackoffState = incrementalRetryBackoffPolicy.createInitialIncrementalRetryBackoffState();
     const requestAbortController = new AbortController();
-    const runRequestAttempt = jest.fn<Promise<string>, []>().mockRejectedValueOnce({statusCode: 503});
+    const runRequestAttempt = jest.fn<Promise<string>, []>().mockRejectedValueOnce({statusCode: 500});
 
     waitForDurationInMilliseconds.mockImplementationOnce(async (_durationInMilliseconds, abortSignal) => {
       requestAbortController.abort();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25507" title="WPB-25507" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25507</a>  Webapp Login issue on custom backend after 5.30 update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This pull request refines the HTTP client’s incremental retry backoff behavior by preventing retries for requests that fail with a 503 Service Unavailable response. Previously, all 5xx responses were treated as retryable; the updated logic now excludes 503 errors from retry attempts. Associated tests were also updated to reflect the new behavior.

### Retry backoff policy updates

- Updated shouldRetryWithIncrementalBackoff in incrementalRetryBackoff.ts so that all 5xx responses except 503 Service Unavailable are considered retryable.
- Improved readability by replacing hardcoded status values with constants from http-status-codes.
- Added test coverage to verify that 503 responses are not retried and updated existing retry expectations accordingly.

### HTTP client and runner test changes

- Updated HttpClient tests to confirm that 503 responses do not trigger retries.
- Replaced previous 503-based retry scenarios with 500-level errors that remain retryable.
- Updated IncrementalRetryBackoffRunner tests with additional parameterized cases to validate the new non-retry behavior for 503 responses.

### Cleanup and maintainability improvements

- Replaced the hardcoded 429 status code with StatusCodes.TOO_MANY_REQUESTS to improve clarity and consistency across the codebase.