### PR TITLE
feat: add multi-ingress SSO flow [WPB-20447]

### DIFF
--- a/apps/webapp/src/script/auth/page/login/util.ts
+++ b/apps/webapp/src/script/auth/page/login/util.ts
@@ -39,7 +39,8 @@ export const requiresPasswordModal = (
 ): boolean =>
   !isOpen &&
   (hasPassword ||
-    (conversationError != null && conversationError.label === BackendErrorLabel.INVALID_CONVERSATION_PASSWORD));
+    (!is.nullOrUndefined(conversationError) &&
+      conversationError.label === BackendErrorLabel.INVALID_CONVERSATION_PASSWORD));
 
 export const buildDomainRedirectUrl = (welcomeUrl: string, existingQuery: string, clientType: ClientType): string => {
   const [path] = welcomeUrl.split('?');

--- a/apps/webapp/src/script/auth/page/login/util.ts
+++ b/apps/webapp/src/script/auth/page/login/util.ts
@@ -104,9 +104,14 @@ export const handleEnterpriseLogin = async ({
   navigate: (route: string) => void;
   apiClient: APIClient;
 }) => {
-  const response = await apiClient.api.account.getDomainRegistration(email);
+  const ssoCodeResponse = await apiClient.api.account.getSSOCodeByEmail(email);
 
-  await match(response)
+  if (is.string(ssoCodeResponse.sso_code)) {
+    return await loginWithSSO(ssoCodeResponse.sso_code, password);
+  }
+
+  const domainRegistration = await apiClient.api.account.getDomainRegistration(email);
+  await match(domainRegistration)
     .with(
       P.union(
         {domain_redirect: DomainRedirect.NONE},

--- a/libraries/api-client/src/account/accountApi.ts
+++ b/libraries/api-client/src/account/accountApi.ts
@@ -259,7 +259,13 @@ export class AccountAPI {
       url: AccountAPI.URL.GET_SSO_CODE_BY_EMAIL,
     };
 
-    const response = await this.client.sendJSON<SSOCode>(config);
-    return PostSSOCodeByEmailSchema.parse(response.data);
+    try {
+      const response = await this.client.sendJSON<SSOCode>(config);
+      return PostSSOCodeByEmailSchema.parse(response.data);
+    } catch {
+      return {
+        sso_code: null,
+      };
+    }
   }
 }

--- a/libraries/api-client/src/account/accountApi.ts
+++ b/libraries/api-client/src/account/accountApi.ts
@@ -24,6 +24,7 @@ import {BackendConfigData} from './backendConfigData';
 import {CallConfigData} from './callConfigData';
 import {DomainData} from './domainData';
 import {DomainRedirect, DomainRedirectPayload} from './domainRedirect';
+import {PostSSOCodeByEmailSchema, SSOCode} from './ssoCode';
 import {SSOSettings} from './ssoSettings';
 
 import {HttpClient, BackendErrorLabel, BackendError, StatusCode} from '../http';
@@ -46,6 +47,7 @@ export class AccountAPI {
     SETTINGS: 'settings',
     SSO: '/sso',
     GET_DOMAIN_REGISTRATION: '/get-domain-registration',
+    GET_SSO_CODE_BY_EMAIL: '/sso/get-by-email',
   };
 
   /**
@@ -246,5 +248,18 @@ export class AccountAPI {
       }
       throw error;
     }
+  }
+
+  public async getSSOCodeByEmail(email: string): Promise<SSOCode> {
+    const config: AxiosRequestConfig = {
+      data: {
+        email,
+      },
+      method: 'post',
+      url: AccountAPI.URL.GET_SSO_CODE_BY_EMAIL,
+    };
+
+    const response = await this.client.sendJSON<SSOCode>(config);
+    return PostSSOCodeByEmailSchema.parse(response.data);
   }
 }

--- a/libraries/api-client/src/account/ssoCode.ts
+++ b/libraries/api-client/src/account/ssoCode.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {z} from 'zod';
+
+/**
+ * Zod schema for validating POST /assets response (201 Created)
+ * Based on backend API specification
+ */
+export const PostSSOCodeByEmailSchema = z.object({
+  sso_code: z.string(),
+});
+
+export type SSOCode = z.infer<typeof PostSSOCodeByEmailSchema>;

--- a/libraries/api-client/src/account/ssoCode.ts
+++ b/libraries/api-client/src/account/ssoCode.ts
@@ -24,7 +24,7 @@ import {z} from 'zod';
  * Based on backend API specification
  */
 export const PostSSOCodeByEmailSchema = z.object({
-  sso_code: z.string(),
+  sso_code: z.string().nullable(),
 });
 
 export type SSOCode = z.infer<typeof PostSSOCodeByEmailSchema>;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20447" title="WPB-20447" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20447</a>  [Web] Implement multi-ingress SSO flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR improves the SSO login flow by adding support for fetching an SSO code via email and using it during enterprise login when available, with fallback to the existing domain-based flow.

### Highlights

- Added getSSOCodeByEmail to AccountAPI
- Added new SSO code response schema/type (ssoCode.ts)
- Added new SSO code API endpoint and related imports
- Improved null/undefined checks in requiresPasswordModal for better type safety