### PR TITLE
Skip enterprise-dependent E2E tests [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -161,9 +161,16 @@ test.describe('account settings', () => {
     password: process.env.SCIM_USER_PASSWORD,
   });
 
-  test(
+  test.skip(
     'I should not be able to change email of user managed by SCIM',
-    {tag: ['@TC-60', '@regression']},
+    {
+      tag: ['@TC-60', '@regression'],
+      annotation: {
+        type: 'skip',
+        description:
+          'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
+      },
+    },
     async ({context, createPage}) => {
       test.setTimeout(180_000);
 
@@ -428,9 +435,16 @@ test.describe('account settings', () => {
     });
   });
 
-  test(
+  test.skip(
     'I want to see the Full Name wherever my name gets displayed',
-    {tag: ['@TC-1948', '@regression']},
+    {
+      tag: ['@TC-1948', '@regression'],
+      annotation: {
+        type: 'skip',
+        description:
+          'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
+      },
+    },
     async ({createPage}) => {
       const page = await createPage(withLogin(memberA));
       const {pages, modals, components} = PageManager.from(page).webapp;

--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -31,224 +31,265 @@ async function joinCall(userPages: PageManager['webapp']['pages']) {
   await expect(userPages.calling().goFullScreen).toBeVisible();
 }
 
-test.describe('Calling', () => {
-  let userA: User;
-  let userB: User;
-  let userC: User;
-  const groupName = 'Calling group';
-  let team: Team;
+test.describe.skip(
+  'Calling',
+  {
+    annotation: {
+      type: 'skip',
+      description:
+        'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
+    },
+  },
+  () => {
+    let userA: User;
+    let userB: User;
+    let userC: User;
+    const groupName = 'Calling group';
+    let team: Team;
 
-  test.beforeEach(async ({createTeam, createUser}) => {
-    userB = await createUser();
-    userC = await createUser();
-    team = await createTeam('Team Call Team', {
-      users: [userB, userC],
-      features: {conferenceCalling: true},
+    test.beforeEach(async ({createTeam, createUser}) => {
+      userB = await createUser();
+      userC = await createUser();
+      team = await createTeam('Team Call Team', {
+        users: [userB, userC],
+        features: {conferenceCalling: true},
+      });
+      userA = team.owner;
     });
-    userA = team.owner;
-  });
 
-  test(
-    'Verify that current call is terminated if you want to call someone else (as caller)',
-    {tag: ['@TC-2802', '@regression']},
-    async ({createPage}) => {
+    test(
+      'Verify that current call is terminated if you want to call someone else (as caller)',
+      {tag: ['@TC-2802', '@regression']},
+      async ({createPage}) => {
+        const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+        await connectWithUser(userAPage, userB);
+        await connectWithUser(userAPage, userC);
+
+        const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+        const {pages: userBPages} = PageManager.from(userBPage).webapp;
+
+        // User A has a call with user B
+        await userAPages.conversationList().getConversation(userB.fullName).open();
+        await userAPages.conversation().clickCallButton();
+        await userBPages.calling().clickAcceptCallButton();
+        await expect(userBPages.calling().callCell).toBeVisible();
+
+        // User A starts a call with user C while in a call with user B
+        await userAPages.conversationList().getConversation(userC.fullName).open();
+        await userAPages.conversation().clickCallButton();
+
+        // A modal is shown prompting him to confirm before cancelling the ongoing call
+        await expect(userAModals.confirm().modalTitle).toContainText('Hang up current call?');
+        await userAModals.confirm().clickAction();
+
+        // The call with user B should be terminated
+        await expect(userBPages.calling().callCell).not.toBeVisible();
+      },
+    );
+
+    test('Verify Raise hand functionality', {tag: ['@TC-8773', '@regression']}, async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
+
+      await createGroup(userAPages, groupName, [userB]);
+
+      // Establish group call; required precondition for hand-raise testing
+      await userAPages.conversationList().getConversation(groupName).open();
+      await userAPages.conversation().clickCallButton();
+
+      await joinCall(userBPages);
+
+      const userACall = await userAPages.calling().maximizeCell();
+      await expect(userACall.selfVideoThumbnail).toBeVisible();
+
+      // Wait for the call to stabilize before testing the toast and thumbnail indicators
+      await userAPage.waitForTimeout(2000);
+      // User A raises hand and verifies the indicator appears on their thumbnail
+      await userACall.toggleHandRaise();
+      const toast = userAPage.getByText('You have raised your hand up');
+
+      await expect(toast).toBeVisible();
+      await expect(userACall.selfVideoThumbnail.getByText('✋')).toBeVisible();
+      await expect(toast).toBeHidden({timeout: 3000});
+
+      await userACall.toggleHandRaise();
+      await expect(userACall.selfVideoThumbnail.getByText('✋')).toBeHidden();
+    });
+
+    test('Verify in call reactions', {tag: ['@TC-8774', '@regression']}, async ({createPage}) => {
       const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
       await connectWithUser(userAPage, userB);
-      await connectWithUser(userAPage, userC);
 
-      const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
-      const {pages: userBPages} = PageManager.from(userBPage).webapp;
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      // User A has a call with user B
       await userAPages.conversationList().getConversation(userB.fullName).open();
       await userAPages.conversation().clickCallButton();
       await userBPages.calling().clickAcceptCallButton();
-      await expect(userBPages.calling().callCell).toBeVisible();
 
-      // User A starts a call with user C while in a call with user B
-      await userAPages.conversationList().getConversation(userC.fullName).open();
-      await userAPages.conversation().clickCallButton();
-
-      // A modal is shown prompting him to confirm before cancelling the ongoing call
-      await expect(userAModals.confirm().modalTitle).toContainText('Hang up current call?');
-      await userAModals.confirm().clickAction();
-
-      // The call with user B should be terminated
-      await expect(userBPages.calling().callCell).not.toBeVisible();
-    },
-  );
-
-  test('Verify Raise hand functionality', {tag: ['@TC-8773', '@regression']}, async ({createPage}) => {
-    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
-
-    const userAPages = PageManager.from(userAPage).webapp.pages;
-    const userBPages = PageManager.from(userBPage).webapp.pages;
-
-    await createGroup(userAPages, groupName, [userB]);
-
-    // Establish group call; required precondition for hand-raise testing
-    await userAPages.conversationList().getConversation(groupName).open();
-    await userAPages.conversation().clickCallButton();
-
-    await joinCall(userBPages);
-
-    const userACall = await userAPages.calling().maximizeCell();
-    await expect(userACall.selfVideoThumbnail).toBeVisible();
-
-    // Wait for the call to stabilize before testing the toast and thumbnail indicators
-    await userAPage.waitForTimeout(2000);
-    // User A raises hand and verifies the indicator appears on their thumbnail
-    await userACall.toggleHandRaise();
-    const toast = userAPage.getByText('You have raised your hand up');
-
-    await expect(toast).toBeVisible();
-    await expect(userACall.selfVideoThumbnail.getByText('✋')).toBeVisible();
-    await expect(toast).toBeHidden({timeout: 3000});
-
-    await userACall.toggleHandRaise();
-    await expect(userACall.selfVideoThumbnail.getByText('✋')).toBeHidden();
-  });
-
-  test('Verify in call reactions', {tag: ['@TC-8774', '@regression']}, async ({createPage}) => {
-    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
-    await connectWithUser(userAPage, userB);
-
-    const userAPages = PageManager.from(userAPage).webapp.pages;
-    const userBPages = PageManager.from(userBPage).webapp.pages;
-
-    await userAPages.conversationList().getConversation(userB.fullName).open();
-    await userAPages.conversation().clickCallButton();
-    await userBPages.calling().clickAcceptCallButton();
-
-    const [userACall, userBCall] = await Promise.all([
-      userAPages.calling().maximizeCell(),
-      userBPages.calling().maximizeCell(),
-    ]);
-
-    const reactionAssertion = expect(userBCall.getReaction({emoji: '👍', sender: userA})).toBeVisible();
-    await userACall.sendReaction('👍');
-    await reactionAssertion;
-  });
-
-  test(
-    'I want to answer incoming call with Join button in conversation view',
-    {tag: ['@TC-2826', '@regression']},
-    async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
-      await connectWithUser(userAPage, userB);
-
-      const userAPages = PageManager.from(userAPage).webapp.pages;
-      const userBPages = PageManager.from(userBPage).webapp.pages;
-
-      await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
-      await userAPages.conversation().clickCallButton();
-
-      const {joinCallButton} = userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'});
-      await expect(joinCallButton).toBeVisible();
-      await expect(userBPages.calling().acceptCallButton).toBeVisible();
-
-      await joinCallButton.click();
-      await expect(userBPages.calling().acceptCallButton).not.toBeVisible();
-    },
-  );
-
-  [
-    {
-      description: 'Verify 1on1 call ringing terminates on second client when accepting call',
-      tag: '@TC-2823',
-      conversationType: '1on1',
-    },
-    {
-      description: 'Verify group call ringing stops on second client when accepting call',
-      tag: '@TC-2824',
-      conversationType: 'group',
-    },
-  ].forEach(({description, tag, conversationType}) => {
-    test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
-      const [userAPage, userBPage1] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
-      await connectWithUser(userAPage, userB);
-
-      const userAPages = PageManager.from(userAPage).webapp.pages;
-      const userBDevice1Pages = PageManager.from(userBPage1).webapp.pages;
-
-      // Log in second device of user B confirming new history
-      const userBPage2 = await createPage(withLogin(userB, {confirmNewHistory: true}));
-      const userBDevice2Pages = PageManager.from(userBPage2).webapp.pages;
-
-      if (conversationType === '1on1') {
-        await userAPages.conversationList().getConversation(userB.fullName).open();
-      } else {
-        await createGroup(userAPages, 'Calling group', [userB]);
-        await userAPages.conversationList().getConversation('Calling group').open();
-      }
-
-      // Ensure no audio is playing on both devices initially
-      await expect.poll(() => isPlayingAudio(userBPage1, AudioType.INCOMING_CALL)).toBe(false);
-      await expect.poll(() => isPlayingAudio(userBPage2, AudioType.INCOMING_CALL)).toBe(false);
-
-      // User A calls user B, confirming both devices are ringing
-      await userAPages.conversation().clickCallButton();
-      await expect(userAPages.calling().callCell).toBeVisible();
-
-      await expect(userBDevice1Pages.calling().callCell).toBeVisible();
-      await expect.poll(() => isPlayingAudio(userBPage1, AudioType.INCOMING_CALL)).toBe(true);
-      await expect.poll(() => isPlayingAudio(userBPage2, AudioType.INCOMING_CALL)).toBe(true);
-
-      // User B accepts the call from the first device and both devices should stop ringing
-      await userBDevice1Pages.calling().clickAcceptCallButton();
-      await expect(userBDevice1Pages.calling().callCell).toBeVisible();
-      await expect.poll(() => isPlayingAudio(userBPage1, AudioType.INCOMING_CALL)).toBe(false);
-      await expect(userBDevice2Pages.calling().callCell).not.toBeVisible();
-      await expect.poll(() => isPlayingAudio(userBPage2, AudioType.INCOMING_CALL)).toBe(false);
-    });
-  });
-
-  test(
-    'Verify I can make another call while current one is ignored',
-    {tag: ['@TC-2803', '@regression']},
-    async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
-      await connectWithUser(userAPage, userB);
-      await connectWithUser(userBPage, userC);
-
-      const userAPages = PageManager.from(userAPage).webapp.pages;
-      const userBPages = PageManager.from(userBPage).webapp.pages;
-
-      // User A calls user B
-      await userAPages.conversationList().getConversation(userB.fullName).open();
-      await userAPages.conversation().clickCallButton();
-
-      // User B declines the call
-      await userBPages.calling().clickLeaveCallButton();
-      await expect(userBPages.calling().callCell).not.toBeVisible();
-
-      // User B calls user C instead
-      await userBPages.conversationList().getConversation(userC.fullName).open();
-      await expect(userBPages.conversation().callButton).toBeEnabled();
-      await userBPages.conversation().startCall();
-      await expect(userBPages.calling().callCell).toBeVisible();
-    },
-  );
-
-  [
-    {
-      description: 'Verify able to join ongoing call',
-      tag: '@TC-2820',
-    },
-    {
-      description: 'Late joiner wants to see the ongoing screen sharing on group call',
-      tag: '@TC-2874',
-      verifyScreenShare: true,
-    },
-  ].forEach(({description, tag, verifyScreenShare}) => {
-    test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
-      const [userAPages, userBPages, userCPage] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-        createPage(withLogin(userC)),
+      const [userACall, userBCall] = await Promise.all([
+        userAPages.calling().maximizeCell(),
+        userBPages.calling().maximizeCell(),
       ]);
 
-      const userCPages = PageManager.from(userCPage).webapp.pages;
+      const reactionAssertion = expect(userBCall.getReaction({emoji: '👍', sender: userA})).toBeVisible();
+      await userACall.sendReaction('👍');
+      await reactionAssertion;
+    });
+
+    test(
+      'I want to answer incoming call with Join button in conversation view',
+      {tag: ['@TC-2826', '@regression']},
+      async ({createPage}) => {
+        const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+        await connectWithUser(userAPage, userB);
+
+        const userAPages = PageManager.from(userAPage).webapp.pages;
+        const userBPages = PageManager.from(userBPage).webapp.pages;
+
+        await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+        await userAPages.conversation().clickCallButton();
+
+        const {joinCallButton} = userBPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'});
+        await expect(joinCallButton).toBeVisible();
+        await expect(userBPages.calling().acceptCallButton).toBeVisible();
+
+        await joinCallButton.click();
+        await expect(userBPages.calling().acceptCallButton).not.toBeVisible();
+      },
+    );
+
+    [
+      {
+        description: 'Verify 1on1 call ringing terminates on second client when accepting call',
+        tag: '@TC-2823',
+        conversationType: '1on1',
+      },
+      {
+        description: 'Verify group call ringing stops on second client when accepting call',
+        tag: '@TC-2824',
+        conversationType: 'group',
+      },
+    ].forEach(({description, tag, conversationType}) => {
+      test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
+        const [userAPage, userBPage1] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+        await connectWithUser(userAPage, userB);
+
+        const userAPages = PageManager.from(userAPage).webapp.pages;
+        const userBDevice1Pages = PageManager.from(userBPage1).webapp.pages;
+
+        // Log in second device of user B confirming new history
+        const userBPage2 = await createPage(withLogin(userB, {confirmNewHistory: true}));
+        const userBDevice2Pages = PageManager.from(userBPage2).webapp.pages;
+
+        if (conversationType === '1on1') {
+          await userAPages.conversationList().getConversation(userB.fullName).open();
+        } else {
+          await createGroup(userAPages, 'Calling group', [userB]);
+          await userAPages.conversationList().getConversation('Calling group').open();
+        }
+
+        // Ensure no audio is playing on both devices initially
+        await expect.poll(() => isPlayingAudio(userBPage1, AudioType.INCOMING_CALL)).toBe(false);
+        await expect.poll(() => isPlayingAudio(userBPage2, AudioType.INCOMING_CALL)).toBe(false);
+
+        // User A calls user B, confirming both devices are ringing
+        await userAPages.conversation().clickCallButton();
+        await expect(userAPages.calling().callCell).toBeVisible();
+
+        await expect(userBDevice1Pages.calling().callCell).toBeVisible();
+        await expect.poll(() => isPlayingAudio(userBPage1, AudioType.INCOMING_CALL)).toBe(true);
+        await expect.poll(() => isPlayingAudio(userBPage2, AudioType.INCOMING_CALL)).toBe(true);
+
+        // User B accepts the call from the first device and both devices should stop ringing
+        await userBDevice1Pages.calling().clickAcceptCallButton();
+        await expect(userBDevice1Pages.calling().callCell).toBeVisible();
+        await expect.poll(() => isPlayingAudio(userBPage1, AudioType.INCOMING_CALL)).toBe(false);
+        await expect(userBDevice2Pages.calling().callCell).not.toBeVisible();
+        await expect.poll(() => isPlayingAudio(userBPage2, AudioType.INCOMING_CALL)).toBe(false);
+      });
+    });
+
+    test(
+      'Verify I can make another call while current one is ignored',
+      {tag: ['@TC-2803', '@regression']},
+      async ({createPage}) => {
+        const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+        await connectWithUser(userAPage, userB);
+        await connectWithUser(userBPage, userC);
+
+        const userAPages = PageManager.from(userAPage).webapp.pages;
+        const userBPages = PageManager.from(userBPage).webapp.pages;
+
+        // User A calls user B
+        await userAPages.conversationList().getConversation(userB.fullName).open();
+        await userAPages.conversation().clickCallButton();
+
+        // User B declines the call
+        await userBPages.calling().clickLeaveCallButton();
+        await expect(userBPages.calling().callCell).not.toBeVisible();
+
+        // User B calls user C instead
+        await userBPages.conversationList().getConversation(userC.fullName).open();
+        await expect(userBPages.conversation().callButton).toBeEnabled();
+        await userBPages.conversation().startCall();
+        await expect(userBPages.calling().callCell).toBeVisible();
+      },
+    );
+
+    [
+      {
+        description: 'Verify able to join ongoing call',
+        tag: '@TC-2820',
+      },
+      {
+        description: 'Late joiner wants to see the ongoing screen sharing on group call',
+        tag: '@TC-2874',
+        verifyScreenShare: true,
+      },
+    ].forEach(({description, tag, verifyScreenShare}) => {
+      test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
+        const [userAPages, userBPages, userCPage] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+          PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+          createPage(withLogin(userC)),
+        ]);
+
+        const userCPages = PageManager.from(userCPage).webapp.pages;
+        await createGroup(userAPages, groupName, [userB, userC]);
+
+        await userAPages.conversationList().getConversation(groupName).open();
+        await userAPages.conversation().clickCallButton();
+
+        await expect(userAPages.calling().callCell).toBeVisible();
+        await joinCall(userBPages);
+
+        // User A starts screen sharing
+        await userAPages.calling().clickToggleScreenShareButton();
+
+        // // User C joins the ongoing call
+        await userCPage.waitForTimeout(5000);
+        await userCPages.conversationList().getConversation(groupName).joinCallButton.click();
+
+        // Confirm that user C joined the call
+        await expect(userCPages.calling().goFullScreen).toBeVisible();
+        await expect(userCPages.calling().gridTiles).toHaveCount(3);
+
+        if (verifyScreenShare) {
+          const userCCall = await userCPages.calling().maximizeCell();
+          await expect(userCCall.getGridTile(userA.fullName).videoElement).toBeVisible();
+        }
+      });
+    });
+
+    test('Verify Call UI checks', {tag: ['@TC-8771', '@regression']}, async ({createPage}) => {
+      const [userAPages, userBPages] = await Promise.all([
+        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+      ]);
+
       await createGroup(userAPages, groupName, [userB, userC]);
 
       await userAPages.conversationList().getConversation(groupName).open();
@@ -257,185 +298,48 @@ test.describe('Calling', () => {
       await expect(userAPages.calling().callCell).toBeVisible();
       await joinCall(userBPages);
 
-      // User A starts screen sharing
-      await userAPages.calling().clickToggleScreenShareButton();
-
-      // // User C joins the ongoing call
-      await userCPage.waitForTimeout(5000);
-      await userCPages.conversationList().getConversation(groupName).joinCallButton.click();
-
-      // Confirm that user C joined the call
-      await expect(userCPages.calling().goFullScreen).toBeVisible();
-      await expect(userCPages.calling().gridTiles).toHaveCount(3);
-
-      if (verifyScreenShare) {
-        const userCCall = await userCPages.calling().maximizeCell();
-        await expect(userCCall.getGridTile(userA.fullName).videoElement).toBeVisible();
-      }
+      await userAPages.calling().maximizeCell();
+      await expect(userAPages.calling().selfVideoThumbnail).toBeVisible();
+      await expect(userAPages.calling().getGridTile(userA.fullName).muteIcon).not.toBeAttached();
     });
-  });
 
-  test('Verify Call UI checks', {tag: ['@TC-8771', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
+    test(
+      'Verify leaving and coming back to the group call',
+      {tag: ['@TC-2808', '@regression']},
+      async ({createPage}) => {
+        const [userAPages, userBPages] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+          PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+        ]);
 
-    await createGroup(userAPages, groupName, [userB, userC]);
+        await createGroup(userAPages, groupName, [userB]);
 
-    await userAPages.conversationList().getConversation(groupName).open();
-    await userAPages.conversation().clickCallButton();
-
-    await expect(userAPages.calling().callCell).toBeVisible();
-    await joinCall(userBPages);
-
-    await userAPages.calling().maximizeCell();
-    await expect(userAPages.calling().selfVideoThumbnail).toBeVisible();
-    await expect(userAPages.calling().getGridTile(userA.fullName).muteIcon).not.toBeAttached();
-  });
-
-  test('Verify leaving and coming back to the group call', {tag: ['@TC-2808', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-    ]);
-
-    await createGroup(userAPages, groupName, [userB]);
-
-    // User A initiates the call
-    await userAPages.conversationList().getConversation(groupName).open();
-    await userAPages.conversation().clickCallButton();
-
-    await expect(userAPages.calling().callCell).toBeVisible();
-
-    // User B joins the call
-    await joinCall(userBPages);
-    await expect(userBPages.calling().goFullScreen).toBeVisible();
-
-    // User B leaves the group call
-    await userBPages.calling().clickLeaveCallButton();
-    await expect(userBPages.calling().callCell).toBeHidden();
-
-    // User B re-joins the ongoing call from the conversation list
-    await userBPages.conversationList().getConversation(groupName).joinCallButton.click({timeout: 30_000});
-
-    await expect(userBPages.calling().goFullScreen).toBeVisible();
-  });
-
-  test('Verify ignoring group call', {tag: ['@TC-2811', '@regression']}, async ({createPage}) => {
-    const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
-
-    const userAPages = PageManager.from(userAPage).webapp.pages;
-    const userBPages = PageManager.from(userBPage).webapp.pages;
-
-    await createGroup(userAPages, groupName, [userB]);
-
-    // User A initiates the call
-    await userAPages.conversationList().getConversation(groupName).open();
-    await userAPages.conversation().clickCallButton();
-
-    await expect(userAPages.calling().callCell).toBeVisible();
-    await expect(userBPages.calling().callCell).toBeVisible();
-    await expect.poll(() => isPlayingAudio(userBPage, AudioType.INCOMING_CALL)).toBe(true);
-
-    await userBPages.calling().clickLeaveCallButton();
-    await expect(userBPages.calling().callCell).toBeHidden();
-    await expect.poll(() => isPlayingAudio(userBPage, AudioType.INCOMING_CALL)).toBe(false);
-  });
-
-  test(
-    'Verify joining and leaving call from second client does not disconnect the first client',
-    {tag: ['@TC-2827', '@regression']},
-    async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
-
-      // Log in a second session/device for User A.
-      const userAPage2 = await createPage(withLogin(userA, {confirmNewHistory: true}));
-      const userADevice2Pages = PageManager.from(userAPage2).webapp.pages;
-
-      // Setup: Create a group to host the call
-      await createGroup(userAPages, groupName, [userB]);
-
-      await test.step('User A starts a call and User B joins', async () => {
+        // User A initiates the call
         await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().clickCallButton();
 
         await expect(userAPages.calling().callCell).toBeVisible();
 
+        // User B joins the call
         await joinCall(userBPages);
-      });
+        await expect(userBPages.calling().goFullScreen).toBeVisible();
 
-      await test.step('User A joins then leaves the call from their second device', async () => {
-        await userADevice2Pages.conversationList().getConversation(groupName).open();
-        await userADevice2Pages.conversation().clickCallButton();
-        await expect(userADevice2Pages.calling().callCell).toBeVisible();
+        // User B leaves the group call
+        await userBPages.calling().clickLeaveCallButton();
+        await expect(userBPages.calling().callCell).toBeHidden();
 
-        await expect(userADevice2Pages.calling().gridTiles).toHaveCount(3);
+        // User B re-joins the ongoing call from the conversation list
+        await userBPages.conversationList().getConversation(groupName).joinCallButton.click({timeout: 30_000});
 
-        // Verify second device successfully disconnected
-        await userADevice2Pages.calling().clickLeaveCallButton();
-        await expect(userADevice2Pages.calling().callCell).not.toBeAttached();
-      });
+        await expect(userBPages.calling().goFullScreen).toBeVisible();
+      },
+    );
 
-      await test.step('Verify User A’s first device remains in the call throughout', async () => {
-        await expect(userAPages.calling().goFullScreen).toBeVisible();
+    test('Verify ignoring group call', {tag: ['@TC-2811', '@regression']}, async ({createPage}) => {
+      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
 
-        await userAPages.calling().clickLeaveCallButton();
-        await expect(userAPages.calling().callCell).not.toBeAttached();
-        // Verify the call is still "joinable" (User B is still there)
-        await expect(userAPages.conversationList().getConversation(groupName).joinCallButton).toBeVisible({
-          timeout: 30_000,
-        });
-      });
-    },
-  );
-
-  test(
-    'I should not stay in the call when I get removed from the group',
-    {tag: ['@TC-2837', '@regression']},
-    async ({createPage}) => {
-      const [userAPages, userBPages, userCPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
-      ]);
-
-      await createGroup(userAPages, groupName, [userB, userC]);
-
-      // User A initiates the call
-      await userAPages.conversationList().getConversation(groupName).open();
-      await userAPages.conversation().clickCallButton();
-
-      await expect(userAPages.calling().callCell).toBeVisible();
-
-      // Ensure all invited members join the call
-      for (const member of [userBPages, userCPages]) {
-        await joinCall(member);
-      }
-
-      // User A removes User B from the group
-      await userAPages.conversation().toggleGroupInformation();
-      await userAPages.conversation().removeMemberFromGroup(userB.fullName);
-      await expect(
-        userAPages.conversation().systemMessages.filter({hasText: `You removed ${userB.fullName}`}),
-      ).toBeVisible();
-
-      // User B is kicked out of a call
-      await expect(userBPages.calling().callCell).not.toBeAttached();
-    },
-  );
-
-  test(
-    'I should not be able to join a call when I get removed from the group',
-    {tag: ['@TC-2838', '@regression']},
-    async ({createPage}) => {
-      const [userAPages, userBPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      ]);
+      const userAPages = PageManager.from(userAPage).webapp.pages;
+      const userBPages = PageManager.from(userBPage).webapp.pages;
 
       await createGroup(userAPages, groupName, [userB]);
 
@@ -445,526 +349,642 @@ test.describe('Calling', () => {
 
       await expect(userAPages.calling().callCell).toBeVisible();
       await expect(userBPages.calling().callCell).toBeVisible();
-      await expect(userBPages.conversationList().getConversation(groupName).joinCallButton).toBeVisible();
+      await expect.poll(() => isPlayingAudio(userBPage, AudioType.INCOMING_CALL)).toBe(true);
 
-      // User A removes User B from the group
-      await userAPages.conversation().toggleGroupInformation();
-      await userAPages.conversation().removeMemberFromGroup(userB.fullName);
-      await expect(
-        userAPages.conversation().systemMessages.filter({hasText: `You removed ${userB.fullName}`}),
-      ).toBeVisible();
+      await userBPages.calling().clickLeaveCallButton();
+      await expect(userBPages.calling().callCell).toBeHidden();
+      await expect.poll(() => isPlayingAudio(userBPage, AudioType.INCOMING_CALL)).toBe(false);
+    });
 
-      // User B cannot join the group call
-      await expect(userBPages.calling().callCell).not.toBeAttached();
-      await expect(userBPages.conversationList().getConversation(groupName).joinCallButton).not.toBeAttached();
-    },
-  );
+    test(
+      'Verify joining and leaving call from second client does not disconnect the first client',
+      {tag: ['@TC-2827', '@regression']},
+      async ({createPage}) => {
+        const [userAPages, userBPages] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+          PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+        ]);
 
