### PR TITLE
Only allow submission of login form once all relevant information was loaded [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/auth/page/login/login.tsx
+++ b/apps/webapp/src/script/auth/page/login/login.tsx
@@ -519,7 +519,7 @@ const LoginComponent = ({
                       )}
                       <Text>{isEnterpriseLoginV2Enabled ? t('login.subheadsso') : t('login.subhead')}</Text>
                       <Form style={{marginTop: 30}} data-uie-name="login">
-                        <LoginForm isFetching={isFetching} onSubmit={handleSubmit} />
+                        <LoginForm isFetching={isFetching || conversationInfoFetching} onSubmit={handleSubmit} />
                         {validationErrors.length > 0
                           ? parseValidationErrors(validationErrors)
                           : authError !== null && authError !== undefined && <Exception errors={[authError]} />}

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -55,11 +55,8 @@ test.describe('Guestroom', () => {
         await guestPages.conversationJoin().joinBrowserButton.click();
         await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
 
-        // Allow the login to be retried if the modal doesn't show up automatically, this is a workaround since the login mask for guest links is out of our control
-        await expect(async () => {
-          await guestPages.login().login(guestUser);
-          await expect(guestBModals.joinGuestLinkPassword().joinForm).toBeVisible();
-        }).toPass({timeout: LOGIN_TIMEOUT});
+        await guestPages.login().login(guestUser);
+        await expect(guestBModals.joinGuestLinkPassword().joinForm).toBeVisible();
 
         await guestBModals.joinGuestLinkPassword().joinConversation('WrongPassword');
         await expect(guestBModals.joinGuestLinkPassword().joinForm).toContainText(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR is an attempt to make the flow of joining a conversation via password protected invite link more reliable.
When a user follows a guest link an isn't logged in already he will be prompted to log in first. However, inside the then executed `handleSubmit()` function within `apps/webapp/src/script/auth/page/login/login.tsx` is a check whether a password is required or not to join the conversation.

```ts
if (
      isLinkPasswordModalOpen !== true &&
      (conversationInfo?.has_password === true ||
        (conversationError !== undefined &&
          conversationError !== null &&
          conversationError.label === BackendErrorLabel.INVALID_CONVERSATION_PASSWORD))
    ) {
      setConversationSubmitData(formLoginData);
      setIsLinkPasswordModalOpen(true);
      return;
    }
```

This check depends on the `conversationInfo` object to be defined which is loaded from the backend in the background. So if the login happens before the object is defined the password check will simply be ignored...
That's why this PR at least disables the login button until the network request for this object is no longer fetching.

**Notes for reviewers**
Sadly this change will only take effect after the next deployment to master as the login happens there. But I was able to successfully and reliably run the test against the locally running frontend during my tests.

