### PR TITLE
Refresh add participants search results [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/UserSearchableList/UserSearchableList.test.tsx
+++ b/apps/webapp/src/script/components/UserSearchableList/UserSearchableList.test.tsx
@@ -1,0 +1,158 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, screen, waitFor} from '@testing-library/react';
+
+import {withThemeAndRootContext} from 'src/script/auth/util/test/TestUtil';
+import {
+  createExecutingFireAndForgetInvokerForTest,
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {ConversationState} from 'src/script/repositories/conversation/ConversationState';
+import {User} from 'src/script/repositories/entity/User';
+import {SearchRepository} from 'src/script/repositories/search/searchRepository';
+import {TeamRepository} from 'src/script/repositories/team/TeamRepository';
+import {TeamState} from 'src/script/repositories/team/TeamState';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {UserSearchableList, UserListProps} from './UserSearchableList';
+
+type UserDefinition = {
+  id: string;
+  name: string;
+  username: string;
+};
+type MinimalSearchRepository = Pick<SearchRepository, 'normalizeQuery' | 'searchByName' | 'searchUserInSet'>;
+type MinimalTeamRepository = Pick<TeamRepository, 'filterExternals' | 'filterRemoteDomainUsers' | 'isSelfConnectedTo'>;
+type MinimalTeamState = Pick<TeamState, 'isInTeam'>;
+type MinimalConversationState = Pick<ConversationState, 'hasConversationWith'>;
+
+function createUser(userDefinition: UserDefinition): User {
+  const {id, name, username} = userDefinition;
+  const user = new User(id, 'example.com', translateForTest);
+  user.name(name);
+  user.username(username);
+
+  return user;
+}
+
+function searchUsersByQuery(query: string, users: User[]): User[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return users.filter(user => {
+    return (
+      user.name().toLowerCase().includes(normalizedQuery) || user.username().toLowerCase().includes(normalizedQuery)
+    );
+  });
+}
+
+describe('UserSearchableList', () => {
+  it('updates the visible add participants list when the filter changes', async () => {
+    const aliceExample = createUser({
+      id: 'alice-id',
+      name: 'Alice Example',
+      username: 'aliceexample',
+    });
+    const bobTest = createUser({
+      id: 'bob-id',
+      name: 'Bob Test',
+      username: 'bobtest',
+    });
+    const charlieExample = createUser({
+      id: 'charlie-id',
+      name: 'Charlie Example',
+      username: 'charlieexample',
+    });
+    const selfUser = createUser({
+      id: 'self-id',
+      name: 'Self User',
+      username: 'selfuser',
+    });
+    const candidateUsers = [aliceExample, bobTest, charlieExample];
+    const searchRepositoryDouble = {
+      normalizeQuery: (query: string) => {
+        return {query: query.trim().toLowerCase(), isHandleQuery: false};
+      },
+      searchByName: async () => {
+        return [];
+      },
+      searchUserInSet: (query: string, users: User[]) => {
+        return searchUsersByQuery(query, users);
+      },
+    } satisfies MinimalSearchRepository;
+    const teamRepositoryDouble = {
+      filterExternals: async (users: User[]) => {
+        return users;
+      },
+      filterRemoteDomainUsers: async (users: User[]) => {
+        return users;
+      },
+      isSelfConnectedTo: () => {
+        return false;
+      },
+    } satisfies MinimalTeamRepository;
+    const teamStateDouble = {
+      isInTeam: () => {
+        return true;
+      },
+    } satisfies MinimalTeamState;
+    const conversationStateDouble = {
+      hasConversationWith: () => {
+        return true;
+      },
+    } satisfies MinimalConversationState;
+    const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
+    const rootProviderWrapper = createRootProviderWrapperForTest(
+      createRootContextValueForTest({
+        fireAndForgetInvoker,
+        translate: translateForTest,
+      }),
+    );
+    const properties: Omit<UserListProps, 'filter'> = {
+      allowRemoteSearch: true,
+      conversationState: conversationStateDouble as ConversationState,
+      filterRemoteTeamUsers: true,
+      isSelectable: true,
+      searchRepository: searchRepositoryDouble as SearchRepository,
+      selfUser,
+      teamRepository: teamRepositoryDouble as TeamRepository,
+      teamState: teamStateDouble as TeamState,
+      users: candidateUsers,
+    };
+
+    const {rerender} = render(
+      withThemeAndRootContext(<UserSearchableList {...properties} filter="" />, rootProviderWrapper),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Example')).toBeInTheDocument();
+      expect(screen.getByText('Bob Test')).toBeInTheDocument();
+      expect(screen.getByText('Charlie Example')).toBeInTheDocument();
+    });
+
+    rerender(withThemeAndRootContext(<UserSearchableList {...properties} filter="test" />, rootProviderWrapper));
+
+    await waitFor(() => {
+      expect(screen.getByText('Bob Test')).toBeInTheDocument();
+      expect(screen.queryByText('Alice Example')).toBeNull();
+      expect(screen.queryByText('Charlie Example')).toBeNull();
+    });
+  });
+});

