### PR TITLE
feat: show loading spinner forever for AV preferences when any of the permission is denied - [WPB-26451]

### DIFF
--- a/apps/webapp/src/script/hooks/useInitializeMediaDevices.test.ts
+++ b/apps/webapp/src/script/hooks/useInitializeMediaDevices.test.ts
@@ -35,10 +35,6 @@ const createStreamHandler = (requestMediaStreamAccess = jest.fn().mockResolvedVa
   }) as unknown as MediaStreamHandler;
 
 describe('useInitializeMediaDevices', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('requests media access, stops received tracks and initializes media devices', async () => {
     const stop = jest.fn();
     const stream = {

--- a/apps/webapp/src/script/hooks/useInitializeMediaDevices.test.ts
+++ b/apps/webapp/src/script/hooks/useInitializeMediaDevices.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {renderHook, waitFor} from '@testing-library/react';
+
+import {MediaDevicesHandler} from 'Repositories/media/MediaDevicesHandler';
+import {MediaStreamHandler} from 'Repositories/media/MediaStreamHandler';
+
+import {useInitializeMediaDevices} from './useInitializeMediaDevices';
+
+const createDevicesHandler = (initializeMediaDevices = jest.fn().mockResolvedValue(undefined)) =>
+  ({
+    initializeMediaDevices,
+  }) as unknown as MediaDevicesHandler;
+
+const createStreamHandler = (requestMediaStreamAccess = jest.fn().mockResolvedValue(undefined)) =>
+  ({
+    requestMediaStreamAccess,
+  }) as unknown as MediaStreamHandler;
+
+describe('useInitializeMediaDevices', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requests media access, stops received tracks and initializes media devices', async () => {
+    const stop = jest.fn();
+    const stream = {
+      getTracks: jest.fn().mockReturnValue([{stop}]),
+    } as unknown as MediaStream;
+
+    const devicesHandler = createDevicesHandler();
+    const streamHandler = createStreamHandler(jest.fn().mockResolvedValue(stream));
+
+    const {result} = renderHook(() => useInitializeMediaDevices(devicesHandler, streamHandler));
+
+    expect(result.current.areMediaDevicesInitialized).toBe(false);
+
+    await waitFor(() => {
+      expect(result.current.areMediaDevicesInitialized).toBe(true);
+    });
+
+    expect(streamHandler.requestMediaStreamAccess).toHaveBeenCalledWith(true);
+    expect(stream.getTracks).toHaveBeenCalled();
+    expect(stop).toHaveBeenCalled();
+    expect(devicesHandler.initializeMediaDevices).toHaveBeenCalledWith(true, true);
+  });
+
+  it('sets areMediaDevicesInitialized to true when media stream access fails', async () => {
+    const devicesHandler = createDevicesHandler();
+    const streamHandler = createStreamHandler(jest.fn().mockRejectedValue(new Error('Permission denied')));
+
+    const {result} = renderHook(() => useInitializeMediaDevices(devicesHandler, streamHandler));
+
+    expect(result.current.areMediaDevicesInitialized).toBe(false);
+
+    await waitFor(() => {
+      expect(result.current.areMediaDevicesInitialized).toBe(true);
+    });
+
+    expect(devicesHandler.initializeMediaDevices).not.toHaveBeenCalled();
+  });
+
+  it('sets areMediaDevicesInitialized to true when media devices initialization fails', async () => {
+    const devicesHandler = createDevicesHandler(jest.fn().mockRejectedValue(new Error('Initialization failed')));
+    const streamHandler = createStreamHandler();
+
+    const {result} = renderHook(() => useInitializeMediaDevices(devicesHandler, streamHandler));
+
+    expect(result.current.areMediaDevicesInitialized).toBe(false);
+
+    await waitFor(() => {
+      expect(result.current.areMediaDevicesInitialized).toBe(true);
+    });
+
+    expect(streamHandler.requestMediaStreamAccess).toHaveBeenCalledWith(true);
+    expect(devicesHandler.initializeMediaDevices).toHaveBeenCalledWith(true, true);
+  });
+});

--- a/apps/webapp/src/script/hooks/useInitializeMediaDevices.ts
+++ b/apps/webapp/src/script/hooks/useInitializeMediaDevices.ts
@@ -36,10 +36,10 @@ export const useInitializeMediaDevices = (devicesHandler: MediaDevicesHandler, s
         stream.getTracks().forEach(track => track.stop());
       }
       await devicesHandler?.initializeMediaDevices(true, true);
-      setAreMediaDevicesInitialized(true);
     } catch (error: unknown) {
       logger.warn(`Initialization of media devices failed:`, error);
-      setAreMediaDevicesInitialized(false);
+    } finally {
+      setAreMediaDevicesInitialized(true);
     }
   }, [devicesHandler, streamHandler]);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26451" title="WPB-26451" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26451</a>  [web] - AV Preferences keeps loading when camera permissions are denied
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
