### PR TITLE
fix: consume ENABLE_ACCOUNT_REGISTRATION FF [WPB-26568]

### DIFF
--- a/apps/webapp/src/script/auth/page/login/util.ts
+++ b/apps/webapp/src/script/auth/page/login/util.ts
@@ -31,6 +31,7 @@ import {actionRoot as ROOT_ACTIONS} from '../../module/action';
 import {ValidationError} from '../../module/action/ValidationError';
 import {ConversationState} from '../../module/reducer/conversationReducer';
 import {QUERY_KEY, ROUTE} from '../../route';
+import {Config} from 'src/script/Config';
 
 export const requiresPasswordModal = (
   isOpen: boolean,
@@ -122,7 +123,9 @@ export const handleEnterpriseLogin = async ({
       res => {
         dispatch(
           ROOT_ACTIONS.authAction.pushAccountRegistrationData({
-            accountCreationEnabled: res.domain_redirect !== DomainRedirect.NO_REGISTRATION,
+            accountCreationEnabled:
+              res.domain_redirect !== DomainRedirect.NO_REGISTRATION &&
+              Config.getConfig().FEATURE.ENABLE_ACCOUNT_REGISTRATION,
             shouldDisplayWarning: res.domain_redirect === DomainRedirect.NO_REGISTRATION && res.due_to_existing_account,
           }) as unknown as UnknownAction,
         );

--- a/apps/webapp/src/script/auth/page/login/util.ts
+++ b/apps/webapp/src/script/auth/page/login/util.ts
@@ -25,13 +25,13 @@ import {pathWithParams} from '@wireapp/commons/lib/util/UrlUtil';
 import {Dispatch, UnknownAction} from 'redux';
 import {match, P} from 'ts-pattern';
 
+import {Config} from 'src/script/Config';
 import {APIClient} from 'src/script/service/apiClientSingleton';
 
 import {actionRoot as ROOT_ACTIONS} from '../../module/action';
 import {ValidationError} from '../../module/action/ValidationError';
 import {ConversationState} from '../../module/reducer/conversationReducer';
 import {QUERY_KEY, ROUTE} from '../../route';
-import {Config} from 'src/script/Config';
 
 export const requiresPasswordModal = (
   isOpen: boolean,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26568" title="WPB-26568" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26568</a>  [Web]  Create Account Buttons are shown on bund-next & bund-qa backends
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Descriptiom

We forgot to implement FF ENABLE_ACCOUNT_REGISTRATION during the implementation of new login flows.
Now, we added and prevented user to create accounf when the FF is false.