### PR TITLE
Add meetings API client module [WPB-20287]

### DIFF
--- a/libraries/api-client/src/meetings/createMeeting.ts
+++ b/libraries/api-client/src/meetings/createMeeting.ts
@@ -19,7 +19,7 @@
 
 import {MeetingRecurrence} from './meetingRecurrence';
 
-export interface NewMeeting {
+export interface CreateMeeting {
   end_time: string;
   invited_emails?: string[];
   recurrence?: MeetingRecurrence;

--- a/libraries/api-client/src/meetings/index.ts
+++ b/libraries/api-client/src/meetings/index.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2025 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libraries/api-client/src/meetings/index.ts
+++ b/libraries/api-client/src/meetings/index.ts
@@ -21,5 +21,5 @@ export * from './meeting';
 export * from './meetingEmailsInvitation';
 export * from './meetingRecurrence';
 export * from './meetingsApi';
-export * from './newMeeting';
+export * from './createMeeting';
 export * from './updateMeeting';

--- a/libraries/api-client/src/meetings/index.ts
+++ b/libraries/api-client/src/meetings/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './meeting';
+export * from './meetingEmailsInvitation';
+export * from './meetingRecurrence';
+export * from './meetingsApi';
+export * from './newMeeting';
+export * from './updateMeeting';

--- a/libraries/api-client/src/meetings/meeting.ts
+++ b/libraries/api-client/src/meetings/meeting.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2025 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libraries/api-client/src/meetings/meeting.ts
+++ b/libraries/api-client/src/meetings/meeting.ts
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {MeetingRecurrence} from './meetingRecurrence';
+
+import {QualifiedId} from '../user/qualifiedId';
+
+export interface Meeting {
+  created_at: string;
+  end_time: string;
+  invited_emails: string[];
+  qualified_conversation: QualifiedId;
+  qualified_creator: QualifiedId;
+  qualified_id: QualifiedId;
+  recurrence?: MeetingRecurrence;
+  start_time: string;
+  title: string;
+  trial: boolean;
+  updated_at: string;
+}

--- a/libraries/api-client/src/meetings/meetingEmailsInvitation.ts
+++ b/libraries/api-client/src/meetings/meetingEmailsInvitation.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2025 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libraries/api-client/src/meetings/meetingEmailsInvitation.ts
+++ b/libraries/api-client/src/meetings/meetingEmailsInvitation.ts
@@ -1,0 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export interface MeetingEmailsInvitation {
+  emails: string[];
+}

--- a/libraries/api-client/src/meetings/meetingRecurrence.ts
+++ b/libraries/api-client/src/meetings/meetingRecurrence.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2025 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libraries/api-client/src/meetings/meetingRecurrence.ts
+++ b/libraries/api-client/src/meetings/meetingRecurrence.ts
@@ -1,0 +1,31 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export enum MeetingRecurrenceFrequency {
+  DAILY = 'daily',
+  WEEKLY = 'weekly',
+  MONTHLY = 'monthly',
+  YEARLY = 'yearly',
+}
+
+export interface MeetingRecurrence {
+  frequency: MeetingRecurrenceFrequency;
+  interval?: number;
+  until?: string;
+}

--- a/libraries/api-client/src/meetings/meetingsApi.ts
+++ b/libraries/api-client/src/meetings/meetingsApi.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2025 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libraries/api-client/src/meetings/meetingsApi.ts
+++ b/libraries/api-client/src/meetings/meetingsApi.ts
@@ -1,0 +1,135 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {AxiosRequestConfig} from 'axios';
+
+import {Meeting} from './meeting';
+import {MeetingEmailsInvitation} from './meetingEmailsInvitation';
+import {NewMeeting} from './newMeeting';
+import {UpdateMeeting} from './updateMeeting';
+
+import {HttpClient} from '../http';
+import {QualifiedId} from '../user/qualifiedId';
+
+export class MeetingsAPI {
+  constructor(private readonly client: HttpClient) {}
+
+  public static readonly URL = {
+    MEETINGS: '/meetings',
+    LIST: '/meetings/list',
+    INVITATIONS: 'invitations',
+    INVITATIONS_DELETE: 'invitations/delete',
+  } as const;
+
+  private generateMeetingUrl(meetingId: QualifiedId): string {
+    return `${MeetingsAPI.URL.MEETINGS}/${meetingId.domain}/${meetingId.id}`;
+  }
+
+  /**
+   * Create a new meeting.
+   */
+  public async createMeeting(newMeeting: NewMeeting): Promise<Meeting> {
+    const config: AxiosRequestConfig = {
+      data: newMeeting,
+      method: 'post',
+      url: MeetingsAPI.URL.MEETINGS,
+    };
+
+    const response = await this.client.sendJSON<Meeting>(config);
+    return response.data;
+  }
+
+  /**
+   * List all meetings for the authenticated user.
+   */
+  public async getMeetingsList(): Promise<Meeting[]> {
+    const config: AxiosRequestConfig = {
+      method: 'get',
+      url: MeetingsAPI.URL.LIST,
+    };
+
+    const response = await this.client.sendJSON<Meeting[]>(config);
+    return response.data;
+  }
+
+  /**
+   * Delete a meeting.
+   */
+  public async deleteMeeting(meetingId: QualifiedId): Promise<void> {
+    const config: AxiosRequestConfig = {
+      method: 'delete',
+      url: this.generateMeetingUrl(meetingId),
+    };
+
+    await this.client.sendJSON<void>(config);
+  }
+
+  /**
+   * Get a single meeting by ID.
+   */
+  public async getMeeting(meetingId: QualifiedId): Promise<Meeting> {
+    const config: AxiosRequestConfig = {
+      method: 'get',
+      url: this.generateMeetingUrl(meetingId),
+    };
+
+    const response = await this.client.sendJSON<Meeting>(config);
+    return response.data;
+  }
+
+  /**
+   * Update an existing meeting.
+   */
+  public async updateMeeting(meetingId: QualifiedId, updateMeeting: UpdateMeeting): Promise<Meeting> {
+    const config: AxiosRequestConfig = {
+      data: updateMeeting,
+      method: 'put',
+      url: this.generateMeetingUrl(meetingId),
+    };
+
+    const response = await this.client.sendJSON<Meeting>(config);
+    return response.data;
+  }
+
+  /**
+   * Add emails to the invited emails of a meeting.
+   */
+  public async addMeetingInvitation(meetingId: QualifiedId, invitation: MeetingEmailsInvitation): Promise<void> {
+    const config: AxiosRequestConfig = {
+      data: invitation,
+      method: 'post',
+      url: `${this.generateMeetingUrl(meetingId)}/${MeetingsAPI.URL.INVITATIONS}`,
+    };
+
+    await this.client.sendJSON<void>(config);
+  }
+
+  /**
+   * Remove emails from the invited emails of a meeting.
+   */
+  public async removeMeetingInvitation(meetingId: QualifiedId, invitation: MeetingEmailsInvitation): Promise<void> {
+    const config: AxiosRequestConfig = {
+      data: invitation,
+      method: 'post',
+      url: `${this.generateMeetingUrl(meetingId)}/${MeetingsAPI.URL.INVITATIONS_DELETE}`,
+    };
+
+    await this.client.sendJSON<void>(config);
+  }
+}

--- a/libraries/api-client/src/meetings/meetingsApi.ts
+++ b/libraries/api-client/src/meetings/meetingsApi.ts
@@ -19,9 +19,9 @@
 
 import {AxiosRequestConfig} from 'axios';
 
+import {CreateMeeting} from './createMeeting';
 import {Meeting} from './meeting';
 import {MeetingEmailsInvitation} from './meetingEmailsInvitation';
-import {NewMeeting} from './newMeeting';
 import {UpdateMeeting} from './updateMeeting';
 
 import {HttpClient} from '../http';
@@ -44,7 +44,7 @@ export class MeetingsAPI {
   /**
    * Create a new meeting.
    */
-  public async createMeeting(newMeeting: NewMeeting): Promise<Meeting> {
+  public async createMeeting(newMeeting: CreateMeeting): Promise<Meeting> {
     const config: AxiosRequestConfig = {
       data: newMeeting,
       method: 'post',

--- a/libraries/api-client/src/meetings/newMeeting.ts
+++ b/libraries/api-client/src/meetings/newMeeting.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2025 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libraries/api-client/src/meetings/newMeeting.ts
+++ b/libraries/api-client/src/meetings/newMeeting.ts
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {MeetingRecurrence} from './meetingRecurrence';
+
+export interface NewMeeting {
+  end_time: string;
+  invited_emails?: string[];
+  recurrence?: MeetingRecurrence;
+  start_time: string;
+  title: string;
+}

--- a/libraries/api-client/src/meetings/updateMeeting.ts
+++ b/libraries/api-client/src/meetings/updateMeeting.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2025 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libraries/api-client/src/meetings/updateMeeting.ts
+++ b/libraries/api-client/src/meetings/updateMeeting.ts
@@ -1,0 +1,27 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {MeetingRecurrence} from './meetingRecurrence';
+
+export interface UpdateMeeting {
+  end_time?: string;
+  recurrence?: MeetingRecurrence;
+  start_time?: string;
+  title?: string;
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20287" title="WPB-20287" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20287</a>  [Web] Fetching and providing Meeting items
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Expose swagger-aligned types and all seven meetings endpoints so the webapp can call the meetings backend without ad-hoc HTTP code.


