### PR TITLE
Make startup feature toggles operable from the Developer Menu [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx
+++ b/apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx
@@ -26,14 +26,20 @@ import {Button, Input, Switch} from '@wireapp/react-ui-kit';
 
 import {ConversationState} from 'Repositories/conversation/ConversationState';
 import {Config, Configuration} from 'src/script/Config';
+import {StartupFeatureToggleName, startupFeatureToggleNames} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {updateLocationSearchForStartupFeatureToggle} from 'src/script/featureToggles/startupFeatureToggleQueryParameters';
 import {useClickOutside} from 'src/script/hooks/useClickOutside';
 import {useApplicationContext} from 'src/script/page/RootProvider';
 import {CoreCryptoLogLevel} from 'Util/debugUtil';
 
 import {wrapperStyles} from './ConfigToolbar.styles';
 
+export function createLocationUrl(pathname: string, search: string, hash: string): string {
+  return `${pathname}${search}${hash}`;
+}
+
 export function ConfigToolbar() {
-  const {fireAndForgetInvoker} = useApplicationContext();
+  const {fireAndForgetInvoker, applicationNavigation, isFeatureToggleEnabled} = useApplicationContext();
   const [showConfig, setShowConfig] = useState(false);
   const [isResettingMLSConversation, setIsResettingMLSConversation] = useState(false);
   const [isGzipEnabled, setIsGzipEnabled] = useState(window.wire?.app.debug?.isGzippingEnabled() ?? false);
@@ -303,6 +309,52 @@ export function ConfigToolbar() {
     );
   };
 
+  function reloadApplicationForStartupFeatureToggle(
+    featureToggleName: StartupFeatureToggleName,
+    shouldEnableFeatureToggle: boolean,
+  ): void {
+    const locationSearch = applicationNavigation.currentSearch;
+    const nextLocationSearch = updateLocationSearchForStartupFeatureToggle({
+      locationSearch,
+      featureToggleName,
+      shouldEnableFeatureToggle,
+    });
+    const locationPathname = applicationNavigation.currentPathname;
+    const locationHash = applicationNavigation.currentHash;
+    const nextLocationUrl = createLocationUrl(locationPathname, nextLocationSearch, locationHash);
+
+    applicationNavigation.navigateTo(nextLocationUrl);
+  }
+
+  function renderStartupFeatureToggleCheckboxList() {
+    return (
+      <fieldset style={{margin: 0, border: 0, padding: 0}}>
+        <legend style={{fontWeight: 'bold', marginBottom: '8px'}}>Startup Feature Toggles</legend>
+        <ul style={{listStyle: 'none', margin: 0, padding: 0}}>
+          {startupFeatureToggleNames.map(featureToggleName => {
+            const featureToggleCheckboxIdentifier = `startup-feature-toggle-checkbox-${featureToggleName}`;
+
+            return (
+              <li key={featureToggleName} style={{marginBottom: '10px'}}>
+                <label htmlFor={featureToggleCheckboxIdentifier} style={{display: 'block'}}>
+                  <input
+                    id={featureToggleCheckboxIdentifier}
+                    type="checkbox"
+                    checked={isFeatureToggleEnabled(featureToggleName)}
+                    onChange={event => {
+                      reloadApplicationForStartupFeatureToggle(featureToggleName, event.currentTarget.checked);
+                    }}
+                  />
+                  {` ${featureToggleName}`}
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      </fieldset>
+    );
+  }
+
   const resetMLSConversation = async () => {
     setIsResettingMLSConversation(true);
     try {
@@ -356,6 +408,10 @@ export function ConfigToolbar() {
       <hr />
 
       <div>{renderCoreCryptoLogLevelSelect()}</div>
+
+      <hr />
+
+      <div>{renderStartupFeatureToggleCheckboxList()}</div>
 
       <hr />
 

--- a/apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx
+++ b/apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx
@@ -40,6 +40,7 @@ export function createLocationUrl(pathname: string, search: string, hash: string
 
 export function ConfigToolbar() {
   const {fireAndForgetInvoker, applicationNavigation, isFeatureToggleEnabled} = useApplicationContext();
+  const alphabeticallySortedStartupFeatureToggleNames = [...startupFeatureToggleNames].sort();
   const [showConfig, setShowConfig] = useState(false);
   const [isResettingMLSConversation, setIsResettingMLSConversation] = useState(false);
   const [isGzipEnabled, setIsGzipEnabled] = useState(window.wire?.app.debug?.isGzippingEnabled() ?? false);
@@ -331,7 +332,7 @@ export function ConfigToolbar() {
       <fieldset style={{margin: 0, border: 0, padding: 0}}>
         <legend style={{fontWeight: 'bold', marginBottom: '8px'}}>Startup Feature Toggles</legend>
         <ul style={{listStyle: 'none', margin: 0, padding: 0}}>
-          {startupFeatureToggleNames.map(featureToggleName => {
+          {alphabeticallySortedStartupFeatureToggleNames.map(featureToggleName => {
             const featureToggleCheckboxIdentifier = `startup-feature-toggle-checkbox-${featureToggleName}`;
 
             return (

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {
+  applockRefactoredFeatureToggleName,
+  reliableWebsocketConnectionFeatureToggleName,
+} from './startupFeatureToggleNames';
+import {startupFeatureToggleQueryParameterName} from './startupFeatureToggles';
+import {updateLocationSearchForStartupFeatureToggle} from './startupFeatureToggleQueryParameters';
+
+describe('updateLocationSearchForStartupFeatureToggle', () => {
+  it('adds a feature toggle to an existing query string and preserves unrelated parameters', () => {
+    const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
+      locationSearch: '?foo=bar',
+      featureToggleName: reliableWebsocketConnectionFeatureToggleName,
+      shouldEnableFeatureToggle: true,
+    });
+
+    expect(updatedLocationSearch).toBe(
+      `?foo=bar&${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}`,
+    );
+  });
+
+  it('removes a feature toggle and preserves other enabled toggles', () => {
+    const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName},${applockRefactoredFeatureToggleName}`,
+      featureToggleName: reliableWebsocketConnectionFeatureToggleName,
+      shouldEnableFeatureToggle: false,
+    });
+
+    expect(updatedLocationSearch).toBe(
+      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
+    );
+  });
+
+  it('removes only the startup feature parameter when the last feature toggle is disabled', () => {
+    const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}&foo=bar`,
+      featureToggleName: reliableWebsocketConnectionFeatureToggleName,
+      shouldEnableFeatureToggle: false,
+    });
+
+    expect(updatedLocationSearch).toBe('?foo=bar');
+  });
+
+  it('returns an empty search string when the last query parameter is removed', () => {
+    const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}`,
+      featureToggleName: reliableWebsocketConnectionFeatureToggleName,
+      shouldEnableFeatureToggle: false,
+    });
+
+    expect(updatedLocationSearch).toBe('');
+  });
+
+  it('ignores unknown feature names already present in query parameter when enabling a new toggle', () => {
+    const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=unknown-feature`,
+      featureToggleName: reliableWebsocketConnectionFeatureToggleName,
+      shouldEnableFeatureToggle: true,
+    });
+
+    expect(updatedLocationSearch).toBe(
+      `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}`,
+    );
+  });
+
+  it('deduplicates feature toggles when enabling an already enabled toggle', () => {
+    const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName},${reliableWebsocketConnectionFeatureToggleName}`,
+      featureToggleName: reliableWebsocketConnectionFeatureToggleName,
+      shouldEnableFeatureToggle: true,
+    });
+
+    expect(updatedLocationSearch).toBe(
+      `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}`,
+    );
+  });
+});

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.ts
@@ -43,7 +43,7 @@ function readEnabledFeatureToggleNameSetFromLocationSearch(
   locationSearch: string,
 ): ReadonlySet<StartupFeatureToggleName> {
   const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(locationSearch);
-  return new Set(startupFeatureToggles.getEnabledFeatureToggleNames());
+  return new Set(startupFeatureToggles.enabledFeatureToggleNames);
 }
 
 function toUpdatedEnabledFeatureToggleNameSet(

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.ts
@@ -1,0 +1,110 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe} from 'true-myth';
+
+import {StartupFeatureToggleName, startupFeatureToggleNames} from './startupFeatureToggleNames';
+import {
+  createStartupFeatureTogglesFromLocationSearch,
+  startupFeatureToggleQueryParameterName,
+} from './startupFeatureToggles';
+
+type UpdateStartupFeatureToggleLocationSearchInput = {
+  readonly locationSearch: string;
+  readonly featureToggleName: StartupFeatureToggleName;
+  readonly shouldEnableFeatureToggle: boolean;
+};
+
+function toOrderedEnabledFeatureToggleNames(
+  enabledFeatureToggleNameSet: ReadonlySet<StartupFeatureToggleName>,
+): readonly StartupFeatureToggleName[] {
+  return startupFeatureToggleNames.filter(featureToggleName => {
+    return enabledFeatureToggleNameSet.has(featureToggleName);
+  });
+}
+
+function readEnabledFeatureToggleNameSetFromLocationSearch(
+  locationSearch: string,
+): ReadonlySet<StartupFeatureToggleName> {
+  const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(locationSearch);
+  return new Set(startupFeatureToggles.getEnabledFeatureToggleNames());
+}
+
+function toUpdatedEnabledFeatureToggleNameSet(
+  enabledFeatureToggleNameSet: ReadonlySet<StartupFeatureToggleName>,
+  featureToggleName: StartupFeatureToggleName,
+  shouldEnableFeatureToggle: boolean,
+): ReadonlySet<StartupFeatureToggleName> {
+  const updatedEnabledFeatureToggleNameSet = new Set(enabledFeatureToggleNameSet);
+
+  if (shouldEnableFeatureToggle) {
+    updatedEnabledFeatureToggleNameSet.add(featureToggleName);
+  } else {
+    updatedEnabledFeatureToggleNameSet.delete(featureToggleName);
+  }
+
+  return updatedEnabledFeatureToggleNameSet;
+}
+
+function serializeEnabledFeatureToggleNames(
+  enabledFeatureToggleNameSet: ReadonlySet<StartupFeatureToggleName>,
+): Maybe<string> {
+  const orderedEnabledFeatureToggleNames = toOrderedEnabledFeatureToggleNames(enabledFeatureToggleNameSet);
+
+  if (orderedEnabledFeatureToggleNames.length === 0) {
+    return Maybe.nothing<string>();
+  }
+
+  return Maybe.just(orderedEnabledFeatureToggleNames.join(','));
+}
+
+export function updateLocationSearchForStartupFeatureToggle(
+  input: UpdateStartupFeatureToggleLocationSearchInput,
+): string {
+  const {locationSearch, featureToggleName, shouldEnableFeatureToggle} = input;
+  const enabledFeatureToggleNameSet = readEnabledFeatureToggleNameSetFromLocationSearch(locationSearch);
+  const updatedEnabledFeatureToggleNameSet = toUpdatedEnabledFeatureToggleNameSet(
+    enabledFeatureToggleNameSet,
+    featureToggleName,
+    shouldEnableFeatureToggle,
+  );
+
+  const queryParameters = new URLSearchParams(locationSearch);
+  const serializedEnabledFeatureToggleNames = serializeEnabledFeatureToggleNames(updatedEnabledFeatureToggleNameSet);
+
+  if (serializedEnabledFeatureToggleNames.isNothing) {
+    queryParameters.delete(startupFeatureToggleQueryParameterName);
+  } else {
+    queryParameters.set(startupFeatureToggleQueryParameterName, serializedEnabledFeatureToggleNames.value);
+  }
+
+  const serializedQueryParameters = queryParameters.toString();
+  return Maybe.of(serializedQueryParameters)
+    .andThen((queryParameterString): Maybe<string> => {
+      if (queryParameterString.length === 0) {
+        return Maybe.nothing<string>();
+      }
+
+      return Maybe.just(queryParameterString);
+    })
+    .map((queryParameterString): string => {
+      return `?${queryParameterString}`;
+    })
+    .unwrapOr('');
+}

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -40,7 +40,7 @@ describe('startupFeatureToggles', function () {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch('?foo=bar');
 
     expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(false);
-    expect(startupFeatureToggles.getEnabledFeatureToggleNames()).toEqual([]);
+    expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([]);
   });
 
   it('enables a whitelisted feature toggle when present in the query parameter', () => {
@@ -57,7 +57,7 @@ describe('startupFeatureToggles', function () {
     );
 
     expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
-    expect(startupFeatureToggles.getEnabledFeatureToggleNames()).not.toContain('unknown-feature');
+    expect(startupFeatureToggles.enabledFeatureToggleNames).not.toContain('unknown-feature');
   });
 
   it('ignores unknown feature toggles from the query parameter', () => {
@@ -65,7 +65,7 @@ describe('startupFeatureToggles', function () {
       `?${startupFeatureToggleQueryParameterName}=unknown-feature`,
     );
 
-    expect(startupFeatureToggles.getEnabledFeatureToggleNames()).toEqual([]);
+    expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([]);
   });
 
   it('keeps only whitelisted feature toggles when known and unknown values are mixed', () => {
@@ -74,7 +74,7 @@ describe('startupFeatureToggles', function () {
     );
 
     expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
-    expect(startupFeatureToggles.getEnabledFeatureToggleNames()).not.toContain('unknown-feature');
+    expect(startupFeatureToggles.enabledFeatureToggleNames).not.toContain('unknown-feature');
   });
 
   it('enables the applock refactored feature toggle when present in the query parameter', () => {
@@ -107,9 +107,7 @@ describe('startupFeatureToggles', function () {
     );
 
     expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
-    expect(startupFeatureToggles.getEnabledFeatureToggleNames()).toEqual([
-      reliableWebsocketConnectionFeatureToggleName,
-    ]);
+    expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([reliableWebsocketConnectionFeatureToggleName]);
   });
 
   it('ignores empty list entries in the feature toggle query parameter', () => {
@@ -118,9 +116,7 @@ describe('startupFeatureToggles', function () {
     );
 
     expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
-    expect(startupFeatureToggles.getEnabledFeatureToggleNames()).toEqual([
-      reliableWebsocketConnectionFeatureToggleName,
-    ]);
+    expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([reliableWebsocketConnectionFeatureToggleName]);
   });
 
   it('treats feature toggle names as case-sensitive', () => {
@@ -130,7 +126,7 @@ describe('startupFeatureToggles', function () {
     );
 
     expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(false);
-    expect(startupFeatureToggles.getEnabledFeatureToggleNames()).not.toContain(uppercaseFeatureToggleName);
+    expect(startupFeatureToggles.enabledFeatureToggleNames).not.toContain(uppercaseFeatureToggleName);
   });
 
   it('contains only whitelisted values in allowedStartupFeatureToggleNames', () => {

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.ts
@@ -30,7 +30,7 @@ const allowedStartupFeatureToggleNameSet = new Set<StartupFeatureToggleName>(all
 
 export type StartupFeatureToggles = {
   readonly isFeatureToggleEnabled: (featureToggleName: StartupFeatureToggleName) => boolean;
-  readonly getEnabledFeatureToggleNames: () => readonly StartupFeatureToggleName[];
+  readonly enabledFeatureToggleNames: readonly StartupFeatureToggleName[];
 };
 
 function trimFeatureToggleName(featureToggleName: string): string {
@@ -68,11 +68,11 @@ export function createStartupFeatureTogglesFromLocationSearch(locationSearch: st
   );
 
   return {
-    isFeatureToggleEnabled: function isFeatureToggleEnabled(featureToggleName: StartupFeatureToggleName): boolean {
+    isFeatureToggleEnabled(featureToggleName) {
       return enabledFeatureToggleNameSet.has(featureToggleName);
     },
 
-    getEnabledFeatureToggleNames: function getEnabledFeatureToggleNames(): readonly StartupFeatureToggleName[] {
+    get enabledFeatureToggleNames() {
       return [...enabledFeatureToggleNameSet];
     },
   };

--- a/apps/webapp/src/script/page/AppMain.tsx
+++ b/apps/webapp/src/script/page/AppMain.tsx
@@ -321,6 +321,20 @@ export const AppMain = (properties: AppMainProps) => {
           wallClock,
           doesApplicationNeedForceReload,
           isFeatureToggleEnabled,
+          applicationNavigation: {
+            get currentPathname(): string {
+              return window.location.pathname;
+            },
+            get currentSearch(): string {
+              return window.location.search;
+            },
+            get currentHash(): string {
+              return window.location.hash;
+            },
+            navigateTo(url) {
+              window.location.assign(url);
+            },
+          },
         }}
       >
         <ErrorBoundary FallbackComponent={ErrorFallback}>

--- a/apps/webapp/src/script/page/RootProvider.tsx
+++ b/apps/webapp/src/script/page/RootProvider.tsx
@@ -25,12 +25,20 @@ import {WallClock} from '../clock/wallClock';
 import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles';
 import {MainViewModel} from '../view_model/MainViewModel';
 
+export type ApplicationNavigation = {
+  readonly currentPathname: string;
+  readonly currentSearch: string;
+  readonly currentHash: string;
+  readonly navigateTo: (url: string) => void;
+};
+
 export type RootContextValue = {
   readonly fireAndForgetInvoker: FireAndForgetInvoker;
   readonly mainViewModel: MainViewModel;
   readonly wallClock: WallClock;
   readonly doesApplicationNeedForceReload: boolean;
   readonly isFeatureToggleEnabled: (featureName: StartupFeatureToggleName) => boolean;
+  readonly applicationNavigation: ApplicationNavigation;
 };
 
 export const RootContext = createContext<RootContextValue | null>(null);

--- a/apps/webapp/src/script/page/testSupport/rootContextTestSupport.tsx
+++ b/apps/webapp/src/script/page/testSupport/rootContextTestSupport.tsx
@@ -19,6 +19,8 @@
 
 import {ReactNode} from 'react';
 
+import {noop} from 'noop-esm';
+
 import {FireAndForgetInvoker} from '@wireapp/core';
 
 import {WallClock, createWallClock} from '../../clock/wallClock';
@@ -99,6 +101,18 @@ export function createRootContextValueForTest(parameters: CreateRootContextValue
     isFeatureToggleEnabled,
     mainViewModel,
     wallClock,
+    applicationNavigation: {
+      get currentPathname(): string {
+        return '/';
+      },
+      get currentSearch(): string {
+        return '';
+      },
+      get currentHash(): string {
+        return '';
+      },
+      navigateTo: noop,
+    },
   };
 }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

This change makes startup feature toggles directly operable from the Developer Menu so developers can enable/disable startup-only features without manually editing URLs.

The intent is to:

- expose all startup feature toggles as checkboxes
- reflect the current startup toggle state
- persist changes via query parameters
- and reload the application so startup-initialized toggle state is applied consistently

It also keeps side effects behind the existing application context abstraction to keep behavior explicit and testable.

---

<img width="786" height="329" alt="2026-05-20 12 58 26 local zinfra io d062f9479624" src="https://github.com/user-attachments/assets/7c069d19-93c3-4e7f-bf24-7bee96fb214b" />
