### PR TITLE
Fix WebSocket reconnect after sleep/wake token refresh race [WPB-21916]

### DIFF
--- a/libraries/api-client/jest.config.js
+++ b/libraries/api-client/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
     '^.+\\.(ts|tsx)$': '@swc/jest',
     '^.+\\.(js|jsx)$': '@swc/jest',
   },
-  transformIgnorePatterns: ['/node_modules/(?!(true-myth|p-timeout|p-cancelable|uuid)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth|p-timeout|p-cancelable|uuid|noop-esm)/)'],
   coverageDirectory: '../../coverage/libraries/api-client',
   coverageThreshold: {
     global: {

--- a/libraries/api-client/src/tcp/webSocketClient.test.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.test.ts
@@ -20,6 +20,7 @@
 /* eslint-disable dot-notation */
 
 import {WebSocketClient} from './webSocketClient';
+import {noop} from 'noop-esm';
 
 import {InvalidTokenError} from '../auth/authenticationError';
 import {MINIMUM_API_VERSION} from '../config';
@@ -204,7 +205,7 @@ describe('WebSocketClient', () => {
 
   describe('onReconnect', () => {
     it('waits for the same in-flight access-token refresh before building reconnect URLs', async () => {
-      let resolveRefreshAccessToken: () => void = () => undefined;
+      let resolveRefreshAccessToken: () => void = noop;
       const refreshAccessTokenPromise = new Promise<void>(resolve => {
         resolveRefreshAccessToken = resolve;
       });

--- a/libraries/api-client/src/tcp/webSocketClient.test.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.test.ts
@@ -81,6 +81,24 @@ function createWebSocketClient(
   });
 }
 
+type WebSocketHttpClient = ConstructorParameters<typeof WebSocketClient>[1];
+type WebSocketReconnectHttpClient = Pick<
+  WebSocketHttpClient,
+  'accessTokenStore' | 'refreshAccessToken' | 'hasValidAccessToken'
+>;
+
+function createWebSocketReconnectHttpClient(
+  webSocketReconnectHttpClient: Pick<WebSocketReconnectHttpClient, 'refreshAccessToken' | 'hasValidAccessToken'>,
+): WebSocketHttpClient {
+  const httpClient: WebSocketReconnectHttpClient = {
+    accessTokenStore: fakeHttpClient.accessTokenStore,
+    refreshAccessToken: webSocketReconnectHttpClient.refreshAccessToken,
+    hasValidAccessToken: webSocketReconnectHttpClient.hasValidAccessToken,
+  };
+
+  return httpClient as WebSocketHttpClient;
+}
+
 const webSocketClients: WebSocketClient[] = [];
 
 describe('WebSocketClient', () => {
@@ -181,6 +199,95 @@ describe('WebSocketClient', () => {
 
         fakeSocket.onerror(new Error('error'));
       });
+    });
+  });
+
+  describe('onReconnect', () => {
+    it('waits for the same in-flight access-token refresh before building reconnect URLs', async () => {
+      let resolveRefreshAccessToken: () => void = () => undefined;
+      const refreshAccessTokenPromise = new Promise<void>(resolve => {
+        resolveRefreshAccessToken = resolve;
+      });
+      let accessTokenIsValid = false;
+      const refreshAccessToken = jest.fn(async () => {
+        await refreshAccessTokenPromise;
+        accessTokenIsValid = true;
+        return accessTokenPayload;
+      });
+      const httpClient = createWebSocketReconnectHttpClient({
+        refreshAccessToken,
+        hasValidAccessToken: () => accessTokenIsValid,
+      });
+      const websocketClient = createWebSocketClient('ws://url', httpClient);
+      webSocketClients.push(websocketClient);
+      const buildWebSocketUrl = jest.spyOn(websocketClient, 'buildWebSocketUrl').mockReturnValue('ws://url/await');
+
+      const firstReconnect = websocketClient['onReconnect']();
+      const secondReconnect = websocketClient['onReconnect']();
+
+      await Promise.resolve();
+
+      expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+      expect(buildWebSocketUrl).not.toHaveBeenCalled();
+
+      resolveRefreshAccessToken();
+
+      await expect(Promise.all([firstReconnect, secondReconnect])).resolves.toEqual([
+        'ws://url/await',
+        'ws://url/await',
+      ]);
+      expect(buildWebSocketUrl).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects reconnect and does not build a WebSocket URL when access-token refresh fails', async () => {
+      const refreshError = new Error('Refresh failed');
+      const httpClient = createWebSocketReconnectHttpClient({
+        refreshAccessToken: jest.fn().mockRejectedValue(refreshError),
+        hasValidAccessToken: () => false,
+      });
+      const websocketClient = createWebSocketClient('ws://url', httpClient);
+      webSocketClients.push(websocketClient);
+      const buildWebSocketUrl = jest.spyOn(websocketClient, 'buildWebSocketUrl').mockReturnValue('ws://url/await');
+
+      await expect(websocketClient['onReconnect']()).rejects.toBe(refreshError);
+
+      expect(buildWebSocketUrl).not.toHaveBeenCalled();
+    });
+
+    it('emits invalid-token event, rejects reconnect, and does not build a WebSocket URL when refresh fails with invalid token', async () => {
+      const invalidTokenError = new InvalidTokenError('Invalid token');
+      const httpClient = createWebSocketReconnectHttpClient({
+        refreshAccessToken: jest.fn().mockRejectedValue(invalidTokenError),
+        hasValidAccessToken: () => false,
+      });
+      const websocketClient = createWebSocketClient('ws://url', httpClient);
+      webSocketClients.push(websocketClient);
+      const buildWebSocketUrl = jest.spyOn(websocketClient, 'buildWebSocketUrl').mockReturnValue('ws://url/await');
+      const invalidTokenListener = jest.fn();
+
+      websocketClient.on(WebSocketClient.TOPIC.ON_INVALID_TOKEN, invalidTokenListener);
+
+      await expect(websocketClient['onReconnect']()).rejects.toBe(invalidTokenError);
+
+      expect(invalidTokenListener).toHaveBeenCalledTimes(1);
+      expect(invalidTokenListener).toHaveBeenCalledWith(invalidTokenError);
+      expect(buildWebSocketUrl).not.toHaveBeenCalled();
+    });
+
+    it('builds a WebSocket URL without refreshing when the access token is already valid', async () => {
+      const refreshAccessToken = jest.fn().mockResolvedValue(accessTokenPayload);
+      const httpClient = createWebSocketReconnectHttpClient({
+        refreshAccessToken,
+        hasValidAccessToken: () => true,
+      });
+      const websocketClient = createWebSocketClient('ws://url', httpClient);
+      webSocketClients.push(websocketClient);
+      const buildWebSocketUrl = jest.spyOn(websocketClient, 'buildWebSocketUrl').mockReturnValue('ws://url/await');
+
+      await expect(websocketClient['onReconnect']()).resolves.toBe('ws://url/await');
+
+      expect(refreshAccessToken).not.toHaveBeenCalled();
+      expect(buildWebSocketUrl).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/libraries/api-client/src/tcp/webSocketClient.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.ts
@@ -68,7 +68,7 @@ export type WebSocketClientOptions = {
 
 export class WebSocketClient extends EventEmitter {
   private clientId?: string;
-  private isRefreshingAccessToken: boolean;
+  private accessTokenRefreshPromise: Maybe<Promise<void>> = Maybe.nothing<Promise<void>>();
   private readonly baseUrl: string;
   private readonly logger: logdown.Logger;
   private readonly socket: ReconnectingWebsocket;
@@ -90,7 +90,6 @@ export class WebSocketClient extends EventEmitter {
     this.isSocketLocked = false;
     this.baseUrl = baseUrl;
     this.client = client;
-    this.isRefreshingAccessToken = false;
     this.socket = new ReconnectingWebsocket(this.onReconnect, {
       backFromSleepHandler: Maybe.nothing(),
       pingInterval: Maybe.nothing(),
@@ -135,7 +134,11 @@ export class WebSocketClient extends EventEmitter {
   private readonly onError = async (error: ErrorEvent) => {
     this.onStateChange(this.socket.getState());
     this.emit(WebSocketClient.TOPIC.ON_ERROR, error);
-    await this.refreshAccessToken();
+    try {
+      await this.refreshAccessToken();
+    } catch {
+      // Refresh failures are already emitted by refreshAccessToken().
+    }
   };
 
   private readonly onReconnect = async () => {
@@ -143,6 +146,11 @@ export class WebSocketClient extends EventEmitter {
       // before we try any connection, we first refresh the access token to make sure we will avoid concurrent accessToken refreshes
       await this.refreshAccessToken();
     }
+
+    if (!this.client.hasValidAccessToken()) {
+      throw new Error('Cannot reconnect WebSocket because access token is invalid after refresh');
+    }
+
     return this.buildWebSocketUrl();
   };
 
@@ -193,11 +201,19 @@ export class WebSocketClient extends EventEmitter {
   }
 
   private async refreshAccessToken(): Promise<void> {
-    if (this.isRefreshingAccessToken) {
-      return;
+    if (this.accessTokenRefreshPromise.isJust) {
+      return this.accessTokenRefreshPromise.value;
     }
-    this.isRefreshingAccessToken = true;
 
+    const accessTokenRefreshPromise = this.refreshAccessTokenOnce().finally(() => {
+      this.accessTokenRefreshPromise = Maybe.nothing<Promise<void>>();
+    });
+    this.accessTokenRefreshPromise = Maybe.just(accessTokenRefreshPromise);
+
+    return accessTokenRefreshPromise;
+  }
+
+  private async refreshAccessTokenOnce(): Promise<void> {
     try {
       await this.client.refreshAccessToken();
     } catch (error: unknown) {
@@ -217,8 +233,8 @@ export class WebSocketClient extends EventEmitter {
       } else {
         this.emit(WebSocketClient.TOPIC.ON_ERROR, error);
       }
-    } finally {
-      this.isRefreshingAccessToken = false;
+
+      throw error;
     }
   }
 
@@ -294,7 +310,13 @@ export class WebSocketClient extends EventEmitter {
       ? `${this.baseUrl}/await?${queryString}`
       : `${this.baseUrl}${this.versionPrefix}/events?${queryString}`;
 
-    this.logger.info(`WebSocket URL: ${websocketAddress}`);
+    const redactedQueryParams = new URLSearchParams(queryParams);
+    redactedQueryParams.set('access_token', '[redacted]');
+    const redactedWebsocketAddress = this.useLegacySocket
+      ? `${this.baseUrl}/await?${redactedQueryParams.toString()}`
+      : `${this.baseUrl}${this.versionPrefix}/events?${redactedQueryParams.toString()}`;
+
+    this.logger.info(`WebSocket URL: ${redactedWebsocketAddress}`);
 
     return websocketAddress;
   }

--- a/libraries/api-client/src/tcp/webSocketClient.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.ts
@@ -68,7 +68,7 @@ export type WebSocketClientOptions = {
 
 export class WebSocketClient extends EventEmitter {
   private clientId?: string;
-  private accessTokenRefreshPromise: Maybe<Promise<void>> = Maybe.nothing<Promise<void>>();
+  private accessTokenRefreshPromise?: Promise<void>;
   private readonly baseUrl: string;
   private readonly logger: logdown.Logger;
   private readonly socket: ReconnectingWebsocket;
@@ -201,16 +201,21 @@ export class WebSocketClient extends EventEmitter {
   }
 
   private async refreshAccessToken(): Promise<void> {
-    if (this.accessTokenRefreshPromise.isJust) {
-      return this.accessTokenRefreshPromise.value;
+    if (this.accessTokenRefreshPromise !== undefined) {
+      return this.accessTokenRefreshPromise;
     }
 
-    const accessTokenRefreshPromise = this.refreshAccessTokenOnce().finally(() => {
-      this.accessTokenRefreshPromise = Maybe.nothing<Promise<void>>();
-    });
-    this.accessTokenRefreshPromise = Maybe.just(accessTokenRefreshPromise);
+    this.accessTokenRefreshPromise = this.refreshAccessTokenWithCleanup();
 
-    return accessTokenRefreshPromise;
+    return this.accessTokenRefreshPromise;
+  }
+
+  private async refreshAccessTokenWithCleanup(): Promise<void> {
+    try {
+      await this.refreshAccessTokenOnce();
+    } finally {
+      this.accessTokenRefreshPromise = undefined;
+    }
   }
 
   private async refreshAccessTokenOnce(): Promise<void> {

--- a/libraries/core/src/account.test.ts
+++ b/libraries/core/src/account.test.ts
@@ -524,6 +524,28 @@ describe('Account', () => {
           });
         });
       });
+
+      it('emits CLOSED without unlocking websocket when legacy notification catch-up fails after websocket open', async () => {
+        const catchUpError = new Error('Legacy catch-up failed');
+        jest
+          .spyOn(dependencies.account.service!.notification, 'legacyProcessNotificationStream')
+          .mockRejectedValue(catchUpError);
+        const unlock = jest.spyOn(dependencies.apiClient.transport.ws, 'unlock');
+        const onConnectionStateChanged = jest.fn<void, [ConnectionState]>();
+
+        const disconnect = await dependencies.account.listen({
+          useLegacy: true,
+          onConnectionStateChanged,
+        });
+
+        await waitFor(() => expect(onConnectionStateChanged).toHaveBeenCalledWith(ConnectionState.CLOSED));
+
+        expect(onConnectionStateChanged).toHaveBeenCalledWith(ConnectionState.PROCESSING_NOTIFICATIONS);
+        expect(onConnectionStateChanged).not.toHaveBeenCalledWith(ConnectionState.LIVE);
+        expect(unlock).not.toHaveBeenCalled();
+
+        disconnect();
+      });
     });
   });
 

--- a/libraries/core/src/account.ts
+++ b/libraries/core/src/account.ts
@@ -787,7 +787,9 @@ export class Account extends TypedEventEmitter<Events> {
     }
     this.apiClient.connect(async abortController => {
       // this call back is called every single time the websocket connection is (re)established
-      this.logger.info('Connection established with websocket, starting notification stream processing');
+      this.logger.info(
+        `Connection established with websocket, starting notification stream processing. useLegacy: ${useLegacy}, aborted: ${abortController.signal.aborted}`,
+      );
       /**
        * This is to avoid passing proposals too early to core crypto
        * @See WPB-18995
@@ -805,8 +807,34 @@ export class Account extends TypedEventEmitter<Events> {
       this.notificationProcessingQueue.resume();
 
       if (useLegacy) {
-        await legacyProcessNotificationStream(abortController);
+        this.logger.info(
+          `Starting legacy notification stream processing after WebSocket open. aborted: ${abortController.signal.aborted}`,
+        );
+        try {
+          await legacyProcessNotificationStream(abortController);
+          this.logger.info(
+            `Completed legacy notification stream processing after WebSocket open. aborted: ${abortController.signal.aborted}, live: ${this.isConnectionLive()}`,
+          );
+        } catch (error: unknown) {
+          this.logger.error(
+            `Failed legacy notification stream processing after WebSocket open. aborted: ${abortController.signal.aborted}, live: ${this.isConnectionLive()}`,
+            error,
+          );
+
+          if (abortController.signal.aborted) {
+            this.logger.info('Ignoring failed legacy notification stream processing because WebSocket was aborted');
+            return;
+          }
+
+          this.pauseAndFlushNotificationQueue();
+          onConnectionStateChanged(ConnectionState.CLOSED);
+        }
+        return;
       }
+
+      this.logger.info(
+        `Notification stream processing callback completed after WebSocket open. useLegacy: ${useLegacy}, aborted: ${abortController.signal.aborted}, live: ${this.isConnectionLive()}`,
+      );
     });
 
     return () => {

--- a/libraries/core/src/account.ts
+++ b/libraries/core/src/account.ts
@@ -788,7 +788,7 @@ export class Account extends TypedEventEmitter<Events> {
     this.apiClient.connect(async abortController => {
       // this call back is called every single time the websocket connection is (re)established
       this.logger.info(
-        `Connection established with websocket, starting notification stream processing. useLegacy: ${useLegacy}, aborted: ${abortController.signal.aborted}`,
+        `WebSocket notification processing started. useLegacy: ${useLegacy}, aborted: ${abortController.signal.aborted}`,
       );
       /**
        * This is to avoid passing proposals too early to core crypto
@@ -808,33 +808,27 @@ export class Account extends TypedEventEmitter<Events> {
 
       if (useLegacy) {
         this.logger.info(
-          `Starting legacy notification stream processing after WebSocket open. aborted: ${abortController.signal.aborted}`,
+          `Legacy notification stream catch-up started after WebSocket open. aborted: ${abortController.signal.aborted}`,
         );
         try {
           await legacyProcessNotificationStream(abortController);
           this.logger.info(
-            `Completed legacy notification stream processing after WebSocket open. aborted: ${abortController.signal.aborted}, live: ${this.isConnectionLive()}`,
+            `Legacy notification stream catch-up completed after WebSocket open. aborted: ${abortController.signal.aborted}, live: ${this.isConnectionLive()}`,
           );
         } catch (error: unknown) {
           this.logger.error(
-            `Failed legacy notification stream processing after WebSocket open. aborted: ${abortController.signal.aborted}, live: ${this.isConnectionLive()}`,
+            `Legacy notification stream catch-up failed after WebSocket open. aborted: ${abortController.signal.aborted}, live: ${this.isConnectionLive()}`,
             error,
           );
 
           if (abortController.signal.aborted) {
-            this.logger.info('Ignoring failed legacy notification stream processing because WebSocket was aborted');
             return;
           }
 
           this.pauseAndFlushNotificationQueue();
           onConnectionStateChanged(ConnectionState.CLOSED);
         }
-        return;
       }
-
-      this.logger.info(
-        `Notification stream processing callback completed after WebSocket open. useLegacy: ${useLegacy}, aborted: ${abortController.signal.aborted}, live: ${this.isConnectionLive()}`,
-      );
     });
 
     return () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem

WebSocket recovery can still fail after a MacBook sleep/wake cycle.

Even after forcing WebSocket reconnects on wake and replacing terminal `CLOSED` wrappers, the app can still get stuck in the reconnect state.

A typical failure pattern after wake looks like this:

- the network changes while the laptop wakes up
- HTTP requests fail with `ERR_NETWORK_CHANGED`
- some requests return `401` or `409`
- the `/await` WebSocket reconnects while access-token refresh is also happening
- the app stays in a reconnecting state instead of recovering to `LIVE`

## Root cause

`WebSocketClient.refreshAccessToken()` only used a boolean guard for concurrent refreshes.

When a refresh was already in progress, another reconnect attempt could return immediately instead of waiting for the same refresh to finish.

That meant WebSocket reconnect could continue and build a WebSocket URL with a stale or expired token.

Refresh failures were also swallowed after emitting the existing error events, so reconnect could continue even though the token refresh did not succeed.

## Change

This makes WebSocket reconnect wait for access-token refresh correctly.

The WebSocket client now:

- shares an in-flight access-token refresh promise between concurrent reconnect attempts
- waits for the refresh to complete before building the WebSocket URL
- rejects reconnect when token refresh fails
- preserves the existing invalid-token and generic error events
- avoids building a WebSocket URL with a known stale token

## Why

After sleep/wake, the browser can produce several network and authentication failures at once.

WebSocket reconnect must not race ahead of access-token recovery. Otherwise the client can reconnect with invalid credentials and remain stuck in the reconnecting state.