### PR TITLE
Exclude meeting conversations from the sidebar list [WPB-25678]

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationSelectors.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationSelectors.ts
@@ -143,7 +143,7 @@ export const isProteus1to1ConversationWithUser = (userId: QualifiedId) =>
 export const isMLS1to1ConversationWithUser = (userId: QualifiedId) =>
   is1to1ConversationWithUser(userId, CONVERSATION_PROTOCOL.MLS);
 
-export const isMeetingConversation = (conversation: Conversation): boolean => {
+export const isConversationForScheduledMeeting = (conversation: Conversation): boolean => {
   return conversation.groupConversationType() === GROUP_CONVERSATION_TYPE.MEETING;
 };
 

--- a/apps/webapp/src/script/repositories/conversation/ConversationSelectors.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationSelectors.ts
@@ -18,7 +18,11 @@
  */
 
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
-import {CONVERSATION_TYPE, Conversation as BackendConversation} from '@wireapp/api-client/lib/conversation/';
+import {
+  CONVERSATION_TYPE,
+  GROUP_CONVERSATION_TYPE,
+  Conversation as BackendConversation,
+} from '@wireapp/api-client/lib/conversation/';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
 
@@ -138,6 +142,10 @@ export const isProteus1to1ConversationWithUser = (userId: QualifiedId) =>
 
 export const isMLS1to1ConversationWithUser = (userId: QualifiedId) =>
   is1to1ConversationWithUser(userId, CONVERSATION_PROTOCOL.MLS);
+
+export const isMeetingConversation = (conversation: Conversation): boolean => {
+  return conversation.groupConversationType() === GROUP_CONVERSATION_TYPE.MEETING;
+};
 
 export const isReadableConversation = (conversation: Conversation): boolean => {
   const states_to_filter = [

--- a/apps/webapp/src/script/repositories/conversation/ConversationState.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationState.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
+import {CONVERSATION_TYPE, GROUP_CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 
 import {randomUUID} from 'crypto';
@@ -92,6 +92,20 @@ describe('ConversationState', () => {
       const conversationState = createConversationState();
       conversationState.conversations([selfProteusConversation, selfMLSConversation, regularConversation]);
       expect(conversationState.getSelfConversations(false)).toEqual([selfProteusConversation]);
+    });
+  });
+
+  describe('visibleConversations', () => {
+    it('excludes meeting conversations from the sidebar list', () => {
+      const conversationState = createConversationState();
+      const meetingConversation = createConversation(CONVERSATION_PROTOCOL.MLS, CONVERSATION_TYPE.REGULAR);
+      meetingConversation.groupConversationType(GROUP_CONVERSATION_TYPE.MEETING);
+
+      conversationState.conversations([regularConversation, meetingConversation]);
+
+      expect(conversationState.conversations()).toHaveLength(2);
+      expect(conversationState.visibleConversations()).toEqual([regularConversation]);
+      expect(conversationState.findConversation(meetingConversation.qualifiedId)).toBe(meetingConversation);
     });
   });
 

--- a/apps/webapp/src/script/repositories/conversation/ConversationState.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationState.ts
@@ -36,7 +36,7 @@ import {
   isProteus1to1ConversationWithUser,
   isSelfConversation,
   isReadableConversation,
-  isMeetingConversation,
+  isConversationForScheduledMeeting,
 } from './ConversationSelectors';
 
 @singleton()
@@ -79,7 +79,7 @@ export class ConversationState {
   ) {
     this.sortedConversations = ko.pureComputed(() =>
       this.filteredConversations()
-        .filter(conversation => !isMeetingConversation(conversation))
+        .filter(conversation => !isConversationForScheduledMeeting(conversation))
         .toSorted(sortGroupsByLastEvent),
     );
     this.selfProteusConversation = ko.pureComputed(() =>

--- a/apps/webapp/src/script/repositories/conversation/ConversationState.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationState.ts
@@ -36,6 +36,7 @@ import {
   isProteus1to1ConversationWithUser,
   isSelfConversation,
   isReadableConversation,
+  isMeetingConversation,
 } from './ConversationSelectors';
 
 @singleton()
@@ -76,7 +77,11 @@ export class ConversationState {
     private readonly userState = container.resolve(UserState),
     private readonly teamState = container.resolve(TeamState),
   ) {
-    this.sortedConversations = ko.pureComputed(() => this.filteredConversations().toSorted(sortGroupsByLastEvent));
+    this.sortedConversations = ko.pureComputed(() =>
+      this.filteredConversations()
+        .filter(conversation => !isMeetingConversation(conversation))
+        .toSorted(sortGroupsByLastEvent),
+    );
     this.selfProteusConversation = ko.pureComputed(() =>
       this.conversations().find(conversation => !isMLSConversation(conversation) && isSelfConversation(conversation)),
     );

--- a/apps/webapp/src/script/repositories/entity/Conversation.ts
+++ b/apps/webapp/src/script/repositories/entity/Conversation.ts
@@ -144,6 +144,7 @@ export class Conversation {
   public readonly isCreatedBySelf: ko.PureComputed<boolean>;
   public readonly isGroup: ko.PureComputed<boolean>;
   public readonly isChannel: ko.PureComputed<boolean>;
+  public readonly isMeeting: ko.PureComputed<boolean>;
   public readonly isGroupOrChannel: ko.PureComputed<boolean>;
   public readonly isGuest: ko.Observable<boolean>;
   public readonly isGuestRoom: ko.PureComputed<boolean>;
@@ -294,6 +295,10 @@ export class Conversation {
 
     this.isChannel = ko.pureComputed(() => {
       return this.groupConversationType() === GROUP_CONVERSATION_TYPE.CHANNEL;
+    });
+
+    this.isMeeting = ko.pureComputed(() => {
+      return this.groupConversationType() === GROUP_CONVERSATION_TYPE.MEETING;
     });
 
     this.isGroupOrChannel = ko.pureComputed(() => {

--- a/libraries/api-client/src/conversation/conversation.ts
+++ b/libraries/api-client/src/conversation/conversation.ts
@@ -57,6 +57,7 @@ export enum CONVERSATION_ACCESS {
 export enum GROUP_CONVERSATION_TYPE {
   CHANNEL = 'channel',
   GROUP_CONVERSATION = 'group_conversation',
+  MEETING = 'meeting',
 }
 
 export enum ADD_PERMISSION {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25678" title="WPB-25678" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25678</a>  [Web] Create / edit meetings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Meeting conversations remain in state for messaging but are filtered out of sorted/visible conversations so they do not appear alongside regular chats.


