### PR TITLE
fix: pass fire-and-forget invoker to cells share modals(WPB-26087)

### DIFF
--- a/apps/webapp/src/script/components/Cells/common/useCellPublicLink/useCellPublicLink.test.ts
+++ b/apps/webapp/src/script/components/Cells/common/useCellPublicLink/useCellPublicLink.test.ts
@@ -20,11 +20,7 @@
 import {act, renderHook, waitFor} from '@testing-library/react';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
-import {
-  createExecutingFireAndForgetInvokerForTest,
-  createRootContextValueForTest,
-  createRootProviderWrapperForTest,
-} from 'src/script/page/testSupport/rootContextTestSupport';
+import {createExecutingFireAndForgetInvokerForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import {CellNode, CellNodeType} from 'src/script/types/cellNode';
 
 import {useCellPublicLink} from './useCellPublicLink';
@@ -41,10 +37,7 @@ describe('useCellPublicLink', () => {
   let mockCellsRepository: jest.Mocked<CellsRepository>;
   let mockNode: CellNode | undefined;
   const mockSetPublicLink = jest.fn();
-  const rootContextValue = createRootContextValueForTest({
-    fireAndForgetInvoker: createExecutingFireAndForgetInvokerForTest(),
-  });
-  const rootProviderWrapper = createRootProviderWrapperForTest(rootContextValue);
+  const defaultFireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
 
   const createMockNode = (overrides: Partial<CellNode> = {}): CellNode => ({
     id: 'test-uuid',
@@ -67,15 +60,17 @@ describe('useCellPublicLink', () => {
     node?: CellNode;
     refreshLinkDataAfterUpdate?: boolean;
     setStatusOnPublicLinkUrl?: boolean;
+    fireAndForgetInvoker?: typeof defaultFireAndForgetInvoker;
   }) => {
     const initialProps = {
       node: options?.node ?? mockNode,
       refreshLinkDataAfterUpdate: options?.refreshLinkDataAfterUpdate ?? false,
       setStatusOnPublicLinkUrl: options?.setStatusOnPublicLinkUrl ?? false,
+      fireAndForgetInvoker: options?.fireAndForgetInvoker ?? defaultFireAndForgetInvoker,
     };
 
     const hook = renderHook(
-      ({node, refreshLinkDataAfterUpdate, setStatusOnPublicLinkUrl}) =>
+      ({node, refreshLinkDataAfterUpdate, setStatusOnPublicLinkUrl, fireAndForgetInvoker}) =>
         useCellPublicLink({
           uuid: 'test-uuid',
           node,
@@ -83,8 +78,9 @@ describe('useCellPublicLink', () => {
           setPublicLink: mockSetPublicLink,
           refreshLinkDataAfterUpdate,
           setStatusOnPublicLinkUrl,
+          fireAndForgetInvoker,
         }),
-      {initialProps, wrapper: rootProviderWrapper},
+      {initialProps},
     );
 
     const rerenderWith = (props: Partial<typeof initialProps>) =>
@@ -92,6 +88,7 @@ describe('useCellPublicLink', () => {
         node: props.node ?? initialProps.node,
         refreshLinkDataAfterUpdate: props.refreshLinkDataAfterUpdate ?? initialProps.refreshLinkDataAfterUpdate,
         setStatusOnPublicLinkUrl: props.setStatusOnPublicLinkUrl ?? initialProps.setStatusOnPublicLinkUrl,
+        fireAndForgetInvoker: props.fireAndForgetInvoker ?? initialProps.fireAndForgetInvoker,
       });
 
     return {...hook, rerenderWith};
@@ -138,6 +135,31 @@ describe('useCellPublicLink', () => {
           Label: 'test-file.pdf',
           Permissions: ['Preview', 'Download'],
         },
+      });
+
+      expect(mockSetPublicLink).toHaveBeenCalledWith({
+        uuid: 'new-link-uuid',
+        url: 'https://cells.example.com/public/test-link',
+        alreadyShared: true,
+      });
+    });
+
+    it('creates a public link with an explicit fire-and-forget invoker outside RootProvider', async () => {
+      mockCellsRepository.createPublicLink.mockResolvedValue({
+        Uuid: 'new-link-uuid',
+        LinkUrl: '/public/test-link',
+      });
+
+      const {result} = renderPublicLinkHook({
+        fireAndForgetInvoker: createExecutingFireAndForgetInvokerForTest(),
+      });
+
+      act(() => {
+        result.current.togglePublicLink();
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
       });
 
       expect(mockSetPublicLink).toHaveBeenCalledWith({

--- a/apps/webapp/src/script/components/Cells/common/useCellPublicLink/useCellPublicLink.ts
+++ b/apps/webapp/src/script/components/Cells/common/useCellPublicLink/useCellPublicLink.ts
@@ -22,9 +22,10 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 import is from '@sindresorhus/is';
 import type {RestShareLink} from '@wireapp/api-client/lib/cells';
 
+import type {FireAndForgetInvoker} from '@wireapp/core';
+
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {Config} from 'src/script/Config';
-import {useApplicationContext} from 'src/script/page/RootProvider';
 import type {CellNode} from 'src/script/types/cellNode';
 
 type PublicLinkStatus = 'idle' | 'loading' | 'error' | 'success';
@@ -37,6 +38,7 @@ interface UseCellPublicLinkParams {
   refreshLinkDataAfterUpdate?: boolean;
   setStatusOnPublicLinkUrl?: boolean;
   includeNodePublicLinkInCallbacks?: boolean;
+  fireAndForgetInvoker: FireAndForgetInvoker;
 }
 
 export const useCellPublicLink = ({
@@ -47,8 +49,8 @@ export const useCellPublicLink = ({
   refreshLinkDataAfterUpdate = false,
   setStatusOnPublicLinkUrl = false,
   includeNodePublicLinkInCallbacks = false,
+  fireAndForgetInvoker,
 }: UseCellPublicLinkParams) => {
-  const {fireAndForgetInvoker} = useApplicationContext();
   const [isEnabled, setIsEnabled] = useState(node?.publicLink?.alreadyShared === true);
   const [status, setStatus] = useState<PublicLinkStatus>(node?.publicLink !== undefined ? 'success' : 'idle');
   const [linkData, setLinkData] = useState<RestShareLink | null>(null);

--- a/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/CellsShareModal.test.tsx
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/CellsShareModal.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ReactNode} from 'react';
+
+import {render} from '@testing-library/react';
+
+import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
+
+import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {createFireAndForgetInvokerForTest} from 'src/script/page/testSupport/rootContextTestSupport';
+import {CellNode, CellNodeType} from 'src/script/types/cellNode';
+
+import {CellsShareModal} from './CellsShareModal';
+
+import {useCellsStore} from '../../../common/useCellsStore/useCellsStore';
+
+const withTheme = (component: ReactNode) => <StyledApp themeId={THEME_ID.DEFAULT}>{component}</StyledApp>;
+
+describe('CellsShareModal', () => {
+  const nodeId = 'node-id';
+
+  const createNode = (): CellNode => ({
+    id: nodeId,
+    name: 'file.pdf',
+    path: '/file.pdf',
+    mimeType: 'application/pdf',
+    sizeMb: '1',
+    extension: 'pdf',
+    uploadedAtTimestamp: Date.now(),
+    owner: 'owner',
+    conversationName: 'Conversation',
+    tags: [],
+    presignedUrlExpiresAt: null,
+    user: null,
+    type: CellNodeType.FILE,
+  });
+
+  const createCellsRepository = (): CellsRepository =>
+    ({
+      createPublicLink: jest.fn(),
+      getPublicLink: jest.fn(),
+      deletePublicLink: jest.fn(),
+      updatePublicLink: jest.fn(),
+    }) as unknown as CellsRepository;
+
+  beforeEach(() => {
+    useCellsStore.getState().clearAll();
+    useCellsStore.getState().setNodes([createNode()]);
+  });
+
+  it('renders global share modal outside RootProvider when fireAndForgetInvoker is provided', () => {
+    expect(() =>
+      render(
+        withTheme(
+          <CellsShareModal
+            type="file"
+            uuid={nodeId}
+            cellsRepository={createCellsRepository()}
+            fireAndForgetInvoker={createFireAndForgetInvokerForTest()}
+            modalId="modal-id"
+          />,
+        ),
+      ),
+    ).not.toThrow('RootContext has not been set');
+  });
+});

--- a/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/CellsShareModal.tsx
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/CellsShareModal.tsx
@@ -62,7 +62,7 @@ interface ShareModalParams {
   fireAndForgetInvoker: FireAndForgetInvoker;
 }
 
-type CellsShareModalProps = Omit<ShareModalParams, 'fireAndForgetInvoker'> & {
+type CellsShareModalProps = ShareModalParams & {
   modalId: string;
 };
 
@@ -89,7 +89,15 @@ export const showShareModal = (properties: ShareModalParams): void => {
         text: t('cells.shareModal.primaryAction'),
       },
       text: {
-        message: <CellsShareModal type={type} uuid={uuid} cellsRepository={cellsRepository} modalId={modalId} />,
+        message: (
+          <CellsShareModal
+            type={type}
+            uuid={uuid}
+            cellsRepository={cellsRepository}
+            fireAndForgetInvoker={fireAndForgetInvoker}
+            modalId={modalId}
+          />
+        ),
         title: t('cells.shareModal.heading'),
       },
     },
@@ -97,11 +105,12 @@ export const showShareModal = (properties: ShareModalParams): void => {
   );
 };
 
-const CellsShareModal = (properties: CellsShareModalProps): ReactElement => {
-  const {type, uuid, cellsRepository, modalId} = properties;
+export const CellsShareModal = (properties: CellsShareModalProps): ReactElement => {
+  const {type, uuid, cellsRepository, fireAndForgetInvoker, modalId} = properties;
   const {status, link, linkData, isEnabled, togglePublicLink, updatePublicLink} = useCellGlobalPublicLink({
     uuid,
     cellsRepository,
+    fireAndForgetInvoker,
   });
   const node = useCellsStore(state => state.nodes.find(cellNode => cellNode.id === uuid));
   const {

--- a/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/useCellGlobalPublicLink.ts
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsShareModal/useCellGlobalPublicLink.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import type {FireAndForgetInvoker} from '@wireapp/core';
+
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {useCellPublicLink} from 'src/script/components/Cells/common/useCellPublicLink/useCellPublicLink';
 
@@ -25,9 +27,14 @@ import {useCellsStore} from '../../../common/useCellsStore/useCellsStore';
 interface UseCellGlobalPublicLinkParams {
   uuid: string;
   cellsRepository: CellsRepository;
+  fireAndForgetInvoker: FireAndForgetInvoker;
 }
 
-export const useCellGlobalPublicLink = ({uuid, cellsRepository}: UseCellGlobalPublicLinkParams) => {
+export const useCellGlobalPublicLink = ({
+  uuid,
+  cellsRepository,
+  fireAndForgetInvoker,
+}: UseCellGlobalPublicLinkParams) => {
   const {nodes, setPublicLink} = useCellsStore();
   const node = nodes.find(n => n.id === uuid);
   return useCellPublicLink({
@@ -37,5 +44,6 @@ export const useCellGlobalPublicLink = ({uuid, cellsRepository}: UseCellGlobalPu
     setPublicLink: data => setPublicLink(uuid, data),
     setStatusOnPublicLinkUrl: true,
     includeNodePublicLinkInCallbacks: true,
+    fireAndForgetInvoker,
   });
 };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/CellsNodeShareModal.test.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/CellsNodeShareModal.test.tsx
@@ -1,0 +1,85 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ReactNode} from 'react';
+
+import {render} from '@testing-library/react';
+
+import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
+
+import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {createFireAndForgetInvokerForTest} from 'src/script/page/testSupport/rootContextTestSupport';
+import {CellNode, CellNodeType} from 'src/script/types/cellNode';
+
+import {CellShareModalContent} from './CellsNodeShareModal';
+
+import {useCellsStore} from '../../../common/useCellsStore/useCellsStore';
+
+const withTheme = (component: ReactNode) => <StyledApp themeId={THEME_ID.DEFAULT}>{component}</StyledApp>;
+
+describe('CellShareModalContent', () => {
+  const conversationId = 'conversation-id';
+  const nodeId = 'node-id';
+
+  const createNode = (): CellNode => ({
+    id: nodeId,
+    name: 'file.pdf',
+    path: '/file.pdf',
+    mimeType: 'application/pdf',
+    sizeMb: '1',
+    extension: 'pdf',
+    uploadedAtTimestamp: Date.now(),
+    owner: 'owner',
+    conversationName: 'Conversation',
+    tags: [],
+    presignedUrlExpiresAt: null,
+    user: null,
+    type: CellNodeType.FILE,
+  });
+
+  const createCellsRepository = (): CellsRepository =>
+    ({
+      createPublicLink: jest.fn(),
+      getPublicLink: jest.fn(),
+      deletePublicLink: jest.fn(),
+      updatePublicLink: jest.fn(),
+    }) as unknown as CellsRepository;
+
+  beforeEach(() => {
+    useCellsStore.getState().clearAll({conversationId});
+    useCellsStore.getState().setNodes({conversationId, nodes: [createNode()]});
+  });
+
+  it('renders conversation share modal outside RootProvider when fireAndForgetInvoker is provided', () => {
+    expect(() =>
+      render(
+        withTheme(
+          <CellShareModalContent
+            type="file"
+            uuid={nodeId}
+            conversationId={conversationId}
+            cellsRepository={createCellsRepository()}
+            fireAndForgetInvoker={createFireAndForgetInvokerForTest()}
+            modalId="modal-id"
+          />,
+        ),
+      ),
+    ).not.toThrow('RootContext has not been set');
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/CellsNodeShareModal.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/CellsNodeShareModal.tsx
@@ -96,6 +96,7 @@ export const showShareModal = ({
             uuid={uuid}
             conversationId={conversationId}
             cellsRepository={cellsRepository}
+            fireAndForgetInvoker={fireAndForgetInvoker}
             modalId={modalId}
           />
         ),
@@ -106,17 +107,19 @@ export const showShareModal = ({
   );
 };
 
-const CellShareModalContent = ({
+export const CellShareModalContent = ({
   type,
   uuid,
   conversationId,
   cellsRepository,
+  fireAndForgetInvoker,
   modalId,
-}: Omit<ShareModalParams, 'fireAndForgetInvoker'> & {modalId: string}) => {
+}: ShareModalParams & {modalId: string}) => {
   const {status, link, linkData, isEnabled, togglePublicLink, updatePublicLink} = useCellConversationPublicLink({
     uuid,
     conversationId,
     cellsRepository,
+    fireAndForgetInvoker,
   });
   const node = useCellsStore(state =>
     state.nodesByConversation[conversationId]?.find(cellNode => cellNode.id === uuid),

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/useCellConversationPublicLink.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsNodeShareModal/useCellConversationPublicLink.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import type {FireAndForgetInvoker} from '@wireapp/core';
+
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {useCellPublicLink} from 'src/script/components/Cells/common/useCellPublicLink/useCellPublicLink';
 
@@ -26,12 +28,14 @@ interface UseCellConversationPublicLinkParams {
   uuid: string;
   conversationId: string;
   cellsRepository: CellsRepository;
+  fireAndForgetInvoker: FireAndForgetInvoker;
 }
 
 export const useCellConversationPublicLink = ({
   uuid,
   conversationId,
   cellsRepository,
+  fireAndForgetInvoker,
 }: UseCellConversationPublicLinkParams) => {
   const {getNodes, setPublicLink} = useCellsStore();
   const nodes = getNodes({conversationId});
@@ -42,5 +46,6 @@ export const useCellConversationPublicLink = ({
     cellsRepository,
     setPublicLink: data => setPublicLink({conversationId, nodeId: uuid, data}),
     refreshLinkDataAfterUpdate: true,
+    fireAndForgetInvoker,
   });
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26087" title="WPB-26087" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26087</a>  [Shared Drive] Blank page when sharing a public link
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
- Thread `fireAndForgetInvoker` through the global and conversation cells share modal props.
- Updated public link hooks to receive the invoker explicitly instead of relying on `RootContext`.
- Added regression coverage for rendering both share modal paths outside `RootProvider`.


