### PR TITLE
feat: update max-width for formatted code block [WPB-16654]

### DIFF
--- a/apps/webapp/src/style/components/lexical-input.less
+++ b/apps/webapp/src/style/components/lexical-input.less
@@ -199,7 +199,8 @@
 .editor-code {
   display: block;
   overflow: auto;
-  max-width: max-content;
+  width: fit-content;
+  max-width: 100%;
   padding: 8px 12px;
   border-radius: 8px;
   margin: 4px 0;

--- a/apps/webapp/src/style/content/conversation/message-quote.less
+++ b/apps/webapp/src/style/content/conversation/message-quote.less
@@ -84,7 +84,8 @@
 
       pre {
         overflow: auto;
-        max-width: var(--conversation-message-asset-width);
+        width: fit-content;
+        max-width: 100%;
         padding: 8px 12px;
         border-radius: 8px;
         background: var(--foreground-fade-8);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16654" title="WPB-16654" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16654</a>  [Web] Code examples have smaller width than possible
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Description

Adjust the code width according to the screen size. 

### Issue
<img width="2019" height="583" alt="Screenshot 2026-06-02 at 17 38 34" src="https://github.com/user-attachments/assets/e98dea76-58aa-49cc-92f6-1516341a2d24" />

### Fixed
<img width="2019" height="583" alt="Screenshot 2026-06-02 at 17 39 36" src="https://github.com/user-attachments/assets/8af11e1a-92a7-490d-8898-da9c71887933" />

