### PR TITLE
Improve MLS epoch mismatch recovery observability [WPB-21916]

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -3843,12 +3843,16 @@ export class ConversationRepository {
     const conversation = this.conversationState.findConversation(conversationId);
 
     if (!conversation) {
+      this.logger.warn('MLS conversation recovered but conversation entity not found; skipping system message', {
+        conversationId,
+      });
       return;
     }
     const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
 
     const event = EventBuilder.buildMLSConversationRecovered(conversation, currentTimestamp);
 
+    this.logger.info('Injecting MLS conversation recovered system message', {conversationId});
     void this.eventRepository.injectEvent(event);
   };
 

--- a/libraries/core/src/conversation/conversationService/conversationService.test.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.test.ts
@@ -35,6 +35,7 @@ import {BackendErrorLabel} from '@wireapp/api-client/lib/http';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
+import {Result, task} from 'true-myth';
 
 import {APIClient} from '@wireapp/api-client';
 import {ErrorType, MlsErrorType} from '@wireapp/core-crypto';
@@ -142,6 +143,7 @@ describe('ConversationService', () => {
       encryptMessage: () => {},
       commitPendingProposals: () => Promise.resolve(),
       getEpoch: () => Promise.resolve(),
+      getSafeEpoch: jest.fn(),
       joinByExternalCommit: jest.fn(),
       registerConversation: jest.fn(),
       register1to1Conversation: jest.fn(),
@@ -468,7 +470,7 @@ describe('ConversationService', () => {
     };
 
     it('re-joins multiple not-established conversations', async () => {
-      const [conversationService, {apiClient}] = await buildConversationService();
+      const [conversationService, {apiClient, mlsService}] = await buildConversationService();
 
       const remoteEpoch = 1;
 
@@ -478,7 +480,7 @@ describe('ConversationService', () => {
       const mockedDBResponse: Conversation[] = [mlsConversation1, mlsConversation2];
       jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
 
-      jest.spyOn(conversationService, 'mlsGroupExistsLocally').mockResolvedValue(false);
+      jest.spyOn(mlsService, 'getSafeEpoch').mockReturnValue(task.fromResult(Result.err("Couldn't find conversation")));
 
       await conversationService.handleConversationsEpochMismatch();
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);
@@ -494,8 +496,7 @@ describe('ConversationService', () => {
       const mockedDBResponse: Conversation[] = [mlsConversation1, mlsConversation2];
       jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
 
-      jest.spyOn(conversationService, 'mlsGroupExistsLocally').mockResolvedValue(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValue(2);
+      jest.spyOn(mlsService, 'getSafeEpoch').mockReturnValue(task.fromResult(Result.ok(2)));
 
       await conversationService.handleConversationsEpochMismatch();
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);
@@ -510,10 +511,7 @@ describe('ConversationService', () => {
       const mockedDBResponse: Conversation[] = [mlsConversation];
       jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
 
-      jest.spyOn(conversationService, 'mlsGroupExistsLocally').mockResolvedValueOnce(true);
-
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(1);
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
+      jest.spyOn(mlsService, 'getSafeEpoch').mockReturnValue(task.fromResult(Result.ok(1)));
 
       await conversationService.handleConversationsEpochMismatch();
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();

--- a/libraries/core/src/conversation/conversationService/conversationService.test.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.test.ts
@@ -244,8 +244,7 @@ describe('ConversationService', () => {
 
       const remoteEpoch = 6;
       const localEpoch = 5;
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
+      jest.spyOn(mlsService, 'getSafeEpoch').mockReturnValue(task.fromResult(Result.ok(localEpoch)));
 
       jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValue({
         qualified_id: mockConversationId,
@@ -288,8 +287,7 @@ describe('ConversationService', () => {
 
       const remoteEpoch = 10;
       const localEpoch = 9;
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
+      jest.spyOn(mlsService, 'getSafeEpoch').mockReturnValue(task.fromResult(Result.ok(localEpoch)));
       jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
         qualified_id: conversationId,
         protocol: CONVERSATION_PROTOCOL.MLS,
@@ -347,8 +345,7 @@ describe('ConversationService', () => {
       const remoteEpoch = 5;
       const localEpoch = 4;
 
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
+      jest.spyOn(mlsService, 'getSafeEpoch').mockReturnValue(task.fromResult(Result.ok(localEpoch)));
 
       jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
         qualified_id: mockConversationId,
@@ -390,8 +387,7 @@ describe('ConversationService', () => {
       const remoteEpoch = 5;
       const localEpoch = 4;
 
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
+      jest.spyOn(mlsService, 'getSafeEpoch').mockReturnValue(task.fromResult(Result.ok(localEpoch)));
 
       jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
         qualified_id: mockConversationId,
@@ -780,8 +776,7 @@ describe('ConversationService', () => {
       const remoteEpoch = 5;
       const localEpoch = 4;
 
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
+      jest.spyOn(mlsService, 'getSafeEpoch').mockReturnValue(task.fromResult(Result.ok(localEpoch)));
 
       jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
         qualified_id: conversationId,
@@ -813,8 +808,7 @@ describe('ConversationService', () => {
       const remoteEpoch = 5;
       const localEpoch = 4;
 
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
+      jest.spyOn(mlsService, 'getSafeEpoch').mockReturnValue(task.fromResult(Result.ok(localEpoch)));
 
       const mockedSubconversationResponse = {
         epoch: remoteEpoch,
@@ -1084,8 +1078,7 @@ describe('ConversationService', () => {
 
       const remoteEpoch = 5;
       const localEpoch = 4;
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
+      jest.spyOn(mlsService, 'getSafeEpoch').mockReturnValue(task.fromResult(Result.ok(localEpoch)));
 
       const getConvSpy = jest.spyOn(apiClient.api.conversation, 'getConversation');
       getConvSpy.mockResolvedValue({
@@ -1365,8 +1358,7 @@ describe('ConversationService', () => {
       const remoteEpoch = 3;
       const localEpoch = 2;
 
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
+      jest.spyOn(mlsService, 'getSafeEpoch').mockReturnValue(task.fromResult(Result.ok(localEpoch)));
 
       jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
         qualified_id,

--- a/libraries/core/src/conversation/conversationService/conversationService.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.ts
@@ -60,6 +60,7 @@ import {MessageTimer, MessageSendingState, RemoveUsersParams} from '../../conver
 import {MLSService, MLSServiceEvents} from '../../messagingProtocols/mls';
 import {
   MlsRecoveryOrchestrator,
+  MlsEpochRecoveryTrigger,
   MlsRecoveryOrchestratorImpl,
   OperationName,
   createDefaultMlsErrorMapper,
@@ -123,8 +124,11 @@ export class ConversationService extends TypedEventEmitter<Events> {
       // Call the low-level API to avoid nested recovery when orchestrator triggers an external commit join
       joinViaExternalCommit: (conversationId: QualifiedId) => this.performJoinByExternalCommitAPI(conversationId),
       resetAndReestablish: (conversationId: QualifiedId) => this.handleBrokenMLSConversation(conversationId),
-      recoverFromEpochMismatch: (conversationId: QualifiedId, subconvId?: SUBCONVERSATION_ID) =>
-        this.recoverMLSGroupFromEpochMismatch(conversationId, subconvId),
+      recoverFromEpochMismatch: (
+        conversationId: QualifiedId,
+        subconvId?: SUBCONVERSATION_ID,
+        trigger?: MlsEpochRecoveryTrigger,
+      ) => this.recoverMLSGroupFromEpochMismatch(conversationId, subconvId, trigger),
       addMissingUsers: (conversationId: QualifiedId, groupId: string, users: QualifiedId[]) =>
         this.performAddUsersToMLSConversationAPI({conversationId, groupId, qualifiedUsers: users}),
       wipeMLSConversation: this.wipeMLSConversation,
@@ -748,18 +752,6 @@ export class ConversationService extends TypedEventEmitter<Events> {
     return this.mlsService.wipeConversation(groupId);
   };
 
-  private async matchesEpoch(groupId: string, backendEpoch: number): Promise<boolean> {
-    const localEpoch = await this.mlsService.getEpoch(groupId);
-
-    this.logger.debug(
-      `Comparing conversation's (group_id: ${groupId}) local and backend epoch number: {local: ${String(
-        localEpoch,
-      )}, backend: ${backendEpoch}}`,
-    );
-    //corecrypto stores epoch number as BigInt, we're mapping both values to be sure comparison is valid
-    return BigInt(localEpoch) === BigInt(backendEpoch);
-  }
-
   public async handleConversationsEpochMismatch() {
     this.logger.warn(`There were some missed messages, handling possible epoch mismatch in MLS conversations.`);
 
@@ -813,44 +805,102 @@ export class ConversationService extends TypedEventEmitter<Events> {
   private async handleConversationEpochMismatch(
     remoteMlsConversation: MLSConversation,
     onSuccessfulRejoin?: () => void,
+    trigger?: MlsEpochRecoveryTrigger,
   ) {
-    const {qualified_id: qualifiedId, group_id: groupId, epoch} = remoteMlsConversation;
+    const {qualified_id: qualifiedId, group_id: groupId, epoch: backendEpoch} = remoteMlsConversation;
+    const hasEpochMismatch = await this.hasEpochMismatch(groupId, backendEpoch, trigger?.operationName);
+    if (!hasEpochMismatch) {
+      this.logger.info(`Conversation has no epoch mismatch, skipping rejoin`, {
+        conversationId: qualifiedId,
+        groupId,
+        backendEpoch,
+        trigger,
+      });
+      return;
+    }
 
-    if (await this.hasEpochMismatch(groupId, epoch)) {
-      this.logger.warn(
-        `Conversation (id ${qualifiedId.id}) was not established or it's epoch number was out of date, joining via external commit`,
-      );
+    const localEpochBeforeRejoin = (await this.mlsService.getSafeEpoch(groupId)).match({
+      Ok: epoch => epoch,
+      Err: () => undefined,
+    });
 
-      try {
-        await this.joinByExternalCommit(qualifiedId);
-        onSuccessfulRejoin?.();
-      } catch (error: unknown) {
-        const message = `There was an error while handling epoch mismatch in MLS conversation (id: ${qualifiedId.id}):`;
-        this.logger.error(message, error);
-      }
+    this.logger.warn(
+      `Conversation (id ${qualifiedId.id}) was not established or it's epoch number was out of date, joining via external commit`,
+      {
+        conversationId: qualifiedId,
+        groupId,
+        backendEpoch,
+        localEpochBeforeRejoin,
+        trigger,
+      },
+    );
+
+    try {
+      await this.joinByExternalCommit(qualifiedId);
+      const localEpochAfterRejoin = (await this.mlsService.getSafeEpoch(groupId)).match({
+        Ok: epoch => epoch,
+        Err: () => undefined,
+      });
+      this.logger.info('MLS external commit rejoin completed after epoch mismatch', {
+        conversationId: qualifiedId,
+        groupId,
+        backendEpoch,
+        localEpochBeforeRejoin,
+        localEpochAfterRejoin,
+        trigger,
+      });
+      onSuccessfulRejoin?.();
+    } catch (error: unknown) {
+      const message = `There was an error while handling epoch mismatch in MLS conversation (id: ${qualifiedId.id}):`;
+      this.logger.error(message, {
+        error,
+        conversationId: qualifiedId,
+        groupId,
+        backendEpoch,
+        localEpochBeforeRejoin,
+        trigger,
+      });
     }
   }
 
   /**
-   * Handles epoch mismatch in a MLS group.
-   * Compares the epoch of the local group with the epoch of the remote conversation.
-   * If the epochs do not match, it will call onEpochMismatch callback.
-   * @param groupId - id of the MLS group
-   * @param epoch - epoch of the remote conversation
-   * @param onEpochMismatch - callback to be called when epochs do not match
+   * Returns whether the local MLS group epoch differs from the backend epoch,
+   * or the group is not present locally (getSafeEpoch error).
    */
-  private async hasEpochMismatch(groupId: string, epoch: number) {
-    const isEstablished = await this.mlsGroupExistsLocally(groupId);
-    const doesEpochMatch = isEstablished && (await this.matchesEpoch(groupId, epoch));
+  private async hasEpochMismatch(
+    groupId: string,
+    backendEpoch: number,
+    operationName?: OperationName,
+  ): Promise<boolean> {
+    const localEpochResult = await this.mlsService.getSafeEpoch(groupId);
 
-    // if conversation is not established or epoch does not match -> try to rejoin
-    const hasEpochMismatch = !isEstablished || !doesEpochMatch;
-    this.logger.info(`Conversation (group_id: ${groupId}) epoch mismatch check result: ${hasEpochMismatch}`, {
-      isEstablished,
-      doesEpochMatch,
-      epoch,
+    return localEpochResult.match({
+      Ok: localEpoch => {
+        const doesEpochMatch = BigInt(localEpoch) === BigInt(backendEpoch);
+        const hasMismatch = !doesEpochMatch;
+        const epochDelta = Number(backendEpoch) - Number(localEpoch);
+
+        this.logger.info(`Conversation (group_id: ${groupId}) epoch mismatch check`, {
+          hasMismatch,
+          doesEpochMatch,
+          backendEpoch,
+          localEpoch,
+          epochDelta,
+          operationName,
+        });
+
+        return hasMismatch;
+      },
+      Err: error => {
+        this.logger.warn(`Local MLS group not readable; treating as epoch mismatch`, {
+          error,
+          groupId,
+          backendEpoch,
+          operationName,
+        });
+        return true;
+      },
     });
-    return hasEpochMismatch;
   }
 
   /**
@@ -860,7 +910,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
   async getMLS1to1Conversation(userId: QualifiedId) {
     const conversation = await this.apiClient.api.conversation.getMLS1to1Conversation(userId);
 
-    if (isMLS1to1Conversation(conversation)) {
+    if (isMLS1to1Conversation(conversation) === true) {
       return conversation;
     }
     return {conversation};
@@ -1026,8 +1076,12 @@ export class ConversationService extends TypedEventEmitter<Events> {
     }
   }
 
-  private async recoverMLSGroupFromEpochMismatch(conversationId: QualifiedId, subconversationId?: SUBCONVERSATION_ID) {
-    this.logger.info(`Recovering MLS group from epoch mismatch`, {conversationId, subconversationId});
+  private async recoverMLSGroupFromEpochMismatch(
+    conversationId: QualifiedId,
+    subconversationId?: SUBCONVERSATION_ID,
+    trigger?: MlsEpochRecoveryTrigger,
+  ) {
+    this.logger.info(`Recovering MLS group from epoch mismatch`, {conversationId, subconversationId, trigger});
     if (subconversationId !== undefined) {
       const parentGroupId = await this.groupIdFromConversationId(conversationId);
       const subconversation = await this.apiClient.api.conversation.getSubconversation(
@@ -1047,8 +1101,10 @@ export class ConversationService extends TypedEventEmitter<Events> {
       throw new Error('Conversation is not an MLS conversation');
     }
 
-    return this.handleConversationEpochMismatch(mlsConversation, () =>
-      this.emit('MLSConversationRecovered', {conversationId: mlsConversation.qualified_id}),
+    return this.handleConversationEpochMismatch(
+      mlsConversation,
+      () => this.emit('MLSConversationRecovered', {conversationId: mlsConversation.qualified_id}),
+      trigger,
     );
   }
 

--- a/libraries/core/src/messagingProtocols/mls/recovery/index.ts
+++ b/libraries/core/src/messagingProtocols/mls/recovery/index.ts
@@ -33,5 +33,6 @@ export type {
   OperationContext,
   MlsRecoveryOrchestrator,
   OrchestratorDeps,
+  MlsEpochRecoveryTrigger,
 } from './mlsRecoveryOrchestrator';
 export {MlsRecoveryOrchestratorImpl, minimalDefaultPolicies, OperationName} from './mlsRecoveryOrchestrator';

--- a/libraries/core/src/messagingProtocols/mls/recovery/mlsRecoveryOrchestrator.test.ts
+++ b/libraries/core/src/messagingProtocols/mls/recovery/mlsRecoveryOrchestrator.test.ts
@@ -78,7 +78,11 @@ describe('MlsRecoveryOrchestrator', () => {
       callBack: cb,
     });
 
-    expect(deps.recoverFromEpochMismatch).toHaveBeenCalledWith(qid(), SUBCONVERSATION_ID.CONFERENCE);
+    expect(deps.recoverFromEpochMismatch).toHaveBeenCalledWith(qid(), SUBCONVERSATION_ID.CONFERENCE, {
+      operationName: OperationName.send,
+      errorType: 'WrongEpoch',
+      groupId: undefined,
+    });
     expect(cb).toHaveBeenCalledTimes(2);
     expect(res).toBe('ok');
   });
@@ -291,7 +295,11 @@ describe('MlsRecoveryOrchestrator', () => {
     // Flush any microtasks from initial rejection handling
     await Promise.resolve();
     expect(cb).toHaveBeenCalledTimes(1);
-    expect(deps.recoverFromEpochMismatch).toHaveBeenCalledWith(qid(), SUBCONVERSATION_ID.CONFERENCE);
+    expect(deps.recoverFromEpochMismatch).toHaveBeenCalledWith(qid(), SUBCONVERSATION_ID.CONFERENCE, {
+      operationName: OperationName.send,
+      errorType: 'WrongEpoch',
+      groupId: undefined,
+    });
 
     // The rerun should not happen until timers advance
     jest.advanceTimersByTime(49);

--- a/libraries/core/src/messagingProtocols/mls/recovery/mlsRecoveryOrchestrator.ts
+++ b/libraries/core/src/messagingProtocols/mls/recovery/mlsRecoveryOrchestrator.ts
@@ -24,6 +24,13 @@ import {LogFactory} from '@wireapp/commons';
 
 import {DomainMlsError, DomainMlsErrorType, MlsErrorMapper} from './mlsErrorMapper';
 
+/** Context captured when epoch-mismatch recovery is triggered, for structured debugging. */
+export type MlsEpochRecoveryTrigger = {
+  operationName: OperationName;
+  errorType: DomainMlsErrorType;
+  groupId?: string;
+};
+
 import {BaseCreateConversationResponse} from '../../../conversation';
 
 /**
@@ -140,7 +147,11 @@ export interface MlsRecoveryOrchestrator {
 export type OrchestratorDeps = {
   joinViaExternalCommit: (conversationId: QualifiedId) => Promise<void>;
   resetAndReestablish: (conversationId: QualifiedId) => Promise<void>;
-  recoverFromEpochMismatch: (conversationId: QualifiedId, subconvId?: SUBCONVERSATION_ID) => Promise<void>;
+  recoverFromEpochMismatch: (
+    conversationId: QualifiedId,
+    subconvId?: SUBCONVERSATION_ID,
+    trigger?: MlsEpochRecoveryTrigger,
+  ) => Promise<void>;
   addMissingUsers: (
     conversationId: QualifiedId,
     groupId: string,
@@ -246,7 +257,20 @@ export class MlsRecoveryOrchestratorImpl implements MlsRecoveryOrchestrator {
 
     switch (policy.action) {
       case 'RecoverFromEpochMismatch': {
-        await this.runOnceWithKey(recoveryKey, () => this.deps.recoverFromEpochMismatch(id, context.subconvId));
+        const trigger: MlsEpochRecoveryTrigger = {
+          operationName: context.operationName,
+          errorType: err.type,
+          groupId: context.groupId ?? err.context?.groupId,
+        };
+        this.logger.info('Triggering MLS epoch mismatch recovery', {
+          conversationId: id,
+          subconvId: context.subconvId,
+          recoveryKey,
+          trigger,
+        });
+        await this.runOnceWithKey(recoveryKey, () =>
+          this.deps.recoverFromEpochMismatch(id, context.subconvId, trigger),
+        );
         break;
       }
       case 'JoinViaExternalCommit': {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add structured logging across the MLS recovery path so Datadog can correlate why clients end up in external-commit rejoin and show the "conversation recovered" system message.


