### PR TITLE
Keep WebSocket reconnect alive during token refresh failures [WPB-21916]

### DIFF
--- a/libraries/api-client/src/tcp/webSocketClient.test.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.test.ts
@@ -20,6 +20,7 @@
 /* eslint-disable dot-notation */
 
 import {WebSocketClient} from './webSocketClient';
+import {ReconnectingWebsocketWallClock} from './reconnectingWebsocket';
 import {noop} from 'noop-esm';
 
 import {InvalidTokenError} from '../auth/authenticationError';
@@ -34,6 +35,8 @@ const accessTokenPayload = {
   token_type: 'Bearer',
   user: 'aaf9a833-ef30-4c22-86a0-9adc8a15b3b4',
 };
+
+const reconnectPendingMarker = 'reconnect-pending';
 
 const fakeHttpClient: any = {
   accessTokenStore: {
@@ -61,35 +64,59 @@ const fakeSocket = {
 
 let currentTimestampInMilliseconds = 1_000_000;
 
-const testWallClock = {
-  clearInterval: globalThis.clearInterval.bind(globalThis),
-  clearTimeout: globalThis.clearTimeout.bind(globalThis),
+const testWallClock: ReconnectingWebsocketWallClock = {
+  clearInterval(intervalIdentifier) {
+    return globalThis.clearInterval(intervalIdentifier);
+  },
+  clearTimeout(timeoutIdentifier) {
+    return globalThis.clearTimeout(timeoutIdentifier);
+  },
 
   get currentTimestampInMilliseconds() {
     return currentTimestampInMilliseconds;
   },
 
-  setInterval: globalThis.setInterval.bind(globalThis),
-  setTimeout: globalThis.setTimeout.bind(globalThis),
+  setInterval(callback, delayInMilliseconds) {
+    return globalThis.setInterval(callback, delayInMilliseconds);
+  },
+  setTimeout(callback, delayInMilliseconds) {
+    return globalThis.setTimeout(callback, delayInMilliseconds);
+  },
 };
-
-function createWebSocketClient(
-  baseUrl: string,
-  client: ConstructorParameters<typeof WebSocketClient>[1],
-): WebSocketClient {
-  return new WebSocketClient(baseUrl, client, {
-    wallClock: testWallClock,
-  });
-}
 
 type WebSocketHttpClient = ConstructorParameters<typeof WebSocketClient>[1];
 type WebSocketReconnectHttpClient = Pick<
   WebSocketHttpClient,
   'accessTokenStore' | 'refreshAccessToken' | 'hasValidAccessToken'
 >;
+type WebSocketReconnectHttpClientOptions = Pick<
+  WebSocketReconnectHttpClient,
+  'refreshAccessToken' | 'hasValidAccessToken'
+>;
+type RetryDelayCallback = () => void;
+type ManualRetryWallClock = {
+  readonly retryDelaysInMilliseconds: number[];
+  readonly runNextRetryDelay: () => void;
+  readonly wallClock: ReconnectingWebsocketWallClock;
+};
+type ManualRetryTimeoutIdentifier = ReturnType<ReconnectingWebsocketWallClock['setTimeout']>;
+
+function createWebSocketClient(
+  baseUrl: string,
+  client: WebSocketHttpClient,
+  wallClock: ReconnectingWebsocketWallClock,
+): WebSocketClient {
+  return new WebSocketClient(baseUrl, client, {
+    wallClock,
+  });
+}
+
+function createWebSocketClientWithTestWallClock(baseUrl: string, client: WebSocketHttpClient): WebSocketClient {
+  return createWebSocketClient(baseUrl, client, testWallClock);
+}
 
 function createWebSocketReconnectHttpClient(
-  webSocketReconnectHttpClient: Pick<WebSocketReconnectHttpClient, 'refreshAccessToken' | 'hasValidAccessToken'>,
+  webSocketReconnectHttpClient: WebSocketReconnectHttpClientOptions,
 ): WebSocketHttpClient {
   const httpClient: WebSocketReconnectHttpClient = {
     accessTokenStore: fakeHttpClient.accessTokenStore,
@@ -98,6 +125,49 @@ function createWebSocketReconnectHttpClient(
   };
 
   return httpClient as WebSocketHttpClient;
+}
+
+function createManualRetryTimeoutIdentifier(): ManualRetryTimeoutIdentifier {
+  const timeoutIdentifier = testWallClock.setTimeout(noop, 0);
+
+  testWallClock.clearTimeout(timeoutIdentifier);
+
+  return timeoutIdentifier;
+}
+
+function createManualRetryWallClock(): ManualRetryWallClock {
+  const retryDelayCallbacks: RetryDelayCallback[] = [];
+  const retryDelaysInMilliseconds: number[] = [];
+  const wallClock: ReconnectingWebsocketWallClock = {
+    clearInterval: testWallClock.clearInterval,
+    clearTimeout: testWallClock.clearTimeout,
+
+    get currentTimestampInMilliseconds() {
+      return currentTimestampInMilliseconds;
+    },
+
+    setInterval: testWallClock.setInterval,
+    setTimeout: (callback, delayInMilliseconds) => {
+      retryDelayCallbacks.push(callback);
+      retryDelaysInMilliseconds.push(delayInMilliseconds);
+
+      return createManualRetryTimeoutIdentifier();
+    },
+  };
+
+  return {
+    retryDelaysInMilliseconds,
+    runNextRetryDelay: () => {
+      retryDelayCallbacks.shift()?.();
+    },
+    wallClock,
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 const webSocketClients: WebSocketClient[] = [];
@@ -113,7 +183,7 @@ describe('WebSocketClient', () => {
 
   describe('handler', () => {
     it('calls "onOpen" when WebSocket opens', async () => {
-      const websocketClient = createWebSocketClient('ws://url', fakeHttpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', fakeHttpClient);
       webSocketClients.push(websocketClient);
       const onOpenSpy = jest.spyOn(websocketClient as any, 'onOpen');
       const socket = websocketClient['socket'];
@@ -126,7 +196,7 @@ describe('WebSocketClient', () => {
     });
 
     it('calls "onClose" when WebSocket closes', async () => {
-      const websocketClient = createWebSocketClient('ws://url', fakeHttpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', fakeHttpClient);
       webSocketClients.push(websocketClient);
       const onCloseSpy = jest.spyOn(websocketClient as any, 'onClose');
       const socket = websocketClient['socket'];
@@ -139,7 +209,7 @@ describe('WebSocketClient', () => {
     });
 
     it('calls "onError" when WebSocket received error', async () => {
-      const websocketClient = createWebSocketClient('ws://url', fakeHttpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', fakeHttpClient);
       webSocketClients.push(websocketClient);
       const onErrorSpy = jest.spyOn(websocketClient as any, 'onError');
       const refreshTokenSpy = jest.spyOn(websocketClient as any, 'refreshAccessToken');
@@ -155,7 +225,7 @@ describe('WebSocketClient', () => {
 
     it('calls "onMessage" when WebSocket received message', async () => {
       const message = {type: ConsumableEvent.MISSED};
-      const websocketClient = createWebSocketClient('ws://url', fakeHttpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', fakeHttpClient);
       webSocketClients.push(websocketClient);
       const onMessageSpy = jest.spyOn(websocketClient as any, 'onMessage');
       const socket = websocketClient['socket'];
@@ -172,7 +242,7 @@ describe('WebSocketClient', () => {
       const onConnect = () => {
         return onConnectResult();
       };
-      const websocketClient = createWebSocketClient('ws://url', fakeHttpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', fakeHttpClient);
       webSocketClients.push(websocketClient);
       const socket = websocketClient['socket'];
       jest.spyOn(socket as any, 'getReconnectingWebsocket').mockReturnValue(fakeSocket);
@@ -188,7 +258,7 @@ describe('WebSocketClient', () => {
   describe('refreshAccessToken', () => {
     // eslint-disable-next-line jest/expect-expect
     it('emits the correct message for invalid tokens', async () => {
-      const websocketClient = createWebSocketClient('ws://url', invalidTokenHttpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', invalidTokenHttpClient);
       webSocketClients.push(websocketClient);
       const socket = websocketClient['socket'];
       jest.spyOn(socket as any, 'getReconnectingWebsocket').mockReturnValue(fakeSocket);
@@ -219,7 +289,7 @@ describe('WebSocketClient', () => {
         refreshAccessToken,
         hasValidAccessToken: () => accessTokenIsValid,
       });
-      const websocketClient = createWebSocketClient('ws://url', httpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', httpClient);
       webSocketClients.push(websocketClient);
       const buildWebSocketUrl = jest.spyOn(websocketClient, 'buildWebSocketUrl').mockReturnValue('ws://url/await');
 
@@ -240,19 +310,41 @@ describe('WebSocketClient', () => {
       expect(buildWebSocketUrl).toHaveBeenCalledTimes(2);
     });
 
-    it('rejects reconnect and does not build a WebSocket URL when access-token refresh fails', async () => {
-      const refreshError = new Error('Refresh failed');
+    it('retries transient refresh failures without rejecting reconnect before building a WebSocket URL', async () => {
+      const refreshError = new Error('Network changed');
+      const manualRetryWallClock = createManualRetryWallClock();
+      let accessTokenIsValid = false;
+      const refreshAccessToken = jest
+        .fn()
+        .mockRejectedValueOnce(refreshError)
+        .mockImplementationOnce(async () => {
+          accessTokenIsValid = true;
+          return accessTokenPayload;
+        });
       const httpClient = createWebSocketReconnectHttpClient({
-        refreshAccessToken: jest.fn().mockRejectedValue(refreshError),
-        hasValidAccessToken: () => false,
+        refreshAccessToken,
+        hasValidAccessToken: () => accessTokenIsValid,
       });
-      const websocketClient = createWebSocketClient('ws://url', httpClient);
+      const websocketClient = createWebSocketClient('ws://url', httpClient, manualRetryWallClock.wallClock);
       webSocketClients.push(websocketClient);
       const buildWebSocketUrl = jest.spyOn(websocketClient, 'buildWebSocketUrl').mockReturnValue('ws://url/await');
 
-      await expect(websocketClient['onReconnect']()).rejects.toBe(refreshError);
+      const reconnectPromise = websocketClient['onReconnect']();
 
+      await flushPromises();
+
+      expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+      await expect(Promise.race([reconnectPromise, Promise.resolve(reconnectPendingMarker)])).resolves.toBe(
+        reconnectPendingMarker,
+      );
       expect(buildWebSocketUrl).not.toHaveBeenCalled();
+      expect(manualRetryWallClock.retryDelaysInMilliseconds).toEqual([1_000]);
+
+      manualRetryWallClock.runNextRetryDelay();
+
+      await expect(reconnectPromise).resolves.toBe('ws://url/await');
+      expect(refreshAccessToken).toHaveBeenCalledTimes(2);
+      expect(buildWebSocketUrl).toHaveBeenCalledTimes(1);
     });
 
     it('emits invalid-token event, rejects reconnect, and does not build a WebSocket URL when refresh fails with invalid token', async () => {
@@ -261,7 +353,7 @@ describe('WebSocketClient', () => {
         refreshAccessToken: jest.fn().mockRejectedValue(invalidTokenError),
         hasValidAccessToken: () => false,
       });
-      const websocketClient = createWebSocketClient('ws://url', httpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', httpClient);
       webSocketClients.push(websocketClient);
       const buildWebSocketUrl = jest.spyOn(websocketClient, 'buildWebSocketUrl').mockReturnValue('ws://url/await');
       const invalidTokenListener = jest.fn();
@@ -281,7 +373,7 @@ describe('WebSocketClient', () => {
         refreshAccessToken,
         hasValidAccessToken: () => true,
       });
-      const websocketClient = createWebSocketClient('ws://url', httpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', httpClient);
       webSocketClients.push(websocketClient);
       const buildWebSocketUrl = jest.spyOn(websocketClient, 'buildWebSocketUrl').mockReturnValue('ws://url/await');
 
@@ -314,7 +406,7 @@ describe('WebSocketClient', () => {
     };
 
     it('does not lock websocket by default', async () => {
-      const websocketClient = createWebSocketClient('ws://url', fakeHttpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', fakeHttpClient);
       webSocketClients.push(websocketClient);
       const onMessageSpy = jest.spyOn(websocketClient as any, 'onMessage');
       const socket = websocketClient['socket'];
@@ -335,7 +427,7 @@ describe('WebSocketClient', () => {
     });
 
     it('emits buffered messages when unlocked', async () => {
-      const websocketClient = createWebSocketClient('ws://url', fakeHttpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', fakeHttpClient);
       webSocketClients.push(websocketClient);
       const onMessageSpy = jest.spyOn(websocketClient as any, 'onMessage');
       const socket = websocketClient['socket'];
@@ -360,7 +452,7 @@ describe('WebSocketClient', () => {
     });
 
     it('emits a long-running retry event once reconnect retries reach one minute', async () => {
-      const websocketClient = createWebSocketClient('ws://url', fakeHttpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', fakeHttpClient);
       webSocketClients.push(websocketClient);
       const retryDetailsListener = jest.fn();
       const socket = websocketClient['socket'];
@@ -385,7 +477,7 @@ describe('WebSocketClient', () => {
     });
 
     it('does not emit a long-running retry event before reconnect retries reach one minute', async () => {
-      const websocketClient = createWebSocketClient('ws://url', fakeHttpClient);
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', fakeHttpClient);
       webSocketClients.push(websocketClient);
       const retryDetailsListener = jest.fn();
       const socket = websocketClient['socket'];

--- a/libraries/api-client/src/tcp/webSocketClient.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.ts
@@ -52,6 +52,11 @@ enum TOPIC {
   ON_STATE_CHANGE = 'WebSocketClient.TOPIC.ON_STATE_CHANGE',
 }
 
+const accessTokenRefreshRetryInitialDelayInMilliseconds = 1_000;
+const accessTokenRefreshRetryMaximumDelayInMilliseconds = 10_000;
+const accessTokenRefreshRetryBackoffFactor = 2;
+const firstRetryAttemptOffset = 1;
+
 export interface WebSocketClient {
   on(event: TOPIC.ON_ERROR, listener: (error: Error | ErrorEvent) => void): this;
   on(event: TOPIC.ON_INVALID_TOKEN, listener: (error: InvalidTokenError | MissingCookieError) => void): this;
@@ -72,6 +77,7 @@ export class WebSocketClient extends EventEmitter {
   private readonly baseUrl: string;
   private readonly logger: logdown.Logger;
   private readonly socket: ReconnectingWebsocket;
+  private readonly wallClock: ReconnectingWebsocketWallClock;
   private websocketState: WEBSOCKET_STATE;
   public client: HttpClient;
   private isSocketLocked: boolean;
@@ -90,6 +96,7 @@ export class WebSocketClient extends EventEmitter {
     this.isSocketLocked = false;
     this.baseUrl = baseUrl;
     this.client = client;
+    this.wallClock = options.wallClock;
     this.socket = new ReconnectingWebsocket(this.onReconnect, {
       backFromSleepHandler: Maybe.nothing(),
       pingInterval: Maybe.nothing(),
@@ -142,14 +149,7 @@ export class WebSocketClient extends EventEmitter {
   };
 
   private readonly onReconnect = async () => {
-    if (!this.client.hasValidAccessToken()) {
-      // before we try any connection, we first refresh the access token to make sure we will avoid concurrent accessToken refreshes
-      await this.refreshAccessToken();
-    }
-
-    if (!this.client.hasValidAccessToken()) {
-      throw new Error('Cannot reconnect WebSocket because access token is invalid after refresh');
-    }
+    await this.waitForValidAccessTokenBeforeReconnect();
 
     return this.buildWebSocketUrl();
   };
@@ -208,6 +208,69 @@ export class WebSocketClient extends EventEmitter {
     this.accessTokenRefreshPromise = this.refreshAccessTokenWithCleanup();
 
     return this.accessTokenRefreshPromise;
+  }
+
+  private async waitForValidAccessTokenBeforeReconnect(): Promise<void> {
+    let retryCount = 0;
+
+    while (!this.client.hasValidAccessToken()) {
+      this.logger.info(`WebSocket reconnect waiting for access-token refresh. retry count: ${retryCount}`);
+
+      try {
+        await this.refreshAccessToken();
+      } catch (error: unknown) {
+        if (this.isInvalidSessionError(error)) {
+          this.logger.warn(
+            'WebSocket reconnect stopped because access-token refresh failed with an invalid session. Logout handling should take over.',
+            error,
+          );
+          throw error;
+        }
+
+        retryCount += 1;
+        const nextRetryDelayInMilliseconds = this.getAccessTokenRefreshRetryDelayInMilliseconds(retryCount);
+        this.logger.warn(
+          `WebSocket reconnect access-token refresh failed transiently. retry count: ${retryCount}, next retry delay: ${nextRetryDelayInMilliseconds}ms`,
+          error,
+        );
+        await this.waitForNextAccessTokenRefreshRetry(nextRetryDelayInMilliseconds);
+        continue;
+      }
+
+      if (this.client.hasValidAccessToken()) {
+        this.logger.info('WebSocket reconnect access-token refresh succeeded; building WebSocket URL');
+        return;
+      }
+
+      retryCount += 1;
+      const nextRetryDelayInMilliseconds = this.getAccessTokenRefreshRetryDelayInMilliseconds(retryCount);
+      this.logger.warn(
+        `WebSocket reconnect access-token refresh completed but token is still invalid. retry count: ${retryCount}, next retry delay: ${nextRetryDelayInMilliseconds}ms`,
+      );
+      await this.waitForNextAccessTokenRefreshRetry(nextRetryDelayInMilliseconds);
+    }
+  }
+
+  private isInvalidSessionError(error: unknown): boolean {
+    return (
+      error instanceof InvalidTokenError ||
+      error instanceof MissingCookieError ||
+      error instanceof MissingCookieAndTokenError
+    );
+  }
+
+  private getAccessTokenRefreshRetryDelayInMilliseconds(retryCount: number): number {
+    const delayInMilliseconds =
+      accessTokenRefreshRetryInitialDelayInMilliseconds *
+      accessTokenRefreshRetryBackoffFactor ** (retryCount - firstRetryAttemptOffset);
+
+    return Math.min(delayInMilliseconds, accessTokenRefreshRetryMaximumDelayInMilliseconds);
+  }
+
+  private waitForNextAccessTokenRefreshRetry(delayInMilliseconds: number): Promise<void> {
+    return new Promise(resolve => {
+      this.wallClock.setTimeout(resolve, delayInMilliseconds);
+    });
   }
 
   private async refreshAccessTokenWithCleanup(): Promise<void> {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Problem

WebSocket recovery can still get stuck after a MacBook sleep/wake cycle.

The observed failure pattern is:

* the Mac wakes up and the network changes
* requests temporarily fail with `ERR_NETWORK_CHANGED`
* some requests return `401`
* the `/await` WebSocket reconnects during the same recovery window
* access-token refresh can fail transiently
* the app remains stuck in a reconnecting state instead of recovering

## Root cause

The WebSocket URL is produced by an async reconnect callback.

After the previous fix https://github.com/wireapp/wire-webapp/pull/21603, that callback correctly waited for access-token refresh and rejected when refresh failed. That avoided reconnecting with a stale token.

However, the underlying reconnecting WebSocket library is not robust when the async URL provider rejects during a reconnect attempt. A transient token-refresh failure after wake can therefore stop reconnect progress instead of allowing the reconnect loop to continue.

So the problem is not that we should reconnect with an invalid token.

The problem is that a temporary token-refresh failure must not permanently break the reconnect loop.

## Change

This makes the reconnect URL provider resilient to transient token-refresh failures.

The WebSocket client now keeps reconnect recovery alive while waiting for a valid access token:

* concurrent reconnect attempts still share the same in-flight token refresh
* transient token-refresh failures are retried instead of escaping from the URL provider
* the WebSocket URL is only built after a valid token is available
* fatal invalid-session handling is preserved
* raw access tokens are not logged