### PR TITLE
increase test timeout for tests using waitForTimeout [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/2FA-for-TeamsSpecs/2fa-for-teams.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/2FA-for-TeamsSpecs/2fa-for-teams.spec.ts
@@ -68,7 +68,9 @@ test.describe('2FA for teams', () => {
   test(
     'I want to receive new verification code email after clicking "Resend code" button',
     {tag: ['@TC-40', '@regression']},
-    async ({createPage, api}) => {
+    async ({createPage, api}, testInfo) => {
+      test.setTimeout(testInfo.timeout + 61_000);
+
       const pageManager = PageManager.from(await createPage());
       const {pages} = pageManager.webapp;
 

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -812,8 +812,9 @@ test.describe('Calling', () => {
   test(
     'I want to see a group call timing out after 300s if no one else joined',
     {tag: ['@TC-2936', '@regression']},
-    async ({createPage}) => {
-      test.setTimeout(390_000);
+    async ({createPage}, testInfo) => {
+      test.setTimeout(testInfo.timeout + 300_000);
+
       const userAPage = await createPage(withLogin(userA));
       const userAPages = PageManager.from(userAPage).webapp.pages;
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesIn1On1-TC-8750.spec.ts
@@ -32,6 +32,8 @@ const textFilePath = getTextFilePath();
 const selfDestructMessageText = 'This message will self-destruct in 10 seconds.';
 
 test('Messages in 1:1', {tag: ['@TC-8750', '@crit-flow-web']}, async ({createTeam, createPage}, testInfo) => {
+  test.setTimeout(testInfo.timeout + 11_000);
+
   // Precondition: Users A and B exist in two separate teams
   const [{owner: memberA}, {owner: memberB}] = await Promise.all([createTeam('Critical A'), createTeam('Critical B')]);
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -37,6 +37,8 @@ test(
   'Messages in Channels',
   {tag: ['@TC-8753', '@crit-flow-web']},
   async ({createUser, createTeam, createPage}, testInfo) => {
+    test.setTimeout(testInfo.timeout + 11_000);
+
     const userB = await createUser();
     const {owner: userA} = await createTeam('Critical Team', {users: [userB], features: {channels: true}});
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInGroups-TC-8751.spec.ts
@@ -39,6 +39,8 @@ test(
   'Messages in Groups',
   {tag: ['@TC-8751', '@crit-flow-web']},
   async ({createUser, createTeam, createPage}, testInfo) => {
+    test.setTimeout(testInfo.timeout + 11_000);
+
     const userB = await createUser();
     const {owner: userA} = await createTeam('Critical Team', {users: [userB]});
 

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -362,8 +362,9 @@ test.describe('Guestroom', () => {
   test(
     'I want to see a system message when wireless guest has expired',
     {tag: ['@TC-3337', '@regression']},
-    async ({createPage}) => {
-      test.setTimeout(150_000);
+    async ({createPage}, testInfo) => {
+      test.setTimeout(testInfo.timeout + 60_000);
+
       let createdLink: string;
       const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage()]);
 

--- a/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/InConversationSearch/inConversationSearch.spec.ts
@@ -68,7 +68,9 @@ test.describe('In Conversation Search', () => {
   test(
     "Verify ephemeral messages aren't shown in collection after timeout",
     {tag: ['@TC-354', '@regression']},
-    async ({createPage}) => {
+    async ({createPage}, testInfo) => {
+      test.setTimeout(testInfo.timeout + 10_000);
+
       const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
       await connectWithUser(userAPage, userB);
 

--- a/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
@@ -138,7 +138,9 @@ test.describe('Mention', () => {
   test(
     'I want to send an ephemeral message with a mention',
     {tag: ['@TC-3491', '@regression']},
-    async ({createPage}) => {
+    async ({createPage}, testInfo) => {
+      test.setTimeout(testInfo.timeout + 10_000);
+
       const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
       await connectWithUser(userAPage, userB);
 

--- a/apps/webapp/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SelfDeletingMessages/selfDeletingMessages.spec.ts
@@ -33,46 +33,60 @@ test.describe('Self Deleting Messages', () => {
     userA = team.owner;
   });
 
-  test('Verify sending ephemeral text message in 1:1', {tag: ['@TC-657', '@regression']}, async ({createPage}) => {
-    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
-    await connectWithUser(userAPage, userB);
+  test(
+    'Verify sending ephemeral text message in 1:1',
+    {tag: ['@TC-657', '@regression']},
+    async ({createPage}, testInfo) => {
+      test.setTimeout(testInfo.timeout + 10_000);
 
-    const userAPages = PageManager.from(userAPage).webapp.pages;
-    const userBPages = PageManager.from(userBPage).webapp.pages;
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      await connectWithUser(userAPage, userB);
 
-    await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
-    await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
-    await userAPages.conversation().enableSelfDeletingMessages();
-    await userAPages.conversation().sendMessage('Gone in 10s');
-    await expect(userBPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
+      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'}).open();
 
-    await userBPage.waitForTimeout(10_000); // Wait for 10s so the message is deleted
-    await expect(userAPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
-    await expect(userBPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
-  });
+      await userAPages.conversation().enableSelfDeletingMessages();
+      await userAPages.conversation().sendMessage('Gone in 10s');
+      await expect(userBPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
 
-  test('Verify sending ephemeral text message in group', {tag: ['@TC-658', '@regression']}, async ({createPage}) => {
-    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
-    const userAPages = PageManager.from(userAPage).webapp.pages;
-    const userBPages = PageManager.from(userBPage).webapp.pages;
+      await userBPage.waitForTimeout(10_000); // Wait for 10s so the message is deleted
+      await expect(userAPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
+      await expect(userBPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
+    },
+  );
 
-    await createGroup(userAPages, 'Test Group', [userB]);
-    await userBPages.conversationList().getConversation('Test Group').open();
+  test(
+    'Verify sending ephemeral text message in group',
+    {tag: ['@TC-658', '@regression']},
+    async ({createPage}, testInfo) => {
+      test.setTimeout(testInfo.timeout + 10_000);
 
-    await userAPages.conversation().enableSelfDeletingMessages();
-    await userAPages.conversation().sendMessage('Gone in 10s');
-    await expect(userBPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
-    await userBPage.waitForTimeout(10_000); // Wait for 10s so the message is deleted
-    await expect(userAPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
-    await expect(userBPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
-  });
+      await createGroup(userAPages, 'Test Group', [userB]);
+      await userBPages.conversationList().getConversation('Test Group').open();
+
+      await userAPages.conversation().enableSelfDeletingMessages();
+      await userAPages.conversation().sendMessage('Gone in 10s');
+      await expect(userBPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
+
+      await userBPage.waitForTimeout(10_000); // Wait for 10s so the message is deleted
+      await expect(userAPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
+      await expect(userBPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
+    },
+  );
 
   test(
     'Verify timer is applied to all messages until turning it off in 1:1',
     {tag: ['@TC-662', '@regression']},
-    async ({createPage}) => {
+    async ({createPage}, testInfo) => {
+      test.setTimeout(testInfo.timeout + 10_000);
+
       const page = await createPage(withLogin(userA));
       await connectWithUser(page, userB);
       const pages = PageManager.from(page).webapp.pages;
@@ -127,7 +141,9 @@ test.describe('Self Deleting Messages', () => {
   test(
     "Verify the message is not deleted for users that didn't read the message",
     {tag: ['@TC-675', '@regression']},
-    async ({createPage}) => {
+    async ({createPage}, testInfo) => {
+      test.setTimeout(testInfo.timeout + 10_000);
+
       const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
       await connectWithUser(userAPage, userB);
 

--- a/apps/webapp/test/e2e_tests/specs/SendingAssets/sendingAssets.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SendingAssets/sendingAssets.spec.ts
@@ -327,7 +327,9 @@ test.describe('Sending Assets', () => {
   test(
     'I should not be able to download sent files when they are obfuscated',
     {tag: ['@TC-3728', '@regression']},
-    async ({createPage}) => {
+    async ({createPage}, testInfo) => {
+      test.setTimeout(testInfo.timeout + 11_000);
+
       const userAPage = await createPage(withLogin(userA));
       await connectWithUser(userAPage, userB);
       const {pages} = PageManager.from(userAPage).webapp;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
In some of our tests we need to manually wait a specific time. E.g. for a self deleting message to delete or the app to lock itself. This adds the manual waiting time to the default timeout configured for all tests in such cases. This way the tests don't time out as easily for example due to the login taking a bit longer.