-  test(
-    'I want to see warning when calling a big group',
-    {tag: ['@TC-2842', '@regression']},
-    async ({createPage, createUser}) => {
-      // Create Users and add to team
-      const extraMembers = await Promise.all(Array.from({length: 4}, () => createUser()));
+        // Log in a second session/device for User A.
+        const userAPage2 = await createPage(withLogin(userA, {confirmNewHistory: true}));
+        const userADevice2Pages = PageManager.from(userAPage2).webapp.pages;
 
-      for (const member of extraMembers) {
-        await team.addTeamMember(member);
-      }
+        // Setup: Create a group to host the call
+        await createGroup(userAPages, groupName, [userB]);
 
-      const allMembers = [userB, userC, ...extraMembers];
-      const userAPage = await createPage(withLogin(userA));
+        await test.step('User A starts a call and User B joins', async () => {
+          await userAPages.conversationList().getConversation(groupName).open();
+          await userAPages.conversation().clickCallButton();
 
-      const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+          await expect(userAPages.calling().callCell).toBeVisible();
 
-      await createGroup(userAPages, groupName, allMembers);
-      await userAPages.conversationList().getConversation(groupName).open();
-      await userAPages.conversation().clickCallButton();
+          await joinCall(userBPages);
+        });
 
-      await expect(userAModals.withoutTitle().modalText).toContainText(
-        `Are you sure you want to call ${allMembers.length} people?`,
-      );
-    },
-  );
+        await test.step('User A joins then leaves the call from their second device', async () => {
+          await userADevice2Pages.conversationList().getConversation(groupName).open();
+          await userADevice2Pages.conversation().clickCallButton();
+          await expect(userADevice2Pages.calling().callCell).toBeVisible();
 
-  test(
-    'I want to see the full call participant list',
-    {tag: ['@TC-2844', '@regression']},
-    async ({createPage, createUser}) => {
-      const guestUser = await createUser();
-      const [userAPage, userBPage, guestPage] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))),
-        PageManager.from(createPage(withLogin(userB))),
-        PageManager.from(createPage(withLogin(guestUser))),
-      ]);
-      await sendConnectionRequest(userAPage, guestUser);
-      await connectWithUser(userAPage, userB);
+          await expect(userADevice2Pages.calling().gridTiles).toHaveCount(3);
 
-      const [userAPages, userBPages, guestPages] = [userAPage, userBPage, guestPage].map(pm => pm.webapp.pages);
+          // Verify second device successfully disconnected
+          await userADevice2Pages.calling().clickLeaveCallButton();
+          await expect(userADevice2Pages.calling().callCell).not.toBeAttached();
+        });
 
-      // --- Setup and Call Initialization ---
-      await test.step('Setup: Accept connection and start group call', async () => {
-        await guestPages.conversationList().openPendingConnectionRequest();
-        await guestPages.connectRequest().clickConnectButton();
-        await expect(userAPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
-        await expect(guestPages.conversationList().getConversation(userA.fullName)).toBeAttached();
+        await test.step('Verify User A’s first device remains in the call throughout', async () => {
+          await expect(userAPages.calling().goFullScreen).toBeVisible();
 
-        await createGroup(userAPages, groupName, [userB, guestUser]);
+          await userAPages.calling().clickLeaveCallButton();
+          await expect(userAPages.calling().callCell).not.toBeAttached();
+          // Verify the call is still "joinable" (User B is still there)
+          await expect(userAPages.conversationList().getConversation(groupName).joinCallButton).toBeVisible({
+            timeout: 30_000,
+          });
+        });
+      },
+    );
 
+    test(
+      'I should not stay in the call when I get removed from the group',
+      {tag: ['@TC-2837', '@regression']},
+      async ({createPage}) => {
+        const [userAPages, userBPages, userCPages] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+          PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+          PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+        ]);
+
+        await createGroup(userAPages, groupName, [userB, userC]);
+
+        // User A initiates the call
         await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().clickCallButton();
-      });
 
-      await test.step('Join call with all participants', async () => {
-        for (const member of [userBPages, guestPages]) {
+        await expect(userAPages.calling().callCell).toBeVisible();
+
+        // Ensure all invited members join the call
+        for (const member of [userBPages, userCPages]) {
           await joinCall(member);
         }
-      });
 
-      const userACall = await userAPages.calling().maximizeCell();
-      await userACall.toggleParticipantsList();
-      await expect(userACall.getCallingParticipant(guestUser.fullName).guestIcon).toBeVisible();
-
-      const participants = [
-        {pages: userBPages, name: userB.fullName, label: 'User B'},
-        {pages: guestPages, name: guestUser.fullName, label: 'Guest User'},
-      ];
-
-      const features = [
-        {
-          name: 'Mute',
-          action: (p: PageManager['webapp']['pages']) => p.calling().toggleMuteButton.click(),
-          verify: async (name: string) => {
-            await expect(userACall.getCallingParticipant(name).muteIcon).not.toBeVisible();
-            await expect(userACall.getGridTile(name).muteIcon).not.toBeVisible();
-          },
-        },
-        {
-          name: 'Screenshare',
-          action: (p: PageManager['webapp']['pages']) => p.calling().clickToggleScreenShareButton(),
-          verify: async (name: string) => {
-            await expect(userACall.getCallingParticipant(name).screenShareIcon).toBeVisible();
-            await expect(userACall.getGridTile(name).videoElement).toBeVisible();
-          },
-        },
-        {
-          name: 'Video',
-          action: (p: PageManager['webapp']['pages']) => p.calling().clickToggleVideoButton(),
-          verify: async (name: string) => {
-            await expect(userACall.getCallingParticipant(name).videoIcon).toBeVisible();
-            await expect(userACall.getGridTile(name).videoElement).toBeVisible();
-          },
-        },
-      ];
-
-      for (const participant of participants) {
-        for (const feature of features) {
-          await test.step(`${participant.label}: Verify ${feature.name}`, async () => {
-            await feature.action(participant.pages);
-            await feature.verify(participant.name);
-          });
-        }
-      }
-    },
-  );
-
-  test(
-    'I want to accept a group video call as a personal account guest',
-    {tag: ['@TC-2852', '@regression']},
-    async ({createPage}) => {
-      test.setTimeout(150_000);
-
-      const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage()]);
-      const {pages: ownerPages, modals: ownerModals} = PageManager.from(userAPage).webapp;
-      const guestPages = PageManager.from(guestPage).webapp.pages;
-
-      const createdLink = await test.step('Owner: Create group and generate guest invitation link', async () => {
-        await createGroup(ownerPages, groupName, []);
-        await ownerPages.conversationList().getConversation(groupName).open();
-        await ownerPages.conversation().toggleGroupInformation();
-        await ownerPages.conversationDetails().openGuestOptions();
-        return await ownerPages.guestOptions().createLink();
-      });
-
-      await test.step('Guest: Navigate to link and log in with personal account', async () => {
-        await guestPage.goto(createdLink.toString());
-        await guestPages.conversationJoin().joinBrowserButton.click();
-        await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
-
-        await guestPages.login().login(userB);
-        await guestPages.conversation().conversationTitle.waitFor({
-          state: 'visible',
-          timeout: LOGIN_TIMEOUT,
-        });
-      });
-
-      await test.step('Owner: Verify guest arrival and initiate video call', async () => {
+        // User A removes User B from the group
+        await userAPages.conversation().toggleGroupInformation();
+        await userAPages.conversation().removeMemberFromGroup(userB.fullName);
         await expect(
-          ownerPages.conversation().systemMessages.filter({hasText: `${userB.fullName} joined`}),
+          userAPages.conversation().systemMessages.filter({hasText: `You removed ${userB.fullName}`}),
         ).toBeVisible();
 
-        await ownerPages.conversation().toggleGroupInformation();
-        await ownerPages.conversation().clickCallButton();
-
-        // Warning modal that guest started using a new device
-        await expect(ownerModals.confirm().modalTitle).toContainText('new device');
-        await ownerModals.confirm().clickAction();
-
-        await expect(ownerPages.calling().callCell).toBeVisible();
-      });
-
-      await test.step('Guest: Join the active call', async () => {
-        const {joinCallButton} = guestPages.conversationList().getConversation(groupName);
-
-        await expect(guestPages.calling().callCell).toBeVisible();
-        await expect(joinCallButton).toBeVisible();
-
-        await joinCallButton.click();
-        await expect(ownerPages.calling().goFullScreen).toBeVisible();
-      });
-    },
-  );
-
-  [
-    {
-      description: 'I want to navigate between call pages',
-      tag: '@TC-2924',
-      verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>, localUser: string) => {
-        await expect(callScreen.getGridTile(localUser)).toBeVisible();
-        await callScreen.goToNextPage();
-        await expect(callScreen.getGridTile(localUser)).toBeHidden();
-        await callScreen.goToPreviousPage();
-        await expect(callScreen.getGridTile(localUser)).toBeVisible();
+        // User B is kicked out of a call
+        await expect(userBPages.calling().callCell).not.toBeAttached();
       },
-    },
-    {
-      description: 'I want to see video tiles ordered alphabetically by user names',
-      tag: '@TC-2927',
-      verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>, localUser: string) => {
-        await expect(callScreen.gridTiles).toHaveCount(6); // Ensure first grid page is full
-        const displayedNames = await callScreen.gridTiles.getByTestId('call-participant-name').allInnerTexts();
-        const listToVerify = displayedNames.filter(name => name !== localUser);
-        const sortedNames = listToVerify.toSorted((a, b) => a.localeCompare(b));
+    );
 
-        expect(listToVerify).toEqual(sortedNames);
+    test(
+      'I should not be able to join a call when I get removed from the group',
+      {tag: ['@TC-2838', '@regression']},
+      async ({createPage}) => {
+        const [userAPages, userBPages] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+          PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+        ]);
+
+        await createGroup(userAPages, groupName, [userB]);
+
+        // User A initiates the call
+        await userAPages.conversationList().getConversation(groupName).open();
+        await userAPages.conversation().clickCallButton();
+
+        await expect(userAPages.calling().callCell).toBeVisible();
+        await expect(userBPages.calling().callCell).toBeVisible();
+        await expect(userBPages.conversationList().getConversation(groupName).joinCallButton).toBeVisible();
+
+        // User A removes User B from the group
+        await userAPages.conversation().toggleGroupInformation();
+        await userAPages.conversation().removeMemberFromGroup(userB.fullName);
+        await expect(
+          userAPages.conversation().systemMessages.filter({hasText: `You removed ${userB.fullName}`}),
+        ).toBeVisible();
+
+        // User B cannot join the group call
+        await expect(userBPages.calling().callCell).not.toBeAttached();
+        await expect(userBPages.conversationList().getConversation(groupName).joinCallButton).not.toBeAttached();
       },
