### PR TITLE
Deduplicate group conversations in search results [WPB-24651]

### DIFF
--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/helpers.test.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/helpers.test.tsx
@@ -18,6 +18,7 @@
  */
 
 import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
+import {createFactory} from '@enormora/objectory';
 
 import {Conversation} from 'Repositories/entity/Conversation';
 import {
@@ -45,6 +46,45 @@ const searchInputPlaceholders = {
   searchDraftsConversations: 'searchDraftsConversations',
   searchPingsConversations: 'searchPingsConversations',
 };
+
+type RecentConversationSearchInputOptions = {
+  conversation: Conversation;
+  conversationsFilter: string;
+};
+
+type GetTabConversationsInput = Parameters<typeof getTabConversations>[0];
+
+const recentConversationSearchInputFactory = createFactory<GetTabConversationsInput>(() => {
+  return {
+    currentTab: SidebarTabs.RECENT,
+    conversations: [],
+    groupConversations: [],
+    directConversations: [],
+    favoriteConversations: [],
+    archivedConversations: [],
+    conversationsFilter: '',
+    channelAndGroupConversations: [],
+    channelConversations: [],
+    isChannelsEnabled: false,
+    draftConversations: [],
+    searchInputPlaceholders,
+  };
+});
+
+function createRecentConversationSearchInput(options: RecentConversationSearchInputOptions): GetTabConversationsInput {
+  const {conversation, conversationsFilter} = options;
+
+  const recentConversationSearchInput = recentConversationSearchInputFactory.build({
+    conversationsFilter,
+  });
+
+  return {
+    ...recentConversationSearchInput,
+    conversations: [conversation],
+    groupConversations: [conversation],
+    channelAndGroupConversations: [conversation],
+  };
+}
 
 describe('conversationFilters', () => {
   it('detects mentions, replies, pings, and archived state', () => {
@@ -291,20 +331,12 @@ describe('getTabConversations', () => {
       users: [generateUser(undefined, {name: 'Florian'})],
     });
 
-    const {conversations: filteredConversations} = getTabConversations({
-      currentTab: SidebarTabs.RECENT,
-      conversations: [florianSupportConversation],
-      groupConversations: [florianSupportConversation],
-      directConversations: [],
-      favoriteConversations: [],
-      archivedConversations: [],
-      conversationsFilter: 'Florian',
-      channelAndGroupConversations: [florianSupportConversation],
-      channelConversations: [],
-      isChannelsEnabled: false,
-      draftConversations: [],
-      searchInputPlaceholders,
-    });
+    const {conversations: filteredConversations} = getTabConversations(
+      createRecentConversationSearchInput({
+        conversation: florianSupportConversation,
+        conversationsFilter: 'Florian',
+      }),
+    );
 
     expect(filteredConversations).toEqual([florianSupportConversation]);
   });
@@ -316,20 +348,12 @@ describe('getTabConversations', () => {
       users: [generateUser(undefined, {name: 'Florian'})],
     });
 
-    const {conversations: filteredConversations} = getTabConversations({
-      currentTab: SidebarTabs.RECENT,
-      conversations: [supportRoomConversation],
-      groupConversations: [supportRoomConversation],
-      directConversations: [],
-      favoriteConversations: [],
-      archivedConversations: [],
-      conversationsFilter: 'Florian',
-      channelAndGroupConversations: [supportRoomConversation],
-      channelConversations: [],
-      isChannelsEnabled: false,
-      draftConversations: [],
-      searchInputPlaceholders,
-    });
+    const {conversations: filteredConversations} = getTabConversations(
+      createRecentConversationSearchInput({
+        conversation: supportRoomConversation,
+        conversationsFilter: 'Florian',
+      }),
+    );
 
     expect(filteredConversations).toEqual([supportRoomConversation]);
   });

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/helpers.test.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/helpers.test.tsx
@@ -284,9 +284,60 @@ describe('getTabConversations', () => {
     expect(filteredConversations[0].display_name()).toEqual('Tim');
   });
 
+  it('should return a group conversation once when its name and participant name match the search filter', () => {
+    const florianSupportConversation = generateConversation({
+      name: 'Florian Support',
+      type: CONVERSATION_TYPE.REGULAR,
+      users: [generateUser(undefined, {name: 'Florian'})],
+    });
+
+    const {conversations: filteredConversations} = getTabConversations({
+      currentTab: SidebarTabs.RECENT,
+      conversations: [florianSupportConversation],
+      groupConversations: [florianSupportConversation],
+      directConversations: [],
+      favoriteConversations: [],
+      archivedConversations: [],
+      conversationsFilter: 'Florian',
+      channelAndGroupConversations: [florianSupportConversation],
+      channelConversations: [],
+      isChannelsEnabled: false,
+      draftConversations: [],
+      searchInputPlaceholders,
+    });
+
+    expect(filteredConversations).toEqual([florianSupportConversation]);
+  });
+
+  it('should return a group conversation when only its participant name matches the search filter', () => {
+    const supportRoomConversation = generateConversation({
+      name: 'Support Room',
+      type: CONVERSATION_TYPE.REGULAR,
+      users: [generateUser(undefined, {name: 'Florian'})],
+    });
+
+    const {conversations: filteredConversations} = getTabConversations({
+      currentTab: SidebarTabs.RECENT,
+      conversations: [supportRoomConversation],
+      groupConversations: [supportRoomConversation],
+      directConversations: [],
+      favoriteConversations: [],
+      archivedConversations: [],
+      conversationsFilter: 'Florian',
+      channelAndGroupConversations: [supportRoomConversation],
+      channelConversations: [],
+      isChannelsEnabled: false,
+      draftConversations: [],
+      searchInputPlaceholders,
+    });
+
+    expect(filteredConversations).toEqual([supportRoomConversation]);
+  });
+
   it('should ignore special characters when filtering conversations', () => {
     const {conversations: filteredConversations} = runTest(SidebarTabs.RECENT, 'web team');
 
+    expect(filteredConversations).toHaveLength(1);
     expect(filteredConversations[0].display_name()).toEqual('Wêb Têam');
   });
 

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/helpers.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/helpers.tsx
@@ -97,14 +97,27 @@ export function getTabConversations({
     }
 
     const filterWord = replaceAccents(conversationsFilter.toLowerCase());
+    const filteredConversations = conversations.filter(conversationSearchFilter);
+    const filteredConversationIds = new Set(
+      filteredConversations.map(conversation => {
+        const {domain, id} = conversation.qualifiedId;
+        return `${domain ?? ''}/${id}`;
+      }),
+    );
     const filteredGroupConversations = groupConversations.filter(group => {
+      const {domain, id} = group.qualifiedId;
+      const groupConversationId = `${domain ?? ''}/${id}`;
+
+      if (filteredConversationIds.has(groupConversationId)) {
+        return false;
+      }
+
       return group.participating_user_ets().some(user => {
         const conversationDisplayName = replaceAccents(user.name().toLowerCase());
         return conversationDisplayName.includes(filterWord);
       });
     });
 
-    const filteredConversations = conversations.filter(conversationSearchFilter);
     const combinedConversations = [...filteredConversations, ...filteredGroupConversations];
 
     return {

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/helpers.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/helpers.tsx
@@ -18,6 +18,7 @@
  */
 
 import {Conversation} from 'Repositories/entity/Conversation';
+import {matchQualifiedIds} from 'Util/qualifiedId';
 import {replaceAccents} from 'Util/stringUtil';
 
 import {SidebarTabs} from './useSidebarStore';
@@ -98,24 +99,26 @@ export function getTabConversations({
 
     const filterWord = replaceAccents(conversationsFilter.toLowerCase());
     const filteredConversations = conversations.filter(conversationSearchFilter);
-    const filteredConversationIds = new Set(
-      filteredConversations.map(conversation => {
-        const {domain, id} = conversation.qualifiedId;
-        return `${domain ?? ''}/${id}`;
-      }),
-    );
-    const filteredGroupConversations = groupConversations.filter(group => {
-      const {domain, id} = group.qualifiedId;
-      const groupConversationId = `${domain ?? ''}/${id}`;
 
-      if (filteredConversationIds.has(groupConversationId)) {
-        return false;
-      }
+    function isGroupConversationAlreadyFiltered(groupConversation: Conversation): boolean {
+      return filteredConversations.some(conversation => {
+        return matchQualifiedIds(conversation.qualifiedId, groupConversation.qualifiedId);
+      });
+    }
 
-      return group.participating_user_ets().some(user => {
+    function groupConversationHasMatchingParticipant(groupConversation: Conversation): boolean {
+      return groupConversation.participating_user_ets().some(user => {
         const conversationDisplayName = replaceAccents(user.name().toLowerCase());
         return conversationDisplayName.includes(filterWord);
       });
+    }
+
+    const filteredGroupConversations = groupConversations.filter(groupConversation => {
+      if (isGroupConversationAlreadyFiltered(groupConversation)) {
+        return false;
+      }
+
+      return groupConversationHasMatchingParticipant(groupConversation);
     });
 
     const combinedConversations = [...filteredConversations, ...filteredGroupConversations];


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24651" title="WPB-24651" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24651</a>  Duplicate group conversation appears in search results when guest name matches part of the group name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This fixes a conversation search issue where the same group conversation could appear twice when:

- the group conversation name matched the search query
- and one of the group participants / guests also matched the same query

The search result building now keeps conversation-name matches as the primary result and excludes those conversations from the participant-name result list.

Participant-name search still works for groups where only the participant name matches.