### PR TITLE
Fix playwright strict mode violation in folder tests [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -322,7 +322,7 @@ test.describe('Folders', () => {
       await test.step('User A removes 1:1 and group conversation with User B from Favorites', async () => {
         const contextMenuDirectConversation = await userAPages
           .conversationList()
-          .getConversation(userB.fullName)
+          .getConversation(userB.fullName, {protocol: 'mls'})
           .openContextMenu();
         await contextMenuDirectConversation.getByRole('button', {name: 'Remove from favorites'}).click();
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The strict mode violation occurred because the name of user B was part of both conversations. Once for the 1:1 and in the group chat because B previously wrote a message causing his name to be shown beneath the group name.


