### PR TITLE
Allow Renovate to fetch approved Git dependency [WPB-22420]

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,5 +7,9 @@ enableGlobalCache: false
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.16.0.cjs
+
+approvedGitRepositories:
+  - 'https://github.com/wireapp/amplify.git'
+
 npmPreapprovedPackages:
   - '@wireapp/*'


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add the Wire-owned amplify repository to Yarn's approvedGitRepositories allow-list.

Renovate lock-file maintenance currently fails during `yarn install --mode=update-lockfile` because Yarn blocks the amplify Git dependency. The dependency is declared as a GitHub URL, but the repository does not currently allow any Git repositories to be fetched.

This keeps Yarn's Git dependency protection enabled while explicitly allowing the existing Wire-owned dependency needed by the webapp package.

---

Renovate [logs](https://developer.mend.io/github/wireapp/wire-webapp/-/job/3e078522-4ae5-4c61-ab2f-c28040e58c6a) 👇 

<img width="2274" height="342" alt="2026-06-11 16 24 00 developer mend io 64d2b01bc1dc" src="https://github.com/user-attachments/assets/24f3ec4a-0e8f-412f-8caa-06dd2af9cab1" />
