### PR TITLE
feat: enforce single active filter type(WPB-25539)

### DIFF
--- a/apps/webapp/src/script/components/CellsGlobalView/common/useGlobalDriveFilters/useGlobalDriveFilters.tsx
+++ b/apps/webapp/src/script/components/CellsGlobalView/common/useGlobalDriveFilters/useGlobalDriveFilters.tsx
@@ -23,7 +23,11 @@ import type {
   FilterConfig,
   FilterItem,
 } from 'Components/Conversation/ConversationCells/common/CellsFiltersBar/filterConfig';
-import {GlobalDriveFiltersState} from 'Components/Conversation/ConversationCells/common/driveFilters/driveFilters';
+import {
+  type GlobalDriveFiltersState,
+  getActiveGlobalDriveFilterType,
+  isFilterTypeDisabled,
+} from 'Components/Conversation/ConversationCells/common/driveFilters/driveFilters';
 import {FILE_TYPE_CATALOG} from 'Components/Conversation/ConversationCells/common/driveFilters/fileTypeCatalog';
 import {useGetAllTags} from 'Components/Conversation/ConversationCells/common/useGetAllTags/useGetAllTags';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
@@ -73,6 +77,7 @@ export const useGlobalDriveFilters = ({
   );
 
   const tagItems = useMemo<FilterItem[]>(() => allTags.map(tag => ({id: tag, label: tag})), [allTags]);
+  const activeFilterType = useMemo(() => getActiveGlobalDriveFilterType(filterState), [filterState]);
 
   const fileTypes = useMemo<FilterItem[]>(
     () =>
@@ -93,6 +98,7 @@ export const useGlobalDriveFilters = ({
         items: tagItems,
         selectedIds: selectedTagIds,
         onSelectionChange: setSelectedTagIds,
+        disabled: isFilterTypeDisabled('tags', activeFilterType),
       },
       {
         type: 'popover',
@@ -101,6 +107,7 @@ export const useGlobalDriveFilters = ({
         items: fileTypes,
         selectedIds: selectedFileTypeIds,
         onSelectionChange: setSelectedFileTypeIds,
+        disabled: isFilterTypeDisabled('fileType', activeFilterType),
       },
       {
         type: 'popover',
@@ -109,6 +116,7 @@ export const useGlobalDriveFilters = ({
         items: MOCK_CONVERSATIONS,
         selectedIds: selectedConversationIds,
         onSelectionChange: setSelectedConversationIds,
+        disabled: isFilterTypeDisabled('conversation', activeFilterType),
       },
       {
         type: 'popover',
@@ -117,6 +125,7 @@ export const useGlobalDriveFilters = ({
         items: MOCK_CREATORS,
         selectedIds: selectedCreatorIds,
         onSelectionChange: setSelectedCreatorIds,
+        disabled: isFilterTypeDisabled('createdBy', activeFilterType),
       },
       {
         type: 'toggle',
@@ -124,9 +133,11 @@ export const useGlobalDriveFilters = ({
         label: t('cells.filter.sharedViaLink'),
         isActive: isSharedViaLink,
         onToggle: toggleSharedViaLink,
+        disabled: isFilterTypeDisabled('sharedViaLink', activeFilterType),
       },
     ],
     [
+      activeFilterType,
       fileTypes,
       tagItems,
       selectedTagIds,

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsFiltersBar/CellsFiltersBar.styles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsFiltersBar/CellsFiltersBar.styles.ts
@@ -19,6 +19,11 @@
 
 import {CSSObject} from '@emotion/react';
 
+const disabledBackground = 'var(--Background-Base-Secondary, #EDEFF0)';
+const darkDisabledBackground = 'var(--Background-Base-Primary, #17181A)';
+const disabledTextColor = 'var(--Backgrounds-On-Surface, #000)';
+const darkDisabledTextColor = 'var(--Backgrounds-On-Surface, #FFFFFF)';
+
 export const clearAllButtonStyles: CSSObject = {
   border: 'none',
   background: 'transparent',
@@ -43,36 +48,49 @@ export const filterGroupStyles: CSSObject = {
   flexWrap: 'wrap',
 };
 
-export const toggleFilterButtonStyles = (isActive: boolean): CSSObject => ({
+export const toggleFilterButtonStyles: CSSObject = {
   display: 'inline-flex',
   alignItems: 'center',
   height: '32px',
   padding: '0 10px',
   borderRadius: '12px',
-  border: `1px solid ${isActive ? 'var(--accent-color-500)' : 'var(--Border-Base-Primary, #DCE0E3)'}`,
-  background: isActive ? 'var(--accent-color-highlight)' : 'var(--Background-Base-Primary, #FFF)',
+  border: '1px solid var(--Border-Base-Primary, #DCE0E3)',
+  background: 'var(--Background-Base-Primary, #FFF)',
   fontSize: 'var(--font-size-small)',
   fontWeight: 'var(--font-weight-semibold)',
   lineHeight: 'var(--line-height-small-plus)',
   letterSpacing: '0.25px',
-  color: isActive ? 'var(--accent-color-500)' : 'var(--main-color)',
+  color: 'var(--main-color)',
   cursor: 'pointer',
   flexShrink: 0,
   whiteSpace: 'nowrap',
   '&:hover': {
     border: '1px solid var(--accent-color-500)',
   },
+  '&[data-active="true"]': {
+    border: '1px solid var(--accent-color-500)',
+    background: 'var(--accent-color-highlight)',
+    color: 'var(--accent-color-500)',
+  },
+  '&[aria-disabled="true"]': {
+    background: disabledBackground,
+    color: disabledTextColor,
+    cursor: 'not-allowed',
+  },
   'body.theme-dark &': {
     border: '1px solid var(--Border-Base-Primary, #34373D)',
     background: 'var(--Background-Base-Primary, #17181A)',
-    color: 'var(--main-color)',
     '&:hover': {
       border: '1px solid var(--accent-color-500)',
     },
-    ...(isActive && {
+    '&[data-active="true"]': {
       border: '1px solid var(--accent-color-500)',
       background: 'var(--accent-color-highlight)',
       color: 'var(--accent-color-500)',
-    }),
+    },
+    '&[aria-disabled="true"]': {
+      background: darkDisabledBackground,
+      color: darkDisabledTextColor,
+    },
   },
-});
+};

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsFiltersBar/CellsFiltersBar.styles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsFiltersBar/CellsFiltersBar.styles.ts
@@ -19,6 +19,8 @@
 
 import {CSSObject} from '@emotion/react';
 
+const outlineBorder = 'var(--Border-Base-Primary, #DCE0E3)';
+const darkOutlineBorder = 'var(--Border-Base-Primary, #34373D)';
 const disabledBackground = 'var(--Background-Base-Secondary, #EDEFF0)';
 const darkDisabledBackground = 'var(--Background-Base-Primary, #17181A)';
 const disabledTextColor = 'var(--Backgrounds-On-Surface, #000)';
@@ -54,7 +56,7 @@ export const toggleFilterButtonStyles: CSSObject = {
   height: '32px',
   padding: '0 10px',
   borderRadius: '12px',
-  border: '1px solid var(--Border-Base-Primary, #DCE0E3)',
+  border: `1px solid ${outlineBorder}`,
   background: 'var(--Background-Base-Primary, #FFF)',
   fontSize: 'var(--font-size-small)',
   fontWeight: 'var(--font-weight-semibold)',
@@ -73,12 +75,13 @@ export const toggleFilterButtonStyles: CSSObject = {
     color: 'var(--accent-color-500)',
   },
   '&[aria-disabled="true"]': {
+    border: `1px solid ${outlineBorder}`,
     background: disabledBackground,
     color: disabledTextColor,
     cursor: 'not-allowed',
   },
   'body.theme-dark &': {
-    border: '1px solid var(--Border-Base-Primary, #34373D)',
+    border: `1px solid ${darkOutlineBorder}`,
     background: 'var(--Background-Base-Primary, #17181A)',
     '&:hover': {
       border: '1px solid var(--accent-color-500)',
@@ -89,6 +92,7 @@ export const toggleFilterButtonStyles: CSSObject = {
       color: 'var(--accent-color-500)',
     },
     '&[aria-disabled="true"]': {
+      border: `1px solid ${darkOutlineBorder}`,
       background: darkDisabledBackground,
       color: darkDisabledTextColor,
     },

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsFiltersBar/CellsFiltersBar.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsFiltersBar/CellsFiltersBar.tsx
@@ -53,14 +53,21 @@ export const CellsFiltersBar = ({filters}: CellsFiltersBarProps) => {
             items={filter.items}
             selectedIds={filter.selectedIds}
             onSelectionChange={filter.onSelectionChange}
+            disabled={filter.disabled}
           />
         ) : (
           <button
             key={filter.id}
             type="button"
-            css={toggleFilterButtonStyles(filter.isActive)}
-            onClick={filter.onToggle}
+            css={toggleFilterButtonStyles}
+            onClick={() => {
+              if (filter.disabled !== true) {
+                filter.onToggle();
+              }
+            }}
             aria-pressed={filter.isActive}
+            aria-disabled={filter.disabled ?? false}
+            data-active={filter.isActive}
             data-uie-name={`filter-${filter.id}`}
           >
             {filter.label}

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsFiltersBar/filterConfig.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsFiltersBar/filterConfig.ts
@@ -17,25 +17,28 @@
  *
  */
 
+import type {ActiveFilterType} from '../driveFilters/driveFilters';
 import {FilterItem} from '../FilterPopover/FilterPopover';
 
 export type {FilterItem};
 
 export type PopoverFilterConfig = {
   type: 'popover';
-  id: string;
+  id: ActiveFilterType;
   label: string;
   items: FilterItem[];
   selectedIds: string[];
   onSelectionChange: (ids: string[]) => void;
+  disabled?: boolean;
 };
 
 export type ToggleFilterConfig = {
   type: 'toggle';
-  id: string;
+  id: ActiveFilterType;
   label: string;
   isActive: boolean;
   onToggle: () => void;
+  disabled?: boolean;
 };
 
 export type FilterConfig = PopoverFilterConfig | ToggleFilterConfig;

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/FilterPopover/FilterPopover.styles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/FilterPopover/FilterPopover.styles.ts
@@ -19,6 +19,13 @@
 
 import {CSSObject} from '@emotion/react';
 
+const outlineBorder = 'var(--Border-Base-Primary, #DCE0E3)';
+const surfaceBackground = 'var(--Background-Base-Primary, #FFF)';
+const disabledBackground = 'var(--Background-Base-Secondary, #EDEFF0)';
+const darkOutlineBorder = 'var(--Border-Base-Primary, #34373D)';
+const darkSurfaceBackground = 'var(--Background-Base-Primary, #17181A)';
+const darkDisabledBackground = 'var(--Background-Base-Primary, #17181A)';
+
 export const triggerButtonStyles: CSSObject = {
   display: 'inline-flex',
   alignItems: 'center',
@@ -26,8 +33,8 @@ export const triggerButtonStyles: CSSObject = {
   height: '32px',
   padding: '0 10px',
   borderRadius: '12px',
-  border: '1px solid var(--Border-Base-Primary, #DCE0E3)',
-  background: 'var(--Background-Base-Primary, #FFF)',
+  border: `1px solid ${outlineBorder}`,
+  background: surfaceBackground,
   fontSize: 'var(--font-size-small)',
   fontWeight: 'var(--font-weight-semibold)',
   lineHeight: 'var(--line-height-small-plus)',
@@ -47,9 +54,13 @@ export const triggerButtonStyles: CSSObject = {
     background: 'var(--accent-color-highlight)',
     color: 'var(--accent-color-500)',
   },
+  '&[data-disabled]': {
+    background: disabledBackground,
+    cursor: 'not-allowed',
+  },
   'body.theme-dark &': {
-    border: '1px solid var(--Border-Base-Primary, #34373D)',
-    background: 'var(--Background-Base-Primary, #17181A)',
+    border: `1px solid ${darkOutlineBorder}`,
+    background: darkSurfaceBackground,
     '&[data-pressed], &[data-hovered]': {
       border: '1px solid var(--accent-color-500)',
     },
@@ -57,6 +68,10 @@ export const triggerButtonStyles: CSSObject = {
       border: '1px solid var(--accent-color-500)',
       background: 'var(--accent-color-highlight)',
       color: 'var(--accent-color-500)',
+    },
+    '&[data-disabled]': {
+      background: darkDisabledBackground,
+      color: 'var(--foreground-secondary, #9FA1A7)',
     },
   },
 };
@@ -86,14 +101,14 @@ export const chevronStyles: CSSObject = {
 export const popoverStyles: CSSObject = {
   width: '260px',
   borderRadius: '12px',
-  border: '1px solid var(--Border-Base-Primary, #DCE0E3)',
-  background: 'var(--Background-Base-Primary, #FFF)',
+  border: `1px solid ${outlineBorder}`,
+  background: surfaceBackground,
   boxShadow: '0 4px 16px rgba(0, 0, 0, 0.12)',
   outline: 'none',
   overflow: 'hidden',
   'body.theme-dark &': {
-    border: '1px solid var(--Border-Base-Primary, #34373D)',
-    background: 'var(--Background-Base-Primary, #17181A)',
+    border: `1px solid ${darkOutlineBorder}`,
+    background: darkSurfaceBackground,
     boxShadow: '0 4px 16px rgba(0, 0, 0, 0.4)',
   },
 };
@@ -112,13 +127,13 @@ export const searchRowStyles: CSSObject = {
   gap: '8px',
   margin: '8px 12px',
   borderRadius: '8px',
-  border: '1px solid var(--Border-Base-Primary, #DCE0E3)',
+  border: `1px solid ${outlineBorder}`,
   boxSizing: 'border-box',
   '&:focus-within': {
     border: '1px solid var(--accent-color-500)',
   },
   'body.theme-dark &': {
-    border: '1px solid var(--Border-Base-Primary, #34373D)',
+    border: `1px solid ${darkOutlineBorder}`,
     '&:focus-within': {
       border: '1px solid var(--accent-color-500)',
     },
@@ -178,14 +193,14 @@ export const itemRowHoverStyles: CSSObject = {
     left: '12px',
     right: '12px',
     height: '1px',
-    background: 'var(--Border-Base-Primary, #DCE0E3)',
+    background: outlineBorder,
   },
   '&:hover': {
     background: 'var(--Background-Base-Secondary, #F5F6F7)',
   },
   'body.theme-dark &': {
     '&:not(:last-child)::after': {
-      background: 'var(--Border-Base-Primary, #34373D)',
+      background: darkOutlineBorder,
     },
     '&:hover': {
       background: 'var(--Background-Base-Secondary, #212326)',
@@ -250,9 +265,9 @@ export const footerStyles: CSSObject = {
   display: 'flex',
   justifyContent: 'center',
   padding: '8px 12px',
-  borderTop: '1px solid var(--Border-Base-Primary, #DCE0E3)',
+  borderTop: `1px solid ${outlineBorder}`,
   'body.theme-dark &': {
-    borderTop: '1px solid var(--Border-Base-Primary, #34373D)',
+    borderTop: `1px solid ${darkOutlineBorder}`,
   },
 };
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/FilterPopover/FilterPopover.styles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/FilterPopover/FilterPopover.styles.ts
@@ -55,6 +55,7 @@ export const triggerButtonStyles: CSSObject = {
     color: 'var(--accent-color-500)',
   },
   '&[data-disabled]': {
+    border: `1px solid ${outlineBorder}`,
     background: disabledBackground,
     cursor: 'not-allowed',
   },
@@ -70,6 +71,7 @@ export const triggerButtonStyles: CSSObject = {
       color: 'var(--accent-color-500)',
     },
     '&[data-disabled]': {
+      border: `1px solid ${darkOutlineBorder}`,
       background: darkDisabledBackground,
       color: 'var(--foreground-secondary, #9FA1A7)',
     },

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/FilterPopover/FilterPopover.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/FilterPopover/FilterPopover.tsx
@@ -68,20 +68,33 @@ interface FilterPopoverProps {
   items: FilterItem[];
   selectedIds: string[];
   onSelectionChange: (ids: string[]) => void;
+  disabled?: boolean;
 }
 
-export const FilterPopover = ({triggerLabel, items, selectedIds, onSelectionChange}: FilterPopoverProps) => {
+export const FilterPopover = ({
+  triggerLabel,
+  items,
+  selectedIds,
+  onSelectionChange,
+  disabled = false,
+}: FilterPopoverProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [searchValue, setSearchValue] = useState('');
 
   const filteredItems = useMemo(() => filterItems(items, searchValue), [items, searchValue]);
 
-  const handleOpenChange = useCallback((open: boolean) => {
-    setIsOpen(open);
-    if (!open) {
-      setSearchValue('');
-    }
-  }, []);
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (disabled && open) {
+        return;
+      }
+      setIsOpen(open);
+      if (!open) {
+        setSearchValue('');
+      }
+    },
+    [disabled],
+  );
 
   const handleItemSelect = useCallback(
     (id: string) => {
@@ -101,6 +114,7 @@ export const FilterPopover = ({triggerLabel, items, selectedIds, onSelectionChan
       <Button
         css={triggerButtonStyles}
         aria-label={triggerLabel}
+        isDisabled={disabled}
         data-uie-name="filter-popover-button"
         data-active={count > 0}
       >

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/driveFilters/driveFilters.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/driveFilters/driveFilters.test.ts
@@ -18,10 +18,13 @@
  */
 
 import {
-  ConversationDriveFiltersState,
-  GlobalDriveFiltersState,
+  type ConversationDriveFiltersState,
+  getActiveConversationDriveFilterType,
+  getActiveGlobalDriveFilterType,
+  type GlobalDriveFiltersState,
   hasActiveConversationDriveFilters,
   hasActiveGlobalDriveFilters,
+  isFilterTypeDisabled,
   toConversationDriveSearchParams,
   toGlobalDriveSearchParams,
 } from './driveFilters';
@@ -103,6 +106,52 @@ describe('hasActiveGlobalDriveFilters', () => {
       expect(hasActiveGlobalDriveFilters({...emptyGlobalFilters, ...activeFilter})).toBe(true);
     },
   );
+});
+
+describe('getActiveConversationDriveFilterType', () => {
+  it('returns null when no filter type is active', () => {
+    expect(getActiveConversationDriveFilterType(emptyFilters)).toBeNull();
+  });
+
+  it('returns tags when tags are selected', () => {
+    expect(getActiveConversationDriveFilterType({...emptyFilters, selectedTagIds: ['tag-a']})).toBe('tags');
+  });
+});
+
+describe('getActiveGlobalDriveFilterType', () => {
+  it('returns null when no filter type is active', () => {
+    expect(getActiveGlobalDriveFilterType(emptyGlobalFilters)).toBeNull();
+  });
+
+  it('returns "conversation" when the global-only conversation filter type is active', () => {
+    expect(getActiveGlobalDriveFilterType({...emptyGlobalFilters, selectedConversationIds: ['conv-a']})).toBe(
+      'conversation',
+    );
+  });
+
+  it('returns tags when tags are selected globally', () => {
+    expect(getActiveGlobalDriveFilterType({...emptyGlobalFilters, selectedTagIds: ['tag-a']})).toBe('tags');
+  });
+});
+
+describe('isFilterTypeDisabled', () => {
+  it('returns false for every filter type when none is active', () => {
+    expect(isFilterTypeDisabled('tags', null)).toBe(false);
+    expect(isFilterTypeDisabled('fileType', null)).toBe(false);
+    expect(isFilterTypeDisabled('createdBy', null)).toBe(false);
+    expect(isFilterTypeDisabled('sharedViaLink', null)).toBe(false);
+  });
+
+  it('returns false for the active filter type itself', () => {
+    expect(isFilterTypeDisabled('tags', 'tags')).toBe(false);
+  });
+
+  it('returns true for any other filter type when one is active', () => {
+    expect(isFilterTypeDisabled('fileType', 'tags')).toBe(true);
+    expect(isFilterTypeDisabled('createdBy', 'tags')).toBe(true);
+    expect(isFilterTypeDisabled('sharedViaLink', 'tags')).toBe(true);
+    expect(isFilterTypeDisabled('conversation', 'tags')).toBe(true);
+  });
 });
 
 describe('toGlobalDriveSearchParams', () => {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/driveFilters/driveFilters.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/driveFilters/driveFilters.ts
@@ -64,6 +64,32 @@ export const hasActiveGlobalDriveFilters = (filters: GlobalDriveFiltersState): b
   filters.selectedConversationIds.length > 0 ||
   is.nonEmptyString(filters.path);
 
+export type ActiveFilterType = 'tags' | 'fileType' | 'createdBy' | 'sharedViaLink' | 'conversation';
+
+export const getActiveConversationDriveFilterType = (
+  filters: ConversationDriveFiltersState,
+): ActiveFilterType | null => {
+  if (filters.selectedTagIds.length > 0) {
+    return 'tags';
+  }
+  if (filters.selectedFileTypeIds.length > 0) {
+    return 'fileType';
+  }
+  if (filters.selectedCreatorIds.length > 0) {
+    return 'createdBy';
+  }
+  if (filters.isSharedViaLink) {
+    return 'sharedViaLink';
+  }
+  return null;
+};
+
+export const getActiveGlobalDriveFilterType = (filters: GlobalDriveFiltersState): ActiveFilterType | null =>
+  filters.selectedConversationIds.length > 0 ? 'conversation' : getActiveConversationDriveFilterType(filters);
+
+export const isFilterTypeDisabled = (filterType: ActiveFilterType, active: ActiveFilterType | null): boolean =>
+  active !== null && active !== filterType;
+
 const toMimeTypes = (selectedFileTypeIds: string[]): string[] | undefined => {
   if (selectedFileTypeIds.length === 0) {
     return undefined;

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useConversationDriveFilters/useConversationDriveFilters.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useConversationDriveFilters/useConversationDriveFilters.tsx
@@ -23,7 +23,11 @@ import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {t} from 'Util/localizerUtil';
 
 import type {FilterConfig, FilterItem} from '../CellsFiltersBar/filterConfig';
-import {ConversationDriveFiltersState} from '../driveFilters/driveFilters';
+import {
+  type ConversationDriveFiltersState,
+  getActiveConversationDriveFilterType,
+  isFilterTypeDisabled,
+} from '../driveFilters/driveFilters';
 import {FILE_TYPE_CATALOG} from '../driveFilters/fileTypeCatalog';
 import {useGetAllTags} from '../useGetAllTags/useGetAllTags';
 
@@ -75,6 +79,7 @@ export const useConversationDriveFilters = ({
   }, []);
 
   const tagItems = useMemo<FilterItem[]>(() => allTags.map(tag => ({id: tag, label: tag})), [allTags]);
+  const activeFilterType = useMemo(() => getActiveConversationDriveFilterType(filterState), [filterState]);
 
   const fileTypes = useMemo<FilterItem[]>(
     () =>
@@ -95,6 +100,7 @@ export const useConversationDriveFilters = ({
         items: tagItems,
         selectedIds: selectedTagIds,
         onSelectionChange: setSelectedTagIds,
+        disabled: isFilterTypeDisabled('tags', activeFilterType),
       },
       {
         type: 'popover',
@@ -103,6 +109,7 @@ export const useConversationDriveFilters = ({
         items: fileTypes,
         selectedIds: selectedFileTypeIds,
         onSelectionChange: setSelectedFileTypeIds,
+        disabled: isFilterTypeDisabled('fileType', activeFilterType),
       },
       {
         type: 'popover',
@@ -111,6 +118,7 @@ export const useConversationDriveFilters = ({
         items: MOCK_CREATORS,
         selectedIds: selectedCreatorIds,
         onSelectionChange: setSelectedCreatorIds,
+        disabled: isFilterTypeDisabled('createdBy', activeFilterType),
       },
       {
         type: 'toggle',
@@ -118,9 +126,11 @@ export const useConversationDriveFilters = ({
         label: t('cells.filter.sharedViaLink'),
         isActive: isSharedViaLink,
         onToggle: toggleSharedViaLink,
+        disabled: isFilterTypeDisabled('sharedViaLink', activeFilterType),
       },
     ],
     [
+      activeFilterType,
       fileTypes,
       tagItems,
       selectedTagIds,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25539" title="WPB-25539" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25539</a>  Enforce single active filter (BE restriction)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add shared drive-filter helpers to detect the currently active filter type and disable the remaining filter controls while one type is selected.

Apply the behavior in both conversation and global Cells filter bars, including popover and toggle filters.

Also update filter button disabled styling and cover the new active-filter helper behavior with focused drive filter tests.


