### PR TITLE
Add release branch Beta deployment workflow [WPB-26469]

### DIFF
--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -1,0 +1,304 @@
+---
+name: Release Cloud
+
+on:
+  # Automatic release/** triggering is intentionally disabled during the
+  # transition. Enable it after release-cloud is the official Beta release path.
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: 'Release branch to deploy to Beta, for example release/2026-06-25.1'
+        required: true
+        type: string
+      confirm_beta_deploy:
+        description: 'Confirm that this will deploy the selected release branch to Beta'
+        required: true
+        default: false
+        type: boolean
+      reason:
+        description: 'Optional reason for manually deploying to Beta'
+        required: false
+        type: string
+
+concurrency:
+  group: release-cloud-beta-${{ inputs.release_branch }}
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  AWS_REGION: eu-central-1
+  ARTIFACT_PATH: apps/server/dist/s3/ebs.zip
+  BETA_ARTIFACT_NAME_PREFIX: release-cloud-ebs
+  BETA_BACKEND_URL: https://staging-nginz-https.zinfra.io/
+  # ADR 0002 calls this target Beta. During the transition, Beta maps to the
+  # existing wire-webapp-staging Elastic Beanstalk environment and URL.
+  BETA_ENVIRONMENT_NAME: wire-webapp-staging
+  BETA_WEBAPP_URL: https://wire-webapp-staging.zinfra.io/
+
+jobs:
+  validate_request:
+    name: Validate manual request
+    runs-on: ubuntu-24.04
+    permissions: {}
+    outputs:
+      release_branch: ${{ steps.validate_request.outputs.release_branch }}
+
+    steps:
+      - name: Validate manual request
+        id: validate_request
+        env:
+          CONFIRM_BETA_DEPLOY: ${{ inputs.confirm_beta_deploy }}
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${CONFIRM_BETA_DEPLOY}" != 'true' ]]; then
+            echo 'confirm_beta_deploy must be true to deploy to Beta.' >&2
+            exit 1
+          fi
+
+          if [[ ! "${RELEASE_BRANCH}" =~ ^release/[0-9]{4}-[0-9]{2}-[0-9]{2}\.[1-9][0-9]*$ ]]; then
+            echo "release_branch must match release/YYYY-MM-DD.N, where N starts at 1: ${RELEASE_BRANCH}" >&2
+            exit 1
+          fi
+
+          echo "release_branch=${RELEASE_BRANCH}" >> "$GITHUB_OUTPUT"
+
+  build_artifact:
+    name: Validate release branch and build artifact
+    runs-on: ubuntu-24.04
+    needs: validate_request
+    permissions:
+      contents: read
+    outputs:
+      artifact_checksum: ${{ steps.artifact_metadata.outputs.artifact_checksum }}
+      artifact_name: ${{ steps.artifact_metadata.outputs.artifact_name }}
+      release_branch: ${{ steps.release_metadata.outputs.release_branch }}
+      release_commit_sha: ${{ steps.release_metadata.outputs.release_commit_sha }}
+      release_identifier: ${{ steps.release_metadata.outputs.release_identifier }}
+
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ needs.validate_request.outputs.release_branch }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: ./bin/yarn --immutable
+
+      - name: Validate release branch
+        id: release_metadata
+        env:
+          RELEASE_BRANCH: ${{ needs.validate_request.outputs.release_branch }}
+        run: |
+          set -euo pipefail
+
+          release_identifier="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts release-identifier-from-branch "${RELEASE_BRANCH}")"
+          release_commit_sha="$(git rev-parse HEAD)"
+
+          {
+            echo "release_branch=${RELEASE_BRANCH}"
+            echo "release_identifier=${release_identifier}"
+            echo "release_commit_sha=${release_commit_sha}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update configuration
+        run: ./bin/yarn nx run webapp:configure
+
+      - name: Build and package
+        run: ./bin/yarn nx run server:package
+
+      - name: Compute artifact metadata
+        id: artifact_metadata
+        env:
+          RELEASE_IDENTIFIER: ${{ steps.release_metadata.outputs.release_identifier }}
+        run: |
+          set -euo pipefail
+
+          artifact_name="${BETA_ARTIFACT_NAME_PREFIX}-${RELEASE_IDENTIFIER}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_checksum="$(sha256sum "${ARTIFACT_PATH}" | awk '{print $1}')"
+
+          {
+            echo "artifact_name=${artifact_name}"
+            echo "artifact_checksum=${artifact_checksum}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ steps.artifact_metadata.outputs.artifact_name }}
+          path: ${{ env.ARTIFACT_PATH }}
+
+  deploy_to_beta:
+    name: Deploy to Beta
+    runs-on: ubuntu-24.04
+    needs: build_artifact
+    permissions: {}
+    environment: wire-webapp-staging
+
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ needs.build_artifact.outputs.artifact_name }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
+        with:
+          aws-access-key-id: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy to Beta
+        id: deploy
+        uses: aws-actions/aws-elasticbeanstalk-deploy@1f56e4e813ae4eb167e69ca324234c336c1df573
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          application-name: Webapp
+          environment-name: ${{ env.BETA_ENVIRONMENT_NAME }}
+          version-label: ${{ needs.build_artifact.outputs.release_identifier }}-${{ github.run_id }}-${{ github.run_attempt }}-beta
+          deployment-package-path: ebs.zip
+          wait-for-deployment: true
+          wait-for-environment-recovery: true
+          deployment-timeout: 150
+          use-existing-application-version-if-available: true
+
+  create_beta_tag:
+    name: Create Beta tag
+    runs-on: ubuntu-24.04
+    needs: [build_artifact, deploy_to_beta]
+    permissions:
+      contents: write
+    outputs:
+      beta_tag_name: ${{ steps.beta_tag.outputs.beta_tag_name }}
+
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.build_artifact.outputs.release_commit_sha }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: ./bin/yarn --immutable
+
+      - name: Create and push Beta tag
+        id: beta_tag
+        env:
+          RELEASE_COMMIT_SHA: ${{ needs.build_artifact.outputs.release_commit_sha }}
+          RELEASE_IDENTIFIER: ${{ needs.build_artifact.outputs.release_identifier }}
+        run: |
+          set -euo pipefail
+
+          git fetch --tags origin
+
+          mapfile -t existing_beta_tag_names < <(git tag --list "${RELEASE_IDENTIFIER}-beta.*")
+          beta_tag_name="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts next-beta-tag "${RELEASE_IDENTIFIER}" "${existing_beta_tag_names[@]}")"
+
+          git config user.email "zebot@users.noreply.github.com"
+          git config user.name "Zebot"
+          git tag --annotate "$beta_tag_name" --message "Release $beta_tag_name" "$RELEASE_COMMIT_SHA"
+          git push origin "refs/tags/$beta_tag_name"
+
+          echo "beta_tag_name=${beta_tag_name}" >> "$GITHUB_OUTPUT"
+
+  run_e2e:
+    name: Run E2E against Beta
+    needs: [build_artifact, create_beta_tag]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/e2e-tests.yml
+    with:
+      webappUrl: https://wire-webapp-staging.zinfra.io/
+      backendUrl: https://staging-nginz-https.zinfra.io/
+      grep: '@regression|@crit-flow-web'
+      testinyRunName: Release ${{ needs.build_artifact.outputs.release_identifier }} ${{ needs.create_beta_tag.outputs.beta_tag_name }}
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
+
+  summarize_release:
+    name: Summarize release
+    runs-on: ubuntu-24.04
+    needs: [build_artifact, deploy_to_beta, create_beta_tag, run_e2e]
+    if: ${{ always() }}
+    permissions: {}
+
+    steps:
+      - name: Add release summary
+        env:
+          ARTIFACT_CHECKSUM: ${{ needs.build_artifact.outputs.artifact_checksum }}
+          ARTIFACT_NAME: ${{ needs.build_artifact.outputs.artifact_name }}
+          BETA_TAG_NAME: ${{ needs.create_beta_tag.outputs.beta_tag_name }}
+          E2E_REPORT_URL: ${{ needs.run_e2e.outputs.reportUrl }}
+          E2E_RESULT: ${{ needs.run_e2e.result }}
+          RELEASE_BRANCH: ${{ needs.build_artifact.outputs.release_branch }}
+          RELEASE_COMMIT_SHA: ${{ needs.build_artifact.outputs.release_commit_sha }}
+          RELEASE_IDENTIFIER: ${{ needs.build_artifact.outputs.release_identifier }}
+          RELEASE_REASON: ${{ inputs.reason }}
+          TESTINY_RUN_NAME: Release ${{ needs.build_artifact.outputs.release_identifier }} ${{ needs.create_beta_tag.outputs.beta_tag_name }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo '## Release Cloud Beta'
+            echo "- Release branch: ${RELEASE_BRANCH}"
+            echo "- Release identifier: ${RELEASE_IDENTIFIER}"
+            echo "- Commit SHA: ${RELEASE_COMMIT_SHA}"
+            echo "- Beta environment: ${BETA_ENVIRONMENT_NAME}"
+            echo "- Beta URL: ${BETA_WEBAPP_URL}"
+            echo "- Artifact name: ${ARTIFACT_NAME}"
+            echo "- Artifact checksum: ${ARTIFACT_CHECKSUM}"
+            echo "- Beta tag: ${BETA_TAG_NAME}"
+            echo "- E2E result: ${E2E_RESULT}"
+
+            if [[ -n "${E2E_REPORT_URL}" ]]; then
+              echo "- E2E report URL: ${E2E_REPORT_URL}"
+            fi
+
+            if [[ -n "${RELEASE_REASON}" ]]; then
+              echo "- Reason: ${RELEASE_REASON}"
+            fi
+
+            echo "- Testiny run name: ${TESTINY_RUN_NAME}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  notify_release_failure:
+    name: Notify release failure
+    runs-on: ubuntu-24.04
+    needs: [build_artifact, deploy_to_beta, create_beta_tag, run_e2e]
+    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
+    permissions: {}
+
+    steps:
+      - name: Announce release failure
+        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+        with:
+          status: failure
+          text: |
+            Release Cloud Beta failed for ${{ needs.build_artifact.outputs.release_branch || inputs.release_branch }} (${{ needs.build_artifact.outputs.release_identifier || needs.build_artifact.outputs.release_branch || inputs.release_branch }})
+            Triggered by: ${{ github.actor }}
+            Build log: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/bin/releaseMetadataCli.test.ts
+++ b/bin/releaseMetadataCli.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {runReleaseMetadataCli} from './releaseMetadataCli';
+
+type ReleaseMetadataCliTestResult = {
+  readonly errors: readonly string[];
+  readonly exitCode: number;
+  readonly outputs: readonly string[];
+};
+
+function runCommand(commandLineArguments: readonly string[]): ReleaseMetadataCliTestResult {
+  const errors: string[] = [];
+  const outputs: string[] = [];
+  const exitCode = runReleaseMetadataCli(commandLineArguments, {
+    writeError(message) {
+      errors.push(message);
+    },
+    writeOutput(message) {
+      outputs.push(message);
+    },
+  });
+
+  return {errors, exitCode, outputs};
+}
+
+describe('releaseMetadataCli', () => {
+  it('prints the release identifier from a valid release branch name', () => {
+    const actualResult = runCommand(['release-identifier-from-branch', 'release/2026-06-19.1']);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['2026-06-19.1'],
+    });
+  });
+
+  it('rejects an invalid release branch name', () => {
+    const actualResult = runCommand(['release-identifier-from-branch', 'release/2026-06-19.0']);
+
+    expect(actualResult).toEqual({
+      errors: ['Invalid release branch name: release/2026-06-19.0'],
+      exitCode: 1,
+      outputs: [],
+    });
+  });
+
+  it('prints the next beta tag name for the release identifier', () => {
+    const actualResult = runCommand([
+      'next-beta-tag',
+      '2026-06-19.1',
+      '2026-06-18.1-beta.9',
+      '2026-06-19.1-beta.1',
+      '2026-06-19.1-beta.2',
+      '2026-06-19.1-production',
+    ]);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['2026-06-19.1-beta.3'],
+    });
+  });
+
+  it('prints usage text for missing command arguments', () => {
+    const actualResult = runCommand(['next-beta-tag']);
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.outputs).toEqual([]);
+    expect(actualResult.errors[0]).toContain('Usage:');
+  });
+});

