### PR TITLE
Add assertion for modal to be the expected one to calling test [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -571,6 +571,8 @@ test.describe('Calling', () => {
     'I want to accept a group video call as a personal account guest',
     {tag: ['@TC-2852', '@regression']},
     async ({createPage}) => {
+      test.setTimeout(150_000);
+
       const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage()]);
       const {pages: ownerPages, modals: ownerModals} = PageManager.from(userAPage).webapp;
       const guestPages = PageManager.from(guestPage).webapp.pages;
@@ -602,8 +604,11 @@ test.describe('Calling', () => {
 
         await ownerPages.conversation().toggleGroupInformation();
         await ownerPages.conversation().clickCallButton();
+
         // Warning modal that guest started using a new device
+        await expect(ownerModals.confirm().modalTitle).toContainText('new device');
         await ownerModals.confirm().clickAction();
+
         await expect(ownerPages.calling().callCell).toBeVisible();
       });
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

We saw some failures in tests recently where accidentially team management was opened instead of the expected confirm dialog being clicked. To make the cause of the issue more visible and easier to debug I added an assertion for the modal to be the right one before clicking the confirm button.
The timeout was also increased as the test needs to wait for two sequential logins and a call to be established.