### PR TITLE
Increase timeouts for long running federation e2e tests [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -207,6 +207,8 @@ test.describe('Federation', () => {
     'I want to share all possible assets in a federated group',
     {tag: ['@TC-8758', '@regression']},
     async ({createPage}) => {
+      test.setTimeout(150_000);
+
       const [normalUserPage, federatedUserPage] = await Promise.all([
         createPage(withLogin(normalUser)),
         createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
@@ -296,6 +298,8 @@ test.describe('Federation', () => {
     'I want to import my backup of conversations with users from different BE and see the conversation contents',
     {tag: ['@TC-3128', '@regression']},
     async ({createPage}, testInfo) => {
+      test.setTimeout(150_000);
+
       const [normalUserPage, federatedUserPage] = await Promise.all([
         createPage(withLogin(normalUser)),
         createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Within reports it was noticeable that these two test cases sometimes exceed the default timeout of 90s per test due to them executing a second login or sending many messages in conversations.


