### PR TITLE
fix: camera initialization flow [WPB-26154]

### DIFF
--- a/apps/webapp/src/script/hooks/useInitializeMediaDevices.ts
+++ b/apps/webapp/src/script/hooks/useInitializeMediaDevices.ts
@@ -35,7 +35,7 @@ export const useInitializeMediaDevices = (devicesHandler: MediaDevicesHandler, s
       if (stream) {
         stream.getTracks().forEach(track => track.stop());
       }
-      await devicesHandler?.initializeMediaDevices();
+      await devicesHandler?.initializeMediaDevices(true, true);
       setAreMediaDevicesInitialized(true);
     } catch (error: unknown) {
       logger.warn(`Initialization of media devices failed:`, error);

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -1927,8 +1927,10 @@ export class CallingRepository {
         }
 
         return this.mediaDevicesHandler
-          .initializeMediaDevices(camera)
-          .then(() => stream)
+          .initializeMediaDevices(camera, false)
+          .then(() => {
+            return stream;
+          })
           .catch((error: unknown) => {
             this.logger.warn('Failed to initialize media devices:', error);
             return stream;

--- a/apps/webapp/src/script/repositories/media/MediaDevicesHandler.ts
+++ b/apps/webapp/src/script/repositories/media/MediaDevicesHandler.ts
@@ -115,7 +115,7 @@ export class MediaDevicesHandler {
       );
     });
 
-    void this.initializeMediaDevices(false);
+    void this.initializeMediaDevices(false, false);
   }
 
   private initializeDeviceState = (supportsUserMedia: boolean) => {
@@ -152,13 +152,13 @@ export class MediaDevicesHandler {
   /**
    * Initialize the list of MediaDevices and subscriptions.
    * @camera: boolean, Only when the camera is queried can the entire device list be accessed.
+   * @refreshMediaStreams: boolean, Only when the refreshMediaStreams is true entire media streams are recreated.
    */
-  public async initializeMediaDevices(camera = false) {
+  public async initializeMediaDevices(camera = false, refreshMediaStreams = false) {
     if (!Runtime.isSupportingUserMedia() || this.devicesAreInit) {
       return;
     }
-
-    await this.refreshMediaDevices(camera);
+    await this.refreshMediaDevices(refreshMediaStreams);
     this.subscribeToDevices();
 
     if (camera) {
@@ -214,10 +214,10 @@ export class MediaDevicesHandler {
 
   /**
    * Update list of available MediaDevices.
-   * @param [camera=false] If `camera=true`, a video track is also created when the device list is read.
+   * @param [refreshMediaStreams=false] If `refreshMediaStreams=true`, a video track is also created when the device list is read.
    * This ensures that the video device labels can also be read. This is necessary for initializing the entire device list.
    */
-  public async refreshMediaDevices(camera = false) {
+  public async refreshMediaDevices(refreshMediaStreams = true) {
     try {
       this.removeAllDevices();
       const mediaDevices = await window.navigator.mediaDevices.enumerateDevices();
@@ -263,7 +263,9 @@ export class MediaDevicesHandler {
         [MediaDeviceType.VIDEO_INPUT]: cameras.length,
       };
 
-      this.onMediaDevicesRefresh?.();
+      if (refreshMediaStreams) {
+        this.onMediaDevicesRefresh?.();
+      }
 
       return mediaDevices;
     } catch (error: unknown) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26154" title="WPB-26154" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26154</a>  [Web] Firefox: Background Effect Initialization Takes More Than 10 Seconds and Causes Call Timeout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summery
This PR fixes an issue where the camera was initialized twice during start the first time.

Our permission handling requires access to a functional camera device to correctly determine the user's media permissions. Due to the previous implementation, the camera initialization was triggered once for permission detection and a once for actual media usage, resulting in unnecessary media re-initialization.



