### PR TITLE
Replace mutable array operations with immutable ES2023 equivalents [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/auth/component/ClientList.tsx
+++ b/apps/webapp/src/script/auth/component/ClientList.tsx
@@ -63,7 +63,7 @@ const ClientListComponent = ({
 
   useEffect(() => {
     setSortedClients(
-      permanentClients.sort((clientA, clientB) => {
+      permanentClients.toSorted((clientA, clientB) => {
         return new Date(clientA.time).getTime() - new Date(clientB.time).getTime();
       }),
     );

--- a/apps/webapp/src/script/clock/deterministicWallClock.ts
+++ b/apps/webapp/src/script/clock/deterministicWallClock.ts
@@ -70,7 +70,7 @@ export function createDeterministicWallClock(options: DeterministicWallClockOpti
       .filter(([, timeoutRegistration]) => {
         return timeoutRegistration.executionTimestampInMilliseconds <= currentTimestampInMilliseconds;
       })
-      .sort((firstTimeoutEntry, secondTimeoutEntry) => {
+      .toSorted((firstTimeoutEntry, secondTimeoutEntry) => {
         const [firstTimeoutIdentifier, firstTimeoutRegistration] = firstTimeoutEntry;
         const [secondTimeoutIdentifier, secondTimeoutRegistration] = secondTimeoutEntry;
 

--- a/apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx
+++ b/apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx
@@ -40,7 +40,7 @@ export function createLocationUrl(pathname: string, search: string, hash: string
 
 export function ConfigToolbar() {
   const {fireAndForgetInvoker, applicationNavigation, isFeatureToggleEnabled} = useApplicationContext();
-  const alphabeticallySortedStartupFeatureToggleNames = [...startupFeatureToggleNames].sort();
+  const alphabeticallySortedStartupFeatureToggleNames = startupFeatureToggleNames.toSorted();
   const [showConfig, setShowConfig] = useState(false);
   const [isResettingMLSConversation, setIsResettingMLSConversation] = useState(false);
   const [isGzipEnabled, setIsGzipEnabled] = useState(window.wire?.app.debug?.isGzippingEnabled() ?? false);

--- a/apps/webapp/src/script/components/ConnectRequests/ConnectionRequests.tsx
+++ b/apps/webapp/src/script/components/ConnectRequests/ConnectionRequests.tsx
@@ -53,7 +53,7 @@ export const ConnectRequests = ({
   const rootContext = useContext(RootContext);
   const {classifiedDomains} = useKoSubscribableChildren(teamState, ['classifiedDomains']);
   const {connectRequests: unsortedConnectionRequests} = useKoSubscribableChildren(userState, ['connectRequests']);
-  const connectionRequests = unsortedConnectionRequests.sort((user1, user2) => {
+  const connectionRequests = unsortedConnectionRequests.toSorted((user1, user2) => {
     const user1Connection = user1.connection();
     const user2Connection = user2.connection();
 

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/plugins/EmojiPickerPlugin/EmojiPickerPlugin.tsx
@@ -133,7 +133,7 @@ export function EmojiPickerPlugin({openStateRef}: Props) {
     });
 
     return filteredEmojis
-      .sort((emojiA, emojiB) => {
+      .toSorted((emojiA, emojiB) => {
         const usageCountA = getUsageCount(emojiA.title);
         const usageCountB = getUsageCount(emojiB.title);
 

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/plugins/MentionsPlugin/MentionsPlugin.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/plugins/MentionsPlugin/MentionsPlugin.tsx
@@ -123,7 +123,7 @@ export function MentionsPlugin({onSearch, openStateRef}: MentionsPluginProps) {
 
   const results = onSearch(queryString);
 
-  const options = results.map(result => new MenuOption(result, result.name())).reverse();
+  const options = results.map(result => new MenuOption(result, result.name())).toReversed();
 
   const insertMention = useCallback(
     (selectedOption: MenuOption, nodeToReplace: TextNode | null, closeMenu: () => void) => {

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/generateNodes.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/generateNodes.ts
@@ -34,7 +34,7 @@ const breakWhere = (words: MentionEntity[], str: string) =>
   );
 
 export const createNodes = (mentions: MentionEntity[], str: string) => {
-  const sortedMentions = mentions.slice(0).sort(({startIndex: o1}, {startIndex: o2}) => o1 - o2);
+  const sortedMentions = mentions.toSorted(({startIndex: o1}, {startIndex: o2}) => o1 - o2);
 
   return breakWhere(sortedMentions, str)
     .map((string: string, index: number) =>

--- a/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/parseMentions.ts
+++ b/apps/webapp/src/script/components/InputBar/InputBarEditor/RichTextEditor/utils/parseMentions.ts
@@ -29,7 +29,7 @@ export const parseMentions = (editor: LexicalEditor, textValue: string, mentions
     $nodesOfType(MentionNode)
       // The nodes given by lexical are not sorted by their position in the text. Instead they are sorted according to the moment they were inserted into the global text.
       // We need to manually sort the nodes by their position before parsing the mentions in the entire text
-      .sort((m1, m2) => (m1.isBefore(m2) ? -1 : 1))
+      .toSorted((m1, m2) => (m1.isBefore(m2) ? -1 : 1))
       .map(node => node.getValue()),
   );
   let position = -1;

--- a/apps/webapp/src/script/components/MessagesList/VirtualizedMessagesList/useLoadMessages.ts
+++ b/apps/webapp/src/script/components/MessagesList/VirtualizedMessagesList/useLoadMessages.ts
@@ -128,7 +128,7 @@ export const useLoadMessages = (
       if (virtualItems.length === 0) {
         return;
       }
-      const [lastItem] = [...virtualItems].reverse();
+      const [lastItem] = virtualItems.toReversed();
 
       if (lastItem.index >= itemsLength - 1) {
         fireAndForgetInvoker.fireAndForget(loadFollowingMessages);

--- a/apps/webapp/src/script/components/Modals/CreateConversation/ConversationType/ConversationFeature.tsx
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/ConversationType/ConversationFeature.tsx
@@ -43,11 +43,10 @@ export const ConversationFeature = ({conversationType}: ConversationFeatureProps
   ];
   const channelFeatures = [t('channelConversationFeature1'), t('channelConversationFeature2')];
 
-  const features = [...generalFeatures];
-
-  if (conversationType === ConversationType.Channel) {
-    features.splice(1, 0, ...channelFeatures);
-  }
+  const features =
+    conversationType === ConversationType.Channel
+      ? generalFeatures.toSpliced(1, 0, ...channelFeatures)
+      : generalFeatures;
 
   return (
     <div css={conversationFeatureContainerCss}>

--- a/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/ParticipantsSelection.tsx
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/ParticipantsSelection.tsx
@@ -63,7 +63,7 @@ export const ParticipantsSelection = () => {
       return teamState.teamUsers();
     }
 
-    return teamState.teamMembers().sort(sortUsersByPriority);
+    return teamState.teamMembers().toSorted(sortUsersByPriority);
   }, [isGuestsEnabled, isTeam, teamState, userState]);
 
   const filteredContacts = contacts.filter(user => user.isAvailable());

--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -183,7 +183,7 @@ const GroupCreationModal = ({
         return teamState.teamUsers();
       }
 
-      return teamState.teamMembers().sort(sortUsersByPriority);
+      return teamState.teamMembers().toSorted(sortUsersByPriority);
     }
     return [];
   }, [isGuestEnabled, isTeam, showContacts, teamState, userState]);

--- a/apps/webapp/src/script/components/UserSearchableList/UserSearchableList.tsx
+++ b/apps/webapp/src/script/components/UserSearchableList/UserSearchableList.tsx
@@ -143,7 +143,7 @@ export const UserSearchableList = ({
       return filteredUsers;
     }
     const {query: normalizedQuery} = searchRepository.normalizeQuery(filter);
-    return [...filteredUsers, ...remoteTeamMembers].sort((userA, userB) =>
+    return [...filteredUsers, ...remoteTeamMembers].toSorted((userA, userB) =>
       sortByPriority(userA.name(), userB.name(), normalizedQuery),
     );
   };

--- a/apps/webapp/src/script/components/calling/CallingCell/CallIngParticipantList/CallingParticipantList.tsx
+++ b/apps/webapp/src/script/components/calling/CallingCell/CallIngParticipantList/CallingParticipantList.tsx
@@ -136,7 +136,7 @@ export const CallingParticipantList = ({
         <ul className="call-ui__participant-list" data-uie-name="list-call-ui-participants">
           {participants
             .slice()
-            .sort((participantA, participantB) => sortUsersByPriority(participantA.user, participantB.user))
+            .toSorted((participantA, participantB) => sortUsersByPriority(participantA.user, participantB.user))
             .map((participant, index, participantsArray) => (
               <li key={participant.clientId} className="call-ui__participant-list__participant">
                 <CallParticipantsListItem

--- a/apps/webapp/src/script/components/calling/VideoControls/EmojisBar/EmojisBar.tsx
+++ b/apps/webapp/src/script/components/calling/VideoControls/EmojisBar/EmojisBar.tsx
@@ -77,7 +77,7 @@ export const EmojisBar = ({onEmojiClick, onPickerEmojiClick, targetWindow}: Emoj
   );
 
   const recentTopEmojis = recentEmojis
-    .sort((emojiA, emojiB) => emojiB.count - emojiA.count)
+    .toSorted((emojiA, emojiB) => emojiB.count - emojiA.count)
     .map(emoji => String.fromCodePoint(parseInt(emoji.unified, 16)))
     .concat(DEFAULT_EMOJI_LIST)
     .slice(0, 8);

--- a/apps/webapp/src/script/page/LeftSidebar/panels/Conversations/tabAndFilterSettings/tabAndFilterSettings.test.tsx
+++ b/apps/webapp/src/script/page/LeftSidebar/panels/Conversations/tabAndFilterSettings/tabAndFilterSettings.test.tsx
@@ -22,16 +22,17 @@ import {fireEvent, render, waitFor} from '@testing-library/react';
 import en from 'I18n/en-US.json';
 import {Config} from 'src/script/Config';
 import {withTheme} from 'src/script/auth/util/test/TestUtil';
-import {setStrings} from 'Util/localizerUtil';
+import {setStrings, t} from 'Util/localizerUtil';
+import {useChannelsFeatureFlag} from 'Util/useChannelsFeatureFlag';
 
 import {TabAndFilterSettings} from './tabAndFilterSettings';
 import {SidebarTabs, useSidebarStore} from '../useSidebarStore';
 
 jest.mock('Util/useChannelsFeatureFlag', () => ({
-  useChannelsFeatureFlag: () => ({
+  useChannelsFeatureFlag: jest.fn(() => ({
     isChannelsEnabled: false,
     shouldShowChannelTab: false,
-  }),
+  })),
 }));
 
 jest.mock('Repositories/team/TeamState', () => ({
@@ -51,6 +52,10 @@ jest.mock('Components/Icon', () => ({
 describe('TabAndFilterSettings', () => {
   beforeEach(() => {
     setStrings({en});
+    jest.mocked(useChannelsFeatureFlag).mockReturnValue({
+      isChannelsEnabled: false,
+      shouldShowChannelTab: false,
+    });
     Config._dangerouslySetConfigFeaturesForDebug({
       ...Config.getConfig().FEATURE,
       ENABLE_ADVANCED_FILTERS: true,
@@ -71,5 +76,32 @@ describe('TabAndFilterSettings', () => {
     await waitFor(() => {
       expect(useSidebarStore.getState().visibleTabs).not.toContain(SidebarTabs.FAVORITES);
     });
+  });
+
+  it('inserts the channels tab between groups and directs when channels are enabled', () => {
+    jest.mocked(useChannelsFeatureFlag).mockReturnValue({
+      isChannelsEnabled: true,
+      shouldShowChannelTab: true,
+    });
+
+    const {getByTitle, getAllByRole} = render(withTheme(<TabAndFilterSettings />));
+
+    fireEvent.click(getByTitle('Customize visible tabs'));
+
+    const tabLabels = getAllByRole('menuitemcheckbox').map(checkboxElement => checkboxElement.textContent);
+
+    expect(tabLabels).toEqual([
+      'Favorites',
+      'Groups',
+      'Channels',
+      t('conversationLabelDirects'),
+      'Folders',
+      t('conversationFooterArchive'),
+      'Unread',
+      'Mentions',
+      'Replies',
+      'Drafts',
+      'Pings',
+    ]);
   });
 });

--- a/apps/webapp/src/script/page/LeftSidebar/panels/Conversations/tabAndFilterSettings/tabAndFilterSettings.tsx
+++ b/apps/webapp/src/script/page/LeftSidebar/panels/Conversations/tabAndFilterSettings/tabAndFilterSettings.tsx
@@ -50,7 +50,7 @@ export const TabAndFilterSettings = () => {
 
   const {shouldShowChannelTab} = useChannelsFeatureFlag();
 
-  const availableTabs = [
+  const defaultTabs = [
     {type: SidebarTabs.FAVORITES, label: t('conversationLabelFavorites')},
     {type: SidebarTabs.GROUPS, label: t('conversationLabelGroups')},
     {type: SidebarTabs.DIRECTS, label: t('conversationLabelDirects')},
@@ -62,10 +62,9 @@ export const TabAndFilterSettings = () => {
     {type: SidebarTabs.DRAFTS, label: t('conversationLabelDrafts')},
     {type: SidebarTabs.PINGS, label: t('conversationLabelPings')},
   ];
-
-  if (shouldShowChannelTab) {
-    availableTabs.splice(2, 0, {type: SidebarTabs.CHANNELS, label: t('conversationLabelChannels')});
-  }
+  const availableTabs = shouldShowChannelTab
+    ? defaultTabs.toSpliced(2, 0, {type: SidebarTabs.CHANNELS, label: t('conversationLabelChannels')})
+    : defaultTabs;
 
   const handleMenuKeyDown = useCallback(
     (event: KeyboardEvent) => {

--- a/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
+++ b/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
@@ -130,7 +130,7 @@ export const PeopleTab = ({
     const nonExternalContacts = await teamRepository.filterExternals(contacts);
     return {
       ...searchResults,
-      contacts: [...searchResults.contacts, ...nonExternalContacts].sort((userA, userB) =>
+      contacts: [...searchResults.contacts, ...nonExternalContacts].toSorted((userA, userB) =>
         sortByPriority(userA.name(), userB.name(), query),
       ),
       others: others,

--- a/apps/webapp/src/script/page/RightSidebar/addParticipants/addParticipants.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/addParticipants/addParticipants.tsx
@@ -126,7 +126,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
   const contacts = useMemo(() => {
     if (isTeam) {
       const isTeamOrServices = isTeamOnly || isServicesRoom;
-      return isTeamOrServices ? teamMembers.sort(sortUsersByPriority) : teamUsers;
+      return isTeamOrServices ? teamMembers.toSorted(sortUsersByPriority) : teamUsers;
     }
     return connectedUsers;
   }, [connectedUsers, isServicesRoom, isTeam, isTeamOnly, teamMembers, teamUsers]);
@@ -137,7 +137,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
       .filter(contact => contact.type === UserType.APP)
       .map(contact => integrationRepository.mapServiceFromUser(contact))
       .filter(contact => compareTransliteration(contact.name(), normalizedQuery))
-      .sort((serviceA, serviceB) => sortByPriority(serviceA.name(), serviceB.name(), normalizedQuery));
+      .toSorted((serviceA, serviceB) => sortByPriority(serviceA.name(), serviceB.name(), normalizedQuery));
   }, [contacts, integrationRepository, searchInput]);
 
   const servicesList = useMemo(() => {

--- a/apps/webapp/src/script/page/RightSidebar/conversationDetails/conversationDetails.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/conversationDetails/conversationDetails.tsx
@@ -186,7 +186,7 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
       });
 
       if (!isSelfUserRemoved) {
-        return [...filteredUsers, selfUser].sort(sortUsersByPriority);
+        return [...filteredUsers, selfUser].toSorted(sortUsersByPriority);
       }
 
       return filteredUsers;

--- a/apps/webapp/src/script/page/RightSidebar/conversationParticipants/conversationParticipants.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/conversationParticipants/conversationParticipants.tsx
@@ -72,7 +72,7 @@ const ConversationParticipants: FC<ConversationParticipantsProps> = ({
     });
 
     if (!isSelfUserRemoved && selfUser) {
-      return [...users, selfUser].sort(sortUsersByPriority);
+      return [...users, selfUser].toSorted(sortUsersByPriority);
     }
 
     return users;

--- a/apps/webapp/src/script/page/RightSidebar/messageDetails/messageDetails.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/messageDetails/messageDetails.tsx
@@ -91,7 +91,7 @@ const MessageDetails: FC<MessageDetailsProps> = ({
 
   const receiptUsers = userRepository
     .findUsersByIds(readReceipts.map(({userId, domain}) => ({domain: domain || '', id: userId})))
-    .sort(sortUsers);
+    .toSorted(sortUsers);
 
   const supportsReactions = useMemo(() => {
     const isPing = messageEntity.super_type === SuperType.PING;

--- a/apps/webapp/src/script/repositories/calling/Call.ts
+++ b/apps/webapp/src/script/repositories/calling/Call.ts
@@ -101,7 +101,7 @@ export class Call {
     this.handRaisedParticipants = ko.pureComputed(() =>
       this.participants()
         .filter(participant => Boolean(participant.handRaisedAt()))
-        .sort((p1, p2) => p1.handRaisedAt()! - p2.handRaisedAt()!),
+        .toSorted((p1, p2) => p1.handRaisedAt()! - p2.handRaisedAt()!),
     );
     this.canvasMixer = new CanvasMediaStreamMixer();
     this.maximizedParticipant = ko.observable(null);
@@ -207,7 +207,7 @@ export class Call {
       // Limit them to 4.
       .slice(0, 4)
       // Sort them by name
-      .sort((participantA, participantB) => sortUsersByPriority(participantA.user, participantB.user));
+      .toSorted((participantA, participantB) => sortUsersByPriority(participantA.user, participantB.user));
 
     // Set the new active speakers.
     const isSameSpeakers =
@@ -238,7 +238,7 @@ export class Call {
 
   updatePages() {
     const selfParticipant = this.getSelfParticipant();
-    const remoteParticipants = this.getRemoteParticipants().sort((p1, p2) => sortUsersByPriority(p1.user, p2.user));
+    const remoteParticipants = this.getRemoteParticipants().toSorted((p1, p2) => sortUsersByPriority(p1.user, p2.user));
 
     const [withVideoAndScreenShare, withoutVideo] = partition(remoteParticipants, participant =>
       participant.isSendingVideo(),

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -731,7 +731,7 @@ export class CallingRepository {
     call.participants.removeAll();
     call.removeAllAudio();
     if (index !== -1) {
-      this.callState.calls.splice(index, 1);
+      this.callState.calls(this.callState.calls().toSpliced(index, 1));
     }
   }
 

--- a/apps/webapp/src/script/repositories/conversation/ConversationAccessPermission.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationAccessPermission.ts
@@ -147,7 +147,7 @@ export function updateAccessRights(accessState: ACCESS_STATE): UpdatedAccessRigh
     .toString(2)
     .split('')
     //reverse so that the index reflects the number of significant figures for finding the feature
-    .reverse()
+    .toReversed()
     //find the name of the feature with the correct sigfigs
     .map((bit: '1' | '0', i) => Object.entries(ACCESS).find(([, bitmask]) => bitmask === +bit << i)?.[0])
     .forEach(feature => {

--- a/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationLabelRepository.ts
@@ -286,7 +286,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
 
     if (favoriteLabel) {
       const folderIndex = this.labels.indexOf(favoriteLabel);
-      this.labels.splice(folderIndex, 1, updatedLabel);
+      this.labels(this.labels().with(folderIndex, updatedLabel));
     } else {
       // The favorite label doesn't need a name since it is set at runtime for i18n compatibility
       this.labels.push(updatedLabel);
@@ -306,7 +306,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
         LabelType.Favorite,
       );
       const folderIndex = this.labels.indexOf(favoriteLabel);
-      this.labels.splice(folderIndex, 1, updatedLabel);
+      this.labels(this.labels().with(folderIndex, updatedLabel));
 
       // trigger a rerender on sidebar to remove the conversation from favorites
       const {currentTab, setCurrentTab} = useSidebarStore.getState();
@@ -349,7 +349,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
   readonly getLabels = (): ConversationLabel[] =>
     this.labels()
       .filter(({type}) => type === LabelType.Custom)
-      .sort(({name: nameA}, {name: nameB}) => nameA.localeCompare(nameB, undefined, {sensitivity: 'base'}));
+      .toSorted(({name: nameA}, {name: nameB}) => nameA.localeCompare(nameB, undefined, {sensitivity: 'base'}));
 
   readonly removeConversationFromLabel = (label: ConversationLabel, removeConversation: Conversation): void => {
     const {setCurrentTab} = useSidebarStore.getState();
@@ -363,7 +363,7 @@ export class ConversationLabelRepository extends TypedEventTarget<{type: 'conver
       label.type,
     );
 
-    this.labels.splice(folderIndex, 1, updatedFolder);
+    this.labels(this.labels().with(folderIndex, updatedFolder));
 
     // Delete folder if it no longer contains any conversation
     if (is.nonEmptyArray(updatedFolder.conversations())) {

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -1368,7 +1368,7 @@ export class ConversationRepository {
 
         return false;
       })
-      .sort((conversationA, conversationB) => {
+      .toSorted((conversationA, conversationB) => {
         return sortByPriority(conversationA.display_name(), conversationB.display_name(), query);
       })
       .map(conversationEntity => {
@@ -1803,7 +1803,7 @@ export class ConversationRepository {
 
     // In the event that multiple 1:1 Proteus conversations exist, we migrate the one with the lowest id
     // See https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/1344602120/Use+case+multiple+1+1+conversation+in+teams+Proteus
-    const proteusConversationToBeKept = proteusConversations.sort((a, b) =>
+    const proteusConversationToBeKept = proteusConversations.toSorted((a, b) =>
       a.qualifiedId.id.localeCompare(b.qualifiedId.id),
     )[0];
 
@@ -2363,7 +2363,7 @@ export class ConversationRepository {
     );
 
     // Sort conversations so mls 1:1 conversations are initialised first
-    const sortedConverstions = [...team1To1Conversations].sort((a, b) => {
+    const sortedConverstions = team1To1Conversations.toSorted((a, b) => {
       const aIsMLSConversation = isMLSConversation(a);
       const bIsMLSConversation = isMLSConversation(b);
 
@@ -2529,8 +2529,7 @@ export class ConversationRepository {
     const userEntities = await this.userRepository.getUsersById(conversationEntity.participating_user_ids(), {
       localOnly: offline,
     });
-    userEntities.sort(sortUsersByPriority);
-    conversationEntity.participating_user_ets(userEntities);
+    conversationEntity.participating_user_ets(userEntities.toSorted(sortUsersByPriority));
 
     if (updateGuests) {
       conversationEntity.updateGuests();
@@ -4718,8 +4717,7 @@ export class ConversationRepository {
       return this.userRepository
         .getUsersById((messageEntity as MemberMessage).userIds(), options)
         .then(userEntities => {
-          userEntities.sort(sortUsersByPriority);
-          (messageEntity as MemberMessage).userEntities(userEntities);
+          (messageEntity as MemberMessage).userEntities(userEntities.toSorted(sortUsersByPriority));
           return messageEntity;
         });
     }

--- a/apps/webapp/src/script/repositories/conversation/ConversationService.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationService.ts
@@ -424,7 +424,7 @@ export class ConversationService {
       const records = await this.storageService.getAll<{time: number}>(StorageSchemata.OBJECT_STORE.EVENTS);
       events = records
         .filter(record => record.time.toString() >= min_date.toISOString())
-        .sort((a, b) => a.time - b.time);
+        .toSorted((a, b) => a.time - b.time);
     }
 
     const conversations = events.reduce((accumulated, event) => {
@@ -434,7 +434,7 @@ export class ConversationService {
     }, {});
 
     return Object.keys(conversations)
-      .sort((id_a, id_b) => conversations[id_b] - conversations[id_a])
+      .toSorted((id_a, id_b) => conversations[id_b] - conversations[id_a])
       .map(id => ({domain: '', id}));
   }
 

--- a/apps/webapp/src/script/repositories/conversation/ConversationState.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationState.ts
@@ -76,7 +76,7 @@ export class ConversationState {
     private readonly userState = container.resolve(UserState),
     private readonly teamState = container.resolve(TeamState),
   ) {
-    this.sortedConversations = ko.pureComputed(() => this.filteredConversations().sort(sortGroupsByLastEvent));
+    this.sortedConversations = ko.pureComputed(() => this.filteredConversations().toSorted(sortGroupsByLastEvent));
     this.selfProteusConversation = ko.pureComputed(() =>
       this.conversations().find(conversation => !isMLSConversation(conversation) && isSelfConversation(conversation)),
     );

--- a/apps/webapp/src/script/repositories/conversation/EventMapper.ts
+++ b/apps/webapp/src/script/repositories/conversation/EventMapper.ts
@@ -114,7 +114,7 @@ export class EventMapper {
    * @returns Resolves with the mapped message entities
    */
   mapJsonEvents(events: EventRecord[], conversationEntity: Conversation): Message[] {
-    const reversedEvents = events.filter(event => !!event).reverse();
+    const reversedEvents = events.filter(event => !!event).toReversed();
     const mappedEvents = reversedEvents.map((event): Message | void => {
       try {
         return this._mapJsonEvent(event, conversationEntity);
@@ -612,6 +612,7 @@ export class EventMapper {
     const {data: eventData, from: sender} = event;
     const {has_service: hasService} = eventData;
     const userIds = eventData.qualified_user_ids || eventData.user_ids.map(id => ({domain: '', id}));
+    let messageUserIds = userIds;
 
     const messageEntity = new MemberMessage();
 
@@ -620,11 +621,11 @@ export class EventMapper {
 
     if (conversationEntity.isGroupOrChannel()) {
       const messageFromCreator = sender === conversationEntity.creator;
-      const creatorIndex = userIds.findIndex(user => user.id === sender);
+      const creatorIndex = messageUserIds.findIndex(user => user.id === sender);
       const creatorIsJoiningMember = messageFromCreator && creatorIndex !== -1;
 
       if (creatorIsJoiningMember) {
-        userIds.splice(creatorIndex, 1);
+        messageUserIds = messageUserIds.toSpliced(creatorIndex, 1);
         messageEntity.memberMessageType = SystemMessageType.CONVERSATION_CREATE;
       }
 
@@ -632,7 +633,7 @@ export class EventMapper {
         messageEntity.showServicesWarning = true;
       }
 
-      messageEntity.userIds(userIds);
+      messageEntity.userIds(messageUserIds);
     }
 
     return messageEntity;

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -1389,7 +1389,7 @@ export class MessageRepository {
       .filter(user => {
         return user.isFederated === false;
       })
-      .sort(({id: idA}, {id: idB}) => idA.localeCompare(idB, undefined, {sensitivity: 'base'}));
+      .toSorted(({id: idA}, {id: idB}) => idA.localeCompare(idB, undefined, {sensitivity: 'base'}));
     const [members, other] = partition(sortedUsers, user => this.teamState.isInTeam(user));
     const selfUser = this.userState.self();
     if (selfUser === undefined) {

--- a/apps/webapp/src/script/repositories/entity/Conversation.ts
+++ b/apps/webapp/src/script/repositories/entity/Conversation.ts
@@ -471,7 +471,7 @@ export class Conversation {
 
     this.messages_unordered = ko.observableArray();
     this.messages = ko.pureComputed(() =>
-      [...this.messages_unordered()].sort((message_a, message_b) => {
+      this.messages_unordered().toSorted((message_a, message_b) => {
         return message_a.timestamp() - message_b.timestamp();
       }),
     );
@@ -1023,8 +1023,7 @@ export class Conversation {
    */
   private getLastDeliveredMessage(): Message | undefined {
     return this.messages()
-      .slice()
-      .reverse()
+      .toReversed()
       .find(messageEntity => {
         const isDelivered = [StatusType.DELIVERED, StatusType.SEEN].includes(messageEntity.status());
         return isDelivered && messageEntity.user().isMe;

--- a/apps/webapp/src/script/repositories/entity/User/User.test.ts
+++ b/apps/webapp/src/script/repositories/entity/User/User.test.ts
@@ -75,6 +75,24 @@ describe('User', () => {
 
       expect(user.devices().length).toBe(2);
     });
+
+    it('keeps own devices sorted by descending creation time', () => {
+      const olderClient = new ClientEntity(false, null);
+      olderClient.id = 'older-client';
+      olderClient.time = '2024-01-01T00:00:00.000Z';
+
+      const newerClient = new ClientEntity(false, null);
+      newerClient.id = 'newer-client';
+      newerClient.time = '2024-01-02T00:00:00.000Z';
+
+      const user = new User();
+      user.isMe = true;
+
+      user.addClient(olderClient);
+      user.addClient(newerClient);
+
+      expect(user.devices().map(clientEntity => clientEntity.id)).toEqual(['newer-client', 'older-client']);
+    });
   });
 
   describe('accent_color', () => {

--- a/apps/webapp/src/script/repositories/entity/User/User.ts
+++ b/apps/webapp/src/script/repositories/entity/User/User.ts
@@ -273,9 +273,11 @@ export class User {
     this.devices.push(new_client_et);
 
     if (this.isMe) {
-      this.devices.sort((client_a, client_b) => {
-        return new Date(client_b.time ?? '').getTime() - new Date(client_a.time ?? '').getTime();
-      });
+      this.devices(
+        this.devices().toSorted((client_a, client_b) => {
+          return new Date(client_b.time ?? '').getTime() - new Date(client_a.time ?? '').getTime();
+        }),
+      );
     }
 
     return true;

--- a/apps/webapp/src/script/repositories/event/EventService.ts
+++ b/apps/webapp/src/script/repositories/event/EventService.ts
@@ -93,7 +93,7 @@ export class EventService {
       const records = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);
       return records
         .filter(record => record.conversation === conversationId && eventIds.includes(record.id ?? ''))
-        .sort(compareEventsById);
+        .toSorted(compareEventsById);
     } catch (error: unknown) {
       const logMessage = `Failed to get events '${eventIds.join(',')}' for conversation '${conversationId}': ${
         toError(error).message
@@ -123,7 +123,7 @@ export class EventService {
       const records = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);
       return records
         .filter(record => record.conversation === conversationId && !!record.ephemeral_expires)
-        .sort(compareEventsById);
+        .toSorted(compareEventsById);
     } catch (error: unknown) {
       const logMessage = `Failed to get ephemeral events for conversation '${conversationId}': ${toError(error).message}`;
       this.logger.error(logMessage, error);
@@ -162,7 +162,7 @@ export class EventService {
       const records = await this.storageService.getAll<EventRecord>(StorageSchemata.OBJECT_STORE.EVENTS);
       return records
         .filter(record => record.id === eventId && record.conversation === conversationId)
-        .sort(compareEventsById)
+        .toSorted(compareEventsById)
         .shift();
     } catch (error: unknown) {
       const logMessage = `Failed to get event '${eventId}' for conversation '${conversationId}': ${toError(error).message}`;
@@ -208,7 +208,7 @@ export class EventService {
           record.conversation === conversationId && record.category >= categoryMin && record.category <= categoryMax,
       )
       .filter(filterExpired)
-      .sort(compareEventsByTime);
+      .toSorted(compareEventsByTime);
   }
 
   async loadEventsReplyingToMessage(conversationId: string, quotedMessageId: string, quotedMessageTime: string) {
@@ -232,7 +232,7 @@ export class EventService {
         );
       })
       .filter(event => hasQuoteForMessage(event, quotedMessageId))
-      .sort(compareEventsByConversation);
+      .toSorted(compareEventsByConversation);
   }
 
   /**
@@ -257,8 +257,10 @@ export class EventService {
     try {
       const events = await this._loadEventsInDateRange(conversationId, fromDate, toDate, limit, includeParams);
       return this.storageService.db
-        ? await (events as Dexie.Collection<any, any>).reverse().sortBy('time')
-        : (events as EventRecord[]).reverse().sort(compareEventsByTime);
+        ? // Dexie.Collection.reverse() is a query API, not Array.prototype.reverse().
+          // eslint-disable-next-line unicorn/no-array-reverse
+          await (events as Dexie.Collection<any, any>).reverse().sortBy('time')
+        : (events as EventRecord[]).toReversed().toSorted(compareEventsByTime);
     } catch (error: unknown) {
       const message = `Failed to load events for conversation '${conversationId}' from database: '${toError(error).message}'`;
       this.logger.error(message);
@@ -293,7 +295,7 @@ export class EventService {
     const events = await this._loadEventsInDateRange(conversationId, fromDate, toDate, limit, includeParams);
     return this.storageService.db
       ? (events as DexieCollection).sortBy('time')
-      : (events as EventRecord[]).sort(compareEventsByTime);
+      : (events as EventRecord[]).toSorted(compareEventsByTime);
   }
 
   /**
@@ -346,7 +348,7 @@ export class EventService {
           (includeTo ? recordDate <= toDate.getTime() : recordDate < toDate.getTime())
         );
       })
-      .sort(compareEventsByConversation)
+      .toSorted(compareEventsByConversation)
       .slice(0, limit);
   }
 

--- a/apps/webapp/src/script/repositories/integration/IntegrationRepository.ts
+++ b/apps/webapp/src/script/repositories/integration/IntegrationRepository.ts
@@ -216,7 +216,7 @@ export class IntegrationRepository {
       if (isCurrentQuery) {
         serviceEntities = serviceEntities
           .filter(serviceEntity => compareTransliteration(serviceEntity.name(), normalizedQuery))
-          .sort((serviceA, serviceB) => sortByPriority(serviceA.name(), serviceB.name(), normalizedQuery));
+          .toSorted((serviceA, serviceB) => sortByPriority(serviceA.name(), serviceB.name(), normalizedQuery));
         this.services(serviceEntities);
         return serviceEntities;
       }

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/renderer.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/renderer.ts
@@ -72,7 +72,7 @@ export class WebGLRenderer {
   };
   readonly positionBuffer: WebGLBuffer | null;
   readonly texCoordBuffer: WebGLBuffer | null;
-  readonly storedStateTextures: (WebGLTexture | null)[];
+  storedStateTextures: (WebGLTexture | null)[];
   readonly fbo: WebGLFramebuffer | null;
 
   private running = false;
@@ -621,7 +621,7 @@ export class WebGLRenderer {
         gl.deleteTexture(texture);
       }
     });
-    this.storedStateTextures.splice(0, this.storedStateTextures.length);
+    this.storedStateTextures = this.storedStateTextures.toSpliced(0, this.storedStateTextures.length);
     if (this.backgroundRenderInfo?.texture) {
       gl.deleteTexture(this.backgroundRenderInfo.texture);
       this.backgroundRenderInfo = null;

--- a/apps/webapp/src/script/repositories/notification/NotificationRepository.ts
+++ b/apps/webapp/src/script/repositories/notification/NotificationRepository.ts
@@ -90,7 +90,7 @@ interface WebappNotifications extends Notification {
 export class NotificationRepository {
   private readonly conversationRepository: ConversationRepository;
   private readonly logger: Logger;
-  readonly notifications: WebappNotifications[];
+  notifications: ReadonlyArray<WebappNotifications>;
   private readonly notificationsPreference: ko.Observable<NotificationPreference>;
   private readonly assetRepository: AssetRepository;
   private isSoftLock = false;
@@ -877,7 +877,7 @@ export class NotificationRepository {
 
     notification.onclose = () => {
       window.clearTimeout(timeoutTriggerId);
-      this.notifications.splice(this.notifications.indexOf(notification), 1);
+      this.notifications = this.notifications.toSpliced(this.notifications.indexOf(notification), 1);
       this.logger.info(`Removed notification for ${messageInfo} in '${conversationId?.id || conversationId}' locally.`);
     };
 
@@ -898,7 +898,7 @@ export class NotificationRepository {
       }, notificationContent.timeout);
     };
 
-    this.notifications.push(notification);
+    this.notifications = this.notifications.concat(notification);
     this.logger.info(`Added notification for ${messageInfo} in '${conversationId?.id || conversationId}' to queue.`);
   }
 

--- a/apps/webapp/src/script/repositories/notification/PreferenceNotificationRepository.ts
+++ b/apps/webapp/src/script/repositories/notification/PreferenceNotificationRepository.ts
@@ -118,7 +118,7 @@ export class PreferenceNotificationRepository {
     const groupedNotifications = groupBy(notifications, notification => notification.type);
     return Object.entries(groupedNotifications)
       .map(([type, notification]) => ({notification, type}))
-      .sort((a, b) => prio(a) - prio(b));
+      .toSorted((a, b) => prio(a) - prio(b));
   }
 
   onClientRemove(_userId: string, clientId: string, domain: string | null): void {

--- a/apps/webapp/src/script/repositories/search/searchRepository.ts
+++ b/apps/webapp/src/script/repositories/search/searchRepository.ts
@@ -88,15 +88,10 @@ export class SearchRepository {
         given user of name Bardia and username of bardia_wire this mapping
         will get name & username properties and return an array value like ['Bardia', 'bardia_wire']
       */
-      const values: string[] = properties
-        .slice()
-        .reverse()
-        .map(prop => {
-          const property = prop as keyof User;
-          return typeof userEntity[property] === 'function'
-            ? (userEntity[property] as Function)()
-            : userEntity[property];
-        });
+      const values: string[] = properties.toReversed().map(prop => {
+        const property = prop as keyof User;
+        return typeof userEntity[property] === 'function' ? (userEntity[property] as Function)() : userEntity[property];
+      });
 
       const uniqueValues = Array.from(new Set(values));
       const matchWeight = uniqueValues.reduce((weight, value, index) => {
@@ -109,7 +104,7 @@ export class SearchRepository {
     }, []);
 
     return weightedResults
-      .sort((result1, result2) => {
+      .toSorted((result1, result2) => {
         if (result2.weight === result1.weight) {
           return result2.user.name() > result1.user.name() ? -1 : 1;
         }
@@ -153,7 +148,7 @@ export class SearchRepository {
 
     const tokens = nameSlug.split(/-/g);
     // computing the match value by testing all components of the property
-    return tokens.reverse().reduce((weight, token, index) => {
+    return tokens.toReversed().reduce((weight, token, index) => {
       const indexWeight = index + 1;
       let tokenWeight = 0;
       const tokenIndex = transliterationIndex(token, termSlug);
@@ -198,7 +193,7 @@ export class SearchRepository {
         // Filter out selfUser
         .filter(user => !user.isMe)
         .filter(user => !isHandleQuery || startsWith(user.username(), query))
-        .sort((userA, userB) => {
+        .toSorted((userA, userB) => {
           if (userA.teamId === teamId && userB.teamId !== teamId) {
             // put team members first
             return -1;

--- a/apps/webapp/src/script/repositories/team/TeamState.ts
+++ b/apps/webapp/src/script/repositories/team/TeamState.ts
@@ -82,7 +82,7 @@ export class TeamState {
       return this.teamMembers()
         .concat(this.userState.connectedUsers())
         .filter((item, index, array) => array.indexOf(item) === index)
-        .sort(sortUsersByPriority);
+        .toSorted(sortUsersByPriority);
     });
 
     this.supportsLegalHold = ko.observable(false);

--- a/apps/webapp/src/script/repositories/user/userState.ts
+++ b/apps/webapp/src/script/repositories/user/userState.ts
@@ -42,7 +42,7 @@ export class UserState {
       .pureComputed(() => {
         return this.users()
           .filter(userEntity => userEntity.isConnected())
-          .sort(sortUsersByPriority);
+          .toSorted(sortUsersByPriority);
       })
       .extend({rateLimit: TIME_IN_MILLIS.SECOND});
   }

--- a/apps/webapp/src/script/util/countryCodes.ts
+++ b/apps/webapp/src/script/util/countryCodes.ts
@@ -1475,7 +1475,7 @@ const COUNTRY_CODES: CountryCode[] = [
 export const getCountryByCode = (countryCode: string): string | void => {
   const parsedCode = parseInt(countryCode, 10);
   const country = COUNTRY_CODES.filter(({code}) => code === parsedCode)
-    .sort((countryA, countryB) => countryA.population - countryB.population)
+    .toSorted((countryA, countryB) => countryA.population - countryB.population)
     .pop();
   if (country) {
     return country.iso;

--- a/apps/webapp/src/script/util/debugUtil.ts
+++ b/apps/webapp/src/script/util/debugUtil.ts
@@ -486,7 +486,7 @@ export class DebugUtil {
     if (this.storageRepository.storageService.db) {
       const records = await this.storageRepository.storageService.db.events.toArray();
       const messages = records.filter(event => event.conversation === conversationId);
-      return messages.slice(-amount).reverse();
+      return messages.slice(-amount).toReversed();
     }
     return [];
   }

--- a/apps/webapp/src/script/util/localizerUtil/localizerUtil.ts
+++ b/apps/webapp/src/script/util/localizerUtil/localizerUtil.ts
@@ -106,7 +106,7 @@ export const LocalizerUtil = {
       userEntities = userEntities.filter(userEntity => !userEntity.isMe);
     }
 
-    const userNames = userEntities.sort(sortUsersByPriority).map(userEntity => {
+    const userNames = userEntities.toSorted(sortUsersByPriority).map(userEntity => {
       const userName = userEntity.name();
       return boldNames ? `[bold]${userName}[/bold]` : userName;
     });
@@ -118,13 +118,16 @@ export const LocalizerUtil = {
     const numberOfNames = userNames.length;
     const joinByAnd = !skipAnd && numberOfNames >= 2;
     if (joinByAnd) {
-      const [secondLastName, lastName] = userNames.splice(userNames.length - 2, 2);
+      const finalPairStartIndex = userNames.length - 2;
+      const [secondLastName, lastName] = userNames.slice(finalPairStartIndex);
+      const userNamesWithoutFinalPair = userNames.toSpliced(finalPairStartIndex, 2);
 
       const exactlyTwoNames = numberOfNames === 2;
       const additionalNames = exactlyTwoNames
         ? `${secondLastName} ${t('and')} ${lastName}`
         : `${secondLastName}${t('enumerationAnd')}${lastName}`;
-      userNames.push(additionalNames);
+      userNamesWithoutFinalPair.push(additionalNames);
+      return userNamesWithoutFinalPair.join(', ');
     }
 
     return userNames.join(', ');

--- a/apps/webapp/src/script/util/messageComparator.ts
+++ b/apps/webapp/src/script/util/messageComparator.ts
@@ -30,7 +30,7 @@ import type {MentionEntity} from '../message/MentionEntity';
  * @returns Are the mentions different from each other
  */
 export function areMentionsDifferent(originalMessageEntity: ContentMessage, updatedMentions: MentionEntity[]): boolean {
-  const flattenToUserId = (mentions: MentionEntity[]): string[] => mentions.map(mention => mention.userId).sort();
+  const flattenToUserId = (mentions: MentionEntity[]): string[] => mentions.map(mention => mention.userId).toSorted();
 
   const existingMentions = flattenToUserId((originalMessageEntity.getFirstAsset() as TextAsset).mentions());
   const userIds = flattenToUserId(updatedMentions);

--- a/apps/webapp/src/script/util/messageRenderer.ts
+++ b/apps/webapp/src/script/util/messageRenderer.ts
@@ -115,7 +115,7 @@ markdownit.renderer.rules.paragraph_open = (tokens, idx) => {
 
   const previousWithMap = tokens
     .slice(0, idx)
-    .reverse()
+    .toReversed()
     .find(({map}) => map?.length);
   const previousPosition = previousWithMap ? (previousWithMap.map || [0, 0])[1] - 1 : 0;
   const count = position - previousPosition;
@@ -158,7 +158,7 @@ export const renderMessage = (message: string, selfId?: QualifiedId, mentionEnti
   let mentionlessText = mentionEntities
     .slice()
     // sort mentions to start with the latest mention first (in order not to have to recompute the index every time we modify the original text)
-    .sort((mention1, mention2) => mention2.startIndex - mention1.startIndex)
+    .toSorted((mention1, mention2) => mention2.startIndex - mention1.startIndex)
     .reduce((strippedText, mention) => {
       const mentionText = message.slice(mention.startIndex, mention.startIndex + mention.length);
       const mentionKey = createMentionHash(mention);

--- a/apps/webapp/src/script/util/stringUtil.test.ts
+++ b/apps/webapp/src/script/util/stringUtil.test.ts
@@ -57,7 +57,7 @@ describe('generateRandomPassword', () => {
 
   it('shuffles characters sufficiently', () => {
     const password = generateRandomPassword(12);
-    const sortedPassword = password.split('').sort().join('');
+    const sortedPassword = password.split('').toSorted().join('');
     expect(password).not.toEqual(sortedPassword); // Rare chance of equality, indicates weak shuffling
   });
 });

--- a/apps/webapp/src/script/util/stringUtil.ts
+++ b/apps/webapp/src/script/util/stringUtil.ts
@@ -275,7 +275,7 @@ export const generateRandomPassword = (passwordLength: number = 8): string => {
   // Shuffle the characters of the password randomly to make it more secure
   password = password
     .split('')
-    .sort(() => getRandomIndex(2) - 1) // Generates either -1 or 1 for shuffling
+    .toSorted(() => getRandomIndex(2) - 1) // Generates either -1 or 1 for shuffling
     .join('');
 
   // Truncate the password to the desired length if necessary

--- a/apps/webapp/src/script/util/util.test.ts
+++ b/apps/webapp/src/script/util/util.test.ts
@@ -183,7 +183,7 @@ describe('sortGroupsByLastEvent', () => {
     groupB.last_event_timestamp(1414505766449);
 
     const groups = [groupA, groupB];
-    const [firstGroup, secondGroup] = groups.sort(sortGroupsByLastEvent);
+    const [firstGroup, secondGroup] = groups.toSorted(sortGroupsByLastEvent);
 
     expect(firstGroup.name()).toEqual(groupA.name());
     expect(secondGroup.name()).toEqual(groupB.name());
@@ -199,7 +199,7 @@ describe('sortGroupsByLastEvent', () => {
     groupB.last_event_timestamp(1414505857975);
 
     const groups = [groupA, groupB];
-    const [firstGroup, secondGroup] = groups.sort(sortGroupsByLastEvent);
+    const [firstGroup, secondGroup] = groups.toSorted(sortGroupsByLastEvent);
 
     expect(firstGroup.name()).toEqual(groupB.name());
     expect(secondGroup.name()).toEqual(groupA.name());
@@ -218,7 +218,7 @@ describe('sortGroupsByLastEvent', () => {
     expect(sortGroupsByLastEvent(groupA, groupB)).toEqual(0);
 
     const groups = [groupA, groupB];
-    const [firstGroup, secondGroup] = groups.sort(sortGroupsByLastEvent);
+    const [firstGroup, secondGroup] = groups.toSorted(sortGroupsByLastEvent);
 
     expect(firstGroup.name()).toEqual(groupA.name());
     expect(secondGroup.name()).toEqual(groupB.name());

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -638,7 +638,7 @@ test.describe('Calling', () => {
         await expect(callScreen.gridTiles).toHaveCount(6); // Ensure first grid page is full
         const displayedNames = await callScreen.gridTiles.getByTestId('call-participant-name').allInnerTexts();
         const listToVerify = displayedNames.filter(name => name !== localUser);
-        const sortedNames = [...listToVerify].sort((a, b) => a.localeCompare(b));
+        const sortedNames = listToVerify.toSorted((a, b) => a.localeCompare(b));
 
         expect(listToVerify).toEqual(sortedNames);
       },

--- a/apps/webapp/test/e2e_tests/utils/mockNotifications.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/mockNotifications.util.ts
@@ -13,19 +13,22 @@ declare global {
  * **Important**: Don't use this function within playwright directly, only in the browser e.g. within `page.evaluate()`.
  */
 const stubNotifications = () => {
-  if (!window.wire?.app?.repository?.notification?.notifications)
+  const notificationRepository = window.wire?.app?.repository?.notification;
+  if (!notificationRepository?.notifications)
     throw new Error("Can't stub notifications - Notifications array wasn't initialized yet");
 
   window.__wireNotifications ??= [];
+  let currentNotifications = notificationRepository.notifications;
 
-  // Mock the push function of the notifications array
-  window.wire.app.repository.notification.notifications.push = (...notifications) => {
-    // Every time one or more notifications are pushed to the array also keep a reference to them in the global variable
-    window.__wireNotifications.push(...notifications);
-
-    // Use the native push function of the prototype to not modify the behavior
-    return Array.prototype.push.apply(window.wire.app.repository.notification.notifications, notifications);
-  };
+  Object.defineProperty(notificationRepository, 'notifications', {
+    configurable: true,
+    get: () => currentNotifications,
+    set: nextNotifications => {
+      const newNotifications = nextNotifications.slice(currentNotifications.length);
+      window.__wireNotifications = window.__wireNotifications.concat(newNotifications);
+      currentNotifications = nextNotifications;
+    },
+  });
 };
 
 /**

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -9,6 +9,7 @@ import {FlatCompat} from '@eslint/eslintrc';
 import emotionPlugin from '@emotion/eslint-plugin';
 import stylisticPlugin from '@stylistic/eslint-plugin';
 import importPlugin from 'eslint-plugin-import';
+import unicornPlugin from 'eslint-plugin-unicorn';
 import tsParser from '@typescript-eslint/parser';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import headerPlugin, {HeaderOptions, HeaderRuleConfig} from '@tony.ganchev/eslint-plugin-header';
@@ -119,6 +120,7 @@ const config: Linter.Config[] = [
       '@emotion': emotionPlugin,
       import: importPlugin,
       'react-hooks': reactHooksPlugin,
+      unicorn: unicornPlugin,
       'header-tony': headerPlugin,
     },
     rules: {
@@ -126,6 +128,8 @@ const config: Linter.Config[] = [
       '@emotion/no-vanilla': 'error',
       '@emotion/import-from-emotion': 'error',
       '@emotion/styled-import': 'error',
+      'unicorn/no-array-reverse': 'error',
+      'unicorn/no-array-sort': 'error',
       'header-tony/header': [
         'error',
         {
@@ -161,6 +165,14 @@ const config: Linter.Config[] = [
         } as HeaderOptions,
       ] as HeaderRuleConfig,
       'id-length': 'warn',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "CallExpression[callee.property.name='splice']",
+          message:
+            'Use toSpliced() instead of splice() to avoid mutating arrays. Reassign the toSpliced() result when ordering must be preserved.',
+        },
+      ],
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/no-var-requires': 'off',
@@ -196,6 +208,9 @@ const config: Linter.Config[] = [
   },
   {
     files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
+    plugins: {
+      unicorn: unicornPlugin,
+    },
     languageOptions: {
       parser: require('espree'),
       parserOptions: {
@@ -208,6 +223,16 @@ const config: Linter.Config[] = [
       // Disable TS-only rules on JS mocks/shims
       '@typescript-eslint/require-array-sort-compare': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
+      'unicorn/no-array-reverse': 'error',
+      'unicorn/no-array-sort': 'error',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "CallExpression[callee.property.name='splice']",
+          message:
+            'Use toSpliced() instead of splice() to avoid mutating arrays. Reassign the toSpliced() result when ordering must be preserved.',
+        },
+      ],
     },
   },
   {

--- a/libraries/api-client/src/apiClient.ts
+++ b/libraries/api-client/src/apiClient.ts
@@ -325,7 +325,7 @@ export class APIClient extends EventEmitter {
    */
   private findHighestCompatibleVersion(versions: number[], min: number, max: number): number | undefined {
     const inRangeVersions = versions.filter(version => version >= min && version <= max);
-    const [highestVersion] = inRangeVersions.sort((a, b) => b - a);
+    const [highestVersion] = inRangeVersions.toSorted((a, b) => b - a);
     return highestVersion;
   }
 

--- a/libraries/api-client/tsconfig.json
+++ b/libraries/api-client/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "rootDir": "src",
     "types": ["node"],
-    "lib": ["dom", "es2022"],
+    "lib": ["dom", "es2024"],
     "target": "es2020",
     "module": "commonjs",
     "moduleResolution": "node",

--- a/libraries/core/src/messagingProtocols/proteus/proteusService/proteusService.test.ts
+++ b/libraries/core/src/messagingProtocols/proteus/proteusService/proteusService.test.ts
@@ -96,7 +96,7 @@ const prepareDataForEncryption = async () => {
   const messageBuffer = new Uint8Array(Buffer.from(message, 'utf8'));
 
   //mocked payload encrypted and returned by corecrypto
-  const encryptedMessageBuffer = messageBuffer.reverse();
+  const encryptedMessageBuffer = messageBuffer.toReversed();
 
   const validPreKey = {
     id: 1337,

--- a/libraries/core/tsconfig.json
+++ b/libraries/core/tsconfig.json
@@ -8,7 +8,7 @@
     "skipLibCheck": true,
     "rootDir": "src",
     "types": ["node"],
-    "lib": ["dom", "es2022"],
+    "lib": ["dom", "es2024"],
     "target": "es2020",
     "module": "commonjs",
     "moduleResolution": "node",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-testing-library": "7.16.2",
+    "eslint-plugin-unicorn": "64.0.0",
     "eslint-plugin-unused-imports": "4.4.1",
     "fake-indexeddb": "6.2.5",
     "generate-changelog": "1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11115,6 +11115,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"builtin-modules@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "builtin-modules@npm:5.2.0"
+  checksum: 10/e45bb00ea475e69a403986dd78ae8d0d36b6323c0f92303b1e3eac625dea2645492f24f0e36e5683aabcf3473f624b1146fd809c5dca513b1784e91019894016
+  languageName: node
+  linkType: hard
+
 "bundle-name@npm:^4.1.0":
   version: 4.1.0
   resolution: "bundle-name@npm:4.1.0"
@@ -11310,6 +11317,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"change-case@npm:^5.4.4":
+  version: 5.4.4
+  resolution: "change-case@npm:5.4.4"
+  checksum: 10/446e5573f3c854290a91292afef92b957d2e43a928260c91989b482aa860caaa29711b6725fc40c200af68061cbab357b033446d16a17bc5c553636994074e92
+  languageName: node
+  linkType: hard
+
 "char-regex@npm:^1.0.2":
   version: 1.0.2
   resolution: "char-regex@npm:1.0.2"
@@ -11373,6 +11387,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ci-info@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "ci-info@npm:4.4.0"
+  checksum: 10/dfded0c630267d89660c8abb988ac8395a382bdfefedcc03e3e2858523312c5207db777c239c34774e3fcff11f015477c19d2ac8a58ea58aa476614a2e64f434
+  languageName: node
+  linkType: hard
+
 "cjs-module-lexer@npm:^2.1.0":
   version: 2.1.1
   resolution: "cjs-module-lexer@npm:2.1.1"
@@ -11393,6 +11414,15 @@ __metadata:
   dependencies:
     source-map: "npm:~0.6.0"
   checksum: 10/efd9efbf400f38a12f99324bad5359bdd153211b048721e4d4ddb629a88865dff3012dca547a14bdd783d78ccf064746e39fd91835546a08e2d811866aff0857
+  languageName: node
+  linkType: hard
+
+"clean-regexp@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "clean-regexp@npm:1.0.0"
+  dependencies:
+    escape-string-regexp: "npm:^1.0.5"
+  checksum: 10/0b1ce281b07da2463c6882ea2e8409119b6cabbd9f687cdbdcee942c45b2b9049a2084f7b5f228c63ef9f21e722963ae0bfe56a735dbdbdd92512867625a7e40
   languageName: node
   linkType: hard
 
@@ -11901,6 +11931,15 @@ __metadata:
   dependencies:
     browserslist: "npm:^4.28.1"
   checksum: 10/83c326dcfef5e174fd3f8f33c892c66e06d567ce27f323a1197a6c280c0178fe18d3e9c5fb95b00c18b98d6c53fba5c646def5fedaa77310a4297d16dfbe2029
+  languageName: node
+  linkType: hard
+
+"core-js-compat@npm:^3.49.0":
+  version: 3.49.0
+  resolution: "core-js-compat@npm:3.49.0"
+  dependencies:
+    browserslist: "npm:^4.28.1"
+  checksum: 10/eb35ad9b31a613092d32e5eb0c9fecb695e680bb29509fe04ae297ef790cea47d06864ef8939c8f5f189cce0bd2807fef8b2d6450f7eeb917ffaaf38a775dece
   languageName: node
   linkType: hard
 
@@ -13981,6 +14020,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-unicorn@npm:64.0.0":
+  version: 64.0.0
+  resolution: "eslint-plugin-unicorn@npm:64.0.0"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.28.5"
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
+    change-case: "npm:^5.4.4"
+    ci-info: "npm:^4.4.0"
+    clean-regexp: "npm:^1.0.0"
+    core-js-compat: "npm:^3.49.0"
+    find-up-simple: "npm:^1.0.1"
+    globals: "npm:^17.4.0"
+    indent-string: "npm:^5.0.0"
+    is-builtin-module: "npm:^5.0.0"
+    jsesc: "npm:^3.1.0"
+    pluralize: "npm:^8.0.0"
+    regexp-tree: "npm:^0.1.27"
+    regjsparser: "npm:^0.13.0"
+    semver: "npm:^7.7.4"
+    strip-indent: "npm:^4.1.1"
+  peerDependencies:
+    eslint: ">=9.38.0"
+  checksum: 10/3211dadefe8ec43526372a302e48503da42f5e1d3b45d8e20bc29e30dd142b442d70d22ea8617a4ca5494b184b36656d0e81c1e299d12a8e991ac1a86ed35e42
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-unused-imports@npm:4.4.1":
   version: 4.4.1
   resolution: "eslint-plugin-unused-imports@npm:4.4.1"
@@ -14860,6 +14925,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-up-simple@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "find-up-simple@npm:1.0.1"
+  checksum: 10/6e374bffda9f8425314eab47ef79752b6e77dcc95c0ad17d257aef48c32fe07bbc41bcafbd22941c25bb94fffaaaa8e178d928867d844c58100c7fe19ec82f72
+  languageName: node
+  linkType: hard
+
 "find-up@npm:^4.0.0, find-up@npm:^4.1.0":
   version: 4.1.0
   resolution: "find-up@npm:4.1.0"
@@ -15657,6 +15729,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globals@npm:^17.4.0":
+  version: 17.6.0
+  resolution: "globals@npm:17.6.0"
+  checksum: 10/2bf0febf31c942edee6f4eca7e939a9c885f8ecfb767048b1c4dd2a32008d0ab136e6076665d76b44b29c2571bbbc1681371caab05fd8ee0067c7618e841b89d
+  languageName: node
+  linkType: hard
+
 "globalthis@npm:^1.0.4":
   version: 1.0.4
   resolution: "globalthis@npm:1.0.4"
@@ -16442,6 +16521,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"indent-string@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "indent-string@npm:5.0.0"
+  checksum: 10/e466c27b6373440e6d84fbc19e750219ce25865cb82d578e41a6053d727e5520dc5725217d6eb1cc76005a1bb1696a0f106d84ce7ebda3033b963a38583fb3b3
+  languageName: node
+  linkType: hard
+
 "inflight@npm:^1.0.4":
   version: 1.0.6
   resolution: "inflight@npm:1.0.6"
@@ -16623,6 +16709,15 @@ __metadata:
   version: 1.1.6
   resolution: "is-buffer@npm:1.1.6"
   checksum: 10/f63da109e74bbe8947036ed529d43e4ae0c5fcd0909921dce4917ad3ea212c6a87c29f525ba1d17c0858c18331cf1046d4fc69ef59ed26896b25c8288a627133
+  languageName: node
+  linkType: hard
+
+"is-builtin-module@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "is-builtin-module@npm:5.0.0"
+  dependencies:
+    builtin-modules: "npm:^5.0.0"
+  checksum: 10/fcb1e458fa08e6d7e8763abaa84bc539ca943b298e15448ba92b79ab8f08c382664b8b1d5e32c59358e87026fed7b1e56e457b955436d7cc860cf0653002e4c6
   languageName: node
   linkType: hard
 
@@ -18368,7 +18463,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsesc@npm:^3.0.2, jsesc@npm:~3.1.0":
+"jsesc@npm:^3.0.2, jsesc@npm:^3.1.0, jsesc@npm:~3.1.0":
   version: 3.1.0
   resolution: "jsesc@npm:3.1.0"
   bin:
@@ -21261,6 +21356,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pluralize@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "pluralize@npm:8.0.0"
+  checksum: 10/17877fdfdb7ddb3639ce257ad73a7c51a30a966091e40f56ea9f2f545b5727ce548d4928f8cb3ce38e7dc0c5150407d318af6a4ed0ea5265d378473b4c2c61ec
+  languageName: node
+  linkType: hard
+
 "pngjs@npm:^3.0.0":
   version: 3.4.0
   resolution: "pngjs@npm:3.4.0"
@@ -23392,6 +23494,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regexp-tree@npm:^0.1.27":
+  version: 0.1.27
+  resolution: "regexp-tree@npm:0.1.27"
+  bin:
+    regexp-tree: bin/regexp-tree
+  checksum: 10/08c70c8adb5a0d4af1061bf9eb05d3b6e1d948c433d6b7008e4b5eb12a49429c2d6ca8e9106339a432aa0d07bd6e1bccc638d8f4ab0d045f3adad22182b300a2
+  languageName: node
+  linkType: hard
+
 "regexp.prototype.flags@npm:^1.5.3, regexp.prototype.flags@npm:^1.5.4":
   version: 1.5.4
   resolution: "regexp.prototype.flags@npm:1.5.4"
@@ -24289,6 +24400,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10/8dbc3168e057a38fc322af909c7f5617483c50caddba135439ff09a754b20bdd6482a5123ff543dad4affa488ecf46ec5fb56d61312ad20bb140199b88dfaea9
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.7.4":
+  version: 7.8.0
+  resolution: "semver@npm:7.8.0"
+  bin:
+    semver: bin/semver.js
+  checksum: 10/039a8f68a581c03c1ac17c990316da57a79a93af9b109b712739c50cd4d464079f7e3fee31c008b472e390c7ba48a11ed2b86e91d8602bf06059d4a266db1426
   languageName: node
   linkType: hard
 
@@ -25266,6 +25386,13 @@ __metadata:
   dependencies:
     min-indent: "npm:^1.0.0"
   checksum: 10/18f045d57d9d0d90cd16f72b2313d6364fd2cb4bf85b9f593523ad431c8720011a4d5f08b6591c9d580f446e78855c5334a30fb91aa1560f5d9f95ed1b4a0530
+  languageName: node
+  linkType: hard
+
+"strip-indent@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "strip-indent@npm:4.1.1"
+  checksum: 10/d322bfdc59855006791a4aebe2a66e0892eab7004a5c064d74b86a0c6ecff2818974c9a5eda54b16d8af6aadbc90a6c02635ffcbec11ab33dd8979b1a6346fc0
   languageName: node
   linkType: hard
 
@@ -27580,6 +27707,7 @@ __metadata:
     eslint-plugin-react: "npm:7.37.5"
     eslint-plugin-react-hooks: "npm:7.1.1"
     eslint-plugin-testing-library: "npm:7.16.2"
+    eslint-plugin-unicorn: "npm:64.0.0"
     eslint-plugin-unused-imports: "npm:4.4.1"
     fake-indexeddb: "npm:6.2.5"
     fs-extra: "npm:11.3.5"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Migrate array updates to the non-mutating ES2023 APIs and make immutable updates the default across the codebase.

Immutability should be preferred over mutation because it makes data flow explicit, avoids hidden in-place state changes, reduces accidental coupling between callers that share references, and makes behavior easier to test and reason about. In practice, returning a new array is safer than mutating an existing one, especially in UI and state-management code where correctness depends on predictable updates.


