### PR TITLE
Expose Testiny reporting for reusable E2E workflow [WPB-26469]

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -41,6 +41,10 @@ on:
       grep:
         type: string
         description: Define which tests to run, the given value will be passed to the `--grep` flag of playwright
+      testinyRunName:
+        type: string
+        required: false
+        description: Define Testiny Run name to upload results to
       keep_traces:
         type: boolean
         description: 'Keep Playwright traces'
@@ -49,6 +53,8 @@ on:
       OP_SERVICE_ACCOUNT_TOKEN:
         required: true
       WIRE_E2E_TEST_BOT_WEBHOOK_URL:
+        required: false
+      TESTINY_API_KEY:
         required: false
     outputs:
       reportArtifactId:
@@ -261,6 +267,11 @@ jobs:
           TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
           TESTINY_RUN_NAME: ${{ inputs.testinyRunName }}
         run: |
+          if [ -z "$TESTINY_API_KEY" ]; then
+            echo "::error::TESTINY_API_KEY secret is required when testinyRunName is provided."
+            exit 1
+          fi
+
           node apps/webapp/test/e2e_tests/scripts/send-playwright-results-to-testiny.ts \
             --report apps/webapp/playwright-report/report.json \
             --run-name "$TESTINY_RUN_NAME"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Prepares the reusable E2E workflow for ADR 0002 release workflows.

This adds `testinyRunName` and `TESTINY_API_KEY` support to the `workflow_call` interface so future release workflows can run E2E against Beta and report results to Testiny.

## Notes

Manual E2E workflow behavior is unchanged.

This PR does not add release, Edge, Beta, or Production deployment behavior.

## Tracking

Part of https://github.com/wireapp/wire-webapp/issues/21597. Follow-up to https://github.com/wireapp/wire-webapp/pull/21598