### PR TITLE
feat: fix grace period for CTR generation [WPB-24526]

### DIFF
--- a/apps/webapp/src/script/E2EIdentity/E2EIdentityEnrollment.ts
+++ b/apps/webapp/src/script/E2EIdentity/E2EIdentityEnrollment.ts
@@ -41,7 +41,7 @@ import {
   MLSStatuses,
 } from './E2EIdentityVerification';
 import {getEnrollmentStore} from './Enrollment.store';
-import {getEnrollmentTimer, hasGracePeriodStartedForSelfClient} from './EnrollmentTimer';
+import {getEnrollmentTimer, getRemainingGracePeriodDelay, hasGracePeriodStartedForSelfClient} from './EnrollmentTimer';
 import {getModalOptions, ModalType} from './Modals';
 import {OIDCService} from './OIDCService';
 import {OIDCServiceStore} from './OIDCService/OIDCServiceStorage';
@@ -230,7 +230,10 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
         intervalDelay: TIME_IN_MILLIS.SECOND * 10,
       });
     }
-    return firingDate - Date.now();
+    return {
+      nextReminderDelay: firingDate - Date.now(),
+      remainingGracePeriodDelay: getRemainingGracePeriodDelay(identity, e2eActivatedAt, this.config.gracePeriodInMs),
+    };
   }
 
   private async processEnrollmentUponExpiry(snoozable: boolean, onUserAction: () => void) {
@@ -399,9 +402,9 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
           resolve();
         },
         secondaryActionFn: async () => {
-          const delay = await this.startTimers();
-          if (delay > 0) {
-            this.showSnoozeConfirmationModal(delay);
+          const {nextReminderDelay, remainingGracePeriodDelay} = await this.startTimers();
+          if (nextReminderDelay > 0) {
+            this.showSnoozeConfirmationModal(remainingGracePeriodDelay);
           }
           resolve();
         },
@@ -429,9 +432,9 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
         },
         secondaryActionFn: async () => {
           onUserAction?.();
-          const delay = await this.startTimers();
-          if (delay > 0) {
-            this.showSnoozeConfirmationModal(delay);
+          const {nextReminderDelay, remainingGracePeriodDelay} = await this.startTimers();
+          if (nextReminderDelay > 0) {
+            this.showSnoozeConfirmationModal(remainingGracePeriodDelay);
           }
           resolve();
         },

--- a/apps/webapp/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.test.ts
+++ b/apps/webapp/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.test.ts
@@ -19,10 +19,34 @@
 
 import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
 import {CredentialType} from '@wireapp/core/lib/messagingProtocols/mls';
+import {createDeterministicWallClock} from 'src/script/clock/deterministicWallClock';
 
 import {getEnrollmentTimer, getRemainingGracePeriodDelay, messageRetentionTime} from './EnrollmentTimer';
 
-import {MLSStatuses} from '../E2EIdentityVerification';
+import {MLSStatuses, WireIdentity} from '../E2EIdentityVerification';
+
+const generateWireIdentity = (
+  credentialType: CredentialType = CredentialType.X509,
+  status: MLSStatuses = MLSStatuses.NOT_ACTIVATED,
+): WireIdentity => ({
+  x509Identity: {
+    free: jest.fn(),
+    certificate: '',
+    displayName: 'John Doe',
+    domain: 'domain',
+    handle: 'johndoe',
+    notAfter: BigInt(0),
+    notBefore: BigInt(0),
+    serialNumber: '',
+    [Symbol.dispose]: () => {},
+  },
+  thumbprint: '',
+  credentialType,
+  status,
+  clientId: 'client-id',
+  deviceId: 'client-id',
+  qualifiedUserId: {id: 'user-id', domain: 'domain'},
+});
 
 describe('e2ei delays', () => {
   const gracePeriod = 7 * TimeInMillis.DAY;
@@ -107,10 +131,50 @@ describe('e2ei delays', () => {
     TimeInMillis.HOUR * 24,
     TimeInMillis.WEEK,
   ])('should keep full remaining grace period for first enrollment: %i ms', grace => {
+    const remainingDelay = getRemainingGracePeriodDelay(undefined, Date.now(), grace);
+
+    expect(remainingDelay).toBe(grace);
+  });
+
+  it('should return a deterministic full grace-period delay when identity is undefined', () => {
+    const deterministicWallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: 1_700_000_000_000,
+    });
+    const grace = TimeInMillis.HOUR * 12;
+
     const remainingDelay = getRemainingGracePeriodDelay(
       undefined,
-      Date.now(),
+      deterministicWallClock.currentTimestampInMilliseconds,
       grace,
+      deterministicWallClock,
+    );
+
+    expect(remainingDelay).toBe(grace);
+  });
+
+  it('should return only the remaining grace-period delay when first enrollment started in the past', () => {
+    const deterministicWallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: 1_700_000_000_000,
+    });
+    const grace = TimeInMillis.DAY * 7;
+    const e2eiActivatedAt = deterministicWallClock.currentTimestampInMilliseconds - TimeInMillis.DAY * 2;
+
+    const remainingDelay = getRemainingGracePeriodDelay(undefined, e2eiActivatedAt, grace, deterministicWallClock);
+
+    expect(remainingDelay).toBe(TimeInMillis.DAY * 5);
+  });
+
+  it('should treat NOT_ACTIVATED identity as first enrollment', () => {
+    const deterministicWallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: 1_700_000_000_000,
+    });
+    const grace = TimeInMillis.HOUR * 6;
+
+    const remainingDelay = getRemainingGracePeriodDelay(
+      generateWireIdentity(CredentialType.X509, MLSStatuses.NOT_ACTIVATED),
+      deterministicWallClock.currentTimestampInMilliseconds,
+      grace,
+      deterministicWallClock,
     );
 
     expect(remainingDelay).toBe(grace);

