### PR TITLE
Handle missing conversation domains in qualified IDs [WPB-26233]

### DIFF
--- a/apps/webapp/src/script/util/qualifiedId.test.ts
+++ b/apps/webapp/src/script/util/qualifiedId.test.ts
@@ -27,6 +27,14 @@ describe('QualifiedId util', () => {
         {domain: '', id: '1', property: 1},
       ],
       [
+        {id: '1', stuff: 'extra'},
+        {domain: 'wire.com', id: '1', property: 1},
+      ],
+      [
+        {domain: undefined, id: '1', stuff: 'extra'},
+        {domain: 'wire.com', id: '1', property: 1},
+      ],
+      [
         {domain: 'wire.com', id: '1', other: 12},
         {domain: 'wire.com', id: '1'},
       ],
@@ -47,6 +55,10 @@ describe('QualifiedId util', () => {
         {domain: 'wire.com', id: '1', other: 12},
         {domain: '', id: '1'},
       ],
+      [
+        {domain: null, id: '1', other: 12},
+        {domain: 'wire.com', id: '1'},
+      ],
     ])('only matches ids if one domain is empty (%s, %s)', (entity1, entity2) => {
       expect(matchQualifiedIds(entity1, entity2)).toBe(true);
     });
@@ -60,7 +72,19 @@ describe('QualifiedId util', () => {
         {domain: 'bella.wire.link', id: '1'},
         {domain: 'wire.com', id: '1'},
       ],
+      [{id: '1'}, {domain: 'wire.com', id: '2'}],
+      [
+        {domain: undefined, id: '1'},
+        {domain: 'wire.com', id: '2'},
+      ],
     ])('does not match entities that have different ids (%s, %s)', (entity1, entity2) => {
+      expect(matchQualifiedIds(entity1, entity2)).toBe(false);
+    });
+
+    it.each([
+      [{domain: 'wire.com', id: '1'}, undefined],
+      [undefined, {domain: 'wire.com', id: '1'}],
+    ])('returns false when one entity is undefined (%s, %s)', (entity1, entity2) => {
       expect(matchQualifiedIds(entity1, entity2)).toBe(false);
     });
   });

--- a/apps/webapp/src/script/util/qualifiedId.ts
+++ b/apps/webapp/src/script/util/qualifiedId.ts
@@ -17,10 +17,16 @@
  *
  */
 
+import is from '@sindresorhus/is';
+
 interface QualifiedEntity {
   [index: string]: any;
-  domain: string | null;
+  domain?: string | null;
   id: string;
+}
+
+function isUnqualifiedDomain(domain: string | null | undefined): boolean {
+  return is.nullOrUndefined(domain) || is.emptyString(domain);
 }
 
 /**
@@ -31,17 +37,14 @@ interface QualifiedEntity {
  * @param entity2 - The second entity to compare
  * @return boolean - do the entities match
  */
-export function matchQualifiedIds(entity1?: QualifiedEntity, entity2?: QualifiedEntity) {
-  if (entity1 === undefined || entity2 === undefined) {
+export function matchQualifiedIds(entity1?: QualifiedEntity, entity2?: QualifiedEntity): boolean {
+  if (is.undefined(entity1) || is.undefined(entity2)) {
     return false;
   }
 
   const idsMatch = entity1.id === entity2.id;
   const domainsMatch =
-    entity1.domain === null ||
-    entity2.domain === null ||
-    entity1.domain.length === 0 ||
-    entity2.domain.length === 0 ||
-    entity1.domain === entity2.domain;
+    isUnqualifiedDomain(entity1.domain) || isUnqualifiedDomain(entity2.domain) || entity1.domain === entity2.domain;
+
   return idsMatch && domainsMatch;
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26233" title="WPB-26233" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26233</a>  [Web] App stuck on "Fetching your connections and conversations" — matchQualifiedIds throws on legacy conversations with an undefined domain
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Accept legacy qualified IDs with omitted or undefined domains in matchQualifiedIds to prevent startup failures when older IndexedDB conversation records are loaded.

Add regression tests for omitted and undefined domains and preserve existing matching behavior for null, empty, and fully qualified domains.

Fixes #21409


