### PR TITLE
Allow reply action to be retried [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/conversation.page.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Locator, Page} from '@playwright/test';
+import {expect, Locator, Page} from '@playwright/test';
 
 import {User} from 'test/e2e_tests/data/user';
 import {downloadAssetAndGetFilePath} from 'test/e2e_tests/utils/asset.util';
@@ -169,8 +169,11 @@ export class ConversationPage {
   }
 
   async replyToMessage(message: Locator) {
-    await message.hover();
-    await message.getByRole('group').getByTestId('do-reply-message').click();
+    // Allow full transaction of hovering and clicking to be retried
+    await expect(async () => {
+      await message.hover();
+      await message.getByRole('group').getByTestId('do-reply-message').click({timeout: 3_000});
+    }).toPass();
   }
 
   async enableSelfDeletingMessages() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is an attempt to reduce flake within tests. Since replying to a message depends on the message to be hovered first it can easily happen that e.g. the message moves and the reply button is no longer shown. As the hover already passed playwright will then only retry the click which will always fail. By wrapping it in expect.toPass() the whole transaction can be retried.


