### PR TITLE
feat: drive sorting integration(WPB-25179)

### DIFF
--- a/apps/webapp/src/script/components/CellsGlobalView/CellsGlobalView.tsx
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsGlobalView.tsx
@@ -61,8 +61,7 @@ export const CellsGlobalView = (properties: CellsGlobalViewProps): ReactElement 
   const isSharedDriveSearchAndFiltersEnabled = isFeatureToggleEnabled(sharedDriveSearchAndFiltersFeatureToggleName);
 
   const {filters, filterState} = useGlobalDriveFilters({cellsRepository, conversationRepository, translate});
-
-  const {getDirectionFor, toggleSort} = useCellsSorting();
+  const {sort, getDirectionFor, toggleSort} = useCellsSorting();
   const legacyFilterState = useMemo<GlobalDriveFiltersState>(
     () => ({
       selectedTagIds: legacyFilters.tags,
@@ -82,6 +81,7 @@ export const CellsGlobalView = (properties: CellsGlobalViewProps): ReactElement 
     conversationRepository,
     fireAndForgetInvoker,
     filters: searchFilterState,
+    sort,
   });
 
   useOnPresignedUrlExpired({refreshCallback: handleReload});

--- a/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsTableColumns.tsx
+++ b/apps/webapp/src/script/components/CellsGlobalView/CellsTable/CellsTableColumns/CellsTableColumns.tsx
@@ -84,8 +84,8 @@ export const getCellsTableColumns = ({
         ? () => (
             <CellsTableSortableHeader
               label={labels.name}
-              direction={getDirectionFor('name_ci')}
-              onClick={() => onToggleSort('name_ci')}
+              direction={getDirectionFor('name')}
+              onClick={() => onToggleSort('name')}
             />
           )
         : labels.name,

--- a/apps/webapp/src/script/components/CellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/CellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {act, renderHook} from '@testing-library/react';
+import {RestNodeCollection} from 'cells-sdk-ts';
+
+import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
+import {UserRepository} from 'Repositories/user/userRepository';
+import {createExecutingFireAndForgetInvokerForTest} from 'src/script/page/testSupport/rootContextTestSupport';
+
+import {useSearchCellsNodes} from './useSearchCellsNodes';
+
+import type {GlobalDriveFiltersState} from '../../Conversation/ConversationCells/common/driveFilters/driveFilters';
+import type {CellsSort} from '../../Conversation/ConversationCells/common/useCellsSorting/useCellsSorting';
+import {useCellsStore} from '../common/useCellsStore/useCellsStore';
+
+const emptyFilters: GlobalDriveFiltersState = {
+  selectedTagIds: [],
+  selectedFileTypeIds: [],
+  selectedCreatorIds: [],
+  selectedConversationIds: [],
+  isSharedViaLink: false,
+};
+
+type FakeCellsRepository = jest.Mocked<Pick<CellsRepository, 'searchNodes'>>;
+type FakeUserRepository = jest.Mocked<Pick<UserRepository, 'getUsersById'>>;
+type FakeConversationRepository = jest.Mocked<
+  Pick<ConversationRepository, 'getAllCellEnabledGroupConversations' | 'getConversationById'>
+>;
+
+function createFakeCellsRepository(searchResult: Partial<RestNodeCollection> = {}): FakeCellsRepository {
+  return {searchNodes: jest.fn().mockResolvedValue({Nodes: [], ...searchResult})};
+}
+
+function createFakeUserRepository(): FakeUserRepository {
+  return {getUsersById: jest.fn().mockResolvedValue([])};
+}
+
+function createFakeConversationRepository(): FakeConversationRepository {
+  return {
+    getAllCellEnabledGroupConversations: jest.fn().mockReturnValue([]),
+    getConversationById: jest.fn(),
+  };
+}
+
+function renderSearchHook({
+  cellsRepository = createFakeCellsRepository(),
+  userRepository = createFakeUserRepository(),
+  conversationRepository = createFakeConversationRepository(),
+  fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest(),
+  filters = emptyFilters,
+  sort = null,
+}: {
+  cellsRepository?: FakeCellsRepository;
+  userRepository?: FakeUserRepository;
+  conversationRepository?: FakeConversationRepository;
+  fireAndForgetInvoker?: ReturnType<typeof createExecutingFireAndForgetInvokerForTest>;
+  filters?: GlobalDriveFiltersState;
+  sort?: CellsSort | null;
+} = {}) {
+  return {
+    fireAndForgetInvoker,
+    ...renderHook(() =>
+      useSearchCellsNodes({
+        cellsRepository: cellsRepository as unknown as CellsRepository,
+        userRepository: userRepository as unknown as UserRepository,
+        conversationRepository: conversationRepository as unknown as ConversationRepository,
+        fireAndForgetInvoker,
+        filters,
+        sort,
+      }),
+    ),
+  };
+}
+
+describe('useSearchCellsNodes', () => {
+  beforeEach(() => {
+    useCellsStore.getState().clearAll();
+  });
+
+  it('uses recency sorting for the global all-files view by default', async () => {
+    const cellsRepository = createFakeCellsRepository();
+    const {fireAndForgetInvoker} = renderSearchHook({cellsRepository});
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(cellsRepository.searchNodes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: '*',
+        sortBy: 'mtime',
+        sortDirection: 'desc',
+        type: 'file',
+      }),
+    );
+  });
+
+  it('lets the selected sort override the global default', async () => {
+    const cellsRepository = createFakeCellsRepository();
+    const {fireAndForgetInvoker} = renderSearchHook({
+      cellsRepository,
+      sort: {field: 'name', direction: 'asc'},
+    });
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(cellsRepository.searchNodes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sortBy: 'name',
+        sortDirection: 'asc',
+        type: 'file',
+      }),
+    );
+  });
+});

