### PR TITLE
fix: stabilize shared Drive loading state(WPB-26425)

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
@@ -207,6 +207,32 @@ describe('useConversationSearchFiles', () => {
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
   });
 
+  it('shows loading when reloading search results', async () => {
+    const reloadSearch = createDeferred<RestNodeCollection>();
+    const cellsRepository = createFakeCellsRepository();
+    cellsRepository.searchNodes.mockResolvedValueOnce({Nodes: []});
+    cellsRepository.searchNodes.mockReturnValueOnce(reloadSearch.promise);
+    const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
+
+    const {result} = renderSearchHook({cellsRepository, fireAndForgetInvoker});
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    act(() => {
+      useCellsStore.getState().setStatus('success');
+    });
+
+    act(() => {
+      void result.current.handleReload();
+    });
+
+    expect(useCellsStore.getState().status).toBe('loading');
+
+    act(() => {
+      reloadSearch.resolve({Nodes: []});
+    });
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+  });
+
   it('does not write to the store when disabled mid-flight', async () => {
     const search = createDeferred<RestNodeCollection>();
     const cellsRepository = {searchNodes: jest.fn().mockReturnValue(search.promise)} as FakeCellsRepository;
@@ -298,11 +324,13 @@ describe('useConversationSearchFiles', () => {
     const {result, fireAndForgetInvoker} = renderSearchHook({onClear});
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    useCellsStore.getState().setNodes({
-      conversationId: CONV_ID,
-      nodes: [staleFolderNode],
+    act(() => {
+      useCellsStore.getState().setNodes({
+        conversationId: CONV_ID,
+        nodes: [staleFolderNode],
+      });
+      useCellsStore.getState().setStatus('success');
     });
-    useCellsStore.getState().setStatus('success');
 
     act(() => result.current.handleSearch(''));
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
@@ -267,10 +267,9 @@ export const useConversationSearchFiles = ({
   };
 
   const handleReload = useCallback(async (): Promise<void> => {
-    setStatus('loading');
     clearAll({conversationId: id});
     await searchNodes({query: normalizeSearchQuery(searchQuery), filters});
-  }, [clearAll, filters, id, searchNodes, searchQuery, setStatus]);
+  }, [clearAll, filters, id, searchNodes, searchQuery]);
 
   useEffect(() => {
     if (!enabled) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26425" title="WPB-26425" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26425</a>  Stabilize Shared Drive loading state
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
**##Summary**
Remove redundant setStatus('loading') before clearAll in search reload.

In useConversationSearchFiles.ts (line 269), handleReload does:

setStatus('loading'); clearAll({conversationId: id}); await searchNodes(...);

And useCellsStore.ts resets status to idle. Since searchNodes immediately sets loading again, the setStatus('loading') before clearAll is redundant and can cause a brief loading -> idle -> loading transition.


