### PR TITLE
Remove unused util isPageLoaded from conversationSidebar pom [WPB-22402]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/components/conversationSidebar.component.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/components/conversationSidebar.component.ts
@@ -20,7 +20,6 @@
 import {Page, Locator} from '@playwright/test';
 
 export class ConversationSidebar {
-  readonly pageLoadingTimeout = 60_000;
   private readonly page: Page;
   readonly navigation: Locator;
   readonly personalStatusLabel: Locator;
@@ -68,10 +67,6 @@ export class ConversationSidebar {
 
   async clickConnectButton() {
     await this.connectButton.click();
-  }
-
-  async isPageLoaded() {
-    await this.preferencesButton.waitFor({state: 'visible', timeout: this.pageLoadingTimeout});
   }
 
   async clickArchive() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22402" title="WPB-22402" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22402</a>  [Web] Support free values as tags feature flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
