### PR TITLE
Fix modal roles to prevent nested dialogs [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/Modals/ModalComponent/ModalComponent.tsx
+++ b/apps/webapp/src/script/components/Modals/ModalComponent/ModalComponent.tsx
@@ -130,10 +130,10 @@ const ModalComponent = ({
           {showLoading ? (
             <LoadingIcon width="48" height="48" css={{path: {fill: 'var(--modal-bg)'}}} />
           ) : (
+            // eslint-disable-next-line jsx-a11y/no-static-element-interactions --- tabIndex is already set to -1 through enum value
             <div
               id={trapId}
               onClick={event => event.stopPropagation()}
-              role="button"
               tabIndex={TabIndex.UNFOCUSABLE}
               onKeyDown={event => (onKeyDown ? onKeyDown(event) : event.stopPropagation())}
               css={{...(hasVisibleClass ? ModalContentVisibleStyles : ModalContentStyles), ...wrapperCSS}}

--- a/apps/webapp/src/script/components/Modals/PrimaryModal/PrimaryModalShell/PrimaryModalShell.tsx
+++ b/apps/webapp/src/script/components/Modals/PrimaryModal/PrimaryModalShell/PrimaryModalShell.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {ReactNode, useEffect, useRef} from 'react';
+import {ReactNode, useEffect} from 'react';
 
 import {Runtime} from '@wireapp/commons';
 
@@ -48,8 +48,6 @@ export const PrimaryModalShell = ({
   size,
   container,
 }: PrimaryModalShellProps) => {
-  const modalsRef = useRef<HTMLDivElement | null>(null);
-
   // Make detached window background inert when modal is shown
   useEffect(() => {
     if (!container) {
@@ -95,15 +93,7 @@ export const PrimaryModalShell = ({
   }, [isShown, container]);
 
   return (
-    <div
-      id="modals"
-      data-uie-name="primary-modals-container"
-      role="dialog"
-      aria-modal="true"
-      aria-label={title}
-      tabIndex={-1}
-      ref={modalsRef}
-    >
+    <div id="modals" data-uie-name="primary-modals-container" aria-label={title}>
       <ModalComponent
         isShown={isShown}
         onClosed={onClose}

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/acknowledge.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/acknowledge.modal.ts
@@ -23,6 +23,6 @@ import {BaseModal} from './base.modal';
 
 export class AcknowledgeModal extends BaseModal {
   constructor(page: Page) {
-    super(page, 'modal-template-acknowledge');
+    super(page);
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/base.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/base.modal.ts
@@ -26,8 +26,8 @@ export abstract class BaseModal {
   readonly actionButton: Locator;
   readonly cancelButton: Locator;
 
-  constructor(page: Page, modalLocator: string) {
-    this.modal = page.getByTestId(modalLocator);
+  constructor(page: Page) {
+    this.modal = page.getByRole('dialog');
     this.modalTitle = this.modal.getByTestId('status-modal-title');
     this.modalText = this.modal.getByTestId('status-modal-text');
     this.actionButton = this.modal.getByTestId('do-action');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/confirm.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/confirm.modal.ts
@@ -23,6 +23,6 @@ import {BaseModal} from './base.modal';
 
 export class ConfirmModal extends BaseModal {
   constructor(page: Page) {
-    super(page, 'modal-template-confirm');
+    super(page);
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/guestLinkPassword.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/guestLinkPassword.modal.ts
@@ -28,7 +28,7 @@ export class GuestLinkPasswordModal extends BaseModal {
   readonly errorMessage: Locator;
 
   constructor(page: Page) {
-    super(page, 'modal-template-guest-link-password');
+    super(page);
 
     this.setPasswordInput = this.modal.getByRole('textbox', {name: 'Set password'});
     this.confirmPasswordInput = this.modal.getByRole('textbox', {name: 'Confirm password'});

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/joinGuestLinkPassword.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/joinGuestLinkPassword.modal.ts
@@ -28,7 +28,7 @@ export class JoinGuestLinkPasswordModal extends BaseModal {
   readonly joinForm: Locator;
 
   constructor(page: Page) {
-    super(page, 'modal');
+    super(page);
 
     this.passwordInput = this.modal.getByRole('textbox', {name: 'Conversation password'});
     this.submitButton = this.modal.getByRole('button', {name: 'Join conversation'});

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/newDevice.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/newDevice.modal.ts
@@ -23,6 +23,6 @@ import {BaseModal} from './base.modal';
 
 export class NewDeviceModal extends BaseModal {
   constructor(page: Page) {
-    super(page, 'modal-account-new-devices');
+    super(page);
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/option.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/option.modal.ts
@@ -23,6 +23,6 @@ import {BaseModal} from './base.modal';
 
 export class OptionModal extends BaseModal {
   constructor(page: Page) {
-    super(page, 'modal-template-option');
+    super(page);
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/password.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/password.modal.ts
@@ -26,7 +26,7 @@ export class PasswordModal extends BaseModal {
 
   constructor(page: Page) {
     // For some reason the password modal is rendered using the `modal-template-option` attribute
-    super(page, 'modal-template-option');
+    super(page);
 
     this.passwordInput = this.modal.getByLabel('Password');
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/passwordAdvancedSecurity.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/passwordAdvancedSecurity.modal.ts
@@ -19,15 +19,13 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {PrimaryModalType} from 'Components/Modals/PrimaryModal/PrimaryModalTypes';
-
 import {BaseModal} from './base.modal';
 
 export class PasswordAdvancedSecurityModal extends BaseModal {
   readonly passwordInput: Locator;
 
   constructor(page: Page) {
-    super(page, PrimaryModalType.PASSWORD_ADVANCED_SECURITY);
+    super(page);
 
     this.passwordInput = this.modal.getByRole('textbox');
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/readReceipt.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/readReceipt.modal.ts
@@ -23,6 +23,6 @@ import {BaseModal} from './base.modal';
 
 export class ReadReceiptModal extends BaseModal {
   constructor(page: Page) {
-    super(page, 'modal-account-read-receipts-changed');
+    super(page);
   }
 }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/withoutTitle.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/withoutTitle.modal.ts
@@ -23,6 +23,6 @@ import {BaseModal} from './base.modal';
 
 export class WithoutTitle extends BaseModal {
   constructor(page: Page) {
-    super(page, 'modal-without-title');
+    super(page);
   }
 }


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


This removes the invalid role "dialog" which was given to the div which serves as portal target for modals.
Also remove "button" role from the whole modal.

**Notest for reviewers**
Manual run of critical flow tests I triggered for this branch to avoid breaking something: https://github.com/wireapp/wire-webapp/actions/runs/27278388908

