### PR TITLE
feat: correct modal styling should be shared inside the detached window while rendering Modal [WPB-26448]

### DIFF
--- a/apps/webapp/src/script/components/Modals/ModalComponent/ModalComponent.test.tsx
+++ b/apps/webapp/src/script/components/Modals/ModalComponent/ModalComponent.test.tsx
@@ -1,0 +1,182 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {act, fireEvent, render} from '@testing-library/react';
+
+import {withTheme} from 'src/script/auth/util/test/TestUtil';
+
+import {ModalComponent} from './ModalComponent';
+
+const renderModal = ({
+  isShown = true,
+  container,
+  onBgClick,
+  onOpened,
+  onClosed,
+}: {
+  isShown?: boolean;
+  container?: Element | DocumentFragment;
+  onBgClick?: () => void;
+  onOpened?: () => void;
+  onClosed?: () => void;
+} = {}) => {
+  return render(
+    withTheme(
+      <ModalComponent
+        isShown={isShown}
+        container={container}
+        onBgClick={onBgClick}
+        onOpened={onOpened}
+        onClosed={onClosed}
+      >
+        <div>Modal content</div>
+      </ModalComponent>,
+    ),
+  );
+};
+
+describe('ModalComponent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not render when isShown is false', () => {
+    const {queryByRole} = renderModal({isShown: false});
+
+    expect(queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders modal content when isShown is true', () => {
+    const {getByRole, getByText} = renderModal();
+
+    expect(getByRole('dialog')).toBeTruthy();
+    expect(getByText('Modal content')).toBeTruthy();
+  });
+
+  it('renders into document.body by default', () => {
+    renderModal();
+
+    expect(document.body.querySelector('[role="dialog"]')).toBeTruthy();
+  });
+
+  it('renders into custom container', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    renderModal({container});
+
+    expect(container.querySelector('[role="dialog"]')).toBeTruthy();
+  });
+
+  it('calls onBgClick when overlay is clicked', () => {
+    const onBgClick = jest.fn();
+    const {getByRole} = renderModal({onBgClick});
+
+    fireEvent.click(getByRole('dialog'));
+
+    expect(onBgClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onBgClick when modal content is clicked', () => {
+    const onBgClick = jest.fn();
+    const {getByText} = renderModal({onBgClick});
+
+    fireEvent.click(getByText('Modal content'));
+
+    expect(onBgClick).not.toHaveBeenCalled();
+  });
+
+  it('calls onOpened when modal is shown', () => {
+    const onOpened = jest.fn();
+
+    renderModal({onOpened});
+
+    expect(onOpened).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClosed after close delay', () => {
+    jest.useFakeTimers();
+
+    const onClosed = jest.fn();
+    const {rerender} = render(
+      withTheme(
+        <ModalComponent isShown onClosed={onClosed}>
+          <div>Modal content</div>
+        </ModalComponent>,
+      ),
+    );
+
+    rerender(
+      withTheme(
+        <ModalComponent isShown={false} onClosed={onClosed}>
+          <div>Modal content</div>
+        </ModalComponent>,
+      ),
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    expect(onClosed).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
+  });
+
+  it('renders into a foreign document container', () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    const iframeDocument = iframe.contentDocument!;
+    const iframeContainer = iframeDocument.createElement('div');
+    iframeDocument.body.appendChild(iframeContainer);
+
+    renderModal({container: iframeContainer});
+
+    expect(iframeContainer.querySelector('[role="dialog"]')).toBeTruthy();
+    expect(iframeDocument.body.textContent).toContain('Modal content');
+  });
+
+  it('adds Emotion modal styles to foreign document head', () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    const iframeDocument = iframe.contentDocument!;
+    const iframeContainer = iframeDocument.createElement('div');
+    iframeDocument.body.appendChild(iframeContainer);
+
+    renderModal({container: iframeContainer});
+
+    expect(iframeDocument.head.querySelector('style[data-emotion^="modal"]')).toBeTruthy();
+  });
+
+  it('does not add modal emotion cache styles to the main document when rendered in a foreign document', () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    const iframeDocument = iframe.contentDocument!;
+    const iframeContainer = iframeDocument.createElement('div');
+    iframeDocument.body.appendChild(iframeContainer);
+
+    renderModal({container: iframeContainer});
+
+    expect(iframeDocument.head.querySelector('style[data-emotion^="modal"]')).toBeTruthy();
+    expect(document.head.querySelector('style[data-emotion^="modal"]')).toBeFalsy();
+  });
+});

