### PR TITLE
fix: clear filter and no search query should reloads the unfiltered search-owned list(WPB-20817)

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
@@ -190,11 +190,13 @@ describe('useConversationSearchFiles', () => {
     const cellsRepository = {searchNodes: jest.fn().mockReturnValue(search.promise)} as FakeCellsRepository;
     const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
 
-    useCellsStore.getState().setNodes({
-      conversationId: CONV_ID,
-      nodes: [staleFolderNode],
+    act(() => {
+      useCellsStore.getState().setNodes({
+        conversationId: CONV_ID,
+        nodes: [staleFolderNode],
+      });
+      useCellsStore.getState().setStatus('success');
     });
-    useCellsStore.getState().setStatus('success');
 
     renderSearchHook({cellsRepository, fireAndForgetInvoker});
 
@@ -279,9 +281,49 @@ describe('useConversationSearchFiles', () => {
     );
   });
 
-  it('calls onClear when the search input is emptied', async () => {
+  it('reloads the unfiltered search list when all filters are cleared with no query', async () => {
     const onClear = jest.fn();
-    const {result, fireAndForgetInvoker} = renderSearchHook({onClear});
+    const cellsRepository = createFakeCellsRepository({
+      Nodes: [createRestNode('all-files.pdf')],
+    });
+    const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
+    const {rerender} = renderHook(
+      ({filters}: {filters: ConversationDriveFiltersState}) =>
+        useConversationSearchFiles({
+          cellsRepository: cellsRepository as unknown as CellsRepository,
+          userRepository: createFakeUserRepository() as unknown as UserRepository,
+          conversationQualifiedId: QUALIFIED_ID,
+          enabled: true,
+          fireAndForgetInvoker,
+          filters,
+          onClear,
+        }),
+      {
+        initialProps: {
+          filters: {
+            ...emptyFilters,
+            selectedFileTypeIds: ['pictures'],
+          },
+        },
+      },
+    );
+
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    act(() => rerender({filters: emptyFilters}));
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(cellsRepository.searchNodes).toHaveBeenLastCalledWith(expect.objectContaining({query: '', recursive: false}));
+    expect(useCellsStore.getState().getNodes({conversationId: CONV_ID})[0]?.name).toBe('all-files.pdf');
+    expect(onClear).not.toHaveBeenCalled();
+  });
+
+  it('reloads the unfiltered search list when the search input is emptied while search is open', async () => {
+    const onClear = jest.fn();
+    const cellsRepository = createFakeCellsRepository({
+      Nodes: [createRestNode('all-files.pdf')],
+    });
+    const {result, fireAndForgetInvoker} = renderSearchHook({cellsRepository, onClear});
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
     act(() => result.current.handleSearch('test'));
@@ -290,7 +332,9 @@ describe('useConversationSearchFiles', () => {
     act(() => result.current.handleSearch(''));
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    expect(onClear).toHaveBeenCalled();
+    expect(cellsRepository.searchNodes).toHaveBeenLastCalledWith(expect.objectContaining({query: '', recursive: false}));
+    expect(useCellsStore.getState().getNodes({conversationId: CONV_ID})[0]?.name).toBe('all-files.pdf');
+    expect(onClear).not.toHaveBeenCalled();
   });
 
   it('clears search-owned rows before handing control back to browse mode', async () => {
@@ -298,13 +342,15 @@ describe('useConversationSearchFiles', () => {
     const {result, fireAndForgetInvoker} = renderSearchHook({onClear});
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    useCellsStore.getState().setNodes({
-      conversationId: CONV_ID,
-      nodes: [staleFolderNode],
+    act(() => {
+      useCellsStore.getState().setNodes({
+        conversationId: CONV_ID,
+        nodes: [staleFolderNode],
+      });
+      useCellsStore.getState().setStatus('success');
     });
-    useCellsStore.getState().setStatus('success');
 
-    act(() => result.current.handleSearch(''));
+    act(() => result.current.handleClearSearch({preserveFilters: false}));
 
     expect(useCellsStore.getState().getNodes({conversationId: CONV_ID})).toEqual([]);
     expect(useCellsStore.getState().getPagination({conversationId: CONV_ID})).toBeNull();

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
@@ -310,10 +310,14 @@ describe('useConversationSearchFiles', () => {
 
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
+    const searchCallCountBeforeClearingFilters = cellsRepository.searchNodes.mock.calls.length;
+
     act(() => rerender({filters: emptyFilters}));
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    expect(cellsRepository.searchNodes).toHaveBeenLastCalledWith(
+    expect(cellsRepository.searchNodes).toHaveBeenCalledTimes(searchCallCountBeforeClearingFilters + 1);
+    expect(cellsRepository.searchNodes).toHaveBeenNthCalledWith(
+      searchCallCountBeforeClearingFilters + 1,
       expect.objectContaining({query: '', recursive: false}),
     );
     expect(useCellsStore.getState().getNodes({conversationId: CONV_ID})[0]?.name).toBe('all-files.pdf');
@@ -331,10 +335,14 @@ describe('useConversationSearchFiles', () => {
     act(() => result.current.handleSearch('test'));
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
+    const searchCallCountBeforeClearingInput = cellsRepository.searchNodes.mock.calls.length;
+
     act(() => result.current.handleSearch(''));
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    expect(cellsRepository.searchNodes).toHaveBeenLastCalledWith(
+    expect(cellsRepository.searchNodes).toHaveBeenCalledTimes(searchCallCountBeforeClearingInput + 1);
+    expect(cellsRepository.searchNodes).toHaveBeenNthCalledWith(
+      searchCallCountBeforeClearingInput + 1,
       expect.objectContaining({query: '', recursive: false}),
     );
     expect(useCellsStore.getState().getNodes({conversationId: CONV_ID})[0]?.name).toBe('all-files.pdf');

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
@@ -313,7 +313,9 @@ describe('useConversationSearchFiles', () => {
     act(() => rerender({filters: emptyFilters}));
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    expect(cellsRepository.searchNodes).toHaveBeenLastCalledWith(expect.objectContaining({query: '', recursive: false}));
+    expect(cellsRepository.searchNodes).toHaveBeenLastCalledWith(
+      expect.objectContaining({query: '', recursive: false}),
+    );
     expect(useCellsStore.getState().getNodes({conversationId: CONV_ID})[0]?.name).toBe('all-files.pdf');
     expect(onClear).not.toHaveBeenCalled();
   });
@@ -332,7 +334,9 @@ describe('useConversationSearchFiles', () => {
     act(() => result.current.handleSearch(''));
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    expect(cellsRepository.searchNodes).toHaveBeenLastCalledWith(expect.objectContaining({query: '', recursive: false}));
+    expect(cellsRepository.searchNodes).toHaveBeenLastCalledWith(
+      expect.objectContaining({query: '', recursive: false}),
+    );
     expect(useCellsStore.getState().getNodes({conversationId: CONV_ID})[0]?.name).toBe('all-files.pdf');
     expect(onClear).not.toHaveBeenCalled();
   });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
@@ -209,6 +209,32 @@ describe('useConversationSearchFiles', () => {
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
   });
 
+  it('shows loading when reloading search results', async () => {
+    const reloadSearch = createDeferred<RestNodeCollection>();
+    const cellsRepository = createFakeCellsRepository();
+    cellsRepository.searchNodes.mockResolvedValueOnce({Nodes: []});
+    cellsRepository.searchNodes.mockReturnValueOnce(reloadSearch.promise);
+    const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
+
+    const {result} = renderSearchHook({cellsRepository, fireAndForgetInvoker});
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    act(() => {
+      useCellsStore.getState().setStatus('success');
+    });
+
+    act(() => {
+      void result.current.handleReload();
+    });
+
+    expect(useCellsStore.getState().status).toBe('loading');
+
+    act(() => {
+      reloadSearch.resolve({Nodes: []});
+    });
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+  });
+
   it('does not write to the store when disabled mid-flight', async () => {
     const search = createDeferred<RestNodeCollection>();
     const cellsRepository = {searchNodes: jest.fn().mockReturnValue(search.promise)} as FakeCellsRepository;

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
@@ -251,7 +251,8 @@ export const useConversationSearchFiles = ({
     setSearchQuery('');
     shouldPerformSearch.current = false;
 
-    const shouldRefreshSearchResults = preserveFilters && hasActiveParams;
+    const shouldRefreshSearchResults =
+      preserveFilters && (enabledRef.current || (allowSearchWhenDisabledRef.current && hasActiveParams));
 
     if (shouldRefreshSearchResults) {
       fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
@@ -310,10 +311,16 @@ export const useConversationSearchFiles = ({
   // restore the default unfiltered file list.
   useEffect(() => {
     if (hadActiveSearchParamsRef.current && !hasActiveParams && !searchValue) {
-      onClear?.();
+      if (enabledRef.current || allowSearchWhenDisabledRef.current) {
+        fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+          await searchNodes({query: '', filters});
+        });
+      } else {
+        onClear?.();
+      }
     }
     hadActiveSearchParamsRef.current = hasActiveParams;
-  }, [hasActiveParams, searchValue, onClear]);
+  }, [filters, fireAndForgetInvoker, hasActiveParams, onClear, searchNodes, searchValue]);
 
   const loadMore = useCallback(
     async (offset: number): Promise<void> => {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
@@ -54,6 +54,11 @@ interface UseConversationSearchFilesProps {
   onClear?: () => void;
 }
 
+type ClearSearchRefreshOptions = {
+  preserveFilters: boolean;
+  hasActiveParamsBeforeClear: boolean;
+};
+
 const DEBOUNCE_TIME = 300;
 
 const normalizeSearchQuery = (query: string): string => (is.nonEmptyStringAndNotWhitespace(query) ? query.trim() : '');
@@ -92,7 +97,7 @@ export const useConversationSearchFiles = ({
     return enabledRef.current === true || allowSearchWhenDisabledRef.current === true;
   }, []);
 
-  const isCurrentSearchRequest = useCallback(
+  const isValidSearchRequest = useCallback(
     (requestVersion: number): boolean => {
       return canSearchOwnResults() === true && requestVersionGate.current.isStale(requestVersion) === false;
     },
@@ -100,13 +105,7 @@ export const useConversationSearchFiles = ({
   );
 
   const shouldRefreshSearchResultsAfterClearingInput = useCallback(
-    ({
-      preserveFilters,
-      hasActiveParamsBeforeClear,
-    }: {
-      preserveFilters: boolean;
-      hasActiveParamsBeforeClear: boolean;
-    }): boolean => {
+    ({preserveFilters, hasActiveParamsBeforeClear}: ClearSearchRefreshOptions): boolean => {
       if (preserveFilters === false) {
         return false;
       }
@@ -165,7 +164,7 @@ export const useConversationSearchFiles = ({
           ...searchParams,
         });
 
-        if (!isCurrentSearchRequest(requestVersion)) {
+        if (!isValidSearchRequest(requestVersion)) {
           return;
         }
 
@@ -180,7 +179,7 @@ export const useConversationSearchFiles = ({
 
         const users = await getUsersFromNodes({nodes: result.Nodes, userRepository});
 
-        if (!isCurrentSearchRequest(requestVersion)) {
+        if (!isValidSearchRequest(requestVersion)) {
           return;
         }
 
@@ -198,7 +197,7 @@ export const useConversationSearchFiles = ({
         setPagination({conversationId: id, pagination});
         setStatus('success');
       } catch (error) {
-        if (!isCurrentSearchRequest(requestVersion)) {
+        if (!isValidSearchRequest(requestVersion)) {
           return;
         }
 
@@ -218,7 +217,7 @@ export const useConversationSearchFiles = ({
     },
     // cellsRepository and userRepository are not dependencies because they're singletons
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [appendNodes, setNodes, setPagination, setStatus, setError, id, domain, isCurrentSearchRequest],
+    [appendNodes, setNodes, setPagination, setStatus, setError, id, domain, isValidSearchRequest],
   );
 
   useLayoutEffect(() => {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
@@ -310,7 +310,9 @@ export const useConversationSearchFiles = ({
   // When the search params transition from "active" to "none" with no search query,
   // restore the default unfiltered file list.
   useEffect(() => {
-    if (hadActiveSearchParamsRef.current && !hasActiveParams && !searchValue) {
+    const hasNoSearchQuery = normalizeSearchQuery(searchValue).length === 0;
+
+    if (hadActiveSearchParamsRef.current && hasActiveParams === false && hasNoSearchQuery) {
       if (enabledRef.current || allowSearchWhenDisabledRef.current) {
         fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
           await searchNodes({query: '', filters});

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
@@ -296,10 +296,9 @@ export const useConversationSearchFiles = ({
   };
 
   const handleReload = useCallback(async (): Promise<void> => {
-    setStatus('loading');
     clearAll({conversationId: id});
     await searchNodes({query: normalizeSearchQuery(searchQuery), filters});
-  }, [clearAll, filters, id, searchNodes, searchQuery, setStatus]);
+  }, [clearAll, filters, id, searchNodes, searchQuery]);
 
   useEffect(() => {
     if (!enabled) {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
@@ -88,11 +88,37 @@ export const useConversationSearchFiles = ({
 
   const {id, domain} = conversationQualifiedId;
 
-  const isCurrentSearchRequest = useCallback((requestVersion: number): boolean => {
-    return (
-      (enabledRef.current || allowSearchWhenDisabledRef.current) && !requestVersionGate.current.isStale(requestVersion)
-    );
+  const canSearchOwnResults = useCallback((): boolean => {
+    return enabledRef.current === true || allowSearchWhenDisabledRef.current === true;
   }, []);
+
+  const isCurrentSearchRequest = useCallback(
+    (requestVersion: number): boolean => {
+      return canSearchOwnResults() === true && requestVersionGate.current.isStale(requestVersion) === false;
+    },
+    [canSearchOwnResults],
+  );
+
+  const shouldRefreshSearchResultsAfterClearingInput = useCallback(
+    ({
+      preserveFilters,
+      hasActiveParamsBeforeClear,
+    }: {
+      preserveFilters: boolean;
+      hasActiveParamsBeforeClear: boolean;
+    }): boolean => {
+      if (preserveFilters === false) {
+        return false;
+      }
+
+      if (enabledRef.current === true) {
+        return true;
+      }
+
+      return allowSearchWhenDisabledRef.current === true && hasActiveParamsBeforeClear === true;
+    },
+    [],
+  );
 
   const searchNodes = useCallback(
     async ({
@@ -251,10 +277,12 @@ export const useConversationSearchFiles = ({
     setSearchQuery('');
     shouldPerformSearch.current = false;
 
-    const shouldRefreshSearchResults =
-      preserveFilters && (enabledRef.current || (allowSearchWhenDisabledRef.current && hasActiveParams));
+    const shouldRefreshSearchResults = shouldRefreshSearchResultsAfterClearingInput({
+      preserveFilters,
+      hasActiveParamsBeforeClear: hasActiveParams,
+    });
 
-    if (shouldRefreshSearchResults) {
+    if (shouldRefreshSearchResults === true) {
       fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
         await searchNodes({query: '', filters});
       });
@@ -312,8 +340,8 @@ export const useConversationSearchFiles = ({
   useEffect(() => {
     const hasNoSearchQuery = normalizeSearchQuery(searchValue).length === 0;
 
-    if (hadActiveSearchParamsRef.current && hasActiveParams === false && hasNoSearchQuery) {
-      if (enabledRef.current || allowSearchWhenDisabledRef.current) {
+    if (hadActiveSearchParamsRef.current === true && hasActiveParams === false && hasNoSearchQuery === true) {
+      if (canSearchOwnResults() === true) {
         fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
           await searchNodes({query: '', filters});
         });
@@ -322,7 +350,7 @@ export const useConversationSearchFiles = ({
       }
     }
     hadActiveSearchParamsRef.current = hasActiveParams;
-  }, [filters, fireAndForgetInvoker, hasActiveParams, onClear, searchNodes, searchValue]);
+  }, [canSearchOwnResults, filters, fireAndForgetInvoker, hasActiveParams, onClear, searchNodes, searchValue]);
 
   const loadMore = useCallback(
     async (offset: number): Promise<void> => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20817" title="WPB-20817" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20817</a>  [Web] Search results are not fetching all files when the search box is empty
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
**##Summary**
when filters go from active to none with no query, the hook now reloads the unfiltered search-owned list if search mode still owns the view, instead of calling browse onClear.


