### PR TITLE
Prevent open redirect through join parameters [WPB-25894]

### DIFF
--- a/apps/server/routes/redirectRoutes.test.ts
+++ b/apps/server/routes/redirectRoutes.test.ts
@@ -2,7 +2,7 @@ import {type Request, type Response} from 'express';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {Maybe} from 'true-myth';
 
-import {createJoinRedirectLocation, redirectToJoinConversation, setNonCacheHeaders} from './redirectRoutes';
+import {createJoinConversationRedirectUrl, redirectToJoinConversation, setNonCacheHeaders} from './redirectRoutes';
 
 type HeaderValueMap = Record<string, string>;
 
@@ -56,42 +56,42 @@ function createJoinRedirectRequest(query: Request['query']): Request {
 
 describe('RedirectRoutes join redirect', () => {
   it('creates a redirect URL with join key, join code and join conversation hash', () => {
-    const redirectLocation = createJoinRedirectLocation({
+    const redirectUrl = createJoinConversationRedirectUrl({
       key: 'conversation-key',
       code: 'conversation-code',
     });
 
-    expect(redirectLocation).toStrictEqual(
+    expect(redirectUrl).toStrictEqual(
       Maybe.just('/auth/?join_key=conversation-key&join_code=conversation-code#/join-conversation'),
     );
   });
 
   it('keeps an encoded ampersand inside the join key value', () => {
     const originalJoinKey = 'safe&destination_url=https://example.invalid#/custom-env-redirect';
-    const redirectLocation = createJoinRedirectLocation({
+    const redirectUrl = createJoinConversationRedirectUrl({
       key: originalJoinKey,
       code: 'code',
     });
 
-    const redirectUrl = new URL(redirectLocation.unwrapOr(''), 'https://app.wire.com');
+    const parsedRedirectUrl = new URL(redirectUrl.unwrapOr(''), 'https://app.wire.com');
 
-    expect(redirectUrl.searchParams.get('destination_url')).toBeNull();
-    expect(redirectUrl.searchParams.get('join_key')).toBe(originalJoinKey);
-    expect(redirectUrl.searchParams.get('join_code')).toBe('code');
-    expect(redirectUrl.hash).toBe('#/join-conversation');
+    expect(parsedRedirectUrl.searchParams.get('destination_url')).toBeNull();
+    expect(parsedRedirectUrl.searchParams.get('join_key')).toBe(originalJoinKey);
+    expect(parsedRedirectUrl.searchParams.get('join_code')).toBe('code');
+    expect(parsedRedirectUrl.hash).toBe('#/join-conversation');
   });
 
   it.each([
     {key: 'safe#/custom-env-redirect', code: 'code'},
     {key: 'key', code: 'safe#/custom-env-redirect'},
   ])('keeps an encoded hash inside the join query value', query => {
-    const redirectLocation = createJoinRedirectLocation(query);
+    const redirectUrl = createJoinConversationRedirectUrl(query);
 
-    const redirectUrl = new URL(redirectLocation.unwrapOr(''), 'https://app.wire.com');
+    const parsedRedirectUrl = new URL(redirectUrl.unwrapOr(''), 'https://app.wire.com');
 
-    expect(redirectUrl.searchParams.get('join_key')).toBe(query.key);
-    expect(redirectUrl.searchParams.get('join_code')).toBe(query.code);
-    expect(redirectUrl.hash).toBe('#/join-conversation');
+    expect(parsedRedirectUrl.searchParams.get('join_key')).toBe(query.key);
+    expect(parsedRedirectUrl.searchParams.get('join_code')).toBe(query.code);
+    expect(parsedRedirectUrl.hash).toBe('#/join-conversation');
   });
 
   it.each([

--- a/apps/server/routes/redirectRoutes.test.ts
+++ b/apps/server/routes/redirectRoutes.test.ts
@@ -1,11 +1,20 @@
-import {type Response} from 'express';
-import {setNonCacheHeaders} from './redirectRoutes';
+import {type Request, type Response} from 'express';
+import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
+import {Maybe} from 'true-myth';
+
+import {createJoinRedirectLocation, redirectToJoinConversation, setNonCacheHeaders} from './redirectRoutes';
 
 type HeaderValueMap = Record<string, string>;
 
 type ResponseWithHeaderCapture = {
   readonly headerValues: HeaderValueMap;
   readonly response: Response;
+};
+
+type JoinRedirectResponse = {
+  readonly response: Response;
+  readonly redirect: jest.Mock;
+  readonly sendStatus: jest.Mock;
 };
 
 function createResponseWithHeaderCapture(): ResponseWithHeaderCapture {
@@ -23,6 +32,100 @@ function createResponseWithHeaderCapture(): ResponseWithHeaderCapture {
     response,
   };
 }
+
+function createJoinRedirectResponse(): JoinRedirectResponse {
+  const redirect = jest.fn();
+  const sendStatus = jest.fn();
+  const response = {
+    redirect,
+    sendStatus,
+  } as unknown as Response;
+
+  return {
+    response,
+    redirect,
+    sendStatus,
+  };
+}
+
+function createJoinRedirectRequest(query: Request['query']): Request {
+  return {
+    query,
+  } as unknown as Request;
+}
+
+describe('RedirectRoutes join redirect', () => {
+  it('creates a redirect URL with join key, join code and join conversation hash', () => {
+    const redirectLocation = createJoinRedirectLocation({
+      key: 'conversation-key',
+      code: 'conversation-code',
+    });
+
+    expect(redirectLocation).toStrictEqual(
+      Maybe.just('/auth/?join_key=conversation-key&join_code=conversation-code#/join-conversation'),
+    );
+  });
+
+  it('keeps an encoded ampersand inside the join key value', () => {
+    const originalJoinKey = 'safe&destination_url=https://example.invalid#/custom-env-redirect';
+    const redirectLocation = createJoinRedirectLocation({
+      key: originalJoinKey,
+      code: 'code',
+    });
+
+    const redirectUrl = new URL(redirectLocation.unwrapOr(''), 'https://app.wire.com');
+
+    expect(redirectUrl.searchParams.get('destination_url')).toBeNull();
+    expect(redirectUrl.searchParams.get('join_key')).toBe(originalJoinKey);
+    expect(redirectUrl.searchParams.get('join_code')).toBe('code');
+    expect(redirectUrl.hash).toBe('#/join-conversation');
+  });
+
+  it.each([
+    {key: 'safe#/custom-env-redirect', code: 'code'},
+    {key: 'key', code: 'safe#/custom-env-redirect'},
+  ])('keeps an encoded hash inside the join query value', query => {
+    const redirectLocation = createJoinRedirectLocation(query);
+
+    const redirectUrl = new URL(redirectLocation.unwrapOr(''), 'https://app.wire.com');
+
+    expect(redirectUrl.searchParams.get('join_key')).toBe(query.key);
+    expect(redirectUrl.searchParams.get('join_code')).toBe(query.code);
+    expect(redirectUrl.hash).toBe('#/join-conversation');
+  });
+
+  it.each([
+    {query: {code: 'code'}, description: 'missing key'},
+    {query: {key: 'key'}, description: 'missing code'},
+    {query: {key: ['first-key', 'second-key'], code: 'code'}, description: 'repeated key'},
+    {query: {key: 'key', code: ['first-code', 'second-code']}, description: 'repeated code'},
+  ])('returns HTTP 400 for $description', ({query}) => {
+    const {response, redirect, sendStatus} = createJoinRedirectResponse();
+    const request = createJoinRedirectRequest(query);
+
+    redirectToJoinConversation(request, response);
+
+    expect(sendStatus).toHaveBeenNthCalledWith(1, HTTP_STATUS.BAD_REQUEST);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects valid join query parameters with HTTP 302', () => {
+    const {response, redirect, sendStatus} = createJoinRedirectResponse();
+    const request = createJoinRedirectRequest({
+      key: 'key',
+      code: 'code',
+    });
+
+    redirectToJoinConversation(request, response);
+
+    expect(redirect).toHaveBeenNthCalledWith(
+      1,
+      HTTP_STATUS.MOVED_TEMPORARILY,
+      '/auth/?join_key=key&join_code=code#/join-conversation',
+    );
+    expect(sendStatus).not.toHaveBeenCalled();
+  });
+});
 
 describe('RedirectRoutes response caching', () => {
   it('sets non-cache headers for version metadata responses', () => {

--- a/apps/server/routes/redirectRoutes.ts
+++ b/apps/server/routes/redirectRoutes.ts
@@ -33,7 +33,7 @@ type JoinRedirectQuery = {
   readonly code?: unknown;
 };
 
-export function createJoinRedirectLocation(query: JoinRedirectQuery): Maybe<string> {
+export function createJoinConversationRedirectUrl(query: JoinRedirectQuery): Maybe<string> {
   const {key, code} = query;
 
   if (!is.nonEmptyString(key) || !is.nonEmptyString(code)) {
@@ -49,18 +49,18 @@ export function createJoinRedirectLocation(query: JoinRedirectQuery): Maybe<stri
 }
 
 export function redirectToJoinConversation(request: Request, response: Response): void {
-  const redirectLocation = createJoinRedirectLocation(request.query);
+  const redirectUrl = createJoinConversationRedirectUrl(request.query);
 
   maybe.match(
     {
-      Just: location => {
-        response.redirect(HTTP_STATUS.MOVED_TEMPORARILY, location);
+      Just: url => {
+        response.redirect(HTTP_STATUS.MOVED_TEMPORARILY, url);
       },
       Nothing: () => {
         response.sendStatus(HTTP_STATUS.BAD_REQUEST);
       },
     },
-    redirectLocation,
+    redirectUrl,
   );
 }
 

--- a/apps/server/routes/redirectRoutes.ts
+++ b/apps/server/routes/redirectRoutes.ts
@@ -17,14 +17,52 @@
  *
  */
 
-import express, {type Response} from 'express';
+import is from '@sindresorhus/is';
+import express, {type Request, type Response} from 'express';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
+import {Maybe, maybe} from 'true-myth';
 
 import type {ServerConfig} from '@wireapp/config';
 
 import * as BrowserUtil from '../util/browserUtil';
 
 const router = express.Router();
+
+type JoinRedirectQuery = {
+  readonly key?: unknown;
+  readonly code?: unknown;
+};
+
+export function createJoinRedirectLocation(query: JoinRedirectQuery): Maybe<string> {
+  const {key, code} = query;
+
+  if (!is.nonEmptyString(key) || !is.nonEmptyString(code)) {
+    return Maybe.nothing();
+  }
+
+  const queryParameters = new URLSearchParams({
+    join_key: key,
+    join_code: code,
+  });
+
+  return Maybe.just(`/auth/?${queryParameters.toString()}#/join-conversation`);
+}
+
+export function redirectToJoinConversation(request: Request, response: Response): void {
+  const redirectLocation = createJoinRedirectLocation(request.query);
+
+  maybe.match(
+    {
+      Just: location => {
+        response.redirect(HTTP_STATUS.MOVED_TEMPORARILY, location);
+      },
+      Nothing: () => {
+        response.sendStatus(HTTP_STATUS.BAD_REQUEST);
+      },
+    },
+    redirectLocation,
+  );
+}
 
 export function setNonCacheHeaders(response: Response): Response {
   response.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
@@ -42,11 +80,7 @@ export const RedirectRoutes = (config: ServerConfig) => [
       : config.ROBOTS.DISALLOW;
     return res.contentType('text/plain; charset=UTF-8').send(robotsContent);
   }),
-  router.get('/join/?', (req, res) => {
-    const key = req.query.key;
-    const code = req.query.code;
-    res.redirect(HTTP_STATUS.MOVED_TEMPORARILY, `/auth/?join_key=${key}&join_code=${code}#/join-conversation`);
-  }),
+  router.get('/join/?', redirectToJoinConversation),
   router.get('/browser/?', (req, res, next) => {
     if (config.DEVELOPMENT) {
       return next();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25894" title="WPB-25894" target="_blank"><img alt="security" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/13902?size=medium" />WPB-25894</a>  [Webapp] Open redirect in /join handler
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Fixes a security issue in the `/join` handler.

The handler previously interpolated `key` and `code` query values directly into the redirect `Location` header. Because these values were not safely encoded, an attacker could use encoded query separators such as `&` or `#` to escape the intended `join_key` / `join_code` values.

This could inject additional query parameters such as `destination_url` or replace the expected `#/join-conversation` fragment.

## Security impact

This is an open redirect issue.

In the worst case, an attacker could craft a link that starts on the trusted `app.wire.com` domain, but eventually redirects the user to an attacker-controlled website.

That attacker-controlled website could imitate Wire or an SSO/login flow and trick the user into entering credentials, recovery information, or other sensitive data.

This does not imply direct server compromise or authentication bypass by itself, but it is still security-relevant because the trusted Wire domain can be abused as part of a phishing or social-engineering flow.

## Intent

The client-side redirect route should not be treated as the security boundary.

The `/join` server handler must only emit a safe redirect target. User-controlled values must stay inside the intended `join_key` and `join_code` query parameters and must not be able to change the final redirect target.