### PR TITLE
Fix asset assertions in federation e2e tests [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ClearConversationContent/clearConversationContent.spec.ts
@@ -236,7 +236,7 @@ test.describe('Clear Conversation Content', () => {
         const messageWithImage = userAPages
           .conversation()
           .getMessage({sender: userB})
-          .filter({has: userAPage.getByRole('img')});
+          .filter({has: userAPage.getByTestId('image-asset')});
         await expect(messageWithImage).toBeVisible();
 
         // 5.4 Files

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -43,7 +43,7 @@ test.describe('Federation', () => {
         const messageWithImage = federatedUserPages
           .conversation()
           .getMessage({sender: normalUser})
-          .filter({has: federatedUserPage.getByRole('img')});
+          .filter({has: federatedUserPage.getByTestId('image-asset')});
         await expect(messageWithImage).toBeVisible();
       },
     },
@@ -86,7 +86,7 @@ test.describe('Federation', () => {
         const messageWithAudio = federatedUserPages
           .conversation()
           .getMessage({sender: normalUser})
-          .filter({has: federatedUserPage.locator('[data-uie-name="audio-asset"]')});
+          .filter({has: federatedUserPage.getByTestId('audio-asset')});
         await expect(messageWithAudio).toBeVisible();
       },
     },
@@ -104,7 +104,7 @@ test.describe('Federation', () => {
         const messageWithVideo = federatedUserPages
           .conversation()
           .getMessage({sender: normalUser})
-          .filter({has: federatedUserPage.locator('[data-uie-name="video-asset"]')});
+          .filter({has: federatedUserPage.getByTestId('video-asset')});
         await expect(messageWithVideo).toBeVisible();
       },
     },
@@ -122,7 +122,7 @@ test.describe('Federation', () => {
         const messageWithFile = federatedUserPages
           .conversation()
           .getMessage({sender: normalUser})
-          .filter({has: federatedUserPage.locator('[data-uie-name="file-asset"]')});
+          .filter({has: federatedUserPage.getByTestId('file-asset')});
         await expect(messageWithFile).toBeVisible();
       },
     },
@@ -355,7 +355,7 @@ test.describe('Federation', () => {
         const messageWithImage = normalUserPages
           .conversation()
           .getMessage({sender: federatedUser})
-          .filter({has: normalUserPage.getByRole('img')});
+          .filter({has: normalUserPage.getByTestId('image-asset')});
         await expect(messageWithImage).toBeVisible();
 
         // Wait for messages to be read before exporting backup
@@ -407,7 +407,7 @@ test.describe('Federation', () => {
         const messageWithImage2Device = normalUserDevice2Pages
           .conversation()
           .getMessage({sender: federatedUser})
-          .filter({has: normalUserDevice2.getByRole('img')});
+          .filter({has: normalUserDevice2.getByTestId('image-asset')});
         await expect(messageWithImage2Device).toBeVisible();
       });
     },

--- a/apps/webapp/test/e2e_tests/specs/SendingAssets/sendingAssets.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SendingAssets/sendingAssets.spec.ts
@@ -156,7 +156,7 @@ test.describe('Sending Assets', () => {
 
       await test.step('User B send message and verify it in message', async () => {
         await pastedFileControls.press('Enter');
-        await expect(pages.conversation().getMessage({sender: userA}).getByRole('img')).toBeVisible();
+        await expect(pages.conversation().getMessage({sender: userA}).getByTestId('image-asset')).toBeVisible();
       });
     },
   );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Within the federation tests often assets like images, audio or video are sent. To verify the message arrived an assertion is used. However for images the assertion `messages.filter({ has: page.getByRole('img') })` was used. This sometimes caused a strict mode violation since a normal text message also contains the users profile picture with that role. (E.g. https://github.com/wireapp/wire-webapp/actions/runs/28428035446/job/84237243040?pr=21650#step:9:254)

This PR makes sure all federation tests use the less accessible but surely stable id to narrow the message the assertion is made upon.
