### PR TITLE
Replace WebSocket wrapper stuck in connecting state [WPB-21916]

### DIFF
--- a/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
@@ -352,6 +352,139 @@ describe('ReconnectingWebsocket', () => {
     RWS.disconnect();
   });
 
+  describe('connecting watchdog', () => {
+    const connectingTimeoutInMilliseconds = 20_000;
+
+    function createSocketFactory(
+      ...sockets: MockReconnectingWebsocketWrapper[]
+    ): jest.Mock<MockReconnectingWebsocketWrapper, []> {
+      const websocketFactory = jest.fn<MockReconnectingWebsocketWrapper, []>();
+
+      sockets.forEach(socket => {
+        websocketFactory.mockReturnValueOnce(socket);
+      });
+
+      return websocketFactory;
+    }
+
+    it('replaces the socket wrapper when it stays CONNECTING past the watchdog timeout', () => {
+      const deterministicWallClock = createDeterministicTimeoutWallClock(0);
+      const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const websocketFactory = createSocketFactory(firstSocket, secondSocket);
+      const RWS = createRWS(jest.fn(), {
+        ...defaultReconnectingWebsocketTestOptions,
+        wallClock: deterministicWallClock,
+        websocketFactory: Maybe.just(websocketFactory),
+      });
+
+      RWS.connect();
+
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds - 1);
+
+      expect(websocketFactory).toHaveBeenCalledTimes(1);
+      expect(RWS['socket']).toBe(firstSocket);
+      expect(firstSocket.close).not.toHaveBeenCalled();
+
+      deterministicWallClock.advanceByMilliseconds(1);
+
+      expect(firstSocket.close).toHaveBeenCalledTimes(1);
+      expect(firstSocket.close).toHaveBeenCalledWith(CloseEventCode.NORMAL_CLOSURE, 'Connecting timeout');
+      expect(websocketFactory).toHaveBeenCalledTimes(2);
+      expect(RWS['socket']).toBe(secondSocket);
+      expectSocketHandlersToBeBound(secondSocket);
+    });
+
+    it('does not replace the socket wrapper if it opens before the watchdog timeout', () => {
+      const deterministicWallClock = createDeterministicTimeoutWallClock(0);
+      const socket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const websocketFactory = createSocketFactory(socket);
+      const RWS = createRWS(jest.fn(), {
+        ...defaultReconnectingWebsocketTestOptions,
+        wallClock: deterministicWallClock,
+        websocketFactory: Maybe.just(websocketFactory),
+      });
+
+      RWS.connect();
+      socket.readyState = WEBSOCKET_STATE.OPEN;
+      socket.onopen?.({type: 'open'} as ReconnectingWebsocketEvent);
+
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds);
+
+      expect(websocketFactory).toHaveBeenCalledTimes(1);
+      expect(socket.close).not.toHaveBeenCalled();
+      expect(RWS['socket']).toBe(socket);
+    });
+
+    it('does not let a stale watchdog replace a newer socket wrapper', () => {
+      const deterministicWallClock = createDeterministicTimeoutWallClock(0);
+      const staleTimeoutWallClock: DeterministicTimeoutWallClock = {
+        ...deterministicWallClock,
+        clearTimeout: jest.fn(),
+      };
+      const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const websocketFactory = createSocketFactory(firstSocket, secondSocket);
+      const RWS = createRWS(jest.fn(), {
+        ...defaultReconnectingWebsocketTestOptions,
+        wallClock: staleTimeoutWallClock,
+        websocketFactory: Maybe.just(websocketFactory),
+      });
+
+      RWS.connect();
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds / 2);
+      RWS['replaceSocketWrapper'](firstSocket, 'Manual replacement');
+
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds / 2);
+
+      expect(firstSocket.close).toHaveBeenCalledTimes(1);
+      expect(firstSocket.close).toHaveBeenCalledWith(CloseEventCode.NORMAL_CLOSURE, 'Manual replacement');
+      expect(websocketFactory).toHaveBeenCalledTimes(2);
+      expect(RWS['socket']).toBe(secondSocket);
+    });
+
+    it('clears the connecting watchdog on disconnect', () => {
+      const deterministicWallClock = createDeterministicTimeoutWallClock(0);
+      const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const websocketFactory = createSocketFactory(firstSocket, secondSocket);
+      const RWS = createRWS(jest.fn(), {
+        ...defaultReconnectingWebsocketTestOptions,
+        wallClock: deterministicWallClock,
+        websocketFactory: Maybe.just(websocketFactory),
+      });
+
+      RWS.connect();
+      RWS.disconnect();
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds);
+
+      expect(websocketFactory).toHaveBeenCalledTimes(1);
+      expect(RWS['socket']).toBe(firstSocket);
+    });
+
+    it('creates a fresh socket wrapper when closing the stale CONNECTING wrapper fails', () => {
+      const deterministicWallClock = createDeterministicTimeoutWallClock(0);
+      const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const websocketFactory = createSocketFactory(firstSocket, secondSocket);
+      const RWS = createRWS(jest.fn(), {
+        ...defaultReconnectingWebsocketTestOptions,
+        wallClock: deterministicWallClock,
+        websocketFactory: Maybe.just(websocketFactory),
+      });
+      firstSocket.close.mockImplementation(() => {
+        throw new Error('close failed');
+      });
+
+      RWS.connect();
+
+      expect(() => deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds)).not.toThrow();
+      expect(firstSocket.close).toHaveBeenCalledTimes(1);
+      expect(websocketFactory).toHaveBeenCalledTimes(2);
+      expect(RWS['socket']).toBe(secondSocket);
+    });
+  });
+
   /**
    * Note that on a real interruption of the connection the ReconnectingWebsocket will not call "onClose" and "onOpen" again
    * but it will call "onReconnect" again. So this test checks at least the second call of "onReconnect".

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -55,6 +55,7 @@ export type LongRunningRetryDetails = {
 type IntervalIdentifier = ReturnType<typeof globalThis.setInterval>;
 
 const longRunningRetryThresholdInMilliseconds = TimeUtil.TimeInMillis.MINUTE;
+const connectingTimeoutInMilliseconds = TimeUtil.TimeInMillis.SECOND * 20;
 
 type BackFromSleepHandler = typeof onBackFromSleep;
 
@@ -94,6 +95,7 @@ export class ReconnectingWebsocket {
   private readonly logger: logdown.Logger;
   private socket?: ReconnectingWebsocketWrapper;
   private pingerId?: IntervalIdentifier;
+  private connectingTimeoutId?: TimeoutIdentifier;
   private readonly PING_INTERVAL = TimeUtil.TimeInMillis.SECOND * 20;
   private hasUnansweredPing: boolean;
   private onOpen?: (event: Event) => void;
@@ -165,7 +167,7 @@ export class ReconnectingWebsocket {
 
         this.stopPinging();
         this.hasUnansweredPing = false;
-        this.replaceSocketWrapperAfterWake(socket);
+        this.replaceSocketWrapper(socket, 'Back from sleep');
       },
       Nothing: () => {
         this.logger.debug('Back from sleep detected, WebSocket instance does not exist, skipping reconnect');
@@ -198,6 +200,7 @@ export class ReconnectingWebsocket {
 
   private readonly internalOnOpen = (event: Event) => {
     this.logger.info(`WebSocket opened (reconnect attempt #${this.reconnectAttemptCount})`);
+    this.stopConnectingWatchdog();
     this.resetLongRunningRetrySequence();
     if (this.socket) {
       this.socket.binaryType = 'arraybuffer';
@@ -224,6 +227,7 @@ export class ReconnectingWebsocket {
     this.logger.info(
       `WebSocket closed — code: ${event?.code}, reason: "${event?.reason || 'none'}", wasClean: ${event?.wasClean ?? 'unknown'}`,
     );
+    this.stopConnectingWatchdog();
     this.stopPinging();
     this.resolvePendingHealthChecks(false);
     if (this.onClose) {
@@ -276,11 +280,48 @@ export class ReconnectingWebsocket {
     }
   }
 
-  private replaceSocketWrapperAfterWake(socket: ReconnectingWebsocketWrapper): void {
+  private startConnectingWatchdog(socket: ReconnectingWebsocketWrapper): void {
+    this.stopConnectingWatchdog();
+
+    this.connectingTimeoutId = this.options.wallClock.setTimeout(() => {
+      if (this.socket !== socket) {
+        return;
+      }
+
+      this.connectingTimeoutId = undefined;
+
+      if (socket.readyState !== WEBSOCKET_STATE.CONNECTING) {
+        return;
+      }
+
+      this.logger.warn(
+        `WebSocket wrapper stayed CONNECTING for ${connectingTimeoutInMilliseconds}ms, replacing wrapper`,
+      );
+
+      this.replaceSocketWrapper(socket, 'Connecting timeout');
+    }, connectingTimeoutInMilliseconds);
+  }
+
+  private stopConnectingWatchdog(): void {
+    if (is.undefined(this.connectingTimeoutId) === false) {
+      this.options.wallClock.clearTimeout(this.connectingTimeoutId);
+      this.connectingTimeoutId = undefined;
+    }
+  }
+
+  private replaceSocketWrapper(socket: ReconnectingWebsocketWrapper, reason: string): void {
+    if (this.socket !== socket) {
+      return;
+    }
+
+    this.stopPinging();
+    this.hasUnansweredPing = false;
+    this.stopConnectingWatchdog();
+
     try {
-      socket.close(CloseEventCode.NORMAL_CLOSURE, 'Back from sleep');
+      socket.close(CloseEventCode.NORMAL_CLOSURE, reason);
     } catch (error) {
-      this.logger.warn('Failed to close stale WebSocket wrapper after wake', error);
+      this.logger.warn(`Failed to close stale WebSocket wrapper during ${reason}`, error);
     }
 
     this.createAndBindSocketWrapper();
@@ -317,6 +358,7 @@ export class ReconnectingWebsocket {
     const nextSocket = this.getReconnectingWebsocket();
     this.socket = nextSocket;
     this.bindSocketHandlers(nextSocket);
+    this.startConnectingWatchdog(nextSocket);
   }
 
   private bindSocketHandlers(socket: ReconnectingWebsocketWrapper): void {
@@ -425,6 +467,7 @@ export class ReconnectingWebsocket {
    */
   private cleanup(): void {
     this.stopPinging();
+    this.stopConnectingWatchdog();
     if (this.stopBackFromSleepHandler.isJust) {
       this.stopBackFromSleepHandler.value();
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem

Some WebSocket connections still do not recover after MacBook sleep/wake.

The latest diagnostics showed a new stuck state:

```text
notificationHandlingState: CLOSED
rawWebSocketState: CONNECTING
rwsReadyState: CONNECTING
rwsConnectLock: true
rwsShouldReconnect: true
rwsRetryCount: 0
hasValidAccessToken: true
navigatorOnline: true
visibilityState: visible
```

So this is no longer primarily a token-refresh issue. The token is valid, the app is online and no refresh is in flight.

The underlying `reconnecting-websocket` wrapper is stuck in `CONNECTING` and does not progress to `OPEN` or `CLOSED`.

## Root cause

The app-level recovery does not help here because the connection is already considered `CONNECTING`.

While in that state, health checks are skipped and the app can remain stuck indefinitely.

A full reload fixes the issue because it creates a completely fresh WebSocket wrapper.

## Change

This adds a transport-level connecting watchdog.

If the same WebSocket wrapper remains in `CONNECTING` for too long, we:

- close the old wrapper best-effort
- ignore late events from the old wrapper through the existing active-socket guard
- create and bind a fresh wrapper
- allow normal reconnect flow to continue

This gives us the same recovery effect as a reload, without requiring a reload.