### PR TITLE
Improve conversation message search responsiveness [WPB-26110]

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -51,6 +51,7 @@
     "copy-webpack-plugin": "13.0.1",
     "core-js": "3.49.0",
     "date-fns": "4.4.0",
+    "debounce-fn": "4.0.0",
     "dexie-batch": "0.4.3",
     "dexie-encrypted": "2.0.0",
     "dotenv-extended": "2.9.0",

--- a/apps/webapp/src/script/page/mainContent/panels/collection/collection.test.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/collection/collection.test.tsx
@@ -40,6 +40,7 @@ import {translateForTest} from 'Util/test/translateForTest';
 import {createUuid} from 'Util/uuid';
 
 import {Collection} from './collection';
+import {FullSearch} from './fullSearch';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 
 jest.mock('./collectionDetails', () => ({
@@ -70,12 +71,19 @@ const createFileMessage = () => {
 
 const createLinkMessage = () => {
   const message = new ContentMessage(createUuid(), translateForTest);
-  const link = new Text(createUuid());
+  const link = new Text(createUuid(), 'term');
   link.previews.push(new LinkPreview({}));
   message.assets.push(link);
   message.category = MessageCategory.LINK_PREVIEW;
   return message;
 };
+
+function createTextMessage(text: string) {
+  const message = new ContentMessage(createUuid(), translateForTest);
+  message.assets.push(new Text(createUuid(), text));
+  message.category = MessageCategory.TEXT;
+  return message;
+}
 
 const createAudioMessage = () => {
   const message = new ContentMessage(createUuid(), translateForTest);
@@ -187,25 +195,19 @@ describe('Collection', () => {
     await act(async () => {
       jest.advanceTimersByTime(1);
     });
-    expect(mockConversationRepository.searchInConversation).toHaveBeenCalled();
+    expect(mockConversationRepository.searchInConversation).toHaveBeenCalledWith(
+      conversation,
+      'term',
+      expect.any(AbortSignal),
+    );
 
     expect(queryByText('CollectionTime')).toBeNull();
   });
 
-  it('runs only the latest pending search while another search is in progress', async () => {
+  it('hides collection content immediately when the parent search term changes', async () => {
     jest.useFakeTimers();
-    let resolveFirstSearch: (value: {messageEntities: ContentMessage[]; query: string}) => void = () => {};
-    mockConversationRepository.searchInConversation.mockImplementation((_conversation: Conversation, query: string) => {
-      if (query === 'term') {
-        return new Promise(resolve => {
-          resolveFirstSearch = resolve;
-        });
-      }
 
-      return Promise.resolve({messageEntities: [], query});
-    });
-
-    const {getAllByText, getByTestId} = render(
+    const {getAllByText, getByTestId, queryByText} = render(
       withTheme(
         <Collection
           assetRepository={mockAssetRepository}
@@ -223,21 +225,121 @@ describe('Collection', () => {
 
     await act(async () => {
       fireEvent.change(input, {target: {value: 'term'}});
+    });
+
+    expect(queryByText('collectionSectionImages')).toBeNull();
+    expect(mockConversationRepository.searchInConversation).not.toHaveBeenCalled();
+  });
+});
+
+describe('FullSearch', () => {
+  const rootProviderWrapper = createRootProviderWrapperForTest(
+    createRootContextValueForTest({translate: translateForTest}),
+  );
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('calls change immediately with the normalized query and debounces the search provider', async () => {
+    jest.useFakeTimers();
+    const change = jest.fn();
+    const searchProvider = jest.fn().mockResolvedValue({
+      messageEntities: [createTextMessage('term result')],
+      query: 'term',
+    });
+
+    const {getByTestId} = render(withTheme(<FullSearch change={change} searchProvider={searchProvider} />), {
+      wrapper: rootProviderWrapper,
+    });
+
+    await act(async () => {
+      fireEvent.change(getByTestId('full-search-header-input'), {target: {value: ' term '}});
+      jest.advanceTimersByTime(499);
+    });
+
+    expect(change).toHaveBeenCalledWith('term');
+    expect(searchProvider).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1);
+    });
+
+    await waitFor(() => expect(searchProvider).toHaveBeenCalledWith('term', expect.any(AbortSignal)));
+  });
+
+  it('clears no-results state immediately when the input is cleared', async () => {
+    jest.useFakeTimers();
+    const searchProvider = jest.fn().mockResolvedValue({messageEntities: [], query: 'term'});
+
+    const {getByTestId, getByText, queryByText} = render(withTheme(<FullSearch searchProvider={searchProvider} />), {
+      wrapper: rootProviderWrapper,
+    });
+
+    await act(async () => {
+      fireEvent.change(getByTestId('full-search-header-input'), {target: {value: 'term'}});
       jest.advanceTimersByTime(500);
     });
-    expect(mockConversationRepository.searchInConversation).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => getByText('fullsearchNoResults'));
+
+    await act(async () => {
+      fireEvent.change(getByTestId('full-search-header-input'), {target: {value: ''}});
+    });
+
+    expect(queryByText('fullsearchNoResults')).toBeNull();
+  });
+
+  it('ignores slow stale search results so the latest query wins', async () => {
+    jest.useFakeTimers();
+    let resolveFirstSearch: (value: {messageEntities: ContentMessage[]; query: string}) => void = () => {};
+    let resolveSecondSearch: (value: {messageEntities: ContentMessage[]; query: string}) => void = () => {};
+    const searchProvider = jest.fn((query: string) => {
+      if (query === 'term') {
+        return new Promise<{messageEntities: ContentMessage[]; query: string}>(resolve => {
+          resolveFirstSearch = resolve;
+        });
+      }
+
+      return new Promise<{messageEntities: ContentMessage[]; query: string}>(resolve => {
+        resolveSecondSearch = resolve;
+      });
+    });
+
+    const {container: renderedContainer, getByTestId} = render(
+      withTheme(<FullSearch searchProvider={searchProvider} />),
+      {wrapper: rootProviderWrapper},
+    );
+    const input = getByTestId('full-search-header-input');
+
+    await act(async () => {
+      fireEvent.change(input, {target: {value: 'term'}});
+      jest.advanceTimersByTime(500);
+    });
+    await waitFor(() => expect(searchProvider).toHaveBeenCalledTimes(1));
 
     await act(async () => {
       fireEvent.change(input, {target: {value: 'terms'}});
       jest.advanceTimersByTime(500);
     });
-    expect(mockConversationRepository.searchInConversation).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(searchProvider).toHaveBeenCalledTimes(2));
+    expect(searchProvider).toHaveBeenLastCalledWith('terms', expect.any(AbortSignal));
 
     await act(async () => {
-      resolveFirstSearch({messageEntities: [], query: 'term'});
+      resolveSecondSearch({messageEntities: [createTextMessage('latest terms result')], query: 'terms'});
+    });
+    await waitFor(() => {
+      expect(renderedContainer.querySelector('[data-uie-name="full-search-item-text"]')?.textContent).toBe(
+        'latest terms result',
+      );
     });
 
-    await waitFor(() => expect(mockConversationRepository.searchInConversation).toHaveBeenCalledTimes(2));
-    expect(mockConversationRepository.searchInConversation).toHaveBeenLastCalledWith(conversation, 'terms');
+    await act(async () => {
+      resolveFirstSearch({messageEntities: [createTextMessage('stale term result')], query: 'term'});
+    });
+
+    expect(renderedContainer.querySelector('[data-uie-name="full-search-item-text"]')?.textContent).toBe(
+      'latest terms result',
+    );
   });
 });

--- a/apps/webapp/src/script/page/mainContent/panels/collection/collection.test.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/collection/collection.test.tsx
@@ -100,6 +100,19 @@ describe('Collection', () => {
   const mockMessageRepository = {} as MessageRepository;
   const mockSelfUser = new User(createUuid(), '', translateForTest);
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConversationRepository.getEventsForCategory.mockResolvedValue(messages);
+    mockConversationRepository.searchInConversation.mockResolvedValue({
+      messageEntities: [createLinkMessage()],
+      query: 'term',
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('displays all image assets', async () => {
     const {getAllByText, getByText, queryByText} = render(
       withTheme(
@@ -167,10 +180,64 @@ describe('Collection', () => {
     await act(async () => {
       const input = getByTestId('full-search-header-input');
       fireEvent.change(input, {target: {value: 'term'}});
-      jest.advanceTimersByTime(500);
+      jest.advanceTimersByTime(499);
     });
-    await waitFor(() => expect(mockConversationRepository.searchInConversation).toHaveBeenCalled());
+    expect(mockConversationRepository.searchInConversation).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(mockConversationRepository.searchInConversation).toHaveBeenCalled();
 
     expect(queryByText('CollectionTime')).toBeNull();
+  });
+
+  it('runs only the latest pending search while another search is in progress', async () => {
+    jest.useFakeTimers();
+    let resolveFirstSearch: (value: {messageEntities: ContentMessage[]; query: string}) => void = () => {};
+    mockConversationRepository.searchInConversation.mockImplementation((_conversation: Conversation, query: string) => {
+      if (query === 'term') {
+        return new Promise(resolve => {
+          resolveFirstSearch = resolve;
+        });
+      }
+
+      return Promise.resolve({messageEntities: [], query});
+    });
+
+    const {getAllByText, getByTestId} = render(
+      withTheme(
+        <Collection
+          assetRepository={mockAssetRepository}
+          messageRepository={mockMessageRepository}
+          conversation={conversation}
+          conversationRepository={mockConversationRepository as any}
+          selfUser={mockSelfUser}
+        />,
+      ),
+      {wrapper: rootProviderWrapper},
+    );
+
+    await waitFor(() => getAllByText('CollectionItem'));
+    const input = getByTestId('full-search-header-input');
+
+    await act(async () => {
+      fireEvent.change(input, {target: {value: 'term'}});
+      jest.advanceTimersByTime(500);
+    });
+    expect(mockConversationRepository.searchInConversation).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      fireEvent.change(input, {target: {value: 'terms'}});
+      jest.advanceTimersByTime(500);
+    });
+    expect(mockConversationRepository.searchInConversation).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirstSearch({messageEntities: [], query: 'term'});
+    });
+
+    await waitFor(() => expect(mockConversationRepository.searchInConversation).toHaveBeenCalledTimes(2));
+    expect(mockConversationRepository.searchInConversation).toHaveBeenLastCalledWith(conversation, 'terms');
   });
 });

--- a/apps/webapp/src/script/page/mainContent/panels/collection/collection.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/collection/collection.tsx
@@ -46,13 +46,13 @@ import {Category, isOfCategory} from './utils';
 
 import {MessageCategory} from '../../../../message/messageCategory';
 
-interface CollectionDetailsProps {
+type CollectionProps = {
   conversation: Conversation;
   conversationRepository: ConversationRepository;
   assetRepository: AssetRepository;
   messageRepository: MessageRepository;
   selfUser: User;
-}
+};
 
 type Categories = Record<Category, ContentMessage[]>;
 
@@ -83,13 +83,8 @@ function splitIntoCategories(messages: ContentMessage[]): Categories {
   );
 }
 
-const Collection = ({
-  conversation,
-  conversationRepository,
-  assetRepository,
-  messageRepository,
-  selfUser,
-}: CollectionDetailsProps) => {
+function Collection(props: CollectionProps) {
+  const {conversation, conversationRepository, assetRepository, messageRepository, selfUser} = props;
   const {fireAndForgetInvoker, translate} = useApplicationContext();
   const [searchTerm, setSearchTerm] = useState('');
   const {display_name, cellsState} = useKoSubscribableChildren(conversation, ['display_name', 'cellsState']);
@@ -222,9 +217,13 @@ const Collection = ({
       <div className="content-list-wrapper">
         <div className="content-list collection-list">
           <FullSearch
-            searchProvider={query => conversationRepository.searchInConversation(conversation, query)}
+            searchProvider={(query, abortSignal) => {
+              return conversationRepository.searchInConversation(conversation, query, abortSignal);
+            }}
             change={setSearchTerm}
-            click={message => amplify.publish(WebAppEvents.CONVERSATION.SHOW, conversation, {exposeMessage: message})}
+            click={message => {
+              amplify.publish(WebAppEvents.CONVERSATION.SHOW, conversation, {exposeMessage: message});
+            }}
           />
           {isCellsEnabled && (
             <SecondaryButton onClick={createNavigate(filesUrl)} fullWidth={true} uieName="shared-drive-id">
@@ -242,6 +241,6 @@ const Collection = ({
       </div>
     </div>
   );
-};
+}
 
 export {Collection};

--- a/apps/webapp/src/script/page/mainContent/panels/collection/fullSearch.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/collection/fullSearch.tsx
@@ -38,7 +38,7 @@ const MAX_VISIBLE_MESSAGES = 30;
 const PRE_MARKED_OFFSET = 20;
 const MAX_TEXT_LENGTH = 60;
 const MAX_OFFSET_INDEX = 30;
-const DEBOUNCE_TIME = 100;
+const DEBOUNCE_TIME = 500;
 const MINIMUM_SEARCH_LENGTH = 2;
 
 export const fullSearchInputSubmitComboStyles: CSSObject = {
@@ -71,30 +71,60 @@ const FullSearch = ({searchProvider, click = noop, change = noop}: FullSearchPro
   const {translate} = useApplicationContext();
   const [searchValue, setSearchValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
+  const latestSearchValueRef = useRef(searchValue);
+  const isSearchingRef = useRef(false);
+  const pendingSearchValueRef = useRef<string | undefined>();
   const [messages, setMessages] = useState<ContentMessage[]>([]);
   const [messageCount, setMessageCount] = useState(0);
   const [hasNoResults, setHasNoResults] = useState(false);
   const [element, setElement] = useEffectRef<HTMLDivElement>();
 
-  const debouncedSearch = useDebouncedCallback(async () => {
-    const trimmedInput = searchValue.trim();
-    change(trimmedInput);
-    if (trimmedInput.length < MINIMUM_SEARCH_LENGTH) {
-      setMessages([]);
-      setMessageCount(0);
-      setHasNoResults(false);
+  const search = async (value: string) => {
+    if (isSearchingRef.current) {
+      pendingSearchValueRef.current = value;
       return;
     }
-    const {messageEntities, query} = await searchProvider(trimmedInput);
-    if (query === trimmedInput) {
-      setHasNoResults(messageEntities.length === 0);
-      setMessages(messageEntities as ContentMessage[]);
-      setMessageCount(MAX_VISIBLE_MESSAGES);
+
+    try {
+      isSearchingRef.current = true;
+      let nextSearchValue = value;
+
+      while (true) {
+        const trimmedInput = nextSearchValue.trim();
+        pendingSearchValueRef.current = undefined;
+        change(trimmedInput);
+
+        if (trimmedInput.length < MINIMUM_SEARCH_LENGTH) {
+          if (latestSearchValueRef.current.trim() === trimmedInput) {
+            setMessages([]);
+            setMessageCount(0);
+            setHasNoResults(false);
+          }
+        } else {
+          const {messageEntities, query} = await searchProvider(trimmedInput);
+          if (query === trimmedInput && latestSearchValueRef.current.trim() === trimmedInput) {
+            setHasNoResults(messageEntities.length === 0);
+            setMessages(messageEntities as ContentMessage[]);
+            setMessageCount(MAX_VISIBLE_MESSAGES);
+          }
+        }
+
+        const pendingSearchValue = pendingSearchValueRef.current as string | undefined;
+        if (pendingSearchValue === undefined || pendingSearchValue.trim() === trimmedInput) {
+          break;
+        }
+        nextSearchValue = pendingSearchValue;
+      }
+    } finally {
+      isSearchingRef.current = false;
     }
-  }, DEBOUNCE_TIME);
+  };
+
+  const debouncedSearch = useDebouncedCallback(search, DEBOUNCE_TIME);
 
   useEffect(() => {
-    void debouncedSearch();
+    latestSearchValueRef.current = searchValue;
+    debouncedSearch(searchValue);
   }, [debouncedSearch, searchValue]);
 
   useEffect(() => {

--- a/apps/webapp/src/script/page/mainContent/panels/collection/fullSearch.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/collection/fullSearch.tsx
@@ -17,14 +17,12 @@
  *
  */
 
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef} from 'react';
 
 import {CSSObject} from '@emotion/react';
-import {useDebouncedCallback} from 'use-debounce';
 
 import {CloseIcon, Input, InputSubmitCombo, SearchIcon} from '@wireapp/react-ui-kit';
 
-import {ContentMessage} from 'Repositories/entity/message/contentMessage';
 import type {Message} from 'Repositories/entity/message/message';
 import {getSearchRegex} from 'Repositories/search/fullTextSearch';
 import {useApplicationContext} from 'src/script/page/rootProvider';
@@ -33,6 +31,8 @@ import {useEffectRef} from 'Util/useEffectRef';
 import {noop} from 'Util/util';
 
 import {FullSearchItem} from './fullSearch/fullSearchItem';
+import type {FullSearchProvider} from './fullSearch/useFullSearch';
+import {useFullSearch} from './fullSearch/useFullSearch';
 
 const MAX_VISIBLE_MESSAGES = 30;
 const PRE_MARKED_OFFSET = 20;
@@ -61,85 +61,40 @@ export const fullSearchInputWrapperStyles: CSSObject = {
   },
 };
 
-interface FullSearchProps {
+type FullSearchProps = {
   change?: (query: string) => void;
   click?: (messageEntity: Message) => void;
-  searchProvider: (query: string) => Promise<{messageEntities: Message[]; query: string}>;
-}
+  searchProvider: FullSearchProvider;
+};
 
-const FullSearch = ({searchProvider, click = noop, change = noop}: FullSearchProps) => {
+function FullSearch(props: FullSearchProps) {
+  const {searchProvider, click = noop, change = noop} = props;
   const {translate} = useApplicationContext();
-  const [searchValue, setSearchValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
-  const latestSearchValueRef = useRef(searchValue);
-  const isSearchingRef = useRef(false);
-  const pendingSearchValueRef = useRef<string | undefined>();
-  const [messages, setMessages] = useState<ContentMessage[]>([]);
-  const [messageCount, setMessageCount] = useState(0);
-  const [hasNoResults, setHasNoResults] = useState(false);
   const [element, setElement] = useEffectRef<HTMLDivElement>();
-
-  const search = async (value: string) => {
-    if (isSearchingRef.current) {
-      pendingSearchValueRef.current = value;
-      return;
-    }
-
-    try {
-      isSearchingRef.current = true;
-      let nextSearchValue = value;
-
-      while (true) {
-        const trimmedInput = nextSearchValue.trim();
-        pendingSearchValueRef.current = undefined;
-        change(trimmedInput);
-
-        if (trimmedInput.length < MINIMUM_SEARCH_LENGTH) {
-          if (latestSearchValueRef.current.trim() === trimmedInput) {
-            setMessages([]);
-            setMessageCount(0);
-            setHasNoResults(false);
-          }
-        } else {
-          const {messageEntities, query} = await searchProvider(trimmedInput);
-          if (query === trimmedInput && latestSearchValueRef.current.trim() === trimmedInput) {
-            setHasNoResults(messageEntities.length === 0);
-            setMessages(messageEntities as ContentMessage[]);
-            setMessageCount(MAX_VISIBLE_MESSAGES);
-          }
-        }
-
-        const pendingSearchValue = pendingSearchValueRef.current as string | undefined;
-        if (pendingSearchValue === undefined || pendingSearchValue.trim() === trimmedInput) {
-          break;
-        }
-        nextSearchValue = pendingSearchValue;
-      }
-    } finally {
-      isSearchingRef.current = false;
-    }
-  };
-
-  const debouncedSearch = useDebouncedCallback(search, DEBOUNCE_TIME);
-
-  useEffect(() => {
-    latestSearchValueRef.current = searchValue;
-    debouncedSearch(searchValue);
-  }, [debouncedSearch, searchValue]);
+  const {hasNoResults, messageCount, messages, searchValue, setMessageCount, updateSearchValue} = useFullSearch({
+    change,
+    debounceMilliseconds: DEBOUNCE_TIME,
+    initialMessageCount: MAX_VISIBLE_MESSAGES,
+    minimumSearchLength: MINIMUM_SEARCH_LENGTH,
+    searchProvider,
+  });
 
   useEffect(() => {
     const parent = element?.closest('.collection-list') as HTMLDivElement;
     const onScroll = () => {
       const showAdditionalMessages = isScrolledBottom(parent) && messages.length;
       if (showAdditionalMessages) {
-        setMessageCount(currentCount => currentCount + MAX_VISIBLE_MESSAGES);
+        setMessageCount(currentCount => {
+          return currentCount + MAX_VISIBLE_MESSAGES;
+        });
       }
     };
     parent?.addEventListener('scroll', onScroll);
     return () => {
       parent?.removeEventListener('scroll', onScroll);
     };
-  }, [element, messages]);
+  }, [element, messages, setMessageCount]);
 
   useEffect(() => {
     if (inputRef.current) {
@@ -151,6 +106,7 @@ const FullSearch = ({searchProvider, click = noop, change = noop}: FullSearchPro
     const regex = getSearchRegex(searchValue);
 
     return (text: string) => {
+      regex.lastIndex = 0;
       const matches = [...text.matchAll(regex)];
       const firstIndex = matches[0]?.index;
       let firstPart = text.substring(0, firstIndex ?? text.length);
@@ -186,7 +142,9 @@ const FullSearch = ({searchProvider, click = noop, change = noop}: FullSearchPro
             ref={inputRef}
             aria-label={translate('fullsearchPlaceholder')}
             placeholder={translate('fullsearchPlaceholder')}
-            onChange={event => setSearchValue(event.currentTarget.value)}
+            onChange={event => {
+              updateSearchValue(event.currentTarget.value);
+            }}
             data-uie-name="full-search-header-input"
           />
 
@@ -195,7 +153,9 @@ const FullSearch = ({searchProvider, click = noop, change = noop}: FullSearchPro
               css={{cursor: 'pointer'}}
               data-uie-name="full-search-dismiss"
               aria-label={translate('fullsearchCancelCloseBtn')}
-              onClick={() => setSearchValue('')}
+              onClick={() => {
+                updateSearchValue('');
+              }}
             />
           )}
         </InputSubmitCombo>
@@ -219,6 +179,6 @@ const FullSearch = ({searchProvider, click = noop, change = noop}: FullSearchPro
       </div>
     </div>
   );
-};
+}
 
 export {FullSearch};

--- a/apps/webapp/src/script/page/mainContent/panels/collection/fullSearch/useFullSearch.ts
+++ b/apps/webapp/src/script/page/mainContent/panels/collection/fullSearch/useFullSearch.ts
@@ -1,0 +1,165 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+
+import is from '@sindresorhus/is';
+import debounceFn from 'debounce-fn';
+
+import type {ContentMessage} from 'Repositories/entity/message/contentMessage';
+import type {Message} from 'Repositories/entity/message/message';
+
+type SearchProviderResult = {messageEntities: Message[]; query: string};
+
+export type FullSearchProvider = (query: string, abortSignal?: AbortSignal) => Promise<SearchProviderResult>;
+
+type UseFullSearchOptions = {
+  change: (query: string) => void;
+  debounceMilliseconds: number;
+  initialMessageCount: number;
+  minimumSearchLength: number;
+  searchProvider: FullSearchProvider;
+};
+
+type UseFullSearchResult = {
+  hasNoResults: boolean;
+  messageCount: number;
+  messages: ContentMessage[];
+  searchValue: string;
+  setMessageCount: Dispatch<SetStateAction<number>>;
+  updateSearchValue: (value: string) => void;
+};
+
+function isAbortError(error: unknown) {
+  if (!is.error(error)) {
+    return false;
+  }
+
+  return error.name === 'AbortError';
+}
+
+export function useFullSearch(options: UseFullSearchOptions): UseFullSearchResult {
+  const {change, debounceMilliseconds, initialMessageCount, minimumSearchLength, searchProvider} = options;
+  const [searchValue, setSearchValue] = useState('');
+  const [messages, setMessages] = useState<ContentMessage[]>([]);
+  const [messageCount, setMessageCount] = useState(0);
+  const [hasNoResults, setHasNoResults] = useState(false);
+
+  const latestSearchQueryRef = useRef('');
+  const latestSearchIdRef = useRef(0);
+  const abortControllerRef = useRef<AbortController | undefined>();
+  const searchProviderRef = useRef(searchProvider);
+
+  useEffect(() => {
+    searchProviderRef.current = searchProvider;
+  }, [searchProvider]);
+
+  const clearSearchResults = useCallback(() => {
+    setMessages([]);
+    setMessageCount(0);
+    setHasNoResults(false);
+  }, []);
+
+  const abortCurrentSearch = useCallback(() => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = undefined;
+  }, []);
+
+  const runSearch = useCallback(
+    async (query: string) => {
+      abortCurrentSearch();
+
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+      const searchId = latestSearchIdRef.current + 1;
+      latestSearchIdRef.current = searchId;
+
+      try {
+        const {messageEntities, query: resolvedQuery} = await searchProviderRef.current(query, abortController.signal);
+        const isLatestSearch =
+          !abortController.signal.aborted &&
+          latestSearchIdRef.current === searchId &&
+          latestSearchQueryRef.current === resolvedQuery;
+
+        if (!isLatestSearch) {
+          return;
+        }
+
+        setHasNoResults(messageEntities.length === 0);
+        setMessages(messageEntities as ContentMessage[]);
+        setMessageCount(initialMessageCount);
+      } catch (error) {
+        if (isAbortError(error)) {
+          return;
+        }
+        throw error;
+      } finally {
+        if (abortControllerRef.current === abortController) {
+          abortControllerRef.current = undefined;
+        }
+      }
+    },
+    [abortCurrentSearch, initialMessageCount],
+  );
+
+  const debouncedRunSearch = useMemo(() => {
+    return debounceFn(
+      (query: string) => {
+        void runSearch(query);
+      },
+      {wait: debounceMilliseconds},
+    );
+  }, [debounceMilliseconds, runSearch]);
+
+  useEffect(() => {
+    return () => {
+      debouncedRunSearch.cancel();
+      abortCurrentSearch();
+    };
+  }, [abortCurrentSearch, debouncedRunSearch]);
+
+  const updateSearchValue = useCallback(
+    (value: string) => {
+      const normalizedQuery = value.trim();
+      setSearchValue(value);
+      latestSearchQueryRef.current = normalizedQuery;
+      change(normalizedQuery);
+
+      if (normalizedQuery.length < minimumSearchLength) {
+        latestSearchIdRef.current += 1;
+        debouncedRunSearch.cancel();
+        abortCurrentSearch();
+        clearSearchResults();
+        return;
+      }
+
+      debouncedRunSearch(normalizedQuery);
+    },
+    [abortCurrentSearch, change, clearSearchResults, debouncedRunSearch, minimumSearchLength],
+  );
+
+  return {
+    hasNoResults,
+    messageCount,
+    messages,
+    searchValue,
+    setMessageCount,
+    updateSearchValue,
+  };
+}

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -1099,12 +1099,13 @@ export class ConversationRepository {
   public async searchInConversation(
     conversationEntity: Conversation,
     query: string,
+    abortSignal?: AbortSignal,
   ): Promise<{messageEntities: Message[]; query: string}> {
     if (!conversationEntity || !query.length) {
       return {messageEntities: [], query};
     }
 
-    const events = await this.conversationService.searchInConversation(conversationEntity.id, query);
+    const events = await this.conversationService.searchInConversation(conversationEntity.id, query, abortSignal);
     const mappedMessages = this.event_mapper.mapJsonEvents(events, conversationEntity);
     const messageEntities = await this.updateMessagesUserEntities(mappedMessages);
     return {messageEntities, query};

--- a/apps/webapp/src/script/repositories/conversation/ConversationService.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationService.test.ts
@@ -99,6 +99,50 @@ describe('ConversationService', () => {
       expect(await conversationService.searchInConversation('conversation-id', 'caption')).toEqual([compositeEvent]);
       expect(await conversationService.searchInConversation('conversation-id', 'unrelated')).toEqual([]);
     });
+
+    it('reuses the search regex without skipping consecutive matches', async () => {
+      const matchingEvents: EventRecord[] = [
+        {
+          primary_key: 'primary-key-1',
+          category: MessageCategory.TEXT,
+          conversation: 'conversation-id',
+          from: 'user-id',
+          time: new Date(0).toISOString(),
+          id: 'event-id-1',
+          type: ClientEvent.CONVERSATION.MESSAGE_ADD,
+          data: {content: 'term'},
+          ephemeral_expires: false,
+        },
+        {
+          primary_key: 'primary-key-2',
+          category: MessageCategory.TEXT,
+          conversation: 'conversation-id',
+          from: 'user-id',
+          time: new Date(1).toISOString(),
+          id: 'event-id-2',
+          type: ClientEvent.CONVERSATION.MESSAGE_ADD,
+          data: {content: 'term'},
+          ephemeral_expires: false,
+        },
+      ];
+
+      const loadEventsWithCategory = jest
+        .fn<
+          ReturnType<EventServiceLike['loadEventsWithCategory']>,
+          Parameters<EventServiceLike['loadEventsWithCategory']>
+        >()
+        .mockResolvedValue(matchingEvents);
+      const eventService: EventServiceLike = {loadEventsWithCategory};
+
+      const conversationService = new ConversationService(
+        eventService,
+        {} as unknown as StorageService,
+        {} as unknown as APIClient,
+        {} as unknown as Core,
+      );
+
+      expect(await conversationService.searchInConversation('conversation-id', 'term')).toEqual(matchingEvents);
+    });
   });
 
   describe('getSafeConversationById', () => {

--- a/apps/webapp/src/script/repositories/conversation/ConversationService.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationService.test.ts
@@ -34,6 +34,25 @@ type EventServiceLike = Pick<EventService, 'loadEventsWithCategory'>;
 
 describe('ConversationService', () => {
   describe('searchInConversation', () => {
+    function createMessageEvent(id: string, content: string, overrides: Partial<EventRecord> = {}): EventRecord {
+      return {
+        primary_key: `primary-key-${id}`,
+        category: MessageCategory.TEXT,
+        conversation: 'conversation-id',
+        from: 'user-id',
+        time: new Date(0).toISOString(),
+        id,
+        type: ClientEvent.CONVERSATION.MESSAGE_ADD,
+        data: {content},
+        ephemeral_expires: false,
+        ...overrides,
+      };
+    }
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('matches multipart message text content', async () => {
       const multipartEvent: EventRecord = {
         primary_key: 'primary-key',
@@ -142,6 +161,78 @@ describe('ConversationService', () => {
       );
 
       expect(await conversationService.searchInConversation('conversation-id', 'term')).toEqual(matchingEvents);
+    });
+
+    it('skips expired ephemeral events', async () => {
+      const expiredEvent = createMessageEvent('expired-event-id', 'term', {ephemeral_expires: true});
+      const matchingEvent = createMessageEvent('matching-event-id', 'term');
+
+      const loadEventsWithCategory = jest
+        .fn<
+          ReturnType<EventServiceLike['loadEventsWithCategory']>,
+          Parameters<EventServiceLike['loadEventsWithCategory']>
+        >()
+        .mockResolvedValue([expiredEvent, matchingEvent]);
+      const eventService: EventServiceLike = {loadEventsWithCategory};
+
+      const conversationService = new ConversationService(
+        eventService,
+        {} as unknown as StorageService,
+        {} as unknown as APIClient,
+        {} as unknown as Core,
+      );
+
+      expect(await conversationService.searchInConversation('conversation-id', 'term')).toEqual([matchingEvent]);
+    });
+
+    it('returns no results for whitespace-only queries without loading events', async () => {
+      const loadEventsWithCategory = jest
+        .fn<
+          ReturnType<EventServiceLike['loadEventsWithCategory']>,
+          Parameters<EventServiceLike['loadEventsWithCategory']>
+        >()
+        .mockResolvedValue([createMessageEvent('matching-event-id', 'term')]);
+      const eventService: EventServiceLike = {loadEventsWithCategory};
+
+      const conversationService = new ConversationService(
+        eventService,
+        {} as unknown as StorageService,
+        {} as unknown as APIClient,
+        {} as unknown as Core,
+      );
+
+      expect(await conversationService.searchInConversation('conversation-id', '   ')).toEqual([]);
+      expect(loadEventsWithCategory).not.toHaveBeenCalled();
+    });
+
+    it('stops aborted searches at a batch boundary', async () => {
+      jest.useFakeTimers();
+      const events = new Array(501).fill(null).map((_, index) => {
+        return createMessageEvent(`event-id-${index}`, 'term');
+      });
+      const loadEventsWithCategory = jest
+        .fn<
+          ReturnType<EventServiceLike['loadEventsWithCategory']>,
+          Parameters<EventServiceLike['loadEventsWithCategory']>
+        >()
+        .mockResolvedValue(events);
+      const eventService: EventServiceLike = {loadEventsWithCategory};
+      const abortController = new AbortController();
+
+      const conversationService = new ConversationService(
+        eventService,
+        {} as unknown as StorageService,
+        {} as unknown as APIClient,
+        {} as unknown as Core,
+      );
+
+      const searchPromise = conversationService.searchInConversation('conversation-id', 'term', abortController.signal);
+      await Promise.resolve();
+
+      abortController.abort();
+      jest.advanceTimersByTime(0);
+
+      await expect(searchPromise).rejects.toMatchObject({name: 'AbortError'});
     });
   });
 

--- a/apps/webapp/src/script/repositories/conversation/ConversationService.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationService.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import is from '@sindresorhus/is';
 import type {
   CONVERSATION_ACCESS_ROLE,
   Conversation as BackendConversation,
@@ -52,6 +53,7 @@ import type {Conversation as ConversationEntity} from 'Repositories/entity/Conve
 import {ClientEvent} from 'Repositories/event/Client';
 import type {EventService} from 'Repositories/event/EventService';
 import {getSearchRegex} from 'Repositories/search/fullTextSearch';
+import type {EventRecord} from 'Repositories/storage';
 import {StorageService} from 'Repositories/storage';
 import {ConversationRecord} from 'Repositories/storage/record/conversationRecord';
 import {StorageSchemata} from 'Repositories/storage/storageSchemata';
@@ -78,16 +80,34 @@ type ConversationEventData = {
   items?: CompositeMessageItem[];
 };
 
-type SearchableConversationEvent = {type?: string; data?: ConversationEventData; ephemeral_expires?: boolean};
+type SearchableConversationEvent = EventRecord & {
+  data?: ConversationEventData;
+  ephemeral_expires?: boolean | number | string;
+  type?: string;
+};
 type ConversationSearchEventLoader = Pick<EventService, 'loadEventsWithCategory'>;
 
-const waitForNextSearchBatch = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+function waitForNextSearchBatch() {
+  return new Promise<void>(resolve => setTimeout(resolve, 0));
+}
+
+function createSearchAbortError() {
+  const error = new Error('Conversation search aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function throwIfSearchAborted(abortSignal?: AbortSignal) {
+  if (abortSignal?.aborted) {
+    throw createSearchAbortError();
+  }
+}
 
 const TextExtractors: Partial<Record<string, (event: SearchableConversationEvent) => string>> = {
   [ClientEvent.CONVERSATION.MESSAGE_ADD]: event => event.data?.content || event.data?.message || '',
   [ClientEvent.CONVERSATION.MULTIPART_MESSAGE_ADD]: event => event.data?.text?.content || '',
   [ClientEvent.CONVERSATION.COMPOSITE_MESSAGE_ADD]: event => {
-    const items = Array.isArray(event.data?.items) ? event.data.items : [];
+    const items: CompositeMessageItem[] = is.array(event.data?.items) ? event.data.items : [];
     return items
       .flatMap(item => {
         if (item?.text) {
@@ -102,6 +122,42 @@ const TextExtractors: Partial<Record<string, (event: SearchableConversationEvent
       .join(' ');
   },
 };
+
+type FindMatchingConversationEventsParameters = {
+  abortSignal?: AbortSignal;
+  events: SearchableConversationEvent[];
+  getSearchableText: (event: SearchableConversationEvent) => string;
+  searchRegex: RegExp;
+};
+
+async function findMatchingConversationEvents(
+  options: FindMatchingConversationEventsParameters,
+): Promise<SearchableConversationEvent[]> {
+  const {abortSignal, events, getSearchableText, searchRegex} = options;
+  const matchingEvents: SearchableConversationEvent[] = [];
+
+  throwIfSearchAborted(abortSignal);
+
+  for (let index = 0; index < events.length; index += 1) {
+    if (index > 0 && index % SEARCH_BATCH_SIZE === 0) {
+      await waitForNextSearchBatch();
+      throwIfSearchAborted(abortSignal);
+    }
+
+    const event = events[index];
+    if (event.ephemeral_expires === true) {
+      continue;
+    }
+
+    const searchableText = getSearchableText(event);
+    searchRegex.lastIndex = 0;
+    if (searchableText && searchRegex.test(searchableText)) {
+      matchingEvents.push(event);
+    }
+  }
+
+  return matchingEvents;
+}
 
 export class ConversationService {
   private readonly eventService: ConversationSearchEventLoader;
@@ -145,7 +201,8 @@ export class ConversationService {
    * fetch failure, leaking errors out of the caller's data model. Prefer the `Task`-returning
    * variant so failures become a first-class case the type-checker can enforce handling for.
    */
-  getConversationById({id, domain}: QualifiedId): Promise<BackendConversation> {
+  getConversationById(qualifiedId: QualifiedId): Promise<BackendConversation> {
+    const {id, domain} = qualifiedId;
     return this.apiClient.api.conversation.getConversation({domain, id});
   }
 
@@ -487,7 +544,11 @@ export class ConversationService {
    * @param query will be checked in against all text messages
    * @returns Resolves with the matching events
    */
-  async searchInConversation(conversation_id: string, query: string): Promise<any> {
+  async searchInConversation(
+    conversation_id: string,
+    query: string,
+    abortSignal?: AbortSignal,
+  ): Promise<SearchableConversationEvent[]> {
     const trimmedQuery = query.trim();
     if (!trimmedQuery.length) {
       return [];
@@ -501,27 +562,16 @@ export class ConversationService {
       category_min,
       category_max,
     )) as SearchableConversationEvent[];
-    const matchingEvents: SearchableConversationEvent[] = [];
     const searchRegex = getSearchRegex(trimmedQuery);
 
-    for (let index = 0; index < events.length; index += 1) {
-      if (index > 0 && index % SEARCH_BATCH_SIZE === 0) {
-        await waitForNextSearchBatch();
-      }
-
-      const event = events[index];
-      if (event.ephemeral_expires === true) {
-        continue;
-      }
-
-      const searchableText = this.getEventSearchableText(event);
-      searchRegex.lastIndex = 0;
-      if (searchableText && searchRegex.test(searchableText)) {
-        matchingEvents.push(event);
-      }
-    }
-
-    return matchingEvents;
+    return findMatchingConversationEvents({
+      abortSignal,
+      events,
+      getSearchableText: event => {
+        return this.getEventSearchableText(event);
+      },
+      searchRegex,
+    });
   }
 
   private getEventSearchableText(event: SearchableConversationEvent): string {

--- a/apps/webapp/src/script/repositories/conversation/ConversationService.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationService.ts
@@ -64,6 +64,7 @@ import {APIClient} from '../../service/apiClientSingleton';
 import {Core} from '../../service/coreSingleton';
 
 const logger = getLogger('ConversationService');
+const SEARCH_BATCH_SIZE = 500;
 
 type CompositeMessageItem = {
   text?: {content?: string; message?: string};
@@ -77,8 +78,10 @@ type ConversationEventData = {
   items?: CompositeMessageItem[];
 };
 
-type SearchableConversationEvent = {type?: string; data?: ConversationEventData};
+type SearchableConversationEvent = {type?: string; data?: ConversationEventData; ephemeral_expires?: boolean};
 type ConversationSearchEventLoader = Pick<EventService, 'loadEventsWithCategory'>;
+
+const waitForNextSearchBatch = () => new Promise<void>(resolve => setTimeout(resolve, 0));
 
 const TextExtractors: Partial<Record<string, (event: SearchableConversationEvent) => string>> = {
   [ClientEvent.CONVERSATION.MESSAGE_ADD]: event => event.data?.content || event.data?.message || '',
@@ -488,13 +491,30 @@ export class ConversationService {
     const category_min = MessageCategory.TEXT;
     const category_max = MessageCategory.TEXT | MessageCategory.LINK | MessageCategory.LINK_PREVIEW;
 
-    const events = await this.eventService.loadEventsWithCategory(conversation_id, category_min, category_max);
-    return events
-      .filter(record => record.ephemeral_expires !== true)
-      .filter(event => {
-        const searchableText = this.getEventSearchableText(event);
-        return searchableText ? fullTextSearch(searchableText, query) : false;
-      });
+    const events = (await this.eventService.loadEventsWithCategory(
+      conversation_id,
+      category_min,
+      category_max,
+    )) as SearchableConversationEvent[];
+    const matchingEvents: SearchableConversationEvent[] = [];
+
+    for (let index = 0; index < events.length; index += 1) {
+      if (index > 0 && index % SEARCH_BATCH_SIZE === 0) {
+        await waitForNextSearchBatch();
+      }
+
+      const event = events[index];
+      if (event.ephemeral_expires === true) {
+        continue;
+      }
+
+      const searchableText = this.getEventSearchableText(event);
+      if (searchableText && fullTextSearch(searchableText, query)) {
+        matchingEvents.push(event);
+      }
+    }
+
+    return matchingEvents;
   }
 
   private getEventSearchableText(event: SearchableConversationEvent): string {

--- a/apps/webapp/src/script/repositories/conversation/ConversationService.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationService.ts
@@ -51,7 +51,7 @@ import {container} from 'tsyringe';
 import type {Conversation as ConversationEntity} from 'Repositories/entity/Conversation';
 import {ClientEvent} from 'Repositories/event/Client';
 import type {EventService} from 'Repositories/event/EventService';
-import {search as fullTextSearch} from 'Repositories/search/fullTextSearch';
+import {getSearchRegex} from 'Repositories/search/fullTextSearch';
 import {StorageService} from 'Repositories/storage';
 import {ConversationRecord} from 'Repositories/storage/record/conversationRecord';
 import {StorageSchemata} from 'Repositories/storage/storageSchemata';
@@ -488,6 +488,11 @@ export class ConversationService {
    * @returns Resolves with the matching events
    */
   async searchInConversation(conversation_id: string, query: string): Promise<any> {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery.length) {
+      return [];
+    }
+
     const category_min = MessageCategory.TEXT;
     const category_max = MessageCategory.TEXT | MessageCategory.LINK | MessageCategory.LINK_PREVIEW;
 
@@ -497,6 +502,7 @@ export class ConversationService {
       category_max,
     )) as SearchableConversationEvent[];
     const matchingEvents: SearchableConversationEvent[] = [];
+    const searchRegex = getSearchRegex(trimmedQuery);
 
     for (let index = 0; index < events.length; index += 1) {
       if (index > 0 && index % SEARCH_BATCH_SIZE === 0) {
@@ -509,7 +515,8 @@ export class ConversationService {
       }
 
       const searchableText = this.getEventSearchableText(event);
-      if (searchableText && fullTextSearch(searchableText, query)) {
+      searchRegex.lastIndex = 0;
+      if (searchableText && searchRegex.test(searchableText)) {
         matchingEvents.push(event);
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12136,6 +12136,7 @@ __metadata:
     css-loader: "npm:7.1.4"
     cssnano: "npm:7.1.9"
     date-fns: "npm:4.4.0"
+    debounce-fn: "npm:4.0.0"
     dexie: "npm:4.4.3"
     dexie-batch: "npm:0.4.3"
     dexie-encrypted: "npm:2.0.0"
@@ -15488,6 +15489,15 @@ __metadata:
   version: 1.0.2
   resolution: "de-indent@npm:1.0.2"
   checksum: 10/30bf43744dca005f9252dbb34ed95dcb3c30dfe52bfed84973b89c29eccff04e27769f222a34c61a93354acf47457785e9032e6184be390ed1d324fb9ab3f427
+  languageName: node
+  linkType: hard
+
+"debounce-fn@npm:4.0.0":
+  version: 4.0.0
+  resolution: "debounce-fn@npm:4.0.0"
+  dependencies:
+    mimic-fn: "npm:^3.0.0"
+  checksum: 10/1f0641c4dbfa38c2893943cd02cf94547840ac8fa21bed95489910bb7d312dd63dbad2d9cfcf0cf0ca47599090f41ebb4c356253aa9993a22461fa1f1d805ead
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26110" title="WPB-26110" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26110</a>  Very slow searching in a conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Improves in-conversation message search responsiveness in the browser.

The search input now debounces queries, avoids stacking multiple expensive searches while the user is still typing, and keeps the browser responsive while scanning large local conversation histories.

## Why It Was Slow

Conversation message search was doing more work than it looked like from the UI:

- Every query loaded all text/link-ish events for the conversation from local storage.
- The app scanned those events in JavaScript on the browser main thread.
- Each event extracted searchable text from multiple message shapes before matching.
- The previous search helper rebuilt the same search regex for every single message.
- If the user kept typing while a search was still running, more full scans could queue up behind the active one.

That means searching a large conversation was not just `N` string checks. It could become repeated local storage reads, repeated message-text extraction, repeated regex compilation, and repeated main-thread scans.

## Fixes

- Increased full message search debounce to 500ms.
- Coalesced in-flight searches so only one search runs at a time.
- Kept only the latest pending query while a search is already running.
- Ignored stale search results when the input has moved on.
- Batched local event scanning and yielded between batches so the browser can keep rendering/responding.
- Compiled the search regex once per query instead of once per message.
- Reset the reused global regex before each event match to avoid skipping consecutive results.

## Tests

- Added coverage for debounce timing and in-flight search coalescing.
- Added coverage for reused regex matching consecutive events without skipping results.

## Verification

- `yarn nx test webapp --testFile=apps/webapp/src/script/page/MainContent/panels/Collection/Collection.test.tsx --runInBand`
- `yarn nx test webapp --testFile=apps/webapp/src/script/repositories/conversation/ConversationService.test.ts --runInBand`
- `yarn nx run webapp:type-check`
