### PR TITLE
chore(e2e): Disable Youtube link preview check in TC-1264 [WPB-25663]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
@@ -49,16 +49,17 @@ test.describe('Link Preview', () => {
             await expect(frame.getByRole('application', {name: 'Pause', exact: true})).toBeVisible();
           },
         },
-        {
-          url: 'https://www.youtube.com/watch?v=BMFsJiAcELY',
-          iframeSelector: 'iframe.youtube',
-          validate: async (frame: FrameLocator) => {
-            await expect(frame.getByLabel('Time elapsed')).not.toBeVisible();
-            await frame.getByRole('button', {name: 'Play video', exact: true}).click();
-            // Video player might take some time to load, so here we aren't checking for the pause button
-            await expect(frame.getByLabel('Time elapsed')).toBeVisible();
-          },
-        },
+        // YouTube has implemented some anti-bot checks on embedded videos so this test is currently disabled [WPB-25663]
+        // {
+        //   url: 'https://www.youtube.com/watch?v=BMFsJiAcELY',
+        //   iframeSelector: 'iframe.youtube',
+        //   validate: async (frame: FrameLocator) => {
+        //     await expect(frame.getByLabel('Time elapsed')).not.toBeVisible();
+        //     await frame.getByRole('button', {name: 'Play video', exact: true}).click();
+        //     // Video player might take some time to load, so here we aren't checking for the pause button
+        //     await expect(frame.getByLabel('Time elapsed')).toBeVisible();
+        //   },
+        // },
         {
           url: 'https://play.spotify.com/album/7buEcyw6fJF3WPgr06BomH',
           iframeSelector: 'iframe.spotify',

--- a/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/LinkPreview/linkPreview.spec.ts
@@ -49,7 +49,7 @@ test.describe('Link Preview', () => {
             await expect(frame.getByRole('application', {name: 'Pause', exact: true})).toBeVisible();
           },
         },
-        // YouTube has implemented some anti-bot checks on embedded videos so this test is currently disabled [WPB-25663]
+        // YouTube has implemented some anti-bot checks on embedded videos so this part of the test is currently disabled [WPB-25663]
         // {
         //   url: 'https://www.youtube.com/watch?v=BMFsJiAcELY',
         //   iframeSelector: 'iframe.youtube',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25663" title="WPB-25663" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25663</a>  [Web][QA] Disable Youtube part of the TC-1264
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25663

Seems like Youtube introduced additional checks to confirm that the user is not a bot. We don’t have any control of it (as we have no control over other previews) and intermediate decision is to disable Youtube part of TC-1264 test 

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/d5d649ec-63cc-4ecc-8004-8d58ce17ca97" />
