### PR TITLE
Reference bug ticket in currently skipped group deletion tests [WPB-25900]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -91,7 +91,7 @@ test.describe('Group Conversation', () => {
     },
   );
 
-  // This test is currently broken due to the backend taking more than 20s to delete the conversation
+  // Skipped due to WPB-25900 -> Group conversations are only deleted locally but not for the other members
   test.skip(
     'I want to delete a group as the Group Creator',
     {tag: ['@TC-1089', '@regression']},
@@ -125,12 +125,12 @@ test.describe('Group Conversation', () => {
       await userAModals.confirm().actionButton.click();
 
       // Verify the group no longer exists for any user
-      await expect(adminGroupLocator).toBeHidden({timeout: 20_000});
-      await expect(memberGroupLocator).toBeHidden({timeout: 20_000});
+      await expect(adminGroupLocator).toBeHidden();
+      await expect(memberGroupLocator).toBeHidden();
     },
   );
 
-  // This test is currently broken due to the backend taking more than 20s to delete the conversation
+  // Skipped due to WPB-25900 -> Group conversations are only deleted locally but not for the other members
   test.skip(
     'I want to be notified about the group deletion when app is in background',
     {tag: ['@TC-1093', '@regression']},
@@ -154,7 +154,7 @@ test.describe('Group Conversation', () => {
       await userAPages.conversation().clickConversationInfoButton();
       await userAPages.conversationDetails().deleteGroupButton.click();
       await userAModals.confirm().actionButton.click();
-      await expect(userAConversation).not.toBeAttached({timeout: 20_000});
+      await expect(userAConversation).not.toBeAttached();
 
       await expect
         .poll(() => getUserBNotifications())
@@ -171,7 +171,7 @@ test.describe('Group Conversation', () => {
     },
   );
 
-  // This test is currently broken due to the backend taking more than 20s to delete the conversation
+  // Skipped due to WPB-25900 -> Group conversations are only deleted locally but not for the other members
   test.skip(
     'I should not be able to search for deleted group',
     {tag: ['@TC-1095', '@regression']},
@@ -203,9 +203,7 @@ test.describe('Group Conversation', () => {
         await pages.conversation().clickConversationInfoButton();
         await pages.conversationDetails().deleteGroupButton.click();
         await modals.confirm().actionButton.click();
-        await expect(userCPages.conversationList().getConversation(group.name)).not.toBeAttached({
-          timeout: 20_000,
-        });
+        await expect(userCPages.conversationList().getConversation(group.name)).not.toBeAttached();
 
         await userCPages.conversationList().searchConversationsInput.fill(group.name);
         await expect(userCPages.conversationList().list).toContainText('No results found');


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25900" title="WPB-25900" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25900</a>  [Web] Deleting a group conversation only deletes it locally and not for others
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Currently group conversations are not deleted for other group members. We initially thought this issue was related to the backend regression causing group deletion to take a long time but it seems like there's some other underlying cause.


