### PR TITLE
Create fresh WebSocket wrapper when closed [WPB-21916]

### DIFF
--- a/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
@@ -21,6 +21,7 @@
 
 import is from '@sindresorhus/is';
 import {once} from 'events';
+import type {CloseEvent, ErrorEvent, Event as ReconnectingWebsocketEvent} from 'reconnecting-websocket';
 import {Maybe} from 'true-myth';
 import {Server as WebSocketServer} from 'ws';
 
@@ -42,6 +43,43 @@ type TimeoutRegistration = {
 type DeterministicTimeoutWallClock = ReconnectingWebsocketWallClock & {
   readonly advanceByMilliseconds: (delayInMilliseconds: number) => void;
 };
+
+type MockReconnectingWebsocketWrapper = {
+  binaryType: BinaryType;
+  close: jest.Mock;
+  onclose: ((event: CloseEvent) => void) | null;
+  onerror: ((event: ErrorEvent) => void) | null;
+  onmessage: ((event: MessageEvent) => void) | null;
+  onopen: ((event: ReconnectingWebsocketEvent) => void) | null;
+  readyState: WEBSOCKET_STATE;
+  reconnect: jest.Mock;
+  send: jest.Mock;
+};
+
+function createMockReconnectingWebsocketWrapper(readyState: WEBSOCKET_STATE): MockReconnectingWebsocketWrapper {
+  const socket: MockReconnectingWebsocketWrapper = {
+    binaryType: 'blob',
+    close: jest.fn(() => {
+      socket.readyState = WEBSOCKET_STATE.CLOSED;
+    }),
+    onclose: null,
+    onerror: null,
+    onmessage: null,
+    onopen: null,
+    readyState,
+    reconnect: jest.fn(),
+    send: jest.fn(),
+  };
+
+  return socket;
+}
+
+function expectSocketHandlersToBeBound(socket: MockReconnectingWebsocketWrapper): void {
+  expect(socket.onclose).toEqual(expect.any(Function));
+  expect(socket.onerror).toEqual(expect.any(Function));
+  expect(socket.onmessage).toEqual(expect.any(Function));
+  expect(socket.onopen).toEqual(expect.any(Function));
+}
 
 function createDeterministicTimeoutWallClock(
   initialCurrentTimestampInMilliseconds: number,
@@ -227,33 +265,90 @@ describe('ReconnectingWebsocket', () => {
 
   it('reconnects in place when connect is called on an open socket', () => {
     const onReconnect = jest.fn().mockReturnValue(getServerAddress());
-    const RWS = createRWS(onReconnect);
-
-    const socket = {
-      readyState: WEBSOCKET_STATE.OPEN,
-      close: jest.fn(),
-      reconnect: jest.fn(),
-      send: jest.fn(),
-      onmessage: undefined,
-      onerror: undefined,
-      onopen: undefined,
-      onclose: undefined,
-    };
-
-    const getSocketSpy = jest.spyOn(
-      RWS as unknown as {getReconnectingWebsocket: () => typeof RWS},
-      'getReconnectingWebsocket',
-    );
-    getSocketSpy.mockReturnValueOnce(socket as unknown as typeof RWS);
+    const socket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.OPEN);
+    const websocketFactory = jest.fn(() => {
+      return socket;
+    });
+    const RWS = createRWS(onReconnect, {
+      ...defaultReconnectingWebsocketTestOptions,
+      websocketFactory: Maybe.just(websocketFactory),
+    });
 
     RWS.connect();
     RWS.connect();
 
-    expect(getSocketSpy).toHaveBeenCalledTimes(1);
+    expect(websocketFactory).toHaveBeenCalledTimes(1);
     expect(socket.reconnect).toHaveBeenCalledTimes(1);
     expect(socket.reconnect).toHaveBeenCalledWith(CloseEventCode.NORMAL_CLOSURE);
     expect(socket.close).not.toHaveBeenCalled();
     expect(RWS['socket']).toBe(socket);
+
+    RWS.disconnect();
+  });
+
+  it('creates a fresh wrapper when connect is called on an existing closed socket', () => {
+    const onReconnect = jest.fn().mockReturnValue(getServerAddress());
+    const closedSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CLOSED);
+    const nextSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+    const sockets = [closedSocket, nextSocket];
+    const websocketFactory = jest.fn(() => {
+      const socket = sockets[websocketFactory.mock.calls.length - 1];
+
+      if (!socket) {
+        throw new Error('Unexpected websocketFactory call');
+      }
+
+      return socket;
+    });
+    const RWS = createRWS(onReconnect, {
+      ...defaultReconnectingWebsocketTestOptions,
+      websocketFactory: Maybe.just(websocketFactory),
+    });
+
+    RWS.connect();
+    expect(RWS['socket']).toBe(closedSocket);
+
+    RWS.connect();
+
+    expect(closedSocket.reconnect).not.toHaveBeenCalled();
+    expect(websocketFactory).toHaveBeenCalledTimes(2);
+    expect(RWS['socket']).toBe(nextSocket);
+    expectSocketHandlersToBeBound(nextSocket);
+
+    RWS.disconnect();
+  });
+
+  it('creates a fresh wrapper when reconnecting after disconnect left the existing socket closed', () => {
+    const onReconnect = jest.fn().mockReturnValue(getServerAddress());
+    const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.OPEN);
+    const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+    const sockets = [firstSocket, secondSocket];
+    const websocketFactory = jest.fn(() => {
+      const socket = sockets[websocketFactory.mock.calls.length - 1];
+
+      if (!socket) {
+        throw new Error('Unexpected websocketFactory call');
+      }
+
+      return socket;
+    });
+    const RWS = createRWS(onReconnect, {
+      ...defaultReconnectingWebsocketTestOptions,
+      websocketFactory: Maybe.just(websocketFactory),
+    });
+
+    RWS.connect();
+    RWS.disconnect();
+
+    expect(firstSocket.close).toHaveBeenCalledWith(CloseEventCode.NORMAL_CLOSURE, 'Closed by client');
+    expect(firstSocket.readyState).toBe(WEBSOCKET_STATE.CLOSED);
+
+    RWS.connect();
+
+    expect(firstSocket.reconnect).not.toHaveBeenCalled();
+    expect(websocketFactory).toHaveBeenCalledTimes(2);
+    expect(RWS['socket']).toBe(secondSocket);
+    expectSocketHandlersToBeBound(secondSocket);
 
     RWS.disconnect();
   });

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -290,16 +290,28 @@ export class ReconnectingWebsocket {
     this.resetLongRunningRetrySequence();
     this.stopPinging();
 
-    if (!is.undefined(this.socket)) {
-      if (this.socket.readyState !== WEBSOCKET_STATE.CLOSED) {
-        this.logger.warn(
-          `Existing WebSocket instance detected in state ${WEBSOCKET_STATE[this.socket.readyState]} (${this.socket.readyState}); reconnecting in place`,
-        );
-      }
-      this.reconnectInPlace(this.socket);
+    const existingSocket = this.socket;
+
+    if (!is.undefined(existingSocket) && !this.isExistingSocketClosed(existingSocket)) {
+      this.logger.warn(
+        `Existing WebSocket instance detected in state ${WEBSOCKET_STATE[existingSocket.readyState]} (${existingSocket.readyState}); reconnecting in place`,
+      );
+      this.reconnectInPlace(existingSocket);
       return;
     }
 
+    if (!is.undefined(existingSocket)) {
+      this.logger.info('Existing WebSocket wrapper is CLOSED, creating a fresh wrapper');
+    }
+
+    this.createAndBindSocketWrapper();
+  }
+
+  private isExistingSocketClosed(socket: ReconnectingWebsocketWrapper): boolean {
+    return socket.readyState === WEBSOCKET_STATE.CLOSED;
+  }
+
+  private createAndBindSocketWrapper(): void {
     const nextSocket = this.getReconnectingWebsocket();
     this.socket = nextSocket;
     this.bindSocketHandlers(nextSocket);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem

After enabling `reliable-websocket-connection`, wake-from-sleep recovery can still get stuck in a closed state.

Runtime state showed:

```javascript
window.wire.app.repository.event.notificationHandlingState()
```

returning:

```text
z.event.NOTIFICATION_HANDLING_STATE.CLOSED
```

and:

```javascript
window.wire.app["apiClient"]?.transport?.ws?.["socket"]?.getState?.()
```

returning:

```text
3
```

`3` is `WEBSOCKET_STATE.CLOSED`.

## Root cause

`ReconnectingWebsocket.connect()` reused any existing socket wrapper and called reconnect in place.

That is correct for active or transitioning wrappers, because it avoids creating duplicate app-owned WebSocket wrappers.

But it is not correct when the existing wrapper is already `CLOSED`. In that terminal state, reconnecting in place can leave the app stuck with the same closed wrapper.

## Change

This updates `connect()` to distinguish between active wrappers and closed wrappers.

The new behavior is:

```text
no wrapper
-> create a new wrapper

existing wrapper is CONNECTING, OPEN, or CLOSING
-> reconnect in place

existing wrapper is CLOSED
-> create a fresh wrapper and bind handlers again
```

The wake-from-sleep behavior is unchanged: when `reliable-websocket-connection` is enabled, the app still does not trust `OPEN` after wake-up and forces reconnect.