### PR TITLE
Remove text-encoding dependency [WPB-22420]

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -166,7 +166,6 @@
     "sinon": "21.1.2",
     "style-loader": "4.0.0",
     "svg-inline-loader": "0.8.2",
-    "text-encoding": "0.7.0",
     "webpack": "5.107.2",
     "webpack-bundle-analyzer": "4.10.2",
     "webpack-cli": "6.0.1",

--- a/apps/webapp/src/script/util/test/mock/browserApiMock.ts
+++ b/apps/webapp/src/script/util/test/mock/browserApiMock.ts
@@ -17,10 +17,39 @@
  *
  */
 
-const encoding = require('text-encoding');
+import {TextDecoder, TextEncoder} from 'node:util';
 
-window.TextEncoder = encoding.TextEncoder;
-window.TextDecoder = encoding.TextDecoder;
+function BrowserTextEncoder() {
+  const textEncoder = new TextEncoder();
+
+  return {
+    get encoding() {
+      return textEncoder.encoding;
+    },
+    encode(input?: string) {
+      return Uint8Array.from(textEncoder.encode(input));
+    },
+    encodeInto(source: string, destination: Uint8Array) {
+      return textEncoder.encodeInto(source, destination);
+    },
+  };
+}
+
+const textEncodingProperties = {
+  TextDecoder: {
+    configurable: true,
+    value: TextDecoder,
+    writable: true,
+  },
+  TextEncoder: {
+    configurable: true,
+    value: BrowserTextEncoder,
+    writable: true,
+  },
+};
+
+Object.defineProperties(globalThis, textEncodingProperties);
+Object.defineProperties(window, textEncodingProperties);
 
 window.z = {userPermission: {}};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11823,7 +11823,6 @@ __metadata:
     speakingurl: "npm:14.0.1"
     style-loader: "npm:4.0.0"
     svg-inline-loader: "npm:0.8.2"
-    text-encoding: "npm:0.7.0"
     tsyringe: "npm:4.10.0"
     underscore: "npm:1.13.8"
     use-debounce: "npm:10.1.1"
@@ -29587,13 +29586,6 @@ __metadata:
     glob: "npm:^7.1.4"
     minimatch: "npm:^3.0.4"
   checksum: 10/8fccb2cb6c8fcb6bb4115394feb833f8b6cf4b9503ec2485c2c90febf435cac62abe882a0c5c51a37b9bbe70640cdd05acf5f45e486ac4583389f4b0855f69e5
-  languageName: node
-  linkType: hard
-
-"text-encoding@npm:0.7.0":
-  version: 0.7.0
-  resolution: "text-encoding@npm:0.7.0"
-  checksum: 10/c61b7a59a54c58f0714da0ef4c1f65732821bb1f761e6f21c3e681e51c6dd56fdefa4fcfccd3254bf47132d87420fbc9898da21a804c89e87861f4e1478d5f18
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Remove the deprecated text-encoding package from the webapp test setup.

The package was only used in browserApiMock.ts to provide TextEncoder and TextDecoder on the test window object. Node already provides these implementations through node:util, so the mock can use the built-in APIs instead of keeping an obsolete dependency around.

This addresses the text-encoding warning from Renovate's Dependency Dashboard and keeps the package manifest and lockfile cleaner without changing production behavior.


