### PR TITLE
Migrate WebSocket reconnect wrapper to partysocket [WPB-21916]

### DIFF
--- a/libraries/api-client/package.json
+++ b/libraries/api-client/package.json
@@ -27,7 +27,7 @@
     "cells-sdk-ts": "0.1.1-alpha18",
     "http-status-codes": "2.3.0",
     "pako": "2.1.0",
-    "reconnecting-websocket": "4.4.0",
+    "partysocket": "1.3.0",
     "spark-md5": "3.0.2",
     "tough-cookie": "4.1.4",
     "ws": "8.21.0",

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.backFromSleep.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.backFromSleep.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {CloseEvent, ErrorEvent, Event} from 'reconnecting-websocket';
+import type {CloseEvent, ErrorEvent} from 'partysocket/ws';
 import {Maybe} from 'true-myth';
 
 import {

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
@@ -21,7 +21,7 @@
 
 import is from '@sindresorhus/is';
 import {once} from 'events';
-import type {CloseEvent, ErrorEvent, Event as ReconnectingWebsocketEvent} from 'reconnecting-websocket';
+import type {CloseEvent, ErrorEvent} from 'partysocket/ws';
 import {Maybe} from 'true-myth';
 import {Server as WebSocketServer} from 'ws';
 
@@ -50,7 +50,7 @@ type MockReconnectingWebsocketWrapper = {
   onclose: ((event: CloseEvent) => void) | null;
   onerror: ((event: ErrorEvent) => void) | null;
   onmessage: ((event: MessageEvent) => void) | null;
-  onopen: ((event: ReconnectingWebsocketEvent) => void) | null;
+  onopen: ((event: Event) => void) | null;
   readyState: WEBSOCKET_STATE;
   reconnect: jest.Mock;
   send: jest.Mock;
@@ -407,7 +407,7 @@ describe('ReconnectingWebsocket', () => {
 
       RWS.connect();
       socket.readyState = WEBSOCKET_STATE.OPEN;
-      socket.onopen?.({type: 'open'} as ReconnectingWebsocketEvent);
+      socket.onopen?.({type: 'open'} as Event);
 
       deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds);
 

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -19,7 +19,7 @@
 
 import is from '@sindresorhus/is';
 import logdown from 'logdown';
-import RWS, {CloseEvent, ErrorEvent, Event, Options} from 'reconnecting-websocket';
+import PartySocketWebSocket, {type CloseEvent, type ErrorEvent, type Options} from 'partysocket/ws';
 import {Maybe} from 'true-myth';
 
 import {LogFactory, TimeUtil} from '@wireapp/commons';
@@ -60,11 +60,17 @@ const connectingTimeoutInMilliseconds = TimeUtil.TimeInMillis.SECOND * 20;
 type BackFromSleepHandler = typeof onBackFromSleep;
 
 type ReconnectingWebsocketWrapper = Pick<
-  RWS,
+  PartySocketWebSocket,
   'binaryType' | 'close' | 'onclose' | 'onerror' | 'onmessage' | 'onopen' | 'readyState' | 'reconnect' | 'send'
 >;
 
 type TimeoutIdentifier = ReturnType<typeof globalThis.setTimeout>;
+type WebSocketEventListener = (event: Event) => void;
+type WebSocketConstructor = new (url: string, protocols?: string | string[]) => WebSocket;
+type WebSocketWithEventListeners = WebSocket & {
+  addEventListener: WebSocket['addEventListener'];
+  removeEventListener: WebSocket['removeEventListener'];
+};
 
 export type ReconnectingWebsocketWallClock = {
   readonly currentTimestampInMilliseconds: number;
@@ -81,9 +87,75 @@ type ReconnectingWebsocketOptions = {
   readonly websocketFactory: Maybe<() => ReconnectingWebsocketWrapper>;
 };
 
+function normalizeMessageEventForPartysocket(event: Event): Event {
+  if (!('data' in event)) {
+    return event;
+  }
+
+  if ((event as MessageEvent).ports !== null) {
+    return event;
+  }
+
+  return {
+    data: (event as MessageEvent).data,
+    lastEventId: (event as MessageEvent).lastEventId,
+    origin: (event as MessageEvent).origin,
+    ports: [],
+    source: (event as MessageEvent).source,
+    type: event.type,
+  } as unknown as MessageEvent;
+}
+
+function createPartysocketCompatibleWebSocketConstructor(
+  WebSocketConstructor: WebSocketConstructor,
+): WebSocketConstructor {
+  return function PartysocketCompatibleWebSocket(url: string, protocols?: string | string[]) {
+    const socket = (
+      is.undefined(protocols) ? new WebSocketConstructor(url) : new WebSocketConstructor(url, protocols)
+    ) as WebSocketWithEventListeners;
+    const originalAddEventListener = socket.addEventListener.bind(socket) as EventTarget['addEventListener'];
+    const originalRemoveEventListener = socket.removeEventListener.bind(socket) as EventTarget['removeEventListener'];
+    const wrappedMessageListeners = new WeakMap<WebSocketEventListener, WebSocketEventListener>();
+
+    socket.addEventListener = ((
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | AddEventListenerOptions,
+    ) => {
+      if (type !== 'message' || !is.function_(listener)) {
+        originalAddEventListener(type, listener, options);
+        return;
+      }
+
+      const wrappedListener = (event: Event) => {
+        listener(normalizeMessageEventForPartysocket(event));
+      };
+      wrappedMessageListeners.set(listener as WebSocketEventListener, wrappedListener);
+      originalAddEventListener(type, wrappedListener as EventListener, options);
+    }) as WebSocket['addEventListener'];
+
+    socket.removeEventListener = ((
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | EventListenerOptions,
+    ) => {
+      if (type !== 'message' || !is.function_(listener)) {
+        originalRemoveEventListener(type, listener, options);
+        return;
+      }
+
+      const wrappedListener = wrappedMessageListeners.get(listener as WebSocketEventListener);
+      originalRemoveEventListener(type, (wrappedListener ?? listener) as EventListener, options);
+      wrappedMessageListeners.delete(listener as WebSocketEventListener);
+    }) as WebSocket['removeEventListener'];
+
+    return socket;
+  } as unknown as WebSocketConstructor;
+}
+
 export class ReconnectingWebsocket {
   private static readonly RECONNECTING_OPTIONS: Options = {
-    WebSocket: WebSocketNode,
+    WebSocket: createPartysocketCompatibleWebSocketConstructor(WebSocketNode),
     connectionTimeout: TimeUtil.TimeInMillis.SECOND * 4,
     debug: false,
     maxReconnectionDelay: TimeUtil.TimeInMillis.SECOND * 10,
@@ -251,6 +323,11 @@ export class ReconnectingWebsocket {
   private readonly sendPing = (): void => {
     if (!this.socket) {
       this.logger.debug('WebSocket instance does not exist, skipping ping');
+      return;
+    }
+
+    if (this.socket.readyState !== WEBSOCKET_STATE.OPEN) {
+      this.logger.debug(`WebSocket is not OPEN (state: ${WEBSOCKET_STATE[this.socket.readyState]}), skipping ping`);
       return;
     }
 
@@ -480,7 +557,11 @@ export class ReconnectingWebsocket {
         return websocketFactory();
       },
       Nothing: () => {
-        return new RWS(this.internalOnReconnect, undefined, ReconnectingWebsocket.RECONNECTING_OPTIONS);
+        return new PartySocketWebSocket(
+          this.internalOnReconnect,
+          undefined,
+          ReconnectingWebsocket.RECONNECTING_OPTIONS,
+        );
       },
     });
   }

--- a/libraries/api-client/src/tcp/webSocketClient.test.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.test.ts
@@ -384,6 +384,49 @@ describe('WebSocketClient', () => {
     });
   });
 
+  describe('buildWebSocketUrl', () => {
+    function createHttpClientWithWebSocketTokens(accessToken: string, nextMarkerToken: string): WebSocketHttpClient {
+      return {
+        ...fakeHttpClient,
+        accessTokenStore: {
+          getAccessToken: () => accessToken,
+          getNextMarkerToken: () => nextMarkerToken,
+        },
+      };
+    }
+
+    it('builds a legacy await WebSocket URL without the async sync marker', () => {
+      const websocketClient = createWebSocketClientWithTestWallClock(
+        'wss://websocket.example.test',
+        createHttpClientWithWebSocketTokens('access-token', 'marker-token'),
+      );
+      webSocketClients.push(websocketClient);
+
+      websocketClient.useVersion(MINIMUM_API_VERSION);
+      websocketClient['clientId'] = 'client-id';
+
+      expect(websocketClient.buildWebSocketUrl()).toBe(
+        'wss://websocket.example.test/await?access_token=access-token&client=client-id',
+      );
+    });
+
+    it('builds an async events WebSocket URL with the sync marker', () => {
+      const websocketClient = createWebSocketClientWithTestWallClock(
+        'wss://websocket.example.test',
+        createHttpClientWithWebSocketTokens('access-token', 'marker-token'),
+      );
+      webSocketClients.push(websocketClient);
+
+      websocketClient.useVersion(MINIMUM_API_VERSION);
+      websocketClient.useAsyncNotificationsSocket();
+      websocketClient['clientId'] = 'client-id';
+
+      expect(websocketClient.buildWebSocketUrl()).toBe(
+        `wss://websocket.example.test/v${MINIMUM_API_VERSION}/events?access_token=access-token&sync_marker=marker-token&client=client-id`,
+      );
+    });
+  });
+
   describe('connect', () => {
     const fakeNotification: ConsumableNotification = {
       type: ConsumableEvent.EVENT,

--- a/libraries/api-client/src/tcp/webSocketClient.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.ts
@@ -19,7 +19,7 @@
 
 import is from '@sindresorhus/is';
 import logdown from 'logdown';
-import {ErrorEvent} from 'reconnecting-websocket';
+import type {ErrorEvent} from 'partysocket/ws';
 import {Maybe} from 'true-myth';
 
 import {EventEmitter} from 'events';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11582,9 +11582,9 @@ __metadata:
     http-status-codes: "npm:2.3.0"
     jest: "npm:30.4.2"
     pako: "npm:2.1.0"
+    partysocket: "npm:1.3.0"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
-    reconnecting-websocket: "npm:4.4.0"
     spark-md5: "npm:3.0.2"
     tough-cookie: "npm:4.1.4"
     ts-node: "npm:10.9.2"
@@ -17439,6 +17439,13 @@ __metadata:
     stream-combiner: "npm:~0.0.4"
     through: "npm:~2.3.1"
   checksum: 10/48ea0e17df89ff45778c25e7111a6691401c902162823ddd7656d83fc972e75380f789f7a48f272f50fe7015420cc04f835d458560bf95e34b2c7a479570c8fb
+  languageName: node
+  linkType: hard
+
+"event-target-polyfill@npm:^0.0.4":
+  version: 0.0.4
+  resolution: "event-target-polyfill@npm:0.0.4"
+  checksum: 10/465f7abfc7d4716365cae732f6940732b0c48315358b228df80d13c85d1b55f2ff8c02c6c98bd1d474fe9e21119d40ff4d907dffe8387ae89ee8a09608365bf9
   languageName: node
   linkType: hard
 
@@ -24584,6 +24591,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"partysocket@npm:1.3.0":
+  version: 1.3.0
+  resolution: "partysocket@npm:1.3.0"
+  dependencies:
+    event-target-polyfill: "npm:^0.0.4"
+  peerDependencies:
+    react: ">=17"
+  peerDependenciesMeta:
+    react:
+      optional: true
+  checksum: 10/9e5566a87377b4337b2554d55c2a6586b5810bbf3db53de2196fc3f8132fe86253e2d3d16f90237f377f9ec24bde59b511798e80e3a5bfde12c2604d006684fe
+  languageName: node
+  linkType: hard
+
 "pascal-case@npm:^3.1.2":
   version: 3.1.2
   resolution: "pascal-case@npm:3.1.2"
@@ -27195,13 +27216,6 @@ __metadata:
   dependencies:
     resolve: "npm:^1.20.0"
   checksum: 10/ad3caed8afdefbc33fbc30e6d22b86c35b3d51c2005546f4e79bcc03c074df804b3640ad18945e6bef9ed12caedc035655ec1082f64a5e94c849ff939dc0a788
-  languageName: node
-  linkType: hard
-
-"reconnecting-websocket@npm:4.4.0":
-  version: 4.4.0
-  resolution: "reconnecting-websocket@npm:4.4.0"
-  checksum: 10/542b09b4604c4050833017e9602867d2dd76631de1790d46238e5a5857a41183e09faf38d373406e4ed7fef8614b43bf43c89aac677104997ccbbf6fa071338c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem

The WebSocket sleep/wake recovery path has been hardened in several small steps, but the underlying `reconnecting-websocket` dependency can still put us in fragile states.

We have seen cases where the internal reconnecting wrapper gets stuck in states like:

```text
readyState: CLOSED
_connectLock: true
_shouldReconnect: true
```

and:

```text
readyState: CONNECTING
_connectLock: true
_shouldReconnect: true
```

Reloading the app fixes those cases because it creates a fresh wrapper.

## Change

This migrates the internal reconnecting WebSocket implementation from `reconnecting-websocket` to [partysocket](https://www.npmjs.com/package/partysocket).

Wire's own `ReconnectingWebsocket` wrapper remains the stable boundary. Callers do not change.

The existing Wire-owned recovery behavior is kept:

- wake-from-sleep replaces stale wrappers
- `CLOSED` wrappers are recreated on connect
- wrappers stuck in `CONNECTING` are replaced by the watchdog
- stale events from replaced wrappers are ignored
- token refresh recovery stays outside the reconnecting library
- WebSocket URL logging remains redacted

## Why

[partysocket](https://www.npmjs.com/package/partysocket) is a maintained reconnecting WebSocket implementation with a compatible API shape for our use case.

This pull request does not try to solve the whole WebSocket architecture. It only replaces the underlying reconnecting implementation behind our existing wrapper, while keeping the recovery invariants we added during the sleep/wake investigation.