### PR TITLE
test: write the federation regression tests [WPB-19988]

### DIFF
--- a/apps/webapp/test/e2e_tests/backend/apiManager.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/apiManager.e2e.ts
@@ -34,6 +34,8 @@ import {UserRepositoryE2E} from './userRepository.e2e';
 
 import {User} from '../data/user';
 
+const TEST_API_VERSION = `v13`;
+
 export class ApiManagerE2E {
   user: UserRepositoryE2E;
   auth: AuthRepositoryE2E;
@@ -47,18 +49,21 @@ export class ApiManagerE2E {
   callingService: CallingServiceClientE2E;
   properties: PropertiesRepositoryE2E;
 
-  constructor() {
-    this.user = new UserRepositoryE2E();
-    this.auth = new AuthRepositoryE2E();
-    this.brig = new BrigRepositoryE2E();
-    this.testService = new TestServiceClientE2E();
-    this.team = new TeamRepositoryE2E();
-    this.conversation = new ConversationRepositoryE2E();
-    this.featureConfig = new FeatureConfigRepositoryE2E();
+  constructor(config: {backendUrl: string; basicAuth: string}) {
+    const backendConfig = {backendUrl: config.backendUrl, apiVersion: TEST_API_VERSION};
+
     this.inbucket = new InbucketClientE2E();
-    this.connection = new ConnectionRepositoryE2E();
+    this.testService = new TestServiceClientE2E();
     this.callingService = new CallingServiceClientE2E();
-    this.properties = new PropertiesRepositoryE2E();
+
+    this.user = new UserRepositoryE2E(backendConfig);
+    this.auth = new AuthRepositoryE2E(backendConfig);
+    this.brig = new BrigRepositoryE2E({...backendConfig, basicAuth: config.basicAuth});
+    this.team = new TeamRepositoryE2E(backendConfig);
+    this.conversation = new ConversationRepositoryE2E(backendConfig);
+    this.featureConfig = new FeatureConfigRepositoryE2E(backendConfig);
+    this.connection = new ConnectionRepositoryE2E(backendConfig);
+    this.properties = new PropertiesRepositoryE2E(backendConfig);
   }
 
   async addDevicesToUser(user: User, numberOfDevices: number) {

--- a/apps/webapp/test/e2e_tests/backend/authRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/authRepository.e2e.ts
@@ -39,10 +39,8 @@ export class AuthRepositoryE2E extends BackendClientE2E {
     }
 
     user.id = response.data.id;
-    user.qualifiedId = {
-      domain: response.data?.domain ?? '',
-      id: response.data.id,
-    };
+    user.qualifiedId = response.data?.qualified_id;
+
     return response;
   }
 

--- a/apps/webapp/test/e2e_tests/backend/backendClient.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/backendClient.e2e.ts
@@ -19,14 +19,12 @@
 
 import axios, {AxiosInstance} from 'axios';
 
-// ToDo: Fix via export from api-client
-const TEST_API_VERSION = `v13`;
 export class BackendClientE2E {
   readonly axiosInstance: AxiosInstance;
 
-  constructor() {
+  constructor(config: {backendUrl: string; apiVersion: string}) {
     this.axiosInstance = axios.create({
-      baseURL: `${process.env.BACKEND_URL}${TEST_API_VERSION}/`,
+      baseURL: `${config.backendUrl}${config.apiVersion}/`,
       withCredentials: true,
       headers: {
         'Content-Type': 'application/json',

--- a/apps/webapp/test/e2e_tests/backend/brigRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/brigRepository.e2e.ts
@@ -19,17 +19,16 @@
 
 import axios, {AxiosInstance} from 'axios';
 
-const BASIC_AUTH = process.env.BASIC_AUTH;
-
 export class BrigRepositoryE2E {
   readonly axiosInstance: AxiosInstance;
 
-  constructor() {
+  constructor(config: {backendUrl: string; basicAuth: string}) {
     this.axiosInstance = axios.create({
-      baseURL: process.env.BACKEND_URL,
+      baseURL: config.backendUrl,
       withCredentials: true,
       headers: {
         'Content-Type': 'application/json',
+        Authorization: `Basic ${config.basicAuth}`,
       },
     });
   }
@@ -37,9 +36,6 @@ export class BrigRepositoryE2E {
   public async getActivationCodeForEmail(email: string): Promise<string> {
     const activationCodeResponse = await this.axiosInstance.get(`/i/users/activation-code`, {
       params: {email: email},
-      headers: {
-        Authorization: `Basic ${BASIC_AUTH}`,
-      },
     });
 
     return activationCodeResponse.data.code;
@@ -51,88 +47,37 @@ export class BrigRepositoryE2E {
         team: teamId,
         invitation_id: invitationId,
       },
-      headers: {
-        Authorization: `Basic ${BASIC_AUTH}`,
-      },
     });
 
     return invitationCodeResponse.data.code;
   }
 
   public async unlockConferenceCallingFeature(teamId: string) {
-    await this.axiosInstance.put(
-      `i/teams/${teamId}/features/conferenceCalling/unlocked`,
-      {},
-      {
-        headers: {
-          Authorization: `Basic ${BASIC_AUTH}`,
-        },
-      },
-    );
+    await this.axiosInstance.put(`i/teams/${teamId}/features/conferenceCalling/unlocked`, {});
   }
 
   public async enableConferenceCallingBackdoorViaBackdoorTeam(teamId: string) {
-    await this.axiosInstance.patch(
-      `i/teams/${teamId}/features/conferenceCalling`,
-      {
-        status: 'enabled',
-      },
-      {
-        headers: {
-          Authorization: `Basic ${BASIC_AUTH}`,
-        },
-      },
-    );
+    await this.axiosInstance.patch(`i/teams/${teamId}/features/conferenceCalling`, {
+      status: 'enabled',
+    });
   }
 
   public async unlockChannelFeature(teamId: string) {
-    await this.axiosInstance.put(
-      `i/teams/${teamId}/features/channels/unlocked`,
-      {},
-      {
-        headers: {
-          Authorization: `Basic ${BASIC_AUTH}`,
-        },
-      },
-    );
+    await this.axiosInstance.put(`i/teams/${teamId}/features/channels/unlocked`, {});
   }
 
   public async unlockSndFactorPasswordChallenge(teamId: string) {
-    await this.axiosInstance.put(
-      `i/teams/${teamId}/features/sndFactorPasswordChallenge/unlocked`,
-      {},
-      {
-        headers: {
-          Authorization: `Basic ${BASIC_AUTH}`,
-        },
-      },
-    );
+    await this.axiosInstance.put(`i/teams/${teamId}/features/sndFactorPasswordChallenge/unlocked`, {});
   }
 
   public async unlockAppLock(teamId: string) {
-    await this.axiosInstance.put(
-      `i/teams/${teamId}/features/appLock/unlocked`,
-      {},
-      {
-        headers: {
-          Authorization: `Basic ${BASIC_AUTH}`,
-        },
-      },
-    );
+    await this.axiosInstance.put(`i/teams/${teamId}/features/appLock/unlocked`, {});
   }
 
   public async enableChannelsFeature(teamId: string) {
-    await this.axiosInstance.patch(
-      `i/teams/${teamId}/features/channels`,
-      {
-        status: 'enabled',
-      },
-      {
-        headers: {
-          Authorization: `Basic ${BASIC_AUTH}`,
-        },
-      },
-    );
+    await this.axiosInstance.patch(`i/teams/${teamId}/features/channels`, {
+      status: 'enabled',
+    });
   }
 
   public async configureMLSFeature(
@@ -143,113 +88,81 @@ export class BrigRepositoryE2E {
       supportedProtocols: ('mls' | 'proteus')[];
     },
   ) {
-    await this.axiosInstance.patch(
-      `i/teams/${teamId}/features/mls`,
-      {
-        status: config.status ?? 'enabled',
-        config: {
-          protocolToggleUsers: [],
-          allowedCipherSuites: [2],
-          defaultProtocol: config?.defaultProtocol ?? 'mls',
-          defaultCipherSuite: 2,
-          supportedProtocols: config?.supportedProtocols ?? ['mls', 'proteus'],
-        },
+    await this.axiosInstance.patch(`i/teams/${teamId}/features/mls`, {
+      status: config.status ?? 'enabled',
+      config: {
+        protocolToggleUsers: [],
+        allowedCipherSuites: [2],
+        defaultProtocol: config?.defaultProtocol ?? 'mls',
+        defaultCipherSuite: 2,
+        supportedProtocols: config?.supportedProtocols ?? ['mls', 'proteus'],
       },
-      {
-        headers: {
-          Authorization: `Basic ${BASIC_AUTH}`,
-        },
-      },
-    );
+    });
   }
 
   public async toggleAppLock(teamId: string, status: 'enabled' | 'disabled', enforceAppLock: boolean = true) {
-    await this.axiosInstance.patch(
-      `i/teams/${teamId}/features/appLock`,
-      {
-        status: status,
-        config: {
-          enforceAppLock: enforceAppLock,
-          inactivityTimeoutSecs: 30,
-        },
+    await this.axiosInstance.patch(`i/teams/${teamId}/features/appLock`, {
+      status: status,
+      config: {
+        enforceAppLock: enforceAppLock,
+        inactivityTimeoutSecs: 30,
       },
-      {
-        headers: {
-          Authorization: `Basic ${BASIC_AUTH}`,
-        },
-      },
-    );
+    });
   }
 
   public async unlockCellsFeature(teamId: string) {
-    await this.axiosInstance.put(
-      `i/teams/${teamId}/features/cells/unlocked`,
-      {},
-      {
-        headers: {
-          Authorization: `Basic ${BASIC_AUTH}`,
-        },
-      },
-    );
+    await this.axiosInstance.put(`i/teams/${teamId}/features/cells/unlocked`, {});
   }
 
   public async enableCells(teamId: string) {
-    await this.axiosInstance.put(
-      `i/teams/${teamId}/features/cells`,
-      {
-        config: {
-          channels: {
-            default: 'enabled',
-            enabled: true,
-          },
-          collabora: {
-            enabled: true,
-          },
-          groups: {
-            default: 'enabled',
-            enabled: true,
-          },
-          metadata: {
-            namespaces: {
-              usermetaTags: {
-                allowFreeValues: true,
-                defaultValues: [],
-              },
+    await this.axiosInstance.put(`i/teams/${teamId}/features/cells`, {
+      config: {
+        channels: {
+          default: 'enabled',
+          enabled: true,
+        },
+        collabora: {
+          enabled: true,
+        },
+        groups: {
+          default: 'enabled',
+          enabled: true,
+        },
+        metadata: {
+          namespaces: {
+            usermetaTags: {
+              allowFreeValues: true,
+              defaultValues: [],
             },
           },
-          one2one: {
-            default: 'enabled',
-            enabled: true,
-          },
-          publicLinks: {
-            enableFiles: true,
-            enableFolders: true,
-            enforceExpirationDefault: 0,
-            enforceExpirationMax: 0,
-            enforcePassword: false,
-          },
-          storage: {
-            perFileQuotaBytes: '104857600',
-            recycle: {
-              allowSkip: false,
-              autoPurgeDays: 30,
-              disable: false,
-            },
-          },
-          users: {
-            externals: true,
-            guests: true,
+        },
+        one2one: {
+          default: 'enabled',
+          enabled: true,
+        },
+        publicLinks: {
+          enableFiles: true,
+          enableFolders: true,
+          enforceExpirationDefault: 0,
+          enforceExpirationMax: 0,
+          enforcePassword: false,
+        },
+        storage: {
+          perFileQuotaBytes: '104857600',
+          recycle: {
+            allowSkip: false,
+            autoPurgeDays: 30,
+            disable: false,
           },
         },
-        status: 'enabled',
-        ttl: 'unlimited',
-      },
-      {
-        headers: {
-          Authorization: `Basic ${BASIC_AUTH}`,
+        users: {
+          externals: true,
+          guests: true,
         },
       },
-    );
+      status: 'enabled',
+      ttl: 'unlimited',
+    });
   }
 
   public async claimDomain(domain: string) {

--- a/apps/webapp/test/e2e_tests/backend/brigRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/brigRepository.e2e.ts
@@ -166,29 +166,17 @@ export class BrigRepositoryE2E {
   }
 
   public async claimDomain(domain: string) {
-    await this.axiosInstance.put(
-      `i/domain-registration/${domain}`,
-      {
-        backend: {
-          config_url: new URL('deeplink.json', process.env.FEDERATION_BACKEND_URL),
-          webapp_url: process.env.FEDERATION_WEBAPP_URL,
-        },
-        domain_redirect: 'backend',
-        team_invite: 'not-allowed',
+    await this.axiosInstance.put(`i/domain-registration/${domain}`, {
+      backend: {
+        config_url: new URL('deeplink.json', process.env.FEDERATION_BACKEND_URL),
+        webapp_url: process.env.FEDERATION_WEBAPP_URL,
       },
-      {
-        headers: {
-          Authorization: `Basic ${BASIC_AUTH}`,
-        },
-      },
-    );
+      domain_redirect: 'backend',
+      team_invite: 'not-allowed',
+    });
   }
 
   public async deleteDomainClaim(domain: string) {
-    await this.axiosInstance.delete(`i/domain-registration/${domain}`, {
-      headers: {
-        Authorization: `Basic ${BASIC_AUTH}`,
-      },
-    });
+    await this.axiosInstance.delete(`i/domain-registration/${domain}`);
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/index.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/index.ts
@@ -105,20 +105,20 @@ export class PageManager {
     }
   };
 
-  openMainPage = () => {
-    return this.page.goto(webAppPath, {waitUntil: 'networkidle'});
+  openMainPage = (baseUrl: string = webAppPath) => {
+    return this.page.goto(new URL('/', baseUrl).toString(), {waitUntil: 'networkidle'});
   };
 
-  openLoginPage = async () => {
-    await this.page.goto(`${webAppPath}auth/#/login`);
+  openLoginPage = async (baseUrl: string = webAppPath) => {
+    await this.page.goto(new URL(`/auth/#/login`, baseUrl).toString());
   };
 
-  openRegistrationPage = async () => {
-    await this.page.goto(`${webAppPath}auth/#/createaccount`);
+  openRegistrationPage = async (baseUrl: string = webAppPath) => {
+    await this.page.goto(new URL(`/auth/#/createaccount`, baseUrl).toString());
   };
 
-  openSSOPage = async () => {
-    await this.page.goto(`${webAppPath}auth/#/sso`);
+  openSSOPage = async (baseUrl: string = webAppPath) => {
+    await this.page.goto(new URL(`/auth/#/sso`, baseUrl).toString());
   };
 
   openUrl = (url: string) => {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -62,7 +62,7 @@ export class ConversationPage {
   readonly cancelRequest: Locator;
   readonly mentionSuggestions: Locator;
   readonly invitePeopleButton: Locator;
-  readonly guestsIndicator: Locator;
+  readonly statusIndicator: Locator;
   readonly replyQuoteBoxAboveMessageInputField: Locator;
 
   readonly getImageAltText = (user: User) => `Image from ${user.fullName}`;
@@ -112,7 +112,7 @@ export class ConversationPage {
     this.cancelRequest = page.getByRole('button', {name: 'Cancel connection request'});
     this.mentionSuggestions = page.getByRole('listbox').getByTestId('item-mention-suggestion');
     this.invitePeopleButton = page.getByRole('button', {name: 'Invite people'});
-    this.guestsIndicator = page.getByTestId('status-indication-badge');
+    this.statusIndicator = page.getByTestId('status-indication-badge');
     this.replyQuoteBoxAboveMessageInputField = page.getByTestId('input-bar-reply-box');
   }
 

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversationDetails.page.ts
@@ -123,16 +123,17 @@ export class ConversationDetailsPage {
     return userLocator.isVisible();
   }
 
-  async openParticipantDetails(fullName: string) {
-    await this.getLocatorByUser(fullName).click();
-  }
+  getParticipant(fullName: string) {
+    const baseLocator = this.getLocatorByUser(fullName);
 
-  getUserRoleIcon(fullName: string) {
-    return this.getLocatorByUser(fullName).getByTestId(/^status-(external|guest|admin)$/);
-  }
-
-  getUserAvailabilityIcon(fullName: string) {
-    return this.getLocatorByUser(fullName).getByTestId('status-availability-icon');
+    return Object.assign(baseLocator, {
+      roleIcon: baseLocator.getByTestId(/^status-(external|guest|admin)$/),
+      availabilityIcon: baseLocator.getByTestId('status-availability-icon'),
+      federatedIcon: baseLocator.getByTestId('status-federated-user'),
+      openDetails: async () => {
+        await baseLocator.click();
+      },
+    });
   }
 
   getLocatorByUser(fullName: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/fullScreenCall.page.ts
@@ -32,6 +32,8 @@ export const FullScreenCallPage = (page: Page) => {
   const gridTiles = component.getByTestId('item-grid');
   const nextPageButton = component.getByRole('button', {name: 'Go to next page'});
   const previousPageButton = component.getByRole('button', {name: 'Go to previous page'});
+  const toggleScreenShareButton = component.getByRole('switch', {name: 'Share Screen'});
+  const toggleVideoButton = component.getByRole('switch', {name: 'Camera'});
 
   /* Press the react button and click the given emoji within the opened toolbar */
   const sendReaction = async (emoji: '👍') => {
@@ -114,5 +116,7 @@ export const FullScreenCallPage = (page: Page) => {
     getGridTile,
     goToNextPage,
     goToPreviousPage,
+    toggleScreenShareButton,
+    toggleVideoButton,
   };
 };

--- a/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Block/block.spec.ts
@@ -59,7 +59,7 @@ export async function blockUserFromProfileView(pageManager: PageManager) {
 export async function blockUserFromOpenGroupProfileView(pageManager: PageManager, userToBlock: User) {
   const {pages, modals} = pageManager.webapp;
   await pages.conversation().clickConversationTitle();
-  await pages.conversationDetails().openParticipantDetails(userToBlock.fullName);
+  await pages.conversationDetails().getParticipant(userToBlock.fullName).openDetails();
   await pages.participantDetails().blockUser();
   await modals.confirm().actionButton.click();
 }

--- a/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Connections/Connections.spec.ts
@@ -87,7 +87,7 @@ test.describe('Connections', () => {
       await test.step('B sends a connection request to C via the group conversation', async () => {
         await memberBPages.conversationList().getConversation('Group').open();
         await memberBPages.conversation().conversationInfoButton.click();
-        await memberBPages.conversationDetails().openParticipantDetails(memberC.fullName);
+        await memberBPages.conversationDetails().getParticipant(memberC.fullName).openDetails();
         await memberBPages.participantDetails().sendConnectRequest();
       });
 

--- a/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
@@ -146,7 +146,7 @@ test.describe('Conversations', () => {
 
       await adminPages.conversationList().getConversation(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
-      await expect(adminPages.conversationDetails().getUserRoleIcon(guestUser.fullName)).toHaveAttribute(
+      await expect(adminPages.conversationDetails().getParticipant(guestUser.fullName).roleIcon).toHaveAttribute(
         'data-uie-name',
         'status-guest',
       );
@@ -273,7 +273,7 @@ test.describe('Conversations', () => {
       await adminPages.conversationList().getConversation(groupName).open();
       await adminPages.conversation().clickConversationInfoButton();
       await expect(adminPages.conversation().membersList).toBeVisible();
-      await expect(adminPages.conversationDetails().getUserRoleIcon(externalUser.fullName)).toHaveAttribute(
+      await expect(adminPages.conversationDetails().getParticipant(externalUser.fullName).roleIcon).toHaveAttribute(
         'data-uie-name',
         'status-external',
       );

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -5,7 +5,7 @@ import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, withLogin, expect, createTeam} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
-import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
+import {createAndSaveBackup, createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Federation', () => {
   const federationBaseUrl = process.env.FEDERATION_WEBAPP_URL!;
@@ -16,6 +16,7 @@ test.describe('Federation', () => {
 
   let normalUser: User;
   let federatedUser: User;
+  const groupName = 'Federated group';
 
   test.beforeEach(async ({api}) => {
     normalUser = (await createTeam(api, 'Normal Team', {features: {conferenceCalling: true}})).owner;
@@ -222,8 +223,8 @@ test.describe('Federation', () => {
       ).toBeVisible();
 
       await test.step('Federated user creates a group and adds normal user to it', async () => {
-        await createGroup(federatedUserPages, 'Federation group', []);
-        await federatedUserPages.conversationList().getConversation('Federation group').open();
+        await createGroup(federatedUserPages, groupName, []);
+        await federatedUserPages.conversationList().getConversation(groupName).open();
         await federatedUserPages.conversation().toggleGroupInformation();
         await federatedUserPages.conversationDetails().clickAddPeopleButton();
         await federatedUserPages.conversationDetails().addUsersToConversation([normalUser.fullName]);
@@ -236,7 +237,7 @@ test.describe('Federation', () => {
           federatedUserPages.conversationDetails().getParticipant(normalUser.fullName).federatedIcon,
         ).toBeVisible();
 
-        await normalUserPages.conversationList().getConversation('Federation group').open();
+        await normalUserPages.conversationList().getConversation(groupName).open();
         await expect(
           normalUserPages
             .conversation()
@@ -290,6 +291,109 @@ test.describe('Federation', () => {
           await verify({federatedUserPage});
         });
       }
+    },
+  );
+
+  test(
+    'I want to import my backup of conversations with users from different BE and see the conversation contents',
+    {tag: ['@TC-3128', '@regression']},
+    async ({createPage}, testInfo) => {
+      const [normalUserPage, federatedUserPage] = await Promise.all([
+        createPage(withLogin(normalUser)),
+        createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
+      ]);
+
+      const normalUserPageManager = PageManager.from(normalUserPage);
+      const {
+        pages: normalUserPages,
+        components: normalUserComponents,
+        modals: normalUserModals,
+      } = normalUserPageManager.webapp;
+      const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
+
+      await test.step('Establish connection between normal and federated user', async () => {
+        await sendConnectionRequest(normalUserPage, federatedUser);
+        await federatedUserPages.conversationList().openPendingConnectionRequest();
+        await federatedUserPages.connectRequest().clickConnectButton();
+      });
+
+      await test.step('Exchange direct messages and verify receipt', async () => {
+        await normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open();
+        await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
+
+        await normalUserPages.conversation().sendMessage('Message from normal user');
+        await federatedUserPages.conversation().sendMessage('Message from federated user');
+
+        await expect(normalUserPages.conversation().getMessage({sender: federatedUser})).toBeVisible();
+        await expect(federatedUserPages.conversation().getMessage({sender: normalUser})).toBeVisible();
+      });
+
+      await test.step('Create a group chat and exchange text and image messages', async () => {
+        await createGroup(federatedUserPages, groupName, [normalUser]);
+        await federatedUserPages.conversationList().getConversation(groupName).open();
+        await normalUserPages.conversationList().getConversation(groupName).open();
+
+        await federatedUserPages.conversation().sendMessage('Group message from federated user');
+        await shareAssetHelper(
+          getImageFilePath(),
+          federatedUserPage,
+          federatedUserPage.getByRole('button', {name: 'Add picture'}),
+        );
+
+        await expect(
+          normalUserPages.conversation().getMessage({content: 'Group message from federated user'}),
+        ).toBeVisible();
+
+        const messageWithImage = normalUserPages
+          .conversation()
+          .getMessage({sender: federatedUser})
+          .filter({has: normalUserPage.getByRole('img')});
+        await expect(messageWithImage).toBeVisible();
+      });
+
+      let backupName: string;
+      await test.step('Create and save backup for the normal user', async () => {
+        await normalUserComponents.conversationSidebar().clickPreferencesButton();
+        backupName = await createAndSaveBackup(testInfo, normalUserPageManager);
+      });
+
+      await test.step('Log out the normal user from the first device', async () => {
+        await normalUserComponents.conversationSidebar().clickPreferencesButton();
+        await normalUserPages.account().clickLogoutButton();
+        await expect(normalUserModals.confirmLogout().modal).toBeVisible();
+        await normalUserModals.confirmLogout().clickConfirm();
+      });
+
+      // --- Second Device Flow ---
+      const normalUserDevice2 = await createPage(withLogin(normalUser, {confirmNewHistory: true}));
+
+      const {pages: normalUserDevice2Pages, components: normalUserDevice2Components} =
+        PageManager.from(normalUserDevice2).webapp;
+
+      await test.step('Import backup on the new device', async () => {
+        await normalUserDevice2Components.conversationSidebar().clickPreferencesButton();
+        await normalUserDevice2Pages.account().backupFileInput.setInputFiles(backupName);
+        await normalUserDevice2Components.conversationSidebar().allConversationsButton.click();
+      });
+
+      await test.step('Verify direct messages are restored on the new device', async () => {
+        await normalUserDevice2Pages
+          .conversationList()
+          .getConversation(federatedUser.fullName, {protocol: 'mls'})
+          .open();
+        await expect(normalUserDevice2Pages.conversation().getMessage({sender: federatedUser})).toBeVisible();
+      });
+
+      await test.step('Verify group messages and media are restored on the new device', async () => {
+        await normalUserDevice2Pages.conversationList().getConversation(groupName).open();
+        await expect(normalUserDevice2Pages.conversation().getMessage({sender: federatedUser})).toBeVisible();
+
+        const messageWithImage2Device = normalUserDevice2Pages
+          .conversation()
+          .getMessage({sender: normalUser})
+          .filter({has: normalUserDevice2.getByRole('img')});
+        await expect(messageWithImage2Device).toBeVisible();
+      });
     },
   );
 

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -223,11 +223,9 @@ test.describe('Federation', () => {
       ).toBeVisible();
 
       await test.step('Normal user creates a group and adds federated user to it', async () => {
-        await createGroup(normalUserPages, groupName, []);
+        await createGroup(normalUserPages, groupName, [federatedUser]);
         await normalUserPages.conversationList().getConversation(groupName).open();
         await normalUserPages.conversation().toggleGroupInformation();
-        await normalUserPages.conversationDetails().clickAddPeopleButton();
-        await normalUserPages.conversationDetails().addUsersToConversation([federatedUser.fullName]);
 
         await expect(
           normalUserPages.conversation().systemMessages.filter({hasText: `You added ${federatedUser.fullName}`}),
@@ -351,10 +349,9 @@ test.describe('Federation', () => {
         await expect(messageWithImage).toBeVisible();
       });
 
-      let backupName: string;
-      await test.step('Create and save backup for the normal user', async () => {
+      const backupName = await test.step('Create and save backup for the normal user', async () => {
         await normalUserComponents.conversationSidebar().clickPreferencesButton();
-        backupName = await createAndSaveBackup(testInfo, normalUserPageManager);
+        return await createAndSaveBackup(testInfo, normalUserPageManager);
       });
 
       await test.step('Log out the normal user from the first device', async () => {

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -293,6 +293,90 @@ test.describe('Federation', () => {
     },
   );
 
+  test(
+    'I want to be able to connect to, block, and unblock a user from different backend',
+    {tag: ['@TC-3129', '@regression']},
+    async ({createPage}) => {
+      const [normalUserPage, federatedUserPage] = await Promise.all([
+        createPage(withLogin(normalUser)),
+        createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
+      ]);
+
+      const {
+        pages: normalUserPages,
+        components: normalUserComponents,
+        modals: normalUserModals,
+      } = PageManager.from(normalUserPage).webapp;
+
+      const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
+
+      const userHandle = federatedUser.qualifiedId?.domain
+        ? `${federatedUser.username}@${federatedUser.qualifiedId?.domain}`
+        : federatedUser.username;
+
+      await test.step('Send connection request to federated user', async () => {
+        await normalUserComponents.conversationSidebar().clickConnectButton();
+        await normalUserPages.startUI().searchInput.fill(userHandle);
+
+        const normalUserSearchRow = normalUserPages.startUI().searchResults.filter({hasText: federatedUser.username});
+        await expect(normalUserSearchRow).toBeVisible();
+        await expect(normalUserSearchRow.getByTestId('status-federated-user')).toBeVisible();
+
+        await normalUserPages.startUI().selectUsers(userHandle);
+        await normalUserModals.userProfile().clickConnectButton();
+      });
+
+      await test.step('Accept connection request from normal user', async () => {
+        await federatedUserPages.conversationList().openPendingConnectionRequest();
+        await federatedUserPages.connectRequest().clickConnectButton();
+      });
+
+      await test.step('Open conversation on both ends', async () => {
+        await Promise.all([
+          normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open(),
+          federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open(),
+        ]);
+      });
+
+      await test.step('Verify conversation details and cross-backend presence indicators', async () => {
+        await normalUserPages.conversation().toggleGroupInformation();
+
+        await expect(normalUserPages.participantDetails().userName).toBeVisible();
+        await expect(normalUserPages.participantDetails().userHandle).toBeVisible();
+        await expect(normalUserPages.conversation().statusIndicator).toContainText('Federated users are present');
+        await expect(normalUserPages.conversation().conversationTitle).toContainText(federatedUser.fullName);
+        await expect(
+          normalUserPages.conversation().systemMessages.filter({hasText: federatedUser.username}),
+        ).toBeVisible();
+      });
+
+      await test.step('Exchange messages between normal and federated users', async () => {
+        await normalUserPages.conversation().sendMessage('Message from normal user');
+        await federatedUserPages.conversation().sendMessage('Message from federated user');
+
+        await expect(normalUserPages.conversation().getMessage({sender: federatedUser})).toBeVisible();
+        await expect(federatedUserPages.conversation().getMessage({sender: normalUser})).toBeVisible();
+      });
+
+      await test.step('Block the federated user and verify status', async () => {
+        await normalUserPages.participantDetails().blockUser();
+        await normalUserModals.confirm().actionButton.click();
+
+        await expect(normalUserPages.participantDetails().userPicture).toHaveAttribute('data-uie-status', 'blocked');
+      });
+
+      await test.step('Unblock the federated user and verify status restoration', async () => {
+        await normalUserPages.participantDetails().unblockButton.click();
+        await normalUserModals.confirm().actionButton.click();
+
+        await expect(normalUserPages.participantDetails().userPicture).not.toHaveAttribute(
+          'data-uie-status',
+          'blocked',
+        );
+      });
+    },
+  );
+
   test('I want to start a 1:1 call with a federated User', {tag: ['@TC-3208', '@regression']}, async ({createPage}) => {
     const [normalUserPage, federatedUserPage] = await Promise.all([
       createPage(withLogin(normalUser)),

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -1,0 +1,22 @@
+import {ApiManagerE2E} from 'test/e2e_tests/backend/apiManager.e2e';
+import {User} from 'test/e2e_tests/data/user';
+import {createUser, test} from 'test/e2e_tests/test.fixtures';
+
+test.describe('Federation', () => {
+  const federationApiManager = new ApiManagerE2E({
+    backendUrl: process.env.FEDERATION_BACKEND_URL!,
+    basicAuth: process.env.FEDERATION_BASIC_AUTH!,
+  });
+
+  let federatedUser: User;
+
+  test.beforeEach(async () => {
+    federatedUser = await createUser(federationApiManager);
+  });
+
+  test.afterEach(async () => {
+    await federationApiManager.deletePersonalUser(federatedUser);
+  });
+
+  test('I want to start a 1:1 call with a federated User', {tag: ['@TC-3208', '@regression']}, async ({}) => {});
+});

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -1,7 +1,7 @@
 import {ApiManagerE2E} from 'test/e2e_tests/backend/apiManager.e2e';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {createUser, test, withLogin} from 'test/e2e_tests/test.fixtures';
+import {createUser, test, withLogin, expect} from 'test/e2e_tests/test.fixtures';
 import {sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Federation', () => {
@@ -39,5 +39,20 @@ test.describe('Federation', () => {
 
     await normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open();
     await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
+
+    await normalUserPages.conversation().callButton.click();
+    await federatedUserPages.calling().acceptCallButton.click();
+
+    await normalUserPages.calling().toggleVideoButton.click();
+    await federatedUserPages.calling().toggleVideoButton.click();
+
+    const normalUserCall = await normalUserPages.calling().maximizeCell();
+    const federatedUserCall = await federatedUserPages.calling().maximizeCell();
+
+    await expect(normalUserCall.getCallingParticipant(federatedUser.fullName).muteIcon).not.toBeVisible();
+    await expect(normalUserCall.getGridTile(federatedUser.fullName).videoElement).toBeVisible();
+
+    await expect(federatedUserCall.getCallingParticipant(normalUser.fullName).muteIcon).not.toBeVisible();
+    await expect(federatedUserCall.getGridTile(normalUser.fullName).videoElement).toBeVisible();
   });
 });

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -19,8 +19,8 @@ test.describe('Federation', () => {
   const groupName = 'Federated group';
 
   test.beforeEach(async ({api}) => {
-    normalUser = (await createTeam(api, 'Normal Team', {features: {conferenceCalling: true}})).owner;
-    federatedUser = (await createTeam(federationApiManager, 'Federated Team')).owner;
+    normalUser = (await createTeam(api, 'Normal Team', {features: {conferenceCalling: true, mls: true}})).owner;
+    federatedUser = (await createTeam(federationApiManager, 'Federated Team', {features: {mls: true}})).owner;
   });
 
   test.afterEach(async ({api}) => {
@@ -222,26 +222,26 @@ test.describe('Federation', () => {
         federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}),
       ).toBeVisible();
 
-      await test.step('Federated user creates a group and adds normal user to it', async () => {
-        await createGroup(federatedUserPages, groupName, []);
-        await federatedUserPages.conversationList().getConversation(groupName).open();
-        await federatedUserPages.conversation().toggleGroupInformation();
-        await federatedUserPages.conversationDetails().clickAddPeopleButton();
-        await federatedUserPages.conversationDetails().addUsersToConversation([normalUser.fullName]);
-
-        await expect(
-          federatedUserPages.conversation().systemMessages.filter({hasText: `You added ${normalUser.fullName}`}),
-        ).toBeVisible();
-        await expect(federatedUserPages.conversation().statusIndicator).toContainText('Federated users are present');
-        await expect(
-          federatedUserPages.conversationDetails().getParticipant(normalUser.fullName).federatedIcon,
-        ).toBeVisible();
-
+      await test.step('Normal user creates a group and adds federated user to it', async () => {
+        await createGroup(normalUserPages, groupName, []);
         await normalUserPages.conversationList().getConversation(groupName).open();
+        await normalUserPages.conversation().toggleGroupInformation();
+        await normalUserPages.conversationDetails().clickAddPeopleButton();
+        await normalUserPages.conversationDetails().addUsersToConversation([federatedUser.fullName]);
+
         await expect(
-          normalUserPages
+          normalUserPages.conversation().systemMessages.filter({hasText: `You added ${federatedUser.fullName}`}),
+        ).toBeVisible();
+        await expect(normalUserPages.conversation().statusIndicator).toContainText('Federated users are present');
+        await expect(
+          normalUserPages.conversationDetails().getParticipant(federatedUser.fullName).federatedIcon,
+        ).toBeVisible();
+
+        await federatedUserPages.conversationList().getConversation(groupName).open();
+        await expect(
+          federatedUserPages
             .conversation()
-            .systemMessages.filter({hasText: `${federatedUser.fullName} added you to the conversation`}),
+            .systemMessages.filter({hasText: `${normalUser.fullName} added you to the conversation`}),
         ).toBeVisible();
       });
 
@@ -329,7 +329,7 @@ test.describe('Federation', () => {
       });
 
       await test.step('Create a group chat and exchange text and image messages', async () => {
-        await createGroup(federatedUserPages, groupName, [normalUser]);
+        await createGroup(normalUserPages, groupName, [federatedUser]);
         await federatedUserPages.conversationList().getConversation(groupName).open();
         await normalUserPages.conversationList().getConversation(groupName).open();
 
@@ -520,7 +520,7 @@ test.describe('Federation', () => {
             federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}),
           ).toBeVisible();
 
-          await createGroup(federatedUserPages, groupName, [normalUser]);
+          await createGroup(normalUserPages, groupName, [federatedUser]);
           await normalUserPages.conversationList().getConversation(groupName).open();
           await federatedUserPages.conversationList().getConversation(groupName).open();
         }
@@ -541,11 +541,9 @@ test.describe('Federation', () => {
       const federatedUserCall = await federatedUserPages.calling().maximizeCell();
 
       await test.step('Verify initial media connection', async () => {
-        // Normal User UI Checks
         await expect(normalUserCall.getCallingParticipant(federatedUser.fullName).muteIcon).not.toBeVisible();
         await expect(normalUserCall.getGridTile(federatedUser.fullName).videoElement).toBeVisible();
 
-        // Federated User UI Checks
         await expect(federatedUserCall.getCallingParticipant(normalUser.fullName).muteIcon).not.toBeVisible();
         await expect(federatedUserCall.getGridTile(normalUser.fullName).videoElement).toBeVisible();
       });

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -1,7 +1,7 @@
 import {ApiManagerE2E} from 'test/e2e_tests/backend/apiManager.e2e';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {createUser, test, withLogin, expect} from 'test/e2e_tests/test.fixtures';
+import {test, withLogin, expect, createTeam} from 'test/e2e_tests/test.fixtures';
 import {sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Federation', () => {
@@ -15,13 +15,13 @@ test.describe('Federation', () => {
   let federatedUser: User;
 
   test.beforeEach(async ({api}) => {
-    normalUser = await createUser(api);
-    federatedUser = await createUser(federationApiManager);
+    normalUser = (await createTeam(api, 'Normal Team')).owner;
+    federatedUser = (await createTeam(federationApiManager, 'Federated Team')).owner;
   });
 
   test.afterEach(async ({api}) => {
-    await api.deletePersonalUser(normalUser);
-    await federationApiManager.deletePersonalUser(federatedUser);
+    await api.team.deleteTeam(normalUser, normalUser.teamId);
+    await federationApiManager.team.deleteTeam(federatedUser, federatedUser.teamId);
   });
 
   test('I want to start a 1:1 call with a federated User', {tag: ['@TC-3208', '@regression']}, async ({createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -18,7 +18,7 @@ test.describe('Federation', () => {
   let federatedUser: User;
 
   test.beforeEach(async ({api}) => {
-    normalUser = (await createTeam(api, 'Normal Team')).owner;
+    normalUser = (await createTeam(api, 'Normal Team', {features: {conferenceCalling: true}})).owner;
     federatedUser = (await createTeam(federationApiManager, 'Federated Team')).owner;
   });
 
@@ -377,35 +377,86 @@ test.describe('Federation', () => {
     },
   );
 
-  test('I want to start a 1:1 call with a federated User', {tag: ['@TC-3208', '@regression']}, async ({createPage}) => {
-    const [normalUserPage, federatedUserPage] = await Promise.all([
-      createPage(withLogin(normalUser)),
-      createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
-    ]);
-    await sendConnectionRequest(normalUserPage, federatedUser);
+  const testData = [
+    {
+      title: 'I want to start a 1:1 call with a federated User',
+      tags: ['@TC-3208', '@regression'],
+      type: '1:1',
+    },
+    {
+      title: 'I want to start a conference call in a federated group with Users from 2 different backends',
+      tags: ['@TC-3220', '@regression'],
+      type: 'group',
+    },
+  ];
 
-    const {pages: normalUserPages} = PageManager.from(normalUserPage).webapp;
-    const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
+  testData.forEach(({title, tags, type}) => {
+    test(title, {tag: tags}, async ({createPage}) => {
+      const [normalUserPage, federatedUserPage] = await Promise.all([
+        createPage(withLogin(normalUser)),
+        createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
+      ]);
 
-    await federatedUserPages.conversationList().openPendingConnectionRequest();
-    await federatedUserPages.connectRequest().clickConnectButton();
+      const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+      const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+      const groupName = 'Federation call group';
 
-    await normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open();
-    await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
+      await test.step('Connect federated users', async () => {
+        await sendConnectionRequest(normalUserPage, federatedUser);
+        await federatedUserPages.conversationList().openPendingConnectionRequest();
+        await federatedUserPages.connectRequest().clickConnectButton();
+      });
 
-    await normalUserPages.conversation().callButton.click();
-    await federatedUserPages.calling().acceptCallButton.click();
+      await test.step('Users open conversations', async () => {
+        if (type === '1:1') {
+          await normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open();
+          await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
+        } else {
+          await expect(
+            federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}),
+          ).toBeVisible();
 
-    await normalUserPages.calling().toggleVideoButton.click();
-    await federatedUserPages.calling().toggleVideoButton.click();
+          await createGroup(federatedUserPages, groupName, [normalUser]);
+          await normalUserPages.conversationList().getConversation(groupName).open();
+          await federatedUserPages.conversationList().getConversation(groupName).open();
+        }
+      });
 
-    const normalUserCall = await normalUserPages.calling().maximizeCell();
-    const federatedUserCall = await federatedUserPages.calling().maximizeCell();
+      await test.step('Start and accept call', async () => {
+        await normalUserPages.conversation().callButton.click();
+        await expect(normalUserPages.calling().callCell).toBeVisible();
+        await federatedUserPages.calling().acceptCallButton.click();
+      });
 
-    await expect(normalUserCall.getCallingParticipant(federatedUser.fullName).muteIcon).not.toBeVisible();
-    await expect(normalUserCall.getGridTile(federatedUser.fullName).videoElement).toBeVisible();
+      await test.step('Enable video streams', async () => {
+        await normalUserPages.calling().toggleVideoButton.click();
+        await federatedUserPages.calling().toggleVideoButton.click();
+      });
 
-    await expect(federatedUserCall.getCallingParticipant(normalUser.fullName).muteIcon).not.toBeVisible();
-    await expect(federatedUserCall.getGridTile(normalUser.fullName).videoElement).toBeVisible();
+      const normalUserCall = await normalUserPages.calling().maximizeCell();
+      const federatedUserCall = await federatedUserPages.calling().maximizeCell();
+
+      await test.step('Verify initial media connection', async () => {
+        // Normal User UI Checks
+        await expect(normalUserCall.getCallingParticipant(federatedUser.fullName).muteIcon).not.toBeVisible();
+        await expect(normalUserCall.getGridTile(federatedUser.fullName).videoElement).toBeVisible();
+
+        // Federated User UI Checks
+        await expect(federatedUserCall.getCallingParticipant(normalUser.fullName).muteIcon).not.toBeVisible();
+        await expect(federatedUserCall.getGridTile(normalUser.fullName).videoElement).toBeVisible();
+      });
+
+      // Conditionally execute group-only interaction steps
+      if (type === 'group') {
+        await test.step('Verify screen sharing controls', async () => {
+          await normalUserCall.toggleVideoButton.click();
+          await expect(federatedUserCall.getGridTile(normalUser.fullName).videoElement).not.toBeVisible();
+
+          await normalUserCall.toggleScreenShareButton.click();
+          await expect(normalUserCall.selfVideoThumbnail.locator('video')).toBeVisible();
+          await expect(federatedUserCall.getGridTile(normalUser.fullName).videoElement).toBeVisible();
+        });
+      }
+    });
   });
 });

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -1,22 +1,43 @@
 import {ApiManagerE2E} from 'test/e2e_tests/backend/apiManager.e2e';
 import {User} from 'test/e2e_tests/data/user';
-import {createUser, test} from 'test/e2e_tests/test.fixtures';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {createUser, test, withLogin} from 'test/e2e_tests/test.fixtures';
+import {sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Federation', () => {
+  const federationBaseUrl = process.env.FEDERATION_WEBAPP_URL!;
   const federationApiManager = new ApiManagerE2E({
     backendUrl: process.env.FEDERATION_BACKEND_URL!,
     basicAuth: process.env.FEDERATION_BASIC_AUTH!,
   });
 
+  let normalUser: User;
   let federatedUser: User;
 
-  test.beforeEach(async () => {
+  test.beforeEach(async ({api}) => {
+    normalUser = await createUser(api);
     federatedUser = await createUser(federationApiManager);
   });
 
-  test.afterEach(async () => {
+  test.afterEach(async ({api}) => {
+    await api.deletePersonalUser(normalUser);
     await federationApiManager.deletePersonalUser(federatedUser);
   });
 
-  test('I want to start a 1:1 call with a federated User', {tag: ['@TC-3208', '@regression']}, async ({}) => {});
+  test('I want to start a 1:1 call with a federated User', {tag: ['@TC-3208', '@regression']}, async ({createPage}) => {
+    const [normalUserPage, federatedUserPage] = await Promise.all([
+      createPage(withLogin(normalUser)),
+      createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
+    ]);
+    await sendConnectionRequest(normalUserPage, federatedUser);
+
+    const {pages: normalUserPages} = PageManager.from(normalUserPage).webapp;
+    const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
+
+    await federatedUserPages.conversationList().openPendingConnectionRequest();
+    await federatedUserPages.connectRequest().clickConnectButton();
+
+    await normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open();
+    await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
+  });
 });

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -1,8 +1,11 @@
+import {Page} from 'playwright/test';
 import {ApiManagerE2E} from 'test/e2e_tests/backend/apiManager.e2e';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, withLogin, expect, createTeam} from 'test/e2e_tests/test.fixtures';
-import {sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
+import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
+import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
+import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
 test.describe('Federation', () => {
   const federationBaseUrl = process.env.FEDERATION_WEBAPP_URL!;
@@ -23,6 +26,244 @@ test.describe('Federation', () => {
     await api.team.deleteTeam(normalUser, normalUser.teamId);
     await federationApiManager.team.deleteTeam(federatedUser, federatedUser.teamId);
   });
+
+  test(
+    'I want to share all possible assets in a federated group',
+    {tag: ['@TC-8758', '@regression']},
+    async ({createPage}) => {
+      const [normalUserPage, federatedUserPage] = await Promise.all([
+        createPage(withLogin(normalUser)),
+        createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
+      ]);
+      await sendConnectionRequest(normalUserPage, federatedUser);
+
+      const {pages: normalUserPages} = PageManager.from(normalUserPage).webapp;
+      const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
+
+      await federatedUserPages.conversationList().openPendingConnectionRequest();
+      await federatedUserPages.connectRequest().clickConnectButton();
+      await expect(
+        federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}),
+      ).toBeVisible();
+
+      await test.step('Federated user creates a group and adds normal user to it', async () => {
+        await createGroup(federatedUserPages, 'Federation group', []);
+        await federatedUserPages.conversationList().getConversation('Federation group').open();
+        await federatedUserPages.conversation().toggleGroupInformation();
+        await federatedUserPages.conversationDetails().clickAddPeopleButton();
+        await federatedUserPages.conversationDetails().addUsersToConversation([normalUser.fullName]);
+
+        await expect(
+          federatedUserPages.conversation().systemMessages.filter({hasText: `You added ${normalUser.fullName}`}),
+        ).toBeVisible();
+        await expect(federatedUserPages.conversation().statusIndicator).toContainText('Federated users are present');
+        await expect(
+          federatedUserPages.conversationDetails().getParticipant(normalUser.fullName).federatedIcon,
+        ).toBeVisible();
+
+        await normalUserPages.conversationList().getConversation('Federation group').open();
+        await expect(
+          normalUserPages
+            .conversation()
+            .systemMessages.filter({hasText: `${federatedUser.fullName} added you to the conversation`}),
+        ).toBeVisible();
+      });
+
+      await test.step('Normal user can send and delete Text message in the federated group', async () => {
+        await normalUserPages.conversation().sendMessage('Hello from staging user');
+
+        const messageNormalUser = normalUserPages.conversation().getMessage({sender: normalUser});
+        await expect(messageNormalUser).toBeVisible();
+        await expect(federatedUserPages.conversation().getMessage({sender: normalUser})).toBeVisible();
+
+        await normalUserPages.conversation().deleteMessage(messageNormalUser, 'Everyone');
+        await expect(messageNormalUser).not.toBeVisible();
+        await expect(federatedUserPage.getByTestId('element-message-delete')).toBeVisible();
+      });
+
+      const testCases = [
+        {
+          name: 'Image',
+          sendAction: async ({normalUserPage}) => {
+            await shareAssetHelper(
+              getImageFilePath(),
+              normalUserPage,
+              normalUserPage.getByRole('button', {name: 'Add picture'}),
+            );
+          },
+          verify: async ({federatedUserPage}) => {
+            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+            const messageWithImage = federatedUserPages
+              .conversation()
+              .getMessage({sender: normalUser})
+              .filter({has: federatedUserPage.getByRole('img')});
+            await expect(messageWithImage).toBeVisible();
+          },
+        },
+        {
+          name: 'Text',
+          sendAction: async ({normalUserPage}) => {
+            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+            await normalUserPages.conversation().sendMessage('Test message');
+            await expect(normalUserPages.conversation().getMessage({content: 'Test message'})).toBeVisible();
+          },
+          verify: async ({federatedUserPage}) => {
+            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+            const message = federatedUserPages.conversation().getMessage({content: 'Test message'});
+            await expect(message).toBeVisible();
+          },
+        },
+        {
+          name: 'Link',
+          sendAction: async ({normalUserPage}) => {
+            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+            await normalUserPages.conversation().sendMessage('https://www.lidl.de/');
+          },
+          verify: async ({federatedUserPage}) => {
+            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+            const message = federatedUserPages.conversation().getMessage({content: 'https://www.lidl.de/'});
+            await expect(message).toBeVisible();
+          },
+        },
+        {
+          name: 'Audio',
+          sendAction: async ({normalUserPage}) => {
+            await shareAssetHelper(
+              getAudioFilePath(),
+              normalUserPage,
+              normalUserPage.getByRole('button', {name: 'Add file'}),
+            );
+          },
+          verify: async ({federatedUserPage}) => {
+            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+            const messageWithAudio = federatedUserPages
+              .conversation()
+              .getMessage({sender: normalUser})
+              .filter({has: federatedUserPage.locator('[data-uie-name="audio-asset"]')});
+            await expect(messageWithAudio).toBeVisible();
+          },
+        },
+        {
+          name: 'Video',
+          sendAction: async ({normalUserPage}) => {
+            await shareAssetHelper(
+              getVideoFilePath(),
+              normalUserPage,
+              normalUserPage.getByRole('button', {name: 'Add file'}),
+            );
+          },
+          verify: async ({federatedUserPage}) => {
+            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+            const messageWithVideo = federatedUserPages
+              .conversation()
+              .getMessage({sender: normalUser})
+              .filter({has: federatedUserPage.locator('[data-uie-name="video-asset"]')});
+            await expect(messageWithVideo).toBeVisible();
+          },
+        },
+        {
+          name: 'File',
+          sendAction: async ({normalUserPage}) => {
+            await shareAssetHelper(
+              getTextFilePath(),
+              normalUserPage,
+              normalUserPage.getByRole('button', {name: 'Add file'}),
+            );
+          },
+          verify: async ({federatedUserPage}) => {
+            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+            const messageWithFile = federatedUserPages
+              .conversation()
+              .getMessage({sender: normalUser})
+              .filter({has: federatedUserPage.locator('[data-uie-name="file-asset"]')});
+            await expect(messageWithFile).toBeVisible();
+          },
+        },
+        {
+          name: 'Ping',
+          sendAction: async ({normalUserPage}) => {
+            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+            await normalUserPages.conversation().sendPing();
+          },
+          verify: async ({federatedUserPage}) => {
+            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+            await expect(federatedUserPages.conversation().getPing()).toBeVisible();
+          },
+        },
+        {
+          name: 'Ephemeral text message',
+          sendAction: async ({normalUserPage}) => {
+            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+            await normalUserPages.conversation().enableSelfDeletingMessages();
+            await normalUserPages.conversation().sendMessage('Gone in 10s');
+          },
+          verify: async ({federatedUserPage}) => {
+            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+            await expect(federatedUserPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
+
+            await federatedUserPage.waitForTimeout(10_000); // Wait for 10s so the message is deleted
+            await expect(federatedUserPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
+          },
+        },
+        {
+          name: 'Reaction',
+          sendAction: async ({normalUserPage}) => {
+            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+            const message = normalUserPages.conversation().getMessage({content: 'Test message'});
+            await expect(message).toBeVisible();
+            await normalUserPages.conversation().reactOnMessage(message, 'plus-one');
+          },
+          verify: async ({federatedUserPage}) => {
+            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+            const messageWithReaction = federatedUserPages.conversation().getMessage({content: 'Test message'});
+            await expect(
+              federatedUserPages.conversation().getReactionOnMessage(messageWithReaction, 'plus-one'),
+            ).toBeVisible();
+          },
+        },
+        {
+          name: 'Reply',
+          sendAction: async ({normalUserPage}) => {
+            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+            const message = normalUserPages.conversation().getMessage({content: 'Test message'});
+
+            await expect(message).toBeVisible();
+            await normalUserPages.conversation().replyToMessage(message);
+            await normalUserPages.conversation().sendMessage('Reply');
+          },
+          verify: async ({federatedUserPage}) => {
+            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+            const replyMessage = federatedUserPages.conversation().getMessage({content: 'Reply'});
+            await expect(replyMessage.getByTestId('quote-item')).toContainText('Test message');
+          },
+        },
+        {
+          name: 'Mention',
+          sendAction: async ({normalUserPage}) => {
+            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+            await normalUserPages.conversation().sendMessageWithUserMention(federatedUser.fullName, 'Test mention');
+          },
+          verify: async ({federatedUserPage}) => {
+            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+            await expect(
+              federatedUserPages.conversation().getMessage({content: `@${federatedUser.fullName}`}),
+            ).toBeVisible();
+          },
+        },
+      ] as const satisfies {
+        name: string;
+        sendAction: (params: {normalUserPage: Page}) => Promise<void>;
+        verify: (params: {federatedUserPage: Page}) => Promise<void>;
+      }[];
+
+      for (const {name, sendAction, verify} of testCases) {
+        await test.step(`Verify user sends ${name} and federated user can see it`, async () => {
+          await sendAction({normalUserPage});
+          await verify({federatedUserPage});
+        });
+      }
+    },
+  );
 
   test('I want to start a 1:1 call with a federated User', {tag: ['@TC-3208', '@regression']}, async ({createPage}) => {
     const [normalUserPage, federatedUserPage] = await Promise.all([

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -27,6 +27,181 @@ test.describe('Federation', () => {
     await federationApiManager.team.deleteTeam(federatedUser, federatedUser.teamId);
   });
 
+  const testCases = [
+    {
+      name: 'Image',
+      sendAction: async ({normalUserPage}) => {
+        await shareAssetHelper(
+          getImageFilePath(),
+          normalUserPage,
+          normalUserPage.getByRole('button', {name: 'Add picture'}),
+        );
+      },
+      verify: async ({federatedUserPage}) => {
+        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+        const messageWithImage = federatedUserPages
+          .conversation()
+          .getMessage({sender: normalUser})
+          .filter({has: federatedUserPage.getByRole('img')});
+        await expect(messageWithImage).toBeVisible();
+      },
+    },
+    {
+      name: 'Text',
+      sendAction: async ({normalUserPage}) => {
+        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+        await normalUserPages.conversation().sendMessage('Test message');
+        await expect(normalUserPages.conversation().getMessage({content: 'Test message'})).toBeVisible();
+      },
+      verify: async ({federatedUserPage}) => {
+        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+        const message = federatedUserPages.conversation().getMessage({content: 'Test message'});
+        await expect(message).toBeVisible();
+      },
+    },
+    {
+      name: 'Link',
+      sendAction: async ({normalUserPage}) => {
+        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+        await normalUserPages.conversation().sendMessage('https://www.lidl.de/');
+      },
+      verify: async ({federatedUserPage}) => {
+        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+        const message = federatedUserPages.conversation().getMessage({content: 'https://www.lidl.de/'});
+        await expect(message).toBeVisible();
+      },
+    },
+    {
+      name: 'Audio',
+      sendAction: async ({normalUserPage}) => {
+        await shareAssetHelper(
+          getAudioFilePath(),
+          normalUserPage,
+          normalUserPage.getByRole('button', {name: 'Add file'}),
+        );
+      },
+      verify: async ({federatedUserPage}) => {
+        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+        const messageWithAudio = federatedUserPages
+          .conversation()
+          .getMessage({sender: normalUser})
+          .filter({has: federatedUserPage.locator('[data-uie-name="audio-asset"]')});
+        await expect(messageWithAudio).toBeVisible();
+      },
+    },
+    {
+      name: 'Video',
+      sendAction: async ({normalUserPage}) => {
+        await shareAssetHelper(
+          getVideoFilePath(),
+          normalUserPage,
+          normalUserPage.getByRole('button', {name: 'Add file'}),
+        );
+      },
+      verify: async ({federatedUserPage}) => {
+        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+        const messageWithVideo = federatedUserPages
+          .conversation()
+          .getMessage({sender: normalUser})
+          .filter({has: federatedUserPage.locator('[data-uie-name="video-asset"]')});
+        await expect(messageWithVideo).toBeVisible();
+      },
+    },
+    {
+      name: 'File',
+      sendAction: async ({normalUserPage}) => {
+        await shareAssetHelper(
+          getTextFilePath(),
+          normalUserPage,
+          normalUserPage.getByRole('button', {name: 'Add file'}),
+        );
+      },
+      verify: async ({federatedUserPage}) => {
+        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+        const messageWithFile = federatedUserPages
+          .conversation()
+          .getMessage({sender: normalUser})
+          .filter({has: federatedUserPage.locator('[data-uie-name="file-asset"]')});
+        await expect(messageWithFile).toBeVisible();
+      },
+    },
+    {
+      name: 'Ping',
+      sendAction: async ({normalUserPage}) => {
+        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+        await normalUserPages.conversation().sendPing();
+      },
+      verify: async ({federatedUserPage}) => {
+        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+        await expect(federatedUserPages.conversation().getPing()).toBeVisible();
+      },
+    },
+    {
+      name: 'Ephemeral text message',
+      sendAction: async ({normalUserPage}) => {
+        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+        await normalUserPages.conversation().enableSelfDeletingMessages();
+        await normalUserPages.conversation().sendMessage('Gone in 10s');
+      },
+      verify: async ({federatedUserPage}) => {
+        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+        await expect(federatedUserPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
+
+        await federatedUserPage.waitForTimeout(10_000); // Wait for 10s so the message is deleted
+        await expect(federatedUserPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
+      },
+    },
+    {
+      name: 'Reaction',
+      sendAction: async ({normalUserPage}) => {
+        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+        const message = normalUserPages.conversation().getMessage({content: 'Test message'});
+        await expect(message).toBeVisible();
+        await normalUserPages.conversation().reactOnMessage(message, 'plus-one');
+      },
+      verify: async ({federatedUserPage}) => {
+        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+        const messageWithReaction = federatedUserPages.conversation().getMessage({content: 'Test message'});
+        await expect(
+          federatedUserPages.conversation().getReactionOnMessage(messageWithReaction, 'plus-one'),
+        ).toBeVisible();
+      },
+    },
+    {
+      name: 'Reply',
+      sendAction: async ({normalUserPage}) => {
+        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+        const message = normalUserPages.conversation().getMessage({content: 'Test message'});
+
+        await expect(message).toBeVisible();
+        await normalUserPages.conversation().replyToMessage(message);
+        await normalUserPages.conversation().sendMessage('Reply');
+      },
+      verify: async ({federatedUserPage}) => {
+        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+        const replyMessage = federatedUserPages.conversation().getMessage({content: 'Reply'});
+        await expect(replyMessage.getByTestId('quote-item')).toContainText('Test message');
+      },
+    },
+    {
+      name: 'Mention',
+      sendAction: async ({normalUserPage}) => {
+        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+        await normalUserPages.conversation().sendMessageWithUserMention(federatedUser.fullName, 'Test mention');
+      },
+      verify: async ({federatedUserPage}) => {
+        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+        await expect(
+          federatedUserPages.conversation().getMessage({content: `@${federatedUser.fullName}`}),
+        ).toBeVisible();
+      },
+    },
+  ] as const satisfies {
+    name: string;
+    sendAction: (params: {normalUserPage: Page}) => Promise<void>;
+    verify: (params: {federatedUserPage: Page}) => Promise<void>;
+  }[];
+
   test(
     'I want to share all possible assets in a federated group',
     {tag: ['@TC-8758', '@regression']},
@@ -81,180 +256,33 @@ test.describe('Federation', () => {
         await expect(federatedUserPage.getByTestId('element-message-delete')).toBeVisible();
       });
 
-      const testCases = [
-        {
-          name: 'Image',
-          sendAction: async ({normalUserPage}) => {
-            await shareAssetHelper(
-              getImageFilePath(),
-              normalUserPage,
-              normalUserPage.getByRole('button', {name: 'Add picture'}),
-            );
-          },
-          verify: async ({federatedUserPage}) => {
-            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-            const messageWithImage = federatedUserPages
-              .conversation()
-              .getMessage({sender: normalUser})
-              .filter({has: federatedUserPage.getByRole('img')});
-            await expect(messageWithImage).toBeVisible();
-          },
-        },
-        {
-          name: 'Text',
-          sendAction: async ({normalUserPage}) => {
-            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-            await normalUserPages.conversation().sendMessage('Test message');
-            await expect(normalUserPages.conversation().getMessage({content: 'Test message'})).toBeVisible();
-          },
-          verify: async ({federatedUserPage}) => {
-            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-            const message = federatedUserPages.conversation().getMessage({content: 'Test message'});
-            await expect(message).toBeVisible();
-          },
-        },
-        {
-          name: 'Link',
-          sendAction: async ({normalUserPage}) => {
-            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-            await normalUserPages.conversation().sendMessage('https://www.lidl.de/');
-          },
-          verify: async ({federatedUserPage}) => {
-            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-            const message = federatedUserPages.conversation().getMessage({content: 'https://www.lidl.de/'});
-            await expect(message).toBeVisible();
-          },
-        },
-        {
-          name: 'Audio',
-          sendAction: async ({normalUserPage}) => {
-            await shareAssetHelper(
-              getAudioFilePath(),
-              normalUserPage,
-              normalUserPage.getByRole('button', {name: 'Add file'}),
-            );
-          },
-          verify: async ({federatedUserPage}) => {
-            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-            const messageWithAudio = federatedUserPages
-              .conversation()
-              .getMessage({sender: normalUser})
-              .filter({has: federatedUserPage.locator('[data-uie-name="audio-asset"]')});
-            await expect(messageWithAudio).toBeVisible();
-          },
-        },
-        {
-          name: 'Video',
-          sendAction: async ({normalUserPage}) => {
-            await shareAssetHelper(
-              getVideoFilePath(),
-              normalUserPage,
-              normalUserPage.getByRole('button', {name: 'Add file'}),
-            );
-          },
-          verify: async ({federatedUserPage}) => {
-            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-            const messageWithVideo = federatedUserPages
-              .conversation()
-              .getMessage({sender: normalUser})
-              .filter({has: federatedUserPage.locator('[data-uie-name="video-asset"]')});
-            await expect(messageWithVideo).toBeVisible();
-          },
-        },
-        {
-          name: 'File',
-          sendAction: async ({normalUserPage}) => {
-            await shareAssetHelper(
-              getTextFilePath(),
-              normalUserPage,
-              normalUserPage.getByRole('button', {name: 'Add file'}),
-            );
-          },
-          verify: async ({federatedUserPage}) => {
-            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-            const messageWithFile = federatedUserPages
-              .conversation()
-              .getMessage({sender: normalUser})
-              .filter({has: federatedUserPage.locator('[data-uie-name="file-asset"]')});
-            await expect(messageWithFile).toBeVisible();
-          },
-        },
-        {
-          name: 'Ping',
-          sendAction: async ({normalUserPage}) => {
-            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-            await normalUserPages.conversation().sendPing();
-          },
-          verify: async ({federatedUserPage}) => {
-            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-            await expect(federatedUserPages.conversation().getPing()).toBeVisible();
-          },
-        },
-        {
-          name: 'Ephemeral text message',
-          sendAction: async ({normalUserPage}) => {
-            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-            await normalUserPages.conversation().enableSelfDeletingMessages();
-            await normalUserPages.conversation().sendMessage('Gone in 10s');
-          },
-          verify: async ({federatedUserPage}) => {
-            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-            await expect(federatedUserPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
+      for (const {name, sendAction, verify} of testCases) {
+        await test.step(`Verify user sends ${name} and federated user can see it`, async () => {
+          await sendAction({normalUserPage});
+          await verify({federatedUserPage});
+        });
+      }
+    },
+  );
 
-            await federatedUserPage.waitForTimeout(10_000); // Wait for 10s so the message is deleted
-            await expect(federatedUserPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
-          },
-        },
-        {
-          name: 'Reaction',
-          sendAction: async ({normalUserPage}) => {
-            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-            const message = normalUserPages.conversation().getMessage({content: 'Test message'});
-            await expect(message).toBeVisible();
-            await normalUserPages.conversation().reactOnMessage(message, 'plus-one');
-          },
-          verify: async ({federatedUserPage}) => {
-            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-            const messageWithReaction = federatedUserPages.conversation().getMessage({content: 'Test message'});
-            await expect(
-              federatedUserPages.conversation().getReactionOnMessage(messageWithReaction, 'plus-one'),
-            ).toBeVisible();
-          },
-        },
-        {
-          name: 'Reply',
-          sendAction: async ({normalUserPage}) => {
-            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-            const message = normalUserPages.conversation().getMessage({content: 'Test message'});
+  test(
+    'I want to share all possible assets in a federated 1:1',
+    {tag: ['@TC-8759', '@regression']},
+    async ({createPage}) => {
+      const [normalUserPage, federatedUserPage] = await Promise.all([
+        createPage(withLogin(normalUser)),
+        createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
+      ]);
+      await sendConnectionRequest(normalUserPage, federatedUser);
 
-            await expect(message).toBeVisible();
-            await normalUserPages.conversation().replyToMessage(message);
-            await normalUserPages.conversation().sendMessage('Reply');
-          },
-          verify: async ({federatedUserPage}) => {
-            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-            const replyMessage = federatedUserPages.conversation().getMessage({content: 'Reply'});
-            await expect(replyMessage.getByTestId('quote-item')).toContainText('Test message');
-          },
-        },
-        {
-          name: 'Mention',
-          sendAction: async ({normalUserPage}) => {
-            const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-            await normalUserPages.conversation().sendMessageWithUserMention(federatedUser.fullName, 'Test mention');
-          },
-          verify: async ({federatedUserPage}) => {
-            const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-            await expect(
-              federatedUserPages.conversation().getMessage({content: `@${federatedUser.fullName}`}),
-            ).toBeVisible();
-          },
-        },
-      ] as const satisfies {
-        name: string;
-        sendAction: (params: {normalUserPage: Page}) => Promise<void>;
-        verify: (params: {federatedUserPage: Page}) => Promise<void>;
-      }[];
+      const {pages: normalUserPages} = PageManager.from(normalUserPage).webapp;
+      const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
+
+      await federatedUserPages.conversationList().openPendingConnectionRequest();
+      await federatedUserPages.connectRequest().clickConnectButton();
+
+      await normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open();
+      await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
 
       for (const {name, sendAction, verify} of testCases) {
         await test.step(`Verify user sends ${name} and federated user can see it`, async () => {

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -309,7 +309,7 @@ test.describe('Folders', () => {
 
         await expect(userBPages.conversationDetails().groupMembers.filter({hasText: userA.fullName})).toBeVisible();
 
-        await userBPages.conversationDetails().openParticipantDetails(userA.fullName);
+        await userBPages.conversationDetails().getParticipant(userA.fullName).openDetails();
         await userBPages.participantDetails().removeFromGroup();
       });
 

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -245,7 +245,7 @@ test.describe('Group Conversation', () => {
 
       await expect(pages.conversationDetails().groupMembers.filter({hasText: userB.fullName})).toBeVisible();
 
-      await pages.conversationDetails().openParticipantDetails(userB.fullName);
+      await pages.conversationDetails().getParticipant(userB.fullName).openDetails();
       await pages.participantDetails().removeFromGroup();
 
       await expect(pages.conversationDetails().groupMembers.filter({hasText: userB.fullName})).not.toBeVisible();
@@ -266,7 +266,7 @@ test.describe('Group Conversation', () => {
       await pages.conversation().toggleGroupInformation();
 
       await expect(pages.conversationDetails().groupMembers.filter({hasText: userB.fullName})).toBeVisible();
-      await pages.conversationDetails().openParticipantDetails(userB.fullName);
+      await pages.conversationDetails().getParticipant(userB.fullName).openDetails();
       await expect(pages.conversation().makeAdminToggle).toBeVisible();
     },
   );
@@ -285,7 +285,7 @@ test.describe('Group Conversation', () => {
       await userBPages.conversation().toggleGroupInformation();
 
       await expect(userBPages.conversationDetails().groupAdmins.filter({hasText: userA.fullName})).toBeVisible();
-      await userBPages.conversationDetails().openParticipantDetails(userA.fullName);
+      await userBPages.conversationDetails().getParticipant(userA.fullName).openDetails();
       await expect(userBPages.conversation().makeAdminToggle).not.toBeVisible();
     },
   );

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -164,7 +164,7 @@ test.describe('Guestroom', () => {
       await pages.conversation().toggleGroupInformation();
       await expect(pages.conversationDetails().groupMembers.filter({hasText: guestUser.firstName})).toBeVisible();
 
-      await pages.conversationDetails().openParticipantDetails(guestUser.firstName);
+      await pages.conversationDetails().getParticipant(guestUser.firstName).openDetails();
       await verify(pages);
     });
   });
@@ -395,7 +395,7 @@ test.describe('Guestroom', () => {
         await expect(guestMember).toBeVisible({timeout: LOGIN_TIMEOUT});
 
         await userAPage.waitForTimeout(60_000);
-        await pages.conversationDetails().openParticipantDetails(guestUser.firstName);
+        await pages.conversationDetails().getParticipant(guestUser.firstName).openDetails();
         await expect(pages.participantDetails().userStatus).toBeVisible();
       });
 
@@ -417,7 +417,7 @@ test.describe('Guestroom', () => {
       const createdLink = await generateGroupGuestsLink(pages, groupName);
 
       await createPage(withGuestUser(createdLink, guestUser.firstName));
-      await expect(pages.conversation().guestsIndicator).toBeVisible();
+      await expect(pages.conversation().statusIndicator).toContainText('Guests are present');
     },
   );
 
@@ -571,7 +571,7 @@ test.describe('Guestroom', () => {
       await test.step('User A sees guest details (to trigger access validation) after 1 minute', async () => {
         await pages.conversation().toggleGroupInformation();
         await userAPage.waitForTimeout(60_000);
-        await pages.conversationDetails().openParticipantDetails(guestUser.firstName);
+        await pages.conversationDetails().getParticipant(guestUser.firstName).openDetails();
         await expect(pages.participantDetails().userStatus).toBeVisible();
       });
 

--- a/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Mention/mention.spec.ts
@@ -568,7 +568,7 @@ test.describe('Mention', () => {
       await test.step('UserA removes userB from the group', async () => {
         await userAPages.conversationList().getConversation('Test Group').open();
         await userAPages.conversation().conversationTitle.click();
-        await userAPages.conversationDetails().openParticipantDetails(userB.fullName);
+        await userAPages.conversationDetails().getParticipant(userB.fullName).openDetails();
         await userAPages.participantDetails().removeFromGroup();
       });
 

--- a/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
@@ -30,7 +30,7 @@ async function openParticipantDetailsFromGroup(
 ) {
   await pages.conversationList().getConversation(groupName).open();
   await pages.conversation().clickConversationInfoButton();
-  await pages.conversationDetails().openParticipantDetails(participantName);
+  await pages.conversationDetails().getParticipant(participantName).openDetails();
 }
 
 async function acceptConnectionRequest(pages: PageManager['webapp']['pages']) {
@@ -162,7 +162,7 @@ test.describe('Participant Profile', () => {
       });
 
       await test.step('User C opens individual people profile of User A', async () => {
-        await pages.conversationDetails().openParticipantDetails(userC.fullName);
+        await pages.conversationDetails().getParticipant(userC.fullName).openDetails();
 
         await expect(pages.participantDetails().userPicture).toBeVisible();
         await expect(pages.participantDetails().userPicture).toHaveAttribute('data-uie-status', 'blocked');

--- a/apps/webapp/test/e2e_tests/specs/ProteusVerification/proteusVerification.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ProteusVerification/proteusVerification.spec.ts
@@ -338,7 +338,8 @@ test.describe('Proteus verification', () => {
           await pages.conversation().clickConversationInfoButton();
           await pages
             .conversationDetails()
-            .openParticipantDetails(pages === userAPages ? userB.fullName : userA.fullName);
+            .getParticipant(pages === userAPages ? userB.fullName : userA.fullName)
+            .openDetails();
           await pages.participantDetails().devicesButton.click();
           await expect(pages.participantDevices().activeDevices).toHaveCount(1);
 
@@ -365,7 +366,7 @@ test.describe('Proteus verification', () => {
       });
 
       await test.step('Action: User A verifies User C`s device', async () => {
-        await userAPages.conversationDetails().openParticipantDetails(userC.fullName);
+        await userAPages.conversationDetails().getParticipant(userC.fullName).openDetails();
         await userAPages.participantDetails().devicesButton.click();
 
         await expect(userAPages.participantDevices().activeDevices).toHaveCount(1);

--- a/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
@@ -476,8 +476,7 @@ test.describe('Status', () => {
       // User B should see the BUSY status in the searchable group participant list
       await userBPages.conversationList().getConversation(groupName).open();
       await userBPages.conversation().clickConversationInfoButton();
-      await expect(userBPages.conversationDetails().getUserAvailabilityIcon(userA.fullName)).toBeVisible();
-      await expect(userBPages.conversationDetails().getUserAvailabilityIcon(userA.fullName)).toHaveAttribute(
+      await expect(userBPages.conversationDetails().getParticipant(userA.fullName).availabilityIcon).toHaveAttribute(
         'data-uie-value',
         'busy',
       );

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -49,21 +49,9 @@ type Fixtures = {
   /**
    * Creates a team and the associated owner, optionally adding members to it
    * Note: The team and owner are automatically deleted when the test completes.
-   * @param options.withMembers Can either be the number of team members to create or an array of existing members to add to the team
-   * @returns an object containing the teams owner and an array of members. The size of the members array matches the number or array length passed to `withMembers`
+   * @returns an object containing the teams owner and an array of users.
    */
-  createTeam: (
-    teamName: string,
-    options?: {
-      users?: (User | {user: User; role?: keyof typeof Role})[];
-      features?: {
-        conferenceCalling?: boolean;
-        channels?: boolean;
-        mls?: boolean | Parameters<BrigRepositoryE2E['configureMLSFeature']>[1];
-        cells?: boolean;
-      };
-    },
-  ) => Promise<Team>;
+  createTeam: (...args: Parameters<typeof createTeam> extends [any, ...infer Args] ? Args : never) => Promise<Team>;
 };
 
 export type Team = {
@@ -140,71 +128,9 @@ export const test = baseTest.extend<Fixtures>({
     const teamOwners: User[] = [];
 
     await use(async (teamName, options) => {
-      const owner = await createUser(api);
-
-      const {teamId} = await api.auth.upgradeUserToTeamOwner(owner, teamName);
-      owner.teamId = teamId;
-
-      teamOwners.push(owner);
-
-      const addTeamMember: Team['addTeamMember'] = async (member, options) => {
-        const invitationId = await api.team.inviteUserToTeam(member.email, owner, Role[options?.role ?? 'MEMBER']);
-        const invitationCode = await api.brig.getTeamInvitationCodeForEmail(owner.teamId, invitationId);
-        await api.team.acceptTeamInvitation(invitationCode, member);
-      };
-
-      if (options?.users) {
-        await Promise.all(
-          options.users.map(user => {
-            if ('user' in user) {
-              return addTeamMember(user.user, {role: user.role});
-            } else {
-              return addTeamMember(user);
-            }
-          }),
-        );
-      }
-
-      if (options?.features && Object.values(options.features).some(Boolean)) {
-        // The team will be reset right after initialization, so we need to wait a short time for it to finish
-        // before changing feature configs since they would otherwise be overwritten (See WPB-23698)
-        await new Promise(resolve => setTimeout(resolve, 5000));
-
-        if (options.features.conferenceCalling) {
-          await api.enableConferenceCallingFeature(teamId);
-          await api.waitForFeatureToBeEnabled(FEATURE_KEY.CONFERENCE_CALLING, teamId, owner.token);
-        }
-
-        if (options.features.mls) {
-          await api.brig.configureMLSFeature(
-            owner.teamId,
-            options.features.mls === true
-              ? {status: 'enabled', defaultProtocol: 'mls', supportedProtocols: ['mls', 'proteus']}
-              : options.features.mls,
-          );
-        }
-
-        if (options.features.channels) {
-          // Creating channels depends on MLS to be enabled
-          await api.brig.configureMLSFeature(owner.teamId, {
-            defaultProtocol: 'mls',
-            supportedProtocols: ['mls', 'proteus'],
-          });
-          await api.waitForFeatureToBeEnabled(FEATURE_KEY.MLS, teamId, owner.token);
-
-          await api.brig.unlockChannelFeature(teamId);
-          await api.brig.enableChannelsFeature(teamId);
-          await api.waitForFeatureToBeEnabled(FEATURE_KEY.CHANNELS, teamId, owner.token);
-        }
-
-        if (options.features.cells) {
-          await api.brig.unlockCellsFeature(teamId);
-          await api.brig.enableCells(teamId);
-          await api.waitForFeatureToBeEnabled(FEATURE_KEY.CELLS, teamId, owner.token);
-        }
-      }
-
-      return {teamId, owner, addTeamMember};
+      const team = await createTeam(api, teamName, options);
+      teamOwners.push(team.owner);
+      return team;
     });
 
     // Deletes each created team and the owner / members associated with it
@@ -267,4 +193,82 @@ export const createUser = async (
   }
 
   return user;
+};
+
+export const createTeam = async (
+  api: ApiManagerE2E,
+  teamName: string,
+  options?: {
+    users?: (User | {user: User; role?: keyof typeof Role})[];
+    features?: {
+      conferenceCalling?: boolean;
+      channels?: boolean;
+      mls?: boolean | Parameters<BrigRepositoryE2E['configureMLSFeature']>[1];
+      cells?: boolean;
+    };
+  },
+) => {
+  const owner = await createUser(api);
+
+  const {teamId} = await api.auth.upgradeUserToTeamOwner(owner, teamName);
+  owner.teamId = teamId;
+
+  const addTeamMember: Team['addTeamMember'] = async (member, options) => {
+    const invitationId = await api.team.inviteUserToTeam(member.email, owner, Role[options?.role ?? 'MEMBER']);
+    const invitationCode = await api.brig.getTeamInvitationCodeForEmail(owner.teamId, invitationId);
+    await api.team.acceptTeamInvitation(invitationCode, member);
+  };
+
+  if (options?.users) {
+    await Promise.all(
+      options.users.map(user => {
+        if ('user' in user) {
+          return addTeamMember(user.user, {role: user.role});
+        } else {
+          return addTeamMember(user);
+        }
+      }),
+    );
+  }
+
+  if (options?.features && Object.values(options.features).some(Boolean)) {
+    // The team will be reset right after initialization, so we need to wait a short time for it to finish
+    // before changing feature configs since they would otherwise be overwritten (See WPB-23698)
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    if (options.features.conferenceCalling) {
+      await api.enableConferenceCallingFeature(teamId);
+      await api.waitForFeatureToBeEnabled(FEATURE_KEY.CONFERENCE_CALLING, teamId, owner.token);
+    }
+
+    if (options.features.mls) {
+      await api.brig.configureMLSFeature(
+        owner.teamId,
+        options.features.mls === true
+          ? {status: 'enabled', defaultProtocol: 'mls', supportedProtocols: ['mls', 'proteus']}
+          : options.features.mls,
+      );
+    }
+
+    if (options.features.channels) {
+      // Creating channels depends on MLS to be enabled
+      await api.brig.configureMLSFeature(owner.teamId, {
+        defaultProtocol: 'mls',
+        supportedProtocols: ['mls', 'proteus'],
+      });
+      await api.waitForFeatureToBeEnabled(FEATURE_KEY.MLS, teamId, owner.token);
+
+      await api.brig.unlockChannelFeature(teamId);
+      await api.brig.enableChannelsFeature(teamId);
+      await api.waitForFeatureToBeEnabled(FEATURE_KEY.CHANNELS, teamId, owner.token);
+    }
+
+    if (options.features.cells) {
+      await api.brig.unlockCellsFeature(teamId);
+      await api.brig.enableCells(teamId);
+      await api.waitForFeatureToBeEnabled(FEATURE_KEY.CELLS, teamId, owner.token);
+    }
+  }
+
+  return {teamId, owner, addTeamMember};
 };

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -217,10 +217,10 @@ export const LOGIN_TIMEOUT = 40_000;
 
 /** PagePlugin to log in as the given user */
 export const withLogin =
-  (user: User | Promise<User>, options?: {confirmNewHistory?: boolean}): PagePlugin =>
+  (user: User | Promise<User>, options?: {baseUrl?: string; confirmNewHistory?: boolean}): PagePlugin =>
   async page => {
     const pageManager = PageManager.from(page);
-    await pageManager.openLoginPage();
+    await pageManager.openLoginPage(options?.baseUrl);
     await pageManager.webapp.pages.login().login(await user);
 
     if (options?.confirmNewHistory) {

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -76,9 +76,15 @@ export type Team = {
 export {expect} from '@playwright/test';
 
 export const test = baseTest.extend<Fixtures>({
+  // Create a new instance of ApiManager for each test
   api: async ({}, use) => {
-    // Create a new instance of ApiManager for each test
-    await use(new ApiManagerE2E());
+    const backendUrl = process.env.BACKEND_URL;
+    if (backendUrl === undefined) throw new Error('Missing environment variable BACKEND_URL');
+
+    const basicAuth = process.env.BASIC_AUTH;
+    if (basicAuth === undefined) throw new Error('Missing environment variable BASIC_AUTH');
+
+    await use(new ApiManagerE2E({backendUrl, basicAuth}));
   },
   pageManager: async ({page}, use) => {
     // Create a new instance of PageManager for each test
@@ -246,7 +252,7 @@ export const withGuestUser =
     await pageManager.webapp.pages.conversation().conversationTitle.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
   };
 
-const createUser = async (
+export const createUser = async (
   api: ApiManagerE2E,
   options?: {disableTelemetry?: boolean} & Parameters<typeof getUser>[0],
 ) => {

--- a/apps/webapp/test/e2e_tests/utils/userActions.ts
+++ b/apps/webapp/test/e2e_tests/utils/userActions.ts
@@ -89,8 +89,13 @@ export async function connectWithUser(sender: Page | PageManager, receiver: Pick
 export async function sendConnectionRequest(sender: Page | PageManager, receiver: User) {
   const {pages, modals, components} = ('webapp' in sender ? sender : PageManager.from(sender)).webapp;
   await components.conversationSidebar().clickConnectButton();
-  await pages.startUI().searchInput.fill(receiver.username);
-  await pages.startUI().selectUsers(receiver.username);
+
+  const userHandle = receiver.qualifiedId?.domain
+    ? `${receiver.username}@${receiver.qualifiedId?.domain}`
+    : receiver.username;
+
+  await pages.startUI().searchInput.fill(userHandle);
+  await pages.startUI().selectUsers(userHandle);
   await modals.userProfile().clickConnectButton();
 }
 

--- a/apps/webapp/test/e2e_tests/utils/userActions.ts
+++ b/apps/webapp/test/e2e_tests/utils/userActions.ts
@@ -95,7 +95,7 @@ export async function sendConnectionRequest(sender: Page | PageManager, receiver
     : receiver.username;
 
   await pages.startUI().searchInput.fill(userHandle);
-  await pages.startUI().selectUsers(userHandle);
+  await pages.startUI().searchResults.filter({hasText: receiver.username}).click();
   await modals.userProfile().clickConnectButton();
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19988" title="WPB-19988" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19988</a>  [Web/QA] Write the Federation regression tests in Playwright
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR introduces new Federation regression test suite.

These tests validate key federation capabilities, including asset sharing, cross-backend communication, backup imports, and real-time audio/video calls between different backend environments.

Changes:
 - New Regression Coverage: Added 6 new automated test cases.
 - Refactored API-related logic to dynamically support requests across different backend environments.
 - Extended the CreateTeam fixture and PageManager to accept and initialize distinct backend configurations.
 - Refactored conversation participant selectors to eliminate duplication and improve maintainability.


