### PR TITLE
fix(core): defer MLS epoch recovery until notification replay finishes [WPB-21916]

### DIFF
--- a/libraries/core/src/account.test.ts
+++ b/libraries/core/src/account.test.ts
@@ -49,6 +49,7 @@ jest.mock('./conversation', () => {
     constructor(..._args: any[]) {}
     // Return unhandled so NotificationService falls back to generic handling in tests
     handleEvent = jest.fn(async () => ({status: 'unhandled' as const}));
+    runDeferredEpochRecovery = jest.fn(async () => undefined);
   }
   return {
     ...actual,
@@ -56,7 +57,8 @@ jest.mock('./conversation', () => {
   };
 });
 
-import {Account, ConnectionState} from './account';
+import {Account} from './account';
+import {ConnectionState} from './connectionState/connectionStateTracker';
 import type {MLSService} from './messagingProtocols/mls';
 import {NotificationSource} from './notification';
 

--- a/libraries/core/src/account.ts
+++ b/libraries/core/src/account.ts
@@ -94,22 +94,13 @@ import {TeamService} from './team/';
 import {UserService} from './user/';
 import {LocalStorageStore} from './util/localStorageStore';
 import {RecurringTaskScheduler} from './util/recurringTaskScheduler';
+import {
+  ConnectionState,
+  ConnectionStateTracker,
+  createConnectionStateTracker,
+} from './connectionState/connectionStateTracker';
 
 export type ProcessedEventPayload = HandledEventPayload;
-
-export enum ConnectionState {
-  /** The WebSocket is closed and no notifications are being processed */
-  CLOSED = 'closed',
-
-  /** The WebSocket is being opened or reconnected */
-  CONNECTING = 'connecting',
-
-  /** The websocket is open but locked and notifications stream is being processed */
-  PROCESSING_NOTIFICATIONS = 'processing_notifications',
-
-  /** The WebSocket is open and new messages are processed live in real time */
-  LIVE = 'live',
-}
 
 export type CreateStoreFn = (storeName: string, key: Uint8Array) => undefined | Promise<CRUDEngine | undefined>;
 
@@ -165,7 +156,7 @@ export class Account extends TypedEventEmitter<Events> {
   private db?: CoreDatabase;
   private encryptedDb?: EncryptedStore<any>;
   private coreCallbacks?: CoreCallbacks;
-  private connectionState: ConnectionState = ConnectionState.CLOSED;
+  private readonly connectionStateTracker: ConnectionStateTracker = createConnectionStateTracker();
 
   /**
    * {@link once}-wrapped {@link MLSService.initialisePendingProposalsTasks}; recreated in
@@ -547,6 +538,7 @@ export class Account extends TypedEventEmitter<Events> {
       subconversationService,
       this.isMLSConversationRecoveryEnabled,
       mlsService,
+      this.connectionStateTracker,
     );
     const notificationService = new NotificationService(this.apiClient, this.storeEngine, conversationService);
 
@@ -579,6 +571,7 @@ export class Account extends TypedEventEmitter<Events> {
   private readonly resetContext = (): void => {
     this.currentClient = undefined;
     this.initialisePendingProposalsTasksOnce = this.createInitialisePendingProposalsTasksOnce();
+    this.connectionStateTracker.setState(ConnectionState.CLOSED);
     delete this.apiClient.context;
     delete this.service;
   };
@@ -831,7 +824,7 @@ export class Account extends TypedEventEmitter<Events> {
     onConnectionStateChanged: (state: ConnectionState) => void,
   ): ((state: ConnectionState) => void) => {
     return (state: ConnectionState): void => {
-      this.connectionState = state;
+      this.connectionStateTracker.setState(state);
       onConnectionStateChanged(state);
       this.logger.info(`Connection state changed to: ${state}`);
     };
@@ -998,6 +991,7 @@ export class Account extends TypedEventEmitter<Events> {
      */
     if (markerId === currentMarkerId) {
       await this.rehydrateMlsPendingProposalsTasksOnLiveTransition();
+      await this.service!.conversation.runDeferredEpochRecovery();
       resumeProposalProcessing();
       resumeMessageSending();
       resumeRejoiningMLSConversations();
@@ -1017,7 +1011,7 @@ export class Account extends TypedEventEmitter<Events> {
 
       const firstEventPayload = notification.data.event.payload[0];
       const notificationTime = firstEventPayload ? this.getNotificationEventTime(firstEventPayload) : null;
-      if (this.connectionState !== ConnectionState.LIVE && notificationTime !== null && notificationTime.length > 0) {
+      if (!this.connectionStateTracker.isLive() && notificationTime !== null && notificationTime.length > 0) {
         onNotificationStreamProgress(notificationTime);
       }
 
@@ -1109,6 +1103,7 @@ export class Account extends TypedEventEmitter<Events> {
         .push(async () => {
           this.logger.info(`Resuming message sending. ${getQueueLength()} messages to be sent`);
           await this.rehydrateMlsPendingProposalsTasksOnLiveTransition();
+          await this.service!.conversation.runDeferredEpochRecovery();
           resumeProposalProcessing();
           resumeMessageSending();
           resumeRejoiningMLSConversations();

--- a/libraries/core/src/connectionState/connectionStateTracker.test.ts
+++ b/libraries/core/src/connectionState/connectionStateTracker.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ConnectionState, createConnectionStateTracker} from './connectionStateTracker';
+
+describe('createConnectionStateTracker', () => {
+  it('defaults to CLOSED', () => {
+    const tracker = createConnectionStateTracker();
+
+    expect(tracker.getState()).toBe(ConnectionState.CLOSED);
+    expect(tracker.isLive()).toBe(false);
+  });
+
+  it('accepts a custom initial state', () => {
+    const tracker = createConnectionStateTracker(ConnectionState.LIVE);
+
+    expect(tracker.getState()).toBe(ConnectionState.LIVE);
+    expect(tracker.isLive()).toBe(true);
+  });
+
+  it('updates state via setState', () => {
+    const tracker = createConnectionStateTracker();
+
+    tracker.setState(ConnectionState.PROCESSING_NOTIFICATIONS);
+
+    expect(tracker.getState()).toBe(ConnectionState.PROCESSING_NOTIFICATIONS);
+    expect(tracker.isLive()).toBe(false);
+  });
+
+  it('isLive is true only in LIVE state', () => {
+    const tracker = createConnectionStateTracker();
+
+    for (const state of [
+      ConnectionState.CLOSED,
+      ConnectionState.CONNECTING,
+      ConnectionState.PROCESSING_NOTIFICATIONS,
+    ]) {
+      tracker.setState(state);
+      expect(tracker.isLive()).toBe(false);
+    }
+
+    tracker.setState(ConnectionState.LIVE);
+    expect(tracker.isLive()).toBe(true);
+  });
+
+  it('returns independent tracker instances', () => {
+    const first = createConnectionStateTracker(ConnectionState.CONNECTING);
+    const second = createConnectionStateTracker(ConnectionState.LIVE);
+
+    first.setState(ConnectionState.CLOSED);
+
+    expect(first.getState()).toBe(ConnectionState.CLOSED);
+    expect(second.getState()).toBe(ConnectionState.LIVE);
+  });
+});

--- a/libraries/core/src/connectionState/connectionStateTracker.ts
+++ b/libraries/core/src/connectionState/connectionStateTracker.ts
@@ -1,0 +1,56 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export enum ConnectionState {
+  /** The WebSocket is closed and no notifications are being processed */
+  CLOSED = 'closed',
+
+  /** The WebSocket is being opened or reconnected */
+  CONNECTING = 'connecting',
+
+  /** The websocket is open but locked and notifications stream is being processed */
+  PROCESSING_NOTIFICATIONS = 'processing_notifications',
+
+  /** The WebSocket is open and new messages are processed live in real time */
+  LIVE = 'live',
+}
+
+export type ConnectionStateTracker = Readonly<{
+  getState: () => ConnectionState;
+  setState: (state: ConnectionState) => void;
+  isLive: () => boolean;
+}>;
+
+/**
+ * Creates a mutable connection-state holder shared between {@link Account} and
+ * {@link ConversationService} (and any other core component that needs it).
+ */
+export function createConnectionStateTracker(
+  initialState: ConnectionState = ConnectionState.CLOSED,
+): ConnectionStateTracker {
+  let state = initialState;
+
+  return {
+    getState: () => state,
+    setState: (nextState: ConnectionState) => {
+      state = nextState;
+    },
+    isLive: () => state === ConnectionState.LIVE,
+  };
+}

--- a/libraries/core/src/conversation/conversationService/conversationService.test.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.test.ts
@@ -51,7 +51,8 @@ import {
 import {MLSServiceEvents} from '../../messagingProtocols/mls/mlsService/mlsService';
 import {ProteusService} from '../../messagingProtocols/proteus';
 import * as MessagingProtocols from '../../messagingProtocols/proteus';
-import {openDB} from '../../storage/coreDb';
+import {ConnectionState, createConnectionStateTracker} from '../../connectionState/connectionStateTracker';
+import {CoreDatabase, openDB} from '../../storage/coreDb';
 import * as PayloadHelper from '../../test/payloadHelper';
 import * as MessageBuilder from '../message/messageBuilder';
 import {SubconversationService} from '../subconversationService/subconversationService';
@@ -788,6 +789,82 @@ describe('ConversationService', () => {
       await conversationService.handleEvent(mockMLSMessageAddEvent);
 
       await new Promise(resolve => setImmediate(resolve));
+
+      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(conversationId);
+      expect(conversationService.emit).toHaveBeenCalledWith('MLSConversationRecovered', {conversationId});
+    });
+
+    it('defers MLS epoch recovery during notification replay and runs recovery after LIVE', async () => {
+      const client = new APIClient({urls: APIClient.BACKEND.STAGING});
+      apiClients.push(client);
+      jest.spyOn(client.api.conversation, 'postMlsMessage').mockResolvedValue({
+        events: [],
+        time: new Date().toISOString(),
+      });
+      jest.spyOn(client.api.user, 'postListClients').mockResolvedValue({
+        qualified_user_map: {},
+      });
+      jest.spyOn(client.api.user, 'getUserSupportedProtocols').mockResolvedValue([
+        CONVERSATION_PROTOCOL.MLS,
+        CONVERSATION_PROTOCOL.PROTEUS,
+      ]);
+      client.context = {
+        clientType: ClientType.NONE,
+        userId: PayloadHelper.getUUID(),
+        clientId: PayloadHelper.getUUID(),
+      };
+
+      const mockedMLSService = {
+        on: jest.fn(),
+        handleMLSMessageAddEvent: jest.fn(),
+        getSafeEpoch: jest.fn(),
+        joinByExternalCommit: jest.fn(),
+      };
+
+      const mockedDb = {
+        get: jest.fn().mockResolvedValue(undefined),
+      } as unknown as CoreDatabase;
+
+      const connectionStateTracker = createConnectionStateTracker(ConnectionState.PROCESSING_NOTIFICATIONS);
+
+      const conversationService = new ConversationService(
+        client,
+        {} as ProteusService,
+        mockedDb,
+        async () => 'mock-group-id',
+        {joinConferenceSubconversation: jest.fn()} as unknown as SubconversationService,
+        () => Promise.resolve(true),
+        mockedMLSService as unknown as MLSService,
+        connectionStateTracker,
+      );
+
+      jest.spyOn(conversationService, 'joinByExternalCommit');
+      jest.spyOn(conversationService, 'emit');
+
+      const conversationId = {id: 'conversationId', domain: 'staging.zinfra.io'};
+      const mockMLSMessageAddEvent = createMLSMessageAddEventMock(conversationId);
+
+      const wrongEpochError = new Error();
+      wrongEpochError.name = CORE_CRYPTO_ERROR_NAMES.MlsErrorWrongEpoch;
+
+      jest.spyOn(mockedMLSService, 'handleMLSMessageAddEvent').mockRejectedValue(wrongEpochError);
+
+      jest.spyOn(mockedMLSService, 'getSafeEpoch').mockReturnValue(task.fromResult(Result.ok(4)));
+
+      jest.spyOn(client.api.conversation, 'getConversation').mockResolvedValue({
+        qualified_id: conversationId,
+        protocol: CONVERSATION_PROTOCOL.MLS,
+        epoch: 5,
+        group_id: 'mock-group-id',
+      } as unknown as Conversation);
+
+      await conversationService.handleEvent(mockMLSMessageAddEvent);
+
+      expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
+      expect(conversationService.emit).not.toHaveBeenCalledWith('MLSConversationRecovered', {conversationId});
+
+      connectionStateTracker.setState(ConnectionState.LIVE);
+      await conversationService.runDeferredEpochRecovery();
 
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(conversationId);
       expect(conversationService.emit).toHaveBeenCalledWith('MLSConversationRecovered', {conversationId});

--- a/libraries/core/src/conversation/conversationService/conversationService.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.ts
@@ -62,6 +62,7 @@ import {isMlsConversationNotFoundError} from '../../messagingProtocols/mls/mlsSe
 import {
   MlsRecoveryOrchestrator,
   MlsEpochRecoveryTrigger,
+  MlsEpochRecoveryDeferredError,
   MlsRecoveryOrchestratorImpl,
   OperationName,
   createDefaultMlsErrorMapper,
@@ -72,12 +73,23 @@ import {
   AddUsersToProteusConversationParams,
   SendProteusMessageParams,
 } from '../../messagingProtocols/proteus/proteusService/proteusService.types';
+import {
+  ConnectionState,
+  ConnectionStateTracker,
+  createConnectionStateTracker,
+} from '../../connectionState/connectionStateTracker';
 import {HandledEventPayload, HandledEventResult} from '../../notification';
 import {CoreDatabase} from '../../storage/coreDb';
 import {isMLSConversation} from '../../util';
 import {mapQualifiedUserClientIdsToFullyQualifiedClientIds} from '../../util/fullyQualifiedClientIdUtils';
 import {isSendingMessage, sendMessage} from '../message/messageSender';
 import {SubconversationService} from '../subconversationService/subconversationService';
+
+type DeferredEpochRecoveryEntry = {
+  conversationId: QualifiedId;
+  subconvId?: SUBCONVERSATION_ID;
+  trigger?: MlsEpochRecoveryTrigger;
+};
 
 type Events = {
   MLSConversationRecovered: {conversationId: QualifiedId};
@@ -90,6 +102,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
   // Track groups currently undergoing recovery due to key material update failure to prevent duplicate work
   private groupIdConversationMap: Map<string, Conversation> = new Map();
   private MLSRecoveryOrchestrator: MlsRecoveryOrchestrator;
+  private readonly deferredEpochRecoveries = new Map<string, DeferredEpochRecoveryEntry>();
 
   constructor(
     private readonly apiClient: APIClient,
@@ -102,6 +115,9 @@ export class ConversationService extends TypedEventEmitter<Events> {
     private readonly subconversationService: SubconversationService,
     private readonly isMLSConversationRecoveryEnabled: () => Promise<boolean>,
     private readonly _mlsService?: MLSService,
+    private readonly connectionStateTracker: ConnectionStateTracker = createConnectionStateTracker(
+      ConnectionState.LIVE,
+    ),
   ) {
     super();
     this.messageTimer = new MessageTimer();
@@ -753,6 +769,37 @@ export class ConversationService extends TypedEventEmitter<Events> {
     return this.mlsService.wipeConversation(groupId);
   };
 
+  /**
+   * Runs epoch-mismatch recovery for conversations that deferred external commit during
+   * notification replay. Called when the connection transitions to LIVE.
+   */
+  public async runDeferredEpochRecovery(): Promise<void> {
+    if (this.deferredEpochRecoveries.size === 0) {
+      this.logger.info('No deferred MLS epoch mismatch recoveries to run');
+      return;
+    }
+
+    this.logger.info('Running deferred MLS epoch mismatch recoveries after notification replay', {
+      count: this.deferredEpochRecoveries.size,
+    });
+
+    const entries = [...this.deferredEpochRecoveries.values()];
+    this.deferredEpochRecoveries.clear();
+
+    for (const {conversationId, subconvId, trigger} of entries) {
+      try {
+        await this.recoverMLSGroupFromEpochMismatch(conversationId, subconvId, trigger, {force: true});
+      } catch (error: unknown) {
+        this.logger.error('Failed to run deferred MLS epoch mismatch recovery', {
+          error,
+          conversationId,
+          subconvId,
+          trigger,
+        });
+      }
+    }
+  }
+
   public async handleConversationsEpochMismatch() {
     this.logger.warn(`There were some missed messages, handling possible epoch mismatch in MLS conversations.`);
 
@@ -1047,7 +1094,8 @@ export class ConversationService extends TypedEventEmitter<Events> {
    * Handle an inbound MLS message-add event with recovery.
    *
    * Policies (see MlsRecoveryOrchestrator):
-   * - WrongEpoch.handleMessageAdd → recover from epoch mismatch and re-run once.
+   * - WrongEpoch.handleMessageAdd → recover from epoch mismatch and re-run once (when LIVE).
+   * - WrongEpoch during notification replay → defer recovery until runDeferredEpochRecovery.
    * - GroupOutOfSync.handleMessageAdd → not handled here; the error bubbles.
    *
    * Returns the decrypted payload when available. Unknown or unrecoverable errors are logged
@@ -1070,6 +1118,14 @@ export class ConversationService extends TypedEventEmitter<Events> {
         },
       });
     } catch (error: unknown) {
+      if (error instanceof MlsEpochRecoveryDeferredError) {
+        this.logger.info('MLS message-add skipped until notification replay completes; returning null', {
+          conversationId: error.conversationId,
+          subconvId: error.subconvId,
+        });
+        return null;
+      }
+
       // For unmapped or unrecoverable errors, avoid surfacing exceptions from event handling
       // and instead log and return null so the event processing queue can continue safely.
       const isSafeMissingSubconversationGroup = event.subconv !== undefined && isMlsConversationNotFoundError(error);
@@ -1084,11 +1140,44 @@ export class ConversationService extends TypedEventEmitter<Events> {
     }
   }
 
+  private getDeferredEpochRecoveryKey(conversationId: QualifiedId, subconvId?: SUBCONVERSATION_ID): string {
+    return `${conversationId.id}@${conversationId.domain}:${subconvId ?? 'none'}`;
+  }
+
+  private shouldDeferEpochRecovery(trigger?: MlsEpochRecoveryTrigger): boolean {
+    return trigger?.operationName === OperationName.handleMessageAdd && !this.connectionStateTracker.isLive();
+  }
+
+  private deferEpochRecovery(
+    conversationId: QualifiedId,
+    subconvId?: SUBCONVERSATION_ID,
+    trigger?: MlsEpochRecoveryTrigger,
+  ): never {
+    const key = this.getDeferredEpochRecoveryKey(conversationId, subconvId);
+    if (!this.deferredEpochRecoveries.has(key)) {
+      this.deferredEpochRecoveries.set(key, {conversationId, subconvId, trigger});
+    }
+
+    this.logger.info('Deferring MLS epoch mismatch recovery until notification replay completes', {
+      conversationId,
+      subconvId,
+      trigger,
+      deferredCount: this.deferredEpochRecoveries.size,
+    });
+
+    throw new MlsEpochRecoveryDeferredError(conversationId, subconvId);
+  }
+
   private async recoverMLSGroupFromEpochMismatch(
     conversationId: QualifiedId,
     subconversationId?: SUBCONVERSATION_ID,
     trigger?: MlsEpochRecoveryTrigger,
+    options?: {force?: boolean},
   ) {
+    if (!options?.force && this.shouldDeferEpochRecovery(trigger)) {
+      this.deferEpochRecovery(conversationId, subconversationId, trigger);
+    }
+
     this.logger.info(`Recovering MLS group from epoch mismatch`, {conversationId, subconversationId, trigger});
     if (subconversationId !== undefined) {
       const parentGroupId = await this.groupIdFromConversationId(conversationId);

--- a/libraries/core/src/index.ts
+++ b/libraries/core/src/index.ts
@@ -17,7 +17,8 @@
  *
  */
 
-export {Account, ConnectionState, ProcessedEventPayload} from './account';
+export {Account, ProcessedEventPayload} from './account';
+export {ConnectionState, createConnectionStateTracker, type ConnectionStateTracker} from './connectionState/connectionStateTracker';
 export * as auth from './auth/';
 export * from './conversation/';
 export {CoreError} from './coreError';

--- a/libraries/core/src/messagingProtocols/mls/recovery/mlsEpochRecoveryDeferredError.test.ts
+++ b/libraries/core/src/messagingProtocols/mls/recovery/mlsEpochRecoveryDeferredError.test.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2025 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,23 +17,18 @@
  *
  */
 
-export type {
-  DomainMlsError,
-  DomainMlsErrorType,
-  ErrorContextInput,
-  ErrorHandler,
-  MlsErrorMapper,
-} from './mlsErrorMapper';
-export {ChainedMlsErrorMapper, createDefaultMlsErrorMapper} from './mlsErrorMapper';
-export type {
-  RecoveryActionKind,
-  RetryPolicy,
-  RecoveryPolicy,
-  PolicyTable,
-  OperationContext,
-  MlsRecoveryOrchestrator,
-  OrchestratorDeps,
-  MlsEpochRecoveryTrigger,
-} from './mlsRecoveryOrchestrator';
-export {MlsRecoveryOrchestratorImpl, minimalDefaultPolicies, OperationName} from './mlsRecoveryOrchestrator';
-export {MlsEpochRecoveryDeferredError} from './mlsEpochRecoveryDeferredError';
+import {QualifiedId} from '@wireapp/api-client/lib/user';
+
+import {MlsEpochRecoveryDeferredError} from './mlsEpochRecoveryDeferredError';
+
+describe('MlsEpochRecoveryDeferredError', () => {
+  it('exposes conversation context', () => {
+    const conversationId: QualifiedId = {id: 'conv', domain: 'wire.test'};
+    const error = new MlsEpochRecoveryDeferredError(conversationId);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('MlsEpochRecoveryDeferredError');
+    expect(error.conversationId).toEqual(conversationId);
+    expect(error.subconvId).toBeUndefined();
+  });
+});

--- a/libraries/core/src/messagingProtocols/mls/recovery/mlsEpochRecoveryDeferredError.ts
+++ b/libraries/core/src/messagingProtocols/mls/recovery/mlsEpochRecoveryDeferredError.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2025 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,23 +17,19 @@
  *
  */
 
-export type {
-  DomainMlsError,
-  DomainMlsErrorType,
-  ErrorContextInput,
-  ErrorHandler,
-  MlsErrorMapper,
-} from './mlsErrorMapper';
-export {ChainedMlsErrorMapper, createDefaultMlsErrorMapper} from './mlsErrorMapper';
-export type {
-  RecoveryActionKind,
-  RetryPolicy,
-  RecoveryPolicy,
-  PolicyTable,
-  OperationContext,
-  MlsRecoveryOrchestrator,
-  OrchestratorDeps,
-  MlsEpochRecoveryTrigger,
-} from './mlsRecoveryOrchestrator';
-export {MlsRecoveryOrchestratorImpl, minimalDefaultPolicies, OperationName} from './mlsRecoveryOrchestrator';
-export {MlsEpochRecoveryDeferredError} from './mlsEpochRecoveryDeferredError';
+import {SUBCONVERSATION_ID} from '@wireapp/api-client/lib/conversation';
+import {QualifiedId} from '@wireapp/api-client/lib/user';
+
+/**
+ * Thrown when MLS epoch-mismatch recovery is intentionally deferred while the
+ * notification backlog is still being replayed (connection not yet LIVE).
+ */
+export class MlsEpochRecoveryDeferredError extends Error {
+  constructor(
+    readonly conversationId: QualifiedId,
+    readonly subconvId?: SUBCONVERSATION_ID,
+  ) {
+    super('MLS epoch recovery deferred until notification replay completes');
+    this.name = 'MlsEpochRecoveryDeferredError';
+  }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Problem
After login, the client replays a large backlog of legacy notifications while local MLS state may already be ahead, behind, or incomplete. When decrypting an MLS message-add failed with WrongEpoch, the recovery orchestrator ran an external-commit rejoin immediately. That could happen in the middle of replay, before later notifications had a chance to apply missing commits.

This led to unnecessary MLSConversationRecovered system messages and made replay noisier. Pausing the rejoin queue did not help, because orchestrator recovery bypassed that queue entirely.

Approach
- Defer epoch-mismatch recovery for inbound handleMessageAdd while the connection is not LIVE. The failed message returns null and replay continues.
- After catch-up finishes, runDeferredEpochRecovery() reconciles any conversations that still need external commit (once per conversation).


