### PR TITLE
chore(e2e): Disabled part pf TC-10549 that checks for system message [WPB-25794]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -441,7 +441,8 @@ test.describe('History Backup', () => {
       await test.step('Validate user A cannot send messages in the left group', async () => {
         await userAComponents.conversationSidebar().allConversationsButton.click();
         await userAPages.conversationList().getConversation(conversationName).open();
-        await expect(userAPages.conversation().systemMessages.filter({hasText: 'You left'})).toBeVisible();
+        // TODO: Re-enable checking for system message after fixing the issue [WPB-25789]
+        // await expect(userAPages.conversation().systemMessages.filter({hasText: 'You left'})).toBeVisible();
         await expect(userAPages.conversation().messageInput).toBeHidden();
       });
     },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25794" title="WPB-25794" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25794</a>  [Web][QA] Skip part of the TC-10549 that checks for system message after applying backup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25794

Disabling the part of the test that checks for system message and system messages are not currently supported in history backup.


