### PR TITLE
Fix missing root context in invite modal [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/Modals/InviteModal/InviteModal.test.tsx
+++ b/apps/webapp/src/script/components/Modals/InviteModal/InviteModal.test.tsx
@@ -21,16 +21,8 @@ import {render, screen, waitFor} from '@testing-library/react';
 
 import {User} from 'Repositories/entity/User';
 import {translateForTest} from 'Util/test/translateForTest';
-import {
-  createRootContextValueForTest,
-  createRootProviderWrapperForTest,
-} from 'src/script/page/testSupport/rootContextTestSupport';
 
 import {InviteModal} from './InviteModal';
-
-const rootProviderWrapper = createRootProviderWrapperForTest(
-  createRootContextValueForTest({translate: translateForTest}),
-);
 
 test('proper render invite modal text', async () => {
   const userName = 'janek';
@@ -38,7 +30,7 @@ test('proper render invite modal text', async () => {
 
   user.username(userName);
 
-  render(<InviteModal selfUser={user} />, {wrapper: rootProviderWrapper});
+  render(<InviteModal translate={translateForTest} selfUser={user} />);
 
   const textarea = await screen.getByTestId('invite-modal-message');
   await waitFor(() => expect((textarea as HTMLTextAreaElement).value).toBe('inviteMessage'));

--- a/apps/webapp/src/script/components/Modals/InviteModal/InviteModal.tsx
+++ b/apps/webapp/src/script/components/Modals/InviteModal/InviteModal.tsx
@@ -24,20 +24,20 @@ import {Runtime} from '@wireapp/commons';
 import * as Icon from 'Components/icon';
 import {ModalComponent} from 'Components/Modals/ModalComponent';
 import {User} from 'Repositories/entity/User';
-import {useApplicationContext} from 'src/script/page/rootProvider';
+import {Translate} from 'Util/localizerUtil';
 import {renderElement} from 'Util/renderElement';
 
 import {Config} from '../../../Config';
 
 interface InviteModalProps {
+  translate: Translate;
   readonly selfUser: User;
   onClose?: () => void;
 }
 
 const {BRAND_NAME: brandName} = Config.getConfig();
 
-const InviteModal = ({selfUser, onClose}: InviteModalProps) => {
-  const {translate} = useApplicationContext();
+const InviteModal = ({translate, selfUser, onClose}: InviteModalProps) => {
   const [isInviteMessageSelected, setIsInviteMessageSelected] = useState<boolean>(false);
   const userName = selfUser.username();
   const inviteMessage = userName

--- a/apps/webapp/src/script/page/leftSidebar/panels/startUi/startUi.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/startUi/startUi.tsx
@@ -142,7 +142,7 @@ const StartUI = ({
     });
   };
 
-  const openInviteModal = () => showInviteModal({selfUser});
+  const openInviteModal = () => showInviteModal({translate, selfUser});
 
   const before = (
     <div id="start-ui-header" className={cx('start-ui-header', {'start-ui-header-integrations': isTeam})}>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is a fix for #21535 in which the translate function was introduced and provided via context. However in this modal the root context isn't accessible requiring us to pass it as prop. This issue was discovered by the last nightly e2e test run for the guestroom feature.


