### PR TITLE
Add reconnect banner WebSocket diagnostics [WPB-21916]

### DIFF
--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -20,11 +20,13 @@
 export const applockRefactoredFeatureToggleName = 'applock-refactored';
 export const sharedDriveSearchAndFiltersFeatureToggleName = 'shared-drive-search-and-filters';
 export const meetingsFeatureToggleName = 'meetings';
+export const websocketConnectivityDiagnosticsFeatureToggleName = 'websocket-connectivity-diagnostics';
 
 export const startupFeatureToggleNames = [
   applockRefactoredFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   meetingsFeatureToggleName,
+  websocketConnectivityDiagnosticsFeatureToggleName,
 ] as const;
 
 export type StartupFeatureToggleName = (typeof startupFeatureToggleNames)[number];

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -27,12 +27,14 @@ import {
   meetingsFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   startupFeatureToggleNames,
+  websocketConnectivityDiagnosticsFeatureToggleName,
 } from './startupFeatureToggleNames';
 
 const featureToggleNamesWithDedicatedExistenceTests = [
   applockRefactoredFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   meetingsFeatureToggleName,
+  websocketConnectivityDiagnosticsFeatureToggleName,
 ] as const;
 
 describe('startupFeatureToggles', function () {
@@ -101,6 +103,14 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.isFeatureToggleEnabled(meetingsFeatureToggleName)).toBe(true);
   });
 
+  it('enables the websocket connectivity diagnostics feature toggle when present in the query parameter', () => {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${websocketConnectivityDiagnosticsFeatureToggleName}`,
+    );
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(websocketConnectivityDiagnosticsFeatureToggleName)).toBe(true);
+  });
+
   it('trims whitespace around feature toggle names', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}= ${applockRefactoredFeatureToggleName} `,
@@ -142,6 +152,7 @@ describe('startupFeatureToggles', function () {
       applockRefactoredFeatureToggleName,
       sharedDriveSearchAndFiltersFeatureToggleName,
       meetingsFeatureToggleName,
+      websocketConnectivityDiagnosticsFeatureToggleName,
     ]);
   });
 

--- a/apps/webapp/src/script/page/appMain.tsx
+++ b/apps/webapp/src/script/page/appMain.tsx
@@ -67,7 +67,10 @@ import {useAppMainState, ViewType} from './state';
 import {ContentState, useAppState} from './useAppState';
 
 import {WallClock} from '../clock/wallClock';
-import {meetingsFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
+import {
+  meetingsFeatureToggleName,
+  websocketConnectivityDiagnosticsFeatureToggleName,
+} from '../featureToggles/startupFeatureToggleNames';
 import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles';
 import {App} from '../main/app';
 import {initialiseMLSMigrationFlow} from '../mls/MLSMigration';
@@ -108,6 +111,9 @@ export const AppMain = (properties: AppMainProps) => {
   } = properties;
   const translate = mainView.translate;
   const apiContext = app.getAPIContext();
+  const isWebSocketConnectivityDiagnosticsEnabled = isFeatureToggleEnabled(
+    websocketConnectivityDiagnosticsFeatureToggleName,
+  );
 
   useActiveWindow(window);
 
@@ -352,7 +358,10 @@ export const AppMain = (properties: AppMainProps) => {
         )}
 
         <AppLock appLockRepository={appLockRepository} clientRepository={repositories.client} />
