### PR TITLE
fix: remove extra label from device select dropdowns - [WPB-26451]

### DIFF
--- a/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/DeviceSelect.styles.ts
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/DeviceSelect.styles.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+
+export const containerStyles: CSSObject = {
+  marginBottom: '20px',
+  width: '100%',
+};
+
+export const selectWrapperStyles: CSSObject = {
+  marginBottom: '-20px',
+  width: '100%',
+};

--- a/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/DeviceSelect.tsx
+++ b/apps/webapp/src/script/page/MainContent/panels/preferences/avPreferences/DeviceSelect.tsx
@@ -23,6 +23,8 @@ import cx from 'classnames';
 
 import {Select} from '@wireapp/react-ui-kit';
 
+import {containerStyles, selectWrapperStyles} from './DeviceSelect.styles';
+
 interface DeviceSelectProps {
   defaultDeviceName?: string;
   devices: MediaDeviceInfo[];
@@ -57,13 +59,13 @@ const DeviceSelect = ({
       className={cx('preferences-option', {
         'preferences-av-select-disabled': disabled,
       })}
-      css={{width: '100%'}}
+      css={containerStyles}
     >
       <div className="preferences-option-icon preferences-av-select-icon">
         <DeviceIcon />
       </div>
 
-      <div css={{width: '100%'}}>
+      <div css={selectWrapperStyles}>
         <Select
           id={uieName}
           onChange={option => {
@@ -76,7 +78,6 @@ const DeviceSelect = ({
           dataUieName={uieName}
           options={devicesList}
           value={currentValue}
-          label={title}
           isDisabled={disabled}
         />
       </div>

--- a/apps/webapp/src/style/content/preferences/av.less
+++ b/apps/webapp/src/style/content/preferences/av.less
@@ -20,6 +20,7 @@
 .preferences-av-detail {
   margin: 16px 0 8px;
 }
+
 .preferences-av-spinner-select {
   display: flex;
 
@@ -88,7 +89,6 @@ body.theme-dark {
 
 .preferences-av-select-icon {
   align-self: center;
-  padding-top: 2px;
 }
 
 .preferences-av-video,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26451" title="WPB-26451" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26451</a>  [web] - AV Preferences keeps loading when camera permissions are denied
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
