### PR TITLE
Enable reliable WebSocket recovery by default [WPB-21916]

### DIFF
--- a/apps/webapp/src/script/auth/main.tsx
+++ b/apps/webapp/src/script/auth/main.tsx
@@ -51,7 +51,6 @@ exposeWrapperGlobals();
 const mainId = 'main';
 
 const apiClient = new APIClient({
-  isReliableWebsocketConnectionEnabled: false,
   wallClock: createWallClock(),
 });
 container.registerInstance(APIClient, apiClient);

--- a/apps/webapp/src/script/auth/page/login/util.test.ts
+++ b/apps/webapp/src/script/auth/page/login/util.test.ts
@@ -153,7 +153,6 @@ describe('Login util', () => {
       navigate = jest.fn();
       loginWithSSO = jest.fn().mockResolvedValue(undefined);
       apiClient = new APIClient({
-        isReliableWebsocketConnectionEnabled: false,
         wallClock: createDeterministicWallClock(),
       });
       jest.spyOn(ROOT_ACTIONS.authAction, 'pushAccountRegistrationData').mockImplementation(() => {

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -17,13 +17,11 @@
  *
  */
 
-export const reliableWebsocketConnectionFeatureToggleName = 'reliable-websocket-connection';
 export const applockRefactoredFeatureToggleName = 'applock-refactored';
 export const sharedDriveSearchAndFiltersFeatureToggleName = 'shared-drive-search-and-filters';
 export const meetingsFeatureToggleName = 'meetings';
 
 export const startupFeatureToggleNames = [
-  reliableWebsocketConnectionFeatureToggleName,
   applockRefactoredFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   meetingsFeatureToggleName,

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
@@ -17,10 +17,7 @@
  *
  */
 
-import {
-  applockRefactoredFeatureToggleName,
-  reliableWebsocketConnectionFeatureToggleName,
-} from './startupFeatureToggleNames';
+import {applockRefactoredFeatureToggleName, meetingsFeatureToggleName} from './startupFeatureToggleNames';
 import {startupFeatureToggleQueryParameterName} from './startupFeatureToggles';
 import {updateLocationSearchForStartupFeatureToggle} from './startupFeatureToggleQueryParameters';
 
@@ -28,31 +25,29 @@ describe('updateLocationSearchForStartupFeatureToggle', () => {
   it('adds a feature toggle to an existing query string and preserves unrelated parameters', () => {
     const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
       locationSearch: '?foo=bar',
-      featureToggleName: reliableWebsocketConnectionFeatureToggleName,
+      featureToggleName: applockRefactoredFeatureToggleName,
       shouldEnableFeatureToggle: true,
     });
 
     expect(updatedLocationSearch).toBe(
-      `?foo=bar&${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}`,
+      `?foo=bar&${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
     );
   });
 
   it('removes a feature toggle and preserves other enabled toggles', () => {
     const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
-      locationSearch: `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName},${applockRefactoredFeatureToggleName}`,
-      featureToggleName: reliableWebsocketConnectionFeatureToggleName,
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName},${meetingsFeatureToggleName}`,
+      featureToggleName: applockRefactoredFeatureToggleName,
       shouldEnableFeatureToggle: false,
     });
 
-    expect(updatedLocationSearch).toBe(
-      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
-    );
+    expect(updatedLocationSearch).toBe(`?${startupFeatureToggleQueryParameterName}=${meetingsFeatureToggleName}`);
   });
 
   it('removes only the startup feature parameter when the last feature toggle is disabled', () => {
     const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
-      locationSearch: `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}&foo=bar`,
-      featureToggleName: reliableWebsocketConnectionFeatureToggleName,
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}&foo=bar`,
+      featureToggleName: applockRefactoredFeatureToggleName,
       shouldEnableFeatureToggle: false,
     });
 
@@ -61,8 +56,8 @@ describe('updateLocationSearchForStartupFeatureToggle', () => {
 
   it('returns an empty search string when the last query parameter is removed', () => {
     const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
-      locationSearch: `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}`,
-      featureToggleName: reliableWebsocketConnectionFeatureToggleName,
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
+      featureToggleName: applockRefactoredFeatureToggleName,
       shouldEnableFeatureToggle: false,
     });
 
@@ -72,24 +67,24 @@ describe('updateLocationSearchForStartupFeatureToggle', () => {
   it('ignores unknown feature names already present in query parameter when enabling a new toggle', () => {
     const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
       locationSearch: `?${startupFeatureToggleQueryParameterName}=unknown-feature`,
-      featureToggleName: reliableWebsocketConnectionFeatureToggleName,
+      featureToggleName: applockRefactoredFeatureToggleName,
       shouldEnableFeatureToggle: true,
     });
 
     expect(updatedLocationSearch).toBe(
-      `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}`,
+      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
     );
   });
 
   it('deduplicates feature toggles when enabling an already enabled toggle', () => {
     const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
-      locationSearch: `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName},${reliableWebsocketConnectionFeatureToggleName}`,
-      featureToggleName: reliableWebsocketConnectionFeatureToggleName,
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName},${applockRefactoredFeatureToggleName}`,
+      featureToggleName: applockRefactoredFeatureToggleName,
       shouldEnableFeatureToggle: true,
     });
 
     expect(updatedLocationSearch).toBe(
-      `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}`,
+      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
     );
   });
 });

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -25,13 +25,11 @@ import {
 import {
   applockRefactoredFeatureToggleName,
   meetingsFeatureToggleName,
-  reliableWebsocketConnectionFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   startupFeatureToggleNames,
 } from './startupFeatureToggleNames';
 
 const featureToggleNamesWithDedicatedExistenceTests = [
-  reliableWebsocketConnectionFeatureToggleName,
   applockRefactoredFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   meetingsFeatureToggleName,
@@ -41,24 +39,24 @@ describe('startupFeatureToggles', function () {
   it('returns disabled toggles when the query parameter is missing', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch('?foo=bar');
 
-    expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(false);
+    expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(false);
     expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([]);
   });
 
   it('enables a whitelisted feature toggle when present in the query parameter', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}`,
+      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
     );
 
-    expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
+    expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(true);
   });
 
   it('enables whitelisted toggles and ignores unknown values in the same parameter', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName},unknown-feature`,
+      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName},unknown-feature`,
     );
 
-    expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
+    expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(true);
     expect(startupFeatureToggles.enabledFeatureToggleNames).not.toContain('unknown-feature');
   });
 
@@ -72,10 +70,10 @@ describe('startupFeatureToggles', function () {
 
   it('keeps only whitelisted feature toggles when known and unknown values are mixed', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=unknown-feature,${reliableWebsocketConnectionFeatureToggleName}`,
+      `?${startupFeatureToggleQueryParameterName}=unknown-feature,${applockRefactoredFeatureToggleName}`,
     );
 
-    expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
+    expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(true);
     expect(startupFeatureToggles.enabledFeatureToggleNames).not.toContain('unknown-feature');
   });
 
