### PR TITLE
Preserve add participants search input while typing [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/page/RightSidebar/addParticipants/addParticipants.test.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/addParticipants/addParticipants.test.tsx
@@ -1,0 +1,252 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
+import ko from 'knockout';
+
+import {withThemeAndRootContext} from 'src/script/auth/util/test/TestUtil';
+import {
+  createExecutingFireAndForgetInvokerForTest,
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {ConversationRepository} from 'src/script/repositories/conversation/ConversationRepository';
+import {Conversation} from 'src/script/repositories/entity/Conversation';
+import {User} from 'src/script/repositories/entity/User';
+import {IntegrationRepository} from 'src/script/repositories/integration/IntegrationRepository';
+import {ServiceEntity} from 'src/script/repositories/integration/ServiceEntity';
+import {SearchRepository} from 'src/script/repositories/search/searchRepository';
+import {TeamRepository} from 'src/script/repositories/team/TeamRepository';
+import {TeamState} from 'src/script/repositories/team/TeamState';
+import {UserState} from 'src/script/repositories/user/userState';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {AddParticipants} from './addParticipants';
+
+type UserDefinition = {
+  id: string;
+  name: string;
+  username: string;
+};
+type MinimalConversationRepository = Pick<ConversationRepository, 'addUsers'>;
+type MinimalIntegrationRepository = Pick<
+  IntegrationRepository,
+  'mapServiceFromUser' | 'searchForServices' | 'services'
+>;
+type MinimalSearchRepository = Pick<SearchRepository, 'normalizeQuery' | 'searchByName' | 'searchUserInSet'>;
+type MinimalTeamRepository = Pick<TeamRepository, 'filterExternals' | 'filterRemoteDomainUsers' | 'isSelfConnectedTo'>;
+type MinimalTeamState = Pick<TeamState, 'isAppsEnabled' | 'isInTeam' | 'isTeam' | 'teamMembers' | 'teamUsers'>;
+type MinimalUserState = Pick<UserState, 'connectedUsers'>;
+
+function createUser(userDefinition: UserDefinition): User {
+  const {id, name, username} = userDefinition;
+  const user = new User(id, 'example.com', translateForTest);
+  user.name(name);
+  user.username(username);
+  user.teamId = 'team-id';
+
+  return user;
+}
+
+function searchUsersByQuery(query: string, users: User[]): User[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return users.filter(user => {
+    return (
+      user.name().toLowerCase().includes(normalizedQuery) || user.username().toLowerCase().includes(normalizedQuery)
+    );
+  });
+}
+
+function createActiveConversation(): Conversation {
+  const activeConversation = new Conversation(
+    'conversation-id',
+    'example.com',
+    CONVERSATION_PROTOCOL.PROTEUS,
+    translateForTest,
+  );
+  activeConversation.teamId = 'team-id';
+
+  Object.defineProperties(activeConversation, {
+    firstUserEntity: {
+      value: ko.pureComputed(() => {
+        return undefined;
+      }),
+    },
+    inTeam: {
+      value: ko.pureComputed(() => {
+        return true;
+      }),
+    },
+    isGroupOrChannel: {
+      value: ko.pureComputed(() => {
+        return true;
+      }),
+    },
+    isGuestAndServicesRoom: {
+      value: ko.pureComputed(() => {
+        return false;
+      }),
+    },
+    isServicesRoom: {
+      value: ko.pureComputed(() => {
+        return false;
+      }),
+    },
+    isTeamOnly: {
+      value: ko.pureComputed(() => {
+        return false;
+      }),
+    },
+  });
+
+  return activeConversation;
+}
+
+function createTeamState(candidateUsers: User[]): MinimalTeamState {
+  return {
+    isAppsEnabled: ko.pureComputed(() => {
+      return false;
+    }),
+    isInTeam: () => {
+      return true;
+    },
+    isTeam: ko.pureComputed(() => {
+      return true;
+    }),
+    teamMembers: ko.pureComputed(() => {
+      return candidateUsers;
+    }),
+    teamUsers: ko.pureComputed(() => {
+      return candidateUsers;
+    }),
+  };
+}
+
+describe('AddParticipants', () => {
+  it('keeps the search input stable and filters visible users while typing', async () => {
+    const user = userEvent.setup();
+    const aliceExample = createUser({
+      id: 'alice-id',
+      name: 'Alice Example',
+      username: 'aliceexample',
+    });
+    const bobTest = createUser({
+      id: 'bob-id',
+      name: 'Bob Test',
+      username: 'bobtest',
+    });
+    const charlieExample = createUser({
+      id: 'charlie-id',
+      name: 'Charlie Example',
+      username: 'charlieexample',
+    });
+    const selfUser = createUser({
+      id: 'self-id',
+      name: 'Self User',
+      username: 'selfuser',
+    });
+    const candidateUsers = [aliceExample, bobTest, charlieExample];
+    const conversationRepositoryDouble = {
+      addUsers: async () => {
+        return undefined;
+      },
+    } satisfies MinimalConversationRepository;
+    const integrationRepositoryDouble = {
+      mapServiceFromUser: () => {
+        return undefined as unknown as ServiceEntity;
+      },
+      searchForServices: async () => {
+        return undefined;
+      },
+      services: ko.observableArray<ServiceEntity>([]),
+    } satisfies MinimalIntegrationRepository;
+    const searchRepositoryDouble = {
+      normalizeQuery: (query: string) => {
+        return {query: query.trim().toLowerCase(), isHandleQuery: false};
+      },
+      searchByName: async () => {
+        return [];
+      },
+      searchUserInSet: (query: string, users: User[]) => {
+        return searchUsersByQuery(query, users);
+      },
+    } satisfies MinimalSearchRepository;
+    const teamRepositoryDouble = {
+      filterExternals: async (users: User[]) => {
+        return users;
+      },
+      filterRemoteDomainUsers: async (users: User[]) => {
+        return users;
+      },
+      isSelfConnectedTo: () => {
+        return true;
+      },
+    } satisfies MinimalTeamRepository;
+    const teamStateDouble = createTeamState(candidateUsers);
+    const userStateDouble = {
+      connectedUsers: ko.pureComputed(() => {
+        return candidateUsers;
+      }),
+    } satisfies MinimalUserState;
+    const rootProviderWrapper = createRootProviderWrapperForTest(
+      createRootContextValueForTest({
+        fireAndForgetInvoker: createExecutingFireAndForgetInvokerForTest(),
+        translate: translateForTest,
+      }),
+    );
+
+    render(
+      withThemeAndRootContext(
+        <AddParticipants
+          activeConversation={createActiveConversation()}
+          conversationRepository={conversationRepositoryDouble as ConversationRepository}
+          integrationRepository={integrationRepositoryDouble as IntegrationRepository}
+          onBack={jest.fn()}
+          onClose={jest.fn()}
+          searchRepository={searchRepositoryDouble as SearchRepository}
+          selfUser={selfUser}
+          teamRepository={teamRepositoryDouble as TeamRepository}
+          teamState={teamStateDouble as TeamState}
+          togglePanel={jest.fn()}
+          userState={userStateDouble as UserState}
+        />,
+        rootProviderWrapper,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Example')).toBeInTheDocument();
+      expect(screen.getByText('Bob Test')).toBeInTheDocument();
+      expect(screen.getByText('Charlie Example')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByRole('textbox', {name: 'addParticipantsSearchPlaceholder'});
+    await user.type(searchInput, 'test');
+
+    await waitFor(() => {
+      expect(searchInput).toHaveValue('test');
+      expect(screen.getByText('Bob Test')).toBeInTheDocument();
+      expect(screen.queryByText('Alice Example')).toBeNull();
+      expect(screen.queryByText('Charlie Example')).toBeNull();
+    });
+  });
+});

--- a/apps/webapp/src/script/page/RightSidebar/addParticipants/addParticipants.tsx
+++ b/apps/webapp/src/script/page/RightSidebar/addParticipants/addParticipants.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {FC, useMemo, useState} from 'react';
+import {FC, useCallback, useMemo, useState} from 'react';
 
 import is from '@sindresorhus/is';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
@@ -181,10 +181,13 @@ const AddParticipants: FC<AddParticipantsProps> = ({
 
   const onAddPeople = () => setCurrentState(PARTICIPANTS_STATE.ADD_PEOPLE);
 
-  const searchServices = async (value: string) => {
-    await integrationRepository.searchForServices(value);
-    setIsInitialServiceSearch(false);
-  };
+  const searchServices = useCallback(
+    async (value: string): Promise<void> => {
+      await integrationRepository.searchForServices(value);
+      setIsInitialServiceSearch(false);
+    },
+    [integrationRepository],
+  );
 
   const onAddServices = async () => {
     setCurrentState(PARTICIPANTS_STATE.ADD_SERVICE);
@@ -211,13 +214,16 @@ const AddParticipants: FC<AddParticipantsProps> = ({
     onBack();
   };
 
-  const onSearchInput = async (value: string) => {
-    setSearchInput(value);
+  const onSearchInput = useCallback(
+    async (value: string): Promise<void> => {
+      setSearchInput(value);
 
-    if (isAddServiceState && activeConversation.protocol === CONVERSATION_PROTOCOL.PROTEUS) {
-      await searchServices(value);
-    }
-  };
+      if (isAddServiceState && activeConversation.protocol === CONVERSATION_PROTOCOL.PROTEUS) {
+        await searchServices(value);
+      }
+    },
+    [activeConversation.protocol, isAddServiceState, searchServices],
+  );
 
   return (
     <div id="add-participants" className="add-participants panel__page">


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Stabilize the search input callback passed from AddParticipants to SearchInput.

SearchInput clears its value in an effect that depends on selectedUsers.length and setInput. AddParticipants previously passed an inline async onSearchInput callback, so each typed character updated local state, rerendered AddParticipants, changed the callback identity, and caused SearchInput to clear the input.

useCallback is used here for correctness, not render optimization: the callback identity is part of SearchInput's effect dependencies. Keeping it stable prevents the input/list reset while preserving the existing service-search behavior.

Follow-up to https://github.com/wireapp/wire-webapp/pull/21589

