### PR TITLE
fix(api-client): reconnect in place instead of spawning a second /await socket [WPB-21916]

### DIFF
--- a/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
@@ -25,7 +25,7 @@ import {Server as WebSocketServer} from 'ws';
 
 import {AddressInfo} from 'net';
 
-import {PingMessage, ReconnectingWebsocket, WEBSOCKET_STATE} from './reconnectingWebsocket';
+import {CloseEventCode, PingMessage, ReconnectingWebsocket, WEBSOCKET_STATE} from './reconnectingWebsocket';
 
 async function startEchoServer(): Promise<WebSocketServer> {
   const server = new WebSocketServer({host: '127.0.0.1', port: 0});
@@ -117,41 +117,35 @@ describe('ReconnectingWebsocket', () => {
     RWS.connect();
   });
 
-  it('closes an existing active socket before reconnecting', () => {
+  it('reconnects in place when connect is called on an open socket', () => {
     const onReconnect = jest.fn().mockReturnValue(getServerAddress());
     const RWS = createRWS(onReconnect);
 
-    const firstSocket = {
+    const socket = {
       readyState: WEBSOCKET_STATE.OPEN,
       close: jest.fn(),
-      send: jest.fn(),
       reconnect: jest.fn(),
+      send: jest.fn(),
       onmessage: undefined,
       onerror: undefined,
       onopen: undefined,
       onclose: undefined,
     };
 
-    const secondSocket = {
-      readyState: WEBSOCKET_STATE.CONNECTING,
-      close: jest.fn(),
-      send: jest.fn(),
-      reconnect: jest.fn(),
-      onmessage: undefined,
-      onerror: undefined,
-      onopen: undefined,
-      onclose: undefined,
-    };
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const getSocketSpy = jest.spyOn(RWS, 'getReconnectingWebsocket');
-    getSocketSpy.mockReturnValueOnce(firstSocket).mockReturnValueOnce(secondSocket);
+    const getSocketSpy = jest.spyOn(
+      RWS as unknown as {getReconnectingWebsocket: () => typeof RWS},
+      'getReconnectingWebsocket',
+    );
+    getSocketSpy.mockReturnValueOnce(socket as unknown as typeof RWS);
 
     RWS.connect();
     RWS.connect();
 
-    expect(firstSocket.close).toHaveBeenCalledWith(1000, 'Reinitializing WebSocket connection');
-    expect(RWS['socket']).toBe(secondSocket);
+    expect(getSocketSpy).toHaveBeenCalledTimes(1);
+    expect(socket.reconnect).toHaveBeenCalledTimes(1);
+    expect(socket.reconnect).toHaveBeenCalledWith(CloseEventCode.NORMAL_CLOSURE);
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(RWS['socket']).toBe(socket);
 
     RWS.disconnect();
   });
@@ -792,7 +786,7 @@ describe('ReconnectingWebsocket', () => {
     it('cleans up resources even when socket does not exist', () => {
       const onReconnect = jest.fn().mockReturnValue(getServerAddress());
       const RWS = createRWS(onReconnect);
-      const cleanupSpy = jest.spyOn(RWS, 'cleanup');
+      const cleanupSpy = jest.spyOn(RWS as any, 'cleanup');
 
       RWS.disconnect();
 

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -217,29 +217,34 @@ export class ReconnectingWebsocket {
     this.send(PingMessage.PING);
   };
 
+  /**
+   * Reconnect on the existing ReconnectingWebSocket wrapper instead of allocating a new one.
+   * The library closes the current underlying WebSocket synchronously in `_disconnect` before
+   * opening the next, so we never leave two `/await` sessions alive from the app.
+   */
+  private reconnectInPlace(socket: RWS): void {
+    try {
+      socket.reconnect(CloseEventCode.NORMAL_CLOSURE);
+    } catch (error) {
+      this.logger.warn('Failed to reconnect WebSocket in place', error);
+    }
+  }
+
   public connect(): void {
     this.logger.info('Initializing WebSocket connection');
     this.resetLongRunningRetrySequence();
+    this.stopPinging();
 
-    if (!is.undefined(this.socket) && this.socket.readyState !== WEBSOCKET_STATE.CLOSED) {
-      this.logger.warn(
-        `Existing WebSocket instance detected in state ${WEBSOCKET_STATE[this.socket.readyState]} (${this.socket.readyState}); closing it before reconnecting`,
-      );
-      const oldSocket = this.socket;
-      // Detach all handlers from the old socket before closing to prevent stale async events
-      // from triggering handlers on the new socket instance
-      oldSocket.onmessage = null;
-      oldSocket.onerror = null;
-      oldSocket.onopen = null;
-      oldSocket.onclose = null;
-      try {
-        oldSocket.close(CloseEventCode.NORMAL_CLOSURE, 'Reinitializing WebSocket connection');
-      } catch (error) {
-        this.logger.warn('Failed to close existing WebSocket instance before reconnecting', error);
+    if (!is.undefined(this.socket)) {
+      if (this.socket.readyState !== WEBSOCKET_STATE.CLOSED) {
+        this.logger.warn(
+          `Existing WebSocket instance detected in state ${WEBSOCKET_STATE[this.socket.readyState]} (${this.socket.readyState}); reconnecting in place`,
+        );
       }
+      this.reconnectInPlace(this.socket);
+      return;
     }
 
-    this.stopPinging();
     const nextSocket = this.getReconnectingWebsocket();
     this.socket = nextSocket;
     this.bindSocketHandlers(nextSocket);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
When connect() was called while a ReconnectingWebSocket wrapper already existed, we allocated a new RWS instance and only fire-and-forget closed the old one. That could leave two OPEN /await sessions on the same client id — both could ping/pong, but Nginz fans notifications to only one, causing silent message loss (LIVE UI, no new notifications).

Reuse the existing wrapper and call reconnect() instead. The library synchronously closes the underlying WebSocket in _disconnect before starting _connect, so the app never holds two competing sessions.

Also update the connect() unit test to assert in-place reconnect rather than close + new instance.


