### PR TITLE
feat: keep the focus trapped inside the wrapper when background sidebar is closed [WPB-24448]

### DIFF
--- a/apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {ChangeEvent, useEffect, useState} from 'react';
+import {ChangeEvent, useEffect, useRef, useState} from 'react';
 
 import {DefaultConversationRoleName} from '@wireapp/api-client/lib/conversation/';
 import cx from 'classnames';
@@ -198,6 +198,15 @@ const FullscreenVideoCall = ({
 
   const [isParticipantsListOpen, toggleParticipantsList] = useToggleState(false);
   const [isBackgroundSidebarOpen, setIsBackgroundSidebarOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const backgroundSidebarHandler = (newValue: boolean): void => {
+    setIsBackgroundSidebarOpen(newValue);
+
+    if (isBackgroundSidebarOpen && newValue === false) {
+      wrapperRef.current?.focus();
+    }
+  };
 
   const callNotification = useAppNotification({
     activeWindow: viewMode === CallingViewMode.DETACHED_WINDOW ? detachedWindow! : window,
@@ -307,6 +316,8 @@ const FullscreenVideoCall = ({
   return (
     <div
       id="video-calling-wrapper"
+      ref={wrapperRef}
+      tabIndex={-1}
       data-uie-name="fullscreen-video-call"
       className={cx('video-calling-wrapper', {
         'app--small-offset': hasOffset && isMiniMode,
@@ -429,7 +440,7 @@ const FullscreenVideoCall = ({
               backgrounds={BUILTIN_BACKGROUNDS}
               onSelectEffect={handleBackgroundSidebarSelect}
               onEnableHighQualityBlur={handleEnableHighQualityBlur}
-              onClose={() => setIsBackgroundSidebarOpen(false)}
+              onClose={() => backgroundSidebarHandler(false)}
               highQualityBlurAllowed={isHighQualityBlurEnabled}
             />
           )}
@@ -488,7 +499,7 @@ const FullscreenVideoCall = ({
               setActiveCallViewTab={setActiveCallViewTab}
               setMaximizedParticipant={setMaximizedParticipant}
               sendEmoji={sendEmoji}
-              onOpenBackgroundSettings={() => setIsBackgroundSidebarOpen(true)}
+              onOpenBackgroundSettings={() => backgroundSidebarHandler(true)}
             />
           </>
         )}
@@ -511,7 +522,7 @@ const FullscreenVideoCall = ({
           backgrounds={BUILTIN_BACKGROUNDS}
           onSelectEffect={handleBackgroundSidebarSelect}
           onEnableHighQualityBlur={handleEnableHighQualityBlur}
-          onClose={() => setIsBackgroundSidebarOpen(false)}
+          onClose={() => backgroundSidebarHandler(false)}
           highQualityBlurAllowed={isHighQualityBlurEnabled}
         />
       )}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24448" title="WPB-24448" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-24448</a>  Accessibility feature for the Blur Background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
On closing the background settings sidebar via keyboard, focus should be trapped inside the on going call wrapper instead of going to the previously opened conversation