@@ -105,43 +103,42 @@ describe('startupFeatureToggles', function () {
 
   it('trims whitespace around feature toggle names', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}= ${reliableWebsocketConnectionFeatureToggleName} `,
+      `?${startupFeatureToggleQueryParameterName}= ${applockRefactoredFeatureToggleName} `,
     );
 
-    expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
+    expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(true);
   });
 
   it('deduplicates duplicated feature toggles', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName},${reliableWebsocketConnectionFeatureToggleName}`,
+      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName},${applockRefactoredFeatureToggleName}`,
     );
 
-    expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
-    expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([reliableWebsocketConnectionFeatureToggleName]);
+    expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(true);
+    expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([applockRefactoredFeatureToggleName]);
   });
 
   it('ignores empty list entries in the feature toggle query parameter', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=,${reliableWebsocketConnectionFeatureToggleName},,`,
+      `?${startupFeatureToggleQueryParameterName}=,${applockRefactoredFeatureToggleName},,`,
     );
 
-    expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
-    expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([reliableWebsocketConnectionFeatureToggleName]);
+    expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(true);
+    expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([applockRefactoredFeatureToggleName]);
   });
 
   it('treats feature toggle names as case-sensitive', () => {
-    const uppercaseFeatureToggleName = reliableWebsocketConnectionFeatureToggleName.toUpperCase();
+    const uppercaseFeatureToggleName = applockRefactoredFeatureToggleName.toUpperCase();
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=${uppercaseFeatureToggleName}`,
     );
 
-    expect(startupFeatureToggles.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(false);
+    expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(false);
     expect(startupFeatureToggles.enabledFeatureToggleNames).not.toContain(uppercaseFeatureToggleName);
   });
 
   it('contains only whitelisted values in allowedStartupFeatureToggleNames', () => {
     expect(allowedStartupFeatureToggleNames).toEqual([
-      reliableWebsocketConnectionFeatureToggleName,
       applockRefactoredFeatureToggleName,
       sharedDriveSearchAndFiltersFeatureToggleName,
       meetingsFeatureToggleName,
@@ -154,7 +151,7 @@ describe('startupFeatureToggles', function () {
 
   it('does not expose mutable enabled toggle state', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=${reliableWebsocketConnectionFeatureToggleName}`,
+      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
     );
 
     expect('enabledFeatureToggleNameSet' in startupFeatureToggles).toBe(false);

--- a/apps/webapp/src/script/main/index.tsx
+++ b/apps/webapp/src/script/main/index.tsx
@@ -42,7 +42,6 @@ import {createApplicationServices} from './createApplicationServices';
 import {SIGN_OUT_REASON} from '../auth/SignOutReason';
 import {createWallClock} from '../clock/wallClock';
 import {Config} from '../Config';
-import {reliableWebsocketConnectionFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
 import {createStartupFeatureTogglesFromLocationSearch} from '../featureToggles/startupFeatureToggles';
 import {createIncrementalHttpRetryBackoffReset} from '../lifecycle/createIncrementalHttpRetryBackoffReset';
 import {APIClient} from '../service/apiClientSingleton';
@@ -85,7 +84,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   const {isFeatureToggleEnabled} = startupFeatureToggles;
   const {fireAndForgetInvoker, wallClock} = applicationServices;
   const apiClient = new APIClient({
-    isReliableWebsocketConnectionEnabled: isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName),
     wallClock,
   });
   const core = new Core(apiClient);

--- a/apps/webapp/src/script/page/RootProvider.test.tsx
+++ b/apps/webapp/src/script/page/RootProvider.test.tsx
@@ -23,7 +23,7 @@ import {renderHook} from '@testing-library/react';
 
 import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles';
 import {createDeterministicWallClock} from '../clock/deterministicWallClock';
-import {reliableWebsocketConnectionFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
+import {applockRefactoredFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
 import {MainViewModel} from '../view_model/MainViewModel';
 import {createRootContextValueForTest, createRootProviderWrapperForTest} from './testSupport/rootContextTestSupport';
 import {RootContext, RootContextValue, RootProvider, useApplicationContext, useMainViewModel} from './RootProvider';
@@ -48,7 +48,7 @@ function createRootProviderWrapper(
     initialCurrentTimestampInMilliseconds: wallClockTimestampInMilliseconds,
   });
   function isFeatureToggleEnabledForTest(featureName: StartupFeatureToggleName): boolean {
-    return featureName === reliableWebsocketConnectionFeatureToggleName;
+    return featureName === applockRefactoredFeatureToggleName;
   }
 
   const isFeatureToggleEnabled = jest.fn(isFeatureToggleEnabledForTest);
@@ -114,7 +114,7 @@ describe('RootProvider', () => {
 
     const {result} = renderHook(useApplicationContext, {wrapper});
 
-    expect(result.current.isFeatureToggleEnabled(reliableWebsocketConnectionFeatureToggleName)).toBe(true);
-    expect(isFeatureToggleEnabled).toHaveBeenCalledWith(reliableWebsocketConnectionFeatureToggleName);
+    expect(result.current.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(true);
+    expect(isFeatureToggleEnabled).toHaveBeenCalledWith(applockRefactoredFeatureToggleName);
   });
 });

--- a/apps/webapp/src/script/service/apiClientSingleton.test.ts
+++ b/apps/webapp/src/script/service/apiClientSingleton.test.ts
@@ -24,7 +24,6 @@ import {APIClient} from './apiClientSingleton';
 describe('APIClientSingleton', () => {
   it('configures wire client metadata headers for backend requests', () => {
     const apiClient = new APIClient({
-      isReliableWebsocketConnectionEnabled: false,
       wallClock: createDeterministicWallClock(),
     });
 
@@ -40,7 +39,6 @@ describe('APIClientSingleton', () => {
 
   it('uses the incremental http retry backoff http client by default', () => {
     const apiClient = new APIClient({
-      isReliableWebsocketConnectionEnabled: false,
       wallClock: createDeterministicWallClock(),
     });
 

--- a/apps/webapp/src/script/service/apiClientSingleton.ts
+++ b/apps/webapp/src/script/service/apiClientSingleton.ts
@@ -33,15 +33,13 @@ type RetryBackoffResettableHttpClient = {
 };
 
 type APIClientProperties = {
-  readonly isReliableWebsocketConnectionEnabled: boolean;
   readonly wallClock: WallClock;
 };
 
 @singleton()
 export class APIClient extends APIClientUnconfigured {
   constructor(
-    {isReliableWebsocketConnectionEnabled, wallClock}: APIClientProperties = {
-      isReliableWebsocketConnectionEnabled: false,
+    {wallClock}: APIClientProperties = {
       wallClock: createWallClock(),
     },
   ) {
@@ -57,7 +55,6 @@ export class APIClient extends APIClientUnconfigured {
         rest: webAppConfiguration.BACKEND_REST,
         ws: webAppConfiguration.BACKEND_WS,
       },
-      isReliableWebsocketConnectionEnabled,
       wallClock,
     };
 

--- a/libraries/api-client/src/apiClient.ts
+++ b/libraries/api-client/src/apiClient.ts
@@ -83,7 +83,6 @@ enum TOPIC {
 }
 
 const defaultConfig = {
-  isReliableWebsocketConnectionEnabled: false,
   wallClock: {
     clearInterval: globalThis.clearInterval.bind(globalThis),
     clearTimeout: globalThis.clearTimeout.bind(globalThis),
@@ -107,7 +106,6 @@ export interface APIClient {
 }
 
 export type APIClientConfiguration = {
-  readonly isReliableWebsocketConnectionEnabled: boolean;
   readonly wallClock: ReconnectingWebsocketWallClock;
 };
 
@@ -208,7 +206,6 @@ export class APIClient extends EventEmitter {
 
     const httpClient = new HttpClient(this.config, this.accessTokenStore);
     const webSocket = new WebSocketClient(this.config.urls.ws, httpClient, {
-      isReliableWebsocketConnectionEnabled: this.config.isReliableWebsocketConnectionEnabled,
       wallClock: this.config.wallClock,
     });
 

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.backFromSleep.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.backFromSleep.test.ts
@@ -116,7 +116,6 @@ describe('ReconnectingWebsocket back from sleep handling', () => {
 
     new ReconnectingWebsocket(jest.fn(), {
       backFromSleepHandler: Maybe.just(backFromSleepHandler),
-      isReliableWebsocketConnectionEnabled: true,
       pingInterval: Maybe.nothing(),
       wallClock: createTestWallClock(0),
       websocketFactory: Maybe.nothing(),
@@ -126,35 +125,11 @@ describe('ReconnectingWebsocket back from sleep handling', () => {
     expect(getLatestBackFromSleepRegistration(registrations)).not.toHaveProperty('isDisconnected');
   });
 
-  it('registers onBackFromSleep with an isDisconnected gate when reliable websocket connection is disabled', () => {
-    const {backFromSleepHandler, registrations} = createBackFromSleepHandlerTestDependencies();
-
-    new ReconnectingWebsocket(jest.fn(), {
-      backFromSleepHandler: Maybe.just(backFromSleepHandler),
-      isReliableWebsocketConnectionEnabled: false,
-      pingInterval: Maybe.nothing(),
-      wallClock: createTestWallClock(0),
-      websocketFactory: Maybe.nothing(),
-    });
-
-    const registration = getLatestBackFromSleepRegistration(registrations);
-
-    expect(backFromSleepHandler).toHaveBeenCalledTimes(1);
-    expect(registration).toHaveProperty('isDisconnected');
-
-    if (!('isDisconnected' in registration)) {
-      throw new Error('Expected onBackFromSleep to be registered with an isDisconnected gate');
-    }
-
-    expect(registration.isDisconnected()).toBe(true);
-  });
-
   it('reconnects in place when back from sleep is detected while the socket is OPEN', () => {
     const {backFromSleepHandler, registrations} = createBackFromSleepHandlerTestDependencies();
     const socket = createMockSocket(WEBSOCKET_STATE.OPEN);
     const websocket = new ReconnectingWebsocket(jest.fn(), {
       backFromSleepHandler: Maybe.just(backFromSleepHandler),
-      isReliableWebsocketConnectionEnabled: true,
       pingInterval: Maybe.nothing(),
       wallClock: createTestWallClock(0),
       websocketFactory: Maybe.just(() => {
@@ -176,7 +151,6 @@ describe('ReconnectingWebsocket back from sleep handling', () => {
     const socket = createMockSocket(WEBSOCKET_STATE.CLOSED);
     const websocket = new ReconnectingWebsocket(jest.fn(), {
       backFromSleepHandler: Maybe.just(backFromSleepHandler),
-      isReliableWebsocketConnectionEnabled: true,
       pingInterval: Maybe.nothing(),
       wallClock: createTestWallClock(0),
       websocketFactory: Maybe.just(() => {
@@ -195,7 +169,6 @@ describe('ReconnectingWebsocket back from sleep handling', () => {
     const {backFromSleepHandler, registrations} = createBackFromSleepHandlerTestDependencies();
     new ReconnectingWebsocket(jest.fn(), {
       backFromSleepHandler: Maybe.just(backFromSleepHandler),
-      isReliableWebsocketConnectionEnabled: true,
       pingInterval: Maybe.nothing(),
       wallClock: createTestWallClock(0),
       websocketFactory: Maybe.nothing(),
@@ -209,7 +182,6 @@ describe('ReconnectingWebsocket back from sleep handling', () => {
     const socket = createMockSocket(WEBSOCKET_STATE.OPEN);
     const websocket = new ReconnectingWebsocket(jest.fn(), {
       backFromSleepHandler: Maybe.just(backFromSleepHandler),
-      isReliableWebsocketConnectionEnabled: true,
       pingInterval: Maybe.nothing(),
       wallClock: createTestWallClock(0),
       websocketFactory: Maybe.just(() => {

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
@@ -197,7 +197,6 @@ describe('ReconnectingWebsocket', () => {
   };
   const defaultReconnectingWebsocketTestOptions = {
     backFromSleepHandler: Maybe.nothing(),
-    isReliableWebsocketConnectionEnabled: true,
     pingInterval: Maybe.nothing<number>(),
     wallClock: testWallClock,
     websocketFactory: Maybe.nothing(),
@@ -854,7 +853,6 @@ describe('ReconnectingWebsocket', () => {
       const customInterval = 10000;
       const RWS = createRWS(onReconnect, {
         backFromSleepHandler: Maybe.nothing(),
-        isReliableWebsocketConnectionEnabled: true,
         pingInterval: Maybe.just(customInterval),
         wallClock: testWallClock,
         websocketFactory: Maybe.nothing(),
@@ -1052,7 +1050,6 @@ describe('ReconnectingWebsocket', () => {
       const onReconnect = jest.fn().mockReturnValue(getServerAddress());
       const RWS = createRWS(onReconnect, {
         backFromSleepHandler: Maybe.nothing(),
-        isReliableWebsocketConnectionEnabled: true,
         pingInterval: Maybe.just(200),
         wallClock: testWallClock,
         websocketFactory: Maybe.nothing(),
@@ -1075,7 +1072,6 @@ describe('ReconnectingWebsocket', () => {
       const onReconnect = jest.fn().mockReturnValue(getServerAddress());
       const RWS = createRWS(onReconnect, {
         backFromSleepHandler: Maybe.nothing(),
-        isReliableWebsocketConnectionEnabled: true,
         pingInterval: Maybe.just(100),
         wallClock: testWallClock,
         websocketFactory: Maybe.nothing(),

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -74,7 +74,6 @@ export type ReconnectingWebsocketWallClock = {
 
 type ReconnectingWebsocketOptions = {
   readonly backFromSleepHandler: Maybe<BackFromSleepHandler>;
-  readonly isReliableWebsocketConnectionEnabled: boolean;
   readonly pingInterval: Maybe<number>;
   readonly wallClock: ReconnectingWebsocketWallClock;
   readonly websocketFactory: Maybe<() => ReconnectingWebsocketWrapper>;
@@ -144,17 +143,9 @@ export class ReconnectingWebsocket {
      * the internal setInterval and must be called when disconnecting to prevent memory leaks.
      * **/
     const backFromSleepHandler = this.options.backFromSleepHandler.unwrapOr(onBackFromSleep);
-    const backFromSleepRegistration: Parameters<BackFromSleepHandler>[0] = this.options
-      .isReliableWebsocketConnectionEnabled
-      ? {
-          callback: this.handleBackFromSleep,
-        }
-      : {
-          callback: this.handleBackFromSleep,
-          isDisconnected: () => {
-            return this.getState() === WEBSOCKET_STATE.CLOSED;
-          },
-        };
+    const backFromSleepRegistration: Parameters<BackFromSleepHandler>[0] = {
+      callback: this.handleBackFromSleep,
+    };
 
     this.stopBackFromSleepHandler = Maybe.just(backFromSleepHandler(backFromSleepRegistration));
   }

--- a/libraries/api-client/src/tcp/webSocketClient.test.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.test.ts
@@ -77,7 +77,6 @@ function createWebSocketClient(
   client: ConstructorParameters<typeof WebSocketClient>[1],
 ): WebSocketClient {
   return new WebSocketClient(baseUrl, client, {
-    isReliableWebsocketConnectionEnabled: true,
     wallClock: testWallClock,
   });
 }

--- a/libraries/api-client/src/tcp/webSocketClient.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.ts
@@ -63,7 +63,6 @@ export interface WebSocketClient {
 export type OnConnect = (abortHandler: AbortController) => void;
 
 export type WebSocketClientOptions = {
-  readonly isReliableWebsocketConnectionEnabled: boolean;
   readonly wallClock: ReconnectingWebsocketWallClock;
 };
 
@@ -94,7 +93,6 @@ export class WebSocketClient extends EventEmitter {
     this.isRefreshingAccessToken = false;
     this.socket = new ReconnectingWebsocket(this.onReconnect, {
       backFromSleepHandler: Maybe.nothing(),
-      isReliableWebsocketConnectionEnabled: options.isReliableWebsocketConnectionEnabled,
       pingInterval: Maybe.nothing(),
       wallClock: options.wallClock,
       websocketFactory: Maybe.nothing(),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem

The reliable WebSocket wake/reconnect behavior is currently hidden behind the startup feature flag:

```text
reliable-websocket-connection
```

That was useful for the first rollout, but it makes internal dogfooding harder because every user has to enable the flag manually.

## Change

This removes the `reliable-websocket-connection` startup feature flag and makes the reliable WebSocket recovery behavior the default.

The actual recovery behavior is unchanged:

```text
wake from sleep -> do not trust OPEN -> reconnect
```

The CLOSED-wrapper recovery also stays in place:

```text
existing wrapper is CLOSED -> create a fresh wrapper
```

## Why

The fix has already been deployed behind the flag and the follow-up CLOSED-wrapper issue has been addressed.

At this point we want everyone internally to run with the fixed behavior by default, without requiring `?enabled-features=reliable-websocket-connection`.