### PR TITLE
Remove usage of backticks from test tiles [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -836,7 +836,7 @@ test.describe('Calling', () => {
   );
 
   test(
-    'I want to see a group call timing out after 90s if I`m the last one left in the call',
+    "I want to see a group call timing out after 90s if I'm the last one left in the call",
     {tag: ['@TC-2937', '@regression']},
     async ({createPage}, testInfo) => {
       test.setTimeout(testInfo.timeout + 90_000);

--- a/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/GroupConversation/groupConversation.spec.ts
@@ -272,7 +272,7 @@ test.describe('Group Conversation', () => {
   );
 
   test(
-    'As a group member I should not see group admin toggle while viewing Admin`s profile in Conversation details',
+    "As a group member I should not see group admin toggle while viewing Admin's profile in Conversation details",
     {tag: ['@TC-1483', '@regression']},
     async ({createPage}) => {
       const [userAPages, userBPages] = await Promise.all([

--- a/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/HistoryBackup/historyBackup.spec.ts
@@ -394,7 +394,7 @@ test.describe('History Backup', () => {
   );
 
   test(
-    'I shouldn`t be able to send messages in the group conversation that I previously left after backup',
+    "I shouldn't be able to send messages in the group conversation that I previously left after backup",
     {tag: ['@TC-10549', '@regression']},
     async ({createPage}, testInfo) => {
       const [userAPageManager, userBPageManager] = await Promise.all([

--- a/apps/webapp/test/e2e_tests/specs/ProteusVerification/proteusVerification.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ProteusVerification/proteusVerification.spec.ts
@@ -131,7 +131,7 @@ test.describe('Proteus verification', () => {
   );
 
   test(
-    'My other clients should be notified when I`m login on a new device',
+    "My other clients should be notified when I'm login on a new device",
     {tag: ['@TC-717', '@regression']},
     async ({createPage}) => {
       const {pages, components, modals} = PageManager.from(await createPage(withLogin(userA))).webapp;
@@ -185,7 +185,7 @@ test.describe('Proteus verification', () => {
     },
   );
 
-  test('Verify other user`s devices in 1on1 conversation', {tag: ['@TC-719', '@regression']}, async ({createPage}) => {
+  test('Verify other users devices in 1on1 conversation', {tag: ['@TC-719', '@regression']}, async ({createPage}) => {
     const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
     await connectWithUser(userAPage, userB);
 
@@ -225,7 +225,7 @@ test.describe('Proteus verification', () => {
       }
     });
 
-    await test.step('Action: User A verifies User B`s device', async () => {
+    await test.step('Action: User A verifies User Bs device', async () => {
       await userAComponents.conversationSidebar().clickAllConversationsButton();
       await userAPages.conversationList().getConversation(userB.fullName).open();
       await userAPages.conversation().clickConversationInfoButton();
@@ -365,7 +365,7 @@ test.describe('Proteus verification', () => {
         ).toBeVisible();
       });
 
-      await test.step('Action: User A verifies User C`s device', async () => {
+      await test.step('Action: User A verifies User Cs device', async () => {
         await userAPages.conversationDetails().getParticipant(userC.fullName).openDetails();
         await userAPages.participantDetails().devicesButton.click();
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The backticks used in test tiles can cause formatting to be broken within reports:
<img width="442" height="83" alt="Bildschirmfoto 2026-06-17 um 09 24 00" src="https://github.com/user-attachments/assets/1acb462f-3516-46e0-b5ca-f11036ee09d0" />
