### PR TITLE
fix: FallbackProcessor initialization in Worker environments [WPB-25918]

### DIFF
--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/processor.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/processor.ts
@@ -78,8 +78,17 @@ class FallbackProcessor implements MediaStreamTrackProcessor {
           await new Promise(r => setTimeout(r, frameDuration - delta));
         }
         timestamp = performance.now();
-        canvas.width = video.videoWidth;
-        canvas.height = video.videoHeight;
+        const width = video.videoWidth;
+        const height = video.videoHeight;
+
+        if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA || width === 0 || height === 0) {
+          return;
+        }
+
+        if (canvas.width !== width || canvas.height !== height) {
+          canvas.width = width;
+          canvas.height = height;
+        }
         ctx.drawImage(video, 0, 0);
         controller.enqueue(new VideoFrame(canvas, {timestamp}));
       },

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/processor.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/processor.ts
@@ -90,7 +90,12 @@ class FallbackProcessor implements MediaStreamTrackProcessor {
           canvas.height = height;
         }
         ctx.drawImage(video, 0, 0);
-        controller.enqueue(new VideoFrame(canvas, {timestamp}));
+        try {
+          controller.enqueue( new VideoFrame(canvas, {timestamp: Math.round(performance.now() * 1000)})); // µs
+        } catch (e: unknown) {
+          running = false;
+          close();
+        }
       },
       cancel: reason => {
         this.logger.log(`[virtual-background] video processor cancelled: ${reason}`);

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/processor.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/processor.ts
@@ -97,5 +97,6 @@ class FallbackProcessor implements MediaStreamTrackProcessor {
   }
 }
 
-const TrackProcessor = 'MediaStreamTrackProcessor' in window ? window.MediaStreamTrackProcessor : FallbackProcessor;
+const TrackProcessor =
+  'MediaStreamTrackProcessor' in globalThis ? (globalThis as any).MediaStreamTrackProcessor : FallbackProcessor;
 export {TrackProcessor};

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/processor.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/processor.ts
@@ -95,7 +95,7 @@ class FallbackProcessor implements MediaStreamTrackProcessor {
         }
         ctx.drawImage(video, 0, 0);
         try {
-          controller.enqueue( new VideoFrame(canvas, {timestamp: Math.round(performance.now() * 1000)})); // µs
+          controller.enqueue(new VideoFrame(canvas, {timestamp: Math.round(performance.now() * 1000)})); // µs
         } catch (e: unknown) {
           running = false;
           close();

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/processor.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/processor.ts
@@ -62,7 +62,7 @@ class FallbackProcessor implements MediaStreamTrackProcessor {
     };
     this.readable = new ReadableStream({
       start: async () => {
-        await Promise.all([video.play(), new Promise(r => video.addEventListener('loadeddata', r, {once: true}))]);
+        await this.startVideo(video);
         frameDuration = 1000 / (track.getSettings().frameRate || 30);
         timestamp = performance.now();
         this.logger.log(`[virtual-background] processor start frameDuration=${frameDuration}`);
@@ -94,6 +94,45 @@ class FallbackProcessor implements MediaStreamTrackProcessor {
       trackStop();
       running = false;
     };
+  }
+
+  private async startVideo(video: HTMLVideoElement): Promise<void> {
+    const waitForLoadedData = (): Promise<void> => {
+      if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+        return Promise.resolve();
+      }
+
+      return new Promise<void>((resolve, reject) => {
+        const cleanup = () => {
+          video.removeEventListener('loadeddata', onLoaded);
+          video.removeEventListener('error', onError);
+        };
+
+        const onLoaded = () => {
+          cleanup();
+          resolve();
+        };
+
+        const onError = () => {
+          cleanup();
+          reject(video.error ?? new Error('Video failed to load'));
+        };
+
+        video.addEventListener('loadeddata', onLoaded, {once: true});
+        video.addEventListener('error', onError, {once: true});
+      });
+    };
+
+    const loaded = waitForLoadedData();
+
+    try {
+      await video.play();
+      await loaded;
+    } catch (error) {
+      video.pause();
+      video.srcObject = null;
+      throw error;
+    }
   }
 }
 

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/processor.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/processor.ts
@@ -54,7 +54,7 @@ class FallbackProcessor implements MediaStreamTrackProcessor {
       throw new Error('Failed to get 2D context from OffscreenCanvas');
     }
     let timestamp = 0;
-    let frameDuration = 1000 / 30;
+    let frameDuration = 1000 / 15;
     const close = () => {
       video.pause();
       video.srcObject = null;
@@ -63,7 +63,11 @@ class FallbackProcessor implements MediaStreamTrackProcessor {
     this.readable = new ReadableStream({
       start: async () => {
         await this.startVideo(video);
-        frameDuration = 1000 / (track.getSettings().frameRate || 30);
+        const configuredFrameRate = track.getSettings().frameRate;
+
+        if (configuredFrameRate && configuredFrameRate > 0) {
+          frameDuration = 1000 / configuredFrameRate;
+        }
         timestamp = performance.now();
         this.logger.log(`[virtual-background] processor start frameDuration=${frameDuration}`);
       },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25918" title="WPB-25918" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-25918</a>  [Web] Add DirectX Support for Chromium on Windows for Background Effect Rendering
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Updated the FallbackProcessor to work correctly in Worker environments where browser APIs such as document or HTMLVideoElement may not be available.
- Added defensive error handling to gracefully catch and ignore unsupported initialization scenarios instead of throwing runtime exceptions.