### PR TITLE
Move Playwright critical flows out of pull requests [WPB-22420]

### DIFF
--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -13,7 +13,7 @@ on:
       timezone: Europe/Berlin
 
 concurrency:
-  group: critical-flow-${{ github.event_name }}-${{ github.ref }}
+  group: precommit-crit-flows-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -1,48 +1,37 @@
+---
 name: precommit-crit-flows
 
 on:
-  pull_request:
-    branches: [master, dev, release/*]
-    types: [opened, synchronize, reopened, ready_for_review]
-  merge_group:
-    branches: [master, dev, release/*]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Why this critical flow run was started
+        required: false
+        type: string
+  schedule:
+    - cron: '17 8,20 * * *'
+      timezone: Europe/Berlin
 
-# Cancel superseded runs on the same PR; slot-level concurrency guards the shared EB environments
 concurrency:
-  group: precommit-pr-${{ github.event.pull_request.number || github.run_id }}
+  group: critical-flow-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
-    if: ${{ github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ github.repository == 'wireapp/wire-webapp' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     outputs:
-      unit_tests_report: ${{ env.UNIT_TEST_REPORT_FILE }}
       build_artifact: ${{ env.BUILD_ARTIFACT }}
-      total_additions: ${{ steps.check_additions.outputs.total_additions }}
-      commit_url: ${{ steps.meta.outputs.commit_url }}
-      committer: ${{ steps.meta.outputs.committer }}
       env_name: ${{ steps.slot.outputs.env_name }}
 
     env:
       BUILD_DIR: apps/server/dist/s3/
       BUILD_ARTIFACT: ebs.zip
-      CHANGELOG_FILE: ./changelog.md
-      UNIT_TEST_REPORT_FILE: ./unit-tests.log
 
     steps:
-      - name: Checkout (pull_request)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Checkout (merge_group)
-        if: ${{ github.event_name == 'merge_group' }}
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
@@ -65,14 +54,11 @@ jobs:
       - name: Compute target EB environment
         id: slot
         run: |
-          if [[ "${{ github.actor }}" == "renovate[bot]" ]]; then
-            # Renovate uses the dedicated precommit environment.
-            echo "env_name=wire-webapp-precommit" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Keep manual runs away from the scheduled critical-flow slot.
+            echo "env_name=wire-webapp-precommit-2" >> "$GITHUB_OUTPUT"
           else
-            # Spread other PRs across 3 pre-created EB environments; merge queue uses run_id.
-            ID="${{ github.event.pull_request.number || github.run_id }}"
-            SLOT=$(( (ID % 3) + 1 ))
-            echo "env_name=wire-webapp-precommit-$SLOT" >> "$GITHUB_OUTPUT"
+            echo "env_name=wire-webapp-precommit-1" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Log target EB environment
@@ -82,34 +68,10 @@ jobs:
           echo "Selected precommit environment: $ENV_NAME"
           echo "Selected precommit URL: https://$ENV_NAME.zinfra.io/"
 
-      - name: Derive PR commit metadata
-        id: meta
-        run: |
-          SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          COMMIT_URL="https://github.com/${{ github.repository }}/commit/$SHA"
-          AUTHOR="$(git show -s --format='%an' "$SHA" || true)"
-          echo "COMMIT_URL=$COMMIT_URL" >> "$GITHUB_ENV"
-          echo "COMMITTER=$AUTHOR" >> "$GITHUB_ENV"
-          echo "commit_url=$COMMIT_URL" >> "$GITHUB_OUTPUT"
-          echo "committer=$AUTHOR" >> "$GITHUB_OUTPUT"
-
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: build-artifact
           path: ${{ env.BUILD_DIR }}${{ env.BUILD_ARTIFACT }}
-
-      - name: Check total PR additions
-        if: ${{ github.event_name == 'pull_request' }}
-        id: check_additions
-        run: |
-          total_additions=$(gh api -H "Accept: application/vnd.github.v3+json" \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
-            | jq -r '.additions')
-          test -n "$total_additions" -a "$total_additions" != null
-          echo "Found total additions: $total_additions"
-          echo "total_additions=$total_additions" >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy_and_run_e2e:
     name: Deploy to precommit and run E2E
@@ -119,15 +81,16 @@ jobs:
     with:
       env_name: ${{ needs.build.outputs.env_name }}
       backendUrl: https://staging-nginz-https.zinfra.io/
-      # Run all E2E tests when attempting to merge to master when running for a PR as well as in the merge queue (base_ref contains the full ref name instead of the short name on merge_group)
-      grep: ${{ case(github.base_ref == 'master' || github.event.merge_group.base_ref == 'refs/heads/master', '', '@crit-flow-web') }}
+      grep: '@crit-flow-web'
+      notify_deployoholics_on_failure: true
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       WEBTEAM_AWS_ACCESS_KEY_ID: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
       WEBTEAM_AWS_SECRET_ACCESS_KEY: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+      WIRE_DEPLOYOHOLICS_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
 
   run_e2e_tests:
-    name: Playwright Critical Flow (precommit)
+    name: Playwright Critical Flow
     if: ${{ always() && github.repository == 'wireapp/wire-webapp' }}
     needs: [deploy_and_run_e2e]
     runs-on: ubuntu-24.04
@@ -145,71 +108,62 @@ jobs:
           fi
 
   e2e-report:
-    name: Generate test report
-    needs: deploy_and_run_e2e
-    if: ${{ success() && (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) }}
+    name: Generate test summary
+    needs: [build, deploy_and_run_e2e]
+    if: ${{ always() && github.repository == 'wireapp/wire-webapp' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
-      - name: Checkout (pull_request)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Checkout (merge_group)
-        if: ${{ github.event_name == 'merge_group' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-
       - name: Download report
+        if: ${{ needs.deploy_and_run_e2e.outputs.reportArtifactId != '' }}
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           artifact-ids: ${{ needs.deploy_and_run_e2e.outputs.reportArtifactId }}
           path: apps/webapp/playwright-report
 
-      - name: Generate PR comment
-        if: ${{ always() && github.event_name == 'pull_request' && github.actor != 'renovate[bot]' }}
-        id: generate_comment
+      - name: Write step summary
+        env:
+          BACKEND_URL: https://staging-nginz-https.zinfra.io/
+          DEPLOY_AND_RUN_E2E_RESULT: ${{ needs.deploy_and_run_e2e.result }}
+          ENV_NAME: ${{ needs.build.outputs.env_name }}
+          GREP: '@crit-flow-web'
+          PRECOMMIT_URL: ${{ needs.deploy_and_run_e2e.outputs.precommit_url }}
+          REPORT_URL: ${{ needs.deploy_and_run_e2e.outputs.reportUrl }}
+          WORKFLOW_DISPATCH_REASON: ${{ inputs.reason }}
         run: |
-          echo "Checking for Playwright report..."
-          ls -la apps/webapp/playwright-report/ || echo "No playwright-report directory found"
-          ls -la apps/webapp/playwright-report/report.json || echo "No report.json found"
+          {
+            echo "## Playwright Critical Flow"
+            echo ""
+            echo "- Environment: \`$ENV_NAME\`"
+            echo "- Webapp URL: $PRECOMMIT_URL"
+            echo "- Backend URL: $BACKEND_URL"
+            echo "- Grep: \`$GREP\`"
+            echo "- Result: \`$DEPLOY_AND_RUN_E2E_RESULT\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          # Check if report.json exists before running the script
-          if [ -f "apps/webapp/playwright-report/report.json" ]; then
-            cd apps/webapp && node --experimental-strip-types test/e2e_tests/scripts/create-playwright-report-summary.ts playwright-report && cd ../..
-            if [ -f apps/webapp/playwright-report-summary.txt ]; then
-              COMMENT=$(cat apps/webapp/playwright-report-summary.txt)
-            else
-              COMMENT="❌ Playwright report summary could not be generated from the report data"
-            fi
-          else
-            COMMENT="❌ No Playwright report.json found - test execution may have failed or no tests were run"
+          if [[ -n "$WORKFLOW_DISPATCH_REASON" ]]; then
+            echo "- Manual run reason: $WORKFLOW_DISPATCH_REASON" >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          echo "comment<<EOF" >> $GITHUB_OUTPUT
-          echo "$COMMENT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          if [[ -n "$REPORT_URL" ]]; then
+            echo "- Report artifact: $REPORT_URL" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Report artifact: unavailable" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
-      - name: Comment on PR
-        if: ${{ always() && github.event_name == 'pull_request' && github.actor != 'renovate[bot]' }}
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
-        with:
-          header: playwright-summary
-          message: |
-            🔗 [Download Full Report Artifact](${{ needs.deploy_and_run_e2e.outputs.reportUrl }})
+          REPORT_FILE="apps/webapp/playwright-report/report.json"
+          if [[ ! -f "$REPORT_FILE" ]]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No Playwright report summary is available." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
 
-            ${{ steps.generate_comment.outputs.comment }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Failure Summary" >> "$GITHUB_STEP_SUMMARY"
+          FAILED_TESTS="$(jq -r '[.. | objects | select(has("specs") and (.specs | length > 0)) | .title as $suite | .specs[] | .title as $title | .tests[] | select(.status == "unexpected") | "- " + $suite + " > " + $title] | unique | .[]?' "$REPORT_FILE" || true)"
+          if [[ -n "$FAILED_TESTS" ]]; then
+            echo "$FAILED_TESTS" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No failed tests found in the report." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/precommit-slot-run.yml
+++ b/.github/workflows/precommit-slot-run.yml
@@ -1,3 +1,4 @@
+---
 name: precommit-slot-run
 
 on:
@@ -12,6 +13,10 @@ on:
       grep:
         type: string
         required: false
+      notify_deployoholics_on_failure:
+        type: boolean
+        required: false
+        default: false
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN:
         required: true
@@ -19,6 +24,8 @@ on:
         required: true
       WEBTEAM_AWS_SECRET_ACCESS_KEY:
         required: true
+      WIRE_DEPLOYOHOLICS_WEBHOOK_URL:
+        required: false
     outputs:
       precommit_url:
         description: URL of the deployed precommit environment
@@ -49,6 +56,19 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: build-artifact
+
+      - name: Validate precommit environment
+        env:
+          ENV_NAME: ${{ inputs.env_name }}
+        run: |
+          case "$ENV_NAME" in
+            wire-webapp-precommit|wire-webapp-precommit-1|wire-webapp-precommit-2|wire-webapp-precommit-3)
+              ;;
+            *)
+              echo "Invalid precommit environment: $ENV_NAME"
+              exit 1
+              ;;
+          esac
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
@@ -99,3 +119,28 @@ jobs:
       grep: ${{ inputs.grep }}
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+  notify_deployoholics:
+    name: Notify Deployoholics about failed critical flow
+    runs-on: ubuntu-24.04
+    needs: [deploy_to_aws, e2e_tests]
+    if: ${{ always() && inputs.notify_deployoholics_on_failure && needs.e2e_tests.result == 'failure' }}
+
+    steps:
+      - name: Announce failed critical flow
+        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+        with:
+          status: failure
+          text: |
+            ❌ Playwright Critical Flow failed ❌
+
+            Workflow: ${{ github.workflow }}
+            Triggered by: ${{ github.actor }}
+            Event: ${{ github.event_name }}
+            Ref: ${{ github.ref_name }}
+            Commit: ${{ github.sha }}
+            Environment: ${{ inputs.env_name }}
+            Build log: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            Report: ${{ needs.e2e_tests.outputs.reportUrl || 'unavailable' }}

--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -1,3 +1,4 @@
+---
 name: Publish and deploy webapp
 
 on:
@@ -273,14 +274,30 @@ jobs:
             echo "targets=${deployment_targets_json}" >> "$GITHUB_ENV"
           fi
 
+  release_critical_flow:
+    name: Playwright Critical Flow (release)
+    needs: [build]
+    if: ${{ github.repository == 'wireapp/wire-webapp' && github.ref_type == 'tag' && (contains(github.ref_name, 'staging') || contains(github.ref_name, 'production')) }}
+    uses: ./.github/workflows/precommit-slot-run.yml
+    with:
+      env_name: wire-webapp-precommit-3
+      backendUrl: https://staging-nginz-https.zinfra.io/
+      grep: '@crit-flow-web'
+      notify_deployoholics_on_failure: true
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      WEBTEAM_AWS_ACCESS_KEY_ID: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+      WEBTEAM_AWS_SECRET_ACCESS_KEY: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+      WIRE_DEPLOYOHOLICS_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+
   deploy_to_aws:
     name: 'Deploy to live environments'
     runs-on: ubuntu-24.04
     env:
       AWS_REGION: eu-central-1
     environment: ${{ matrix.target }}
-    needs: [build, set_deployment_targets]
-    if: ${{needs.set_deployment_targets.outputs.deployment_targets}}
+    needs: [build, set_deployment_targets, release_critical_flow]
+    if: ${{ always() && needs.build.result == 'success' && needs.set_deployment_targets.result == 'success' && needs.set_deployment_targets.outputs.deployment_targets && (needs.release_critical_flow.result == 'success' || needs.release_critical_flow.result == 'skipped') }}
 
     strategy:
       matrix:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Run the Playwright critical flow as a scheduled and release-gated confidence check instead of a required check on every pull request.

The previous setup deployed pull request builds to shared precommit environments and ran critical-flow E2E tests before merge. That made normal pull request feedback slower and added contention around a limited number of precommit slots.

The workflow now runs twice per day and can still be triggered manually when needed. Staging and production releases call the same precommit slot workflow as a release gate, so critical flows still block releases without blocking ordinary pull requests.

Failed critical-flow test runs now notify Deployoholics using the existing deployment failure notification channel. This makes failed scheduled or release-gated runs visible without relying on pull request comments.


