### PR TITLE
Skip E2E status job without run-e2e label [WPB-22420]

### DIFF
--- a/.github/workflows/precommit-e2e-tests.yml
+++ b/.github/workflows/precommit-e2e-tests.yml
@@ -99,7 +99,7 @@ jobs:
 
   run_e2e_tests:
     name: Playwright Critical Flow
-    if: ${{ always() && github.repository == 'wireapp/wire-webapp' }}
+    if: ${{ always() && github.repository == 'wireapp/wire-webapp' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-e2e')) }}
     needs: [deploy_and_run_e2e]
     runs-on: ubuntu-24.04
     timeout-minutes: 5


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
In https://github.com/wireapp/wire-webapp/pull/21631 we introduced a small bug. We want to run the E2E status job only for pull requests when the `run-e2e` label is present.

The build job already respected the label guard, but the status job used `always()` without the same condition. This caused unlabeled pull requests to fail because the upstream E2E job was intentionally skipped.

Apply the same pull request label guard to the status job so unlabeled pull requests stay skipped while scheduled and manual runs keep their existing behavior.