--- a/apps/webapp/src/script/components/CellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
+++ b/apps/webapp/src/script/components/CellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
@@ -28,6 +28,7 @@ import {
   GlobalDriveFiltersState,
   toGlobalDriveSearchParams,
 } from 'Components/Conversation/ConversationCells/common/driveFilters/driveFilters';
+import {CellsSort} from 'Components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {UserRepository} from 'Repositories/user/userRepository';
@@ -45,6 +46,7 @@ interface UseSearchCellsNodesProps {
   conversationRepository: ConversationRepository;
   fireAndForgetInvoker: FireAndForgetInvoker;
   filters: GlobalDriveFiltersState;
+  sort: CellsSort | null;
 }
 
 type SearchNodesProperties = {
@@ -69,7 +71,7 @@ const DEBOUNCE_TIME = 300;
 const FETCH_ALL_QUERY = '*';
 
 export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSearchCellsNodesResult => {
-  const {cellsRepository, userRepository, conversationRepository, fireAndForgetInvoker, filters} = properties;
+  const {cellsRepository, userRepository, conversationRepository, fireAndForgetInvoker, filters, sort} = properties;
   const {setNodes, setStatus, setPagination, clearAll} = useCellsStore();
 
   const [searchValue, setSearchValue] = useState('');
@@ -84,15 +86,14 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
       try {
         setStatus(status);
 
-        const shouldSort = query.length === 0 || query === FETCH_ALL_QUERY;
         const searchParams = toGlobalDriveSearchParams(filters);
 
         const result = await cellsRepository.searchNodes({
           query,
           limit,
           ...searchParams,
-          sortBy: shouldSort ? 'mtime' : undefined,
-          sortDirection: shouldSort ? 'desc' : undefined,
+          sortBy: sort?.field ?? 'mtime',
+          sortDirection: sort?.direction ?? 'desc',
           type: 'file',
         });
 
@@ -142,7 +143,7 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
     },
     // cellsRepository is not a dependency because it's a singleton
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [pageSize, setNodes, setPagination, setStatus, filters],
+    [pageSize, setNodes, setPagination, setStatus, filters, sort],
   );
 
   const searchNodesDebounced = useDebouncedCallback(async (value: string): Promise<void> => {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableColumns.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTableColumns/CellsTableColumns.tsx
@@ -81,8 +81,8 @@ export const getCellsTableColumns = ({
       ? () => (
           <CellsTableSortableHeader
             label={labels.name}
-            direction={getDirectionFor('name_ci')}
-            onClick={() => onToggleSort('name_ci')}
+            direction={getDirectionFor('name')}
+            onClick={() => onToggleSort('name')}
           />
         )
       : labels.name,

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
@@ -92,7 +92,8 @@ export const ConversationCells = memo(
     const isCellsStateReady = cellsState === CONVERSATION_CELLS_STATE.READY;
     const isCellsStatePending = cellsState === CONVERSATION_CELLS_STATE.PENDING;
 
-    const {sort, setSort, getDirectionFor, toggleSort} = useCellsSorting();
+    const sortScopeKey = `${conversationId}:${isSearchViewOpen ? 'search' : 'browse'}`;
+    const {sort, setSort, getDirectionFor, toggleSort} = useCellsSorting(sortScopeKey);
 
     const {refresh, setOffset} = useGetAllCellsNodes({
       cellsRepository,
@@ -148,12 +149,6 @@ export const ConversationCells = memo(
       }
       wasSearchViewOpen.current = isSearchViewOpen;
     }, [clearAll, clearAllFilters, clearSearch, conversationId, isSearchViewOpen]);
-
-    // Sort is per-view: switching conversation or toggling between search and browse
-    // returns to the default (unsorted) order.
-    useEffect(() => {
-      setSort(null);
-    }, [conversationId, isSearchViewOpen, setSort]);
 
     // Navigating into a folder or the recycle bin happens via the URL hash without
     // remounting; reset the sort on those transitions too.

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
@@ -92,6 +92,8 @@ export const ConversationCells = memo(
     const isCellsStateReady = cellsState === CONVERSATION_CELLS_STATE.READY;
     const isCellsStatePending = cellsState === CONVERSATION_CELLS_STATE.PENDING;
 
+    const {sort, getDirectionFor, toggleSort, resetSort} = useCellsSorting();
+
     const {refresh, setOffset} = useGetAllCellsNodes({
       cellsRepository,
       conversationQualifiedId,
@@ -100,6 +102,7 @@ export const ConversationCells = memo(
       enabled: isCellsStateReady && !isSearchViewOpen,
       fireAndForgetInvoker,
       userRepository,
+      sort,
     });
 
     const {filters, filterState, clearAllFilters} = useConversationDriveFilters({
@@ -107,8 +110,6 @@ export const ConversationCells = memo(
       conversationRepository,
       translate,
     });
-
-    const {getDirectionFor, toggleSort} = useCellsSorting();
 
     const {
       searchValue,
@@ -125,6 +126,7 @@ export const ConversationCells = memo(
       userRepository,
       filters: filterState,
       onClear: refresh,
+      sort,
     });
 
     // Search view open ⇒ load-more UI + search-hook data; closed ⇒ page-nav UI + browse-hook data.
@@ -146,6 +148,20 @@ export const ConversationCells = memo(
       }
       wasSearchViewOpen.current = isSearchViewOpen;
     }, [clearAll, clearAllFilters, clearSearch, conversationId, isSearchViewOpen]);
+
+    // Sort is per-view: switching conversation or toggling between search and browse
+    // returns to the default (unsorted) order.
+    useEffect(() => {
+      resetSort();
+    }, [conversationId, isSearchViewOpen, resetSort]);
+
+    // Navigating into a folder or the recycle bin happens via the URL hash without
+    // remounting; reset the sort on those transitions too.
+    useEffect(() => {
+      const handleHashChange = (): void => resetSort();
+      window.addEventListener('hashchange', handleHashChange);
+      return () => window.removeEventListener('hashchange', handleHashChange);
+    }, [resetSort]);
 
     const handleRefresh = useCallback((): void => {
       if (isInSearchMode) {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
@@ -92,7 +92,7 @@ export const ConversationCells = memo(
     const isCellsStateReady = cellsState === CONVERSATION_CELLS_STATE.READY;
     const isCellsStatePending = cellsState === CONVERSATION_CELLS_STATE.PENDING;
 
-    const {sort, getDirectionFor, toggleSort, resetSort} = useCellsSorting();
+    const {sort, setSort, getDirectionFor, toggleSort} = useCellsSorting();
 
     const {refresh, setOffset} = useGetAllCellsNodes({
       cellsRepository,
@@ -152,16 +152,16 @@ export const ConversationCells = memo(
     // Sort is per-view: switching conversation or toggling between search and browse
     // returns to the default (unsorted) order.
     useEffect(() => {
-      resetSort();
-    }, [conversationId, isSearchViewOpen, resetSort]);
+      setSort(null);
+    }, [conversationId, isSearchViewOpen, setSort]);
 
     // Navigating into a folder or the recycle bin happens via the URL hash without
     // remounting; reset the sort on those transitions too.
     useEffect(() => {
-      const handleHashChange = (): void => resetSort();
+      const handleHashChange = (): void => setSort(null);
       window.addEventListener('hashchange', handleHashChange);
       return () => window.removeEventListener('hashchange', handleHashChange);
-    }, [resetSort]);
+    }, [setSort]);
 
     const handleRefresh = useCallback((): void => {
       if (isInSearchMode) {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.test.ts
@@ -82,6 +82,30 @@ describe('useCellsSorting', () => {
     expect(result.current.getDirectionFor('size')).toBeUndefined();
   });
 
+  it('derives an unsorted state immediately when the sorting scope changes', () => {
+    const {result, rerender} = renderHook(({scopeKey}: {scopeKey: string}) => useCellsSorting(scopeKey), {
+      initialProps: {scopeKey: 'conversation-a:browse'},
+    });
+
+    act(() => result.current.toggleSort('name'));
+    expect(result.current.sort).toEqual({field: 'name', direction: 'asc'});
+
+    rerender({scopeKey: 'conversation-a:search'});
+
+    expect(result.current.sort).toBeNull();
+    expect(result.current.getDirectionFor('name')).toBeUndefined();
+
+    act(() => result.current.toggleSort('name'));
+
+    expect(result.current.sort).toEqual({field: 'name', direction: 'asc'});
+
+    rerender({scopeKey: 'conversation-a:browse'});
+    rerender({scopeKey: 'conversation-a:search'});
+
+    expect(result.current.sort).toBeNull();
+    expect(result.current.getDirectionFor('name')).toBeUndefined();
+  });
+
   it('keeps setSort stable across sort changes', () => {
     const {result} = renderHook(() => useCellsSorting());
     const setSort = result.current.setSort;

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.test.ts
@@ -26,7 +26,7 @@ describe('useCellsSorting', () => {
     const {result} = renderHook(() => useCellsSorting());
 
     expect(result.current.sort).toBeNull();
-    expect(result.current.getDirectionFor('name_ci')).toBeUndefined();
+    expect(result.current.getDirectionFor('name')).toBeUndefined();
     expect(result.current.getDirectionFor('mtime')).toBeUndefined();
     expect(result.current.getDirectionFor('size')).toBeUndefined();
   });
@@ -34,9 +34,9 @@ describe('useCellsSorting', () => {
   it('applies the default direction when selecting a sort field', () => {
     const {result} = renderHook(() => useCellsSorting());
 
-    act(() => result.current.toggleSort('name_ci'));
-    expect(result.current.sort).toEqual({field: 'name_ci', direction: 'asc'});
-    expect(result.current.getDirectionFor('name_ci')).toBe('asc');
+    act(() => result.current.toggleSort('name'));
+    expect(result.current.sort).toEqual({field: 'name', direction: 'asc'});
+    expect(result.current.getDirectionFor('name')).toBe('asc');
 
     act(() => result.current.toggleSort('mtime'));
     expect(result.current.sort).toEqual({field: 'mtime', direction: 'desc'});
@@ -50,14 +50,14 @@ describe('useCellsSorting', () => {
   it('toggles the active sort field between ascending and descending', () => {
     const {result} = renderHook(() => useCellsSorting());
 
-    act(() => result.current.toggleSort('name_ci'));
-    expect(result.current.sort).toEqual({field: 'name_ci', direction: 'asc'});
+    act(() => result.current.toggleSort('name'));
+    expect(result.current.sort).toEqual({field: 'name', direction: 'asc'});
 
-    act(() => result.current.toggleSort('name_ci'));
-    expect(result.current.sort).toEqual({field: 'name_ci', direction: 'desc'});
+    act(() => result.current.toggleSort('name'));
+    expect(result.current.sort).toEqual({field: 'name', direction: 'desc'});
 
-    act(() => result.current.toggleSort('name_ci'));
-    expect(result.current.sort).toEqual({field: 'name_ci', direction: 'asc'});
+    act(() => result.current.toggleSort('name'));
+    expect(result.current.sort).toEqual({field: 'name', direction: 'asc'});
   });
 
   it('returns a direction only for the active sort field', () => {
@@ -65,7 +65,7 @@ describe('useCellsSorting', () => {
 
     act(() => result.current.toggleSort('mtime'));
 
-    expect(result.current.getDirectionFor('name_ci')).toBeUndefined();
+    expect(result.current.getDirectionFor('name')).toBeUndefined();
     expect(result.current.getDirectionFor('mtime')).toBe('desc');
     expect(result.current.getDirectionFor('size')).toBeUndefined();
   });
@@ -76,9 +76,18 @@ describe('useCellsSorting', () => {
     act(() => result.current.toggleSort('size'));
     expect(result.current.sort).toEqual({field: 'size', direction: 'asc'});
 
-    act(() => result.current.resetSort());
+    act(() => result.current.setSort(null));
 
     expect(result.current.sort).toBeNull();
     expect(result.current.getDirectionFor('size')).toBeUndefined();
+  });
+
+  it('keeps setSort stable across sort changes', () => {
+    const {result} = renderHook(() => useCellsSorting());
+    const setSort = result.current.setSort;
+
+    act(() => result.current.toggleSort('name'));
+
+    expect(result.current.setSort).toBe(setSort);
   });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.ts
@@ -56,20 +56,46 @@ export const toAriaSort = (direction: CellsSortDirection | undefined): 'ascendin
   return 'none';
 };
 
-export const useCellsSorting = () => {
-  const [sort, setSort] = useState<CellsSort | null>(null);
+interface CellsSortingState {
+  scopeKey: string;
+  sort: CellsSort | null;
+}
 
-  const toggleSort = useCallback((field: CellsSortField) => {
-    setSort(current => {
-      // Selecting a different column starts at that column's default direction.
-      if (current?.field !== field) {
-        return {field, direction: DEFAULT_DIRECTION[field]};
-      }
-      // Re-selecting the active column flips the direction. The unsorted state is only
-      // reached when entering a new sorting scope, not by clicking the active column.
-      return {field, direction: current.direction === 'asc' ? 'desc' : 'asc'};
-    });
-  }, []);
+const DEFAULT_SCOPE_KEY = 'default';
+
+export const useCellsSorting = (scopeKey = DEFAULT_SCOPE_KEY) => {
+  const [state, setSortState] = useState<CellsSortingState>({scopeKey, sort: null});
+
+  // Scope changes must clear synchronously so request hooks never receive a stale sort.
+  if (state.scopeKey !== scopeKey) {
+    setSortState({scopeKey, sort: null});
+  }
+
+  const sort = state.scopeKey === scopeKey ? state.sort : null;
+
+  const setSort = useCallback(
+    (nextSort: CellsSort | null) => {
+      setSortState({scopeKey, sort: nextSort});
+    },
+    [scopeKey],
+  );
+
+  const toggleSort = useCallback(
+    (field: CellsSortField) => {
+      setSortState(current => {
+        const currentSort = current.scopeKey === scopeKey ? current.sort : null;
+
+        // Selecting a different column starts at that column's default direction.
+        if (currentSort?.field !== field) {
+          return {scopeKey, sort: {field, direction: DEFAULT_DIRECTION[field]}};
+        }
+        // Re-selecting the active column flips the direction. The unsorted state is only
+        // reached when entering a new sorting scope, not by clicking the active column.
+        return {scopeKey, sort: {field, direction: currentSort.direction === 'asc' ? 'desc' : 'asc'}};
+      });
+    },
+    [scopeKey],
+  );
 
   const getDirectionFor = useCallback(
     (field: CellsSortField): CellsSortDirection | undefined => (sort?.field === field ? sort.direction : undefined),

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.ts
@@ -76,7 +76,5 @@ export const useCellsSorting = () => {
     [sort],
   );
 
-  const resetSort = () => setSort(null);
-
-  return {sort, toggleSort, resetSort, getDirectionFor};
+  return {sort, setSort, toggleSort, getDirectionFor};
 };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.ts
@@ -21,7 +21,7 @@ import {useCallback, useState} from 'react';
 
 import {CellsSortDirection} from '../CellsSortIcon/CellsSortIcon';
 
-export type CellsSortField = 'name_ci' | 'mtime' | 'size';
+export type CellsSortField = 'name' | 'mtime' | 'size';
 
 export interface CellsSort {
   field: CellsSortField;
@@ -31,7 +31,7 @@ export interface CellsSort {
 // Direction applied the first time a column is selected:
 // name → A→Z, modified → newest first, size → smallest first.
 const DEFAULT_DIRECTION: Record<CellsSortField, CellsSortDirection> = {
-  name_ci: 'asc',
+  name: 'asc',
   mtime: 'desc',
   size: 'asc',
 };
@@ -39,7 +39,7 @@ const DEFAULT_DIRECTION: Record<CellsSortField, CellsSortDirection> = {
 // Maps a table column id (the accessor key) to its backend sort field. Columns absent
 // from this map are not sortable and receive no aria-sort.
 export const SORTABLE_COLUMN_FIELD: Record<string, CellsSortField> = {
-  name: 'name_ci',
+  name: 'name',
   sizeMb: 'size',
   uploadedAtTimestamp: 'mtime',
 };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
@@ -28,6 +28,7 @@ import {CellNode, CellNodeType} from 'src/script/types/cellNode';
 import {useConversationSearchFiles} from './useConversationSearchFiles';
 
 import type {ConversationDriveFiltersState} from '../common/driveFilters/driveFilters';
+import type {CellsSort} from '../common/useCellsSorting/useCellsSorting';
 import {useCellsStore} from '../common/useCellsStore/useCellsStore';
 
 const CONV_ID = 'conv-abc';
@@ -87,6 +88,7 @@ function renderSearchHook({
   onClear = jest.fn(),
   fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest(),
   filters = emptyFilters,
+  sort = null,
 }: {
   cellsRepository?: FakeCellsRepository;
   userRepository?: FakeUserRepository;
@@ -95,6 +97,7 @@ function renderSearchHook({
   onClear?: () => void;
   fireAndForgetInvoker?: ReturnType<typeof createExecutingFireAndForgetInvokerForTest>;
   filters?: ConversationDriveFiltersState;
+  sort?: CellsSort | null;
 } = {}) {
   return {
     fireAndForgetInvoker,
@@ -109,6 +112,7 @@ function renderSearchHook({
         fireAndForgetInvoker,
         filters,
         onClear,
+        sort,
       }),
     ),
   };
@@ -166,6 +170,24 @@ describe('useConversationSearchFiles', () => {
         deleted: false,
         sortBy: undefined,
         sortDirection: undefined,
+      }),
+    );
+  });
+
+  it('uses the selected sort for the empty search view', async () => {
+    const cellsRepository = createFakeCellsRepository();
+    const {fireAndForgetInvoker} = renderSearchHook({
+      cellsRepository,
+      sort: {field: 'size', direction: 'asc'},
+    });
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(cellsRepository.searchNodes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: '',
+        recursive: false,
+        sortBy: 'size',
+        sortDirection: 'asc',
       }),
     );
   });
@@ -250,6 +272,7 @@ describe('useConversationSearchFiles', () => {
           fireAndForgetInvoker,
           filters: emptyFilters,
           onClear: jest.fn(),
+          sort: null,
         }),
       {initialProps: {enabled: true}},
     );
@@ -280,6 +303,8 @@ describe('useConversationSearchFiles', () => {
           query: 'doc',
           recursive: true,
           path: `${CONV_ID}@${DOMAIN}/Arjita`,
+          sortBy: 'mtime',
+          sortDirection: 'desc',
         }),
       ),
     );
@@ -303,7 +328,34 @@ describe('useConversationSearchFiles', () => {
     expect(cellsRepository.searchNodes).toHaveBeenCalledWith(
       expect.objectContaining({
         recursive: true,
+        sortBy: 'mtime',
+        sortDirection: 'desc',
       }),
+    );
+  });
+
+  it('lets the selected sort override the active search default', async () => {
+    const cellsRepository = createFakeCellsRepository();
+    const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
+    const {result} = renderSearchHook({
+      cellsRepository,
+      fireAndForgetInvoker,
+      sort: {field: 'name', direction: 'asc'},
+    });
+
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    act(() => result.current.handleSearch('doc'));
+
+    await waitFor(() =>
+      expect(cellsRepository.searchNodes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: 'doc',
+          recursive: true,
+          sortBy: 'name',
+          sortDirection: 'asc',
+        }),
+      ),
     );
   });
 
@@ -323,6 +375,7 @@ describe('useConversationSearchFiles', () => {
           fireAndForgetInvoker,
           filters,
           onClear,
+          sort: null,
         }),
       {
         initialProps: {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
@@ -174,15 +174,33 @@ describe('useConversationSearchFiles', () => {
     );
   });
 
-  it('uses the selected sort for the empty search view', async () => {
+  it('reloads the empty search view when the selected sort changes', async () => {
     const cellsRepository = createFakeCellsRepository();
-    const {fireAndForgetInvoker} = renderSearchHook({
-      cellsRepository,
-      sort: {field: 'size', direction: 'asc'},
-    });
+    const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
+    const {rerender} = renderHook(
+      ({sort}: {sort: CellsSort | null}) =>
+        useConversationSearchFiles({
+          cellsRepository: cellsRepository as unknown as CellsRepository,
+          userRepository: createFakeUserRepository() as unknown as UserRepository,
+          conversationQualifiedId: QUALIFIED_ID,
+          enabled: true,
+          fireAndForgetInvoker,
+          filters: emptyFilters,
+          onClear: jest.fn(),
+          sort,
+        }),
+      {initialProps: {sort: null}},
+    );
+
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+    const searchCallCountBeforeSorting = cellsRepository.searchNodes.mock.calls.length;
+
+    act(() => rerender({sort: {field: 'size', direction: 'asc'}}));
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    expect(cellsRepository.searchNodes).toHaveBeenCalledWith(
+    expect(cellsRepository.searchNodes).toHaveBeenCalledTimes(searchCallCountBeforeSorting + 1);
+    expect(cellsRepository.searchNodes).toHaveBeenNthCalledWith(
+      searchCallCountBeforeSorting + 1,
       expect.objectContaining({
         query: '',
         recursive: false,

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
@@ -39,6 +39,7 @@ import {getCellsApiPath} from '../common/getCellsApiPath/getCellsApiPath';
 import {getCellsFilesPath} from '../common/getCellsFilesPath/getCellsFilesPath';
 import {LOAD_MORE_INCREMENT, LOAD_MORE_INITIAL_SIZE} from '../common/loadMorePagination/loadMorePagination';
 import {RECYCLE_BIN_PATH} from '../common/recycleBin/recycleBin';
+import {CellsSort} from '../common/useCellsSorting/useCellsSorting';
 import {useCellsStore} from '../common/useCellsStore/useCellsStore';
 import {getUsersFromNodes} from '../useGetAllCellsNodes/getUsersFromNodes';
 import {transformDataToCellsNodes, transformToCellPagination} from '../useGetAllCellsNodes/transformDataToCellsNodes';
@@ -52,6 +53,7 @@ interface UseConversationSearchFilesProps {
   fireAndForgetInvoker: FireAndForgetInvoker;
   filters: ConversationDriveFiltersState;
   onClear?: () => void;
+  sort: CellsSort | null;
 }
 
 type ClearSearchRefreshOptions = {
@@ -72,6 +74,7 @@ export const useConversationSearchFiles = ({
   fireAndForgetInvoker,
   filters,
   onClear,
+  sort,
 }: UseConversationSearchFilesProps) => {
   const {setNodes, appendNodes, setStatus, setPagination, setError, clearAll} = useCellsStore();
 
@@ -146,9 +149,6 @@ export const useConversationSearchFiles = ({
         const isRecycleBin = getCellsFilesPath() === RECYCLE_BIN_PATH;
         const isSearchingOrFiltering = hasQuery || hasFilters;
 
-        // recency sort for searches inside the recycle bin only
-        const forceRecencySort = isRecycleBin && hasQuery;
-
         // search scopes to the folder the user is browsing
         const searchRootPath = getCellsApiPath({conversationQualifiedId: {id, domain}});
 
@@ -158,8 +158,10 @@ export const useConversationSearchFiles = ({
           limit: append ? LOAD_MORE_INCREMENT : LOAD_MORE_INITIAL_SIZE,
           offset,
           path: searchRootPath,
-          sortBy: forceRecencySort ? 'mtime' : undefined,
-          sortDirection: forceRecencySort ? 'desc' : undefined,
+          // A user-selected sort always wins; for active searches/filters fall back to recency;
+          // the empty view (no query, no filters) sends no sort to preserve browse/folders-first order.
+          sortBy: sort?.field ?? (isSearchingOrFiltering ? 'mtime' : undefined),
+          sortDirection: sort?.direction ?? (isSearchingOrFiltering ? 'desc' : undefined),
           deleted: isRecycleBin,
           ...searchParams,
         });
@@ -217,7 +219,7 @@ export const useConversationSearchFiles = ({
     },
     // cellsRepository and userRepository are not dependencies because they're singletons
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [appendNodes, setNodes, setPagination, setStatus, setError, id, domain, isValidSearchRequest],
+    [appendNodes, setNodes, setPagination, setStatus, setError, id, domain, isValidSearchRequest, sort],
   );
 
   useLayoutEffect(() => {
@@ -349,6 +351,30 @@ export const useConversationSearchFiles = ({
     }
     hadActiveSearchParamsRef.current = hasActiveParams;
   }, [canSearchOwnResults, filters, fireAndForgetInvoker, hasActiveParams, onClear, searchNodes, searchValue]);
+
+  // Re-run the search whenever the sort changes. The main search effect above already
+  // refetches when a query/filter is active (it depends on the sort-aware searchNodes), so
+  // this only needs to cover the empty search view, which that effect bails out of.
+  const hasInitialisedSortRef = useRef(false);
+  useEffect(() => {
+    if (!enabled) {
+      hasInitialisedSortRef.current = false;
+      return;
+    }
+    if (!hasInitialisedSortRef.current) {
+      hasInitialisedSortRef.current = true;
+      return;
+    }
+    const hasSearchOrActiveParams = searchQuery.trim().length > 0 || hasActiveParams;
+    if (hasSearchOrActiveParams) {
+      return;
+    }
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      await searchNodes({query: '', filters});
+    });
+    // searchQuery/filters are read at fire time; only sort (and enable state) should trigger this.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sort, enabled]);
 
   const loadMore = useCallback(
     async (offset: number): Promise<void> => {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
@@ -92,6 +92,7 @@ export const useConversationSearchFiles = ({
 
   const searchParams = useMemo(() => toConversationDriveSearchParams(filters), [filters]);
   const hasActiveParams = hasActiveSearchParams(searchParams);
+  const hasSearchOrActiveParams = searchQuery.trim().length > 0 || hasActiveParams;
   const hadActiveSearchParamsRef = useRef(hasActiveParams);
 
   const {id, domain} = conversationQualifiedId;
@@ -308,7 +309,6 @@ export const useConversationSearchFiles = ({
 
     // Re-run search whenever typing has triggered it, a query is present,
     // or the mapped search params carry any filter.
-    const hasSearchOrActiveParams = searchQuery.trim().length > 0 || hasActiveParams;
     if (!shouldPerformSearch.current && !hasSearchOrActiveParams) {
       return;
     }
@@ -316,7 +316,7 @@ export const useConversationSearchFiles = ({
     fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
       await searchNodes({query: normalizeSearchQuery(searchQuery), filters});
     });
-  }, [searchNodes, searchQuery, enabled, filters, hasActiveParams, fireAndForgetInvoker]);
+  }, [searchNodes, searchQuery, enabled, filters, hasSearchOrActiveParams, fireAndForgetInvoker]);
 
   // Fire an initial unfiltered fetch when the hook becomes enabled (search view opens) so
   // the load-more dataset is populated even before the user types or selects a filter.
@@ -338,9 +338,9 @@ export const useConversationSearchFiles = ({
   // When the search params transition from "active" to "none" with no search query,
   // restore the default unfiltered file list.
   useEffect(() => {
-    const hasNoSearchQuery = normalizeSearchQuery(searchValue).length === 0;
+    const hasNoSearchInput = normalizeSearchQuery(searchValue).length === 0;
 
-    if (hadActiveSearchParamsRef.current === true && hasActiveParams === false && hasNoSearchQuery === true) {
+    if (hadActiveSearchParamsRef.current === true && hasActiveParams === false && hasNoSearchInput === true) {
       if (canSearchOwnResults() === true) {
         fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
           await searchNodes({query: '', filters});
@@ -352,29 +352,25 @@ export const useConversationSearchFiles = ({
     hadActiveSearchParamsRef.current = hasActiveParams;
   }, [canSearchOwnResults, filters, fireAndForgetInvoker, hasActiveParams, onClear, searchNodes, searchValue]);
 
-  // Re-run the search whenever the sort changes. The main search effect above already
-  // refetches when a query/filter is active (it depends on the sort-aware searchNodes), so
-  // this only needs to cover the empty search view, which that effect bails out of.
-  const hasInitialisedSortRef = useRef(false);
+  // The main search effect above refetches active query/filter searches when `searchNodes`
+  // changes with the selected sort. Empty search has no query/filter, so it needs this
+  // explicit sort-change fetch.
+  const previousSortRef = useRef(sort);
   useEffect(() => {
-    if (!enabled) {
-      hasInitialisedSortRef.current = false;
+    const previousSort = previousSortRef.current;
+    previousSortRef.current = sort;
+
+    if (!enabled || previousSort === sort) {
       return;
     }
-    if (!hasInitialisedSortRef.current) {
-      hasInitialisedSortRef.current = true;
-      return;
-    }
-    const hasSearchOrActiveParams = searchQuery.trim().length > 0 || hasActiveParams;
+
     if (hasSearchOrActiveParams) {
       return;
     }
     fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
       await searchNodes({query: '', filters});
     });
-    // searchQuery/filters are read at fire time; only sort (and enable state) should trigger this.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sort, enabled]);
+  }, [enabled, filters, fireAndForgetInvoker, hasSearchOrActiveParams, searchNodes, sort]);
 
   const loadMore = useCallback(
     async (offset: number): Promise<void> => {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.test.ts
@@ -139,6 +139,31 @@ describe('useGetAllCellsNodes', () => {
     );
   });
 
+  it('resets to the first page before fetching when sort changes', async () => {
+    const cellsRepository = createFakeCellsRepository();
+    const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
+
+    const {result, rerender} = renderGetAllNodesHook({cellsRepository, fireAndForgetInvoker});
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    act(() => result.current.setOffset(50));
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(cellsRepository.getAllNodes).toHaveBeenLastCalledWith(expect.objectContaining({offset: 50}));
+
+    act(() => rerender({enabled: true, sort: {field: 'name', direction: 'asc'}}));
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(cellsRepository.getAllNodes).toHaveBeenCalledTimes(3);
+    expect(cellsRepository.getAllNodes).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        offset: 0,
+        sortBy: 'name',
+        sortDirection: 'asc',
+      }),
+    );
+  });
+
   it('does not let an older response overwrite a newer fetch', async () => {
     const firstFetch = createDeferred<RestNodeCollection>();
     const secondFetch = createDeferred<RestNodeCollection>();

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.test.ts
@@ -26,6 +26,7 @@ import {createExecutingFireAndForgetInvokerForTest} from 'src/script/page/testSu
 
 import {useGetAllCellsNodes} from './useGetAllCellsNodes';
 
+import type {CellsSort} from '../common/useCellsSorting/useCellsSorting';
 import {useCellsStore} from '../common/useCellsStore/useCellsStore';
 
 const CONV_ID = 'conv-abc';
@@ -60,24 +61,27 @@ function renderGetAllNodesHook({
   userRepository = createFakeUserRepository(),
   enabled = true,
   fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest(),
+  sort = null,
 }: {
   cellsRepository?: FakeCellsRepository;
   userRepository?: FakeUserRepository;
   enabled?: boolean;
   fireAndForgetInvoker?: ReturnType<typeof createExecutingFireAndForgetInvokerForTest>;
+  sort?: CellsSort | null;
 } = {}) {
   return {
     fireAndForgetInvoker,
     ...renderHook(
-      ({enabled}: {enabled: boolean}) =>
+      ({enabled, sort}: {enabled: boolean; sort: CellsSort | null}) =>
         useGetAllCellsNodes({
           cellsRepository: cellsRepository as unknown as CellsRepository,
           userRepository: userRepository as unknown as UserRepository,
           conversationQualifiedId: QUALIFIED_ID,
           enabled,
           fireAndForgetInvoker,
+          sort,
         }),
-      {initialProps: {enabled}},
+      {initialProps: {enabled, sort}},
     ),
   };
 }
@@ -96,7 +100,7 @@ describe('useGetAllCellsNodes', () => {
     const {rerender} = renderGetAllNodesHook({cellsRepository, fireAndForgetInvoker});
     await waitFor(() => expect(cellsRepository.getAllNodes).toHaveBeenCalledTimes(1));
 
-    act(() => rerender({enabled: false}));
+    act(() => rerender({enabled: false, sort: null}));
 
     act(() => {
       fetch.resolve({Nodes: [createRestNode('stale-file.txt')]});
@@ -104,6 +108,35 @@ describe('useGetAllCellsNodes', () => {
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
     expect(useCellsStore.getState().getNodes({conversationId: CONV_ID})).toHaveLength(0);
+  });
+
+  it('keeps the browse order natural when no sort is selected', async () => {
+    const cellsRepository = createFakeCellsRepository();
+    const {fireAndForgetInvoker} = renderGetAllNodesHook({cellsRepository});
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(cellsRepository.getAllNodes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sortBy: undefined,
+        sortDirection: undefined,
+      }),
+    );
+  });
+
+  it('passes the selected sort to the browse request', async () => {
+    const cellsRepository = createFakeCellsRepository();
+    const {fireAndForgetInvoker} = renderGetAllNodesHook({
+      cellsRepository,
+      sort: {field: 'mtime', direction: 'desc'},
+    });
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(cellsRepository.getAllNodes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sortBy: 'mtime',
+        sortDirection: 'desc',
+      }),
+    );
   });
 
   it('does not let an older response overwrite a newer fetch', async () => {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.ts
@@ -45,6 +45,11 @@ interface UseGetAllCellsNodesProps {
   sort: CellsSort | null;
 }
 
+interface CellsQueryState {
+  offset: number;
+  sort: CellsSort | null;
+}
+
 export const useGetAllCellsNodes = ({
   cellsRepository,
   userRepository,
@@ -54,7 +59,23 @@ export const useGetAllCellsNodes = ({
   sort,
 }: UseGetAllCellsNodesProps) => {
   const {setNodes, pageSize, setStatus, setPagination, setError, clearAll} = useCellsStore();
-  const [offset, setOffset] = useState(0);
+  const [queryState, setQueryState] = useState<CellsQueryState>({offset: 0, sort});
+
+  // Sort changes must reset pagination before fetchNodes is created so requests
+  // never run with the new sort and the previous page offset.
+  if (queryState.sort !== sort) {
+    setQueryState({offset: 0, sort});
+  }
+
+  const offset = queryState.sort === sort ? queryState.offset : 0;
+
+  const setOffset = useCallback(
+    (nextOffset: number) => {
+      setQueryState({offset: nextOffset, sort});
+    },
+    [sort],
+  );
+
   const requestVersionGate = useRef(createRequestVersionGate());
   const enabledRef = useRef(enabled);
   enabledRef.current = enabled;
@@ -127,12 +148,6 @@ export const useGetAllCellsNodes = ({
     // cellsRepository and userRepository are not dependencies because they're singletons
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [domain, id, isCurrentFetchRequest, offset, pageSize, sort, setError, setNodes, setPagination, setStatus]);
-
-  // A new sort criterion re-pages from the top; the fetch effect below then refetches
-  // because fetchNodes depends on both offset and sort.
-  useEffect(() => {
-    setOffset(0);
-  }, [sort]);
 
   const handleHashChange = useCallback((): void => {
     if (enabled !== true) {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.ts
@@ -32,6 +32,7 @@ import {transformDataToCellsNodes, transformToCellPagination} from './transformD
 import {getCellsApiPath} from '../common/getCellsApiPath/getCellsApiPath';
 import {getCellsFilesPath} from '../common/getCellsFilesPath/getCellsFilesPath';
 import {RECYCLE_BIN_PATH} from '../common/recycleBin/recycleBin';
+import {CellsSort} from '../common/useCellsSorting/useCellsSorting';
 import {useCellsStore} from '../common/useCellsStore/useCellsStore';
 import {createRequestVersionGate} from '../useConversationSearch/requestVersionGate';
 
@@ -41,6 +42,7 @@ interface UseGetAllCellsNodesProps {
   conversationQualifiedId: QualifiedId;
   enabled: boolean;
   fireAndForgetInvoker: FireAndForgetInvoker;
+  sort: CellsSort | null;
 }
 
 export const useGetAllCellsNodes = ({
@@ -49,6 +51,7 @@ export const useGetAllCellsNodes = ({
   conversationQualifiedId,
   enabled,
   fireAndForgetInvoker,
+  sort,
 }: UseGetAllCellsNodesProps) => {
   const {setNodes, pageSize, setStatus, setPagination, setError, clearAll} = useCellsStore();
   const [offset, setOffset] = useState(0);
@@ -80,6 +83,8 @@ export const useGetAllCellsNodes = ({
         limit: pageSize,
         offset,
         deleted: getCellsFilesPath() === RECYCLE_BIN_PATH,
+        sortBy: sort?.field,
+        sortDirection: sort?.direction,
       });
 
       if (!isCurrentFetchRequest(requestVersion)) {
@@ -121,7 +126,13 @@ export const useGetAllCellsNodes = ({
     }
     // cellsRepository and userRepository are not dependencies because they're singletons
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [domain, id, isCurrentFetchRequest, offset, pageSize, setError, setNodes, setPagination, setStatus]);
+  }, [domain, id, isCurrentFetchRequest, offset, pageSize, sort, setError, setNodes, setPagination, setStatus]);
+
+  // A new sort criterion re-pages from the top; the fetch effect below then refetches
+  // because fetchNodes depends on both offset and sort.
+  useEffect(() => {
+    setOffset(0);
+  }, [sort]);
 
   const handleHashChange = useCallback((): void => {
     if (enabled !== true) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25179" title="WPB-25179" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25179</a>  [Web] Sorting of all columns
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Sorting of all columns

**Sort persistence —**

Sort selected in browse view → carry into search view of same conversation? Vice versa?

Sort selected in Conversation A's browse → carry to Conversation B?

Sort selected in Shared Drive → carry to global Drive (and back)?

based on our last discussions with @Olga Anna Skoczylas we reset in all 3

**Rule of thumb:** user-applied sort always wins. Default is mtime/desc whenever content is being actively searched/filtered. Default is BE natural (folders-first) when the view is in a passive/browse state (browse mode, or search open but nothing entered).