### PR TITLE
Fix build on windows [WPB-22420]

### DIFF
--- a/apps/webapp/webpack.config.common.js
+++ b/apps/webapp/webpack.config.common.js
@@ -245,7 +245,8 @@ module.exports = {
         },
         // Copy and flatten everything from core-crypto src
         {
-          from: path.resolve(ROOT_PATH, 'node_modules/@wireapp/core-crypto/src/**/*'),
+          context: path.resolve(ROOT_PATH, 'node_modules/@wireapp/core-crypto/src'),
+          from: '**/*',
           to: `${dist}/min/[name][ext]`,
         },
       ],


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
We noticed that the glob pattern defined within webpack only works on unix systems. This small change allows the webapp to be built and run on windows as well.


