### PR TITLE
feat: hide profile pictures for incoming cloud connection requests - WPB-26227

### DIFF
--- a/apps/webapp/src/script/components/Avatar/Avatar.tsx
+++ b/apps/webapp/src/script/components/Avatar/Avatar.tsx
@@ -80,6 +80,7 @@ interface AvatarProps extends HTMLProps<HTMLDivElement> {
   isResponsive?: boolean;
   onAvatarClick?: (participant: User | ServiceEntity) => void;
   hideAvailabilityStatus?: boolean;
+  hideProfilePicture?: boolean;
 }
 
 const Avatar = ({

--- a/apps/webapp/src/script/components/Avatar/UserAvatar/UserAvatar.test.tsx
+++ b/apps/webapp/src/script/components/Avatar/UserAvatar/UserAvatar.test.tsx
@@ -157,6 +157,36 @@ describe('UserAvatar', () => {
     expect(statusAvailabilityIcon.getAttribute('data-uie-value')).toEqual('busy');
   });
 
+  it('does not render the profile picture image when hideProfilePicture is true', () => {
+    const participant = new User('id');
+    participant.name('Anton Bertha');
+
+    const props = {
+      avatarSize: AVATAR_SIZE.LARGE,
+      participant,
+      state: STATE.NONE,
+      hideProfilePicture: true,
+    };
+
+    const {queryByRole} = render(<UserAvatar {...props} />);
+    expect(queryByRole('img')).toBeNull();
+  });
+
+  it('renders the profile picture image when hideProfilePicture is false', () => {
+    const participant = new User('id');
+    participant.name('Anton Bertha');
+
+    const props = {
+      avatarSize: AVATAR_SIZE.LARGE,
+      participant,
+      state: STATE.NONE,
+      hideProfilePicture: false,
+    };
+
+    const {getByRole} = render(<UserAvatar {...props} />);
+    expect(getByRole('img')).not.toBeNull();
+  });
+
   it('does not show availability icon if param is false', async () => {
     const participant = new User('id');
 

--- a/apps/webapp/src/script/components/Avatar/UserAvatar/UserAvatar.tsx
+++ b/apps/webapp/src/script/components/Avatar/UserAvatar/UserAvatar.tsx
@@ -51,6 +51,7 @@ interface UserAvatarProps {
   participant: User;
   state: STATE;
   hideAvailabilityStatus?: boolean;
+  hideProfilePicture?: boolean;
   teamState?: TeamState;
 }
 
@@ -78,6 +79,7 @@ export const UserAvatar = ({
   state,
   onAvatarInteraction,
   hideAvailabilityStatus = false,
+  hideProfilePicture = false,
   teamState = container.resolve(TeamState),
   ...props
 }: UserAvatarProps) => {
@@ -119,14 +121,16 @@ export const UserAvatar = ({
       <AvatarBackground backgroundColor={backgroundColor} />
 
       {initials && <AvatarInitials avatarSize={avatarSize} initials={initials} />}
-      <AvatarImage
-        avatarSize={avatarSize}
-        avatarAlt={avatarImgAlt}
-        backgroundColor={backgroundColor}
-        isGrey={isImageGrey}
-        mediumPicture={mediumPictureResource}
-        previewPicture={previewPictureResource}
-      />
+      {!hideProfilePicture && (
+        <AvatarImage
+          avatarSize={avatarSize}
+          avatarAlt={avatarImgAlt}
+          backgroundColor={backgroundColor}
+          isGrey={isImageGrey}
+          mediumPicture={mediumPictureResource}
+          previewPicture={previewPictureResource}
+        />
+      )}
       {noBadge !== true && shouldShowBadge(avatarSize, state) && (
         <AvatarBadge state={state} iconSize={getIconSize(avatarSize)} />
       )}

--- a/apps/webapp/src/script/components/ConnectRequests/ConnectionRequests.tsx
+++ b/apps/webapp/src/script/components/ConnectRequests/ConnectionRequests.tsx
@@ -151,6 +151,7 @@ export const ConnectRequests = ({
                 noBadge
                 noFilter
                 hideAvailabilityStatus
+                hideProfilePicture={connectRequest.domain === 'wire.com' || connectRequest.domain === 'staging.zinfra.io'}
               />
 
               <UnverifiedUserWarning />

--- a/apps/webapp/src/script/components/ConnectRequests/ConnectionRequests.tsx
+++ b/apps/webapp/src/script/components/ConnectRequests/ConnectionRequests.tsx
@@ -151,7 +151,9 @@ export const ConnectRequests = ({
                 noBadge
                 noFilter
                 hideAvailabilityStatus
-                hideProfilePicture={connectRequest.domain === 'wire.com' || connectRequest.domain === 'staging.zinfra.io'}
+                hideProfilePicture={
+                  connectRequest.domain === 'wire.com' || connectRequest.domain === 'staging.zinfra.io'
+                }
               />
 
               <UnverifiedUserWarning />


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26227" title="WPB-26227" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26227</a>  [Web] Hide (incoming) connection request profile picture
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR hides the profile picture of *incoming* connection requests until accepted, if the sender of the connection request is a Wire cloud account (or staging, for testing purposes).

This is a measure taken to contrast receiving unsolicited crude pictures via profile pictures in connection requests.