### PR TITLE
Add backend notification dump to developer menu [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx
+++ b/apps/webapp/src/script/components/ConfigToolbar/ConfigToolbar.tsx
@@ -38,6 +38,23 @@ export function createLocationUrl(pathname: string, search: string, hash: string
   return `${pathname}${search}${hash}`;
 }
 
+function getStartOfToday(): Date {
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  return startOfToday;
+}
+
+function toDateInputValue(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+type NotificationDumpToMode = 'now' | 'date';
+
+function getEndOfDate(dateInputValue: string): Date {
+  return new Date(`${dateInputValue}T23:59:59.999`);
+}
+
 export function ConfigToolbar() {
   const {fireAndForgetInvoker, applicationNavigation, isFeatureToggleEnabled} = useApplicationContext();
   const alphabeticallySortedStartupFeatureToggleNames = startupFeatureToggleNames.toSorted();
@@ -58,6 +75,10 @@ export function ConfigToolbar() {
     window.wire?.app?.debug?.isVideoBackgroundEffectsFeatureEnabled() ?? false,
   );
   const [coreCryptoLevel, setCoreCryptoLevel] = useState<CoreCryptoLogLevel>(CoreCryptoLogLevel.Info);
+  const [notificationDumpFrom, setNotificationDumpFrom] = useState(() => toDateInputValue(getStartOfToday()));
+  const [notificationDumpToMode, setNotificationDumpToMode] = useState<NotificationDumpToMode>('now');
+  const [notificationDumpToDate, setNotificationDumpToDate] = useState(() => toDateInputValue(new Date()));
+  const [isDownloadingNotifications, setIsDownloadingNotifications] = useState(false);
 
   // Toggle config tool on 'cmd/ctrl + shift + 2'
   useEffect(() => {
@@ -367,6 +388,91 @@ export function ConfigToolbar() {
     }
   };
 
+  const downloadNotificationsDump = async () => {
+    setIsDownloadingNotifications(true);
+    try {
+      const from = new Date(`${notificationDumpFrom}T00:00:00`);
+      const to = notificationDumpToMode === 'now' ? new Date() : getEndOfDate(notificationDumpToDate);
+
+      if (Number.isNaN(from.getTime())) {
+        throw new Error('Invalid start date');
+      }
+
+      if (Number.isNaN(to.getTime())) {
+        throw new Error('Invalid end date');
+      }
+
+      if (from.getTime() > to.getTime()) {
+        throw new Error('Start date must be before end date');
+      }
+
+      await window.wire?.app?.debug?.downloadNotificationsDump(from, to);
+    } catch (error: unknown) {
+      console.error('Error downloading notifications dump:', error);
+    } finally {
+      setIsDownloadingNotifications(false);
+    }
+  };
+
+  const renderNotificationDumpSection = () => {
+    return (
+      <>
+        <h3>Notification Dump</h3>
+        <p>
+          Fetches raw notification payloads from the backend for the selected time range and saves them as JSON. Message
+          content stays encrypted (OTR/MLS ciphertext only); nothing is decrypted locally.
+        </p>
+        <div style={{marginBottom: '10px'}}>
+          <label htmlFor="notification-dump-from" style={{display: 'block', fontWeight: 'bold'}}>
+            From
+          </label>
+          <input
+            id="notification-dump-from"
+            type="date"
+            value={notificationDumpFrom}
+            onChange={event => setNotificationDumpFrom(event.currentTarget.value)}
+            style={{padding: '6px 8px', width: '100%'}}
+          />
+        </div>
+        <div style={{marginBottom: '10px'}}>
+          <span style={{display: 'block', fontWeight: 'bold', marginBottom: '8px'}}>To</span>
+          <label htmlFor="notification-dump-to-now" style={{display: 'block', marginBottom: '8px'}}>
+            <input
+              id="notification-dump-to-now"
+              type="radio"
+              name="notification-dump-to-mode"
+              checked={notificationDumpToMode === 'now'}
+              onChange={() => setNotificationDumpToMode('now')}
+            />
+            {' Now'}
+          </label>
+          <label htmlFor="notification-dump-to-date-mode" style={{display: 'block', marginBottom: '8px'}}>
+            <input
+              id="notification-dump-to-date-mode"
+              type="radio"
+              name="notification-dump-to-mode"
+              checked={notificationDumpToMode === 'date'}
+              onChange={() => setNotificationDumpToMode('date')}
+            />
+            {' Date'}
+          </label>
+          {notificationDumpToMode === 'date' && (
+            <input
+              id="notification-dump-to-date"
+              type="date"
+              value={notificationDumpToDate}
+              onChange={event => setNotificationDumpToDate(event.currentTarget.value)}
+              style={{padding: '6px 8px', width: '100%'}}
+            />
+          )}
+        </div>
+        <Button disabled={isDownloadingNotifications} onClick={downloadNotificationsDump}>
+          {isDownloadingNotifications ? 'Downloading…' : 'Download notifications'}
+        </Button>
+      </>
+    );
+  };
+
   if (!showConfig) {
     return null;
   }
@@ -391,6 +497,12 @@ export function ConfigToolbar() {
       <Button disabled={isResettingMLSConversation} onClick={resetMLSConversation}>
         Reset MLS Conversation
       </Button>
+
+      <hr />
+
+      <div>{renderNotificationDumpSection()}</div>
+
+      <hr />
 
       <div>{renderAvsSwitch()}</div>
 

--- a/apps/webapp/src/script/util/debugUtil.ts
+++ b/apps/webapp/src/script/util/debugUtil.ts
@@ -63,6 +63,7 @@ import {getStorage} from 'Util/localStorage';
 import {getLogger, Logger} from 'Util/logger';
 
 import {TIME_IN_MILLIS} from './timeUtil';
+import {downloadBlob} from './util';
 import {createUuid} from './uuid';
 
 import {E2EIHandler} from '../E2EIdentity';
@@ -79,6 +80,31 @@ export enum CoreCryptoLogLevel {
   Warn = 5,
   Error = 6,
 }
+
+export type NotificationBackendDumpEvent = {
+  notificationId: string;
+  type: string;
+  time: string;
+  from?: string;
+  conversation?: string;
+  qualified_conversation?: QualifiedId;
+  senderClient?: string;
+  recipientClient?: string;
+};
+
+export type NotificationBackendDump = {
+  fetchedAt: string;
+  clientId?: string;
+  lastNotificationId?: string;
+  timeRange: {from: string; to: string};
+  counts: {
+    notifications: number;
+    events: number;
+    eventsInRange: number;
+  };
+  eventsInRange: NotificationBackendDumpEvent[];
+  notifications: Notification[];
+};
 
 export class DebugUtil {
   private readonly logger: Logger;
@@ -489,6 +515,128 @@ export class DebugUtil {
       return messages.slice(-amount).toReversed();
     }
     return [];
+  }
+
+  private hasEventTime(event: BackendEvent): event is BackendEvent & {time: string} {
+    return 'time' in event && is.nonEmptyString(event.time);
+  }
+
+  private isEventInTimeRange(event: BackendEvent, from: Date, to: Date): boolean {
+    if (!this.hasEventTime(event)) {
+      return false;
+    }
+
+    const eventTime = new Date(event.time).getTime();
+    return eventTime >= from.getTime() && eventTime <= to.getTime();
+  }
+
+  private async getCurrentClientId(): Promise<string | undefined> {
+    const currentClientId = this.clientState.currentClient?.id;
+    if (is.nonEmptyString(currentClientId)) {
+      return currentClientId;
+    }
+
+    const clients = await this.clientRepository.getClientsForSelf();
+    return clients.find(client => client.isPermanent())?.id ?? clients[0]?.id;
+  }
+
+  private async fetchAllNotifications(clientId?: string): Promise<Notification[]> {
+    const notifications: Notification[] = [];
+    let sinceNotificationId: string | undefined;
+
+    while (true) {
+      const page = await this.eventRepository.notificationService.getNotifications(
+        clientId,
+        sinceNotificationId,
+        EventRepository.CONFIG.NOTIFICATION_BATCHES.MAX,
+      );
+
+      notifications.push(...page.notifications);
+      this.logger.info(`Fetched ${notifications.length} notification(s) from backend`);
+
+      if (!page.has_more) {
+        break;
+      }
+
+      sinceNotificationId = page.notifications.at(-1)?.id;
+      if (!is.nonEmptyString(sinceNotificationId)) {
+        break;
+      }
+    }
+
+    return notifications;
+  }
+
+  async dumpNotificationsFromBackend(from: Date, to: Date): Promise<NotificationBackendDump> {
+    if (from.getTime() > to.getTime()) {
+      throw new Error('Invalid time range: "from" must be before "to"');
+    }
+
+    const clientId = await this.getCurrentClientId();
+    const lastNotificationRecord = await this.storageRepository.storageService.load<{value: string}>(
+      StorageSchemata.OBJECT_STORE.AMPLIFY,
+      DatabaseKeys.PRIMARY_KEY_LAST_NOTIFICATION,
+    );
+    const lastNotificationId = lastNotificationRecord?.value;
+    const notifications = await this.fetchAllNotifications(clientId);
+    const notificationsInRange = notifications.filter(notification =>
+      notification.payload.some(event => this.isEventInTimeRange(event, from, to)),
+    );
+    const eventsInRange = notificationsInRange.flatMap(notification =>
+      notification.payload
+        .filter((event): event is BackendEvent & {time: string} => this.isEventInTimeRange(event, from, to))
+        .map(event => {
+          const summary: NotificationBackendDumpEvent = {
+            notificationId: notification.id,
+            type: event.type,
+            time: event.time,
+          };
+
+          if ('from' in event) {
+            summary.from = event.from;
+          }
+
+          if ('conversation' in event) {
+            summary.conversation = event.conversation;
+          }
+
+          if ('qualified_conversation' in event) {
+            summary.qualified_conversation = event.qualified_conversation;
+          }
+
+          if (event.type === CONVERSATION_EVENT.OTR_MESSAGE_ADD) {
+            const otrEvent = event as ConversationOtrMessageAddEvent;
+            summary.senderClient = otrEvent.data.sender;
+            summary.recipientClient = otrEvent.data.recipient;
+          }
+
+          return summary;
+        }),
+    );
+
+    const dump: NotificationBackendDump = {
+      fetchedAt: new Date().toISOString(),
+      clientId,
+      lastNotificationId,
+      timeRange: {from: from.toISOString(), to: to.toISOString()},
+      counts: {
+        notifications: notificationsInRange.length,
+        events: notifications.flatMap(notification => notification.payload).length,
+        eventsInRange: eventsInRange.length,
+      },
+      eventsInRange,
+      notifications: notificationsInRange,
+    };
+
+    this.logger.info('Notification backend dump ready', dump.counts);
+    return dump;
+  }
+
+  async downloadNotificationsDump(from: Date, to: Date): Promise<void> {
+    const dump = await this.dumpNotificationsFromBackend(from, to);
+    const blob = new Blob([JSON.stringify(dump, null, 2)], {type: 'application/json'});
+    const filename = `wire-notifications-${from.toISOString()}-${to.toISOString()}.json`.replaceAll(':', '-');
+    downloadBlob(blob, filename, 'application/json');
   }
 
   async haveISentThisMessageToMyOtherClients(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add a debug-only "Notification Dump" section to the ConfigToolbar so support and engineering can export raw notification payloads from the backend for a selected time range.
DebugUtil fetches paginated notifications for the current web client, filters events by timestamp, and saves a JSON file containing metadata, an event summary, and the matching raw notification objects. Message payloads are not decrypted locally; OTR/MLS content remains ciphertext. The UI exposes a start date picker and an end range of either "Now" or a specific end date (end of day).


