### PR TITLE
Fix federated backup export/import e2e test [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -382,12 +382,18 @@ test.describe('Federation', () => {
           .conversationList()
           .getConversation(federatedUser.fullName, {protocol: 'mls'})
           .open();
+        await expect(normalUserDevice2Pages.conversation().getMessage({sender: normalUser})).toBeVisible();
         await expect(normalUserDevice2Pages.conversation().getMessage({sender: federatedUser})).toBeVisible();
       });
 
       await test.step('Verify group messages and media are restored on the new device', async () => {
         await normalUserDevice2Pages.conversationList().getConversation(groupName).open();
-        await expect(normalUserDevice2Pages.conversation().getMessage({sender: federatedUser})).toBeVisible();
+
+        await expect(
+          normalUserDevice2Pages
+            .conversation()
+            .getMessage({sender: federatedUser, content: 'Group message from federated user'}),
+        ).toBeVisible();
 
         const messageWithImage2Device = normalUserDevice2Pages
           .conversation()

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -391,7 +391,7 @@ test.describe('Federation', () => {
 
         const messageWithImage2Device = normalUserDevice2Pages
           .conversation()
-          .getMessage({sender: normalUser})
+          .getMessage({sender: federatedUser})
           .filter({has: normalUserDevice2.getByRole('img')});
         await expect(messageWithImage2Device).toBeVisible();
       });

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -320,20 +320,26 @@ test.describe('Federation', () => {
       });
 
       await test.step('Exchange direct messages and verify receipt', async () => {
-        await normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open();
         await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
+        const oneOnOneConversation = await normalUserPages
+          .conversationList()
+          .getConversation(federatedUser.fullName, {protocol: 'mls'})
+          .open();
 
         await normalUserPages.conversation().sendMessage('Message from normal user');
         await federatedUserPages.conversation().sendMessage('Message from federated user');
 
         await expect(normalUserPages.conversation().getMessage({sender: federatedUser})).toBeVisible();
         await expect(federatedUserPages.conversation().getMessage({sender: normalUser})).toBeVisible();
+
+        // Wait for messages to be read before exporting backup
+        await expect(oneOnOneConversation.unreadIndicator).not.toBeVisible();
       });
 
       await test.step('Create a group chat and exchange text and image messages', async () => {
         await createGroup(normalUserPages, groupName, [federatedUser]);
         await federatedUserPages.conversationList().getConversation(groupName).open();
-        await normalUserPages.conversationList().getConversation(groupName).open();
+        const groupConversation = await normalUserPages.conversationList().getConversation(groupName).open();
 
         await federatedUserPages.conversation().sendMessage('Group message from federated user');
         await shareAssetHelper(
@@ -351,6 +357,9 @@ test.describe('Federation', () => {
           .getMessage({sender: federatedUser})
           .filter({has: normalUserPage.getByRole('img')});
         await expect(messageWithImage).toBeVisible();
+
+        // Wait for messages to be read before exporting backup
+        await expect(groupConversation.unreadIndicator).not.toBeVisible();
       });
 
       const backupName = await test.step('Create and save backup for the normal user', async () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Within the most recent [release branches](https://github.com/wireapp/wire-webapp/actions/runs/28219195688/job/83597491230?pr=21650) there was a strict mode violation in one of the federation e2e tests
Nothing major but something which can happen if the messages aren't marked as read before the backup is exported. This change ensures the test stays deterministic and fixes an issue where the wrong user was used to assert on the sent image.