--- a/apps/webapp/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.test.ts
+++ b/apps/webapp/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.test.ts
@@ -20,7 +20,7 @@
 import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
 import {CredentialType} from '@wireapp/core/lib/messagingProtocols/mls';
 
-import {getEnrollmentTimer, messageRetentionTime} from './EnrollmentTimer';
+import {getEnrollmentTimer, getRemainingGracePeriodDelay, messageRetentionTime} from './EnrollmentTimer';
 
 import {MLSStatuses} from '../E2EIdentityVerification';
 
@@ -98,5 +98,21 @@ describe('e2ei delays', () => {
 
     expect(isSnoozable).toBeTruthy();
     expect(firingDate).toBe(gracePeriodStartingPoint);
+  });
+
+  it.each([
+    TimeInMillis.HOUR,
+    TimeInMillis.HOUR * 6,
+    TimeInMillis.HOUR * 12,
+    TimeInMillis.HOUR * 24,
+    TimeInMillis.WEEK,
+  ])('should keep full remaining grace period for first enrollment: %i ms', grace => {
+    const remainingDelay = getRemainingGracePeriodDelay(
+      undefined,
+      Date.now(),
+      grace,
+    );
+
+    expect(remainingDelay).toBe(grace);
   });
 });

--- a/apps/webapp/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.ts
+++ b/apps/webapp/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.ts
@@ -17,13 +17,14 @@
  *
  */
 
+import is from '@sindresorhus/is';
 import {randomInt} from '@wireapp/commons/lib/util/RandomUtil';
 import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
 import {CredentialType} from '@wireapp/core/lib/messagingProtocols/mls';
+
 import {WallClock, createWallClock} from 'src/script/clock/wallClock';
 
 import {MLSStatuses, WireIdentity} from '../E2EIdentityVerification';
-import is from '@sindresorhus/is';
 
 const FIVE_MINUTES = TimeInMillis.MINUTE * 5;
 const FIFTEEN_MINUTES = TimeInMillis.MINUTE * 15;

--- a/apps/webapp/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.ts
+++ b/apps/webapp/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.ts
@@ -102,6 +102,15 @@ export function getEnrollmentTimer(
   return {isSnoozable: nextTick > 0, firingDate: Date.now() + nextTick};
 }
 
