### PR TITLE
Preserve browser WebSocket fallback for PartySocket [WPB-21916]

### DIFF
--- a/libraries/api-client/src/tcp/reconnectingWebsocket.browserConstructor.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.browserConstructor.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createPartysocketCompatibleWebSocketConstructor} from './reconnectingWebsocket';
+
+describe('createPartysocketCompatibleWebSocketConstructor', () => {
+  it('preserves an undefined constructor so browser builds can use the global WebSocket fallback', () => {
+    const constructorForPartysocket = createPartysocketCompatibleWebSocketConstructor(undefined);
+
+    expect(constructorForPartysocket).toBeUndefined();
+  });
+
+  it('does not wrap the browser global WebSocket constructor', () => {
+    const originalWebSocketDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'WebSocket');
+
+    class BrowserWebSocket {}
+
+    Object.defineProperty(globalThis, 'WebSocket', {
+      configurable: true,
+      value: BrowserWebSocket,
+    });
+
+    try {
+      const constructorForPartysocket = createPartysocketCompatibleWebSocketConstructor(
+        BrowserWebSocket as unknown as typeof globalThis.WebSocket,
+      );
+
+      expect(constructorForPartysocket).toBe(BrowserWebSocket);
+    } finally {
+      if (originalWebSocketDescriptor) {
+        Object.defineProperty(globalThis, 'WebSocket', originalWebSocketDescriptor);
+      } else {
+        delete (globalThis as Partial<typeof globalThis>).WebSocket;
+      }
+    }
+  });
+});

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -106,7 +106,7 @@ function normalizeMessageEventForPartysocket(event: Event): Event {
   } as unknown as MessageEvent;
 }
 
-function createPartysocketCompatibleWebSocketConstructor(
+export function createPartysocketCompatibleWebSocketConstructor(
   WebSocketConstructor: WebSocketConstructor | undefined,
 ): WebSocketConstructor | undefined {
   if (is.undefined(WebSocketConstructor) || globalThis.WebSocket === WebSocketConstructor) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
When the API client is bundled for the webapp, the package browser shim replaces the Node WebSocket module with the browser shim. That shim does not export WebSocketNode, so the constructor passed into the PartySocket adapter can be undefined.

Keep undefined constructors untouched so PartySocket can fall back to the global browser WebSocket, matching the behavior the previous reconnecting-websocket integration relied on. Also avoid wrapping the browser global constructor.

Add a focused regression test for the browser-shimmed constructor path.


