### PR TITLE
Reduce Jest output noise in continuous integration [WPB-22420]

### DIFF
--- a/apps/server/jest.config.js
+++ b/apps/server/jest.config.js
@@ -17,6 +17,8 @@
  *
  */
 
+const isContinuousIntegrationEnvironment = process.env.CI === 'true';
+
 module.exports = {
   preset: '../../jest.preset.js',
   collectCoverageFrom: [
@@ -38,7 +40,9 @@ module.exports = {
       statements: 18,
     },
   },
+  coverageReporters: isContinuousIntegrationEnvironment ? ['html', 'lcov', 'text-summary'] : undefined,
   moduleDirectories: ['node_modules', __dirname],
+  reporters: isContinuousIntegrationEnvironment ? ['github-actions', 'summary'] : ['default'],
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/dist'],
   transformIgnorePatterns: ['/node_modules/(?!(true-myth|@sindresorhus/is)/)'],

--- a/apps/webapp/jest.config.ts
+++ b/apps/webapp/jest.config.ts
@@ -23,6 +23,7 @@ import {dirname} from 'path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const isContinuousIntegrationEnvironment = process.env.CI === 'true';
 
 process.env.TZ = 'UTC';
 
@@ -50,7 +51,8 @@ const config: Config = {
     '^react(.*)$': '<rootDir>/../../node_modules/react$1',
     '.*\\.glsl': 'jest-transform-stub',
   },
-  reporters: ['default'],
+  coverageReporters: isContinuousIntegrationEnvironment ? ['html', 'lcov', 'text-summary'] : undefined,
+  reporters: isContinuousIntegrationEnvironment ? ['github-actions', 'summary'] : ['default'],
   setupFilesAfterEnv: ['<rootDir>/setupTests.js'],
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {

--- a/libraries/api-client/jest.config.js
+++ b/libraries/api-client/jest.config.js
@@ -17,6 +17,8 @@
  *
  */
 
+const isContinuousIntegrationEnvironment = process.env.CI === 'true';
+
 module.exports = {
   displayName: 'api-client-lib',
   testEnvironment: 'node',
@@ -35,6 +37,8 @@ module.exports = {
       statements: 53,
     },
   },
+  coverageReporters: isContinuousIntegrationEnvironment ? ['html', 'lcov', 'text-summary'] : undefined,
   testMatch: ['<rootDir>/src/**/__tests__/**/*.[jt]s?(x)', '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)'],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
+  reporters: isContinuousIntegrationEnvironment ? ['github-actions', 'summary'] : ['default'],
 };

--- a/libraries/core/jest.config.js
+++ b/libraries/core/jest.config.js
@@ -18,6 +18,7 @@
  */
 
 const {TextDecoder, TextEncoder} = require('util');
+const isContinuousIntegrationEnvironment = process.env.CI === 'true';
 
 module.exports = {
   displayName: 'core-lib',
@@ -42,6 +43,8 @@ module.exports = {
       statements: 62,
     },
   },
+  coverageReporters: isContinuousIntegrationEnvironment ? ['html', 'lcov', 'text-summary'] : undefined,
   testMatch: ['<rootDir>/src/**/__tests__/**/*.[jt]s?(x)', '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)'],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
+  reporters: isContinuousIntegrationEnvironment ? ['github-actions', 'summary'] : ['default'],
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Make the GitHub Actions test output easier to read by using quieter Jest reporting in continuous integration.

CI should show the important signal: failing tests, GitHub annotations, the test summary, and the coverage summary. It should not print unnecessary per-suite or full coverage-table output when the run is successful.

This keeps local Jest output unchanged for developer feedback, but switches CI to the built-in GitHub Actions and summary reporters. Coverage reporting also uses text-summary in CI so the logs stay useful without becoming noisy.

The intent is to make CI failures easier to scan and reduce log noise while keeping coverage thresholds, coverage artifacts, and actionable failure output.


