### PR TITLE
Fix stale unread conversation preview [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/conversationListCell/components/cellDescription/cellDescription.test.tsx
+++ b/apps/webapp/src/script/components/conversationListCell/components/cellDescription/cellDescription.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
+import {act, render, screen} from '@testing-library/react';
+import type {RenderResult} from '@testing-library/react';
+import type {ReactElement} from 'react';
+
+import {NOTIFICATION_STATE} from 'Repositories/conversation/NotificationSetting';
+import {Conversation} from 'Repositories/entity/Conversation';
+import {ContentMessage} from 'Repositories/entity/message/ContentMessage';
+import {Text} from 'Repositories/entity/message/Text';
+import {User} from 'Repositories/entity/User';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {translateForTest} from 'Util/test/translateForTest';
+import {createUuid} from 'Util/uuid';
+
+import {CellDescription} from './cellDescription';
+
+const rootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate: translateForTest}),
+);
+
+type ConversationWithUnreadTextMessage = {
+  conversation: Conversation;
+  unreadMessage: ContentMessage;
+};
+
+function createConversationWithUnreadTextMessage(): ConversationWithUnreadTextMessage {
+  const conversation = new Conversation(createUuid(), '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
+  const selfUser = new User(createUuid(), '', translateForTest);
+  selfUser.isMe = true;
+  conversation.selfUser(selfUser);
+  conversation.mutedState(NOTIFICATION_STATE.EVERYTHING);
+
+  const sender = new User(createUuid(), '', translateForTest);
+  const unreadMessage = new ContentMessage(createUuid(), translateForTest);
+  unreadMessage.user(sender);
+  unreadMessage.timestamp(1);
+  unreadMessage.assets([new Text(createUuid(), 'Unread preview')]);
+
+  conversation.setTimestamp(0, Conversation.TIMESTAMP_TYPE.LAST_READ, true);
+  conversation.messages_unordered.push(unreadMessage);
+
+  return {conversation, unreadMessage};
+}
+
+function renderCellDescription(conversation: Conversation): RenderResult {
+  return render(
+    <CellDescription
+      conversation={conversation}
+      mutedState={conversation.mutedState()}
+      isActive={false}
+      isRequest={conversation.isRequest()}
+      unreadState={conversation.unreadState()}
+    />,
+    {wrapper: rootProviderWrapper},
+  );
+}
+
+function createCellDescriptionElement(conversation: Conversation): ReactElement {
+  return (
+    <CellDescription
+      conversation={conversation}
+      mutedState={conversation.mutedState()}
+      isActive={false}
+      isRequest={conversation.isRequest()}
+      unreadState={conversation.unreadState()}
+    />
+  );
+}
+
+describe('CellDescription', () => {
+  it('removes the unread second-line preview after the conversation becomes read', () => {
+    const {conversation, unreadMessage} = createConversationWithUnreadTextMessage();
+    const {rerender} = renderCellDescription(conversation);
+
+    expect(screen.getByText(/Unread preview/)).toBeDefined();
+
+    act(() => {
+      conversation.setTimestamp(unreadMessage.timestamp(), Conversation.TIMESTAMP_TYPE.LAST_READ);
+    });
+
+    rerender(createCellDescriptionElement(conversation));
+
+    expect(screen.queryByText(/Unread preview/)).toBeNull();
+  });
+});

--- a/apps/webapp/src/script/components/conversationListCell/components/cellDescription/cellDescription.tsx
+++ b/apps/webapp/src/script/components/conversationListCell/components/cellDescription/cellDescription.tsx
@@ -17,8 +17,6 @@
  *
  */
 
-import {useMemo} from 'react';
-
 import cx from 'classnames';
 
 import * as Icon from 'Components/icon';
@@ -38,13 +36,10 @@ interface Props {
   unreadState: UnreadState;
 }
 
-export const CellDescription = ({conversation, mutedState, isActive, isRequest, unreadState}: Props) => {
+export const CellDescription = ({conversation, isActive}: Props) => {
   const {translate} = useApplicationContext();
-  void isRequest;
-  void mutedState;
-  void unreadState;
 
-  const cellState = useMemo(() => generateCellState(conversation, translate), [conversation, translate]);
+  const cellState = generateCellState(conversation, translate);
 
   const storageKey = generateConversationInputStorageKey(conversation);
   // Hardcoded __amplify__ because of StorageUtil saving as __amplify__<storage_key>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is a fix for #21535 in which we removed the fragile memoization around CellDescription state generation so mutable Knockout conversation state is recalculated whenever React rerenders the cell.