--- a/bin/releaseMetadataCli.ts
+++ b/bin/releaseMetadataCli.ts
@@ -1,0 +1,75 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import process from 'node:process';
+
+import {createNextBetaTagName, extractReleaseIdentifierFromBranchName} from './releaseMetadata';
+
+type ReleaseMetadataCliDependencies = {
+  readonly writeError: (message: string) => void;
+  readonly writeOutput: (message: string) => void;
+};
+
+const usageText = [
+  'Usage:',
+  '  releaseMetadataCli.ts release-identifier-from-branch <release/YYYY-MM-DD.N>',
+  '  releaseMetadataCli.ts next-beta-tag <YYYY-MM-DD.N> [existing-tag ...]',
+].join('\n');
+
+function writeResult(
+  result: ReturnType<typeof extractReleaseIdentifierFromBranchName> | ReturnType<typeof createNextBetaTagName>,
+  dependencies: ReleaseMetadataCliDependencies,
+): number {
+  if (result.isErr) {
+    dependencies.writeError(result.error.message);
+    return 1;
+  }
+
+  dependencies.writeOutput(result.value);
+  return 0;
+}
+
+export function runReleaseMetadataCli(
+  commandLineArguments: readonly string[],
+  dependencies: ReleaseMetadataCliDependencies,
+): number {
+  const [commandName, primaryValue, ...remainingValues] = commandLineArguments;
+
+  if (commandName === 'release-identifier-from-branch' && primaryValue !== undefined) {
+    return writeResult(extractReleaseIdentifierFromBranchName(primaryValue), dependencies);
+  }
+
+  if (commandName === 'next-beta-tag' && primaryValue !== undefined) {
+    return writeResult(createNextBetaTagName(primaryValue, remainingValues), dependencies);
+  }
+
+  dependencies.writeError(usageText);
+  return 1;
+}
+
+if (require.main === module) {
+  process.exitCode = runReleaseMetadataCli(process.argv.slice(2), {
+    writeError(message): void {
+      console.error(message);
+    },
+    writeOutput(message): void {
+      console.log(message);
+    },
+  });
+}


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Summary

Adds the first release-cloud workflow step for ADR 0002.

This introduces release branch → Beta deployment automation.

## Details

The workflow:

- is manually triggered during the transition
- accepts an explicit `release_branch` input
- validates `release/YYYY-MM-DD.N`
- builds the release artifact once
- deploys the artifact to the temporary Beta mapping
- creates `YYYY-MM-DD.N-beta.M` only after successful Beta deployment
- runs E2E against Beta
- reports E2E results to Testiny

During the transition, ADR “Beta” maps to the existing `wire-webapp-staging` environment.

## Notes

During the transition this workflow is manual-only.

It intentionally does not run automatically on `release/**` yet, because the old release process is still active. This avoids surprising current release operations by deploying to the temporary Beta mapping, creating ADR-style Beta tags, running E2E, or reporting to Testiny automatically.

The automatic `release/**` trigger can be enabled later when the new release-cloud flow becomes the official Beta release path.

## Tracking

Part of https://github.com/wireapp/wire-webapp/issues/21597.

Follow-up to:

- https://github.com/wireapp/wire-webapp/pull/21598
- https://github.com/wireapp/wire-webapp/pull/21634
- https://github.com/wireapp/wire-webapp/pull/21641