### PR TITLE
Fix WebSocket reconnect watchdog timing and guest link E2E flow [WPB-21916]

### DIFF
--- a/apps/webapp/test/e2e_tests/locators/visibility.ts
+++ b/apps/webapp/test/e2e_tests/locators/visibility.ts
@@ -1,0 +1,37 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Locator} from '@playwright/test';
+
+export async function isLocatorVisible(locator: Locator): Promise<boolean> {
+  try {
+    return await locator.isVisible();
+  } catch {
+    return false;
+  }
+}
+
+export async function waitForVisible(locator: Locator, timeout: number): Promise<boolean> {
+  try {
+    await locator.waitFor({state: 'visible', timeout});
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/joinGuestLinkPassword.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/joinGuestLinkPassword.modal.ts
@@ -30,9 +30,9 @@ export class JoinGuestLinkPasswordModal extends BaseModal {
   constructor(page: Page) {
     super(page);
 
-    this.passwordInput = this.modal.getByRole('textbox', {name: 'Conversation password'});
-    this.submitButton = this.modal.getByRole('button', {name: 'Join conversation'});
-    this.joinForm = this.modal;
+    this.passwordInput = page.getByRole('textbox', {name: /Conversation password/i});
+    this.submitButton = page.getByRole('button', {name: /^Join Conversation$/i});
+    this.joinForm = page.getByTestId('guest-password-join-form');
   }
 
   async joinConversation(password: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/joinGuestLinkPassword.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/joinGuestLinkPassword.modal.ts
@@ -32,7 +32,7 @@ export class JoinGuestLinkPasswordModal extends BaseModal {
 
     this.passwordInput = this.modal.getByRole('textbox', {name: 'Conversation password'});
     this.submitButton = this.modal.getByRole('button', {name: 'Join conversation'});
-    this.joinForm = this.modal.filter({has: this.passwordInput});
+    this.joinForm = this.modal;
   }
 
   async joinConversation(password: string) {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/modals/joinGuestLinkPassword.modal.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/modals/joinGuestLinkPassword.modal.ts
@@ -32,7 +32,7 @@ export class JoinGuestLinkPasswordModal extends BaseModal {
 
     this.passwordInput = this.modal.getByRole('textbox', {name: 'Conversation password'});
     this.submitButton = this.modal.getByRole('button', {name: 'Join conversation'});
-    this.joinForm = this.modal.getByTestId('guest-password-join-form');
+    this.joinForm = this.modal.filter({has: this.passwordInput});
   }
 
   async joinConversation(password: string) {

--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -17,9 +17,10 @@
  *
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Page} from '@playwright/test';
 
 import {getUser, User} from 'test/e2e_tests/data/user';
+import {isLocatorVisible, waitForVisible} from 'test/e2e_tests/locators/visibility';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {connectWithUser, loginUser, logOutUser} from 'test/e2e_tests/utils/userActions';
 
@@ -29,23 +30,6 @@ const SCIM_LOGIN_TIMEOUT = 120_000;
 const newDeviceModalTestId = 'modal-account-new-devices';
 const scimLoginPollIntervalMilliseconds = 1_000;
 const scimLoginMaximumAttempts = Math.ceil(SCIM_LOGIN_TIMEOUT / scimLoginPollIntervalMilliseconds);
-
-function isLocatorVisible(locator: Locator): Promise<boolean> {
-  return locator.isVisible().catch(() => {
-    return false;
-  });
-}
-
-async function waitForVisible(locator: Locator, timeout: number): Promise<boolean> {
-  return locator.waitFor({state: 'visible', timeout}).then(
-    () => {
-      return true;
-    },
-    () => {
-      return false;
-    },
-  );
-}
 
 async function dismissNewDeviceModalIfVisible(page: Page): Promise<boolean> {
   const newDeviceModal = page.getByTestId(newDeviceModalTestId);

--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -17,11 +17,103 @@
  *
  */
 
+import {Locator, Page} from '@playwright/test';
+
 import {getUser, User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {connectWithUser, loginUser, logOutUser} from 'test/e2e_tests/utils/userActions';
 
 import {test, expect, LOGIN_TIMEOUT, withLogin} from '../../test.fixtures';
+
+const SCIM_LOGIN_TIMEOUT = 120_000;
+const newDeviceModalTestId = 'modal-account-new-devices';
+const scimLoginPollIntervalMilliseconds = 1_000;
+const scimLoginMaximumAttempts = Math.ceil(SCIM_LOGIN_TIMEOUT / scimLoginPollIntervalMilliseconds);
+
+function isLocatorVisible(locator: Locator): Promise<boolean> {
+  return locator.isVisible().catch(() => {
+    return false;
+  });
+}
+
+async function waitForVisible(locator: Locator, timeout: number): Promise<boolean> {
+  return locator.waitFor({state: 'visible', timeout}).then(
+    () => {
+      return true;
+    },
+    () => {
+      return false;
+    },
+  );
+}
+
+async function dismissNewDeviceModalIfVisible(page: Page): Promise<boolean> {
+  const newDeviceModal = page.getByTestId(newDeviceModalTestId);
+
+  if (!(await waitForVisible(newDeviceModal, 500))) {
+    return false;
+  }
+
+  await newDeviceModal.getByRole('button', {name: /^Ok$/i}).click();
+  await expect(newDeviceModal).toBeHidden({timeout: 5_000});
+
+  return true;
+}
+
+async function completeScimPostLoginFlow(page: Page, pageManager: PageManager): Promise<void> {
+  const {pages, components} = pageManager.webapp;
+  const removeDeviceButton = page.getByRole('button', {name: 'Remove device'}).first();
+  const historyConfirmButton = pages.historyInfo().continueButton;
+  const sidebar = components.conversationSidebar().sidebar;
+
+  for (let attempt = 0; attempt < scimLoginMaximumAttempts; attempt += 1) {
+    await dismissNewDeviceModalIfVisible(page);
+
+    if (await isLocatorVisible(sidebar)) {
+      return;
+    }
+
+    if (await waitForVisible(removeDeviceButton, 500)) {
+      await removeDeviceButton.click();
+      continue;
+    }
+
+    if (await waitForVisible(historyConfirmButton, 500)) {
+      await historyConfirmButton.click();
+      continue;
+    }
+
+    await page.waitForTimeout(scimLoginPollIntervalMilliseconds);
+  }
+
+  throw new Error(`SCIM login did not reach the sidebar within ${SCIM_LOGIN_TIMEOUT}ms`);
+}
+
+async function openAccountSettingsForScim(page: Page, pageManager: PageManager): Promise<void> {
+  const {pages, components} = pageManager.webapp;
+  const accountHeading = page.getByRole('heading', {name: 'Account', level: 2});
+
+  await expect(async () => {
+    await dismissNewDeviceModalIfVisible(page);
+
+    if (!(await isLocatorVisible(pages.settings().accountButton))) {
+      await components.conversationSidebar().preferencesButton.click({timeout: 5_000});
+    }
+
+    await dismissNewDeviceModalIfVisible(page);
+
+    if (await isLocatorVisible(accountHeading)) {
+      return;
+    }
+
+    await pages.settings().accountButton.click({timeout: 5_000});
+    await dismissNewDeviceModalIfVisible(page);
+    await expect(accountHeading).toBeVisible({timeout: 5_000});
+  }).toPass({
+    timeout: 60_000,
+    intervals: [500, 1_000, 2_000],
+  });
+}
 
 test.describe('account settings', () => {
   let owner: User;
@@ -89,11 +181,13 @@ test.describe('account settings', () => {
     'I should not be able to change email of user managed by SCIM',
     {tag: ['@TC-60', '@regression']},
     async ({context, createPage}) => {
+      test.setTimeout(180_000);
+
       const page = await createPage(context);
       const pageManager = PageManager.from(page);
       await pageManager.openMainPage();
 
-      const {pages, components} = pageManager.webapp;
+      const {pages} = pageManager.webapp;
       const [idpPage] = await Promise.all([
         context.waitForEvent('page'),
         pages.singleSignOn().enterEmailOnSSOPage(ssoUser.email),
@@ -105,18 +199,12 @@ test.describe('account settings', () => {
         await idpPage.getByRole('button', {name: 'Sign In'}).click();
       });
 
-      await test.step('Remove an existing device and confirm new history', async () => {
-        // Since this test re-uses the same user over and over again we need to always remove one of the previously registered devices
-        await page.getByRole('button', {name: 'Remove device'}).first().click({timeout: LOGIN_TIMEOUT});
-        // We will also always be prompted to confirm the new history on this device
-        await pages.historyInfo().clickConfirmButton();
-        await expect(components.conversationSidebar().sidebar, `Login took more than ${LOGIN_TIMEOUT}s`).toBeVisible({
-          timeout: LOGIN_TIMEOUT,
-        });
+      await test.step('Complete post-login flow', async () => {
+        await completeScimPostLoginFlow(page, pageManager);
       });
 
-      await pages.sidebar().clickPreferencesButton();
-      await pages.settings().accountButton.click();
+      await openAccountSettingsForScim(page, pageManager);
+      await dismissNewDeviceModalIfVisible(page);
       await expect(pages.account().emailDisplay).not.toBeVisible();
     },
   );

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -1,4 +1,4 @@
-import {Page} from 'playwright/test';
+import {Locator, Page} from 'playwright/test';
 import {getUser, User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin, Team, LOGIN_TIMEOUT, withGuestUser} from 'test/e2e_tests/test.fixtures';
@@ -13,13 +13,52 @@ import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActio
  * * @returns A promise that resolves to the generated guest link string.
  */
 
-const generateGroupGuestsLink = async (pages: PageManager['webapp']['pages'], groupName: string, password?: string) => {
+async function generateGroupGuestsLink(
+  pages: PageManager['webapp']['pages'],
+  groupName: string,
+  password?: string,
+): Promise<string> {
   await pages.conversationList().getConversation(groupName).open();
   await pages.conversation().toggleGroupInformation();
   await pages.conversationDetails().openGuestOptions();
 
   return await pages.guestOptions().createLink({password});
-};
+}
+
+function waitForFirstVisibleLocator(locators: Locator[], timeout: number): Promise<Locator | undefined> {
+  return Promise.race(
+    locators.map(async locator => {
+      try {
+        await locator.waitFor({state: 'visible', timeout});
+        return locator;
+      } catch {
+        return undefined;
+      }
+    }),
+  );
+}
+
+async function openPasswordJoinFormAsExistingUser(
+  guestPages: PageManager['webapp']['pages'],
+  guestBModals: PageManager['webapp']['modals'],
+  guestUser: User,
+): Promise<void> {
+  const joinAsMemberButton = guestPages.conversationJoin().joinAsMemberButton;
+  const passwordJoinForm = guestBModals.joinGuestLinkPassword().joinForm;
+
+  await guestPages.login().login(guestUser);
+
+  const visiblePostLoginTarget = await waitForFirstVisibleLocator(
+    [joinAsMemberButton, passwordJoinForm],
+    LOGIN_TIMEOUT,
+  );
+
+  if (visiblePostLoginTarget === joinAsMemberButton) {
+    await joinAsMemberButton.click();
+  }
+
+  await expect(passwordJoinForm).toBeVisible();
+}
 
 test.describe('Guestroom', () => {
   let team: Team;
@@ -55,8 +94,7 @@ test.describe('Guestroom', () => {
         await guestPages.conversationJoin().joinBrowserButton.click();
         await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
 
-        await guestPages.login().login(guestUser);
-        await expect(guestBModals.joinGuestLinkPassword().joinForm).toBeVisible();
+        await openPasswordJoinFormAsExistingUser(guestPages, guestBModals, guestUser);
 
         await guestBModals.joinGuestLinkPassword().joinConversation('WrongPassword');
         await expect(guestBModals.joinGuestLinkPassword().joinForm).toContainText(

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -1,5 +1,7 @@
 import {Locator, Page} from 'playwright/test';
+
 import {getUser, User} from 'test/e2e_tests/data/user';
+import {isLocatorVisible, waitForVisible} from 'test/e2e_tests/locators/visibility';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin, Team, LOGIN_TIMEOUT, withGuestUser} from 'test/e2e_tests/test.fixtures';
 import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
@@ -44,23 +46,6 @@ async function keepCurrentPageOnTestEnvironment(page: Page): Promise<void> {
   currentUrl.port = testEnvironmentUrl.port;
 
   await page.goto(currentUrl.toString());
-}
-
-function isLocatorVisible(locator: Locator): Promise<boolean> {
-  return locator.isVisible().catch(() => {
-    return false;
-  });
-}
-
-async function waitForVisible(locator: Locator, timeout: number): Promise<boolean> {
-  return locator.waitFor({state: 'visible', timeout}).then(
-    () => {
-      return true;
-    },
-    () => {
-      return false;
-    },
-  );
 }
 
 async function completeEnterpriseGuestroomPostLoginFlow(

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -25,6 +25,74 @@ async function generateGroupGuestsLink(
   return await pages.guestOptions().createLink({password});
 }
 
+const guestroomEnterpriseLoginTimeout = 120_000;
+const guestroomEnterpriseLoginPollInterval = 1_000;
+const guestroomEnterpriseLoginMaximumAttempts = Math.ceil(
+  guestroomEnterpriseLoginTimeout / guestroomEnterpriseLoginPollInterval,
+);
+
+async function keepCurrentPageOnTestEnvironment(page: Page): Promise<void> {
+  if (process.env.WEBAPP_URL === undefined) {
+    throw new Error('Missing env var "WEBAPP_URL"');
+  }
+
+  const testEnvironmentUrl = new URL(process.env.WEBAPP_URL);
+  const currentUrl = new URL(page.url());
+
+  currentUrl.protocol = testEnvironmentUrl.protocol;
+  currentUrl.hostname = testEnvironmentUrl.hostname;
+  currentUrl.port = testEnvironmentUrl.port;
+
+  await page.goto(currentUrl.toString());
+}
+
+function isLocatorVisible(locator: Locator): Promise<boolean> {
+  return locator.isVisible().catch(() => {
+    return false;
+  });
+}
+
+async function waitForVisible(locator: Locator, timeout: number): Promise<boolean> {
+  return locator.waitFor({state: 'visible', timeout}).then(
+    () => {
+      return true;
+    },
+    () => {
+      return false;
+    },
+  );
+}
+
+async function completeEnterpriseGuestroomPostLoginFlow(
+  page: Page,
+  pages: PageManager['webapp']['pages'],
+  components: PageManager['webapp']['components'],
+): Promise<void> {
+  const removeDeviceButton = page.getByRole('button', {name: 'Remove device'}).first();
+  const historyConfirmButton = pages.historyInfo().continueButton;
+  const sidebar = components.conversationSidebar().sidebar;
+
+  for (let attempt = 0; attempt < guestroomEnterpriseLoginMaximumAttempts; attempt += 1) {
+    if (await isLocatorVisible(sidebar)) {
+      return;
+    }
+
+    if (await waitForVisible(removeDeviceButton, 500)) {
+      await removeDeviceButton.click();
+      continue;
+    }
+
+    if (await waitForVisible(historyConfirmButton, 500)) {
+      await historyConfirmButton.click();
+      continue;
+    }
+
+    await page.waitForTimeout(guestroomEnterpriseLoginPollInterval);
+  }
+
+  throw new Error(`Guestroom enterprise login did not reach the sidebar within ${guestroomEnterpriseLoginTimeout}ms`);
+}
+
 function waitForFirstVisibleLocator(locators: Locator[], timeout: number): Promise<Locator | undefined> {
   return Promise.race(
     locators.map(async locator => {
@@ -641,6 +709,7 @@ test.describe('Guestroom', () => {
 
       await guestPage.goto(createdLink.toString());
       await guestPages.conversationJoin().joinBrowserButton.click();
+      await keepCurrentPageOnTestEnvironment(guestPage);
       await expect(guestPages.conversationJoin().enterpriseLoginButton).toBeVisible();
 
       await guestPages.conversationJoin().enterpriseLoginButton.click();
@@ -655,15 +724,7 @@ test.describe('Guestroom', () => {
       await idpPage.getByRole('textbox', {name: 'Password'}).fill(ssoUser.password);
       await idpPage.getByRole('button', {name: 'Sign In'}).click();
 
-      await guestPage.getByRole('button', {name: 'Remove device'}).first().click({timeout: LOGIN_TIMEOUT});
-      // // We will also always be prompted to confirm the new history on this device
-      await guestPages.historyInfo().clickConfirmButton();
-
-      await expect(guestComponents.conversationSidebar().sidebar, `Login took more than ${LOGIN_TIMEOUT}s`).toBeVisible(
-        {
-          timeout: LOGIN_TIMEOUT,
-        },
-      );
+      await completeEnterpriseGuestroomPostLoginFlow(guestPage, guestPages, guestComponents);
 
       await expect(guestPages.conversationList().getConversation(groupName)).toBeVisible();
     },

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -93,17 +93,17 @@ async function completeEnterpriseGuestroomPostLoginFlow(
   throw new Error(`Guestroom enterprise login did not reach the sidebar within ${guestroomEnterpriseLoginTimeout}ms`);
 }
 
-function waitForFirstVisibleLocator(locators: Locator[], timeout: number): Promise<Locator | undefined> {
-  return Promise.race(
-    locators.map(async locator => {
-      try {
+async function waitForFirstVisibleLocator(locators: Locator[], timeout: number): Promise<Locator | undefined> {
+  try {
+    return await Promise.any(
+      locators.map(async locator => {
         await locator.waitFor({state: 'visible', timeout});
         return locator;
-      } catch {
-        return undefined;
-      }
-    }),
-  );
+      }),
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 async function openPasswordJoinFormAsExistingUser(

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
@@ -262,9 +262,13 @@ describe('ReconnectingWebsocket', () => {
     RWS.connect();
   });
 
-  it('reconnects in place when connect is called on an open socket', () => {
+  it.each([
+    {socketState: WEBSOCKET_STATE.OPEN, socketStateName: 'OPEN'},
+    {socketState: WEBSOCKET_STATE.CONNECTING, socketStateName: 'CONNECTING'},
+    {socketState: WEBSOCKET_STATE.CLOSING, socketStateName: 'CLOSING'},
+  ])('reconnects the existing $socketStateName socket in place when connect is called again', ({socketState}) => {
     const onReconnect = jest.fn().mockReturnValue(getServerAddress());
-    const socket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.OPEN);
+    const socket = createMockReconnectingWebsocketWrapper(socketState);
     const websocketFactory = jest.fn(() => {
       return socket;
     });
@@ -367,18 +371,19 @@ describe('ReconnectingWebsocket', () => {
       return websocketFactory;
     }
 
-    it('replaces the socket wrapper when it stays CONNECTING past the watchdog timeout', () => {
+    it('replaces the socket wrapper when it stays CONNECTING past the watchdog timeout', async () => {
       const deterministicWallClock = createDeterministicTimeoutWallClock(0);
       const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
       const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
       const websocketFactory = createSocketFactory(firstSocket, secondSocket);
-      const RWS = createRWS(jest.fn(), {
+      const RWS = createRWS(jest.fn().mockResolvedValue('ws://example.invalid'), {
         ...defaultReconnectingWebsocketTestOptions,
         wallClock: deterministicWallClock,
         websocketFactory: Maybe.just(websocketFactory),
       });
 
       RWS.connect();
+      await RWS['internalOnReconnect']();
 
       deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds - 1);
 
@@ -395,6 +400,87 @@ describe('ReconnectingWebsocket', () => {
       expectSocketHandlersToBeBound(secondSocket);
     });
 
+    it('does not start the connecting watchdog while waiting for the reconnect URL', async () => {
+      const deterministicWallClock = createDeterministicTimeoutWallClock(0);
+      const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const websocketFactory = createSocketFactory(firstSocket, secondSocket);
+      let resolveReconnectUrl: (websocketUrl: string) => void = () => {};
+      const reconnectUrlPromise = new Promise<string>(resolve => {
+        resolveReconnectUrl = resolve;
+      });
+      const RWS = createRWS(
+        jest.fn(() => reconnectUrlPromise),
+        {
+          ...defaultReconnectingWebsocketTestOptions,
+          wallClock: deterministicWallClock,
+          websocketFactory: Maybe.just(websocketFactory),
+        },
+      );
+
+      RWS.connect();
+      const reconnectPromise = RWS['internalOnReconnect']();
+
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds);
+
+      expect(firstSocket.close).not.toHaveBeenCalled();
+      expect(websocketFactory).toHaveBeenCalledTimes(1);
+      expect(RWS['socket']).toBe(firstSocket);
+      expect(RWS['connectingTimeoutId']).toBeUndefined();
+
+      resolveReconnectUrl('ws://example.invalid');
+      await expect(reconnectPromise).resolves.toBe('ws://example.invalid');
+
+      expect(RWS['connectingTimeoutId']).toBeDefined();
+
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds);
+
+      expect(firstSocket.close).toHaveBeenCalledTimes(1);
+      expect(firstSocket.close).toHaveBeenCalledWith(CloseEventCode.NORMAL_CLOSURE, 'Connecting timeout');
+      expect(websocketFactory).toHaveBeenCalledTimes(2);
+      expect(RWS['socket']).toBe(secondSocket);
+    });
+
+    it('does not arm a watchdog from a reconnect flow whose socket was replaced while waiting for the reconnect URL', async () => {
+      const deterministicWallClock = createDeterministicTimeoutWallClock(0);
+      const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const thirdSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
+      const websocketFactory = createSocketFactory(firstSocket, secondSocket, thirdSocket);
+      let resolveReconnectUrl: (websocketUrl: string) => void = () => {};
+      const reconnectUrlPromise = new Promise<string>(resolve => {
+        resolveReconnectUrl = resolve;
+      });
+      const RWS = createRWS(
+        jest.fn(() => reconnectUrlPromise),
+        {
+          ...defaultReconnectingWebsocketTestOptions,
+          wallClock: deterministicWallClock,
+          websocketFactory: Maybe.just(websocketFactory),
+        },
+      );
+
+      RWS.connect();
+      const reconnectPromise = RWS['internalOnReconnect']();
+
+      RWS['replaceSocketWrapper'](firstSocket, 'Manual replacement');
+
+      expect(RWS['socket']).toBe(secondSocket);
+      expect(RWS['connectingTimeoutId']).toBeUndefined();
+
+      resolveReconnectUrl('ws://example.invalid');
+      await expect(reconnectPromise).resolves.toBe('ws://example.invalid');
+
+      expect(RWS['connectingTimeoutId']).toBeUndefined();
+
+      deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds);
+
+      expect(websocketFactory).toHaveBeenCalledTimes(2);
+      expect(secondSocket.close).not.toHaveBeenCalled();
+      expect(RWS['socket']).toBe(secondSocket);
+      expect(RWS['socket']).not.toBe(thirdSocket);
+    });
+
     it('restarts the watchdog from internalOnReconnect after close stopped it', async () => {
       const deterministicWallClock = createDeterministicTimeoutWallClock(0);
       const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
@@ -407,6 +493,8 @@ describe('ReconnectingWebsocket', () => {
       });
 
       RWS.connect();
+
+      await RWS['internalOnReconnect']();
 
       expect(RWS['connectingTimeoutId']).toBeDefined();
 
@@ -433,7 +521,7 @@ describe('ReconnectingWebsocket', () => {
       await expect(RWS['internalOnReconnect']()).resolves.toBe('ws://example.invalid');
     });
 
-    it('starts the watchdog from internalOnReconnect before the socket becomes CONNECTING', async () => {
+    it('does not start the watchdog after internalOnReconnect resolves if the socket is already OPEN', async () => {
       const deterministicWallClock = createDeterministicTimeoutWallClock(0);
       const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.OPEN);
       const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
@@ -451,7 +539,7 @@ describe('ReconnectingWebsocket', () => {
 
       await RWS['internalOnReconnect']();
 
-      expect(RWS['connectingTimeoutId']).toBeDefined();
+      expect(RWS['connectingTimeoutId']).toBeUndefined();
 
       deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds);
 
@@ -461,7 +549,7 @@ describe('ReconnectingWebsocket', () => {
       expect(RWS['connectingTimeoutId']).toBeUndefined();
     });
 
-    it('starts the watchdog when reconnecting in place', () => {
+    it('starts the watchdog when reconnecting in place', async () => {
       const deterministicWallClock = createDeterministicTimeoutWallClock(0);
       const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.OPEN);
       const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
@@ -469,7 +557,7 @@ describe('ReconnectingWebsocket', () => {
       firstSocket.reconnect.mockImplementation(() => {
         firstSocket.readyState = WEBSOCKET_STATE.CONNECTING;
       });
-      const RWS = createRWS(jest.fn(), {
+      const RWS = createRWS(jest.fn().mockResolvedValue('ws://example.invalid'), {
         ...defaultReconnectingWebsocketTestOptions,
         wallClock: deterministicWallClock,
         websocketFactory: Maybe.just(websocketFactory),
@@ -483,6 +571,7 @@ describe('ReconnectingWebsocket', () => {
       RWS.connect();
 
       expect(firstSocket.reconnect).toHaveBeenCalledTimes(1);
+      await RWS['internalOnReconnect']();
       expect(RWS['connectingTimeoutId']).toBeDefined();
 
       deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds);
@@ -563,17 +652,18 @@ describe('ReconnectingWebsocket', () => {
       expect(RWS['socket']).toBe(firstSocket);
     });
 
-    it('does not replace the socket wrapper if it opens before the watchdog timeout', () => {
+    it('does not replace the socket wrapper if it opens before the watchdog timeout', async () => {
       const deterministicWallClock = createDeterministicTimeoutWallClock(0);
       const socket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
       const websocketFactory = createSocketFactory(socket);
-      const RWS = createRWS(jest.fn(), {
+      const RWS = createRWS(jest.fn().mockResolvedValue('ws://example.invalid'), {
         ...defaultReconnectingWebsocketTestOptions,
         wallClock: deterministicWallClock,
         websocketFactory: Maybe.just(websocketFactory),
       });
 
       RWS.connect();
+      await RWS['internalOnReconnect']();
       socket.readyState = WEBSOCKET_STATE.OPEN;
       socket.onopen?.({type: 'open'} as Event);
 
@@ -584,7 +674,7 @@ describe('ReconnectingWebsocket', () => {
       expect(RWS['socket']).toBe(socket);
     });
 
-    it('does not let a stale watchdog replace a newer socket wrapper', () => {
+    it('does not let a stale watchdog replace a newer socket wrapper', async () => {
       const deterministicWallClock = createDeterministicTimeoutWallClock(0);
       const staleTimeoutWallClock: DeterministicTimeoutWallClock = {
         ...deterministicWallClock,
@@ -593,13 +683,14 @@ describe('ReconnectingWebsocket', () => {
       const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
       const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
       const websocketFactory = createSocketFactory(firstSocket, secondSocket);
-      const RWS = createRWS(jest.fn(), {
+      const RWS = createRWS(jest.fn().mockResolvedValue('ws://example.invalid'), {
         ...defaultReconnectingWebsocketTestOptions,
         wallClock: staleTimeoutWallClock,
         websocketFactory: Maybe.just(websocketFactory),
       });
 
       RWS.connect();
+      await RWS['internalOnReconnect']();
       deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds / 2);
       RWS['replaceSocketWrapper'](firstSocket, 'Manual replacement');
 
@@ -630,12 +721,12 @@ describe('ReconnectingWebsocket', () => {
       expect(RWS['socket']).toBe(firstSocket);
     });
 
-    it('creates a fresh socket wrapper when closing the stale CONNECTING wrapper fails', () => {
+    it('creates a fresh socket wrapper when closing the stale CONNECTING wrapper fails', async () => {
       const deterministicWallClock = createDeterministicTimeoutWallClock(0);
       const firstSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
       const secondSocket = createMockReconnectingWebsocketWrapper(WEBSOCKET_STATE.CONNECTING);
       const websocketFactory = createSocketFactory(firstSocket, secondSocket);
-      const RWS = createRWS(jest.fn(), {
+      const RWS = createRWS(jest.fn().mockResolvedValue('ws://example.invalid'), {
         ...defaultReconnectingWebsocketTestOptions,
         wallClock: deterministicWallClock,
         websocketFactory: Maybe.just(websocketFactory),
@@ -645,6 +736,7 @@ describe('ReconnectingWebsocket', () => {
       });
 
       RWS.connect();
+      await RWS['internalOnReconnect']();
 
       expect(() => deterministicWallClock.advanceByMilliseconds(connectingTimeoutInMilliseconds)).not.toThrow();
       expect(firstSocket.close).toHaveBeenCalledTimes(1);

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.ts
@@ -290,11 +290,7 @@ export class ReconnectingWebsocket {
     const attempt = this.reconnectAttemptCount + 1;
     this.logger.info(`Connecting to WebSocket (attempt #${attempt})`);
     this.recordReconnectAttempt(this.options.wallClock.currentTimestampInMilliseconds);
-    const socket = this.socket;
-
-    if (!is.undefined(socket)) {
-      this.startConnectingWatchdog(socket);
-    }
+    const reconnectingSocket = this.socket;
 
     // The ping is needed to keep the connection alive as long as possible.
     // Otherwise the connection would be closed after 1 min of inactivity and re-established.
@@ -302,7 +298,19 @@ export class ReconnectingWebsocket {
       this.startPinging();
       this.logger.debug(`Ping started (interval: ${this.PING_INTERVAL}ms)`);
     }
-    return this.onReconnect();
+
+    const websocketUrl = await this.onReconnect();
+    const socket = reconnectingSocket;
+
+    if (this.socket !== socket) {
+      return websocketUrl;
+    }
+
+    if (!is.undefined(socket) && socket.readyState === WEBSOCKET_STATE.CONNECTING) {
+      this.startConnectingWatchdog(socket);
+    }
+
+    return websocketUrl;
   };
 
   private readonly internalOnClose = (event: CloseEvent) => {
@@ -430,7 +438,6 @@ export class ReconnectingWebsocket {
         `Existing WebSocket instance detected in state ${WEBSOCKET_STATE[existingSocket.readyState]} (${existingSocket.readyState}); reconnecting in place`,
       );
       this.reconnectInPlace(existingSocket);
-      this.startConnectingWatchdog(existingSocket);
       return;
     }
 
@@ -449,7 +456,6 @@ export class ReconnectingWebsocket {
     const nextSocket = this.getReconnectingWebsocket();
     this.socket = nextSocket;
     this.bindSocketHandlers(nextSocket);
-    this.startConnectingWatchdog(nextSocket);
   }
 
   private bindSocketHandlers(socket: ReconnectingWebsocketWrapper): void {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This fixes the failing precommit Playwright checks by addressing two separate issues:

* defer the WebSocket CONNECTING watchdog until `onReconnect()` has resolved
* keep reconnect-in-place behavior for active sockets so we do not create duplicate `/await` sessions
* only start the watchdog when the current socket is still CONNECTING
* update the password-protected guest link E2E flow to click the existing-user Join button after login before expecting the password modal

## Why

`onReconnect()` can wait for access-token refresh before returning the WebSocket URL. Starting the CONNECTING watchdog before that means the watchdog can measure token-refresh time instead of actual WebSocket connection time.

The fix keeps the existing reconnect-in-place behavior intact while making the watchdog timing more precise.