### PR TITLE
Use static date for snapshot test [WPB-22420]

### DIFF
--- a/libraries/react-ui-kit/src/Inputs/DatePickerField/DatePickerField.test.tsx
+++ b/libraries/react-ui-kit/src/Inputs/DatePickerField/DatePickerField.test.tsx
@@ -19,7 +19,7 @@
 
 /* eslint-disable jest/expect-expect */
 
-import {getLocalTimeZone, today} from '@internationalized/date';
+import {CalendarDate, getLocalTimeZone, today} from '@internationalized/date';
 
 import {DatePickerField} from './DatePickerField';
 
@@ -37,7 +37,7 @@ const defaultProps: React.ComponentProps<typeof DatePickerField> = {
   id: 'date-picker-test',
   labels: defaultLabels,
   ariaLabel: 'Select date',
-  value: today(getLocalTimeZone()),
+  value: new CalendarDate(2026, 6, 16),
   onChange: () => undefined,
 };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
A dynamic date was used within snapshot tests, causing the CI to fail every day as the date would change and no longer match the snapshot.


