### PR TITLE
Use mirrored Playwright image [WPB-25060]

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -144,7 +144,7 @@ jobs:
     timeout-minutes: 45
     needs: [bootstrap_smoke_test, compute_shards]
     container:
-      image: mcr.microsoft.com/playwright:v1.61.1-noble
+      image: quay.io/wire/mirror-images/playwright:v1.61.1-noble
       options: --ipc=host
 
     strategy:

--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,8 @@
     },
     {
       "matchDepNames": ["playwright", "@playwright/test", "quay.io/wire/mirror-images/playwright"],
-      "groupName": "playwright"
+      "groupName": "playwright",
+      "addLabels": ["run-e2e"]
     },
     {
       "matchPackageNames": ["nx", "@nx/**"],

--- a/renovate.json
+++ b/renovate.json
@@ -15,8 +15,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/^\\.github/workflows/e2e-tests\\.yml$/"],
-      "matchStrings": ["image:\\s+mcr\\.microsoft\\.com/playwright:(?<currentValue>v\\d+\\.\\d+\\.\\d+-noble)"],
-      "depNameTemplate": "mcr.microsoft.com/playwright",
+      "matchStrings": ["image:\\s+quay\\.io/wire/mirror-images/playwright:(?<currentValue>v\\d+\\.\\d+\\.\\d+-noble)"],
+      "depNameTemplate": "quay.io/wire/mirror-images/playwright",
       "datasourceTemplate": "docker",
       "extractVersionTemplate": "^v(?<version>\\d+\\.\\d+\\.\\d+)-noble$"
     }
@@ -39,7 +39,7 @@
       "groupName": "docker images"
     },
     {
-      "matchDepNames": ["playwright", "@playwright/test", "mcr.microsoft.com/playwright"],
+      "matchDepNames": ["playwright", "@playwright/test", "quay.io/wire/mirror-images/playwright"],
       "groupName": "playwright"
     },
     {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25060" title="WPB-25060" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25060</a>  Set up pull-through-cache for web team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Switch the E2E workflow container from mcr.microsoft.com/playwright to the self-managed quay.io/wire/mirror-images/playwright image. We mirror this image now on quay.io which we update automatically every time a new version is released. This gives us more control and a more reliable pipeline because we cannot run in any rate limit anymore.

Update Renovate's custom regex manager and Playwright package group so future updates track the mirrored image together with the Playwright npm dependencies.