-    },
-  ].forEach(({description, tag, verify}) => {
-    test(description, {tag: [tag, '@regression']}, async ({createPage, createUser}) => {
-      const {pages: userAPages, modals: userAModals} = PageManager.from(await createPage(withLogin(userA))).webapp;
+    );
 
-      const {groupMembers, memberPages} =
-        await test.step('Setup: Create members and initialize all browser pages', async () => {
-          // Generate a large participant list to trigger pagination
-          const extraMembers = await Promise.all(Array.from({length: 7}, () => createUser()));
-          const groupMembers = [userB, userC, ...extraMembers];
+    test(
+      'I want to see warning when calling a big group',
+      {tag: ['@TC-2842', '@regression']},
+      async ({createPage, createUser}) => {
+        // Create Users and add to team
+        const extraMembers = await Promise.all(Array.from({length: 4}, () => createUser()));
 
-          await Promise.all(extraMembers.map(member => team.addTeamMember(member)));
+        for (const member of extraMembers) {
+          await team.addTeamMember(member);
+        }
 
-          const memberPages = await Promise.all(
-            groupMembers.map(async member => {
-              const page = await createPage(withLogin(member));
-              return PageManager.from(page).webapp.pages;
-            }),
-          );
+        const allMembers = [userB, userC, ...extraMembers];
+        const userAPage = await createPage(withLogin(userA));
 
-          return {groupMembers, memberPages};
+        const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+
+        await createGroup(userAPages, groupName, allMembers);
+        await userAPages.conversationList().getConversation(groupName).open();
+        await userAPages.conversation().clickCallButton();
+
+        await expect(userAModals.withoutTitle().modalText).toContainText(
+          `Are you sure you want to call ${allMembers.length} people?`,
+        );
+      },
+    );
+
+    test(
+      'I want to see the full call participant list',
+      {tag: ['@TC-2844', '@regression']},
+      async ({createPage, createUser}) => {
+        const guestUser = await createUser();
+        const [userAPage, userBPage, guestPage] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))),
+          PageManager.from(createPage(withLogin(userB))),
+          PageManager.from(createPage(withLogin(guestUser))),
+        ]);
+        await sendConnectionRequest(userAPage, guestUser);
+        await connectWithUser(userAPage, userB);
+
+        const [userAPages, userBPages, guestPages] = [userAPage, userBPage, guestPage].map(pm => pm.webapp.pages);
+
+        // --- Setup and Call Initialization ---
+        await test.step('Setup: Accept connection and start group call', async () => {
+          await guestPages.conversationList().openPendingConnectionRequest();
+          await guestPages.connectRequest().clickConnectButton();
+          await expect(userAPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
+          await expect(guestPages.conversationList().getConversation(userA.fullName)).toBeAttached();
+
+          await createGroup(userAPages, groupName, [userB, guestUser]);
+
+          await userAPages.conversationList().getConversation(groupName).open();
+          await userAPages.conversation().clickCallButton();
         });
 
-      await test.step('Action: User A initiates the group call', async () => {
-        await createGroup(userAPages, groupName, groupMembers);
-        await userAPages.conversationList().getConversation(groupName).open();
-        await userAPages.conversation().clickCallButton();
-        // Warning modal about large group call
-        await userAModals.withoutTitle().clickAction();
-        await expect(userAPages.calling().goFullScreen).toBeVisible();
-      });
+        await test.step('Join call with all participants', async () => {
+          for (const member of [userBPages, guestPages]) {
+            await joinCall(member);
+          }
+        });
 
-      await test.step('Action: All members accept the incoming call', async () => {
-        await Promise.all(
-          memberPages.map(async memberPage => {
-            await joinCall(memberPage);
-          }),
-        );
-      });
-
-      await test.step('Verify functionality', async () => {
-        const callScreen = await userAPages.calling().maximizeCell();
-        await verify(callScreen, userA.fullName);
-      });
-    });
-  });
-
-  [
-    {
-      description: 'As a moderator I want to mute another participant',
-      tag: '@TC-2928',
-      verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
-        const contextMenu = await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
-        await contextMenu.muteButton.click();
-
-        await expect(callScreen.getCallingParticipant(userB.fullName).muteIcon).toBeVisible();
-        await expect(callScreen.getGridTile(userB.fullName).muteIcon).toBeVisible();
-      },
-    },
-    {
-      description: 'As moderator of a call I want to mute all other participants',
-      tag: '@TC-2929',
-      verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
-        const firstContextMenu = await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
-        await firstContextMenu.muteButton.click();
-
-        const secondContextMenu = await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
-        await secondContextMenu.muteOthersButton.click();
-
-        for (const participant of [userB, userC]) {
-          await expect(callScreen.getCallingParticipant(participant.fullName).muteIcon).toBeVisible();
-          await expect(callScreen.getGridTile(participant.fullName).muteIcon).toBeVisible();
-        }
-      },
-    },
-  ].forEach(({description, tag, verify}) => {
-    test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
-      const [userAPages, userBPages, userCPages] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-        PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
-      ]);
-
-      await test.step('Setup: Create group and start call', async () => {
-        await createGroup(userAPages, groupName, [userB, userC]);
-        await userAPages.conversationList().getConversation(groupName).open();
-        await userAPages.conversation().clickCallButton();
-
-        await expect(userAPages.calling().callCell).toBeVisible();
-      });
-
-      await test.step('All participants join the call', async () => {
-        for (const member of [userBPages, userCPages]) {
-          await joinCall(member);
-          await member.calling().toggleMute(); // Ensure active mic state
-        }
-      });
-
-      await test.step('Verify moderator can mute other participants', async () => {
         const userACall = await userAPages.calling().maximizeCell();
         await userACall.toggleParticipantsList();
+        await expect(userACall.getCallingParticipant(guestUser.fullName).guestIcon).toBeVisible();
 
-        await expect(userACall.getCallingParticipant(userB.fullName).muteIcon).not.toBeVisible();
-        await expect(userACall.getCallingParticipant(userC.fullName).muteIcon).not.toBeVisible();
+        const participants = [
+          {pages: userBPages, name: userB.fullName, label: 'User B'},
+          {pages: guestPages, name: guestUser.fullName, label: 'Guest User'},
+        ];
 
-        await verify(userACall);
+        const features = [
+          {
+            name: 'Mute',
+            action: (p: PageManager['webapp']['pages']) => p.calling().toggleMuteButton.click(),
+            verify: async (name: string) => {
+              await expect(userACall.getCallingParticipant(name).muteIcon).not.toBeVisible();
+              await expect(userACall.getGridTile(name).muteIcon).not.toBeVisible();
+            },
+          },
+          {
+            name: 'Screenshare',
+            action: (p: PageManager['webapp']['pages']) => p.calling().clickToggleScreenShareButton(),
+            verify: async (name: string) => {
+              await expect(userACall.getCallingParticipant(name).screenShareIcon).toBeVisible();
+              await expect(userACall.getGridTile(name).videoElement).toBeVisible();
+            },
+          },
+          {
+            name: 'Video',
+            action: (p: PageManager['webapp']['pages']) => p.calling().clickToggleVideoButton(),
+            verify: async (name: string) => {
+              await expect(userACall.getCallingParticipant(name).videoIcon).toBeVisible();
+              await expect(userACall.getGridTile(name).videoElement).toBeVisible();
+            },
+          },
+        ];
+
+        for (const participant of participants) {
+          for (const feature of features) {
+            await test.step(`${participant.label}: Verify ${feature.name}`, async () => {
+              await feature.action(participant.pages);
+              await feature.verify(participant.name);
+            });
+          }
+        }
+      },
+    );
+
+    test(
+      'I want to accept a group video call as a personal account guest',
+      {tag: ['@TC-2852', '@regression']},
+      async ({createPage}) => {
+        test.setTimeout(150_000);
+
+        const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage()]);
+        const {pages: ownerPages, modals: ownerModals} = PageManager.from(userAPage).webapp;
+        const guestPages = PageManager.from(guestPage).webapp.pages;
+
+        const createdLink = await test.step('Owner: Create group and generate guest invitation link', async () => {
+          await createGroup(ownerPages, groupName, []);
+          await ownerPages.conversationList().getConversation(groupName).open();
+          await ownerPages.conversation().toggleGroupInformation();
+          await ownerPages.conversationDetails().openGuestOptions();
+          return await ownerPages.guestOptions().createLink();
+        });
+
+        await test.step('Guest: Navigate to link and log in with personal account', async () => {
+          await guestPage.goto(createdLink.toString());
+          await guestPages.conversationJoin().joinBrowserButton.click();
+          await expect(guestPages.conversationJoin().joinAsGuestButton).toBeVisible();
+
+          await guestPages.login().login(userB);
+          await guestPages.conversation().conversationTitle.waitFor({
+            state: 'visible',
+            timeout: LOGIN_TIMEOUT,
+          });
+        });
+
+        await test.step('Owner: Verify guest arrival and initiate video call', async () => {
+          await expect(
+            ownerPages.conversation().systemMessages.filter({hasText: `${userB.fullName} joined`}),
+          ).toBeVisible();
+
+          await ownerPages.conversation().toggleGroupInformation();
+          await ownerPages.conversation().clickCallButton();
+
+          // Warning modal that guest started using a new device
+          await expect(ownerModals.confirm().modalTitle).toContainText('new device');
+          await ownerModals.confirm().clickAction();
+
+          await expect(ownerPages.calling().callCell).toBeVisible();
+        });
+
+        await test.step('Guest: Join the active call', async () => {
+          const {joinCallButton} = guestPages.conversationList().getConversation(groupName);
+
+          await expect(guestPages.calling().callCell).toBeVisible();
+          await expect(joinCallButton).toBeVisible();
+
+          await joinCallButton.click();
+          await expect(ownerPages.calling().goFullScreen).toBeVisible();
+        });
+      },
+    );
+
+    [
+      {
+        description: 'I want to navigate between call pages',
+        tag: '@TC-2924',
+        verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>, localUser: string) => {
+          await expect(callScreen.getGridTile(localUser)).toBeVisible();
+          await callScreen.goToNextPage();
+          await expect(callScreen.getGridTile(localUser)).toBeHidden();
+          await callScreen.goToPreviousPage();
+          await expect(callScreen.getGridTile(localUser)).toBeVisible();
+        },
+      },
+      {
+        description: 'I want to see video tiles ordered alphabetically by user names',
+        tag: '@TC-2927',
+        verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>, localUser: string) => {
+          await expect(callScreen.gridTiles).toHaveCount(6); // Ensure first grid page is full
+          const displayedNames = await callScreen.gridTiles.getByTestId('call-participant-name').allInnerTexts();
+          const listToVerify = displayedNames.filter(name => name !== localUser);
+          const sortedNames = listToVerify.toSorted((a, b) => a.localeCompare(b));
+
+          expect(listToVerify).toEqual(sortedNames);
+        },
+      },
+    ].forEach(({description, tag, verify}) => {
+      test(description, {tag: [tag, '@regression']}, async ({createPage, createUser}) => {
+        const {pages: userAPages, modals: userAModals} = PageManager.from(await createPage(withLogin(userA))).webapp;
+
+        const {groupMembers, memberPages} =
+          await test.step('Setup: Create members and initialize all browser pages', async () => {
+            // Generate a large participant list to trigger pagination
+            const extraMembers = await Promise.all(Array.from({length: 7}, () => createUser()));
+            const groupMembers = [userB, userC, ...extraMembers];
+
+            await Promise.all(extraMembers.map(member => team.addTeamMember(member)));
+
+            const memberPages = await Promise.all(
+              groupMembers.map(async member => {
+                const page = await createPage(withLogin(member));
+                return PageManager.from(page).webapp.pages;
+              }),
+            );
+
+            return {groupMembers, memberPages};
+          });
+
+        await test.step('Action: User A initiates the group call', async () => {
+          await createGroup(userAPages, groupName, groupMembers);
+          await userAPages.conversationList().getConversation(groupName).open();
+          await userAPages.conversation().clickCallButton();
+          // Warning modal about large group call
+          await userAModals.withoutTitle().clickAction();
+          await expect(userAPages.calling().goFullScreen).toBeVisible();
+        });
+
+        await test.step('Action: All members accept the incoming call', async () => {
+          await Promise.all(
+            memberPages.map(async memberPage => {
+              await joinCall(memberPage);
+            }),
+          );
+        });
+
+        await test.step('Verify functionality', async () => {
+          const callScreen = await userAPages.calling().maximizeCell();
+          await verify(callScreen, userA.fullName);
+        });
       });
     });
-  });
 
-  [
-    {
-      description: 'I want to unmute myself after I got muted',
-      tag: '@TC-2931',
-      verify: async (userCallPage: Page) => {
-        const userCallPages = PageManager.from(userCallPage).webapp.pages;
-        await userCallPages.calling().fullScreenMuteButton.click();
-        await expect(userCallPages.calling().getGridTile(userB.fullName).muteIcon).not.toBeVisible();
+    [
+      {
+        description: 'As a moderator I want to mute another participant',
+        tag: '@TC-2928',
+        verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
+          const contextMenu = await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
+          await contextMenu.muteButton.click();
+
+          await expect(callScreen.getCallingParticipant(userB.fullName).muteIcon).toBeVisible();
+          await expect(callScreen.getGridTile(userB.fullName).muteIcon).toBeVisible();
+        },
       },
-    },
-    {
-      description: 'I want to get notified when I got muted',
-      tag: '@TC-2932',
-      verify: async (userCallPage: Page) => {
-        await expect(userCallPage.getByText('You have been muted')).toBeVisible();
+      {
+        description: 'As moderator of a call I want to mute all other participants',
+        tag: '@TC-2929',
+        verify: async (callScreen: ReturnType<PageManager['webapp']['pages']['fullScreenCall']>) => {
+          const firstContextMenu = await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
+          await firstContextMenu.muteButton.click();
+
+          const secondContextMenu = await callScreen.getCallingParticipant(userB.fullName).openContextMenu();
+          await secondContextMenu.muteOthersButton.click();
+
+          for (const participant of [userB, userC]) {
+            await expect(callScreen.getCallingParticipant(participant.fullName).muteIcon).toBeVisible();
+            await expect(callScreen.getGridTile(participant.fullName).muteIcon).toBeVisible();
+          }
+        },
       },
-    },
-  ].forEach(({description, tag, verify}) => {
-    test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+    ].forEach(({description, tag, verify}) => {
+      test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
+        const [userAPages, userBPages, userCPages] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+          PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+          PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+        ]);
 
-      const userAPages = PageManager.from(userAPage).webapp.pages;
-      const userBPages = PageManager.from(userBPage).webapp.pages;
+        await test.step('Setup: Create group and start call', async () => {
+          await createGroup(userAPages, groupName, [userB, userC]);
+          await userAPages.conversationList().getConversation(groupName).open();
+          await userAPages.conversation().clickCallButton();
 
-      await test.step('Setup: Create group and start call', async () => {
-        await createGroup(userAPages, groupName, [userB]);
-        await userAPages.conversationList().getConversation(groupName).open();
-        await userAPages.conversation().clickCallButton();
+          await expect(userAPages.calling().callCell).toBeVisible();
+        });
 
-        await expect(userAPages.calling().callCell).toBeVisible();
-      });
+        await test.step('All participants join the call', async () => {
+          for (const member of [userBPages, userCPages]) {
+            await joinCall(member);
+            await member.calling().toggleMute(); // Ensure active mic state
+          }
+        });
 
-      await test.step('User B joins the call', async () => {
-        await joinCall(userBPages);
-        await userBPages.calling().toggleMute(); // Ensure active mic state
-        await userBPages.calling().maximizeCell();
-      });
+        await test.step('Verify moderator can mute other participants', async () => {
+          const userACall = await userAPages.calling().maximizeCell();
+          await userACall.toggleParticipantsList();
 
-      await test.step('Moderator mutes User B', async () => {
-        const userACall = await userAPages.calling().maximizeCell();
-        await userACall.toggleParticipantsList();
-        const userBParticipant = userACall.getCallingParticipant(userB.fullName);
+          await expect(userACall.getCallingParticipant(userB.fullName).muteIcon).not.toBeVisible();
+          await expect(userACall.getCallingParticipant(userC.fullName).muteIcon).not.toBeVisible();
 
-        await expect(userBParticipant.muteIcon).not.toBeVisible();
-
-        const contextMenu = await userBParticipant.openContextMenu();
-        await contextMenu.muteButton.click();
-
-        await expect(userBParticipant.muteIcon).toBeVisible();
-      });
-
-      await test.step('Verify mute functionality', async () => {
-        await verify(userBPage);
+          await verify(userACall);
+        });
       });
     });
-  });
 
-  test(
-    'I want to see a group call timing out after 300s if no one else joined',
-    {tag: ['@TC-2936', '@regression']},
-    async ({createPage}, testInfo) => {
-      test.setTimeout(testInfo.timeout + 300_000);
+    [
+      {
+        description: 'I want to unmute myself after I got muted',
+        tag: '@TC-2931',
+        verify: async (userCallPage: Page) => {
+          const userCallPages = PageManager.from(userCallPage).webapp.pages;
+          await userCallPages.calling().fullScreenMuteButton.click();
+          await expect(userCallPages.calling().getGridTile(userB.fullName).muteIcon).not.toBeVisible();
+        },
+      },
+      {
+        description: 'I want to get notified when I got muted',
+        tag: '@TC-2932',
+        verify: async (userCallPage: Page) => {
+          await expect(userCallPage.getByText('You have been muted')).toBeVisible();
+        },
+      },
+    ].forEach(({description, tag, verify}) => {
+      test(description, {tag: [tag, '@regression']}, async ({createPage}) => {
+        const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
 
-      const userAPage = await createPage(withLogin(userA));
-      const userAPages = PageManager.from(userAPage).webapp.pages;
+        const userAPages = PageManager.from(userAPage).webapp.pages;
+        const userBPages = PageManager.from(userBPage).webapp.pages;
 
-      await createGroup(userAPages, groupName, [userB, userC]);
+        await test.step('Setup: Create group and start call', async () => {
+          await createGroup(userAPages, groupName, [userB]);
+          await userAPages.conversationList().getConversation(groupName).open();
+          await userAPages.conversation().clickCallButton();
 
-      // User A initiates the call
-      await userAPages.conversationList().getConversation(groupName).open();
-      await userAPages.conversation().clickCallButton();
-      await expect(userAPages.calling().callCell).toBeVisible();
+          await expect(userAPages.calling().callCell).toBeVisible();
+        });
 
-      await userAPage.waitForTimeout(300_000);
-      await expect(
-        userAPages
-          .conversation()
-          .systemMessages.filter({hasText: 'Your call was ended because no other participant joined.'}),
-      ).toBeVisible();
-      await expect(userAPages.calling().callCell).not.toBeVisible();
-    },
-  );
+        await test.step('User B joins the call', async () => {
+          await joinCall(userBPages);
+          await userBPages.calling().toggleMute(); // Ensure active mic state
+          await userBPages.calling().maximizeCell();
+        });
 
-  test(
-    "I want to see a group call timing out after 90s if I'm the last one left in the call",
-    {tag: ['@TC-2937', '@regression']},
-    async ({createPage}, testInfo) => {
-      test.setTimeout(testInfo.timeout + 90_000);
+        await test.step('Moderator mutes User B', async () => {
+          const userACall = await userAPages.calling().maximizeCell();
+          await userACall.toggleParticipantsList();
+          const userBParticipant = userACall.getCallingParticipant(userB.fullName);
 
-      const [userAPage, userBPage, userCPage] = await Promise.all([
-        createPage(withLogin(userA)),
-        createPage(withLogin(userB)),
-        createPage(withLogin(userC)),
-      ]);
+          await expect(userBParticipant.muteIcon).not.toBeVisible();
 
-      const userAPages = PageManager.from(userAPage).webapp.pages;
-      const userBPages = PageManager.from(userBPage).webapp.pages;
-      const userCPages = PageManager.from(userCPage).webapp.pages;
+          const contextMenu = await userBParticipant.openContextMenu();
+          await contextMenu.muteButton.click();
 
-      await test.step('Setup: Create group and start call', async () => {
+          await expect(userBParticipant.muteIcon).toBeVisible();
+        });
+
+        await test.step('Verify mute functionality', async () => {
+          await verify(userBPage);
+        });
+      });
+    });
+
+    test(
+      'I want to see a group call timing out after 300s if no one else joined',
+      {tag: ['@TC-2936', '@regression']},
+      async ({createPage}, testInfo) => {
+        test.setTimeout(testInfo.timeout + 300_000);
+
+        const userAPage = await createPage(withLogin(userA));
+        const userAPages = PageManager.from(userAPage).webapp.pages;
+
         await createGroup(userAPages, groupName, [userB, userC]);
+
+        // User A initiates the call
         await userAPages.conversationList().getConversation(groupName).open();
         await userAPages.conversation().clickCallButton();
-
         await expect(userAPages.calling().callCell).toBeVisible();
-      });
 
-      await test.step('User B and User C join the call', async () => {
-        for (const member of [userBPages, userCPages]) {
-          await joinCall(member);
-        }
-        await expect(userAPages.calling().gridTiles).toHaveCount(3);
-      });
-
-      await test.step('User B and User C leave the call', async () => {
-        for (const member of [userBPages, userCPages]) {
-          await member.calling().clickLeaveCallButton();
-          await expect(member.calling().goFullScreen).toBeHidden();
-        }
-      });
-
-      await test.step('Verify call ends for User A after 90s of being the last one in the call', async () => {
-        await userAPage.waitForTimeout(90_000);
-        await expect(userAPages.calling().goFullScreen).toBeHidden();
+        await userAPage.waitForTimeout(300_000);
         await expect(
           userAPages
             .conversation()
-            .systemMessages.filter({hasText: 'Your call was ended because all other participants left'}),
+            .systemMessages.filter({hasText: 'Your call was ended because no other participant joined.'}),
         ).toBeVisible();
-      });
-    },
-  );
+        await expect(userAPages.calling().callCell).not.toBeVisible();
+      },
+    );
 
