### PR TITLE
Type-check root bin/ scripts and align ts-node release commands [WPB-22420]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Build libraries
         run: yarn nx run-many -t build --projects=tag:type:lib
 
+      - name: Type check workspace tools
+        run: yarn nx run workspace-tools:type-check
+
       - name: Lint file names
         run: yarn lint:fileNames
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Build libraries
         run: yarn nx run-many -t build --projects=tag:type:lib
 
-      - name: Type check workspace tools
-        run: yarn nx run workspace-tools:type-check
+      - name: Type check
+        run: yarn type-check
 
       - name: Lint file names
         run: yarn lint:fileNames

--- a/bin/release_tag.ts
+++ b/bin/release_tag.ts
@@ -18,7 +18,7 @@
  */
 
 import {execSync} from 'child_process';
-import * as logdown from 'logdown';
+import logdown = require('logdown');
 import * as path from 'path';
 import * as readline from 'readline';
 

--- a/bin/release_tag.ts
+++ b/bin/release_tag.ts
@@ -18,7 +18,7 @@
  */
 
 import {execSync} from 'child_process';
-import logdown = require('logdown');
+import logdown from 'logdown';
 import * as path from 'path';
 import * as readline from 'readline';
 

--- a/nx.json
+++ b/nx.json
@@ -17,6 +17,11 @@
       "dependsOn": ["^build"],
       "cache": true,
       "inputs": ["default", "{workspaceRoot}/eslint.config.ts"]
+    },
+    "type-check": {
+      "dependsOn": ["^build"],
+      "cache": true,
+      "inputs": ["default", "^production"]
     }
   },
   "namedInputs": {

--- a/project.json
+++ b/project.json
@@ -11,37 +11,37 @@
     "changelog-production": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "ts-node ./bin/changelog.ts production 2>&1 | grep -v '\\[dotenv@'"
+        "command": "ts-node --project ./tsconfig.bin.json ./bin/changelog.ts production 2>&1 | grep -v '\\[dotenv@'"
       }
     },
     "changelog-staging": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "ts-node ./bin/changelog.ts staging 2>&1 | grep -v '\\[dotenv@'"
+        "command": "ts-node --project ./tsconfig.bin.json ./bin/changelog.ts staging 2>&1 | grep -v '\\[dotenv@'"
       }
     },
     "changelog-rc": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "ts-node ./bin/changelog.ts production master 2>&1 | grep -v '\\[dotenv@'"
+        "command": "ts-node --project ./tsconfig.bin.json ./bin/changelog.ts production master 2>&1 | grep -v '\\[dotenv@'"
       }
     },
     "release-staging": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "git checkout master && git pull origin master && ts-node ./bin/release_tag.ts staging"
+        "command": "git checkout master && git pull origin master && ts-node --project ./tsconfig.bin.json ./bin/release_tag.ts staging"
       }
     },
     "release-production": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "git checkout master && git pull origin master && ts-node ./bin/release_tag.ts production"
+        "command": "git checkout master && git pull origin master && ts-node --project ./tsconfig.bin.json ./bin/release_tag.ts production"
       }
     },
     "release-custom": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "npx ts-node ./bin/release_tag.ts"
+        "command": "npx ts-node --project ./tsconfig.bin.json ./bin/release_tag.ts"
       }
     },
     "clean-jest": {

--- a/project.json
+++ b/project.json
@@ -79,7 +79,7 @@
     "type-check": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "echo \"workspace-tools has no type-check\""
+        "command": "tsc --project ./tsconfig.bin.json --noEmit"
       }
     }
   },

--- a/tsconfig.bin.json
+++ b/tsconfig.bin.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2024",
+    "lib": ["ES2024"],
+    "types": ["node"],
+    "rootDir": "."
+  },
+  "include": ["bin/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tmp"]
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This change adds real TypeScript coverage for the repo-root `bin/` scripts and makes the runtime `ts-node` commands use the same config.