### PR TITLE
feat: De-duplicate user ids before owner lookup[WPB-26426]

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/getUsersFromNodes.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/getUsersFromNodes.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {RestNode} from 'cells-sdk-ts';
+
+import {UserRepository} from 'Repositories/user/userRepository';
+
+import {getUsersFromNodes} from './getUsersFromNodes';
+
+type FakeUserRepository = jest.Mocked<Pick<UserRepository, 'getUsersById'>>;
+
+const createRestNodeWithOwner = (ownerQualifiedId: string): RestNode => ({
+  Path: 'conversation-id@example.com/file.txt',
+  Type: 'LEAF',
+  Uuid: ownerQualifiedId,
+  UserMetadata: [
+    {
+      Namespace: 'usermeta-owner-uuid',
+      JsonValue: JSON.stringify(ownerQualifiedId),
+    },
+  ],
+});
+
+const createRestNodeWithoutOwner = (): RestNode => ({
+  Path: 'conversation-id@example.com/file-without-owner.txt',
+  Type: 'LEAF',
+  Uuid: 'file-without-owner.txt',
+});
+
+describe('getUsersFromNodes', () => {
+  it('looks up each valid owner id only once', async () => {
+    const userRepository: FakeUserRepository = {getUsersById: jest.fn().mockResolvedValue([])};
+
+    await getUsersFromNodes({
+      nodes: [
+        createRestNodeWithOwner('owner-a@example.com'),
+        createRestNodeWithOwner('owner-b@example.com'),
+        createRestNodeWithOwner('owner-a@example.com'),
+        createRestNodeWithoutOwner(),
+        createRestNodeWithOwner('owner-b@example.com'),
+      ],
+      userRepository: userRepository as unknown as UserRepository,
+    });
+
+    expect(userRepository.getUsersById).toHaveBeenCalledWith([
+      {id: 'owner-a', domain: 'example.com'},
+      {id: 'owner-b', domain: 'example.com'},
+    ]);
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/getUsersFromNodes.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/getUsersFromNodes.ts
@@ -24,6 +24,26 @@ import {UserRepository} from 'Repositories/user/userRepository';
 
 import {getUserQualifiedIdFromNode} from '../common/getUserQualifiedIdFromNode/getUserQualifiedIdFromNode';
 
+const getQualifiedIdKey = ({domain, id}: QualifiedId): string => `${domain}/${id}`;
+
+const getUniqueQualifiedIds = (userIds: QualifiedId[]): QualifiedId[] => {
+  const uniqueUserIds: QualifiedId[] = [];
+  const uniqueUserKeys = new Set<string>();
+
+  userIds.forEach(userId => {
+    const key = getQualifiedIdKey(userId);
+
+    if (uniqueUserKeys.has(key)) {
+      return;
+    }
+
+    uniqueUserKeys.add(key);
+    uniqueUserIds.push(userId);
+  });
+
+  return uniqueUserIds;
+};
+
 export const getUsersFromNodes = async ({
   nodes,
   userRepository,
@@ -35,7 +55,7 @@ export const getUsersFromNodes = async ({
     return [];
   }
 
-  return userRepository.getUsersById(
-    nodes.map(node => getUserQualifiedIdFromNode(node)).filter(Boolean) as QualifiedId[],
-  );
+  const userIds = nodes.map(node => getUserQualifiedIdFromNode(node)).filter(Boolean) as QualifiedId[];
+
+  return userRepository.getUsersById(getUniqueQualifiedIds(userIds));
 };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/getUsersFromNodes.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/getUsersFromNodes.ts
@@ -26,22 +26,20 @@ import {getUserQualifiedIdFromNode} from '../common/getUserQualifiedIdFromNode/g
 
 const getQualifiedIdKey = ({domain, id}: QualifiedId): string => `${domain}/${id}`;
 
+const isQualifiedId = (userId: QualifiedId | null): userId is QualifiedId => userId !== null;
+
 const getUniqueQualifiedIds = (userIds: QualifiedId[]): QualifiedId[] => {
-  const uniqueUserIds: QualifiedId[] = [];
-  const uniqueUserKeys = new Set<string>();
+  const uniqueUserIds = new Map<string, QualifiedId>();
 
   userIds.forEach(userId => {
     const key = getQualifiedIdKey(userId);
 
-    if (uniqueUserKeys.has(key)) {
-      return;
+    if (!uniqueUserIds.has(key)) {
+      uniqueUserIds.set(key, userId);
     }
-
-    uniqueUserKeys.add(key);
-    uniqueUserIds.push(userId);
   });
 
-  return uniqueUserIds;
+  return Array.from(uniqueUserIds.values());
 };
 
 export const getUsersFromNodes = async ({
@@ -55,7 +53,7 @@ export const getUsersFromNodes = async ({
     return [];
   }
 
-  const userIds = nodes.map(node => getUserQualifiedIdFromNode(node)).filter(Boolean) as QualifiedId[];
+  const userIds = nodes.map(node => getUserQualifiedIdFromNode(node)).filter(isQualifiedId);
 
   return userRepository.getUsersById(getUniqueQualifiedIds(userIds));
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26426" title="WPB-26426" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26426</a>  De-duplicate user ids before owner lookup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### ##Summary
getUsersFromNodes passes every node owner id into userRepository.getUsersById, including duplicates.

This is avoidable work and may add delay after the Cells API response, because UI loading remains active until user lookup finishes.

Proposed change: build a unique list of valid qualified user ids before calling getUsersById.