-  test('I want to see multiple active speakers in 1 call', {tag: ['@TC-2945', '@regression']}, async ({createPage}) => {
-    const [userAPages, userBPages, userCPages] = await Promise.all([
-      PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
-      PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
-    ]);
+    test(
+      "I want to see a group call timing out after 90s if I'm the last one left in the call",
+      {tag: ['@TC-2937', '@regression']},
+      async ({createPage}, testInfo) => {
+        test.setTimeout(testInfo.timeout + 90_000);
 
-    await test.step('Setup: Create group and start call', async () => {
-      await createGroup(userAPages, groupName, [userB, userC]);
-      await userAPages.conversationList().getConversation(groupName).open();
-      await userAPages.conversation().clickCallButton();
+        const [userAPage, userBPage, userCPage] = await Promise.all([
+          createPage(withLogin(userA)),
+          createPage(withLogin(userB)),
+          createPage(withLogin(userC)),
+        ]);
 
-      await expect(userAPages.calling().callCell).toBeVisible();
-    });
+        const userAPages = PageManager.from(userAPage).webapp.pages;
+        const userBPages = PageManager.from(userBPage).webapp.pages;
+        const userCPages = PageManager.from(userCPage).webapp.pages;
 
-    await test.step('User B and User C join the call', async () => {
-      for (const member of [userBPages, userCPages]) {
-        await joinCall(member);
-      }
-    });
+        await test.step('Setup: Create group and start call', async () => {
+          await createGroup(userAPages, groupName, [userB, userC]);
+          await userAPages.conversationList().getConversation(groupName).open();
+          await userAPages.conversation().clickCallButton();
 
-    await test.step('Verify 2 speakers are active in the call', async () => {
-      const userACall = await userAPages.calling().maximizeCell();
-      await userACall.toggleParticipantsList();
-
-      await userBPages.calling().maximizeCell();
-      await userBPages.calling().unmuteSelfInFullScreen();
-
-      await expect(userBPages.calling().getGridTile(userB.fullName).muteIcon).toBeHidden(); // Ensure active video state
-
-      await expect(userACall.getCallingParticipant(userA.fullName).activeSpeakerIcon).toBeVisible();
-      await expect(userACall.getCallingParticipant(userB.fullName).activeSpeakerIcon).toBeVisible({timeout: 30_000});
-    });
-  });
-
-  [
-    {id: '@TC-2908', title: 'I want to have 1:1 CBR audio call when the caller turned it on'} as const,
-    {id: '@TC-2909', title: 'I want to have 1:1 CBR audio call when the receiver turned it on'} as const,
-  ].forEach(({id, title}) => {
-    test(title, {tag: [id, '@regression']}, async ({createPage}) => {
-      const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
-      await connectWithUser(userAPage, userB);
-
-      const {pages: userAPages} = PageManager.from(userAPage).webapp;
-      const {pages: userBPages} = PageManager.from(userBPage).webapp;
-
-      if (id === '@TC-2908') {
-        await test.step('Caller enables CBR', async () => {
-          const {pages: callerPages, components: callerComponents} = PageManager.from(userAPage).webapp;
-          await callerComponents.conversationSidebar().preferencesButton.click();
-          await callerPages.settings().audioVideoButton.click();
-          await callerPages.audioVideoSettings().variableBitrateCheckbox.click();
-          await callerComponents.conversationSidebar().allConversationsButton.click();
+          await expect(userAPages.calling().callCell).toBeVisible();
         });
-      }
-      if (id === '@TC-2909') {
-        await test.step('Receiver enables CBR', async () => {
-          const {pages: receiverPages, components: receiverComponents} = PageManager.from(userBPage).webapp;
-          await receiverComponents.conversationSidebar().preferencesButton.click();
-          await receiverPages.settings().audioVideoButton.click();
-          await receiverPages.audioVideoSettings().variableBitrateCheckbox.click();
-          await receiverComponents.conversationSidebar().allConversationsButton.click();
+
+        await test.step('User B and User C join the call', async () => {
+          for (const member of [userBPages, userCPages]) {
+            await joinCall(member);
+          }
+          await expect(userAPages.calling().gridTiles).toHaveCount(3);
         });
-      }
 
-      await test.step('UserA calls userB', async () => {
-        await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
-        await userAPages.conversation().callButton.click();
-        await userBPages.calling().acceptCallButton.click();
-      });
+        await test.step('User B and User C leave the call', async () => {
+          for (const member of [userBPages, userCPages]) {
+            await member.calling().clickLeaveCallButton();
+            await expect(member.calling().goFullScreen).toBeHidden();
+          }
+        });
 
-      await test.step('Caller and receiver see CBR text in call window', async () => {
-        await expect(userAPages.calling().callCell).toContainText('CBR');
-        await expect(userBPages.calling().callCell).toContainText('CBR');
+        await test.step('Verify call ends for User A after 90s of being the last one in the call', async () => {
+          await userAPage.waitForTimeout(90_000);
+          await expect(userAPages.calling().goFullScreen).toBeHidden();
+          await expect(
+            userAPages
+              .conversation()
+              .systemMessages.filter({hasText: 'Your call was ended because all other participants left'}),
+          ).toBeVisible();
+        });
+      },
+    );
+
+    test(
+      'I want to see multiple active speakers in 1 call',
+      {tag: ['@TC-2945', '@regression']},
+      async ({createPage}) => {
+        const [userAPages, userBPages, userCPages] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))).then(pm => pm.webapp.pages),
+          PageManager.from(createPage(withLogin(userB))).then(pm => pm.webapp.pages),
+          PageManager.from(createPage(withLogin(userC))).then(pm => pm.webapp.pages),
+        ]);
+
+        await test.step('Setup: Create group and start call', async () => {
+          await createGroup(userAPages, groupName, [userB, userC]);
+          await userAPages.conversationList().getConversation(groupName).open();
+          await userAPages.conversation().clickCallButton();
+
+          await expect(userAPages.calling().callCell).toBeVisible();
+        });
+
+        await test.step('User B and User C join the call', async () => {
+          for (const member of [userBPages, userCPages]) {
+            await joinCall(member);
+          }
+        });
+
+        await test.step('Verify 2 speakers are active in the call', async () => {
+          const userACall = await userAPages.calling().maximizeCell();
+          await userACall.toggleParticipantsList();
+
+          await userBPages.calling().maximizeCell();
+          await userBPages.calling().unmuteSelfInFullScreen();
+
+          await expect(userBPages.calling().getGridTile(userB.fullName).muteIcon).toBeHidden(); // Ensure active video state
+
+          await expect(userACall.getCallingParticipant(userA.fullName).activeSpeakerIcon).toBeVisible();
+          await expect(userACall.getCallingParticipant(userB.fullName).activeSpeakerIcon).toBeVisible({
+            timeout: 30_000,
+          });
+        });
+      },
+    );
+
+    [
+      {id: '@TC-2908', title: 'I want to have 1:1 CBR audio call when the caller turned it on'} as const,
+      {id: '@TC-2909', title: 'I want to have 1:1 CBR audio call when the receiver turned it on'} as const,
+    ].forEach(({id, title}) => {
+      test(title, {tag: [id, '@regression']}, async ({createPage}) => {
+        const [userAPage, userBPage] = await Promise.all([createPage(withLogin(userA)), createPage(withLogin(userB))]);
+        await connectWithUser(userAPage, userB);
+
+        const {pages: userAPages} = PageManager.from(userAPage).webapp;
+        const {pages: userBPages} = PageManager.from(userBPage).webapp;
+
+        if (id === '@TC-2908') {
+          await test.step('Caller enables CBR', async () => {
+            const {pages: callerPages, components: callerComponents} = PageManager.from(userAPage).webapp;
+            await callerComponents.conversationSidebar().preferencesButton.click();
+            await callerPages.settings().audioVideoButton.click();
+            await callerPages.audioVideoSettings().variableBitrateCheckbox.click();
+            await callerComponents.conversationSidebar().allConversationsButton.click();
+          });
+        }
+        if (id === '@TC-2909') {
+          await test.step('Receiver enables CBR', async () => {
+            const {pages: receiverPages, components: receiverComponents} = PageManager.from(userBPage).webapp;
+            await receiverComponents.conversationSidebar().preferencesButton.click();
+            await receiverPages.settings().audioVideoButton.click();
+            await receiverPages.audioVideoSettings().variableBitrateCheckbox.click();
+            await receiverComponents.conversationSidebar().allConversationsButton.click();
+          });
+        }
+
+        await test.step('UserA calls userB', async () => {
+          await userAPages.conversationList().getConversation(userB.fullName, {protocol: 'mls'}).open();
+          await userAPages.conversation().callButton.click();
+          await userBPages.calling().acceptCallButton.click();
+        });
+
+        await test.step('Caller and receiver see CBR text in call window', async () => {
+          await expect(userAPages.calling().callCell).toContainText('CBR');
+          await expect(userBPages.calling().callCell).toContainText('CBR');
+        });
       });
     });
-  });
-});
+  },
+);