+export function getRemainingGracePeriodDelay(
+  identity: WireIdentity | undefined,
+  e2eiActivatedAt: number,
+  teamGracePeriodDuration: number,
+): number {
+  const {end} = getGracePeriod(identity, e2eiActivatedAt, teamGracePeriodDuration);
+  return Math.max(0, end - Date.now());
+}
+
 export function hasGracePeriodStartedForSelfClient(
   identity: WireIdentity | undefined,
   e2eiActivatedAt: number,

--- a/apps/webapp/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.ts
+++ b/apps/webapp/src/script/E2EIdentity/EnrollmentTimer/EnrollmentTimer.ts
@@ -20,8 +20,10 @@
 import {randomInt} from '@wireapp/commons/lib/util/RandomUtil';
 import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
 import {CredentialType} from '@wireapp/core/lib/messagingProtocols/mls';
+import {WallClock, createWallClock} from 'src/script/clock/wallClock';
 
 import {MLSStatuses, WireIdentity} from '../E2EIdentityVerification';
+import is from '@sindresorhus/is';
 
 const FIVE_MINUTES = TimeInMillis.MINUTE * 5;
 const FIFTEEN_MINUTES = TimeInMillis.MINUTE * 15;
@@ -38,21 +40,25 @@ type GracePeriod = {
   /** end date of the grace period (unix timestamp) */
   end: number;
 };
+
+const wallClock = createWallClock();
 /**
  * Will return a suitable snooze time based on the grace period
  * @param deadline - the full grace period length in milliseconds
  */
-function getNextTick({end, start}: GracePeriod): number {
-  if (Date.now() >= end) {
+function getNextTick({end, start}: GracePeriod, activeWallClock: WallClock): number {
+  const now = activeWallClock.currentTimestampInMilliseconds;
+
+  if (now >= end) {
     // If the grace period is over, we should force the user to enroll
     return 0;
   }
 
-  if (Date.now() < start) {
+  if (now < start) {
     // If we are not in the grace period yet, we start the timer when the grace period starts
-    return start - Date.now();
+    return start - now;
   }
-  const validityPeriod = end - Date.now();
+  const validityPeriod = end - now;
 
   if (validityPeriod <= FIFTEEN_MINUTES) {
     return Math.min(FIVE_MINUTES, validityPeriod);
@@ -70,17 +76,25 @@ function getGracePeriod(
   identity: WireIdentity | undefined,
   e2eActivatedAt: number,
   teamGracePeriodDuration: number,
+  activeWallClock: WallClock,
 ): GracePeriod {
-  const isFirstEnrollment = identity?.credentialType === CredentialType.Basic;
+  const isFirstEnrollment =
+    is.undefined(identity) ||
+    identity.status === MLSStatuses.NOT_ACTIVATED ||
+    identity.credentialType === CredentialType.Basic;
+
   if (isFirstEnrollment) {
     // For a new device, the deadline is the e2ei activate date + the grace period
-    return {end: e2eActivatedAt + teamGracePeriodDuration, start: Date.now()};
+    return {
+      end: e2eActivatedAt + teamGracePeriodDuration,
+      start: activeWallClock.currentTimestampInMilliseconds,
+    };
   }
 
   // To be sure the device does not expire, we want to keep a safe delay
   const safeDelay = randomInt(TimeInMillis.DAY) + messageRetentionTime;
 
-  const end = Number(identity?.x509Identity?.notAfter) * TimeInMillis.SECOND;
+  const end = Number(identity.x509Identity?.notAfter) * TimeInMillis.SECOND;
   const start = Math.max(end - safeDelay, end - teamGracePeriodDuration);
 
   return {end, start};
@@ -90,32 +104,35 @@ export function getEnrollmentTimer(
   identity: WireIdentity | undefined,
   e2eiActivatedAt: number,
   teamGracePeriodDuration: number,
+  activeWallClock: WallClock = wallClock,
 ) {
   if (identity?.status === MLSStatuses.EXPIRED) {
-    return {isSnoozable: false, firingDate: Date.now()};
+    return {isSnoozable: false, firingDate: activeWallClock.currentTimestampInMilliseconds};
   }
 
-  const deadline = getGracePeriod(identity, e2eiActivatedAt, teamGracePeriodDuration);
-  const nextTick = getNextTick(deadline);
+  const deadline = getGracePeriod(identity, e2eiActivatedAt, teamGracePeriodDuration, activeWallClock);
+  const nextTick = getNextTick(deadline, activeWallClock);
 
   // When logging in to a old device that doesn't have an identity yet, we trigger an enrollment timer
-  return {isSnoozable: nextTick > 0, firingDate: Date.now() + nextTick};
+  return {isSnoozable: nextTick > 0, firingDate: activeWallClock.currentTimestampInMilliseconds + nextTick};
 }
 
 export function getRemainingGracePeriodDelay(
   identity: WireIdentity | undefined,
   e2eiActivatedAt: number,
   teamGracePeriodDuration: number,
+  activeWallClock: WallClock = wallClock,
 ): number {
-  const {end} = getGracePeriod(identity, e2eiActivatedAt, teamGracePeriodDuration);
-  return Math.max(0, end - Date.now());
+  const {end} = getGracePeriod(identity, e2eiActivatedAt, teamGracePeriodDuration, activeWallClock);
+  return Math.max(0, end - activeWallClock.currentTimestampInMilliseconds);
 }
 
 export function hasGracePeriodStartedForSelfClient(
   identity: WireIdentity | undefined,
   e2eiActivatedAt: number,
   teamGracePeriodDuration: number,
+  activeWallClock: WallClock = wallClock,
 ) {
-  const deadline = getGracePeriod(identity, e2eiActivatedAt, teamGracePeriodDuration);
-  return Date.now() >= deadline.start;
+  const deadline = getGracePeriod(identity, e2eiActivatedAt, teamGracePeriodDuration, activeWallClock);
+  return activeWallClock.currentTimestampInMilliseconds >= deadline.start;
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24526" title="WPB-24526" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24526</a>  [Web] Wrong time shown on Web when grace period is active
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This pull request improves E2E identity enrollment by making grace period handling more accurate.

- Added getRemainingGracePeriodDelay to calculate the actual remaining enrollment grace period using the user's identity details, activation time, and team settings.
- Updated the enrollment flow to use this remaining time for timers and snooze confirmation modals, ensuring users see the correct grace period instead of the original full duration.
- Added tests for getRemainingGracePeriodDelay, including parameterized cases covering different grace period lengths to verify expected behavior.