### PR TITLE
feat: enhance detached window handling for external links and modals [WPB-26355]

### DIFF
--- a/apps/webapp/src/script/hooks/useActiveWindow.ts
+++ b/apps/webapp/src/script/hooks/useActiveWindow.ts
@@ -21,7 +21,7 @@ import {useEffect} from 'react';
 
 import {create} from 'zustand';
 
-type ActiveWindowState = {
+export type ActiveWindowState = {
   activeWindow: Window;
   setActiveWindow: (newWindow: Window) => void;
 };

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.test.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.test.ts
@@ -56,20 +56,20 @@ import {CallingViewMode, CallState, MuteState} from './CallState';
 import {CALL_MESSAGE_TYPE} from './enum/CallMessageType';
 import {LEAVE_CALL_REASON} from './enum/LeaveCallReason';
 import {Participant} from './Participant';
-import type {ActiveWindowState} from 'Hooks/useActiveWindow';
 import {useActiveWindowState} from 'Hooks/useActiveWindow';
 
 import {buildMediaDevicesHandler, createConversation, createSelfParticipant} from '../../auth/util/test/testUtil';
 import {Core} from '../../service/coreSingleton';
 import {Warnings} from '../../view_model/WarningsContainer';
 import {z} from 'zod';
-import {translateForTest, translateWithPrefixForTest} from 'Util/test/translateForTest';
+import {translateForTest} from 'Util/test/translateForTest';
 import {MessageRepository} from 'Repositories/conversation/MessageRepository';
 import {MediaStreamHandler} from 'Repositories/media/MediaStreamHandler';
 import {MediaDevicesHandler} from 'Repositories/media/MediaDevicesHandler';
 import {BackgroundEffectsHandler} from 'Repositories/media/backgroundEffectsHandler';
 import {APIClient} from '../../service/apiClientSingleton';
 import {ConversationState} from 'Repositories/conversation/ConversationState';
+import {Translate} from 'Util/localizerUtil';
 
 type AudioFlowStat = {
   bytesReceived?: number;
@@ -126,6 +126,9 @@ function createCallingRepositoryForTest({
   };
 }
 
+const translateWithPrefixForTest: Translate = (translationKey, _substitutions, _dangerousSubstitutions, _skipEscape) =>
+  `translated:${translationKey}`;
+
 describe('CallingRepository', () => {
   const testFactory = new TestFactory();
   let callingRepository: CallingRepository;
@@ -149,7 +152,7 @@ describe('CallingRepository', () => {
     callingRepository['callState'].calls([]);
     callingRepository['conversationState'].conversations([]);
     callingRepository.destroy();
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   afterAll(() => {
@@ -178,8 +181,8 @@ describe('CallingRepository', () => {
 
       callingRepository['conversationState'].conversations.push(conversation);
       callingRepository['callState'].calls([call]);
-      spyOn(callingRepository, 'muteCall').and.callThrough();
-      spyOn(wCall, 'recvMsg').and.callThrough();
+      jest.spyOn(callingRepository, 'muteCall');
+      jest.spyOn(wCall, 'recvMsg');
 
       const event: CallingEvent = {
         content: {
@@ -224,8 +227,8 @@ describe('CallingRepository', () => {
 
       callingRepository['conversationState'].conversations.push(conversation);
       callingRepository['callState'].calls([call]);
-      spyOn(callingRepository, 'muteCall').and.callThrough();
-      spyOn(wCall, 'recvMsg').and.callThrough();
+      jest.spyOn(callingRepository, 'muteCall');
+      jest.spyOn(wCall, 'recvMsg');
 
       const event: CallingEvent = {
         content: {
@@ -270,8 +273,8 @@ describe('CallingRepository', () => {
 
       callingRepository['conversationState'].conversations.push(conversation);
       callingRepository['callState'].calls([call]);
-      spyOn(callingRepository, 'muteCall').and.callThrough();
-      spyOn(wCall, 'recvMsg').and.callThrough();
+      jest.spyOn(callingRepository, 'muteCall');
+      jest.spyOn(wCall, 'recvMsg');
 
       const someOtherClientId = 'some-other-client';
 
@@ -299,13 +302,20 @@ describe('CallingRepository', () => {
   });
 
   describe('startCall', () => {
+    beforeEach(() => {
+      const subscribeToEpochUpdates = jest.mocked(
+        container.resolve(Core).service!.subconversation.subscribeToEpochUpdates,
+      );
+      subscribeToEpochUpdates?.mockClear();
+    });
+
     it.each([CONVERSATION_PROTOCOL.PROTEUS, CONVERSATION_PROTOCOL.MLS])(
       'starts a ONEONONE call for proteus or MLS 1:1 conversation',
       async protocol => {
         const conversation = createConversation(CONVERSATION_TYPE.ONE_TO_ONE, protocol);
         const callType = CALL_TYPE.NORMAL;
         const NO_MEETING = 0;
-        spyOn(wCall, 'start');
+        jest.spyOn(wCall, 'start');
         await callingRepository.startCall(conversation);
         expect(wCall.start).toHaveBeenCalledWith(wUser, conversation.id, callType, CONV_TYPE.ONEONONE, 0, NO_MEETING);
       },
@@ -316,7 +326,7 @@ describe('CallingRepository', () => {
       const conversation = createConversation(CONVERSATION_TYPE.REGULAR, CONVERSATION_PROTOCOL.PROTEUS);
       const callType = CALL_TYPE.NORMAL;
       const NO_MEETING = 0;
-      spyOn(wCall, 'start');
+      jest.spyOn(wCall, 'start');
       await callingRepository.startCall(conversation);
       expect(wCall.start).toHaveBeenCalledWith(wUser, conversation.id, callType, CONV_TYPE.CONFERENCE, 0, NO_MEETING);
     });
@@ -326,7 +336,7 @@ describe('CallingRepository', () => {
       const conversation = createConversation(CONVERSATION_TYPE.REGULAR, CONVERSATION_PROTOCOL.MLS);
       const callType = CALL_TYPE.NORMAL;
       const NO_MEETING = 0;
-      spyOn(wCall, 'start');
+      jest.spyOn(wCall, 'start');
       await callingRepository.startCall(conversation);
       expect(wCall.start).toHaveBeenCalledWith(
         wUser,
@@ -377,6 +387,13 @@ describe('CallingRepository', () => {
   });
 
   describe('answerCall', () => {
+    beforeEach(() => {
+      const subscribeToEpochUpdates = jest.mocked(
+        container.resolve(Core).service!.subconversation.subscribeToEpochUpdates,
+      );
+      subscribeToEpochUpdates?.mockClear();
+    });
+
     it('subscribes to epoch updates after answering a mls conference call', async () => {
       const conversationId = {domain: 'example.com', id: 'conversation2'};
       const selfParticipant = createSelfParticipant();
@@ -470,16 +487,18 @@ describe('CallingRepository', () => {
   });
 
   describe('showNoCameraModal', () => {
+    afterEach(() => {
+      useActiveWindowState.getState().setActiveWindow(window);
+    });
+
     it('renders in the main window when the main window is focused', () => {
       const translate = jest.fn(translateWithPrefixForTest);
       const {repository: isolatedCallingRepository} = createCallingRepositoryForTest({translate});
       const showModal = jest.spyOn(PrimaryModal, 'show').mockImplementation(() => undefined as never);
-      const activeWindowSpy = jest
-        .spyOn(useActiveWindowState, 'getState')
-        .mockReturnValue({activeWindow: window} as unknown as ActiveWindowState);
       const detachedDocument = document.implementation.createHTMLDocument('detached');
       isolatedCallingRepository['callState'].viewMode(CallingViewMode.DETACHED_WINDOW);
       isolatedCallingRepository['callState'].detachedWindow({document: detachedDocument} as Window);
+      useActiveWindowState.getState().setActiveWindow(window);
 
       isolatedCallingRepository['showNoCameraModal']();
 
@@ -492,7 +511,6 @@ describe('CallingRepository', () => {
         translate,
       );
 
-      activeWindowSpy.mockRestore();
       showModal.mockRestore();
     });
 
@@ -502,11 +520,9 @@ describe('CallingRepository', () => {
       const showModal = jest.spyOn(PrimaryModal, 'show').mockImplementation(() => undefined as never);
       const detachedDocument = document.implementation.createHTMLDocument('detached');
       const detachedWindow = {document: detachedDocument} as Window;
-      const activeWindowSpy = jest
-        .spyOn(useActiveWindowState, 'getState')
-        .mockReturnValue({activeWindow: detachedWindow} as ActiveWindowState);
       isolatedCallingRepository['callState'].viewMode(CallingViewMode.DETACHED_WINDOW);
       isolatedCallingRepository['callState'].detachedWindow(detachedWindow);
+      useActiveWindowState.getState().setActiveWindow(detachedWindow);
 
       isolatedCallingRepository['showNoCameraModal']();
 
@@ -519,7 +535,6 @@ describe('CallingRepository', () => {
         translate,
       );
 
-      activeWindowSpy.mockRestore();
       showModal.mockRestore();
     });
   });
@@ -581,8 +596,8 @@ describe('CallingRepository', () => {
       const audioTrack = source.createTrack();
       const selfMediaStream = new MediaStream([audioTrack]);
       selfParticipant.audioStream(selfMediaStream);
-      spyOn(selfParticipant, 'getMediaStream').and.callThrough();
-      spyOn(callingRepository, 'findCall').and.returnValue(call);
+      jest.spyOn(selfParticipant, 'getMediaStream');
+      jest.spyOn(callingRepository, 'findCall').mockReturnValue(call);
 
       const queries = [1, 2, 3, 4].map(() => {
         return callingRepository['getCallMediaStream']('', true, false, false).then(mediaStream => {
@@ -608,10 +623,10 @@ describe('CallingRepository', () => {
       const source = new window.RTCAudioSource();
       const audioTrack = source.createTrack();
       const selfMediaStream = new MediaStream([audioTrack]);
-      spyOn(callingRepository['mediaStreamHandler'], 'requestMediaStream').and.returnValue(
-        Promise.resolve(selfMediaStream),
-      );
-      spyOn(callingRepository, 'findCall').and.returnValue(call);
+      jest
+        .spyOn(callingRepository['mediaStreamHandler'], 'requestMediaStream')
+        .mockReturnValue(Promise.resolve(selfMediaStream));
+      jest.spyOn(callingRepository, 'findCall').mockReturnValue(call);
 
       const queries = [1, 2, 3, 4].map(() => {
         return callingRepository['getCallMediaStream']('', true, false, false).then(mediaStream => {
@@ -670,8 +685,8 @@ describe('CallingRepository', () => {
       callingRepository['conversationState'].conversations.push(conversation);
       callingRepository['callState'].calls([call]);
 
-      spyOn(Warnings, 'showWarning');
-      spyOn(Warnings, 'hideWarning');
+      jest.spyOn(Warnings, 'showWarning');
+      jest.spyOn(Warnings, 'hideWarning');
     });
 
     // skipping test for now. Once we have correct stats about network
@@ -714,7 +729,7 @@ describe('CallingRepository', () => {
     });
 
     it('logs warning when JSON parsing fails', () => {
-      spyOn(callingRepository['logger'], 'warn');
+      jest.spyOn(callingRepository['logger'], 'warn');
       const invalidJsonString = '{invalid-json';
 
       callingRepository['updateCallQuality'](conversationId, userId, remoteClientId, invalidJsonString);
@@ -726,7 +741,7 @@ describe('CallingRepository', () => {
     });
 
     it('logs warning when network quality info schema validation fails', () => {
-      spyOn(callingRepository['logger'], 'warn');
+      jest.spyOn(callingRepository['logger'], 'warn');
 
       const invalidQualityInfo = JSON.stringify({
         quality: 'invalid-quality',
@@ -760,8 +775,8 @@ describe('CallingRepository', () => {
   describe('stopMediaSource', () => {
     it('releases media streams', () => {
       const selfParticipant = createSelfParticipant();
-      spyOn(selfParticipant, 'releaseAudioStream');
-      spyOn(selfParticipant, 'releaseVideoStream');
+      jest.spyOn(selfParticipant, 'releaseAudioStream');
+      jest.spyOn(selfParticipant, 'releaseVideoStream');
 
       const call = new Call(
         {domain: '', id: ''},
@@ -771,7 +786,7 @@ describe('CallingRepository', () => {
         CALL_TYPE.NORMAL,
         buildMediaDevicesHandler(),
       );
-      spyOn(callingRepository['callState'], 'joinedCall').and.returnValue(call);
+      jest.spyOn(callingRepository['callState'], 'joinedCall').mockReturnValue(call);
       callingRepository.stopMediaSource(MediaType.AUDIO);
 
       expect(selfParticipant.releaseAudioStream).toHaveBeenCalledTimes(1);
@@ -804,8 +819,8 @@ describe('CallingRepository', () => {
     describe('on incoming call', () => {
       it('toggle on', async () => {
         selfParticipant.videoState(VIDEO_STATE.STOPPED);
-        spyOn(selfParticipant, 'releaseVideoStream');
-        spyOn(wCall, 'setVideoSendState');
+        jest.spyOn(selfParticipant, 'releaseVideoStream');
+        jest.spyOn(wCall, 'setVideoSendState');
         call.state(CALL_STATE.INCOMING);
         callingRepository.toggleCamera(call);
         expect(selfParticipant.releaseVideoStream).toHaveBeenCalledTimes(0);
@@ -814,8 +829,8 @@ describe('CallingRepository', () => {
 
       it('toggle off', async () => {
         selfParticipant.videoState(VIDEO_STATE.STARTED);
-        spyOn(selfParticipant, 'releaseVideoStream');
-        spyOn(wCall, 'setVideoSendState');
+        jest.spyOn(selfParticipant, 'releaseVideoStream');
+        jest.spyOn(wCall, 'setVideoSendState');
         call.state(CALL_STATE.INCOMING);
         callingRepository.toggleCamera(call);
 
@@ -827,8 +842,8 @@ describe('CallingRepository', () => {
     describe('on running call', () => {
       it('toggle on', async () => {
         selfParticipant.videoState(VIDEO_STATE.STOPPED);
-        spyOn(selfParticipant, 'releaseVideoStream');
-        spyOn(wCall, 'setVideoSendState');
+        jest.spyOn(selfParticipant, 'releaseVideoStream');
+        jest.spyOn(wCall, 'setVideoSendState');
         call.state(CALL_STATE.MEDIA_ESTAB);
         callingRepository.toggleCamera(call);
         expect(selfParticipant.releaseVideoStream).toHaveBeenCalledTimes(0);
@@ -837,8 +852,8 @@ describe('CallingRepository', () => {
 
       it('toggle off', async () => {
         selfParticipant.videoState(VIDEO_STATE.STARTED);
-        spyOn(selfParticipant, 'releaseVideoStream');
-        spyOn(wCall, 'setVideoSendState');
+        jest.spyOn(selfParticipant, 'releaseVideoStream');
+        jest.spyOn(wCall, 'setVideoSendState');
         call.state(CALL_STATE.MEDIA_ESTAB);
         callingRepository.toggleCamera(call);
 
@@ -849,8 +864,8 @@ describe('CallingRepository', () => {
       // This is an edge case. You can toggleCamera on when you have screen share enabled!
       it('toggle on when screen shared', async () => {
         selfParticipant.videoState(VIDEO_STATE.SCREENSHARE);
-        spyOn(selfParticipant, 'releaseVideoStream');
-        spyOn(wCall, 'setVideoSendState');
+        jest.spyOn(selfParticipant, 'releaseVideoStream');
+        jest.spyOn(wCall, 'setVideoSendState');
         call.state(CALL_STATE.MEDIA_ESTAB);
         callingRepository.toggleCamera(call);
         // Screen sharing should be stopped first
@@ -1078,21 +1093,22 @@ describe.skip('E2E audio call', () => {
   let wCall: Wcall;
 
   beforeAll(() => {
-    spyOn(client, 'fetchConfig').and.returnValue(Promise.resolve({ice_servers: []}));
-    spyOn(mockedClient, 'getCallMediaStream').and.returnValue(
-      Promise.resolve(new MediaStream([new window.RTCAudioSource().createTrack()])),
-    );
-    spyOn(mockedClient, 'getMediaStream').and.returnValue(
-      Promise.resolve(new MediaStream([new window.RTCAudioSource().createTrack()])),
-    );
-    spyOn(client, 'onCallEvent').and.callThrough();
-    spyOn(mockedClient, 'updateParticipantStream').and.callThrough();
-    spyOn(mockedClient, 'incomingCallCallback').and.callFake(call => {
+    jest.spyOn(client, 'fetchConfig').mockReturnValue(Promise.resolve({ice_servers: []}));
+    jest
+      .spyOn(mockedClient, 'getCallMediaStream')
+      .mockReturnValue(Promise.resolve(new MediaStream([new window.RTCAudioSource().createTrack()])));
+    jest
+      .spyOn(mockedClient, 'getMediaStream')
+      .mockReturnValue(Promise.resolve(new MediaStream([new window.RTCAudioSource().createTrack()])));
+    jest.spyOn(client, 'onCallEvent');
+    jest.spyOn(mockedClient, 'updateParticipantStream');
+    jest.spyOn(mockedClient, 'incomingCallCallback').mockImplementation(call => {
       client.answerCall(call, CALL_TYPE.NORMAL);
     });
-    spyOn(mockedClient, 'checkConcurrentJoinedCall').and.returnValue(Promise.resolve(true));
-    spyOn(mockedClient, 'sendMessage').and.callFake(
-      (context, convId, userId, clientid, destUserId, destDeviceId, payload) => {
+    jest.spyOn(mockedClient, 'checkConcurrentJoinedCall').mockReturnValue(Promise.resolve(true));
+    jest
+      .spyOn(mockedClient, 'sendMessage')
+      .mockImplementation((context, convId, userId, clientid, destUserId, destDeviceId, payload) => {
         wCall.recvMsg(
           remoteWuser,
           payload,
@@ -1105,8 +1121,7 @@ describe.skip('E2E audio call', () => {
           CONV_TYPE.CONFERENCE,
           0, // no meeting
         );
-      },
-    );
+      });
     return client.initAvs(user, 'device').then(({wCall: wCallInstance, wUser}) => {
       remoteWuser = createAutoAnsweringWuser(wCallInstance, client);
       wCall = wCallInstance;
@@ -1215,7 +1230,7 @@ describe('NotificationHandlingState', () => {
   });
 
   it('handle STREAM state notification', done => {
-    spyOn(wCall, 'processNotifications').and.callThrough();
+    jest.spyOn(wCall, 'processNotifications');
 
     amplify.publish(WebAppEvents.EVENT.NOTIFICATION_HANDLING_STATE, NOTIFICATION_HANDLING_STATE.STREAM);
 
@@ -1224,7 +1239,7 @@ describe('NotificationHandlingState', () => {
   });
 
   it('handle RECOVERY state notification', done => {
-    spyOn(wCall, 'processNotifications').and.callThrough();
+    jest.spyOn(wCall, 'processNotifications');
 
     amplify.publish(WebAppEvents.EVENT.NOTIFICATION_HANDLING_STATE, NOTIFICATION_HANDLING_STATE.RECOVERY);
 
@@ -1233,7 +1248,7 @@ describe('NotificationHandlingState', () => {
   });
 
   it('handle WEB_SOCKET state notification', done => {
-    spyOn(wCall, 'processNotifications').and.callThrough();
+    jest.spyOn(wCall, 'processNotifications');
 
     amplify.publish(WebAppEvents.EVENT.NOTIFICATION_HANDLING_STATE, NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
 
@@ -1265,8 +1280,8 @@ describe('init AVS state', () => {
     nowMock.mockReturnValue(0);
     client.initAvs(user, 'device').then(({wCall: wCallInstance, wUser}) => {
       createAutoAnsweringWuser(wCallInstance, client);
-      spyOn(wCallInstance, 'setBackground').and.callThrough();
-      spyOn(wCallInstance, 'poll').and.callThrough();
+      jest.spyOn(wCallInstance, 'setBackground');
+      jest.spyOn(wCallInstance, 'poll');
       nowMock.mockReturnValue(500);
       jest.advanceTimersByTime(500);
 
@@ -1281,8 +1296,8 @@ describe('init AVS state', () => {
     nowMock.mockReturnValue(0);
     client.initAvs(user, 'device').then(({wCall: wCallInstance, wUser}) => {
       createAutoAnsweringWuser(wCallInstance, client);
-      spyOn(wCallInstance, 'setBackground').and.callThrough();
-      spyOn(wCallInstance, 'poll').and.callThrough();
+      jest.spyOn(wCallInstance, 'setBackground');
+      jest.spyOn(wCallInstance, 'poll');
       nowMock.mockReturnValue(3001);
       jest.advanceTimersByTime(500);
 
@@ -1297,8 +1312,10 @@ describe('init AVS state', () => {
     nowMock.mockReturnValue(0);
     client.initAvs(user, 'device').then(({wCall: wCallInstance, wUser}) => {
       createAutoAnsweringWuser(wCallInstance, client);
-      spyOn(wCallInstance, 'setBackground').and.throwError('AVS set background fails');
-      spyOn(wCallInstance, 'poll').and.callThrough();
+      jest.spyOn(wCallInstance, 'setBackground').mockImplementation(() => {
+        throw new Error('AVS set background fails');
+      });
+      jest.spyOn(wCallInstance, 'poll');
       nowMock.mockReturnValue(3001);
       jest.advanceTimersByTime(500);
 
@@ -1332,7 +1349,7 @@ describe('setupDetachedWindowExternalLinksClick', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('opens _blank links in the opener window', () => {

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.test.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.test.ts
@@ -43,10 +43,12 @@ import {createUuid} from 'Util/uuid';
 
 import {Call} from './Call';
 import {CallingRepository, setupDetachedWindowExternalLinksClick} from './CallingRepository';
-import {CallState, MuteState} from './CallState';
+import {CallingViewMode, CallState, MuteState} from './CallState';
 import {CALL_MESSAGE_TYPE} from './enum/CallMessageType';
 import {LEAVE_CALL_REASON} from './enum/LeaveCallReason';
 import {Participant} from './Participant';
+import type {ActiveWindowState} from 'Hooks/useActiveWindow';
+import {useActiveWindowState} from 'Hooks/useActiveWindow';
 
 import {buildMediaDevicesHandler, createConversation, createSelfParticipant} from '../../auth/util/test/testUtil';
 import {Core} from '../../service/coreSingleton';
@@ -403,6 +405,79 @@ describe('CallingRepository', () => {
         undefined,
         translate,
       );
+    });
+  });
+
+  describe('showNoCameraModal', () => {
+    it('renders in the main window when the main window is focused', () => {
+      const translate = jest.fn((translationKey: string) => `translated:${translationKey}`);
+      const isolatedCallingRepository = new CallingRepository(
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        translate,
+      );
+      const showModal = jest.spyOn(PrimaryModal, 'show').mockImplementation(() => undefined as never);
+      const activeWindowSpy = jest
+        .spyOn(useActiveWindowState, 'getState')
+        .mockReturnValue({activeWindow: window} as unknown as ActiveWindowState);
+      const detachedDocument = document.implementation.createHTMLDocument('detached');
+      isolatedCallingRepository['callState'].viewMode(CallingViewMode.DETACHED_WINDOW);
+      isolatedCallingRepository['callState'].detachedWindow({document: detachedDocument} as Window);
+
+      isolatedCallingRepository['showNoCameraModal']();
+
+      expect(showModal).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          container: undefined,
+        }),
+        undefined,
+        translate,
+      );
+
+      activeWindowSpy.mockRestore();
+      showModal.mockRestore();
+    });
+
+    it('renders in the detached window when the detached window is focused', () => {
+      const translate = jest.fn((translationKey: string) => `translated:${translationKey}`);
+      const isolatedCallingRepository = new CallingRepository(
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        translate,
+      );
+      const showModal = jest.spyOn(PrimaryModal, 'show').mockImplementation(() => undefined as never);
+      const detachedDocument = document.implementation.createHTMLDocument('detached');
+      const detachedWindow = {document: detachedDocument} as Window;
+      const activeWindowSpy = jest
+        .spyOn(useActiveWindowState, 'getState')
+        .mockReturnValue({activeWindow: detachedWindow} as unknown as ActiveWindowState);
+      isolatedCallingRepository['callState'].viewMode(CallingViewMode.DETACHED_WINDOW);
+      isolatedCallingRepository['callState'].detachedWindow(detachedWindow);
+
+      isolatedCallingRepository['showNoCameraModal']();
+
+      expect(showModal).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          container: detachedDocument.body,
+        }),
+        undefined,
+        translate,
+      );
+
+      activeWindowSpy.mockRestore();
+      showModal.mockRestore();
     });
   });
 
@@ -1240,11 +1315,18 @@ describe('init AVS state', () => {
   });
 });
 
+const createLinkInsideDetachedWindow = (detachedWindow: Window, target = '_blank') => {
+  detachedWindow.document.body.innerHTML = `<a href="https://wire.com" target="${target}">Wire</a>`;
+  return detachedWindow.document.querySelector('a')!;
+};
+
 describe('setupDetachedWindowExternalLinksClick', () => {
   let detachedWindow: Window;
   let openerWindow: Window;
 
   beforeEach(() => {
+    jest.spyOn(Runtime, 'isDesktopApp').mockReturnValue(true);
+
     detachedWindow = {
       document: document.implementation.createHTMLDocument('detached-window'),
     } as Window;
@@ -1259,12 +1341,9 @@ describe('setupDetachedWindowExternalLinksClick', () => {
   });
 
   it('opens _blank links in the opener window', () => {
-    detachedWindow.document.body.innerHTML = `
-      <a href="https://wire.com" target="_blank">Wire</a>
-    `;
+    const link = createLinkInsideDetachedWindow(detachedWindow, '_blank');
 
     const cleanup = setupDetachedWindowExternalLinksClick(detachedWindow, openerWindow);
-    const link = detachedWindow.document.querySelector('a')!;
 
     link.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
 
@@ -1273,12 +1352,22 @@ describe('setupDetachedWindowExternalLinksClick', () => {
   });
 
   it('does not handle non _blank links', () => {
-    detachedWindow.document.body.innerHTML = `
-      <a href="https://wire.com" target="_self">Wire</a>
-    `;
+    const link = createLinkInsideDetachedWindow(detachedWindow, '_self');
 
     const cleanup = setupDetachedWindowExternalLinksClick(detachedWindow, openerWindow);
-    const link = detachedWindow.document.querySelector('a')!;
+
+    link.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
+
+    expect(openerWindow.open).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('does not handle links outside the desktop app', () => {
+    jest.spyOn(Runtime, 'isDesktopApp').mockReturnValue(false);
+
+    const link = createLinkInsideDetachedWindow(detachedWindow, '_blank');
+
+    const cleanup = setupDetachedWindowExternalLinksClick(detachedWindow, openerWindow);
 
     link.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
 
@@ -1287,14 +1376,11 @@ describe('setupDetachedWindowExternalLinksClick', () => {
   });
 
   it('removes the click listener on cleanup', () => {
-    detachedWindow.document.body.innerHTML = `
-      <a href="https://wire.com" target="_blank">Wire</a>
-    `;
+    const link = createLinkInsideDetachedWindow(detachedWindow, '_blank');
 
     const cleanup = setupDetachedWindowExternalLinksClick(detachedWindow, openerWindow);
     cleanup();
 
-    const link = detachedWindow.document.querySelector('a')!;
     link.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
 
     expect(openerWindow.open).not.toHaveBeenCalled();

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.test.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.test.ts
@@ -24,7 +24,16 @@ import 'jsdom-worker';
 import {Subscription} from 'knockout';
 import {container} from 'tsyringe';
 
-import {CALL_TYPE, CONV_TYPE, QUALITY, REASON, STATE as CALL_STATE, VIDEO_STATE, Wcall} from '@wireapp/avs';
+import {
+  CALL_TYPE,
+  CONV_TYPE,
+  QUALITY,
+  REASON,
+  STATE as CALL_STATE,
+  VIDEO_STATE,
+  Wcall,
+  type WcallAudioCbrChangeHandler,
+} from '@wireapp/avs';
 import {Runtime} from '@wireapp/commons';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
@@ -37,7 +46,7 @@ import {EventRepository} from 'Repositories/event/EventRepository';
 import {NOTIFICATION_HANDLING_STATE} from 'Repositories/event/NotificationHandlingState';
 import {MediaType} from 'Repositories/media/MediaType';
 import {UserRepository} from 'Repositories/user/userRepository';
-import {serverTimeHandler} from 'src/script/time/serverTimeHandler';
+import type {ServerTimeHandler} from 'src/script/time/serverTimeHandler';
 import {TestFactory} from 'test/helper/TestFactory';
 import {createUuid} from 'Util/uuid';
 
@@ -54,7 +63,68 @@ import {buildMediaDevicesHandler, createConversation, createSelfParticipant} fro
 import {Core} from '../../service/coreSingleton';
 import {Warnings} from '../../view_model/WarningsContainer';
 import {z} from 'zod';
-import {translateForTest} from 'Util/test/translateForTest';
+import {translateForTest, translateWithPrefixForTest} from 'Util/test/translateForTest';
+import {MessageRepository} from 'Repositories/conversation/MessageRepository';
+import {MediaStreamHandler} from 'Repositories/media/MediaStreamHandler';
+import {MediaDevicesHandler} from 'Repositories/media/MediaDevicesHandler';
+import {BackgroundEffectsHandler} from 'Repositories/media/backgroundEffectsHandler';
+import {APIClient} from '../../service/apiClientSingleton';
+import {ConversationState} from 'Repositories/conversation/ConversationState';
+
+type AudioFlowStat = {
+  bytesReceived?: number;
+  bytesSent?: number;
+  id?: string;
+  kind?: string;
+  mediaType?: string;
+};
+
+function createCallingRepositoryForTest({
+  backgroundEffectsHandler = {} as BackgroundEffectsHandler,
+  callState = new CallState(),
+  conversationState = {} as ConversationState,
+  eventRepository = {injectEvent: jest.fn()} as Pick<EventRepository, 'injectEvent'>,
+  mediaDevicesHandler = buildMediaDevicesHandler(),
+  mediaStreamHandler = {} as MediaStreamHandler,
+  messageRepository = {} as MessageRepository,
+  serverTimeHandler = {toServerTimestamp: jest.fn().mockImplementation(() => Date.now())} as Pick<
+    ServerTimeHandler,
+    'toServerTimestamp'
+  >,
+  translate = translateWithPrefixForTest,
+  userRepository = {} as UserRepository,
+  apiClient = {} as APIClient,
+}: {
+  backgroundEffectsHandler?: BackgroundEffectsHandler;
+  callState?: CallState;
+  conversationState?: ConversationState;
+  eventRepository?: Pick<EventRepository, 'injectEvent'>;
+  mediaDevicesHandler?: MediaDevicesHandler;
+  mediaStreamHandler?: MediaStreamHandler;
+  messageRepository?: MessageRepository;
+  serverTimeHandler?: Pick<ServerTimeHandler, 'toServerTimestamp'>;
+  translate?: typeof translateWithPrefixForTest;
+  userRepository?: UserRepository;
+  apiClient?: APIClient;
+} = {}) {
+  return {
+    callState,
+    conversationState,
+    repository: new CallingRepository(
+      messageRepository as unknown as MessageRepository,
+      eventRepository as EventRepository,
+      userRepository,
+      mediaStreamHandler,
+      mediaDevicesHandler,
+      serverTimeHandler as ServerTimeHandler,
+      backgroundEffectsHandler,
+      translate,
+      apiClient,
+      conversationState,
+      callState,
+    ),
+  };
+}
 
 describe('CallingRepository', () => {
   const testFactory = new TestFactory();
@@ -375,17 +445,8 @@ describe('CallingRepository', () => {
 
   describe('showNoAudioInputModal', () => {
     it('uses the injected translate function', () => {
-      const translate = jest.fn((translationKey: string) => `translated:${translationKey}`);
-      const isolatedCallingRepository = new CallingRepository(
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        translate,
-      );
+      const translate = jest.fn(translateWithPrefixForTest);
+      const {repository: isolatedCallingRepository} = createCallingRepositoryForTest({translate});
 
       const showModal = jest.spyOn(PrimaryModal, 'show').mockImplementation(() => undefined as never);
 
@@ -410,17 +471,8 @@ describe('CallingRepository', () => {
 
   describe('showNoCameraModal', () => {
     it('renders in the main window when the main window is focused', () => {
-      const translate = jest.fn((translationKey: string) => `translated:${translationKey}`);
-      const isolatedCallingRepository = new CallingRepository(
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        translate,
-      );
+      const translate = jest.fn(translateWithPrefixForTest);
+      const {repository: isolatedCallingRepository} = createCallingRepositoryForTest({translate});
       const showModal = jest.spyOn(PrimaryModal, 'show').mockImplementation(() => undefined as never);
       const activeWindowSpy = jest
         .spyOn(useActiveWindowState, 'getState')
@@ -445,23 +497,14 @@ describe('CallingRepository', () => {
     });
 
     it('renders in the detached window when the detached window is focused', () => {
-      const translate = jest.fn((translationKey: string) => `translated:${translationKey}`);
-      const isolatedCallingRepository = new CallingRepository(
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        translate,
-      );
+      const translate = jest.fn(translateWithPrefixForTest);
+      const {repository: isolatedCallingRepository} = createCallingRepositoryForTest({translate});
       const showModal = jest.spyOn(PrimaryModal, 'show').mockImplementation(() => undefined as never);
       const detachedDocument = document.implementation.createHTMLDocument('detached');
       const detachedWindow = {document: detachedDocument} as Window;
       const activeWindowSpy = jest
         .spyOn(useActiveWindowState, 'getState')
-        .mockReturnValue({activeWindow: detachedWindow} as unknown as ActiveWindowState);
+        .mockReturnValue({activeWindow: detachedWindow} as ActiveWindowState);
       isolatedCallingRepository['callState'].viewMode(CallingViewMode.DETACHED_WINDOW);
       isolatedCallingRepository['callState'].detachedWindow(detachedWindow);
 
@@ -907,35 +950,19 @@ describe('CallingRepository ISO', () => {
 
       const conversation = new Conversation(createUuid(), '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
 
-      const callingRepo = new CallingRepository(
-        {
-          grantMessage: jest.fn(),
-        } as any, // MessageRepository
-        {
-          injectEvent: jest.fn(),
-        } as any, // EventRepository
-        {} as any, // UserRepository
-        {} as any, // MediaStreamHandler
-        buildMediaDevicesHandler(), // mediaDevicesHandler
-        {
-          toServerTimestamp: jest.fn().mockImplementation(() => Date.now()),
-        } as any, // ServerTimeHandler
-        {} as any, // BackgroundEffectsHandler
-        undefined,
-        {} as any, // APIClient
-        {
+      const {repository: callingRepo} = createCallingRepositoryForTest({
+        conversationState: {
           findConversation: jest.fn().mockImplementation(() => conversation),
           participating_user_ets: jest.fn(),
-        } as any, // ConversationState
-        new CallState(),
-      );
+        } as unknown as ConversationState,
+      });
 
       const avs = await callingRepo.initAvs(selfUser, createUuid());
       // provide global handle for cleanup
       avsUser = avs.wUser;
       avsCall = avs.wCall;
 
-      const event: any = {
+      const event: CallingEvent = {
         content: {
           props: {
             audiocbr: 'false',
@@ -1033,40 +1060,38 @@ describe('CallingRepository ISO', () => {
 
 // eslint-disable-next-line jest/no-disabled-tests
 describe.skip('E2E audio call', () => {
-  const messageRepository = {
-    grantMessage: () => Promise.resolve(true),
-  } as any;
-  const eventRepository = {injectEvent: () => {}} as any;
+  const {repository: client} = createCallingRepositoryForTest({
+    eventRepository: {injectEvent: () => {}} as unknown as EventRepository,
+  });
+  type E2ECallingRepositorySpies = {
+    checkConcurrentJoinedCall: () => Promise<boolean>;
+    getCallMediaStream: (...args: unknown[]) => Promise<MediaStream>;
+    getMediaStream: (...args: unknown[]) => Promise<MediaStream>;
+    incomingCallCallback: (call: Call) => void;
+    sendMessage: (...args: unknown[]) => void;
+    updateParticipantStream: (...args: unknown[]) => void;
+  };
 
-  const client = new CallingRepository(
-    messageRepository,
-    eventRepository,
-    {} as UserRepository,
-    serverTimeHandler as any,
-    {} as any,
-    {} as any,
-    {} as any,
-    undefined,
-  );
+  const mockedClient = client as CallingRepository & E2ECallingRepositorySpies;
   const user = new User('user-1', '', translateForTest);
   let remoteWuser: number;
   let wCall: Wcall;
 
   beforeAll(() => {
     spyOn(client, 'fetchConfig').and.returnValue(Promise.resolve({ice_servers: []}));
-    spyOn<any>(client, 'getCallMediaStream').and.returnValue(
+    spyOn(mockedClient, 'getCallMediaStream').and.returnValue(
       Promise.resolve(new MediaStream([new window.RTCAudioSource().createTrack()])),
     );
-    spyOn<any>(client, 'getMediaStream').and.returnValue(
+    spyOn(mockedClient, 'getMediaStream').and.returnValue(
       Promise.resolve(new MediaStream([new window.RTCAudioSource().createTrack()])),
     );
     spyOn(client, 'onCallEvent').and.callThrough();
-    spyOn<any>(client, 'updateParticipantStream').and.callThrough();
-    spyOn<any>(client, 'incomingCallCallback').and.callFake(call => {
+    spyOn(mockedClient, 'updateParticipantStream').and.callThrough();
+    spyOn(mockedClient, 'incomingCallCallback').and.callFake(call => {
       client.answerCall(call, CALL_TYPE.NORMAL);
     });
-    spyOn<any>(client, 'checkConcurrentJoinedCall').and.returnValue(Promise.resolve(true));
-    spyOn<any>(client, 'sendMessage').and.callFake(
+    spyOn(mockedClient, 'checkConcurrentJoinedCall').and.returnValue(Promise.resolve(true));
+    spyOn(mockedClient, 'sendMessage').and.callFake(
       (context, convId, userId, clientid, destUserId, destDeviceId, payload) => {
         wCall.recvMsg(
           remoteWuser,
@@ -1171,27 +1196,12 @@ describe.skip('E2E audio call', () => {
 });
 
 describe('NotificationHandlingState', () => {
-  const messageRepository = {
-    grantMessage: () => Promise.resolve(true),
-  } as any;
-  const eventRepository = {
-    injectEvent: () => {},
-  } as any;
-
-  const mediaDevicesHandler = {
-    setOnMediaDevicesRefreshHandler: () => {},
-  } as any;
-
-  const client = new CallingRepository(
-    messageRepository,
-    eventRepository,
-    {} as UserRepository,
-    serverTimeHandler as any,
-    mediaDevicesHandler,
-    {} as any,
-    {} as any,
-    undefined,
-  );
+  const {repository: client} = createCallingRepositoryForTest({
+    eventRepository: {injectEvent: () => {}} as unknown as EventRepository,
+    mediaDevicesHandler: {
+      setOnMediaDevicesRefreshHandler: () => {},
+    } as unknown as MediaDevicesHandler,
+  });
   const user = new User('user-1', '', translateForTest);
   let wCall: Wcall;
   let wUserNumber: number;
@@ -1233,27 +1243,12 @@ describe('NotificationHandlingState', () => {
 });
 
 describe('init AVS state', () => {
-  const messageRepository = {
-    grantMessage: () => Promise.resolve(true),
-  } as any;
-  const eventRepository = {
-    injectEvent: () => {},
-  } as any;
-
-  const mediaDevicesHandler = {
-    setOnMediaDevicesRefreshHandler: () => {},
-  } as any;
-
-  const client = new CallingRepository(
-    messageRepository,
-    eventRepository,
-    {} as UserRepository,
-    serverTimeHandler as any,
-    mediaDevicesHandler,
-    {} as any,
-    {} as any,
-    undefined,
-  );
+  const {repository: client} = createCallingRepositoryForTest({
+    eventRepository: {injectEvent: () => {}} as unknown as EventRepository,
+    mediaDevicesHandler: {
+      setOnMediaDevicesRefreshHandler: () => {},
+    } as unknown as MediaDevicesHandler,
+  });
   const user = new User('user-1', '', translateForTest);
   beforeEach(() => {
     jest.useFakeTimers();
@@ -1387,14 +1382,15 @@ describe('setupDetachedWindowExternalLinksClick', () => {
   });
 });
 
-function extractAudioStats(stats: any) {
-  const audioStats: any[] = [];
-  stats.forEach((userStats: any) => {
-    userStats.stats.forEach((data: any) => {
-      if (data.kind === 'audio' || data.mediaType === 'audio') {
-        const bytesFlowing = data.bytesReceived || data.bytesSent;
+function extractAudioStats(stats: Array<{stats: RTCStatsReport}>) {
+  const audioStats: Array<{bytesFlowing: number; id: string | undefined}> = [];
+  stats.forEach(userStats => {
+    userStats.stats.forEach(data => {
+      const audioStat = data as AudioFlowStat;
+      if (audioStat.kind === 'audio' || audioStat.mediaType === 'audio') {
+        const bytesFlowing = audioStat.bytesReceived || audioStat.bytesSent;
         if (bytesFlowing !== undefined && bytesFlowing > 0) {
-          audioStats.push({bytesFlowing, id: data.id});
+          audioStats.push({bytesFlowing, id: audioStat.id});
         }
       }
     });
@@ -1414,13 +1410,14 @@ function createAutoAnsweringWuser(wCall: Wcall, remoteCallingRepository: Calling
     _unused: string | null,
     payload: string,
   ) => {
-    const event = {
-      content: JSON.parse(payload),
+    const event: CallingEvent = {
+      content: JSON.parse(payload) as CallingEvent['content'],
       conversation: conversationId,
       from: userId,
       sender: clientId,
-      time: Date.now(),
-    } as any;
+      time: new Date().toISOString(),
+      type: CALL.E_CALL,
+    };
     remoteCallingRepository.onCallEvent(event, EventRepository.SOURCE.WEB_SOCKET);
     return 0;
   };
@@ -1447,7 +1444,7 @@ function createAutoAnsweringWuser(wCall: Wcall, remoteCallingRepository: Calling
     () => {}, // `closeh`,
     () => {}, // `metricsh`,
     requestConfig, // `cfg_reqh`,
-    (() => {}) as any, // `acbrh`,
+    (() => {}) as WcallAudioCbrChangeHandler, // `acbrh`,
     () => {}, // `vstateh`,
     0,
   );

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -62,6 +62,7 @@ import {useCallAlertState} from 'Components/calling/useCallAlertState';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {CALL_QUALITY_FEEDBACK_KEY} from 'Components/Modals/QualityFeedbackModal/constants';
 import {RatingListLabel} from 'Components/Modals/QualityFeedbackModal/typings';
+import {useActiveWindowState} from 'Hooks/useActiveWindow';
 import {NetworkQualityInfo, NetworkQualityInfoSchema} from 'Repositories/calling/calling.schema';
 import {isMLSConversation, MLSConversation} from 'Repositories/conversation/ConversationSelectors';
 import {ConversationState} from 'Repositories/conversation/ConversationState';
@@ -155,7 +156,11 @@ type SubconversationData = {
   members: SubconversationEpochInfoMember[];
 };
 
-export const setupDetachedWindowExternalLinksClick = (detachedWindow: Window, openerWindow: Window): (() => void) => {
+export const setupDetachedWindowExternalLinksClick = (detachedWindow: Window, openerWindow: Window) => {
+  if (!Runtime.isDesktopApp()) {
+    return () => {};
+  }
+
   const handleClick = (event: MouseEvent) => {
     const anchor = (event.target as HTMLElement).closest('a');
     if (anchor?.target === '_blank' && anchor.href) {
@@ -3001,15 +3006,18 @@ export class CallingRepository {
   /**
    * Helper method to get modal container and restore focus callback
    * Call this method immediately before showing a modal to ensure the correct active element is captured.
+   * Prefer the currently focused window so detached calls still show modals in the window the user interacted with.
    * @returns Object containing container and focus restoration callback
    */
   private getModalContainerAndRestoreFocusCallback() {
     const detachedWindow = this.callState.detachedWindow();
     const isDetachedWindow = this.callState.viewMode() === CallingViewMode.DETACHED_WINDOW;
+    const activeWindow = useActiveWindowState.getState().activeWindow;
+    const modalWindow = isDetachedWindow && detachedWindow && activeWindow === detachedWindow ? detachedWindow : window;
 
     const context = captureModalFocusContext({
-      targetDocument: isDetachedWindow && detachedWindow ? detachedWindow.document : undefined,
-      container: isDetachedWindow && detachedWindow ? detachedWindow.document.body : undefined,
+      targetDocument: modalWindow.document,
+      container: modalWindow === window ? undefined : modalWindow.document.body,
     });
 
     return {

--- a/apps/webapp/src/script/util/test/translateForTest.ts
+++ b/apps/webapp/src/script/util/test/translateForTest.ts
@@ -22,3 +22,5 @@ import type {Translate} from 'Util/localizerUtil';
 export function translateForTest(translationKey: Parameters<Translate>[0]): string {
   return translationKey;
 }
+
+export const translateWithPrefixForTest: Translate = translationKey => `translated:${translationKey}`;

--- a/apps/webapp/src/script/util/test/translateForTest.ts
+++ b/apps/webapp/src/script/util/test/translateForTest.ts
@@ -22,5 +22,3 @@ import type {Translate} from 'Util/localizerUtil';
 export function translateForTest(translationKey: Parameters<Translate>[0]): string {
   return translationKey;
 }
-
-export const translateWithPrefixForTest: Translate = translationKey => `translated:${translationKey}`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26355" title="WPB-26355" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26355</a>  [Desktop] Support Article link for camera is not clickable in maximized window on Mac
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Before
- In Electron, links with target="_blank" opened from the detached about:blank window were not handled correctly and could fail to open.
- When user interacts with video button on main window while detached calling was active, No Camera Access modal is crashed and will not be displayed.

### After
- _blank links are delegated to the opener window using openerWindow.open(...), ensuring they follow the same handling as links opened from the main application window.
- Modals are rendered in whichever window currently has focus (main window or detached window)