### PR TITLE
Skip critical flow status job without run-e2e label [WPB-22420]

### DIFF
--- a/.github/workflows/precommit-crit-flows.yml
+++ b/.github/workflows/precommit-crit-flows.yml
@@ -94,7 +94,7 @@ jobs:
 
   run_e2e_tests:
     name: Playwright Critical Flow
-    if: ${{ always() && github.repository == 'wireapp/wire-webapp' }}
+    if: ${{ always() && github.repository == 'wireapp/wire-webapp' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-e2e')) }}
     needs: [deploy_and_run_e2e]
     runs-on: ubuntu-24.04
     timeout-minutes: 5


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Fixes the `precommit-crit-flows` workflow for pull requests without the `run-e2e` label which was introduced in https://github.com/wireapp/wire-webapp/pull/21567

The workflow was intended to run critical flow E2E tests on pull requests only when the `run-e2e` label is set.

## Problem

The `build` and E2E execution path already respect the label guard.

However, the `run_e2e_tests` status job used `always()` without the same pull request label condition. This meant the job still ran for unlabeled pull requests after the upstream E2E job was skipped.

As a result, unlabeled pull requests could fail with `needs.deploy_and_run_e2e.result` being `skipped`.

## Intent

Keep unlabeled pull requests quiet.

They should not run critical flow E2E tests, and they should not fail because the workflow intentionally skipped the upstream jobs.