### PR TITLE
Avoid full repository fetch for pull request checks [WPB-22420]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,15 +64,19 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-          fetch-depth: 0
-          # Uses the head commit (not merge commit) for PRs
+          fetch-depth: 1
+          # Uses the head commit, not the merge commit.
+          # Keep this shallow. Nx gets the base branch explicitly in the next step.
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Fetch base branch for Nx format checks
+      - name: Fetch base branch for Nx checks
         if: ${{ github.event_name == 'pull_request' }}
         env:
           BASE_REF: ${{ github.base_ref }}
-        run: git fetch origin "${BASE_REF}:${BASE_REF}"
+        run: |
+          git fetch --no-tags --depth=1 origin \
+            "${BASE_REF}:refs/remotes/origin/${BASE_REF}" \
+            "${BASE_REF}:${BASE_REF}"
 
       - name: Checkout (non-PR)
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## What changed

This updates the pull request checkout in the CI workflow to avoid fetching the **full** repository history, all branches, and tags.

Instead, pull request jobs now:

- check out the PR head SHA with a shallow checkout
- fetch only the PR base branch afterwards
- keep both refs needed by the existing Nx scripts:
  - `origin/${BASE_REF}`
  - `${BASE_REF}`

## Why

The previous pull request checkout used `fetch-depth: 0`.

That made `actions/checkout` fetch all branches and tags before checking out the PR head SHA. In one observed run, [the fetch took roughly 29 seconds](https://github.com/wireapp/wire-webapp/actions/runs/28081046688/job/83135879354?pr=21636) while the actual checkout took less than a second.

We only need the PR head and the base branch for the affected Nx checks, so a full repository fetch is unnecessary.