### PR TITLE
feat: temporarily disable the Background effects regardless of backend [WPB-26420]

### DIFF
--- a/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.test.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffectsHandler.test.ts
@@ -400,7 +400,7 @@ describe('BackgroundEffectsHandler', () => {
     expect(preferredEffectWrites).toHaveLength(0);
   });
 
-  it('enables feature when background effects feature is enabled', () => {
+  it('keeps feature disabled when background effects feature is enabled', () => {
     const features: Partial<FeatureList> = {
       backgroundEffects: {
         status: FEATURE_STATUS.ENABLED,
@@ -411,11 +411,11 @@ describe('BackgroundEffectsHandler', () => {
 
     new BackgroundEffectsHandler(mockController, teamState);
 
-    expect(backgroundEffectsStore.getState().isFeatureEnabled).toBe(true);
+    expect(backgroundEffectsStore.getState().isFeatureEnabled).toBe(false);
     expect(backgroundEffectsStore.getState().isPerformancePanelEnabled).toBe(false);
   });
 
-  it('enables feature from TeamState even when storage flag is false', () => {
+  it('keeps feature disabled from TeamState even when storage flag is false', () => {
     mockStorage.getItem.mockImplementation((key: string) => {
       if (key === VIDEO_BACKGROUND_EFFECTS_FEATURE_STORAGE_KEY) {
         return 'false';
@@ -433,7 +433,7 @@ describe('BackgroundEffectsHandler', () => {
 
     new BackgroundEffectsHandler(mockController, teamState);
 
-    expect(backgroundEffectsStore.getState().isFeatureEnabled).toBe(true);
+    expect(backgroundEffectsStore.getState().isFeatureEnabled).toBe(false);
     expect(backgroundEffectsStore.getState().isPerformancePanelEnabled).toBe(false);
   });
 
@@ -469,7 +469,7 @@ describe('BackgroundEffectsHandler', () => {
     expect(backgroundEffectsStore.getState().isPerformancePanelEnabled).toBe(false);
   });
 
-  it('updates feature enabled state when TeamState background effects feature changes', () => {
+  it('keeps feature disabled when TeamState background effects feature changes', () => {
     teamState.teamFeatures(undefined);
 
     new BackgroundEffectsHandler(mockController, teamState);
@@ -485,7 +485,7 @@ describe('BackgroundEffectsHandler', () => {
 
     teamState.teamFeatures(features);
 
-    expect(backgroundEffectsStore.getState().isFeatureEnabled).toBe(true);
+    expect(backgroundEffectsStore.getState().isFeatureEnabled).toBe(false);
     expect(backgroundEffectsStore.getState().isPerformancePanelEnabled).toBe(false);
   });
 });

--- a/apps/webapp/src/script/repositories/team/TeamState.ts
+++ b/apps/webapp/src/script/repositories/team/TeamState.ts
@@ -134,9 +134,9 @@ export class TeamState {
       () => this.teamFeatures()?.conferenceCalling?.status === FEATURE_STATUS.ENABLED,
     );
 
-    this.isBackgroundEffectsEnabled = ko.pureComputed(() => {
-      return this.teamFeatures()?.backgroundEffects?.status === FEATURE_STATUS.ENABLED;
-    });
+    // Temporarily disable the Background effects regardless of backend state.
+    // This will be reverted after 6th of July 2026
+    this.isBackgroundEffectsEnabled = ko.pureComputed(() => false);
 
     this.isGuestLinkEnabled = ko.pureComputed(
       () => this.teamFeatures()?.conversationGuestLinks?.status === FEATURE_STATUS.ENABLED,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26420" title="WPB-26420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26420</a>  [Desktop] Preparation for Release of Background Setting 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Temporarily disable the Background effects regardless of backend state.
This PR will be reverted after the release of webapp on 06th of July 2026