--- a/apps/webapp/src/script/components/Modals/ModalComponent/ModalComponent.tsx
+++ b/apps/webapp/src/script/components/Modals/ModalComponent/ModalComponent.tsx
@@ -17,9 +17,11 @@
  *
  */
 
-import React, {useEffect, useId, useRef, useState, HTMLProps} from 'react';
+import React, {HTMLProps, useEffect, useId, useRef, useState} from 'react';
 
-import {CSSObject} from '@emotion/react';
+import createCache from '@emotion/cache';
+import {CacheProvider, CSSObject} from '@emotion/react';
+import weakMemoize from '@emotion/weak-memoize';
 import {createPortal} from 'react-dom';
 
 import {TabIndex} from '@wireapp/react-ui-kit';
@@ -49,6 +51,8 @@ interface ModalComponentProps extends HTMLProps<HTMLDivElement> {
 }
 
 const CLOSE_DELAY = 350;
+
+const memoizedCreateCacheForHead = weakMemoize((container: HTMLHeadElement) => createCache({container, key: 'modal'}));
 
 const ModalComponent = ({
   id,
@@ -113,39 +117,46 @@ const ModalComponent = ({
     return null;
   }
 
-  return (
-    <>
-      {createPortal(
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
+  const portalTarget = container || document.body;
+  const targetDocument = (portalTarget as HTMLElement).ownerDocument ?? document;
+  const isForeignDocument = targetDocument !== document;
+
+  const content = (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
+    <div
+      role="dialog"
+      aria-modal="true"
+      onClick={onBgClick}
+      id={id}
+      css={hasVisibleClass ? ModalOverlayVisibleStyles : ModalOverlayStyles}
+      tabIndex={TabIndex.FOCUSABLE}
+      className={className}
+      {...rest}
+    >
+      {showLoading ? (
+        <LoadingIcon width="48" height="48" css={{path: {fill: 'var(--modal-bg)'}}} />
+      ) : (
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions --- tabIndex is already set to -1 through enum value
         <div
-          role="dialog"
-          aria-modal="true"
-          onClick={onBgClick}
-          id={id}
-          css={hasVisibleClass ? ModalOverlayVisibleStyles : ModalOverlayStyles}
-          tabIndex={TabIndex.FOCUSABLE}
-          className={className}
-          {...rest}
+          id={trapId}
+          onClick={event => event.stopPropagation()}
+          tabIndex={TabIndex.UNFOCUSABLE}
+          onKeyDown={event => (onKeyDown ? onKeyDown(event) : event.stopPropagation())}
+          css={{...(hasVisibleClass ? ModalContentVisibleStyles : ModalContentStyles), ...wrapperCSS}}
         >
-          {showLoading ? (
-            <LoadingIcon width="48" height="48" css={{path: {fill: 'var(--modal-bg)'}}} />
-          ) : (
-            // eslint-disable-next-line jsx-a11y/no-static-element-interactions --- tabIndex is already set to -1 through enum value
-            <div
-              id={trapId}
-              onClick={event => event.stopPropagation()}
-              tabIndex={TabIndex.UNFOCUSABLE}
-              onKeyDown={event => (onKeyDown ? onKeyDown(event) : event.stopPropagation())}
-              css={{...(hasVisibleClass ? ModalContentVisibleStyles : ModalContentStyles), ...wrapperCSS}}
-            >
-              {hasVisibleClass ? children : null}
-            </div>
-          )}
-        </div>,
-        container || document.body,
+          {hasVisibleClass ? children : null}
+        </div>
       )}
-    </>
+    </div>
   );
+
+  const portalContent = isForeignDocument ? (
+    <CacheProvider value={memoizedCreateCacheForHead(targetDocument.head)}>{content}</CacheProvider>
+  ) : (
+    content
+  );
+
+  return createPortal(portalContent, portalTarget);
 };
 
 export {ModalComponent};


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26448" title="WPB-26448" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26448</a>  [Web] - Modal is appended at the bottom of detached window instead of as a pop up.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


Buggy UI
<img width="1256" height="905" alt="image" src="https://github.com/user-attachments/assets/2a62fe98-a72a-4d70-977f-176401fa3af6" />

Fixed UI
<img width="1244" height="905" alt="image" src="https://github.com/user-attachments/assets/76d9a84d-35ac-4dcf-ada3-bd77b2aee1e4" />