-        <WarningsContainer onRefresh={app.refresh} />
+        <WarningsContainer
+          onRefresh={app.refresh}
+          isWebSocketConnectivityDiagnosticsEnabled={isWebSocketConnectivityDiagnosticsEnabled}
+        />
 
         {!locked && (
           <>

--- a/apps/webapp/src/script/view_model/WarningsContainer/WarningsContainer.test.tsx
+++ b/apps/webapp/src/script/view_model/WarningsContainer/WarningsContainer.test.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {act, fireEvent, render} from '@testing-library/react';
+import {act, cleanup, fireEvent, render, waitFor} from '@testing-library/react';
 
 import {translateForTest} from 'Util/test/translateForTest';
 import {
@@ -26,6 +26,11 @@ import {
 } from 'src/script/page/testSupport/rootContextTestSupport';
 
 import {WarningsContainer} from './WarningsContainer';
+import {
+  collectWebSocketConnectivityDiagnostics,
+  WebSocketConnectivityDiagnosticsDependencies,
+} from './webSocketConnectivityDiagnostics';
+import {useWarningsState} from './WarningsState';
 
 import {Warnings} from '.';
 
@@ -34,6 +39,24 @@ const rootProviderWrapper = createRootProviderWrapperForTest(
 );
 
 describe('WarningsContainer', () => {
+  const originalClipboard = navigator.clipboard;
+
+  beforeEach(() => {
+    useWarningsState.setState({name: '', warnings: []});
+  });
+
+  afterEach(() => {
+    cleanup();
+    act(() => {
+      useWarningsState.setState({name: '', warnings: []});
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard,
+    });
+    jest.restoreAllMocks();
+  });
+
   it('does not render when no warning is in the queue', async () => {
     const {container} = render(<WarningsContainer onRefresh={jest.fn()} />, {wrapper: rootProviderWrapper});
 
@@ -146,6 +169,161 @@ describe('WarningsContainer', () => {
     });
     const WarningElement = getByTestId('connectivity-reconnect');
     expect(WarningElement).toBeTruthy();
+  });
+
+  it('does not render websocket connectivity diagnostics button by default', () => {
+    const {queryByTestId} = render(<WarningsContainer onRefresh={jest.fn()} />, {wrapper: rootProviderWrapper});
+    act(() => {
+      Warnings.showWarning(Warnings.TYPE.CONNECTIVITY_RECONNECT);
+    });
+
+    expect(queryByTestId('do-copy-websocket-connectivity-diagnostics')).toBeNull();
+  });
+
+  it('does not render websocket connectivity diagnostics button when disabled', () => {
+    const {queryByTestId} = render(
+      <WarningsContainer onRefresh={jest.fn()} isWebSocketConnectivityDiagnosticsEnabled={false} />,
+      {wrapper: rootProviderWrapper},
+    );
+    act(() => {
+      Warnings.showWarning(Warnings.TYPE.CONNECTIVITY_RECONNECT);
+    });
+
+    expect(queryByTestId('do-copy-websocket-connectivity-diagnostics')).toBeNull();
+  });
+
+  it('renders websocket connectivity diagnostics button for connectivity_reconnect when enabled', () => {
+    const {getByTestId} = render(
+      <WarningsContainer onRefresh={jest.fn()} isWebSocketConnectivityDiagnosticsEnabled />,
+      {wrapper: rootProviderWrapper},
+    );
+    act(() => {
+      Warnings.showWarning(Warnings.TYPE.CONNECTIVITY_RECONNECT);
+    });
+
+    expect(getByTestId('do-copy-websocket-connectivity-diagnostics')).toBeTruthy();
+  });
+
+  it('does not render websocket connectivity diagnostics button for no_internet when enabled', () => {
+    const {queryByTestId} = render(
+      <WarningsContainer onRefresh={jest.fn()} isWebSocketConnectivityDiagnosticsEnabled />,
+      {wrapper: rootProviderWrapper},
+    );
+    act(() => {
+      Warnings.showWarning(Warnings.TYPE.NO_INTERNET);
+    });
+
+    expect(queryByTestId('do-copy-websocket-connectivity-diagnostics')).toBeNull();
+  });
+
+  it('copies websocket connectivity diagnostics JSON to the clipboard', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    jest.spyOn(console, 'info').mockImplementation(jest.fn());
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {writeText},
+    });
+
+    const {getByTestId} = render(
+      <WarningsContainer onRefresh={jest.fn()} isWebSocketConnectivityDiagnosticsEnabled />,
+      {wrapper: rootProviderWrapper},
+    );
+    act(() => {
+      Warnings.showWarning(Warnings.TYPE.CONNECTIVITY_RECONNECT);
+    });
+
+    fireEvent.click(getByTestId('do-copy-websocket-connectivity-diagnostics'));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const [serializedDiagnostics] = writeText.mock.calls[0];
+    expect(() => JSON.parse(serializedDiagnostics)).not.toThrow();
+    expect(serializedDiagnostics).not.toContain('access_token');
+  });
+
+  it('does not include raw token values in websocket connectivity diagnostics', () => {
+    const diagnosticsDependencies: WebSocketConnectivityDiagnosticsDependencies = {
+      apiClient: {
+        transport: {
+          http: {
+            accessTokenStore: {
+              accessTokenData: {
+                access_token: 'secret-access-token',
+              },
+              markerToken: 'secret-marker-token',
+              tokenExpirationDate: 1_234,
+            },
+            hasValidAccessToken: () => true,
+          },
+          ws: {
+            accessTokenRefreshPromise: Promise.resolve(),
+            bufferedMessages: ['buffered-message'],
+            isLocked: () => true,
+            socket: {
+              getState: () => 1,
+              hasUnansweredPing: true,
+              lastMessageTimestamp: 1_000,
+              pendingHealthChecks: new Set([jest.fn()]),
+              reconnectAttemptCount: 2,
+              reconnectSequenceRetryCount: 1,
+              socket: {
+                _closeCalled: false,
+                _connectLock: true,
+                _shouldReconnect: true,
+                readyState: 3,
+                retryCount: 4,
+                url: 'wss://example.invalid/events?access_token=secret-access-token',
+              },
+              stopBackFromSleepHandler: {isJust: true},
+            },
+            useLegacySocket: false,
+            websocketState: 0,
+          },
+        },
+      },
+      browserDocument: {
+        hasFocus: () => true,
+        visibilityState: 'visible',
+      },
+      browserNavigator: {
+        onLine: true,
+      },
+      browserWindow: {
+        wire: {
+          app: {
+            repository: {
+              event: {
+                notificationHandlingState: () => 'WEB_SOCKET',
+              },
+            },
+          },
+        },
+      } as Window,
+      currentTimestampMilliseconds: () => 2_000,
+    };
+
+    const diagnostics = collectWebSocketConnectivityDiagnostics(diagnosticsDependencies);
+    const serializedDiagnostics = JSON.stringify(diagnostics);
+
+    expect(diagnostics.webSocketClientState.websocketStateName).toBe('CONNECTING');
+    expect(diagnostics.wireReconnectingWebsocketWrapperState.rawWebSocketStateName).toBe('OPEN');
+    expect(diagnostics.underlyingReconnectingWebSocketState.rwsReadyStateName).toBe('CLOSED');
+    expect(serializedDiagnostics).not.toContain('secret-access-token');
+    expect(serializedDiagnostics).not.toContain('secret-marker-token');
+    expect(serializedDiagnostics).not.toContain('access_token');
+    expect(serializedDiagnostics).not.toContain('wss://example.invalid');
+  });
+
+  it('collects websocket connectivity diagnostics when window.wire is missing', () => {
+    const diagnostics = collectWebSocketConnectivityDiagnostics({
+      browserDocument: document,
+      browserNavigator: navigator,
+      browserWindow: window,
+      currentTimestampMilliseconds: () => 2_000,
+    });
+
+    expect(diagnostics.appState.notificationHandlingState).toBeUndefined();
+    expect(diagnostics.wireReconnectingWebsocketWrapperState.hasWrapper).toBe(false);
+    expect(diagnostics.underlyingReconnectingWebSocketState.hasUnderlyingSocket).toBe(false);
   });
 
   it('correctly renders warning of type call_quality_poor', () => {

--- a/apps/webapp/src/script/view_model/WarningsContainer/WarningsContainer.tsx
+++ b/apps/webapp/src/script/view_model/WarningsContainer/WarningsContainer.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useEffect} from 'react';
+import {Fragment, useEffect} from 'react';
 
 import cx from 'classnames';
 
@@ -29,14 +29,16 @@ import {afterRender} from 'Util/util';
 
 import {closeWarning, useWarningsState} from './WarningsState';
 import {CONFIG, TYPE} from './WarningsTypes';
+import {copyWebSocketConnectivityDiagnostics} from './webSocketConnectivityDiagnostics';
 
 import {Config} from '../../Config';
 
 interface WarningProps {
-  onRefresh: () => void;
+  readonly onRefresh: () => void;
+  readonly isWebSocketConnectivityDiagnosticsEnabled?: boolean;
 }
 
-const WarningsContainer = ({onRefresh}: WarningProps) => {
+const WarningsContainer = ({onRefresh, isWebSocketConnectivityDiagnosticsEnabled = false}: WarningProps) => {
   const {translate} = useApplicationContext();
   const name = useWarningsState(state => state.name);
   const warnings = useWarningsState(state => state.warnings);
@@ -281,6 +283,19 @@ const WarningsContainer = ({onRefresh}: WarningProps) => {
         <div data-uie-name="connectivity-reconnect" className="warning-bar warning-bar-connection">
           <div className="warning-bar-message">
             <span>{translate('warningConnectivityConnectionLost', {brandName})}</span>
+            {isWebSocketConnectivityDiagnosticsEnabled && (
+              <Fragment>
+                &nbsp;
+                <button
+                  type="button"
+                  className="warning-bar-link button-reset-default"
+                  data-uie-name="do-copy-websocket-connectivity-diagnostics"
+                  onClick={() => void copyWebSocketConnectivityDiagnostics()}
+                >
+                  Copy diagnostics
+                </button>
+              </Fragment>
+            )}
             <Icon.LoadingIcon className="warning-bar-spinner" data-uie-name="status-loading" />
           </div>
         </div>

--- a/apps/webapp/src/script/view_model/WarningsContainer/webSocketConnectivityDiagnostics.ts
+++ b/apps/webapp/src/script/view_model/WarningsContainer/webSocketConnectivityDiagnostics.ts
@@ -1,0 +1,289 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {container} from 'tsyringe';
+
+import {APIClient} from '../../service/apiClientSingleton';
+
+type UnknownRecord = Record<string, unknown>;
+
+type ClipboardWriter = {
+  readonly writeText?: (text: string) => Promise<void>;
+};
+
+type DiagnosticsWindow = Window & {
+  readonly wire?: {
+    readonly app?: {
+      readonly repository?: {
+        readonly event?: {
+          readonly notificationHandlingState?: () => unknown;
+        };
+      };
+    };
+  };
+};
+
+type DiagnosticsDocument = Pick<Document, 'hasFocus' | 'visibilityState'>;
+
+type DiagnosticsNavigator = Pick<Navigator, 'onLine'> & {
+  readonly clipboard?: ClipboardWriter;
+};
+
+export type WebSocketConnectivityDiagnosticsDependencies = {
+  readonly apiClient?: unknown;
+  readonly browserDocument?: DiagnosticsDocument;
+  readonly browserNavigator?: DiagnosticsNavigator;
+  readonly browserWindow?: DiagnosticsWindow;
+  readonly currentTimestampMilliseconds?: () => number;
+};
+
+export type WebSocketConnectivityDiagnostics = {
+  readonly timestamp: string;
+  readonly appState: {
+    readonly notificationHandlingState: unknown;
+    readonly navigatorOnLine: boolean | undefined;
+    readonly documentVisibilityState: DocumentVisibilityState | undefined;
+    readonly documentHasFocus: boolean | undefined;
+  };
+  readonly webSocketClientState: {
+    readonly useLegacySocket: unknown;
+    readonly isLocked: boolean | undefined;
+    readonly bufferedMessagesLength: number | undefined;
+    readonly websocketState: number | undefined;
+    readonly websocketStateName: string | undefined;
+    readonly accessTokenRefreshInFlight: boolean;
+  };
+  readonly wireReconnectingWebsocketWrapperState: {
+    readonly hasWrapper: boolean;
+    readonly rawWebSocketState: number | undefined;
+    readonly rawWebSocketStateName: string | undefined;
+    readonly hasUnansweredPing: unknown;
+    readonly lastMessageTimestamp: number | undefined;
+    readonly millisecondsSinceLastMessage: number | undefined;
+    readonly pingerActive: boolean;
+    readonly pendingHealthChecksSize: number | undefined;
+    readonly sleepHandlerActive: boolean;
+    readonly reconnectAttemptCount: number | undefined;
+    readonly reconnectSequenceRetryCount: number | undefined;
+  };
+  readonly underlyingReconnectingWebSocketState: {
+    readonly hasUnderlyingSocket: boolean;
+    readonly rwsReadyState: number | undefined;
+    readonly rwsReadyStateName: string | undefined;
+    readonly rwsConnectLock: unknown;
+    readonly rwsShouldReconnect: unknown;
+    readonly rwsCloseCalled: unknown;
+    readonly rwsRetryCount: number | undefined;
+  };
+  readonly authState: {
+    readonly hasValidAccessToken: boolean | undefined;
+    readonly tokenExpirationTimestamp: number | undefined;
+    readonly millisecondsUntilTokenExpiration: number | undefined;
+    readonly hasMarkerToken: boolean;
+  };
+};
+
+const webSocketReadyStateNames: Readonly<Record<number, string>> = {
+  0: 'CONNECTING',
+  1: 'OPEN',
+  2: 'CLOSING',
+  3: 'CLOSED',
+};
+const diagnosticsJsonIndentationSpaces = 2;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null;
+}
+
+function toRecord(value: unknown): UnknownRecord | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function toNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function getArrayLength(value: unknown): number | undefined {
+  return Array.isArray(value) ? value.length : undefined;
+}
+
+function getSetSize(value: unknown): number | undefined {
+  return value instanceof Set ? value.size : undefined;
+}
+
+function getReadyStateName(readyState: number | undefined): string | undefined {
+  return readyState === undefined ? undefined : webSocketReadyStateNames[readyState];
+}
+
+function callBooleanGetter(target: UnknownRecord | undefined, getterName: string): boolean | undefined {
+  const getter = target?.[getterName];
+
+  if (typeof getter !== 'function') {
+    return undefined;
+  }
+
+  try {
+    return Boolean(getter.call(target));
+  } catch {
+    return undefined;
+  }
+}
+
+function callUnknownGetter(target: UnknownRecord | undefined, getterName: string): unknown {
+  const getter = target?.[getterName];
+
+  if (typeof getter !== 'function') {
+    return undefined;
+  }
+
+  try {
+    return getter.call(target);
+  } catch {
+    return undefined;
+  }
+}
+
+function readNotificationHandlingState(browserWindow: DiagnosticsWindow | undefined): unknown {
+  return callUnknownGetter(toRecord(browserWindow?.wire?.app?.repository?.event), 'notificationHandlingState');
+}
+
+function readDocumentHasFocus(browserDocument: DiagnosticsDocument | undefined): boolean | undefined {
+  try {
+    return browserDocument?.hasFocus();
+  } catch {
+    return undefined;
+  }
+}
+
+function readDefaultApiClient(browserWindow: DiagnosticsWindow | undefined): unknown {
+  if (!browserWindow?.wire?.app) {
+    return undefined;
+  }
+
+  try {
+    return container.resolve(APIClient);
+  } catch {
+    return undefined;
+  }
+}
+
+function createDefaultDependencies(): WebSocketConnectivityDiagnosticsDependencies {
+  const browserWindow = globalThis.window as DiagnosticsWindow | undefined;
+
+  return {
+    apiClient: readDefaultApiClient(browserWindow),
+    browserDocument: globalThis.document,
+    browserNavigator: globalThis.navigator,
+    browserWindow,
+    currentTimestampMilliseconds: Date.now,
+  };
+}
+
+function isMaybeJust(value: unknown): boolean {
+  return isRecord(value) && value.isJust === true;
+}
+
+export function collectWebSocketConnectivityDiagnostics(
+  dependencies: WebSocketConnectivityDiagnosticsDependencies = createDefaultDependencies(),
+): WebSocketConnectivityDiagnostics {
+  const {
+    apiClient,
+    browserDocument,
+    browserNavigator,
+    browserWindow,
+    currentTimestampMilliseconds = Date.now,
+  } = dependencies;
+  const currentTimestamp = currentTimestampMilliseconds();
+  const apiClientRecord = toRecord(apiClient);
+  const transport = toRecord(apiClientRecord?.transport);
+  const webSocketClient = toRecord(transport?.ws);
+  const httpClient = toRecord(transport?.http);
+  const accessTokenStore = toRecord(httpClient?.accessTokenStore);
+  const wrapper = toRecord(webSocketClient?.socket);
+  const underlyingReconnectingWebSocket = toRecord(wrapper?.socket);
+  const webSocketClientState = toNumber(webSocketClient?.websocketState);
+  const rawWebSocketState = toNumber(callUnknownGetter(wrapper, 'getState'));
+  const rwsReadyState = toNumber(underlyingReconnectingWebSocket?.readyState);
+  const lastMessageTimestamp = toNumber(wrapper?.lastMessageTimestamp);
+  const tokenExpirationTimestamp = toNumber(accessTokenStore?.tokenExpirationDate);
+
+  return {
+    timestamp: new Date(currentTimestamp).toISOString(),
+    appState: {
+      notificationHandlingState: readNotificationHandlingState(browserWindow),
+      navigatorOnLine: browserNavigator?.onLine,
+      documentVisibilityState: browserDocument?.visibilityState,
+      documentHasFocus: readDocumentHasFocus(browserDocument),
+    },
+    webSocketClientState: {
+      useLegacySocket: webSocketClient?.useLegacySocket,
+      isLocked: callBooleanGetter(webSocketClient, 'isLocked'),
+      bufferedMessagesLength: getArrayLength(webSocketClient?.bufferedMessages),
+      websocketState: webSocketClientState,
+      websocketStateName: getReadyStateName(webSocketClientState),
+      accessTokenRefreshInFlight: webSocketClient?.accessTokenRefreshPromise !== undefined,
+    },
+    wireReconnectingWebsocketWrapperState: {
+      hasWrapper: wrapper !== undefined,
+      rawWebSocketState,
+      rawWebSocketStateName: getReadyStateName(rawWebSocketState),
+      hasUnansweredPing: wrapper?.hasUnansweredPing,
+      lastMessageTimestamp,
+      millisecondsSinceLastMessage:
+        lastMessageTimestamp === undefined || lastMessageTimestamp === 0
+          ? undefined
+          : currentTimestamp - lastMessageTimestamp,
+      pingerActive: wrapper?.pingerId !== undefined,
+      pendingHealthChecksSize: getSetSize(wrapper?.pendingHealthChecks),
+      sleepHandlerActive: isMaybeJust(wrapper?.stopBackFromSleepHandler),
+      reconnectAttemptCount: toNumber(wrapper?.reconnectAttemptCount),
+      reconnectSequenceRetryCount: toNumber(wrapper?.reconnectSequenceRetryCount),
+    },
+    underlyingReconnectingWebSocketState: {
+      hasUnderlyingSocket: underlyingReconnectingWebSocket !== undefined,
+      rwsReadyState,
+      rwsReadyStateName: getReadyStateName(rwsReadyState),
+      rwsConnectLock: underlyingReconnectingWebSocket?._connectLock,
+      rwsShouldReconnect: underlyingReconnectingWebSocket?._shouldReconnect,
+      rwsCloseCalled: underlyingReconnectingWebSocket?._closeCalled,
+      rwsRetryCount: toNumber(underlyingReconnectingWebSocket?.retryCount),
+    },
+    authState: {
+      hasValidAccessToken: callBooleanGetter(httpClient, 'hasValidAccessToken'),
+      tokenExpirationTimestamp,
+      millisecondsUntilTokenExpiration:
+        tokenExpirationTimestamp === undefined ? undefined : tokenExpirationTimestamp - currentTimestamp,
+      hasMarkerToken: typeof accessTokenStore?.markerToken === 'string' && accessTokenStore.markerToken.length > 0,
+    },
+  };
+}
+
+export async function copyWebSocketConnectivityDiagnostics(): Promise<void> {
+  const diagnostics = collectWebSocketConnectivityDiagnostics();
+  const serializedDiagnostics = JSON.stringify(diagnostics, null, diagnosticsJsonIndentationSpaces);
+
+  console.info('WebSocket connectivity diagnostics', diagnostics);
+
+  try {
+    await navigator.clipboard.writeText(serializedDiagnostics);
+  } catch (error) {
+    console.warn('Failed to copy WebSocket connectivity diagnostics to clipboard', error);
+    console.info(serializedDiagnostics);
+  }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add startup-gated WebSocket connectivity diagnostics to the reconnect banner.

When `websocket-connectivity-diagnostics` is enabled through `enabled-features`, the reconnect warning renders a Copy diagnostics action. The action copies sanitized WebSocket, wrapper, app, and auth state to the clipboard and logs the same diagnostics for developers.

The diagnostics intentionally omit token values, raw WebSocket URLs, cookies, user IDs, client IDs, and other identifiers. Tests cover feature flag parsing, banner gating, clipboard behavior, missing runtime state, ready-state mapping, and token sanitization.


