### PR TITLE
fix(core): skip conference MLS decrypt while leaving a call [WPB-24984]

### DIFF
--- a/libraries/core/src/conversation/conversationService/conversationService.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.ts
@@ -58,6 +58,7 @@ import {
 
 import {MessageTimer, MessageSendingState, RemoveUsersParams} from '../../conversation/';
 import {MLSService, MLSServiceEvents} from '../../messagingProtocols/mls';
+import {isMlsConversationNotFoundError} from '../../messagingProtocols/mls/mlsService/coreCryptoMlsError';
 import {
   MlsRecoveryOrchestrator,
   MlsRecoveryOrchestratorImpl,
@@ -1021,7 +1022,14 @@ export class ConversationService extends TypedEventEmitter<Events> {
     } catch (error: unknown) {
       // For unmapped or unrecoverable errors, avoid surfacing exceptions from event handling
       // and instead log and return null so the event processing queue can continue safely.
-      this.logger.error('Failed to handle MLS message-add event after recovery; returning null', {error, event});
+      const isSafeMissingSubconversationGroup = event.subconv !== undefined && isMlsConversationNotFoundError(error);
+
+      this.logger.error(
+        isSafeMissingSubconversationGroup
+          ? 'MLS message-add for subconversation skipped: local group missing (safe after leave); returning null'
+          : 'Failed to handle MLS message-add event after recovery; returning null',
+        {error, event},
+      );
       return null;
     }
   }

--- a/libraries/core/src/messagingProtocols/mls/mlsService/coreCryptoMlsError.test.ts
+++ b/libraries/core/src/messagingProtocols/mls/mlsService/coreCryptoMlsError.test.ts
@@ -28,6 +28,7 @@ import {
   isBrokenMLSConversationError,
   isCoreCryptoMLSConversationAlreadyExistsError,
   isCoreCryptoMLSWrongEpochError,
+  isMlsConversationNotFoundError,
   isMLSGroupOutOfSyncError,
   isMLSStaleMessageError,
   serializeAbortReason,
@@ -54,6 +55,13 @@ describe('CoreCryptoMLSError helpers', () => {
       const other = new Error('nope');
       expect(isCoreCryptoMLSConversationAlreadyExistsError(other)).toBe(false);
       expect(isCoreCryptoMLSConversationAlreadyExistsError(42)).toBe(false);
+    });
+
+    it('detects MlsErrorOther when the local MLS group is missing', () => {
+      const err = new Error("Couldn't find conversation");
+      err.name = CORE_CRYPTO_ERROR_NAMES.MlsErrorOther;
+      expect(isMlsConversationNotFoundError(err)).toBe(true);
+      expect(isMlsConversationNotFoundError(new Error('other'))).toBe(false);
     });
   });
 

--- a/libraries/core/src/messagingProtocols/mls/mlsService/coreCryptoMlsError.ts
+++ b/libraries/core/src/messagingProtocols/mls/mlsService/coreCryptoMlsError.ts
@@ -62,6 +62,22 @@ const isOtherErrorToIgnore = (error: Error): boolean => {
   );
 };
 
+const CONVERSATION_NOT_FOUND_MESSAGE = "Couldn't find conversation";
+
+/** Local MLS group was removed (e.g. after leaving a call subconversation). */
+export const isMlsConversationNotFoundError = (error: unknown): boolean => {
+  if (!(error instanceof Error) || error.name !== CORE_CRYPTO_ERROR_NAMES.MlsErrorOther) {
+    return false;
+  }
+
+  if (error.message.includes(CONVERSATION_NOT_FOUND_MESSAGE)) {
+    return true;
+  }
+
+  const nestedMessage = (error as {context?: {context?: {msg?: string}}}).context?.context?.msg;
+  return nestedMessage === CONVERSATION_NOT_FOUND_MESSAGE;
+};
+
 export const shouldMLSDecryptionErrorBeIgnored = (error: unknown): error is Error => {
   return (
     error instanceof Error && (mlsDecryptionErrorNamesToIgnore.includes(error.name) || isOtherErrorToIgnore(error))


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24984" title="WPB-24984" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24984</a>  [Web]  "Couldnt find conversation" error 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->



After leaving a call, queued conference subconversation message-add events can fail with core-crypto "Couldn't find conversation" once the local MLS group has been wiped. 
That is expected and not actionable.

Add isMlsConversationNotFoundError() alongside the other MLS error guards and use it when logging handleMLSMessageAdd failures for subconversation events.
Those cases now emit a dedicated message so Datadog triage can separate them from genuine MLS message-add failures.