### PR TITLE
Add role dialog to component Modal from ui-kit [WPB-22420]

### DIFF
--- a/libraries/react-ui-kit/src/Surface/Modal/Modal.tsx
+++ b/libraries/react-ui-kit/src/Surface/Modal/Modal.tsx
@@ -187,7 +187,7 @@ export const Modal: React.FC<ModalProps & React.HTMLProps<HTMLDivElement>> = ({
   ...props
 }) => (
   <OverlayWrapper {...props} data-uie-name="modal">
-    <ModalBody fullscreen={fullscreen} style={bodyStyle}>
+    <ModalBody fullscreen={fullscreen} style={bodyStyle} role="dialog">
       <ModalContent>{children}</ModalContent>
       {onClose !== noop && <ModalClose onClick={onClose} data-uie-name="do-close" />}
       {actions.length > 0 && <ModalActions actions={actions} data-uie-name="modal-actions" />}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is a follow up for #21485 to also make the other kind of modal component accessible


