### PR TITLE
Fix missing root context in service modal [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/Modals/ServiceModal/ServiceModal.tsx
+++ b/apps/webapp/src/script/components/Modals/ServiceModal/ServiceModal.tsx
@@ -23,13 +23,14 @@ import {ModalComponent} from 'Components/Modals/ModalComponent';
 import {IntegrationRepository} from 'Repositories/integration/IntegrationRepository';
 import {ServiceEntity} from 'Repositories/integration/ServiceEntity';
 import {SidebarTabs, useSidebarStore} from 'src/script/page/leftSidebar/panels/conversations/useSidebarStore';
-import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
+import {Translate} from 'Util/localizerUtil';
 import {renderElement} from 'Util/renderElement';
 
 import {ActionsViewModel} from '../../../view_model/ActionsViewModel';
 
 interface ServiceModalProps {
+  translate: Translate;
   readonly service: ServiceEntity;
   readonly integrationRepository: IntegrationRepository;
   readonly actionsViewModel: ActionsViewModel;
@@ -37,8 +38,13 @@ interface ServiceModalProps {
   readonly avatarSize?: AVATAR_SIZE;
 }
 
-const ServiceModal = ({service, avatarSize = AVATAR_SIZE.LARGE, actionsViewModel, onClose}: ServiceModalProps) => {
-  const {translate} = useApplicationContext();
+const ServiceModal = ({
+  translate,
+  service,
+  avatarSize = AVATAR_SIZE.LARGE,
+  actionsViewModel,
+  onClose,
+}: ServiceModalProps) => {
   const {setCurrentTab: setCurrentSidebarTab} = useSidebarStore();
 
   const onOpenService = () => {

--- a/apps/webapp/src/script/page/leftSidebar/panels/startUi/startUi.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/startUi/startUi.tsx
@@ -135,6 +135,7 @@ const StartUI = ({
 
   const openService = (service: ServiceEntity) => {
     showServiceModal({
+      translate,
       actionsViewModel: mainViewModel.actions,
       integrationRepository: integrationRepository,
       service: service,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is a fix for #21535 in which the translate function was introduced and provided via context. However in this modal the root context isn't accessible requiring us to pass it as prop. This issue was discovered by the last nightly e2e test run for the guestroom feature.


