### PR TITLE
Remove intersection-observer dependency [WPB-22420]

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -144,7 +144,6 @@
     "dexie": "4.4.3",
     "html-webpack-plugin": "5.6.7",
     "i18next-scanner": "4.6.0",
-    "intersection-observer": "0.12.2",
     "jest-canvas-mock": "2.5.2",
     "jest-jasmine2": "30.4.2",
     "jest-transform-stub": "2.0.0",

--- a/apps/webapp/setupTests.js
+++ b/apps/webapp/setupTests.js
@@ -25,9 +25,9 @@
  * ---------------------------------------------------------------------------
  */
 import 'core-js/full/reflect';
-import 'intersection-observer';
 import 'core-js/stable/structured-clone';
 import 'fake-indexeddb/auto';
+import 'jest-canvas-mock';
 import '@testing-library/jest-dom';
 
 /**
@@ -37,6 +37,7 @@ import '@testing-library/jest-dom';
  */
 import 'src/script/util/test/mock/createObjectUrlMock';
 import 'src/script/util/test/mock/cryptoMock';
+import 'src/script/util/test/mock/intersectionObserverMock';
 import 'src/script/util/test/mock/matchMediaMock';
 import 'src/script/util/test/mock/mediaDevicesMock';
 import 'src/script/util/test/mock/navigatorPermissionsMock';

--- a/apps/webapp/src/script/components/Avatar/AvatarImage.test.tsx
+++ b/apps/webapp/src/script/components/Avatar/AvatarImage.test.tsx
@@ -23,10 +23,26 @@ import {AVATAR_SIZE} from 'Components/Avatar';
 import {AssetRemoteData} from 'Repositories/assets/assetRemoteData';
 import {AssetRepository} from 'Repositories/assets/assetRepository';
 import {User} from 'Repositories/entity/User';
+import {viewportObserver} from 'Util/DOM/viewportObserver';
 
 import {AvatarImage} from './AvatarImage';
 
 describe('AvatarImage', () => {
+  let originalTrackElement: typeof viewportObserver.trackElement;
+
+  beforeEach(() => {
+    originalTrackElement = viewportObserver.trackElement;
+
+    viewportObserver.trackElement = (element, onVisibilityChange) => {
+      onVisibilityChange(true, true);
+    };
+  });
+
+  afterEach(() => {
+    viewportObserver.trackElement = originalTrackElement;
+    jest.resetAllMocks();
+  });
+
   it('fetches full avatar image for large avatars', async () => {
     const assetRepoSpy = {
       getObjectUrl: jasmine.createSpy().and.returnValue(Promise.resolve()),

--- a/apps/webapp/src/script/util/test/mock/intersectionObserverMock.ts
+++ b/apps/webapp/src/script/util/test/mock/intersectionObserverMock.ts
@@ -1,0 +1,41 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+function createIntersectionObserver(
+  _callback: IntersectionObserverCallback,
+  options: IntersectionObserverInit = {},
+): IntersectionObserver {
+  return {
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    root: options.root ?? null,
+    rootMargin: options.rootMargin ?? '0px',
+    takeRecords: jest.fn(() => {
+      return [];
+    }),
+    thresholds: Array.isArray(options.threshold) ? options.threshold : [options.threshold ?? 0],
+    unobserve: jest.fn(),
+  };
+}
+
+Object.defineProperty(window, 'IntersectionObserver', {
+  configurable: true,
+  value: jest.fn(createIntersectionObserver),
+  writable: true,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11767,7 +11767,6 @@ __metadata:
     html-webpack-plugin: "npm:5.6.7"
     i18next-scanner: "npm:4.6.0"
     immer: "npm:11.1.8"
-    intersection-observer: "npm:0.12.2"
     jest-canvas-mock: "npm:2.5.2"
     jest-jasmine2: "npm:30.4.2"
     jest-transform-stub: "npm:2.0.0"
@@ -19344,13 +19343,6 @@ __metadata:
   version: 3.1.1
   resolution: "interpret@npm:3.1.1"
   checksum: 10/bc9e11126949c4e6ff49b0b819e923a9adc8e8bf3f9d4f2d782de6d5f592774f6fee4457c10bd08c6a2146b4baee460ccb242c99e5397defa9c846af0d00505a
-  languageName: node
-  linkType: hard
-
-"intersection-observer@npm:0.12.2":
-  version: 0.12.2
-  resolution: "intersection-observer@npm:0.12.2"
-  checksum: 10/cb1a6369bd1636b3f227d7cb7fec22f5a35b9d8ba9e26303b405d50c54c3ef02c5a547107b1d951e7eb421e192a564222faf4660a21fad69c34dcb9f926c159c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Remove the deprecated intersection-observer package from the webapp test setup.

The package was only used as a Jest environment polyfill. The test setup now provides a small local IntersectionObserver mock instead, which is enough for tests that only require the browser API to exist. Tests that need custom observer behavior can still override window.IntersectionObserver explicitly.

This addresses the intersection-observer warning from Renovate's Dependency Dashboard without changing production behavior.