--- a/apps/webapp/src/script/components/UserSearchableList/UserSearchableList.tsx
+++ b/apps/webapp/src/script/components/UserSearchableList/UserSearchableList.tsx
@@ -17,8 +17,9 @@
  *
  */
 
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
+import is from '@sindresorhus/is';
 import {QualifiedId, UserType} from '@wireapp/api-client/lib/user';
 import {container} from 'tsyringe';
 import {useDebouncedCallback} from 'use-debounce';
@@ -76,6 +77,13 @@ export const UserSearchableList = ({
 
   const [filteredUsers, setFilteredUsers] = useState<User[]>([]);
   const [remoteTeamMembers, setRemoteTeamMembers] = useState<User[]>([]);
+  const currentFilter = useRef(filter);
+  const remoteTeamMembersFilter = useRef(filter);
+  currentFilter.current = filter;
+
+  useEffect(() => {
+    setRemoteTeamMembers([]);
+  }, [filter]);
 
   const filteredSelectedUsers = selectedUsers ? searchRepository.searchUserInSet(filter, selectedUsers) : undefined;
 
@@ -94,9 +102,14 @@ export const UserSearchableList = ({
 
     // We shouldn't show any members that have the 'external' role and are not already locally known.
     const nonExternalMembers = await teamRepository.filterExternals(uniqueMembers);
-    setRemoteTeamMembers(
-      filterRemoteTeamUsers ? await teamRepository.filterRemoteDomainUsers(nonExternalMembers) : nonExternalMembers,
-    );
+    const nextRemoteTeamMembers = filterRemoteTeamUsers
+      ? await teamRepository.filterRemoteDomainUsers(nonExternalMembers)
+      : nonExternalMembers;
+
+    if (currentFilter.current === query) {
+      remoteTeamMembersFilter.current = query;
+      setRemoteTeamMembers(nextRemoteTeamMembers);
+    }
   }, SEARCH_MEMBERS_DEBOUNCE_MILLISECONDS);
 
   // Filter all list items if a filter is provided
@@ -117,7 +130,7 @@ export const UserSearchableList = ({
           user.username() === normalizedQuery,
       );
 
-    if (normalizedQuery !== '' && selfInTeam && allowRemoteSearch === true) {
+    if (is.nonEmptyString(normalizedQuery) && selfInTeam && allowRemoteSearch === true) {
       fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
         await fetchMembersFromBackend(filter, results);
       });
@@ -152,7 +165,7 @@ export const UserSearchableList = ({
   ]);
 
   const foundUserEntities = () => {
-    if (!remoteTeamMembers.length) {
+    if (remoteTeamMembersFilter.current !== filter || is.emptyArray(remoteTeamMembers)) {
       return filteredUsers;
     }
     const {query: normalizedQuery} = searchRepository.normalizeQuery(filter);
@@ -177,7 +190,7 @@ export const UserSearchableList = ({
       user.type === UserType.REGULAR,
   );
   const isEmptyUserList = userList.length === 0;
-  const isSearching = filter.length > 0;
+  const isSearching = is.nonEmptyString(filter);
   const noResultsDataUieName = !isSearching ? 'status-all-added' : 'status-no-matches';
   const noResultsTranslationText = !isSearching ? 'searchListEveryoneParticipates' : 'searchListNoMatches';
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Fixes stale search results in the channel/group `Add participants` people list.

This is related to #21585, which fixed the same class of stale search behavior in the Connect people search. In this flow, `AddParticipants` owns the search input and passes it to `UserSearchableList` as `filter`. Local filtering already reacts to the filter, but remote team-member results could outlive the query that produced them.