### PR TITLE
Use fire-and-forget invoker for people search [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/auth/util/test/TestUtil.tsx
+++ b/apps/webapp/src/script/auth/util/test/TestUtil.tsx
@@ -131,6 +131,13 @@ export function withTheme(component: React.ReactNode): React.ReactElement {
   return <StyledApp themeId={THEME_ID.DEFAULT}>{rootProviderWrapper({children: component})}</StyledApp>;
 }
 
+export function withThemeAndRootContext(
+  component: React.ReactNode,
+  rootProviderWrapperForTest: ReturnType<typeof createRootProviderWrapperForTest>,
+): React.ReactElement {
+  return <StyledApp themeId={THEME_ID.DEFAULT}>{rootProviderWrapperForTest({children: component})}</StyledApp>;
+}
+
 const wrapComponent = (
   component: React.ReactNode,
   store: MockStoreEnhanced<RecursivePartial<RootState>, ThunkDispatch<RootState, Api, AnyAction>>,

--- a/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.test.tsx
+++ b/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.test.tsx
@@ -20,7 +20,13 @@
 import {render, screen, waitFor} from '@testing-library/react';
 import ko from 'knockout';
 
-import {withTheme} from 'src/script/auth/util/test/TestUtil';
+import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
+
+import {
+  createExecutingFireAndForgetInvokerForTest,
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
 import {ConversationState} from 'src/script/repositories/conversation/ConversationState';
 import {User} from 'src/script/repositories/entity/User';
 import {SearchRepository} from 'src/script/repositories/search/searchRepository';
@@ -90,6 +96,13 @@ function createTeamState(): TeamState {
   return teamState;
 }
 
+function withThemeAndRootContext(
+  element: React.ReactElement,
+  rootProviderWrapper: ReturnType<typeof createRootProviderWrapperForTest>,
+): React.ReactElement {
+  return <StyledApp themeId={THEME_ID.DEFAULT}>{rootProviderWrapper({children: element})}</StyledApp>;
+}
+
 describe('PeopleTab', () => {
   it('updates the visible people list when the search query changes', async () => {
     const aliceExample = createUser({
@@ -131,6 +144,13 @@ describe('PeopleTab', () => {
     const conversationRepositoryDouble = {} satisfies MinimalConversationRepository;
     const userRepositoryDouble = {} satisfies MinimalUserRepository;
     const onSearchResults = jest.fn<void, [SearchResultsData | undefined]>();
+    const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
+    const rootProviderWrapper = createRootProviderWrapperForTest(
+      createRootContextValueForTest({
+        fireAndForgetInvoker,
+        translate: translateForTest,
+      }),
+    );
 
     const properties: PeopleTabProps = {
       canInviteTeamMembers: false,
@@ -150,7 +170,9 @@ describe('PeopleTab', () => {
       userState: new UserState(),
     };
 
-    const {rerender} = render(withTheme(<PeopleTab {...properties} searchQuery="" />));
+    const {rerender} = render(
+      withThemeAndRootContext(<PeopleTab {...properties} searchQuery="" />, rootProviderWrapper),
+    );
 
     expect(screen.getByText('Alice Example')).toBeInTheDocument();
     expect(screen.getByText('Bob Test')).toBeInTheDocument();
@@ -162,7 +184,7 @@ describe('PeopleTab', () => {
 
     onSearchResults.mockClear();
 
-    rerender(withTheme(<PeopleTab {...properties} searchQuery="test" />));
+    rerender(withThemeAndRootContext(<PeopleTab {...properties} searchQuery="test" />, rootProviderWrapper));
 
     await waitFor(() => {
       expect(screen.queryByText('Alice Example')).toBeNull();

--- a/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.test.tsx
+++ b/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.test.tsx
@@ -20,8 +20,7 @@
 import {render, screen, waitFor} from '@testing-library/react';
 import ko from 'knockout';
 
-import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
-
+import {withThemeAndRootContext} from 'src/script/auth/util/test/TestUtil';
 import {
   createExecutingFireAndForgetInvokerForTest,
   createRootContextValueForTest,
@@ -94,13 +93,6 @@ function createTeamState(): TeamState {
   };
 
   return teamState;
-}
-
-function withThemeAndRootContext(
-  element: React.ReactElement,
-  rootProviderWrapper: ReturnType<typeof createRootProviderWrapperForTest>,
-): React.ReactElement {
-  return <StyledApp themeId={THEME_ID.DEFAULT}>{rootProviderWrapper({children: element})}</StyledApp>;
 }
 
 describe('PeopleTab', () => {

--- a/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
+++ b/apps/webapp/src/script/page/LeftSidebar/panels/StartUI/PeopleTab.tsx
@@ -86,7 +86,7 @@ export const PeopleTab = ({
   onClickUser,
   onSearchResults,
 }: PeopleTabProps) => {
-  const {translate} = useApplicationContext();
+  const {fireAndForgetInvoker, translate} = useApplicationContext();
   const logger = getLogger('PeopleSearch');
   const [topPeople, setTopPeople] = useState<User[]>([]);
   const teamSize = teamState.teamSize();
@@ -213,8 +213,10 @@ export const PeopleTab = ({
   }, SEARCH_DEBOUNCE_MILLISECONDS);
 
   useEffect(() => {
-    void debouncedSearch();
-  }, [debouncedSearch, searchQuery]);
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await debouncedSearch();
+    });
+  }, [debouncedSearch, fireAndForgetInvoker, searchQuery]);
 
   useEffect(() => {
     // keep track of the most up to date value of the search query (in order to cancel outdated queries)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
As a follow-up to https://github.com/wireapp/wire-webapp/pull/21585#discussion_r3436812571