### PR TITLE
Restart WebSocket connecting watchdog on reconnect [WPB-21916]

### DIFF
--- a/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
@@ -395,6 +395,174 @@ describe('ReconnectingWebsocket', () => {
       expectSocketHandlersToBeBound(secondSocket);
     });
 
+    it('restarts the watchdog from internalOnReconnect after close stopped it', async () => {
+      const deterministicWallClock = createDeterministicTimeoutWallClock(0);
+      const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const websocketFactory = createSocketFactory(firstSocket, secondSocket);
+      const RWS = createRWS(jest.fn().mockResolvedValue('ws://example.invalid'), {
+        ...defaultReconnectingWebsocketTestOptions,
+        wallClock: deterministicWallClock,
+        websocketFactory: Maybe.just(websocketFactory),
+      });
+
+      RWS.connect();
+
+      expect(RWS['connectingTimeoutId']).toBeDefined();
+
+      firstSocket.onclose?.({code: CloseEventCode.NORMAL_CLOSURE, reason: 'closed', wasClean: true} as CloseEvent);
+
+      expect(RWS['connectingTimeoutId']).toBeUndefined();
+
+      firstSocket.readyState = WEBSOCKET_STATE.CONNECTING;
+      await RWS['internalOnReconnect']();
+
+      expect(RWS['connectingTimeoutId']).toBeDefined();
+
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds);
+
+      expect(firstSocket.close).toHaveBeenCalledTimes(1);
+      expect(firstSocket.close).toHaveBeenCalledWith(CloseEventCode.NORMAL_CLOSURE, 'Connecting timeout');
+      expect(websocketFactory).toHaveBeenCalledTimes(2);
+      expect(RWS['socket']).toBe(secondSocket);
+    });
+
+    it('does not throw when internalOnReconnect runs before a socket is assigned', async () => {
+      const RWS = createRWS(jest.fn().mockResolvedValue('ws://example.invalid'));
+
+      await expect(RWS['internalOnReconnect']()).resolves.toBe('ws://example.invalid');
+    });
+
+    it('starts the watchdog from internalOnReconnect before the socket becomes CONNECTING', async () => {
+      const deterministicWallClock = createDeterministicTimeoutWallClock(0);
+      const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.OPEN);
+      const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const websocketFactory = createSocketFactory(firstSocket, secondSocket);
+      const RWS = createRWS(jest.fn().mockResolvedValue('ws://example.invalid'), {
+        ...defaultReconnectingWebsocketTestOptions,
+        wallClock: deterministicWallClock,
+        websocketFactory: Maybe.just(websocketFactory),
+      });
+
+      RWS.connect();
+      firstSocket.onopen?.({type: 'open'} as Event);
+
+      expect(RWS['connectingTimeoutId']).toBeUndefined();
+
+      await RWS['internalOnReconnect']();
+
+      expect(RWS['connectingTimeoutId']).toBeDefined();
+
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds);
+
+      expect(firstSocket.close).not.toHaveBeenCalled();
+      expect(websocketFactory).toHaveBeenCalledTimes(1);
+      expect(RWS['socket']).toBe(firstSocket);
+      expect(RWS['connectingTimeoutId']).toBeUndefined();
+    });
+
+    it('starts the watchdog when reconnecting in place', () => {
+      const deterministicWallClock = createDeterministicTimeoutWallClock(0);
+      const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.OPEN);
+      const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const websocketFactory = createSocketFactory(firstSocket, secondSocket);
+      firstSocket.reconnect.mockImplementation(() => {
+        firstSocket.readyState = WEBSOCKET_STATE.CONNECTING;
+      });
+      const RWS = createRWS(jest.fn(), {
+        ...defaultReconnectingWebsocketTestOptions,
+        wallClock: deterministicWallClock,
+        websocketFactory: Maybe.just(websocketFactory),
+      });
+
+      RWS.connect();
+      firstSocket.onopen?.({type: 'open'} as Event);
+
+      expect(RWS['connectingTimeoutId']).toBeUndefined();
+
+      RWS.connect();
+
+      expect(firstSocket.reconnect).toHaveBeenCalledTimes(1);
+      expect(RWS['connectingTimeoutId']).toBeDefined();
+
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds);
+
+      expect(firstSocket.close).toHaveBeenCalledTimes(1);
+      expect(firstSocket.close).toHaveBeenCalledWith(CloseEventCode.NORMAL_CLOSURE, 'Connecting timeout');
+      expect(websocketFactory).toHaveBeenCalledTimes(2);
+      expect(RWS['socket']).toBe(secondSocket);
+    });
+
+    it('does not let repeated internalOnReconnect watchdog timers replace a newer socket wrapper', async () => {
+      const deterministicWallClock = createDeterministicTimeoutWallClock(0);
+      let shouldClearTimeout = true;
+      const wallClockWithOptionalClear: DeterministicTimeoutWallClock = {
+        advanceByMilliseconds: deterministicWallClock.advanceByMilliseconds,
+        clearInterval: deterministicWallClock.clearInterval,
+        clearTimeout(timeoutIdentifier): void {
+          if (shouldClearTimeout) {
+            deterministicWallClock.clearTimeout(timeoutIdentifier);
+          }
+        },
+        get currentTimestampInMilliseconds() {
+          return deterministicWallClock.currentTimestampInMilliseconds;
+        },
+        setInterval: deterministicWallClock.setInterval,
+        setTimeout: deterministicWallClock.setTimeout,
+      };
+      const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const websocketFactory = createSocketFactory(firstSocket, secondSocket);
+      const RWS = createRWS(jest.fn().mockResolvedValue('ws://example.invalid'), {
+        ...defaultReconnectingWebsocketTestOptions,
+        wallClock: wallClockWithOptionalClear,
+        websocketFactory: Maybe.just(websocketFactory),
+      });
+
+      RWS.connect();
+      firstSocket.onclose?.({code: CloseEventCode.NORMAL_CLOSURE, reason: 'closed', wasClean: true} as CloseEvent);
+      firstSocket.readyState = WEBSOCKET_STATE.CONNECTING;
+      shouldClearTimeout = false;
+
+      await RWS['internalOnReconnect']();
+      await RWS['internalOnReconnect']();
+
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds / 2);
+      RWS['replaceSocketWrapper'](firstSocket, 'Manual replacement');
+
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds / 2);
+
+      expect(firstSocket.close).toHaveBeenCalledTimes(1);
+      expect(firstSocket.close).toHaveBeenCalledWith(CloseEventCode.NORMAL_CLOSURE, 'Manual replacement');
+      expect(websocketFactory).toHaveBeenCalledTimes(2);
+      expect(RWS['socket']).toBe(secondSocket);
+    });
+
+    it('clears the watchdog when a socket opens after internalOnReconnect', async () => {
+      const deterministicWallClock = createDeterministicTimeoutWallClock(0);
+      const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const websocketFactory = createSocketFactory(firstSocket, secondSocket);
+      const RWS = createRWS(jest.fn().mockResolvedValue('ws://example.invalid'), {
+        ...defaultReconnectingWebsocketTestOptions,
+        wallClock: deterministicWallClock,
+        websocketFactory: Maybe.just(websocketFactory),
+      });
+
+      RWS.connect();
+      await RWS['internalOnReconnect']();
+      firstSocket.readyState = WEBSOCKET_STATE.OPEN;
+      firstSocket.onopen?.({type: 'open'} as Event);
+
+      expect(RWS['connectingTimeoutId']).toBeUndefined();
+
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds);
+
+      expect(websocketFactory).toHaveBeenCalledTimes(1);
+      expect(firstSocket.close).not.toHaveBeenCalled();
+      expect(RWS['socket']).toBe(firstSocket);
+    });
+
     it('does not replace the socket wrapper if it opens before the watchdog timeout', () => {
       const deterministicWallClock = createDeterministicTimeoutWallClock(0);
       const socket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -290,6 +290,12 @@ export class ReconnectingWebsocket {
     const attempt = this.reconnectAttemptCount + 1;
     this.logger.info(`Connecting to WebSocket (attempt #${attempt})`);
     this.recordReconnectAttempt(this.options.wallClock.currentTimestampInMilliseconds);
+    const socket = this.socket;
+
+    if (!is.undefined(socket)) {
+      this.startConnectingWatchdog(socket);
+    }
+
     // The ping is needed to keep the connection alive as long as possible.
     // Otherwise the connection would be closed after 1 min of inactivity and re-established.
     if (this.isPingingEnabled) {
@@ -363,6 +369,9 @@ export class ReconnectingWebsocket {
 
   private startConnectingWatchdog(socket: ReconnectingWebsocketWrapper): void {
     this.stopConnectingWatchdog();
+    this.logger.debug(
+      `Starting WebSocket CONNECTING watchdog (state: ${WEBSOCKET_STATE[socket.readyState]} (${socket.readyState}), timeout: ${connectingTimeoutInMilliseconds}ms)`,
+    );
 
     this.connectingTimeoutId = this.options.wallClock.setTimeout(() => {
       if (this.socket !== socket) {
@@ -421,6 +430,7 @@ export class ReconnectingWebsocket {
         `Existing WebSocket instance detected in state ${WEBSOCKET_STATE[existingSocket.readyState]} (${existingSocket.readyState}); reconnecting in place`,
       );
       this.reconnectInPlace(existingSocket);
+      this.startConnectingWatchdog(existingSocket);
       return;
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem

Some WebSocket connections can still get stuck after sleep/wake even with the connecting watchdog deployed.

The latest diagnostics showed:

```text
notificationHandlingState: CLOSED
rawWebSocketState: CONNECTING
rwsReadyState: CONNECTING
rwsConnectLock: true
rwsShouldReconnect: true
hasValidAccessToken: true
accessTokenRefreshInFlight: false
sleepHandlerActive: true
connectingWatchdogActive: false
```

So the token is valid, no refresh is running, and the WebSocket wrapper is stuck in `CONNECTING`.

The important part is that the connecting watchdog is not active.

## Root cause

The watchdog was started when Wire created and bound a fresh WebSocket wrapper.

However, the watchdog is stopped when the underlying socket closes. PartySocket can then retry internally on the same wrapper. That reconnect attempt calls the async URL provider again, but Wire does not create a new wrapper in that path.

So the wrapper can enter `CONNECTING` again without a watchdog.

## Change

This restarts the connecting watchdog whenever the underlying reconnect attempt starts.

The watchdog is now active for:

- freshly created wrappers
- reconnect attempts started internally by PartySocket
- reconnect-in-place attempts on an existing wrapper

The watchdog remains socket-instance-safe. If a stale timer fires for an old wrapper, it does not replace the active wrapper.

## Why

The app-level recovery skips health checks while the connection is considered `CONNECTING`.

So if the WebSocket wrapper gets stuck in `CONNECTING` without a watchdog, nothing else recovers it.

The watchdog must cover every `CONNECTING` attempt, not only the initial wrapper creation.