### PR TITLE
Add env vars for federation environment to .env template [WPB-25319]

### DIFF
--- a/apps/webapp/test/e2e_tests/.env.staging.tpl
+++ b/apps/webapp/test/e2e_tests/.env.staging.tpl
@@ -46,3 +46,8 @@ BACKEND_URL=op://Test Automation/BackendConnection staging/backendUrl
 WEBAPP_URL=op://Test Automation/BackendConnection staging/webappUrl
 DOMAIN=op://Test Automation/BackendConnection staging/domain
 BASIC_AUTH=op://Test Automation/BackendConnection staging/basicAuth
+
+FEDERATION_BACKEND_URL=op://Test Automation/BackendConnection anta/backendUrl
+FEDERATION_WEBAPP_URL=op://Test Automation/BackendConnection anta/webappUrl
+FEDERATION_DOMAIN=op://Test Automation/BackendConnection anta/domain
+FEDERATION_BASIC_AUTH=op://Test Automation/BackendConnection anta/basicAuth


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25319" title="WPB-25319" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25319</a>  [Web][QA] Write Critical Flow -> On Prem Login Redirect
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
A new env var was used for TC-8757 however the env vars were not defined in the .env template resulting in them to be undefined on CI


