### PR TITLE
Fix eslint resolver issue with capitalized import of icon component [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/Modals/LeaveGroupAdminModal/LeaveGroupAdminModal.tsx
+++ b/apps/webapp/src/script/components/Modals/LeaveGroupAdminModal/LeaveGroupAdminModal.tsx
@@ -23,7 +23,7 @@ import is from '@sindresorhus/is';
 
 import {Button, ButtonVariant} from '@wireapp/react-ui-kit';
 
-import * as Icon from 'Components/Icon';
+import * as Icon from 'Components/icon';
 import {ModalComponent} from 'Components/Modals/ModalComponent';
 import {handleEscDown} from 'Util/keyboardUtil';
 import {t} from 'Util/localizerUtil';


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Not sure how this reached the dev branch but due to the casing of the import not matching the casing of the generated file eslint throws an error blocking all PRs at the moment.