### PR TITLE
Increase timeout for login of SCIM user [WPB-21916]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -110,8 +110,8 @@ test.describe('account settings', () => {
         await page.getByRole('button', {name: 'Remove device'}).first().click({timeout: LOGIN_TIMEOUT});
         // We will also always be prompted to confirm the new history on this device
         await pages.historyInfo().clickConfirmButton();
-        await expect(components.conversationSidebar().sidebar, `Login took more than ${LOGIN_TIMEOUT}s`).toBeVisible({
-          timeout: LOGIN_TIMEOUT,
+        await expect(components.conversationSidebar().sidebar, 'Login took more than 60s').toBeVisible({
+          timeout: 60_000, // The login for this user may take some time since it's persisted and checking for messages takes extra time
         });
       });
 

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -621,11 +621,9 @@ test.describe('Guestroom', () => {
       // // We will also always be prompted to confirm the new history on this device
       await guestPages.historyInfo().clickConfirmButton();
 
-      await expect(guestComponents.conversationSidebar().sidebar, `Login took more than ${LOGIN_TIMEOUT}s`).toBeVisible(
-        {
-          timeout: LOGIN_TIMEOUT,
-        },
-      );
+      await expect(guestComponents.conversationSidebar().sidebar, 'Login took more than 60s').toBeVisible({
+        timeout: 60_000, // The login for this user may take some time since it's persisted and checking for messages takes extra time
+      });
 
       await expect(guestPages.conversationList().getConversation(groupName)).toBeVisible();
     },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The login of this user needs some extra time. Since it is persisted and has a lot of devices checking for new messages during login takes longer than usual.


