### PR TITLE
Add release branch creation workflow [WPB-26469]

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,0 +1,172 @@
+---
+name: Create Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_identifier:
+        description: 'Release identifier, for example 2026-06-29.1'
+        required: true
+        type: string
+      source_ref:
+        description: 'Source ref to create the release branch from. During the transition this defaults to dev; after the branch model cutover this should become main.'
+        required: true
+        default: dev
+        type: string
+      confirm_create_release_branch:
+        description: 'Confirm that this will create and push release/<release_identifier>'
+        required: true
+        default: false
+        type: boolean
+      reason:
+        description: 'Optional reason for creating the release branch'
+        required: false
+        type: string
+
+concurrency:
+  group: create-release-branch-${{ inputs.release_identifier }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  validate_request:
+    name: Validate request
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      release_branch: ${{ steps.validate_request.outputs.release_branch }}
+      source_ref: ${{ steps.validate_request.outputs.source_ref }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: ./bin/yarn --immutable
+
+      - name: Validate request
+        id: validate_request
+        env:
+          CONFIRM_CREATE_RELEASE_BRANCH: ${{ inputs.confirm_create_release_branch }}
+          RELEASE_IDENTIFIER: ${{ inputs.release_identifier }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${CONFIRM_CREATE_RELEASE_BRANCH}" != 'true' ]]; then
+            echo 'confirm_create_release_branch must be true to create and push the release branch.' >&2
+            exit 1
+          fi
+
+          if [[ -z "${SOURCE_REF//[[:space:]]/}" ]]; then
+            echo 'source_ref must not be empty.' >&2
+            exit 1
+          fi
+
+          release_branch="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts release-branch "${RELEASE_IDENTIFIER}")"
+
+          if git ls-remote --exit-code --heads origin "${release_branch}" > /dev/null; then
+            echo "Release branch already exists on origin: ${release_branch}" >&2
+            exit 1
+          else
+            ls_remote_exit_code="$?"
+
+            if [[ "${ls_remote_exit_code}" -ne 2 ]]; then
+              echo "Unable to check whether release branch exists on origin: ${release_branch}" >&2
+              exit "${ls_remote_exit_code}"
+            fi
+          fi
+
+          {
+            echo "release_branch=${release_branch}"
+            echo "source_ref=${SOURCE_REF}"
+          } >> "$GITHUB_OUTPUT"
+
+  create_release_branch:
+    name: Create release branch
+    runs-on: ubuntu-24.04
+    needs: validate_request
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Create and push release branch
+        id: create_release_branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BRANCH: ${{ needs.validate_request.outputs.release_branch }}
+          SOURCE_REF: ${{ needs.validate_request.outputs.source_ref }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags --depth=1 origin "+refs/heads/${SOURCE_REF}:refs/remotes/origin/${SOURCE_REF}"
+          source_commit_sha="$(git rev-parse "refs/remotes/origin/${SOURCE_REF}^{commit}")"
+
+          if git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" > /dev/null; then
+            echo "Release branch already exists on origin: ${RELEASE_BRANCH}" >&2
+            exit 1
+          else
+            ls_remote_exit_code="$?"
+
+            if [[ "${ls_remote_exit_code}" -ne 2 ]]; then
+              echo "Unable to check whether release branch exists on origin: ${RELEASE_BRANCH}" >&2
+              exit "${ls_remote_exit_code}"
+            fi
+          fi
+
+          git branch "${RELEASE_BRANCH}" "${source_commit_sha}"
+          git -c http.extraheader="AUTHORIZATION: bearer ${GITHUB_TOKEN}" push origin "refs/heads/${RELEASE_BRANCH}:refs/heads/${RELEASE_BRANCH}"
+
+          echo "source_commit_sha=${source_commit_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Write summary
+        env:
+          ACTOR: ${{ github.actor }}
+          REASON: ${{ inputs.reason }}
+          RELEASE_BRANCH: ${{ needs.validate_request.outputs.release_branch }}
+          RELEASE_IDENTIFIER: ${{ inputs.release_identifier }}
+          SOURCE_COMMIT_SHA: ${{ steps.create_release_branch.outputs.source_commit_sha }}
+          SOURCE_REF: ${{ needs.validate_request.outputs.source_ref }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo '## Release branch created'
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Release identifier | \`${RELEASE_IDENTIFIER}\` |"
+            echo "| Created release branch | \`${RELEASE_BRANCH}\` |"
+            echo "| Source ref | \`${SOURCE_REF}\` |"
+            echo "| Source commit SHA | \`${SOURCE_COMMIT_SHA}\` |"
+            echo "| Actor | \`${ACTOR}\` |"
+
+            if [[ -n "${REASON}" ]]; then
+              echo "| Reason | ${REASON} |"
+            fi
+
+            echo "| Workflow run | ${WORKFLOW_RUN_URL} |"
+            echo
+            echo 'No deployment or tag creation was performed by this workflow.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -77,6 +77,21 @@ jobs:
             exit 1
           fi
 
+          if [[ "${SOURCE_REF}" == refs/* || "${SOURCE_REF}" == origin/* ]]; then
+            echo "source_ref must be a branch name like dev, main, or release/YYYY-MM-DD.N, not a fully qualified or remote-style ref: ${SOURCE_REF}" >&2
+            exit 1
+          fi
+
+          if [[ "${SOURCE_REF}" == -* ]]; then
+            echo "source_ref must not begin with '-': ${SOURCE_REF}" >&2
+            exit 1
+          fi
+
+          if ! git check-ref-format --branch "${SOURCE_REF}" > /dev/null; then
+            echo "source_ref must be a valid branch name: ${SOURCE_REF}" >&2
+            exit 1
+          fi
+
           release_branch="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts release-branch "${RELEASE_IDENTIFIER}")"
 
           if git ls-remote --exit-code --heads origin "${release_branch}" > /dev/null; then

--- a/bin/releaseMetadata.test.ts
+++ b/bin/releaseMetadata.test.ts
@@ -22,6 +22,7 @@ import assert from 'node:assert';
 import {
   createNextBetaTagName,
   createProductionTagName,
+  createReleaseBranchName,
   extractReleaseIdentifierFromBranchName,
   isReleaseBranchName,
   productionTagExists,
@@ -86,6 +87,27 @@ describe('releaseMetadata', () => {
 
     expect(actualReleaseIdentifier.error.message).toBe('Invalid release branch name: release/2026-06-01');
   });
+
+  it('createReleaseBranchName() creates the release branch name from the release identifier', () => {
+    const releaseIdentifier = '2026-06-19.1';
+
+    const actualReleaseBranchName = createReleaseBranchName(releaseIdentifier);
+
+    assert(actualReleaseBranchName.isOk === true);
+
+    expect(actualReleaseBranchName.value).toBe('release/2026-06-19.1');
+  });
+
+  it.each(['2026-06-19.0', '2026-06-19', '2026-6-19.1', 'release/2026-06-19.1'])(
+    'createReleaseBranchName() rejects invalid release identifier "%s"',
+    invalidReleaseIdentifier => {
+      const actualReleaseBranchName = createReleaseBranchName(invalidReleaseIdentifier);
+
+      assert(actualReleaseBranchName.isErr === true);
+
+      expect(actualReleaseBranchName.error.message).toBe(`Invalid release identifier: ${invalidReleaseIdentifier}`);
+    },
+  );
 
   it('createProductionTagName() creates the production tag name from the release identifier', () => {
     const releaseIdentifier = '2026-06-19.1';

--- a/bin/releaseMetadata.ts
+++ b/bin/releaseMetadata.ts
@@ -26,6 +26,7 @@ type NonZeroDecimalDigit = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
 
 export type ReleaseIdentifier =
   NonEmptyString<`${number}${number}${number}${number}-${number}${number}-${number}${number}.${NonZeroDecimalDigit}${string}`>;
+export type ReleaseBranchName = NonEmptyString<`release/${ReleaseIdentifier}`>;
 export type BetaTagName = NonEmptyString<`${ReleaseIdentifier}-beta.${number}`>;
 export type ProductionTagName = NonEmptyString<`${ReleaseIdentifier}-production`>;
 export type ReleaseTagName = BetaTagName | ProductionTagName;
@@ -71,6 +72,16 @@ export function extractReleaseIdentifierFromBranchName(branchName: string): Resu
   }
 
   return Result.ok(branchNameMatch[1] as ReleaseIdentifier);
+}
+
+export function createReleaseBranchName(releaseIdentifier: string): Result<ReleaseBranchName, Error> {
+  const releaseIdentifierResult = validateReleaseIdentifier(releaseIdentifier);
+
+  if (releaseIdentifierResult.isErr) {
+    return Result.err(releaseIdentifierResult.error);
+  }
+
+  return Result.ok(`release/${releaseIdentifierResult.value}` as ReleaseBranchName);
 }
 
 export function createProductionTagName(releaseIdentifier: string): Result<ProductionTagName, Error> {

--- a/bin/releaseMetadataCli.test.ts
+++ b/bin/releaseMetadataCli.test.ts
@@ -61,6 +61,26 @@ describe('releaseMetadataCli', () => {
     });
   });
 
+  it('prints the release branch name for the release identifier', () => {
+    const actualResult = runCommand(['release-branch', '2026-06-19.1']);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['release/2026-06-19.1'],
+    });
+  });
+
+  it('rejects an invalid release branch release identifier', () => {
+    const actualResult = runCommand(['release-branch', 'release/2026-06-19.1']);
+
+    expect(actualResult).toEqual({
+      errors: ['Invalid release identifier: release/2026-06-19.1'],
+      exitCode: 1,
+      outputs: [],
+    });
+  });
+
   it('prints the next beta tag name for the release identifier', () => {
     const actualResult = runCommand([
       'next-beta-tag',

--- a/bin/releaseMetadataCli.ts
+++ b/bin/releaseMetadataCli.ts
@@ -22,6 +22,7 @@ import process from 'node:process';
 import {
   createNextBetaTagName,
   createProductionTagName,
+  createReleaseBranchName,
   extractReleaseIdentifierFromBranchName,
 } from './releaseMetadata';
 
@@ -35,6 +36,7 @@ const nodeExecutableAndScriptPathArgumentCount = 2;
 const usageText = [
   'Usage:',
   '  releaseMetadataCli.ts release-identifier-from-branch <release/YYYY-MM-DD.N>',
+  '  releaseMetadataCli.ts release-branch <YYYY-MM-DD.N>',
   '  releaseMetadataCli.ts next-beta-tag <YYYY-MM-DD.N> [existing-tag ...]',
   '  releaseMetadataCli.ts production-tag <YYYY-MM-DD.N>',
 ].join('\n');
@@ -42,6 +44,7 @@ const usageText = [
 function writeResult(
   result:
     | ReturnType<typeof extractReleaseIdentifierFromBranchName>
+    | ReturnType<typeof createReleaseBranchName>
     | ReturnType<typeof createNextBetaTagName>
     | ReturnType<typeof createProductionTagName>,
   dependencies: ReleaseMetadataCliDependencies,
@@ -63,6 +66,10 @@ export function runReleaseMetadataCli(
 
   if (commandName === 'release-identifier-from-branch' && primaryValue !== undefined) {
     return writeResult(extractReleaseIdentifierFromBranchName(primaryValue), dependencies);
+  }
+
+  if (commandName === 'release-branch' && primaryValue !== undefined) {
+    return writeResult(createReleaseBranchName(primaryValue), dependencies);
   }
 
   if (commandName === 'next-beta-tag' && primaryValue !== undefined) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Adds a manual GitHub Actions workflow for creating ADR 0002 release branches.

The workflow creates `release/YYYY-MM-DD.N` from a selected source ref after explicit confirmation.

## Details

This adds `.github/workflows/create-release-branch.yml`.

The workflow:

- accepts a `release_identifier` input
- validates `YYYY-MM-DD.N`
- rejects `.0` release identifiers
- accepts a `source_ref`
- defaults `source_ref` to `dev` during the transition
- fails if the target release branch already exists
- creates and pushes `release/<release_identifier>`
- writes a GitHub step summary with the source commit and created branch

## Notes

During the transition, `source_ref` defaults to `dev`.

After the branch model cutover, this should be changed to `main`.

This pull request intentionally does not:

- deploy anything
- create Beta tags
- create Production tags
- change the old release path
- change Docker publishing
- change Helm publishing
- update `wire-builds`
- rename branches

Deployment is handled separately by the `release-cloud` workflow.

## Tracking

Part of https://github.com/wireapp/wire-webapp/issues/21597.

Follow-up to:

- https://github.com/wireapp/wire-webapp/pull/21598
- https://github.com/wireapp/wire-webapp/pull/21634
- https://github.com/wireapp/wire-webapp/pull/21641
- https://github.com/wireapp/wire-webapp/pull/21648
- https://github.com/wireapp/wire-webapp/pull/21664