### PR TITLE
fix: WPB-26424 Display basic metadata on received assets even if remote is missing

### DIFF
--- a/apps/webapp/src/script/repositories/cryptography/CryptographyMapper.ts
+++ b/apps/webapp/src/script/repositories/cryptography/CryptographyMapper.ts
@@ -393,18 +393,16 @@ export class CryptographyMapper {
 
     if (preview !== null && preview !== undefined) {
       const remote = preview.remote;
-      if (remote === null || remote === undefined) {
-        return {data, type: ClientEvent.CONVERSATION.ASSET_ADD};
+      if (remote !== null && remote !== undefined) {
+        data = {
+          ...data,
+          preview_domain: remote.assetDomain ?? undefined,
+          preview_key: remote.assetId ?? undefined,
+          preview_otr_key: new Uint8Array(remote.otrKey),
+          preview_sha256: new Uint8Array(remote.sha256),
+          preview_token: remote.assetToken ?? undefined,
+        };
       }
-
-      data = {
-        ...data,
-        preview_domain: remote.assetDomain ?? undefined,
-        preview_key: remote.assetId ?? undefined,
-        preview_otr_key: new Uint8Array(remote.otrKey),
-        preview_sha256: new Uint8Array(remote.sha256),
-        preview_token: remote.assetToken ?? undefined,
-      };
     }
 
     const isImage =


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26424" title="WPB-26424" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26424</a>  [Web] [Assets] Asset previews are not displayed when sent by Bots (or old clients)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Fix for WPB-26424, possibly introduced on commit b83a7fb02f.

Previously assets without "remote" were still displayed.
The early return in case "remote" was missing, caused some assets to be displayed with "data" starting values (zeros and nulls)