### PR TITLE
chore (e2e): Added an option to run E2E tests against QA env

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,6 +12,7 @@ on:
         options:
           - https://wire-webapp-dev.zinfra.io/
           - https://wire-webapp-master.zinfra.io/
+          - https://wire-webapp-qa.zinfra.io/
       backendUrl:
         type: choice
         description: Define which backend should be used


### PR DESCRIPTION
We were missing this option in the test run menu in Git Actions. This PR adds it. 