### PR TITLE
fix(api-client): force WebSocket reconnect after sleep when socket stays OPEN [WPB-21916]

### DIFF
--- a/libraries/api-client/src/tcp/reconnectingWebsocket.backFromSleep.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.backFromSleep.test.ts
@@ -50,6 +50,7 @@ describe('ReconnectingWebsocket back from sleep', () => {
   it('forces reconnect when waking with an OPEN zombie socket', () => {
     const RWS = new ReconnectingWebsocket(async () => 'ws://localhost');
     const reconnect = jest.fn();
+    const rescheduleSpy = jest.spyOn(RWS as never as {reschedulePinging: () => void}, 'reschedulePinging');
 
     RWS['socket'] = {
       readyState: WEBSOCKET_STATE.OPEN,
@@ -60,6 +61,7 @@ describe('ReconnectingWebsocket back from sleep', () => {
     sleepWakeCallback!();
 
     expect(reconnect).toHaveBeenCalledTimes(1);
+    expect(rescheduleSpy).toHaveBeenCalledTimes(1);
     expect(RWS['sleepReconnectPending']).toBe(true);
   });
 

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.backFromSleep.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.backFromSleep.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+jest.mock('../utils/backFromSleepHandler/backFromSleepHandler');
+
+import {onBackFromSleep} from '../utils/backFromSleepHandler/backFromSleepHandler';
+
+import {ReconnectingWebsocket, WEBSOCKET_STATE} from './reconnectingWebsocket';
+
+const mockedOnBackFromSleep = jest.mocked(onBackFromSleep);
+
+describe('ReconnectingWebsocket back from sleep', () => {
+  let sleepWakeCallback: (() => void) | undefined;
+
+  beforeEach(() => {
+    sleepWakeCallback = undefined;
+    mockedOnBackFromSleep.mockImplementation(({callback}) => {
+      sleepWakeCallback = callback;
+      return jest.fn();
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers onBackFromSleep without an isDisconnected gate', () => {
+    new ReconnectingWebsocket(async () => 'ws://localhost');
+
+    expect(mockedOnBackFromSleep).toHaveBeenCalledTimes(1);
+    expect(mockedOnBackFromSleep.mock.calls[0][0].isDisconnected).toBeUndefined();
+  });
+
+  it('forces reconnect when waking with an OPEN zombie socket', () => {
+    const RWS = new ReconnectingWebsocket(async () => 'ws://localhost');
+    const reconnect = jest.fn();
+
+    RWS['socket'] = {
+      readyState: WEBSOCKET_STATE.OPEN,
+      reconnect,
+    } as never;
+
+    expect(sleepWakeCallback).toBeDefined();
+    sleepWakeCallback!();
+
+    expect(reconnect).toHaveBeenCalledTimes(1);
+    expect(RWS['sleepReconnectPending']).toBe(true);
+  });
+
+  it('forces reconnect when waking with a CLOSED socket', () => {
+    const RWS = new ReconnectingWebsocket(async () => 'ws://localhost');
+    const reconnect = jest.fn();
+
+    RWS['socket'] = {
+      readyState: WEBSOCKET_STATE.CLOSED,
+      reconnect,
+    } as never;
+
+    sleepWakeCallback!();
+
+    expect(reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reconnect when the WebSocket instance does not exist', () => {
+    new ReconnectingWebsocket(async () => 'ws://localhost');
+
+    expect(() => sleepWakeCallback!()).not.toThrow();
+  });
+
+  it('logs reconnect completion after a sleep-initiated reconnect opens', () => {
+    const RWS = new ReconnectingWebsocket(async () => 'ws://localhost');
+    const loggerInfo = jest.spyOn(RWS['logger'], 'info');
+
+    RWS['sleepReconnectPending'] = true;
+    RWS['internalOnOpen']({} as Event);
+
+    expect(loggerInfo).toHaveBeenCalledWith('Back from sleep reconnect completed, WebSocket opened');
+    expect(RWS['sleepReconnectPending']).toBe(false);
+  });
+});

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
@@ -25,6 +25,8 @@ import {Server as WebSocketServer} from 'ws';
 
 import {AddressInfo} from 'net';
 
+import {CloseEvent} from 'reconnecting-websocket';
+
 import {PingMessage, ReconnectingWebsocket, WEBSOCKET_STATE} from './reconnectingWebsocket';
 
 async function startEchoServer(): Promise<WebSocketServer> {
@@ -881,6 +883,64 @@ describe('ReconnectingWebsocket', () => {
       });
 
       RWS.connect();
+    });
+
+    it('keeps the ping interval running after the socket closes', done => {
+      const onReconnect = jest.fn().mockReturnValue(getServerAddress());
+      const RWS = createRWS(onReconnect);
+
+      RWS.setOnOpen(() => {
+        const pingerId = RWS['pingerId'];
+        expect(pingerId).toBeDefined();
+
+        RWS['internalOnClose']({
+          code: 1006,
+          reason: '',
+          wasClean: false,
+        } as CloseEvent);
+
+        expect(RWS['pingerId']).toBe(pingerId);
+        RWS.disconnect();
+        done();
+      });
+
+      RWS.connect();
+    });
+
+    it('keeps the ping interval running after a ping timeout reconnect', done => {
+      const onReconnect = jest.fn().mockReturnValue(getServerAddress());
+      const RWS = createRWS(onReconnect, {pingInterval: 100});
+
+      RWS.setOnOpen(() => {
+        const pingerId = RWS['pingerId'];
+        RWS['hasUnansweredPing'] = true;
+
+        setTimeout(() => {
+          RWS['sendPing']();
+          expect(RWS['pingerId']).toBe(pingerId);
+          RWS.disconnect();
+          done();
+        }, 50);
+      });
+
+      RWS.connect();
+    }, 2000);
+
+    it('forces reconnect on ping tick when socket is CLOSED', () => {
+      const onReconnect = jest.fn().mockReturnValue(getServerAddress());
+      const RWS = createRWS(onReconnect);
+      const reconnect = jest.fn();
+
+      RWS['socket'] = {
+        close: jest.fn(),
+        readyState: WEBSOCKET_STATE.CLOSED,
+        reconnect,
+      } as never;
+
+      RWS['sendPing']();
+
+      expect(reconnect).toHaveBeenCalledTimes(1);
+      RWS.disconnect();
     });
   });
 

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -142,6 +142,7 @@ export class ReconnectingWebsocket {
 
   private readonly internalOnOpen = (event: Event) => {
     this.logger.info(`WebSocket opened (reconnect attempt #${this.reconnectAttemptCount})`);
+    this.hasUnansweredPing = false;
     if (this.sleepReconnectPending) {
       this.sleepReconnectPending = false;
       this.logger.info('Back from sleep reconnect completed, WebSocket opened');
@@ -174,6 +175,7 @@ export class ReconnectingWebsocket {
 
     // Force reconnect even if the browser keeps the socket in OPEN state after sleep.
     this.sleepReconnectPending = true;
+    this.reschedulePinging();
     this.socket.reconnect();
   }
 
@@ -183,10 +185,7 @@ export class ReconnectingWebsocket {
     this.recordReconnectAttempt(Date.now());
     // The ping is needed to keep the connection alive as long as possible.
     // Otherwise the connection would be closed after 1 min of inactivity and re-established.
-    if (this.isPingingEnabled) {
-      this.startPinging();
-      this.logger.debug(`Ping started (interval: ${this.PING_INTERVAL}ms)`);
-    }
+    this.ensurePinging();
     return this.onReconnect();
   };
 
@@ -194,39 +193,80 @@ export class ReconnectingWebsocket {
     this.logger.info(
       `WebSocket closed — code: ${event?.code}, reason: "${event?.reason || 'none'}", wasClean: ${event?.wasClean ?? 'unknown'}`,
     );
-    this.stopPinging();
+    this.hasUnansweredPing = false;
     this.resolvePendingHealthChecks(false);
     if (this.onClose) {
       this.onClose(event);
     }
   };
 
-  private startPinging(): void {
-    this.stopPinging();
-    this.hasUnansweredPing = false;
+  /**
+   * Starts the ping interval if pinging is enabled and not already running.
+   * The interval is kept alive across reconnects and is only cleared on disconnect/cleanup.
+   */
+  private ensurePinging(): void {
+    if (!this.isPingingEnabled || this.pingerId !== undefined) {
+      return;
+    }
+
+    this.logger.debug(`Ping interval started (interval: ${this.PING_INTERVAL}ms)`);
     this.pingerId = setInterval(this.sendPing, this.PING_INTERVAL);
+  }
+
+  /**
+   * Restarts the ping interval timer. Used after wake-from-sleep so the next tick is not
+   * delayed by time spent suspended while the OS had timers paused.
+   */
+  private reschedulePinging(): void {
+    if (!this.isPingingEnabled) {
+      return;
+    }
+
+    this.stopPinging();
+    this.pingerId = setInterval(this.sendPing, this.PING_INTERVAL);
+    this.logger.debug(`Ping interval rescheduled (interval: ${this.PING_INTERVAL}ms)`);
   }
 
   private stopPinging(): void {
     if (this.pingerId) {
       clearInterval(this.pingerId);
+      this.pingerId = undefined;
     }
   }
 
   private readonly sendPing = (): void => {
+    if (!this.isPingingEnabled) {
+      return;
+    }
+
     if (!this.socket) {
-      this.logger.debug('WebSocket instance does not exist, skipping ping');
+      this.logger.debug('Ping tick — WebSocket instance does not exist, skipping ping');
+      return;
+    }
+
+    const state = this.getState();
+
+    if (state === WEBSOCKET_STATE.CONNECTING || state === WEBSOCKET_STATE.CLOSING) {
+      this.logger.debug(`Ping tick — socket is transitioning (state: ${WEBSOCKET_STATE[state]}), skipping ping`);
+      return;
+    }
+
+    if (state === WEBSOCKET_STATE.CLOSED) {
+      this.logger.info('Ping tick — socket CLOSED, forcing reconnect');
+      this.hasUnansweredPing = false;
+      this.socket.reconnect();
       return;
     }
 
     if (this.hasUnansweredPing) {
       this.logger.warn(
-        `Ping timeout — no pong received within ${this.PING_INTERVAL}ms, WebSocket state: ${WEBSOCKET_STATE[this.getState()]} (${this.getState()}), forcing reconnect`,
+        `Ping timeout — no pong received within ${this.PING_INTERVAL}ms, WebSocket state: ${WEBSOCKET_STATE[state]} (${state}), forcing reconnect`,
       );
-      this.stopPinging();
+      this.hasUnansweredPing = false;
       this.socket.reconnect();
       return;
     }
+
     this.logger.debug('Sending ping');
     this.hasUnansweredPing = true;
     this.send(PingMessage.PING);
@@ -254,10 +294,10 @@ export class ReconnectingWebsocket {
       }
     }
 
-    this.stopPinging();
     const nextSocket = this.getReconnectingWebsocket();
     this.socket = nextSocket;
     this.bindSocketHandlers(nextSocket);
+    this.ensurePinging();
   }
 
   private bindSocketHandlers(socket: RWS): void {

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -88,6 +88,7 @@ export class ReconnectingWebsocket {
   private reconnectSequenceRetryCount = 0;
   private reconnectSequenceStartTimestamp: Maybe<number> = Maybe.nothing<number>();
   private hasReportedLongRunningRetry = false;
+  private sleepReconnectPending = false;
 
   constructor(
     private readonly onReconnect: () => Promise<string>,
@@ -112,19 +113,7 @@ export class ReconnectingWebsocket {
      * the internal setInterval and must be called when disconnecting to prevent memory leaks.
      * **/
     this.stopBackFromSleepHandler = onBackFromSleep({
-      callback: () => {
-        if (!this.socket) {
-          this.logger.debug('WebSocket instance does not exist, skipping reconnect after sleep');
-          return;
-        }
-        const state = this.getState();
-        this.logger.info(
-          `Back from sleep detected, WebSocket state: ${WEBSOCKET_STATE[state]} (${state}), forcing reconnect`,
-        );
-        // Force reconnect even if the browser keeps the socket in OPEN state after sleep.
-        this.socket.reconnect();
-      },
-      isDisconnected: () => this.getState() === WEBSOCKET_STATE.CLOSED,
+      callback: () => this.handleBackFromSleep(),
     });
   }
 
@@ -153,6 +142,10 @@ export class ReconnectingWebsocket {
 
   private readonly internalOnOpen = (event: Event) => {
     this.logger.info(`WebSocket opened (reconnect attempt #${this.reconnectAttemptCount})`);
+    if (this.sleepReconnectPending) {
+      this.sleepReconnectPending = false;
+      this.logger.info('Back from sleep reconnect completed, WebSocket opened');
+    }
     this.resetLongRunningRetrySequence();
     if (this.socket) {
       this.socket.binaryType = 'arraybuffer';
@@ -161,6 +154,28 @@ export class ReconnectingWebsocket {
       this.onOpen(event);
     }
   };
+
+  private handleBackFromSleep(): void {
+    if (!this.socket) {
+      this.logger.info('Back from sleep detected, skipping reconnect — WebSocket instance does not exist');
+      return;
+    }
+
+    const state = this.getState();
+    const timeSinceLastMessage = this.lastMessageTimestamp > 0 ? Date.now() - this.lastMessageTimestamp : undefined;
+    const idleDescription =
+      timeSinceLastMessage !== undefined
+        ? `last message ${timeSinceLastMessage}ms ago`
+        : 'no messages received on this connection yet';
+
+    this.logger.info(
+      `Back from sleep detected, WebSocket state: ${WEBSOCKET_STATE[state]} (${state}), ${idleDescription}, unansweredPing: ${this.hasUnansweredPing}, forcing reconnect`,
+    );
+
+    // Force reconnect even if the browser keeps the socket in OPEN state after sleep.
+    this.sleepReconnectPending = true;
+    this.socket.reconnect();
+  }
 
   private readonly internalOnReconnect = async (): Promise<string> => {
     const attempt = this.reconnectAttemptCount + 1;
@@ -351,6 +366,7 @@ export class ReconnectingWebsocket {
    */
   private cleanup(): void {
     this.stopPinging();
+    this.sleepReconnectPending = false;
     // Clear the sleep detection interval if it exists
     this.stopBackFromSleepHandler?.();
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
After laptop sleep, the TCP connection can die while the browser still reports readyState as OPEN. The sleep handler detected wake correctly, but reconnect was gated on isDisconnected (socket === CLOSED), so the common zombie-OPEN case was skipped and the client could stay silent with no messages and no offline banner.

Always call reconnect on wake, regardless of socket state. Add Datadog-friendly logs for wake detection, reconnect initiation, and successful reopen (including idle time and unansweredPing context). Add regression tests to prevent reintroducing the isDisconnected gate.


