### PR TITLE
test: refactor "leaveConversation" modal [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/leaveConversation.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/leaveConversation.modal.ts
@@ -31,8 +31,4 @@ export class LeaveConversationModal extends OptionModal {
   async toggleCheckbox() {
     await this.modalCheckbox.click();
   }
-
-  async clickConfirm() {
-    await this.actionButton.click();
-  }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/leaveConversation.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/leaveConversation.modal.ts
@@ -36,10 +36,6 @@ export class LeaveConversationModal {
     await this.modalCheckbox.click();
   }
 
-  async clickCancel() {
-    await this.cancelButton.click();
-  }
-
   async clickConfirm() {
     await this.confirmButton.click();
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/leaveConversation.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/leaveConversation.modal.ts
@@ -27,8 +27,4 @@ export class LeaveConversationModal extends OptionModal {
     super(page);
     this.modalCheckbox = this.modal.getByText('clear the content');
   }
-
-  async toggleCheckbox() {
-    await this.modalCheckbox.click();
-  }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/leaveConversation.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/leaveConversation.modal.ts
@@ -18,18 +18,14 @@
  */
 
 import {Page, Locator} from '@playwright/test';
+import {OptionModal} from './option.modal';
 
-export class LeaveConversationModal {
-  readonly modal: Locator;
+export class LeaveConversationModal extends OptionModal {
   readonly modalCheckbox: Locator;
-  readonly cancelButton: Locator;
-  readonly confirmButton: Locator;
 
   constructor(page: Page) {
-    this.modal = page.getByTestId('modal-template-option');
+    super(page);
     this.modalCheckbox = this.modal.getByText('clear the content');
-    this.cancelButton = this.modal.getByTestId('do-secondary');
-    this.confirmButton = this.modal.getByTestId('do-action');
   }
 
   async toggleCheckbox() {
@@ -37,6 +33,6 @@ export class LeaveConversationModal {
   }
 
   async clickConfirm() {
-    await this.confirmButton.click();
+    await this.actionButton.click();
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
@@ -203,7 +203,7 @@ test.describe('Conversations', () => {
       await adminPages.conversationList().getConversation(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
       await adminPages.conversation().leaveConversation();
-      await modals.leaveConversation().clickConfirm();
+      await modals.leaveConversation().actionButton.click();
       await expect(adminPages.conversation().systemMessages.filter({hasText: 'You left'})).toBeVisible();
 
       // User B sees the empty admins section

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
@@ -55,7 +55,7 @@ test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({creat
     await expect(memberPages.conversationDetails().groupMembers.filter({hasText: member.fullName})).toBeVisible();
 
     await memberPages.conversation().leaveConversation();
-    await memberModals.leaveConversation().clickConfirm();
+    await memberModals.leaveConversation().actionButton.click();
     await expect(memberPages.conversation().messageInput).not.toBeAttached();
   });
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -102,7 +102,7 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
     const contextMenu = await conversation.openContextMenu();
     await contextMenu.leaveConversationButton.click();
     await modals.leaveConversation().toggleCheckbox();
-    await modals.leaveConversation().clickConfirm();
+    await modals.leaveConversation().actionButton.click();
     await expect(pages.conversation().messageInput).not.toBeAttached();
   });
 });

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/conversationManagement-TC-8636.spec.ts
@@ -101,7 +101,7 @@ test('Conversation Management', {tag: ['@TC-8636', '@crit-flow-web']}, async ({c
     const {pages, modals} = ownerPageManager.webapp;
     const contextMenu = await conversation.openContextMenu();
     await contextMenu.leaveConversationButton.click();
-    await modals.leaveConversation().toggleCheckbox();
+    await modals.leaveConversation().modalCheckbox.click();
     await modals.leaveConversation().actionButton.click();
     await expect(pages.conversation().messageInput).not.toBeAttached();
   });

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -229,7 +229,7 @@ test.describe('Group Conversation', () => {
       // User A leaves conversation through options menu from conversation list
       const contextMenu = await userAPages.conversationList().getConversation(groupName).openContextMenu();
       await contextMenu.leaveConversationButton.click();
-      await userAModals.leaveConversation().confirmButton.click();
+      await userAModals.leaveConversation().actionButton.click();
 
       await expect(userBPages.conversation().systemMessages.filter({hasText: `${userA.fullName} left`})).toBeVisible();
     },

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -318,7 +318,7 @@ test.describe('Guestroom', () => {
       // Guest leaves the conversation
       await guestPages.conversation().toggleGroupInformation();
       await guestPages.conversation().leaveConversation();
-      await guestModals.leaveConversation().clickConfirm();
+      await guestModals.leaveConversation().actionButton.click();
 
       await expect(
         ownerPages.conversation().systemMessages.filter({hasText: `${guestUser.fullName} left`}),

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -420,7 +420,7 @@ test.describe('History Backup', () => {
       await test.step('User A leaves the group', async () => {
         await userAPages.conversation().toggleGroupInformation();
         await userAPages.conversation().leaveConversation();
-        await userAModals.leaveConversation().clickConfirm();
+        await userAModals.leaveConversation().actionButton.click();
         await expect(userAPages.conversation().systemMessages.filter({hasText: 'You left'})).toBeVisible();
       });
 

--- a/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
@@ -174,7 +174,7 @@ test.describe('Status', () => {
       sendAction: async ({userAPageManager}) => {
         const {pages, modals} = userAPageManager;
         await pages.conversation().leaveConversation();
-        await modals.leaveConversation().clickConfirm();
+        await modals.leaveConversation().actionButton.click();
       },
     },
     {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR refactors the `LeaveConversation` modal to follow the DRY principle by extending OptionModal (and therefore BaseModal). It also cleans up the codebase by removing unnecessary single-line wrapper methods.