### PR TITLE
fix: ignore stale default drive fetches(WPB-20817)

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {act, renderHook, waitFor} from '@testing-library/react';
+import {RestNode, RestNodeCollection} from 'cells-sdk-ts';
+
+import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {UserRepository} from 'Repositories/user/userRepository';
+import {createExecutingFireAndForgetInvokerForTest} from 'src/script/page/testSupport/rootContextTestSupport';
+
+import {useGetAllCellsNodes} from './useGetAllCellsNodes';
+
+import {useCellsStore} from '../common/useCellsStore/useCellsStore';
+
+const CONV_ID = 'conv-abc';
+const DOMAIN = 'staging.zinfra.io';
+const QUALIFIED_ID = {id: CONV_ID, domain: DOMAIN};
+
+type FakeCellsRepository = jest.Mocked<Pick<CellsRepository, 'getAllNodes'>>;
+type FakeUserRepository = jest.Mocked<Pick<UserRepository, 'getUsersById'>>;
+
+function createRestNode(name: string, uuid = name): RestNode {
+  return {Path: `${CONV_ID}@${DOMAIN}/${name}`, Type: 'LEAF', Uuid: uuid};
+}
+
+function createFakeCellsRepository(result: Partial<RestNodeCollection> = {}): FakeCellsRepository {
+  return {getAllNodes: jest.fn().mockResolvedValue({Nodes: [], ...result})};
+}
+
+function createFakeUserRepository(): FakeUserRepository {
+  return {getUsersById: jest.fn().mockResolvedValue([])};
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return {promise, resolve};
+}
+
+function renderGetAllNodesHook({
+  cellsRepository = createFakeCellsRepository(),
+  userRepository = createFakeUserRepository(),
+  enabled = true,
+  fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest(),
+}: {
+  cellsRepository?: FakeCellsRepository;
+  userRepository?: FakeUserRepository;
+  enabled?: boolean;
+  fireAndForgetInvoker?: ReturnType<typeof createExecutingFireAndForgetInvokerForTest>;
+} = {}) {
+  return {
+    fireAndForgetInvoker,
+    ...renderHook(
+      ({enabled}: {enabled: boolean}) =>
+        useGetAllCellsNodes({
+          cellsRepository: cellsRepository as unknown as CellsRepository,
+          userRepository: userRepository as unknown as UserRepository,
+          conversationQualifiedId: QUALIFIED_ID,
+          enabled,
+          fireAndForgetInvoker,
+        }),
+      {initialProps: {enabled}},
+    ),
+  };
+}
+
+describe('useGetAllCellsNodes', () => {
+  beforeEach(() => {
+    useCellsStore.getState().clearAll({conversationId: CONV_ID});
+    window.location.hash = `/conversation/${CONV_ID}/${DOMAIN}/files`;
+  });
+
+  it('does not write to the store when disabled mid-flight', async () => {
+    const fetch = createDeferred<RestNodeCollection>();
+    const cellsRepository = {getAllNodes: jest.fn().mockReturnValue(fetch.promise)} as FakeCellsRepository;
+    const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
+
+    const {rerender} = renderGetAllNodesHook({cellsRepository, fireAndForgetInvoker});
+    await waitFor(() => expect(cellsRepository.getAllNodes).toHaveBeenCalledTimes(1));
+
+    act(() => rerender({enabled: false}));
+
+    act(() => {
+      fetch.resolve({Nodes: [createRestNode('stale-file.txt')]});
+    });
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(useCellsStore.getState().getNodes({conversationId: CONV_ID})).toHaveLength(0);
+  });
+
+  it('does not let an older response overwrite a newer fetch', async () => {
+    const firstFetch = createDeferred<RestNodeCollection>();
+    const secondFetch = createDeferred<RestNodeCollection>();
+    const cellsRepository = {
+      getAllNodes: jest.fn().mockReturnValueOnce(firstFetch.promise).mockReturnValueOnce(secondFetch.promise),
+    } as FakeCellsRepository;
+    const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
+
+    const {result} = renderGetAllNodesHook({cellsRepository, fireAndForgetInvoker});
+    await waitFor(() => expect(cellsRepository.getAllNodes).toHaveBeenCalledTimes(1));
+
+    act(() => result.current.setOffset(50));
+    await waitFor(() => expect(cellsRepository.getAllNodes).toHaveBeenCalledTimes(2));
+
+    act(() => {
+      secondFetch.resolve({Nodes: [createRestNode('new-file.txt')]});
+    });
+    await waitFor(() =>
+      expect(useCellsStore.getState().getNodes({conversationId: CONV_ID})[0]?.name).toBe('new-file.txt'),
+    );
+
+    act(() => {
+      firstFetch.resolve({Nodes: [createRestNode('stale-file.txt')]});
+    });
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(useCellsStore.getState().getNodes({conversationId: CONV_ID})[0]?.name).toBe('new-file.txt');
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {useEffect, useCallback, useState} from 'react';
+import {useEffect, useCallback, useRef, useState} from 'react';
 
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
 
@@ -33,6 +33,7 @@ import {getCellsApiPath} from '../common/getCellsApiPath/getCellsApiPath';
 import {getCellsFilesPath} from '../common/getCellsFilesPath/getCellsFilesPath';
 import {RECYCLE_BIN_PATH} from '../common/recycleBin/recycleBin';
 import {useCellsStore} from '../common/useCellsStore/useCellsStore';
+import {createRequestVersionGate} from '../useConversationSearch/requestVersionGate';
 
 interface UseGetAllCellsNodesProps {
   cellsRepository: CellsRepository;
@@ -51,10 +52,23 @@ export const useGetAllCellsNodes = ({
 }: UseGetAllCellsNodesProps) => {
   const {setNodes, pageSize, setStatus, setPagination, setError, clearAll} = useCellsStore();
   const [offset, setOffset] = useState(0);
+  const requestVersionGate = useRef(createRequestVersionGate());
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
 
   const {domain, id} = conversationQualifiedId;
 
+  const isCurrentFetchRequest = useCallback((requestVersion: number): boolean => {
+    return enabledRef.current && !requestVersionGate.current.isStale(requestVersion);
+  }, []);
+
   const fetchNodes = useCallback(async () => {
+    if (!enabledRef.current) {
+      return;
+    }
+
+    const requestVersion = requestVersionGate.current.next();
+
     try {
       setError(null);
       setStatus('loading');
@@ -68,6 +82,10 @@ export const useGetAllCellsNodes = ({
         deleted: getCellsFilesPath() === RECYCLE_BIN_PATH,
       });
 
+      if (!isCurrentFetchRequest(requestVersion)) {
+        return;
+      }
+
       if (result.Nodes === undefined || result.Nodes.length === 0) {
         setNodes({conversationId: id, nodes: []});
         setStatus('success');
@@ -76,6 +94,10 @@ export const useGetAllCellsNodes = ({
       }
 
       const users = await getUsersFromNodes({nodes: result.Nodes, userRepository});
+
+      if (!isCurrentFetchRequest(requestVersion)) {
+        return;
+      }
 
       // filter out draft nodes from results
       const filteredNodes = result.Nodes.filter(node => node.IsDraft !== true);
@@ -88,6 +110,10 @@ export const useGetAllCellsNodes = ({
 
       setStatus('success');
     } catch (error: unknown) {
+      if (!isCurrentFetchRequest(requestVersion)) {
+        return;
+      }
+
       setError(error instanceof Error ? error : new Error('Failed to fetch files', {cause: error}));
       setPagination({conversationId: id, pagination: null});
       setStatus('error');
@@ -95,7 +121,7 @@ export const useGetAllCellsNodes = ({
     }
     // cellsRepository and userRepository are not dependencies because they're singletons
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [domain, id, offset, pageSize, setError, setNodes, setPagination, setStatus]);
+  }, [domain, id, isCurrentFetchRequest, offset, pageSize, setError, setNodes, setPagination, setStatus]);
 
   const handleHashChange = useCallback((): void => {
     if (enabled !== true) {
@@ -108,6 +134,7 @@ export const useGetAllCellsNodes = ({
 
   useEffect(() => {
     if (enabled !== true) {
+      requestVersionGate.current.invalidate();
       return;
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20817" title="WPB-20817" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20817</a>  [Web] Search results are not fetching all files when the search box is empty
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Add request-version guarding to `useGetAllCellsNodes`
- Prevent stale default-drive fetch responses from writing nodes, pagination, status, or errors after a newer request/disabled state
- Add regression tests for disabled mid-flight and older-response-overwrites-newer cases


