### PR TITLE
Fix missing root context in guest link password modal [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/Cells/ShareModal/CellsShareModalContent.tsx
+++ b/apps/webapp/src/script/components/Cells/ShareModal/CellsShareModalContent.tsx
@@ -257,6 +257,7 @@ export const CellsShareModalContent = ({
           <div css={styles.passwordContentStyles}>
             <div css={styles.passwordActionButtonStyles}>
               <PasswordGeneratorButton
+                translate={translate}
                 passwordLength={Config.getConfig().MINIMUM_PASSWORD_LENGTH}
                 onGeneratePassword={password.onGeneratePassword}
               />

--- a/apps/webapp/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.tsx
+++ b/apps/webapp/src/script/components/Modals/PrimaryModal/GuestLinkPasswordForm/GuestLinkPasswordForm.tsx
@@ -56,6 +56,7 @@ export const GuestLinkPasswordForm = ({
   return (
     <>
       <PasswordGeneratorButton
+        translate={translate}
         passwordLength={Config.getConfig().MINIMUM_PASSWORD_LENGTH}
         onGeneratePassword={onGeneratePassword}
       />

--- a/apps/webapp/src/script/components/PasswordGeneratorButton/PasswordGeneratorButton.test.tsx
+++ b/apps/webapp/src/script/components/PasswordGeneratorButton/PasswordGeneratorButton.test.tsx
@@ -21,25 +21,17 @@ import {act} from 'react';
 import {render} from '@testing-library/react';
 
 import {translateForTest} from 'Util/test/translateForTest';
-import {
-  createRootContextValueForTest,
-  createRootProviderWrapperForTest,
-} from 'src/script/page/testSupport/rootContextTestSupport';
 
 import {PasswordGeneratorButton} from './PasswordGeneratorButton';
 
 import {withTheme} from '../../auth/util/test/TestUtil';
 
-const rootProviderWrapper = createRootProviderWrapperForTest(
-  createRootContextValueForTest({translate: translateForTest}),
-);
-
 describe('PasswordGeneratorButton', () => {
   it('calls onGeneratePassword prop with a random password when clicked', () => {
     const onGeneratePasswordMock = jest.fn();
-    const {getByTestId} = render(withTheme(<PasswordGeneratorButton onGeneratePassword={onGeneratePasswordMock} />), {
-      wrapper: rootProviderWrapper,
-    });
+    const {getByTestId} = render(
+      withTheme(<PasswordGeneratorButton translate={translateForTest} onGeneratePassword={onGeneratePasswordMock} />),
+    );
     const generatePasswordButton = getByTestId('do-generate-password');
 
     act(() => {
@@ -53,8 +45,13 @@ describe('PasswordGeneratorButton', () => {
   it('calls onGeneratePassword prop with a random password with 15 charachters when clicked', () => {
     const onGeneratePasswordMock = jest.fn();
     const {getByTestId} = render(
-      withTheme(<PasswordGeneratorButton passwordLength={15} onGeneratePassword={onGeneratePasswordMock} />),
-      {wrapper: rootProviderWrapper},
+      withTheme(
+        <PasswordGeneratorButton
+          translate={translateForTest}
+          passwordLength={15}
+          onGeneratePassword={onGeneratePasswordMock}
+        />,
+      ),
     );
     const generatePasswordButton = getByTestId('do-generate-password');
 
@@ -67,18 +64,18 @@ describe('PasswordGeneratorButton', () => {
   });
 
   it('displays a shield icon next to the button label', () => {
-    const {getByTestId} = render(withTheme(<PasswordGeneratorButton onGeneratePassword={jest.fn()} />), {
-      wrapper: rootProviderWrapper,
-    });
+    const {getByTestId} = render(
+      withTheme(<PasswordGeneratorButton translate={translateForTest} onGeneratePassword={jest.fn()} />),
+    );
     const shieldIcon = getByTestId('generate-password-icon');
     expect(shieldIcon).toBeTruthy();
   });
 
   it('uses the onGeneratePassword prop to generate a new password each time the button is clicked', () => {
     const onGeneratePasswordMock = jest.fn();
-    const {getByTestId} = render(withTheme(<PasswordGeneratorButton onGeneratePassword={onGeneratePasswordMock} />), {
-      wrapper: rootProviderWrapper,
-    });
+    const {getByTestId} = render(
+      withTheme(<PasswordGeneratorButton translate={translateForTest} onGeneratePassword={onGeneratePasswordMock} />),
+    );
     const generatePasswordButton = getByTestId('do-generate-password');
 
     act(() => {

--- a/apps/webapp/src/script/components/PasswordGeneratorButton/PasswordGeneratorButton.tsx
+++ b/apps/webapp/src/script/components/PasswordGeneratorButton/PasswordGeneratorButton.tsx
@@ -20,17 +20,20 @@
 import {Button, ButtonVariant} from '@wireapp/react-ui-kit';
 
 import * as Icon from 'Components/icon';
-import {useApplicationContext} from 'src/script/page/rootProvider';
+import {Translate} from 'Util/localizerUtil';
 import {generateRandomPassword} from 'Util/stringUtil';
 
 interface PasswordGeneratorButtonProps {
+  translate: Translate;
   passwordLength?: number;
   onGeneratePassword: (password: string) => void;
 }
 
-export const PasswordGeneratorButton = ({passwordLength = 8, onGeneratePassword}: PasswordGeneratorButtonProps) => {
-  const {translate} = useApplicationContext();
-
+export const PasswordGeneratorButton = ({
+  translate,
+  passwordLength = 8,
+  onGeneratePassword,
+}: PasswordGeneratorButtonProps) => {
   const generatePassword = () => {
     const password = generateRandomPassword(passwordLength);
     onGeneratePassword(password);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is a fix for #21535 in which the `translate` function was introduced and provided via context. However in this modal the root context isn't accessible requiring us to pass it as prop.
This issue was discovered by the last [nightly e2e test run](https://github.com/wireapp/wire-webapp/actions/runs/27927423670/job/82632667063) for the guestroom feature.