--- a/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -151,12 +151,24 @@ test.describe('Clear Conversation Content', () => {
   });
 
   [
-    {tag: '@TC-156', conversationType: 'group'},
-    {tag: '@TC-8779', conversationType: '1:1'},
-  ].forEach(({tag, conversationType}) => {
-    test(
+    {tag: '@TC-156', conversationType: 'group', skipBecauseIbisFeatureProvisioning: true},
+    {tag: '@TC-8779', conversationType: '1:1', skipBecauseIbisFeatureProvisioning: false},
+  ].forEach(({tag, conversationType, skipBecauseIbisFeatureProvisioning}) => {
+    const conversationContentTest = skipBecauseIbisFeatureProvisioning ? test.skip : test;
+    const testDetails = skipBecauseIbisFeatureProvisioning
+      ? {
+          tag: [tag, '@regression'],
+          annotation: {
+            type: 'skip',
+            description:
+              'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
+          },
+        }
+      : {tag: [tag, '@regression']};
+
+    conversationContentTest(
       `I want to see incoming picture, ping and call after I clear content of a ${conversationType} conversation via conversation list`,
-      {tag: [tag, '@regression']},
+      testDetails,
       async ({createPage}) => {
         const [userAPage, userBPage, userCPage] = await Promise.all([
           createPage(withLogin(userA)),

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsCall-TC-8755.spec.ts
@@ -20,9 +20,16 @@
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin} from '../../test.fixtures';
 
-test(
+test.skip(
   'Calls in channels with device switch and screenshare',
-  {tag: ['@TC-8755', '@crit-flow-web']},
+  {
+    tag: ['@TC-8755', '@crit-flow-web'],
+    annotation: {
+      type: 'skip',
+      description:
+        'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
+    },
+  },
   async ({createUser, createTeam, createPage, api}) => {
     test.setTimeout(150_000);
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/channelsManagement-TC-8752.spec.ts
@@ -20,111 +20,122 @@ import {PageManager} from 'test/e2e_tests/pageManager';
 import {sendTextMessageToConversation} from 'test/e2e_tests/utils/userActions';
 import {test, expect, withLogin} from '../../test.fixtures';
 
-test('Channels Management', {tag: ['@TC-8752', '@crit-flow-web']}, async ({createUser, createTeam, createPage}) => {
-  const conversation1 = 'Test Channel 1';
-  const conversation2 = 'Test Channel 2';
+test.skip(
+  'Channels Management',
+  {
+    tag: ['@TC-8752', '@crit-flow-web'],
+    annotation: {
+      type: 'skip',
+      description:
+        'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
+    },
+  },
+  async ({createUser, createTeam, createPage}) => {
+    const conversation1 = 'Test Channel 1';
+    const conversation2 = 'Test Channel 2';
 
-  const member = await createUser();
-  const team = await createTeam('Channels Management', {
-    users: [member],
-    features: {channels: true, mls: true},
-  });
-  const owner = team.owner;
+    const member = await createUser();
+    const team = await createTeam('Channels Management', {
+      users: [member],
+      features: {channels: true, mls: true},
+    });
+    const owner = team.owner;
 
-  const [ownerPageManager, memberPageManager] = await Promise.all([
-    PageManager.from(createPage(withLogin(owner))),
-    PageManager.from(createPage(withLogin(member))),
-  ]);
+    const [ownerPageManager, memberPageManager] = await Promise.all([
+      PageManager.from(createPage(withLogin(owner))),
+      PageManager.from(createPage(withLogin(member))),
+    ]);
 
-  const {pages: ownerPages, modals: ownerModals} = ownerPageManager.webapp;
-  const {pages: memberPages, modals: memberModals} = memberPageManager.webapp;
+    const {pages: ownerPages, modals: ownerModals} = ownerPageManager.webapp;
+    const {pages: memberPages, modals: memberModals} = memberPageManager.webapp;
 
-  await test.step('Team owner creates a channel with available member', async () => {
-    await ownerPages.conversationList().clickCreateGroup();
-    await ownerModals.createConversation().createChannel(conversation1, {members: [member]});
-    await expect(ownerPages.conversationList().getConversation(conversation1)).toBeVisible();
-  });
+    await test.step('Team owner creates a channel with available member', async () => {
+      await ownerPages.conversationList().clickCreateGroup();
+      await ownerModals.createConversation().createChannel(conversation1, {members: [member]});
+      await expect(ownerPages.conversationList().getConversation(conversation1)).toBeVisible();
+    });
 
-  await test.step('Team members leave the conversation', async () => {
-    await sendTextMessageToConversation(
-      memberPageManager,
-      conversation1,
-      `Hello ${conversation1}, ${member.firstName} here!`,
-    );
-    await memberPages.conversation().toggleGroupInformation();
-    await expect(memberPages.conversationDetails().groupMembers.filter({hasText: member.fullName})).toBeVisible();
+    await test.step('Team members leave the conversation', async () => {
+      await sendTextMessageToConversation(
+        memberPageManager,
+        conversation1,
+        `Hello ${conversation1}, ${member.firstName} here!`,
+      );
+      await memberPages.conversation().toggleGroupInformation();
+      await expect(memberPages.conversationDetails().groupMembers.filter({hasText: member.fullName})).toBeVisible();
 
-    await memberPages.conversation().leaveConversation();
-    await memberModals.leaveConversation().actionButton.click();
-    await expect(memberPages.conversation().messageInput).not.toBeAttached();
-  });
+      await memberPages.conversation().leaveConversation();
+      await memberModals.leaveConversation().actionButton.click();
+      await expect(memberPages.conversation().messageInput).not.toBeAttached();
+    });
 
-  await test.step('Team owner confirm member left', async () => {
-    await ownerPages.conversationList().getConversation(conversation1).open();
-    await expect(ownerPages.conversation().systemMessages.filter({hasText: `${member.fullName} left`})).toBeVisible();
-  });
+    await test.step('Team owner confirm member left', async () => {
+      await ownerPages.conversationList().getConversation(conversation1).open();
+      await expect(ownerPages.conversation().systemMessages.filter({hasText: `${member.fullName} left`})).toBeVisible();
+    });
 
-  await test.step('Team owner creates another channel', async () => {
-    await ownerPages.conversationList().clickCreateGroup();
-    await ownerModals.createConversation().createChannel(conversation2, {members: [member]});
-    await expect(ownerPages.conversationList().getConversation(conversation2)).toBeVisible();
-  });
+    await test.step('Team owner creates another channel', async () => {
+      await ownerPages.conversationList().clickCreateGroup();
+      await ownerModals.createConversation().createChannel(conversation2, {members: [member]});
+      await expect(ownerPages.conversationList().getConversation(conversation2)).toBeVisible();
+    });
 
-  await test.step('Team owner makes the member an admin', async () => {
-    await ownerPages.conversation().toggleGroupInformation();
-    await ownerPages.conversation().makeUserAdmin(member.fullName);
-  });
+    await test.step('Team owner makes the member an admin', async () => {
+      await ownerPages.conversation().toggleGroupInformation();
+      await ownerPages.conversation().makeUserAdmin(member.fullName);
+    });
 
-  await test.step('Team member confirms admin status', async () => {
-    await memberPages.conversationList().getConversation(conversation2).open();
-    await memberPages.conversation().toggleGroupInformation();
-    await expect(memberPages.conversation().adminsList.filter({hasText: member.fullName})).toBeVisible();
-  });
+    await test.step('Team member confirms admin status', async () => {
+      await memberPages.conversationList().getConversation(conversation2).open();
+      await memberPages.conversation().toggleGroupInformation();
+      await expect(memberPages.conversation().adminsList.filter({hasText: member.fullName})).toBeVisible();
+    });
 
-  await test.step('Team admin remove member', async () => {
-    await ownerPages.conversation().toggleGroupInformation();
-    await ownerPages.conversation().removeAdminFromGroup(member.fullName);
-    await ownerModals.confirm().actionButton.click();
-  });
+    await test.step('Team admin remove member', async () => {
+      await ownerPages.conversation().toggleGroupInformation();
+      await ownerPages.conversation().removeAdminFromGroup(member.fullName);
+      await ownerModals.confirm().actionButton.click();
+    });
 
-  await test.step('Team member verifies they have been removed by the owner', async () => {
-    await memberPages.conversationList().getConversation(conversation2).open();
-    await expect(memberPages.conversation().messageInput).not.toBeAttached();
-  });
+    await test.step('Team member verifies they have been removed by the owner', async () => {
+      await memberPages.conversationList().getConversation(conversation2).open();
+      await expect(memberPages.conversation().messageInput).not.toBeAttached();
+    });
 
-  await test.step('Team owner add member back to the same conversation', async () => {
-    await ownerPages.conversationList().getConversation(conversation2).open();
-    await expect(
-      ownerPages.conversation().systemMessages.filter({hasText: `You removed ${member.fullName}`}),
-    ).toBeVisible();
-    await ownerPages.conversation().clickAddMemberButton();
-    await ownerPages.conversationDetails().addUsersToConversation([member.fullName]);
-  });
+    await test.step('Team owner add member back to the same conversation', async () => {
+      await ownerPages.conversationList().getConversation(conversation2).open();
+      await expect(
+        ownerPages.conversation().systemMessages.filter({hasText: `You removed ${member.fullName}`}),
+      ).toBeVisible();
+      await ownerPages.conversation().clickAddMemberButton();
+      await ownerPages.conversationDetails().addUsersToConversation([member.fullName]);
+    });
 
-  await test.step('Team member confirms they have been added back to the conversation', async () => {
-    await memberPages.conversationList().getConversation(conversation2).open();
-    await memberPages.conversation().toggleGroupInformation();
-    await expect(
-      memberPages.conversation().systemMessages.filter({hasText: `${owner.fullName} added you to the conversation`}),
-    ).toBeVisible();
-  });
+    await test.step('Team member confirms they have been added back to the conversation', async () => {
+      await memberPages.conversationList().getConversation(conversation2).open();
+      await memberPages.conversation().toggleGroupInformation();
+      await expect(
+        memberPages.conversation().systemMessages.filter({hasText: `${owner.fullName} added you to the conversation`}),
+      ).toBeVisible();
+    });
 
-  await test.step('Team owner promote member to admin', async () => {
-    await ownerPages.conversationList().getConversation(conversation2).open();
-    await ownerPages.conversation().makeUserAdmin(member.fullName);
-  });
+    await test.step('Team owner promote member to admin', async () => {
+      await ownerPages.conversationList().getConversation(conversation2).open();
+      await ownerPages.conversation().makeUserAdmin(member.fullName);
+    });
 
-  await test.step('Team member confirms admin status', async () => {
-    await memberPages.conversationList().getConversation(conversation2).open();
-    await memberPages.conversation().toggleGroupInformation();
-    await expect(memberPages.conversation().adminsList.filter({hasText: member.fullName})).toBeVisible();
-  });
+    await test.step('Team member confirms admin status', async () => {
+      await memberPages.conversationList().getConversation(conversation2).open();
+      await memberPages.conversation().toggleGroupInformation();
+      await expect(memberPages.conversation().adminsList.filter({hasText: member.fullName})).toBeVisible();
+    });
 
-  await test.step('Team owner send a message', async () => {
-    await sendTextMessageToConversation(ownerPageManager, conversation2, 'Hello team! Admin here.');
-  });
+    await test.step('Team owner send a message', async () => {
+      await sendTextMessageToConversation(ownerPageManager, conversation2, 'Hello team! Admin here.');
+    });
 
-  await test.step('Team member sees the message', async () => {
-    await expect(memberPages.conversation().getMessage({content: 'Hello team! Admin here.'})).toBeVisible();
-  });
-});
+    await test.step('Team member sees the message', async () => {
+      await expect(memberPages.conversation().getMessage({content: 'Hello team! Admin here.'})).toBeVisible();
+    });
+  },
+);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupCalls-TC-8632.spec.ts
@@ -33,9 +33,16 @@ test.beforeEach(async ({createUser, createTeam}) => {
   owner = team.owner;
 });
 
-test(
+test.skip(
   'Planning group call with sending various messages during call',
-  {tag: ['@TC-8632', '@crit-flow-web']},
+  {
+    tag: ['@TC-8632', '@crit-flow-web'],
+    annotation: {
+      type: 'skip',
+      description:
+        'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
+    },
+  },
   async ({createPage}) => {
     const [ownerPageManager, memberPageManager] = await Promise.all([
       PageManager.from(createPage(withLogin(owner))),

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/groupVideoCall-TC-8637.spec.ts
@@ -21,99 +21,110 @@ import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin} from '../../test.fixtures';
 import {createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
-test('Group Video call', {tag: ['@TC-8637', '@crit-flow-web']}, async ({createTeam, createUser, createPage, api}) => {
-  test.setTimeout(150_000);
-  let callingServiceInstanceId: string;
+test.skip(
+  'Group Video call',
+  {
+    tag: ['@TC-8637', '@crit-flow-web'],
+    annotation: {
+      type: 'skip',
+      description:
+        'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
+    },
+  },
+  async ({createTeam, createUser, createPage, api}) => {
+    test.setTimeout(150_000);
+    let callingServiceInstanceId: string;
 
-  const conversationName = 'CriticalCall';
-  const teamMember = await createUser();
-  const guestUser = await createUser();
-  const team = await createTeam('Critical', {users: [teamMember], features: {conferenceCalling: true}});
-  const teamOwner = team.owner;
+    const conversationName = 'CriticalCall';
+    const teamMember = await createUser();
+    const guestUser = await createUser();
+    const team = await createTeam('Critical', {users: [teamMember], features: {conferenceCalling: true}});
+    const teamOwner = team.owner;
 
-  const [ownerPageManager, guestPageManager] = await Promise.all([
-    PageManager.from(createPage(withLogin(teamOwner))),
-    PageManager.from(createPage(withLogin(guestUser))),
-  ]);
-  await sendConnectionRequest(ownerPageManager, guestUser);
+    const [ownerPageManager, guestPageManager] = await Promise.all([
+      PageManager.from(createPage(withLogin(teamOwner))),
+      PageManager.from(createPage(withLogin(guestUser))),
+    ]);
+    await sendConnectionRequest(ownerPageManager, guestUser);
 
-  const ownerPages = ownerPageManager.webapp.pages;
-  const guestPages = guestPageManager.webapp.pages;
+    const ownerPages = ownerPageManager.webapp.pages;
+    const guestPages = guestPageManager.webapp.pages;
 
-  await test.step('Guest user accepts connection request from owner', async () => {
-    await guestPages.conversationList().openPendingConnectionRequest();
-    await guestPages.connectRequest().clickConnectButton();
-    await expect(ownerPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
-    await expect(guestPages.conversationList().getConversation(teamOwner.fullName)).toBeAttached();
-  });
+    await test.step('Guest user accepts connection request from owner', async () => {
+      await guestPages.conversationList().openPendingConnectionRequest();
+      await guestPages.connectRequest().clickConnectButton();
+      await expect(ownerPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
+      await expect(guestPages.conversationList().getConversation(teamOwner.fullName)).toBeAttached();
+    });
 
-  await test.step('Owner and team member are in a group conversation together', async () => {
-    await createGroup(ownerPages, conversationName, [teamMember]);
-  });
+    await test.step('Owner and team member are in a group conversation together', async () => {
+      await createGroup(ownerPages, conversationName, [teamMember]);
+    });
 
-  await test.step('Owner invites guest user to the group', async () => {
-    await ownerPages.conversationList().getConversation(conversationName).open();
-    await ownerPages.conversation().clickConversationTitle();
-    await ownerPages.conversationDetails().clickAddPeopleButton();
-    await ownerPages.conversationDetails().addUsersToConversation([guestUser.fullName]);
-    await expect(ownerPages.conversationDetails().groupMembers.filter({hasText: guestUser.fullName})).toBeVisible();
-    await expect(ownerPages.conversationDetails().groupMembers.filter({hasText: teamMember.fullName})).toBeVisible();
-  });
+    await test.step('Owner invites guest user to the group', async () => {
+      await ownerPages.conversationList().getConversation(conversationName).open();
+      await ownerPages.conversation().clickConversationTitle();
+      await ownerPages.conversationDetails().clickAddPeopleButton();
+      await ownerPages.conversationDetails().addUsersToConversation([guestUser.fullName]);
+      await expect(ownerPages.conversationDetails().groupMembers.filter({hasText: guestUser.fullName})).toBeVisible();
+      await expect(ownerPages.conversationDetails().groupMembers.filter({hasText: teamMember.fullName})).toBeVisible();
+    });
 
-  await test.step('Guest user joins the group', async () => {
-    await expect(guestPages.conversationList().getConversation(conversationName)).toBeVisible();
-  });
+    await test.step('Guest user joins the group', async () => {
+      await expect(guestPages.conversationList().getConversation(conversationName)).toBeVisible();
+    });
 
-  await test.step('Owner calls the group', async () => {
-    const response = await api.callingService.createInstance(teamMember.password, teamMember.email);
-    callingServiceInstanceId = response.id;
-    await api.callingService.setAcceptNextCall(callingServiceInstanceId);
-    await ownerPages.conversation().clickCallButton();
-    await expect(ownerPages.calling().callCell).toBeVisible();
-  });
+    await test.step('Owner calls the group', async () => {
+      const response = await api.callingService.createInstance(teamMember.password, teamMember.email);
+      callingServiceInstanceId = response.id;
+      await api.callingService.setAcceptNextCall(callingServiceInstanceId);
+      await ownerPages.conversation().clickCallButton();
+      await expect(ownerPages.calling().callCell).toBeVisible();
+    });
 
-  await test.step('Team member and guest user answer call from calling notification', async () => {
-    // Team member answers the call automatically with the help of Calling Service
-    await guestPages.calling().clickAcceptCallButton();
-  });
+    await test.step('Team member and guest user answer call from calling notification', async () => {
+      // Team member answers the call automatically with the help of Calling Service
+      await guestPages.calling().clickAcceptCallButton();
+    });
 
-  await test.step('Owner switches audio on and sends audio', async () => {});
+    await test.step('Owner switches audio on and sends audio', async () => {});
 
-  await test.step(`Team member is able to "hear" owner's audio`, async () => {
-    await api.callingService.verifyAudioIsBeingReceived(callingServiceInstanceId);
-  });
+    await test.step(`Team member is able to "hear" owner's audio`, async () => {
+      await api.callingService.verifyAudioIsBeingReceived(callingServiceInstanceId);
+    });
 
-  await test.step('Owner turns on camera', async () => {
-    await ownerPages.calling().clickToggleVideoButton();
-  });
+    await test.step('Owner turns on camera', async () => {
+      await ownerPages.calling().clickToggleVideoButton();
+    });
 
-  await test.step('Team member is able to "see" owner', async () => {
-    await api.callingService.verifyVideoIsBeingReceived(callingServiceInstanceId);
-  });
+    await test.step('Team member is able to "see" owner', async () => {
+      await api.callingService.verifyVideoIsBeingReceived(callingServiceInstanceId);
+    });
 
-  await test.step('Owner swaps video and audio devices', async () => {
-    const {pages, components} = ownerPageManager.webapp;
-    await components.conversationSidebar().clickPreferencesButton();
-    await pages.settings().clickAudioVideoSettingsButton();
-    await pages.audioVideoSettings().selectMicrophone('Fake Audio Input 2');
-    await pages.audioVideoSettings().selectSpeaker('Fake Audio Output 2');
-    await pages.audioVideoSettings().selectCamera('Fake Camera 2');
-  });
+    await test.step('Owner swaps video and audio devices', async () => {
+      const {pages, components} = ownerPageManager.webapp;
+      await components.conversationSidebar().clickPreferencesButton();
+      await pages.settings().clickAudioVideoSettingsButton();
+      await pages.audioVideoSettings().selectMicrophone('Fake Audio Input 2');
+      await pages.audioVideoSettings().selectSpeaker('Fake Audio Output 2');
+      await pages.audioVideoSettings().selectCamera('Fake Camera 2');
+    });
 
-  await test.step("Team member is able to 'see' and 'hear' owner's new audio and video", async () => {
-    await api.callingService.verifyAudioIsBeingReceived(callingServiceInstanceId);
-    await api.callingService.verifyVideoIsBeingReceived(callingServiceInstanceId);
-  });
+    await test.step("Team member is able to 'see' and 'hear' owner's new audio and video", async () => {
+      await api.callingService.verifyAudioIsBeingReceived(callingServiceInstanceId);
+      await api.callingService.verifyVideoIsBeingReceived(callingServiceInstanceId);
+    });
 
-  await test.step('Owner turns on screenshare', async () => {
-    await ownerPages.calling().clickToggleScreenShareButton();
-  });
+    await test.step('Owner turns on screenshare', async () => {
+      await ownerPages.calling().clickToggleScreenShareButton();
+    });
 
-  await test.step("Team member is able to 'see' owner's screen", async () => {
-    await api.callingService.verifyVideoIsBeingReceived(callingServiceInstanceId);
-  });
+    await test.step("Team member is able to 'see' owner's screen", async () => {
+      await api.callingService.verifyVideoIsBeingReceived(callingServiceInstanceId);
+    });
 
-  await test.step('Owner ends call', async () => {
-    await ownerPages.calling().clickLeaveCallButton();
-  });
-});
+    await test.step('Owner ends call', async () => {
+      await ownerPages.calling().clickLeaveCallButton();
+    });
+  },
+);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/loginWithClaimedDomain-TC-8781.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/loginWithClaimedDomain-TC-8781.spec.ts
@@ -22,38 +22,49 @@ import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, LOGIN_TIMEOUT} from '../../test.fixtures';
 import {getUser} from 'test/e2e_tests/data/user';
 
-test('SSO login with claimed domain', {tag: ['@TC-8781', '@regression']}, async ({context, createPage}) => {
-  const page = await createPage(context);
-  const pageManager = PageManager.from(page);
-  await pageManager.openMainPage();
+test.skip(
+  'SSO login with claimed domain',
+  {
+    tag: ['@TC-8781', '@regression'],
+    annotation: {
+      type: 'skip',
+      description:
+        'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
+    },
+  },
+  async ({context, createPage}) => {
+    const page = await createPage(context);
+    const pageManager = PageManager.from(page);
+    await pageManager.openMainPage();
 
-  const ssoUser = getUser({
-    email: process.env.SSO_CLAIMED_DOMAIN_CODE,
-    username: process.env.SSO_CLAIMED_USER_EMAIL,
-    password: process.env.SSO_CLAIMED_USER_PASSWORD,
-  });
-
-  const {pages, components} = pageManager.webapp;
-  const [idpPage] = await Promise.all([
-    context.waitForEvent('page'),
-    pages.singleSignOn().enterEmailOnSSOPage(ssoUser.email),
-  ]);
-
-  await test.step('Log in on IDP page', async () => {
-    await idpPage.getByRole('textbox', {name: 'Username'}).fill(ssoUser.username, {timeout: 20_000});
-    await idpPage.getByRole('textbox', {name: 'Password'}).fill(ssoUser.password);
-    await idpPage.getByRole('button', {name: 'Sign In'}).click();
-  });
-
-  await test.step('Remove an existing device and confirm new history', async () => {
-    // Since this test re-uses the same user over and over again we need to always remove one of the previously registered devices
-    await page.getByRole('button', {name: 'Remove device'}).first().click({timeout: LOGIN_TIMEOUT});
-    // We will also always be prompted to confirm the new history on this device
-    await pages.historyInfo().clickConfirmButton();
-    await expect(components.conversationSidebar().sidebar, `Login took more than ${LOGIN_TIMEOUT}s`).toBeVisible({
-      timeout: LOGIN_TIMEOUT,
+    const ssoUser = getUser({
+      email: process.env.SSO_CLAIMED_DOMAIN_CODE,
+      username: process.env.SSO_CLAIMED_USER_EMAIL,
+      password: process.env.SSO_CLAIMED_USER_PASSWORD,
     });
-  });
 
-  await expect(pages.sidebar().allConversationsButton).toBeVisible();
-});
+    const {pages, components} = pageManager.webapp;
+    const [idpPage] = await Promise.all([
+      context.waitForEvent('page'),
+      pages.singleSignOn().enterEmailOnSSOPage(ssoUser.email),
+    ]);
+
+    await test.step('Log in on IDP page', async () => {
+      await idpPage.getByRole('textbox', {name: 'Username'}).fill(ssoUser.username, {timeout: 20_000});
+      await idpPage.getByRole('textbox', {name: 'Password'}).fill(ssoUser.password);
+      await idpPage.getByRole('button', {name: 'Sign In'}).click();
+    });
+
+    await test.step('Remove an existing device and confirm new history', async () => {
+      // Since this test re-uses the same user over and over again we need to always remove one of the previously registered devices
+      await page.getByRole('button', {name: 'Remove device'}).first().click({timeout: LOGIN_TIMEOUT});
+      // We will also always be prompted to confirm the new history on this device
+      await pages.historyInfo().clickConfirmButton();
+      await expect(components.conversationSidebar().sidebar, `Login took more than ${LOGIN_TIMEOUT}s`).toBeVisible({
+        timeout: LOGIN_TIMEOUT,
+      });
+    });
+
+    await expect(pages.sidebar().allConversationsButton).toBeVisible();
+  },
+);

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/messagesInChannels-TC-8753.spec.ts
@@ -33,9 +33,16 @@ const videoFilePath = getVideoFilePath();
 const audioFilePath = getAudioFilePath();
 const textFilePath = getTextFilePath();
 
-test(
+test.skip(
   'Messages in Channels',
-  {tag: ['@TC-8753', '@crit-flow-web']},
+  {
+    tag: ['@TC-8753', '@crit-flow-web'],
+    annotation: {
+      type: 'skip',
+      description:
+        'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
+    },
+  },
   async ({createUser, createTeam, createPage}, testInfo) => {
     test.setTimeout(testInfo.timeout + 11_000);
 

--- a/apps/webapp/test/e2e_tests/specs/CriticalFlow/onPremLoginRedirect-TC-8757.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CriticalFlow/onPremLoginRedirect-TC-8757.spec.ts
@@ -46,26 +46,37 @@ test.describe('On Prem Login Redirect Flow', () => {
     });
   });
 
-  test('On Prem Login Redirect', {tag: ['@TC-8757', '@regression']}, async ({context, createPage}) => {
-    const page = await createPage(context);
-    const pageManager = PageManager.from(page);
-    const {pages} = pageManager.webapp;
+  test.skip(
+    'On Prem Login Redirect',
+    {
+      tag: ['@TC-8757', '@regression'],
+      annotation: {
+        type: 'skip',
+        description:
+          'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
+      },
+    },
+    async ({context, createPage}) => {
+      const page = await createPage(context);
+      const pageManager = PageManager.from(page);
+      const {pages} = pageManager.webapp;
 
-    await test.step('Open login page and enter email with claimed domain', async () => {
-      await pageManager.openSSOPage();
-      await pages.singleSignOn().enterEmailOnSSOPage(email);
-    });
+      await test.step('Open login page and enter email with claimed domain', async () => {
+        await pageManager.openSSOPage();
+        await pages.singleSignOn().enterEmailOnSSOPage(email);
+      });
 
-    await test.step('Verify connect-to-organization backend dialog is shown', async () => {
-      await expect(page.getByText("Connect to your organization's backend?")).toBeVisible();
-      await expect(page.getByText(webappUrl)).toBeVisible();
-    });
+      await test.step('Verify connect-to-organization backend dialog is shown', async () => {
+        await expect(page.getByText("Connect to your organization's backend?")).toBeVisible();
+        await expect(page.getByText(webappUrl)).toBeVisible();
+      });
 
-    await test.step('Click connect and verify redirect to on-prem webapp', async () => {
-      await page.getByRole('button', {name: 'Connect'}).click();
-      await expect(page).toHaveURL(new RegExp(String.raw`${webappUrl}`), {timeout: 20_000});
-    });
-  });
+      await test.step('Click connect and verify redirect to on-prem webapp', async () => {
+        await page.getByRole('button', {name: 'Connect'}).click();
+        await expect(page).toHaveURL(new RegExp(String.raw`${webappUrl}`), {timeout: 20_000});
+      });
+    },
+  );
 
   test.afterEach(async ({api}) => {
     await test.step('Delete claimed domain registration', async () => {

--- a/apps/webapp/test/e2e_tests/specs/Drive/drive.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Drive/drive.spec.ts
@@ -43,206 +43,216 @@ const getCellsImageLocator = (conversation: ConversationPage, user: User): Locat
   return conversation.messageItems.getByRole('button', {name: new RegExp(`^Image from ${user.fullName}`)});
 };
 
-test.describe('Conversations', () => {
-  // User A is a team owner, User B is a team member
-  let userA: User;
-  let userB: User;
-
-  const teamName = 'Cells Critical Team';
-  const conversationName = 'Cells Critical Conversation';
-  const initialMessageText = 'Here is an image for you';
-  const editedMessageText = 'Here is an image for you, friend';
-  const replyMessageText = 'Nice image, thanks!';
-
-  const imageFilePath = getImageFilePath();
-  const videoFilePath = getVideoFilePath();
-
-  test.beforeEach(async ({createTeam, createUser}) => {
-    userB = await createUser();
-    const team = await createTeam(teamName, {users: [userB], features: {cells: true}});
-    userA = team.owner;
-  });
-
-  test(
-    'Uploading an file in a group conversation',
-    {tag: ['@crit-flow-cells', '@regression', '@TC-8785']},
-    async ({createPage}, testInfo) => {
-      const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))),
-        PageManager.from(createPage(withLogin(userB))),
-      ]);
-      await connectWithUser(userAPageManager, userB);
-
-      const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
-      const {pages: userBPages, modals: userBModals} = userBPageManager.webapp;
-
-      await test.step('Preconditions: Both users log in and open the group', async () => {
-        await createGroup(userAPages, conversationName, [userB], {cells: true});
-      });
-
-      await test.step('User A sends an image to User B in a group conversation', async () => {
-        await userAPages.conversationList().getConversation(conversationName).open();
-        await userBPages.conversationList().getConversation(conversationName).open();
-        await userAComponents.inputBarControls().clickShareFile(imageFilePath);
-        await userAComponents.inputBarControls().clickSendMessage();
-
-        await expect(getCellsImageLocator(userBPages.conversation(), userA)).toBeVisible();
-      });
-
-      await test.step('User B opens the image in the conversation', async () => {
-        await getCellsImageLocator(userBPages.conversation(), userA).click();
-
-        await expect(userBModals.cellsFileDetailView().image).toBeVisible();
-      });
-
-      await test.step('User B downloads the image in the conversation', async () => {
-        const filePath = await userBModals.cellsFileDetailView().downloadAsset(testInfo.outputDir);
-        const downloadQRCodeValue = await getLocalQRCodeValue(filePath);
-        const localQRCodeValue = await getLocalQRCodeValue(imageFilePath);
-        expect(downloadQRCodeValue).toBe(localQRCodeValue);
-      });
-
-      await test.step('User A opens group conversation files and sees the image file there', async () => {
-        await userAPages.conversation().clickFilesTab();
-        await userAPages.cellsConversationFiles().getFile(ImageQRCodeFileName).click();
-
-        await expect(userAModals.cellsFileDetailView().image).toBeVisible();
-      });
+test.describe.skip(
+  'Conversations',
+  {
+    annotation: {
+      type: 'skip',
+      description:
+        'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
     },
-  );
+  },
+  () => {
+    // User A is a team owner, User B is a team member
+    let userA: User;
+    let userB: User;
 
-  test(
-    'Edit multipart message in a group conversation',
-    {tag: ['@crit-flow-cells', '@regression', '@TC-8786']},
-    async ({createPage}) => {
-      const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))),
-        PageManager.from(createPage(withLogin(userB))),
-      ]);
-      await connectWithUser(userAPageManager, userB);
+    const teamName = 'Cells Critical Team';
+    const conversationName = 'Cells Critical Conversation';
+    const initialMessageText = 'Here is an image for you';
+    const editedMessageText = 'Here is an image for you, friend';
+    const replyMessageText = 'Nice image, thanks!';
 
-      const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
-      const {pages: userBPages} = userBPageManager.webapp;
+    const imageFilePath = getImageFilePath();
+    const videoFilePath = getVideoFilePath();
 
-      await test.step('Preconditions: Create group with drive enabled', async () => {
-        await createGroup(userAPages, conversationName, [userB], {cells: true});
-      });
+    test.beforeEach(async ({createTeam, createUser}) => {
+      userB = await createUser();
+      const team = await createTeam(teamName, {users: [userB], features: {cells: true}});
+      userA = team.owner;
+    });
 
-      await test.step('User A sends a multipart message in a group conversation', async () => {
-        await userAPages.conversationList().getConversation(conversationName).open();
-        await userAComponents.inputBarControls().clickShareFile(imageFilePath);
-        await userAComponents.inputBarControls().setMessageInput(initialMessageText);
-        await userAComponents.inputBarControls().clickSendMessage();
-        await userBPages.conversationList().getConversation(conversationName).open();
+    test(
+      'Uploading an file in a group conversation',
+      {tag: ['@crit-flow-cells', '@regression', '@TC-8785']},
+      async ({createPage}, testInfo) => {
+        const [userAPageManager, userBPageManager] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))),
+          PageManager.from(createPage(withLogin(userB))),
+        ]);
+        await connectWithUser(userAPageManager, userB);
 
-        const multipartMessage = userBPages.conversation().getMessage({sender: userA});
-        await expect(multipartMessage).toContainText(initialMessageText);
-        await expect(multipartMessage.getByRole('button', {name: `Image from ${userA.fullName}`})).toBeVisible();
-      });
+        const {pages: userAPages, modals: userAModals, components: userAComponents} = userAPageManager.webapp;
+        const {pages: userBPages, modals: userBModals} = userBPageManager.webapp;
 
-      await test.step('User A edits text part of the multipart message', async () => {
-        const message = userAPages.conversation().getMessage({sender: userA});
-        await userAPages.conversation().editMessage(message);
-        await userAComponents.inputBarControls().setMessageInput(editedMessageText);
-        await userAComponents.inputBarControls().clickSendMessage();
+        await test.step('Preconditions: Both users log in and open the group', async () => {
+          await createGroup(userAPages, conversationName, [userB], {cells: true});
+        });
 
-        const multipartMessage = userBPages.conversation().getMessage({sender: userA});
-        await expect(multipartMessage).toContainText(editedMessageText);
-        await expect(multipartMessage.getByRole('button', {name: `Image from ${userA.fullName}`})).toBeVisible();
-      });
-    },
-  );
+        await test.step('User A sends an image to User B in a group conversation', async () => {
+          await userAPages.conversationList().getConversation(conversationName).open();
+          await userBPages.conversationList().getConversation(conversationName).open();
+          await userAComponents.inputBarControls().clickShareFile(imageFilePath);
+          await userAComponents.inputBarControls().clickSendMessage();
 
-  test(
-    'Replying to multipart message in a group conversation',
-    {tag: ['@crit-flow-cells', '@regression', '@TC-8787']},
-    async ({createPage}) => {
-      const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))),
-        PageManager.from(createPage(withLogin(userB))),
-      ]);
-      await connectWithUser(userAPageManager, userB);
+          await expect(getCellsImageLocator(userBPages.conversation(), userA)).toBeVisible();
+        });
 
-      const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
-      const {pages: userBPages, components: userBComponents} = userBPageManager.webapp;
+        await test.step('User B opens the image in the conversation', async () => {
+          await getCellsImageLocator(userBPages.conversation(), userA).click();
 
-      await test.step('Preconditions: Create group with drive enabled', async () => {
-        await createGroup(userAPages, conversationName, [userB], {cells: true});
-      });
+          await expect(userBModals.cellsFileDetailView().image).toBeVisible();
+        });
 
-      await test.step('User A sends a multipart message to User B in a group conversation', async () => {
-        await userAPages.conversationList().getConversation(conversationName).open();
-        await userAComponents.inputBarControls().clickShareFile(imageFilePath);
-        await userAComponents.inputBarControls().setMessageInput(initialMessageText);
-        await userAComponents.inputBarControls().clickSendMessage();
-        await userBPages.conversationList().getConversation(conversationName).open();
+        await test.step('User B downloads the image in the conversation', async () => {
+          const filePath = await userBModals.cellsFileDetailView().downloadAsset(testInfo.outputDir);
+          const downloadQRCodeValue = await getLocalQRCodeValue(filePath);
+          const localQRCodeValue = await getLocalQRCodeValue(imageFilePath);
+          expect(downloadQRCodeValue).toBe(localQRCodeValue);
+        });
 
-        const multipartMessage = userBPages.conversation().getMessage({sender: userA});
-        await expect(multipartMessage).toContainText(initialMessageText);
-        await expect(multipartMessage.getByRole('button', {name: `Image from ${userA.fullName}`})).toBeVisible();
-      });
+        await test.step('User A opens group conversation files and sees the image file there', async () => {
+          await userAPages.conversation().clickFilesTab();
+          await userAPages.cellsConversationFiles().getFile(ImageQRCodeFileName).click();
 
-      await test.step('User B replies to a multipart message', async () => {
-        const message = userBPages.conversation().getMessage({sender: userA});
-        await userBPages.conversation().replyToMessage(message);
-        await userBComponents.inputBarControls().setMessageInput(replyMessageText);
-        await userBComponents.inputBarControls().clickSendMessage();
+          await expect(userAModals.cellsFileDetailView().image).toBeVisible();
+        });
+      },
+    );
 
-        const reply = userAPages.conversation().getMessage({content: replyMessageText});
-        await expect(reply).toBeVisible();
-      });
-    },
-  );
+    test(
+      'Edit multipart message in a group conversation',
+      {tag: ['@crit-flow-cells', '@regression', '@TC-8786']},
+      async ({createPage}) => {
+        const [userAPageManager, userBPageManager] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))),
+          PageManager.from(createPage(withLogin(userB))),
+        ]);
+        await connectWithUser(userAPageManager, userB);
 
-  test(
-    'Searching files in a group conversation',
-    {tag: ['@crit-flow-cells', '@regression', '@TC-8788']},
-    async ({createPage}) => {
-      const [userAPageManager, userBPageManager] = await Promise.all([
-        PageManager.from(createPage(withLogin(userA))),
-        PageManager.from(createPage(withLogin(userB))),
-      ]);
-      await connectWithUser(userAPageManager, userB);
+        const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
+        const {pages: userBPages} = userBPageManager.webapp;
 
-      const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
-      const {pages: userBPages} = userBPageManager.webapp;
+        await test.step('Preconditions: Create group with drive enabled', async () => {
+          await createGroup(userAPages, conversationName, [userB], {cells: true});
+        });
 
-      await test.step('Preconditions: Create group with drive enabled', async () => {
-        await createGroup(userAPages, conversationName, [userB], {cells: true});
-      });
+        await test.step('User A sends a multipart message in a group conversation', async () => {
+          await userAPages.conversationList().getConversation(conversationName).open();
+          await userAComponents.inputBarControls().clickShareFile(imageFilePath);
+          await userAComponents.inputBarControls().setMessageInput(initialMessageText);
+          await userAComponents.inputBarControls().clickSendMessage();
+          await userBPages.conversationList().getConversation(conversationName).open();
 
-      await test.step('User A sends a message with assets in a group conversation', async () => {
-        await userAPages.conversationList().getConversation(conversationName).open();
-        await userAComponents.inputBarControls().clickShareFile(imageFilePath);
-        await userAComponents.inputBarControls().clickShareFile(videoFilePath);
-        await userAComponents.inputBarControls().clickSendMessage();
-        await userBPages.conversationList().getConversation(conversationName).open();
+          const multipartMessage = userBPages.conversation().getMessage({sender: userA});
+          await expect(multipartMessage).toContainText(initialMessageText);
+          await expect(multipartMessage.getByRole('button', {name: `Image from ${userA.fullName}`})).toBeVisible();
+        });
 
-        await expect(getImageInMultipartMessageLocator(userBPages.conversation(), userA)).toBeVisible();
-        await expect(getVideoInMultipartMessageLocator(userBPages.conversation(), userA)).toBeVisible();
-      });
+        await test.step('User A edits text part of the multipart message', async () => {
+          const message = userAPages.conversation().getMessage({sender: userA});
+          await userAPages.conversation().editMessage(message);
+          await userAComponents.inputBarControls().setMessageInput(editedMessageText);
+          await userAComponents.inputBarControls().clickSendMessage();
 
-      await test.step('User B opens Files tab and searches for a file', async () => {
-        await userBPages.conversation().clickFilesTab();
+          const multipartMessage = userBPages.conversation().getMessage({sender: userA});
+          await expect(multipartMessage).toContainText(editedMessageText);
+          await expect(multipartMessage.getByRole('button', {name: `Image from ${userA.fullName}`})).toBeVisible();
+        });
+      },
+    );
 
-        // Initially both files should be visible
-        await expect(userBPages.cellsConversationFiles().filesList).toHaveCount(2);
+    test(
+      'Replying to multipart message in a group conversation',
+      {tag: ['@crit-flow-cells', '@regression', '@TC-8787']},
+      async ({createPage}) => {
+        const [userAPageManager, userBPageManager] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))),
+          PageManager.from(createPage(withLogin(userB))),
+        ]);
+        await connectWithUser(userAPageManager, userB);
 
-        // Files might take some time to get indexed by the search engine, that's why this block might be retried
-        await expect(async () => {
-          // Search for the video file
-          await userBPages.cellsConversationFiles().searchFile(VideoFileName);
-          await expect(userBPages.cellsConversationFiles().filesList).toHaveCount(1, {timeout: 1500});
-          await expect(userBPages.cellsConversationFiles().getFile(VideoFileName)).toBeVisible({timeout: 500});
-        }).toPass({intervals: [1_000, 2_000, 5_000], timeout: 10_000});
-        // Search for a non-existing file
-        await userBPages.cellsConversationFiles().searchFile('non-existing-file.txt');
-        await expect(userBPages.cellsConversationFiles().filesList).toHaveCount(0);
+        const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
+        const {pages: userBPages, components: userBComponents} = userBPageManager.webapp;
 
-        // Clearing the search input and making sure both files are visible again
-        await userBPages.cellsConversationFiles().searchFile('');
-        await expect(userBPages.cellsConversationFiles().filesList).toHaveCount(2);
-      });
-    },
-  );
-});
+        await test.step('Preconditions: Create group with drive enabled', async () => {
+          await createGroup(userAPages, conversationName, [userB], {cells: true});
+        });
+
+        await test.step('User A sends a multipart message to User B in a group conversation', async () => {
+          await userAPages.conversationList().getConversation(conversationName).open();
+          await userAComponents.inputBarControls().clickShareFile(imageFilePath);
+          await userAComponents.inputBarControls().setMessageInput(initialMessageText);
+          await userAComponents.inputBarControls().clickSendMessage();
+          await userBPages.conversationList().getConversation(conversationName).open();
+
+          const multipartMessage = userBPages.conversation().getMessage({sender: userA});
+          await expect(multipartMessage).toContainText(initialMessageText);
+          await expect(multipartMessage.getByRole('button', {name: `Image from ${userA.fullName}`})).toBeVisible();
+        });
+
+        await test.step('User B replies to a multipart message', async () => {
+          const message = userBPages.conversation().getMessage({sender: userA});
+          await userBPages.conversation().replyToMessage(message);
+          await userBComponents.inputBarControls().setMessageInput(replyMessageText);
+          await userBComponents.inputBarControls().clickSendMessage();
+
+          const reply = userAPages.conversation().getMessage({content: replyMessageText});
+          await expect(reply).toBeVisible();
+        });
+      },
+    );
+
+    test(
+      'Searching files in a group conversation',
+      {tag: ['@crit-flow-cells', '@regression', '@TC-8788']},
+      async ({createPage}) => {
+        const [userAPageManager, userBPageManager] = await Promise.all([
+          PageManager.from(createPage(withLogin(userA))),
+          PageManager.from(createPage(withLogin(userB))),
+        ]);
+        await connectWithUser(userAPageManager, userB);
+
+        const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
+        const {pages: userBPages} = userBPageManager.webapp;
+
+        await test.step('Preconditions: Create group with drive enabled', async () => {
+          await createGroup(userAPages, conversationName, [userB], {cells: true});
+        });
+
+        await test.step('User A sends a message with assets in a group conversation', async () => {
+          await userAPages.conversationList().getConversation(conversationName).open();
+          await userAComponents.inputBarControls().clickShareFile(imageFilePath);
+          await userAComponents.inputBarControls().clickShareFile(videoFilePath);
+          await userAComponents.inputBarControls().clickSendMessage();
+          await userBPages.conversationList().getConversation(conversationName).open();
+
+          await expect(getImageInMultipartMessageLocator(userBPages.conversation(), userA)).toBeVisible();
+          await expect(getVideoInMultipartMessageLocator(userBPages.conversation(), userA)).toBeVisible();
+        });
+
+        await test.step('User B opens Files tab and searches for a file', async () => {
+          await userBPages.conversation().clickFilesTab();
+
+          // Initially both files should be visible
+          await expect(userBPages.cellsConversationFiles().filesList).toHaveCount(2);
+
+          // Files might take some time to get indexed by the search engine, that's why this block might be retried
+          await expect(async () => {
+            // Search for the video file
+            await userBPages.cellsConversationFiles().searchFile(VideoFileName);
+            await expect(userBPages.cellsConversationFiles().filesList).toHaveCount(1, {timeout: 1500});
+            await expect(userBPages.cellsConversationFiles().getFile(VideoFileName)).toBeVisible({timeout: 500});
+          }).toPass({intervals: [1_000, 2_000, 5_000], timeout: 10_000});
+          // Search for a non-existing file
+          await userBPages.cellsConversationFiles().searchFile('non-existing-file.txt');
+          await expect(userBPages.cellsConversationFiles().filesList).toHaveCount(0);
+
+          // Clearing the search input and making sure both files are visible again
+          await userBPages.cellsConversationFiles().searchFile('');
+          await expect(userBPages.cellsConversationFiles().filesList).toHaveCount(2);
+        });
+      },
+    );
+  },
+);

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -7,574 +7,584 @@ import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} f
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
 import {createAndSaveBackup, createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
-test.describe('Federation', () => {
-  const federationBaseUrl = process.env.FEDERATION_WEBAPP_URL!;
-  const federationApiManager = new ApiManagerE2E({
-    backendUrl: process.env.FEDERATION_BACKEND_URL!,
-    basicAuth: process.env.FEDERATION_BASIC_AUTH!,
-  });
-
-  let normalUser: User;
-  let federatedUser: User;
-  const groupName = 'Federated group';
-
-  test.beforeEach(async ({api}) => {
-    normalUser = (await createTeam(api, 'Normal Team', {features: {conferenceCalling: true, mls: true}})).owner;
-    federatedUser = (await createTeam(federationApiManager, 'Federated Team', {features: {mls: true}})).owner;
-  });
-
-  test.afterEach(async ({api}) => {
-    await api.team.deleteTeam(normalUser, normalUser.teamId);
-    await federationApiManager.team.deleteTeam(federatedUser, federatedUser.teamId);
-  });
-
-  const testCases = [
-    {
-      name: 'Image',
-      sendAction: async ({normalUserPage}) => {
-        await shareAssetHelper(
-          getImageFilePath(),
-          normalUserPage,
-          normalUserPage.getByRole('button', {name: 'Add picture'}),
-        );
-      },
-      verify: async ({federatedUserPage}) => {
-        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-        const messageWithImage = federatedUserPages
-          .conversation()
-          .getMessage({sender: normalUser})
-          .filter({has: federatedUserPage.getByRole('img')});
-        await expect(messageWithImage).toBeVisible();
-      },
+test.describe.skip(
+  'Federation',
+  {
+    annotation: {
+      type: 'skip',
+      description:
+        'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
     },
-    {
-      name: 'Text',
-      sendAction: async ({normalUserPage}) => {
-        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-        await normalUserPages.conversation().sendMessage('Test message');
-        await expect(normalUserPages.conversation().getMessage({content: 'Test message'})).toBeVisible();
-      },
-      verify: async ({federatedUserPage}) => {
-        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-        const message = federatedUserPages.conversation().getMessage({content: 'Test message'});
-        await expect(message).toBeVisible();
-      },
-    },
-    {
-      name: 'Link',
-      sendAction: async ({normalUserPage}) => {
-        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-        await normalUserPages.conversation().sendMessage('https://www.lidl.de/');
-      },
-      verify: async ({federatedUserPage}) => {
-        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-        const message = federatedUserPages.conversation().getMessage({content: 'https://www.lidl.de/'});
-        await expect(message).toBeVisible();
-      },
-    },
-    {
-      name: 'Audio',
-      sendAction: async ({normalUserPage}) => {
-        await shareAssetHelper(
-          getAudioFilePath(),
-          normalUserPage,
-          normalUserPage.getByRole('button', {name: 'Add file'}),
-        );
-      },
-      verify: async ({federatedUserPage}) => {
-        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-        const messageWithAudio = federatedUserPages
-          .conversation()
-          .getMessage({sender: normalUser})
-          .filter({has: federatedUserPage.locator('[data-uie-name="audio-asset"]')});
-        await expect(messageWithAudio).toBeVisible();
-      },
-    },
-    {
-      name: 'Video',
-      sendAction: async ({normalUserPage}) => {
-        await shareAssetHelper(
-          getVideoFilePath(),
-          normalUserPage,
-          normalUserPage.getByRole('button', {name: 'Add file'}),
-        );
-      },
-      verify: async ({federatedUserPage}) => {
-        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-        const messageWithVideo = federatedUserPages
-          .conversation()
-          .getMessage({sender: normalUser})
-          .filter({has: federatedUserPage.locator('[data-uie-name="video-asset"]')});
-        await expect(messageWithVideo).toBeVisible();
-      },
-    },
-    {
-      name: 'File',
-      sendAction: async ({normalUserPage}) => {
-        await shareAssetHelper(
-          getTextFilePath(),
-          normalUserPage,
-          normalUserPage.getByRole('button', {name: 'Add file'}),
-        );
-      },
-      verify: async ({federatedUserPage}) => {
-        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-        const messageWithFile = federatedUserPages
-          .conversation()
-          .getMessage({sender: normalUser})
-          .filter({has: federatedUserPage.locator('[data-uie-name="file-asset"]')});
-        await expect(messageWithFile).toBeVisible();
-      },
-    },
-    {
-      name: 'Ping',
-      sendAction: async ({normalUserPage}) => {
-        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-        await normalUserPages.conversation().sendPing();
-      },
-      verify: async ({federatedUserPage}) => {
-        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-        await expect(federatedUserPages.conversation().getPing()).toBeVisible();
-      },
-    },
-    {
-      name: 'Ephemeral text message',
-      sendAction: async ({normalUserPage}) => {
-        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-        await normalUserPages.conversation().enableSelfDeletingMessages();
-        await normalUserPages.conversation().sendMessage('Gone in 10s');
-      },
-      verify: async ({federatedUserPage}) => {
-        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-        await expect(federatedUserPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
+  },
+  () => {
+    const federationBaseUrl = process.env.FEDERATION_WEBAPP_URL!;
+    const federationApiManager = new ApiManagerE2E({
+      backendUrl: process.env.FEDERATION_BACKEND_URL!,
+      basicAuth: process.env.FEDERATION_BASIC_AUTH!,
+    });
 
-        await federatedUserPage.waitForTimeout(10_000); // Wait for 10s so the message is deleted
-        await expect(federatedUserPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
-      },
-    },
-    {
-      name: 'Reaction',
-      sendAction: async ({normalUserPage}) => {
-        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-        const message = normalUserPages.conversation().getMessage({content: 'Test message'});
-        await expect(message).toBeVisible();
-        await normalUserPages.conversation().reactOnMessage(message, 'plus-one');
-      },
-      verify: async ({federatedUserPage}) => {
-        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-        const messageWithReaction = federatedUserPages.conversation().getMessage({content: 'Test message'});
-        await expect(
-          federatedUserPages.conversation().getReactionOnMessage(messageWithReaction, 'plus-one'),
-        ).toBeVisible();
-      },
-    },
-    {
-      name: 'Reply',
-      sendAction: async ({normalUserPage}) => {
-        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-        const message = normalUserPages.conversation().getMessage({content: 'Test message'});
+    let normalUser: User;
+    let federatedUser: User;
+    const groupName = 'Federated group';
 
-        await expect(message).toBeVisible();
-        await normalUserPages.conversation().replyToMessage(message);
-        await normalUserPages.conversation().sendMessage('Reply');
-      },
-      verify: async ({federatedUserPage}) => {
-        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-        const replyMessage = federatedUserPages.conversation().getMessage({content: 'Reply'});
-        await expect(replyMessage.getByTestId('quote-item')).toContainText('Test message');
-      },
-    },
-    {
-      name: 'Mention',
-      sendAction: async ({normalUserPage}) => {
-        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-        await normalUserPages.conversation().sendMessageWithUserMention(federatedUser.fullName, 'Test mention');
-      },
-      verify: async ({federatedUserPage}) => {
-        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-        await expect(
-          federatedUserPages.conversation().getMessage({content: `@${federatedUser.fullName}`}),
-        ).toBeVisible();
-      },
-    },
-  ] as const satisfies {
-    name: string;
-    sendAction: (params: {normalUserPage: Page}) => Promise<void>;
-    verify: (params: {federatedUserPage: Page}) => Promise<void>;
-  }[];
+    test.beforeEach(async ({api}) => {
+      normalUser = (await createTeam(api, 'Normal Team', {features: {conferenceCalling: true, mls: true}})).owner;
+      federatedUser = (await createTeam(federationApiManager, 'Federated Team', {features: {mls: true}})).owner;
+    });
 
-  test(
-    'I want to share all possible assets in a federated group',
-    {tag: ['@TC-8758', '@regression']},
-    async ({createPage}) => {
-      test.setTimeout(150_000);
+    test.afterEach(async ({api}) => {
+      await api.team.deleteTeam(normalUser, normalUser.teamId);
+      await federationApiManager.team.deleteTeam(federatedUser, federatedUser.teamId);
+    });
 
-      const [normalUserPage, federatedUserPage] = await Promise.all([
-        createPage(withLogin(normalUser)),
-        createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
-      ]);
-      await sendConnectionRequest(normalUserPage, federatedUser);
-
-      const {pages: normalUserPages} = PageManager.from(normalUserPage).webapp;
-      const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
-
-      await federatedUserPages.conversationList().openPendingConnectionRequest();
-      await federatedUserPages.connectRequest().clickConnectButton();
-      await expect(
-        federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}),
-      ).toBeVisible();
-
-      await test.step('Normal user creates a group and adds federated user to it', async () => {
-        await createGroup(normalUserPages, groupName, [federatedUser]);
-        await normalUserPages.conversationList().getConversation(groupName).open();
-        await normalUserPages.conversation().toggleGroupInformation();
-
-        await expect(
-          normalUserPages.conversation().systemMessages.filter({hasText: `You added ${federatedUser.fullName}`}),
-        ).toBeVisible();
-        await expect(normalUserPages.conversation().statusIndicator).toContainText('Federated users are present');
-        await expect(
-          normalUserPages.conversationDetails().getParticipant(federatedUser.fullName).federatedIcon,
-        ).toBeVisible();
-
-        await federatedUserPages.conversationList().getConversation(groupName).open();
-        await expect(
-          federatedUserPages
+    const testCases = [
+      {
+        name: 'Image',
+        sendAction: async ({normalUserPage}) => {
+          await shareAssetHelper(
+            getImageFilePath(),
+            normalUserPage,
+            normalUserPage.getByRole('button', {name: 'Add picture'}),
+          );
+        },
+        verify: async ({federatedUserPage}) => {
+          const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+          const messageWithImage = federatedUserPages
             .conversation()
-            .systemMessages.filter({hasText: `${normalUser.fullName} added you to the conversation`}),
-        ).toBeVisible();
-      });
-
-      await test.step('Normal user can send and delete Text message in the federated group', async () => {
-        await normalUserPages.conversation().sendMessage('Hello from staging user');
-
-        const messageNormalUser = normalUserPages.conversation().getMessage({sender: normalUser});
-        await expect(messageNormalUser).toBeVisible();
-        await expect(federatedUserPages.conversation().getMessage({sender: normalUser})).toBeVisible();
-
-        await normalUserPages.conversation().deleteMessage(messageNormalUser, 'Everyone');
-        await expect(messageNormalUser).not.toBeVisible();
-        await expect(federatedUserPage.getByTestId('element-message-delete')).toBeVisible();
-      });
-
-      for (const {name, sendAction, verify} of testCases) {
-        await test.step(`Verify user sends ${name} and federated user can see it`, async () => {
-          await sendAction({normalUserPage});
-          await verify({federatedUserPage});
-        });
-      }
-    },
-  );
-
-  test(
-    'I want to share all possible assets in a federated 1:1',
-    {tag: ['@TC-8759', '@regression']},
-    async ({createPage}) => {
-      const [normalUserPage, federatedUserPage] = await Promise.all([
-        createPage(withLogin(normalUser)),
-        createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
-      ]);
-      await sendConnectionRequest(normalUserPage, federatedUser);
-
-      const {pages: normalUserPages} = PageManager.from(normalUserPage).webapp;
-      const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
-
-      await federatedUserPages.conversationList().openPendingConnectionRequest();
-      await federatedUserPages.connectRequest().clickConnectButton();
-
-      await normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open();
-      await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
-
-      for (const {name, sendAction, verify} of testCases) {
-        await test.step(`Verify user sends ${name} and federated user can see it`, async () => {
-          await sendAction({normalUserPage});
-          await verify({federatedUserPage});
-        });
-      }
-    },
-  );
-
-  test(
-    'I want to import my backup of conversations with users from different BE and see the conversation contents',
-    {tag: ['@TC-3128', '@regression']},
-    async ({createPage}, testInfo) => {
-      test.setTimeout(150_000);
-
-      const [normalUserPage, federatedUserPage] = await Promise.all([
-        createPage(withLogin(normalUser)),
-        createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
-      ]);
-
-      const normalUserPageManager = PageManager.from(normalUserPage);
-      const {
-        pages: normalUserPages,
-        components: normalUserComponents,
-        modals: normalUserModals,
-      } = normalUserPageManager.webapp;
-      const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
-
-      await test.step('Establish connection between normal and federated user', async () => {
-        await sendConnectionRequest(normalUserPage, federatedUser);
-        await federatedUserPages.conversationList().openPendingConnectionRequest();
-        await federatedUserPages.connectRequest().clickConnectButton();
-      });
-
-      await test.step('Exchange direct messages and verify receipt', async () => {
-        await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
-        const oneOnOneConversation = await normalUserPages
-          .conversationList()
-          .getConversation(federatedUser.fullName, {protocol: 'mls'})
-          .open();
-
-        await normalUserPages.conversation().sendMessage('Message from normal user');
-        await federatedUserPages.conversation().sendMessage('Message from federated user');
-
-        await expect(normalUserPages.conversation().getMessage({sender: federatedUser})).toBeVisible();
-        await expect(federatedUserPages.conversation().getMessage({sender: normalUser})).toBeVisible();
-
-        // Wait for messages to be read before exporting backup
-        await expect(oneOnOneConversation.unreadIndicator).not.toBeVisible();
-      });
-
-      await test.step('Create a group chat and exchange text and image messages', async () => {
-        await createGroup(normalUserPages, groupName, [federatedUser]);
-        await federatedUserPages.conversationList().getConversation(groupName).open();
-        const groupConversation = await normalUserPages.conversationList().getConversation(groupName).open();
-
-        await federatedUserPages.conversation().sendMessage('Group message from federated user');
-        await shareAssetHelper(
-          getImageFilePath(),
-          federatedUserPage,
-          federatedUserPage.getByRole('button', {name: 'Add picture'}),
-        );
-
-        await expect(
-          normalUserPages.conversation().getMessage({content: 'Group message from federated user'}),
-        ).toBeVisible();
-
-        const messageWithImage = normalUserPages
-          .conversation()
-          .getMessage({sender: federatedUser})
-          .filter({has: normalUserPage.getByRole('img')});
-        await expect(messageWithImage).toBeVisible();
-
-        // Wait for messages to be read before exporting backup
-        await expect(groupConversation.unreadIndicator).not.toBeVisible();
-      });
-
-      const backupName = await test.step('Create and save backup for the normal user', async () => {
-        await normalUserComponents.conversationSidebar().clickPreferencesButton();
-        return await createAndSaveBackup(testInfo, normalUserPageManager);
-      });
-
-      await test.step('Log out the normal user from the first device', async () => {
-        await normalUserComponents.conversationSidebar().clickPreferencesButton();
-        await normalUserPages.account().clickLogoutButton();
-        await expect(normalUserModals.confirmLogout().modal).toBeVisible();
-        await normalUserModals.confirmLogout().clickConfirm();
-      });
-
-      // --- Second Device Flow ---
-      const normalUserDevice2 = await createPage(withLogin(normalUser, {confirmNewHistory: true}));
-
-      const {pages: normalUserDevice2Pages, components: normalUserDevice2Components} =
-        PageManager.from(normalUserDevice2).webapp;
-
-      await test.step('Import backup on the new device', async () => {
-        await normalUserDevice2Components.conversationSidebar().clickPreferencesButton();
-        await normalUserDevice2Pages.account().backupFileInput.setInputFiles(backupName);
-        await normalUserDevice2Components.conversationSidebar().allConversationsButton.click();
-      });
-
-      await test.step('Verify direct messages are restored on the new device', async () => {
-        await normalUserDevice2Pages
-          .conversationList()
-          .getConversation(federatedUser.fullName, {protocol: 'mls'})
-          .open();
-        await expect(normalUserDevice2Pages.conversation().getMessage({sender: normalUser})).toBeVisible();
-        await expect(normalUserDevice2Pages.conversation().getMessage({sender: federatedUser})).toBeVisible();
-      });
-
-      await test.step('Verify group messages and media are restored on the new device', async () => {
-        await normalUserDevice2Pages.conversationList().getConversation(groupName).open();
-
-        await expect(
-          normalUserDevice2Pages
+            .getMessage({sender: normalUser})
+            .filter({has: federatedUserPage.getByRole('img')});
+          await expect(messageWithImage).toBeVisible();
+        },
+      },
+      {
+        name: 'Text',
+        sendAction: async ({normalUserPage}) => {
+          const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+          await normalUserPages.conversation().sendMessage('Test message');
+          await expect(normalUserPages.conversation().getMessage({content: 'Test message'})).toBeVisible();
+        },
+        verify: async ({federatedUserPage}) => {
+          const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+          const message = federatedUserPages.conversation().getMessage({content: 'Test message'});
+          await expect(message).toBeVisible();
+        },
+      },
+      {
+        name: 'Link',
+        sendAction: async ({normalUserPage}) => {
+          const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+          await normalUserPages.conversation().sendMessage('https://www.lidl.de/');
+        },
+        verify: async ({federatedUserPage}) => {
+          const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+          const message = federatedUserPages.conversation().getMessage({content: 'https://www.lidl.de/'});
+          await expect(message).toBeVisible();
+        },
+      },
+      {
+        name: 'Audio',
+        sendAction: async ({normalUserPage}) => {
+          await shareAssetHelper(
+            getAudioFilePath(),
+            normalUserPage,
+            normalUserPage.getByRole('button', {name: 'Add file'}),
+          );
+        },
+        verify: async ({federatedUserPage}) => {
+          const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+          const messageWithAudio = federatedUserPages
             .conversation()
-            .getMessage({sender: federatedUser, content: 'Group message from federated user'}),
-        ).toBeVisible();
+            .getMessage({sender: normalUser})
+            .filter({has: federatedUserPage.locator('[data-uie-name="audio-asset"]')});
+          await expect(messageWithAudio).toBeVisible();
+        },
+      },
+      {
+        name: 'Video',
+        sendAction: async ({normalUserPage}) => {
+          await shareAssetHelper(
+            getVideoFilePath(),
+            normalUserPage,
+            normalUserPage.getByRole('button', {name: 'Add file'}),
+          );
+        },
+        verify: async ({federatedUserPage}) => {
+          const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+          const messageWithVideo = federatedUserPages
+            .conversation()
+            .getMessage({sender: normalUser})
+            .filter({has: federatedUserPage.locator('[data-uie-name="video-asset"]')});
+          await expect(messageWithVideo).toBeVisible();
+        },
+      },
+      {
+        name: 'File',
+        sendAction: async ({normalUserPage}) => {
+          await shareAssetHelper(
+            getTextFilePath(),
+            normalUserPage,
+            normalUserPage.getByRole('button', {name: 'Add file'}),
+          );
+        },
+        verify: async ({federatedUserPage}) => {
+          const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+          const messageWithFile = federatedUserPages
+            .conversation()
+            .getMessage({sender: normalUser})
+            .filter({has: federatedUserPage.locator('[data-uie-name="file-asset"]')});
+          await expect(messageWithFile).toBeVisible();
+        },
+      },
+      {
+        name: 'Ping',
+        sendAction: async ({normalUserPage}) => {
+          const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+          await normalUserPages.conversation().sendPing();
+        },
+        verify: async ({federatedUserPage}) => {
+          const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+          await expect(federatedUserPages.conversation().getPing()).toBeVisible();
+        },
+      },
+      {
+        name: 'Ephemeral text message',
+        sendAction: async ({normalUserPage}) => {
+          const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+          await normalUserPages.conversation().enableSelfDeletingMessages();
+          await normalUserPages.conversation().sendMessage('Gone in 10s');
+        },
+        verify: async ({federatedUserPage}) => {
+          const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+          await expect(federatedUserPages.conversation().getMessage({content: 'Gone in 10s'})).toBeVisible();
 
-        const messageWithImage2Device = normalUserDevice2Pages
-          .conversation()
-          .getMessage({sender: federatedUser})
-          .filter({has: normalUserDevice2.getByRole('img')});
-        await expect(messageWithImage2Device).toBeVisible();
-      });
-    },
-  );
-
-  test(
-    'I want to be able to connect to, block, and unblock a user from different backend',
-    {tag: ['@TC-3129', '@regression']},
-    async ({createPage}) => {
-      const [normalUserPage, federatedUserPage] = await Promise.all([
-        createPage(withLogin(normalUser)),
-        createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
-      ]);
-
-      const {
-        pages: normalUserPages,
-        components: normalUserComponents,
-        modals: normalUserModals,
-      } = PageManager.from(normalUserPage).webapp;
-
-      const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
-
-      const userHandle = federatedUser.qualifiedId?.domain
-        ? `${federatedUser.username}@${federatedUser.qualifiedId?.domain}`
-        : federatedUser.username;
-
-      await test.step('Send connection request to federated user', async () => {
-        await normalUserComponents.conversationSidebar().clickConnectButton();
-        await normalUserPages.startUI().searchInput.fill(userHandle);
-
-        const normalUserSearchRow = normalUserPages.startUI().searchResults.filter({hasText: federatedUser.username});
-        await expect(normalUserSearchRow).toBeVisible();
-        await expect(normalUserSearchRow.getByTestId('status-federated-user')).toBeVisible();
-
-        await normalUserPages.startUI().selectUsers(userHandle);
-        await normalUserModals.userProfile().clickConnectButton();
-      });
-
-      await test.step('Accept connection request from normal user', async () => {
-        await federatedUserPages.conversationList().openPendingConnectionRequest();
-        await federatedUserPages.connectRequest().clickConnectButton();
-      });
-
-      await test.step('Open conversation on both ends', async () => {
-        await Promise.all([
-          normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open(),
-          federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open(),
-        ]);
-      });
-
-      await test.step('Verify conversation details and cross-backend presence indicators', async () => {
-        await normalUserPages.conversation().toggleGroupInformation();
-
-        await expect(normalUserPages.participantDetails().userName).toBeVisible();
-        await expect(normalUserPages.participantDetails().userHandle).toBeVisible();
-        await expect(normalUserPages.conversation().statusIndicator).toContainText('Federated users are present');
-        await expect(normalUserPages.conversation().conversationTitle).toContainText(federatedUser.fullName);
-        await expect(
-          normalUserPages.conversation().systemMessages.filter({hasText: federatedUser.username}),
-        ).toBeVisible();
-      });
-
-      await test.step('Exchange messages between normal and federated users', async () => {
-        await normalUserPages.conversation().sendMessage('Message from normal user');
-        await federatedUserPages.conversation().sendMessage('Message from federated user');
-
-        await expect(normalUserPages.conversation().getMessage({sender: federatedUser})).toBeVisible();
-        await expect(federatedUserPages.conversation().getMessage({sender: normalUser})).toBeVisible();
-      });
-
-      await test.step('Block the federated user and verify status', async () => {
-        await normalUserPages.participantDetails().blockUser();
-        await normalUserModals.confirm().actionButton.click();
-
-        await expect(normalUserPages.participantDetails().userPicture).toHaveAttribute('data-uie-status', 'blocked');
-      });
-
-      await test.step('Unblock the federated user and verify status restoration', async () => {
-        await normalUserPages.participantDetails().unblockButton.click();
-        await normalUserModals.confirm().actionButton.click();
-
-        await expect(normalUserPages.participantDetails().userPicture).not.toHaveAttribute(
-          'data-uie-status',
-          'blocked',
-        );
-      });
-    },
-  );
-
-  const testData = [
-    {
-      title: 'I want to start a 1:1 call with a federated User',
-      tags: ['@TC-3208', '@regression'],
-      type: '1:1',
-    },
-    {
-      title: 'I want to start a conference call in a federated group with Users from 2 different backends',
-      tags: ['@TC-3220', '@regression'],
-      type: 'group',
-    },
-  ];
-
-  testData.forEach(({title, tags, type}) => {
-    test(title, {tag: tags}, async ({createPage}) => {
-      const [normalUserPage, federatedUserPage] = await Promise.all([
-        createPage(withLogin(normalUser)),
-        createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
-      ]);
-
-      const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
-      const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
-      const groupName = 'Federation call group';
-
-      await test.step('Connect federated users', async () => {
-        await sendConnectionRequest(normalUserPage, federatedUser);
-        await federatedUserPages.conversationList().openPendingConnectionRequest();
-        await federatedUserPages.connectRequest().clickConnectButton();
-      });
-
-      await test.step('Users open conversations', async () => {
-        if (type === '1:1') {
-          await normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open();
-          await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
-        } else {
+          await federatedUserPage.waitForTimeout(10_000); // Wait for 10s so the message is deleted
+          await expect(federatedUserPages.conversation().getMessage({content: 'Gone in 10s'})).not.toBeVisible();
+        },
+      },
+      {
+        name: 'Reaction',
+        sendAction: async ({normalUserPage}) => {
+          const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+          const message = normalUserPages.conversation().getMessage({content: 'Test message'});
+          await expect(message).toBeVisible();
+          await normalUserPages.conversation().reactOnMessage(message, 'plus-one');
+        },
+        verify: async ({federatedUserPage}) => {
+          const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+          const messageWithReaction = federatedUserPages.conversation().getMessage({content: 'Test message'});
           await expect(
-            federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}),
+            federatedUserPages.conversation().getReactionOnMessage(messageWithReaction, 'plus-one'),
           ).toBeVisible();
+        },
+      },
+      {
+        name: 'Reply',
+        sendAction: async ({normalUserPage}) => {
+          const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+          const message = normalUserPages.conversation().getMessage({content: 'Test message'});
 
+          await expect(message).toBeVisible();
+          await normalUserPages.conversation().replyToMessage(message);
+          await normalUserPages.conversation().sendMessage('Reply');
+        },
+        verify: async ({federatedUserPage}) => {
+          const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+          const replyMessage = federatedUserPages.conversation().getMessage({content: 'Reply'});
+          await expect(replyMessage.getByTestId('quote-item')).toContainText('Test message');
+        },
+      },
+      {
+        name: 'Mention',
+        sendAction: async ({normalUserPage}) => {
+          const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+          await normalUserPages.conversation().sendMessageWithUserMention(federatedUser.fullName, 'Test mention');
+        },
+        verify: async ({federatedUserPage}) => {
+          const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+          await expect(
+            federatedUserPages.conversation().getMessage({content: `@${federatedUser.fullName}`}),
+          ).toBeVisible();
+        },
+      },
+    ] as const satisfies {
+      name: string;
+      sendAction: (params: {normalUserPage: Page}) => Promise<void>;
+      verify: (params: {federatedUserPage: Page}) => Promise<void>;
+    }[];
+
+    test(
+      'I want to share all possible assets in a federated group',
+      {tag: ['@TC-8758', '@regression']},
+      async ({createPage}) => {
+        test.setTimeout(150_000);
+
+        const [normalUserPage, federatedUserPage] = await Promise.all([
+          createPage(withLogin(normalUser)),
+          createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
+        ]);
+        await sendConnectionRequest(normalUserPage, federatedUser);
+
+        const {pages: normalUserPages} = PageManager.from(normalUserPage).webapp;
+        const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
+
+        await federatedUserPages.conversationList().openPendingConnectionRequest();
+        await federatedUserPages.connectRequest().clickConnectButton();
+        await expect(
+          federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}),
+        ).toBeVisible();
+
+        await test.step('Normal user creates a group and adds federated user to it', async () => {
           await createGroup(normalUserPages, groupName, [federatedUser]);
           await normalUserPages.conversationList().getConversation(groupName).open();
+          await normalUserPages.conversation().toggleGroupInformation();
+
+          await expect(
+            normalUserPages.conversation().systemMessages.filter({hasText: `You added ${federatedUser.fullName}`}),
+          ).toBeVisible();
+          await expect(normalUserPages.conversation().statusIndicator).toContainText('Federated users are present');
+          await expect(
+            normalUserPages.conversationDetails().getParticipant(federatedUser.fullName).federatedIcon,
+          ).toBeVisible();
+
           await federatedUserPages.conversationList().getConversation(groupName).open();
+          await expect(
+            federatedUserPages
+              .conversation()
+              .systemMessages.filter({hasText: `${normalUser.fullName} added you to the conversation`}),
+          ).toBeVisible();
+        });
+
+        await test.step('Normal user can send and delete Text message in the federated group', async () => {
+          await normalUserPages.conversation().sendMessage('Hello from staging user');
+
+          const messageNormalUser = normalUserPages.conversation().getMessage({sender: normalUser});
+          await expect(messageNormalUser).toBeVisible();
+          await expect(federatedUserPages.conversation().getMessage({sender: normalUser})).toBeVisible();
+
+          await normalUserPages.conversation().deleteMessage(messageNormalUser, 'Everyone');
+          await expect(messageNormalUser).not.toBeVisible();
+          await expect(federatedUserPage.getByTestId('element-message-delete')).toBeVisible();
+        });
+
+        for (const {name, sendAction, verify} of testCases) {
+          await test.step(`Verify user sends ${name} and federated user can see it`, async () => {
+            await sendAction({normalUserPage});
+            await verify({federatedUserPage});
+          });
         }
-      });
+      },
+    );
 
-      await test.step('Start and accept call', async () => {
-        await normalUserPages.conversation().callButton.click();
-        await expect(normalUserPages.calling().callCell).toBeVisible();
-        await federatedUserPages.calling().acceptCallButton.click();
-      });
+    test(
+      'I want to share all possible assets in a federated 1:1',
+      {tag: ['@TC-8759', '@regression']},
+      async ({createPage}) => {
+        const [normalUserPage, federatedUserPage] = await Promise.all([
+          createPage(withLogin(normalUser)),
+          createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
+        ]);
+        await sendConnectionRequest(normalUserPage, federatedUser);
 
-      await test.step('Enable video streams', async () => {
-        await normalUserPages.calling().toggleVideoButton.click();
-        await federatedUserPages.calling().toggleVideoButton.click();
-      });
+        const {pages: normalUserPages} = PageManager.from(normalUserPage).webapp;
+        const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
 
-      const normalUserCall = await normalUserPages.calling().maximizeCell();
-      const federatedUserCall = await federatedUserPages.calling().maximizeCell();
+        await federatedUserPages.conversationList().openPendingConnectionRequest();
+        await federatedUserPages.connectRequest().clickConnectButton();
 
-      await test.step('Verify initial media connection', async () => {
-        await expect(normalUserCall.getCallingParticipant(federatedUser.fullName).muteIcon).not.toBeVisible();
-        await expect(normalUserCall.getGridTile(federatedUser.fullName).videoElement).toBeVisible();
+        await normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open();
+        await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
 
-        await expect(federatedUserCall.getCallingParticipant(normalUser.fullName).muteIcon).not.toBeVisible();
-        await expect(federatedUserCall.getGridTile(normalUser.fullName).videoElement).toBeVisible();
-      });
+        for (const {name, sendAction, verify} of testCases) {
+          await test.step(`Verify user sends ${name} and federated user can see it`, async () => {
+            await sendAction({normalUserPage});
+            await verify({federatedUserPage});
+          });
+        }
+      },
+    );
 
-      // Conditionally execute group-only interaction steps
-      if (type === 'group') {
-        await test.step('Verify screen sharing controls', async () => {
-          await normalUserCall.toggleVideoButton.click();
-          await expect(federatedUserCall.getGridTile(normalUser.fullName).videoElement).not.toBeVisible();
+    test(
+      'I want to import my backup of conversations with users from different BE and see the conversation contents',
+      {tag: ['@TC-3128', '@regression']},
+      async ({createPage}, testInfo) => {
+        test.setTimeout(150_000);
 
-          await normalUserCall.toggleScreenShareButton.click();
-          await expect(normalUserCall.selfVideoThumbnail.locator('video')).toBeVisible();
+        const [normalUserPage, federatedUserPage] = await Promise.all([
+          createPage(withLogin(normalUser)),
+          createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
+        ]);
+
+        const normalUserPageManager = PageManager.from(normalUserPage);
+        const {
+          pages: normalUserPages,
+          components: normalUserComponents,
+          modals: normalUserModals,
+        } = normalUserPageManager.webapp;
+        const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
+
+        await test.step('Establish connection between normal and federated user', async () => {
+          await sendConnectionRequest(normalUserPage, federatedUser);
+          await federatedUserPages.conversationList().openPendingConnectionRequest();
+          await federatedUserPages.connectRequest().clickConnectButton();
+        });
+
+        await test.step('Exchange direct messages and verify receipt', async () => {
+          await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
+          const oneOnOneConversation = await normalUserPages
+            .conversationList()
+            .getConversation(federatedUser.fullName, {protocol: 'mls'})
+            .open();
+
+          await normalUserPages.conversation().sendMessage('Message from normal user');
+          await federatedUserPages.conversation().sendMessage('Message from federated user');
+
+          await expect(normalUserPages.conversation().getMessage({sender: federatedUser})).toBeVisible();
+          await expect(federatedUserPages.conversation().getMessage({sender: normalUser})).toBeVisible();
+
+          // Wait for messages to be read before exporting backup
+          await expect(oneOnOneConversation.unreadIndicator).not.toBeVisible();
+        });
+
+        await test.step('Create a group chat and exchange text and image messages', async () => {
+          await createGroup(normalUserPages, groupName, [federatedUser]);
+          await federatedUserPages.conversationList().getConversation(groupName).open();
+          const groupConversation = await normalUserPages.conversationList().getConversation(groupName).open();
+
+          await federatedUserPages.conversation().sendMessage('Group message from federated user');
+          await shareAssetHelper(
+            getImageFilePath(),
+            federatedUserPage,
+            federatedUserPage.getByRole('button', {name: 'Add picture'}),
+          );
+
+          await expect(
+            normalUserPages.conversation().getMessage({content: 'Group message from federated user'}),
+          ).toBeVisible();
+
+          const messageWithImage = normalUserPages
+            .conversation()
+            .getMessage({sender: federatedUser})
+            .filter({has: normalUserPage.getByRole('img')});
+          await expect(messageWithImage).toBeVisible();
+
+          // Wait for messages to be read before exporting backup
+          await expect(groupConversation.unreadIndicator).not.toBeVisible();
+        });
+
+        const backupName = await test.step('Create and save backup for the normal user', async () => {
+          await normalUserComponents.conversationSidebar().clickPreferencesButton();
+          return await createAndSaveBackup(testInfo, normalUserPageManager);
+        });
+
+        await test.step('Log out the normal user from the first device', async () => {
+          await normalUserComponents.conversationSidebar().clickPreferencesButton();
+          await normalUserPages.account().clickLogoutButton();
+          await expect(normalUserModals.confirmLogout().modal).toBeVisible();
+          await normalUserModals.confirmLogout().clickConfirm();
+        });
+
+        // --- Second Device Flow ---
+        const normalUserDevice2 = await createPage(withLogin(normalUser, {confirmNewHistory: true}));
+
+        const {pages: normalUserDevice2Pages, components: normalUserDevice2Components} =
+          PageManager.from(normalUserDevice2).webapp;
+
+        await test.step('Import backup on the new device', async () => {
+          await normalUserDevice2Components.conversationSidebar().clickPreferencesButton();
+          await normalUserDevice2Pages.account().backupFileInput.setInputFiles(backupName);
+          await normalUserDevice2Components.conversationSidebar().allConversationsButton.click();
+        });
+
+        await test.step('Verify direct messages are restored on the new device', async () => {
+          await normalUserDevice2Pages
+            .conversationList()
+            .getConversation(federatedUser.fullName, {protocol: 'mls'})
+            .open();
+          await expect(normalUserDevice2Pages.conversation().getMessage({sender: normalUser})).toBeVisible();
+          await expect(normalUserDevice2Pages.conversation().getMessage({sender: federatedUser})).toBeVisible();
+        });
+
+        await test.step('Verify group messages and media are restored on the new device', async () => {
+          await normalUserDevice2Pages.conversationList().getConversation(groupName).open();
+
+          await expect(
+            normalUserDevice2Pages
+              .conversation()
+              .getMessage({sender: federatedUser, content: 'Group message from federated user'}),
+          ).toBeVisible();
+
+          const messageWithImage2Device = normalUserDevice2Pages
+            .conversation()
+            .getMessage({sender: federatedUser})
+            .filter({has: normalUserDevice2.getByRole('img')});
+          await expect(messageWithImage2Device).toBeVisible();
+        });
+      },
+    );
+
+    test(
+      'I want to be able to connect to, block, and unblock a user from different backend',
+      {tag: ['@TC-3129', '@regression']},
+      async ({createPage}) => {
+        const [normalUserPage, federatedUserPage] = await Promise.all([
+          createPage(withLogin(normalUser)),
+          createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
+        ]);
+
+        const {
+          pages: normalUserPages,
+          components: normalUserComponents,
+          modals: normalUserModals,
+        } = PageManager.from(normalUserPage).webapp;
+
+        const {pages: federatedUserPages} = PageManager.from(federatedUserPage).webapp;
+
+        const userHandle = federatedUser.qualifiedId?.domain
+          ? `${federatedUser.username}@${federatedUser.qualifiedId?.domain}`
+          : federatedUser.username;
+
+        await test.step('Send connection request to federated user', async () => {
+          await normalUserComponents.conversationSidebar().clickConnectButton();
+          await normalUserPages.startUI().searchInput.fill(userHandle);
+
+          const normalUserSearchRow = normalUserPages.startUI().searchResults.filter({hasText: federatedUser.username});
+          await expect(normalUserSearchRow).toBeVisible();
+          await expect(normalUserSearchRow.getByTestId('status-federated-user')).toBeVisible();
+
+          await normalUserPages.startUI().selectUsers(userHandle);
+          await normalUserModals.userProfile().clickConnectButton();
+        });
+
+        await test.step('Accept connection request from normal user', async () => {
+          await federatedUserPages.conversationList().openPendingConnectionRequest();
+          await federatedUserPages.connectRequest().clickConnectButton();
+        });
+
+        await test.step('Open conversation on both ends', async () => {
+          await Promise.all([
+            normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open(),
+            federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open(),
+          ]);
+        });
+
+        await test.step('Verify conversation details and cross-backend presence indicators', async () => {
+          await normalUserPages.conversation().toggleGroupInformation();
+
+          await expect(normalUserPages.participantDetails().userName).toBeVisible();
+          await expect(normalUserPages.participantDetails().userHandle).toBeVisible();
+          await expect(normalUserPages.conversation().statusIndicator).toContainText('Federated users are present');
+          await expect(normalUserPages.conversation().conversationTitle).toContainText(federatedUser.fullName);
+          await expect(
+            normalUserPages.conversation().systemMessages.filter({hasText: federatedUser.username}),
+          ).toBeVisible();
+        });
+
+        await test.step('Exchange messages between normal and federated users', async () => {
+          await normalUserPages.conversation().sendMessage('Message from normal user');
+          await federatedUserPages.conversation().sendMessage('Message from federated user');
+
+          await expect(normalUserPages.conversation().getMessage({sender: federatedUser})).toBeVisible();
+          await expect(federatedUserPages.conversation().getMessage({sender: normalUser})).toBeVisible();
+        });
+
+        await test.step('Block the federated user and verify status', async () => {
+          await normalUserPages.participantDetails().blockUser();
+          await normalUserModals.confirm().actionButton.click();
+
+          await expect(normalUserPages.participantDetails().userPicture).toHaveAttribute('data-uie-status', 'blocked');
+        });
+
+        await test.step('Unblock the federated user and verify status restoration', async () => {
+          await normalUserPages.participantDetails().unblockButton.click();
+          await normalUserModals.confirm().actionButton.click();
+
+          await expect(normalUserPages.participantDetails().userPicture).not.toHaveAttribute(
+            'data-uie-status',
+            'blocked',
+          );
+        });
+      },
+    );
+
+    const testData = [
+      {
+        title: 'I want to start a 1:1 call with a federated User',
+        tags: ['@TC-3208', '@regression'],
+        type: '1:1',
+      },
+      {
+        title: 'I want to start a conference call in a federated group with Users from 2 different backends',
+        tags: ['@TC-3220', '@regression'],
+        type: 'group',
+      },
+    ];
+
+    testData.forEach(({title, tags, type}) => {
+      test(title, {tag: tags}, async ({createPage}) => {
+        const [normalUserPage, federatedUserPage] = await Promise.all([
+          createPage(withLogin(normalUser)),
+          createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),
+        ]);
+
+        const normalUserPages = PageManager.from(normalUserPage).webapp.pages;
+        const federatedUserPages = PageManager.from(federatedUserPage).webapp.pages;
+        const groupName = 'Federation call group';
+
+        await test.step('Connect federated users', async () => {
+          await sendConnectionRequest(normalUserPage, federatedUser);
+          await federatedUserPages.conversationList().openPendingConnectionRequest();
+          await federatedUserPages.connectRequest().clickConnectButton();
+        });
+
+        await test.step('Users open conversations', async () => {
+          if (type === '1:1') {
+            await normalUserPages.conversationList().getConversation(federatedUser.fullName, {protocol: 'mls'}).open();
+            await federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}).open();
+          } else {
+            await expect(
+              federatedUserPages.conversationList().getConversation(normalUser.fullName, {protocol: 'mls'}),
+            ).toBeVisible();
+
+            await createGroup(normalUserPages, groupName, [federatedUser]);
+            await normalUserPages.conversationList().getConversation(groupName).open();
+            await federatedUserPages.conversationList().getConversation(groupName).open();
+          }
+        });
+
+        await test.step('Start and accept call', async () => {
+          await normalUserPages.conversation().callButton.click();
+          await expect(normalUserPages.calling().callCell).toBeVisible();
+          await federatedUserPages.calling().acceptCallButton.click();
+        });
+
+        await test.step('Enable video streams', async () => {
+          await normalUserPages.calling().toggleVideoButton.click();
+          await federatedUserPages.calling().toggleVideoButton.click();
+        });
+
+        const normalUserCall = await normalUserPages.calling().maximizeCell();
+        const federatedUserCall = await federatedUserPages.calling().maximizeCell();
+
+        await test.step('Verify initial media connection', async () => {
+          await expect(normalUserCall.getCallingParticipant(federatedUser.fullName).muteIcon).not.toBeVisible();
+          await expect(normalUserCall.getGridTile(federatedUser.fullName).videoElement).toBeVisible();
+
+          await expect(federatedUserCall.getCallingParticipant(normalUser.fullName).muteIcon).not.toBeVisible();
           await expect(federatedUserCall.getGridTile(normalUser.fullName).videoElement).toBeVisible();
         });
-      }
+
+        // Conditionally execute group-only interaction steps
+        if (type === 'group') {
+          await test.step('Verify screen sharing controls', async () => {
+            await normalUserCall.toggleVideoButton.click();
+            await expect(federatedUserCall.getGridTile(normalUser.fullName).videoElement).not.toBeVisible();
+
+            await normalUserCall.toggleScreenShareButton.click();
+            await expect(normalUserCall.selfVideoThumbnail.locator('video')).toBeVisible();
+            await expect(federatedUserCall.getGridTile(normalUser.fullName).videoElement).toBeVisible();
+          });
+        }
+      });
     });
-  });
-});
+  },
+);

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -677,9 +677,16 @@ test.describe('Guestroom', () => {
     password: process.env.SCIM_USER_PASSWORD,
   });
 
-  test(
+  test.skip(
     'I want to join guestroom invite with enterprise login',
-    {tag: ['@TC-3477', '@regression']},
+    {
+      tag: ['@TC-3477', '@regression'],
+      annotation: {
+        type: 'skip',
+        description:
+          'TODO: temporarily skipped because this E2E depends on IBIS/enterprise feature provisioning and currently blocks delivery.',
+      },
+    },
     async ({context, createPage}) => {
       test.setTimeout(150_000); // Due to the two logins this test can sometimes take a bit longer
       const [userAPage, guestPage] = await Promise.all([createPage(withLogin(userA)), createPage(context)]);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Temporarily skip Playwright / E2E tests that depend on IBIS or enterprise feature provisioning.

This includes tests around enterprise-only setup such as conference calling, channels, cells / Drive, and enterprise login where the test result currently depends on provisioning outside the Web team's direct control.

## Why

The current precommit E2E flow blocks release progress on tests that are not failing because of a product-code change in Web, but because they depend on external enterprise provisioning.

We should not lose time waiting on bottlenecks that we do not control. Instead, we should keep delivering safely and make the temporary skip explicit.