### PR TITLE
Enable enhanced call audio processing by default [WPB-26722]

### DIFF
--- a/apps/webapp/src/script/components/AppContainer/AppContainer.tsx
+++ b/apps/webapp/src/script/components/AppContainer/AppContainer.tsx
@@ -45,7 +45,6 @@ import {useTheme} from './hooks/useTheme';
 import {runClientVersionCheck} from '../../application-periodic-checks/runClientVersionCheck';
 import {startApplicationPeriodicChecks} from '../../application-periodic-checks/startApplicationPeriodicChecks';
 import {Config, Configuration} from '../../Config';
-import {enhancedCallAudioProcessingFeatureToggleName} from '../../featureToggles/startupFeatureToggleNames';
 import {StartupFeatureToggleName} from '../../featureToggles/startupFeatureToggles';
 import {setAppLocale} from '../../localization/Localizer';
 import {App} from '../../main/app';
@@ -86,16 +85,9 @@ export const AppContainer = (properties: AppProps) => {
     wallClock,
   } = properties;
   setAppLocale();
-  const isEnhancedCallAudioProcessingEnabled = isFeatureToggleEnabled(enhancedCallAudioProcessingFeatureToggleName);
   const app = useMemo(() => {
-    return new App(
-      container.resolve(Core),
-      container.resolve(APIClient),
-      config,
-      translate,
-      isEnhancedCallAudioProcessingEnabled,
-    );
-  }, [config, isEnhancedCallAudioProcessingEnabled, translate]);
+    return new App(container.resolve(Core), container.resolve(APIClient), config, translate);
+  }, [config, translate]);
   const enableAutoLogin = Config.getConfig().FEATURE.ENABLE_AUTO_LOGIN;
 
   // Publishing application on the global scope for debug and testing purposes.

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -20,13 +20,11 @@
 export const applockRefactoredFeatureToggleName = 'applock-refactored';
 export const sharedDriveSearchAndFiltersFeatureToggleName = 'shared-drive-search-and-filters';
 export const meetingsFeatureToggleName = 'meetings';
-export const enhancedCallAudioProcessingFeatureToggleName = 'enhanced-call-audio-processing';
 
 export const startupFeatureToggleNames = [
   applockRefactoredFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   meetingsFeatureToggleName,
-  enhancedCallAudioProcessingFeatureToggleName,
 ] as const;
 
 export type StartupFeatureToggleName = (typeof startupFeatureToggleNames)[number];

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
@@ -17,11 +17,7 @@
  *
  */
 
-import {
-  applockRefactoredFeatureToggleName,
-  enhancedCallAudioProcessingFeatureToggleName,
-  meetingsFeatureToggleName,
-} from './startupFeatureToggleNames';
+import {applockRefactoredFeatureToggleName, meetingsFeatureToggleName} from './startupFeatureToggleNames';
 import {startupFeatureToggleQueryParameterName} from './startupFeatureToggles';
 import {updateLocationSearchForStartupFeatureToggle} from './startupFeatureToggleQueryParameters';
 
@@ -48,15 +44,15 @@ describe('updateLocationSearchForStartupFeatureToggle', () => {
     expect(updatedLocationSearch).toBe(`?${startupFeatureToggleQueryParameterName}=${meetingsFeatureToggleName}`);
   });
 
-  it('adds the enhanced call audio processing feature toggle while preserving other enabled toggles', () => {
+  it('adds a startup feature toggle while preserving other enabled toggles', () => {
     const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
       locationSearch: `?${startupFeatureToggleQueryParameterName}=${meetingsFeatureToggleName}`,
-      featureToggleName: enhancedCallAudioProcessingFeatureToggleName,
+      featureToggleName: applockRefactoredFeatureToggleName,
       shouldEnableFeatureToggle: true,
     });
 
     expect(updatedLocationSearch).toBe(
-      `?${startupFeatureToggleQueryParameterName}=${meetingsFeatureToggleName}%2C${enhancedCallAudioProcessingFeatureToggleName}`,
+      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}%2C${meetingsFeatureToggleName}`,
     );
   });
 

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -24,7 +24,6 @@ import {
 } from './startupFeatureToggles';
 import {
   applockRefactoredFeatureToggleName,
-  enhancedCallAudioProcessingFeatureToggleName,
   meetingsFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   startupFeatureToggleNames,
@@ -34,7 +33,6 @@ const featureToggleNamesWithDedicatedExistenceTests = [
   applockRefactoredFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   meetingsFeatureToggleName,
-  enhancedCallAudioProcessingFeatureToggleName,
 ] as const;
 
 describe('startupFeatureToggles', function () {
@@ -103,23 +101,6 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.isFeatureToggleEnabled(meetingsFeatureToggleName)).toBe(true);
   });
 
-  it('enables the enhanced call audio processing feature toggle when present in the query parameter', () => {
-    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=${enhancedCallAudioProcessingFeatureToggleName}`,
-    );
-
-    expect(startupFeatureToggles.isFeatureToggleEnabled(enhancedCallAudioProcessingFeatureToggleName)).toBe(true);
-  });
-
-  it('enables the enhanced call audio processing feature toggle together with other startup feature toggles', () => {
-    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=${meetingsFeatureToggleName},${enhancedCallAudioProcessingFeatureToggleName}`,
-    );
-
-    expect(startupFeatureToggles.isFeatureToggleEnabled(meetingsFeatureToggleName)).toBe(true);
-    expect(startupFeatureToggles.isFeatureToggleEnabled(enhancedCallAudioProcessingFeatureToggleName)).toBe(true);
-  });
-
   it('trims whitespace around feature toggle names', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}= ${applockRefactoredFeatureToggleName} `,
@@ -161,7 +142,6 @@ describe('startupFeatureToggles', function () {
       applockRefactoredFeatureToggleName,
       sharedDriveSearchAndFiltersFeatureToggleName,
       meetingsFeatureToggleName,
-      enhancedCallAudioProcessingFeatureToggleName,
     ]);
   });
 

--- a/apps/webapp/src/script/main/app.ts
+++ b/apps/webapp/src/script/main/app.ts
@@ -196,7 +196,6 @@ export class App {
     private readonly apiClient: APIClient,
     private readonly config: Configuration,
     private readonly translate: Translate,
-    private readonly isEnhancedCallAudioProcessingEnabled: boolean,
   ) {
     this.config = config;
     this.apiClient.on(APIClient.TOPIC.ON_LOGOUT, () =>
@@ -235,10 +234,7 @@ export class App {
     // Initialize permissions
     void initializePermissions();
 
-    const mediaConstraintsHandler = new MediaConstraintsHandler(
-      container.resolve(UserState),
-      this.isEnhancedCallAudioProcessingEnabled,
-    );
+    const mediaConstraintsHandler = new MediaConstraintsHandler(container.resolve(UserState));
 
     const mediaStreamHandler = new MediaStreamHandler(mediaConstraintsHandler);
     const mediaDevicesHandler = new MediaDevicesHandler();

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/avPreferences.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/avPreferences.tsx
@@ -28,7 +28,6 @@ import {MediaDevicesHandler} from 'Repositories/media/MediaDevicesHandler';
 import type {MediaDeviceType} from 'Repositories/media/MediaDeviceType';
 import {MediaStreamHandler} from 'Repositories/media/MediaStreamHandler';
 import type {PropertiesRepository} from 'Repositories/properties/propertiesRepository';
-import {enhancedCallAudioProcessingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 
 import {AudioOutPreferences} from './avPreferences/audioOutPreferences';
@@ -49,8 +48,7 @@ interface AVPreferencesProps {
 }
 
 const AVPreferencesComponent = ({propertiesRepository, callingRepository, deviceSupport}: AVPreferencesProps) => {
-  const {isFeatureToggleEnabled, translate} = useApplicationContext();
-  const isEnhancedCallAudioProcessingEnabled = isFeatureToggleEnabled(enhancedCallAudioProcessingFeatureToggleName);
+  const {translate} = useApplicationContext();
   const devicesHandler = container.resolve(MediaDevicesHandler);
   const constraintsHandler = container.resolve(MediaConstraintsHandler);
   const streamHandler = container.resolve(MediaStreamHandler);
@@ -88,7 +86,6 @@ const AVPreferencesComponent = ({propertiesRepository, callingRepository, device
       <CallOptions
         {...{constraintsHandler, propertiesRepository}}
         hasActiveCall={callingRepository.hasActiveCall}
-        isEnhancedCallAudioProcessingEnabled={isEnhancedCallAudioProcessingEnabled}
         refreshAudioInput={() => {
           return callingRepository.refreshAudioInput();
         }}

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/avPreferences/callOptions.test.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/avPreferences/callOptions.test.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {fireEvent, render, screen} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 
 import {withThemeAndRootContext} from 'src/script/auth/util/test/TestUtil';
 import {
@@ -32,9 +32,9 @@ import type {PropertiesRepository} from 'Repositories/properties/propertiesRepos
 import {CallOptions} from './callOptions';
 
 interface RenderCallOptionsParameters {
-  isEnhancedCallAudioProcessingEnabled?: boolean;
   hasActiveCall?: boolean;
   agcPreference?: boolean;
+  refreshAudioInput?: jest.Mock<Promise<MediaStream>>;
 }
 
 function createPropertiesRepositoryForTest(): PropertiesRepository {
@@ -53,7 +53,7 @@ function createPropertiesRepositoryForTest(): PropertiesRepository {
 }
 
 function renderCallOptions(parameters: RenderCallOptionsParameters = {}) {
-  const {isEnhancedCallAudioProcessingEnabled = false, hasActiveCall = false, agcPreference = false} = parameters;
+  const {hasActiveCall = false, agcPreference = false} = parameters;
   const constraintsHandler = {
     getAgcPreference: jest.fn(() => {
       return agcPreference;
@@ -61,9 +61,11 @@ function renderCallOptions(parameters: RenderCallOptionsParameters = {}) {
     setAgcPreference: jest.fn(),
   } as unknown as MediaConstraintsHandler;
   const propertiesRepository = createPropertiesRepositoryForTest();
-  const refreshAudioInput = jest.fn(async (): Promise<MediaStream> => {
-    return {} as MediaStream;
-  });
+  const refreshAudioInput =
+    parameters.refreshAudioInput ??
+    jest.fn(async (): Promise<MediaStream> => {
+      return {} as MediaStream;
+    });
   const rootContextValue = createRootContextValueForTest({translate: translateForTest});
   const rootProviderWrapper = createRootProviderWrapperForTest(rootContextValue);
 
@@ -74,7 +76,6 @@ function renderCallOptions(parameters: RenderCallOptionsParameters = {}) {
         hasActiveCall={() => {
           return hasActiveCall;
         }}
-        isEnhancedCallAudioProcessingEnabled={isEnhancedCallAudioProcessingEnabled}
         propertiesRepository={propertiesRepository}
         refreshAudioInput={refreshAudioInput}
       />,
@@ -90,10 +91,9 @@ function getAgcCheckbox(): HTMLInputElement {
 }
 
 describe('CallOptions', () => {
-  it('shows AGC as enabled by default when enhanced call audio processing is enabled', () => {
+  it('shows AGC as enabled by default when the stored AGC preference is enabled', () => {
     renderCallOptions({
       agcPreference: true,
-      isEnhancedCallAudioProcessingEnabled: true,
     });
 
     expect(getAgcCheckbox().checked).toBe(true);
@@ -107,25 +107,42 @@ describe('CallOptions', () => {
     expect(constraintsHandler.setAgcPreference).toHaveBeenCalledWith(true);
   });
 
-  it('refreshes active audio input after AGC changes when enhanced call audio processing is enabled during an active call', () => {
+  it('refreshes active audio input after AGC changes during an active call', async () => {
     const {refreshAudioInput} = renderCallOptions({
       hasActiveCall: true,
-      isEnhancedCallAudioProcessingEnabled: true,
     });
 
     fireEvent.click(getAgcCheckbox());
 
-    expect(refreshAudioInput).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(refreshAudioInput).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('does not refresh active audio input after AGC changes when enhanced call audio processing is disabled', () => {
+  it('does not refresh active audio input after AGC changes when there is no active call', () => {
     const {refreshAudioInput} = renderCallOptions({
-      hasActiveCall: true,
-      isEnhancedCallAudioProcessingEnabled: false,
+      hasActiveCall: false,
     });
 
     fireEvent.click(getAgcCheckbox());
 
     expect(refreshAudioInput).not.toHaveBeenCalled();
+  });
+
+  it('handles audio input refresh failures after AGC changes', async () => {
+    const refreshAudioInput = jest.fn(async (): Promise<MediaStream> => {
+      throw new Error('refresh failed');
+    });
+
+    renderCallOptions({
+      hasActiveCall: true,
+      refreshAudioInput,
+    });
+
+    fireEvent.click(getAgcCheckbox());
+
+    await waitFor(() => {
+      expect(refreshAudioInput).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/avPreferences/callOptions.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/avPreferences/callOptions.tsx
@@ -39,7 +39,6 @@ const logger = getLogger('CallOptions');
 interface CallOptionsProps {
   constraintsHandler: MediaConstraintsHandler;
   hasActiveCall: () => boolean;
-  isEnhancedCallAudioProcessingEnabled: boolean;
   propertiesRepository: PropertiesRepository;
   refreshAudioInput: () => Promise<MediaStream>;
 }
@@ -47,7 +46,6 @@ interface CallOptionsProps {
 const CallOptions = ({
   constraintsHandler,
   hasActiveCall,
-  isEnhancedCallAudioProcessingEnabled,
   propertiesRepository,
   refreshAudioInput,
 }: CallOptionsProps) => {
@@ -96,7 +94,7 @@ const CallOptions = ({
       constraintsHandler.setAgcPreference(isChecked);
       setAgcEnabled(isChecked);
 
-      if (isEnhancedCallAudioProcessingEnabled && hasActiveCall()) {
+      if (hasActiveCall()) {
         try {
           await refreshAudioInput();
         } catch (error: unknown) {
@@ -106,7 +104,7 @@ const CallOptions = ({
         }
       }
     },
-    [constraintsHandler, hasActiveCall, isEnhancedCallAudioProcessingEnabled, refreshAudioInput],
+    [constraintsHandler, hasActiveCall, refreshAudioInput],
   );
 
   const handleSoundlessCallsChange = useCallback(

--- a/apps/webapp/src/script/repositories/media/MediaConstraintsHandler.test.ts
+++ b/apps/webapp/src/script/repositories/media/MediaConstraintsHandler.test.ts
@@ -76,13 +76,13 @@ describe('MediaConstraintsHandler', () => {
     createAvailableDevices();
   };
 
-  const createConstraintsHandler = (selfUserId = createUuid(), isEnhancedCallAudioProcessingEnabled = false) => {
+  const createConstraintsHandler = (selfUserId = createUuid()) => {
     const userState = {
       self: () => {
         return new User(selfUserId, '', translateForTest);
       },
     };
-    return new MediaConstraintsHandler(userState as UserState, isEnhancedCallAudioProcessingEnabled);
+    return new MediaConstraintsHandler(userState as UserState);
   };
 
   const defaultId = MediaConstraintsHandler.CONFIG.DEFAULT_DEVICE_ID;
@@ -122,7 +122,11 @@ describe('MediaConstraintsHandler', () => {
       ) as ExtendedMediaTrackConstraints;
 
       expect(constraints.audio.deviceId).toBeUndefined();
-      expect(constraints.audio).toEqual({autoGainControl: false});
+      expect(constraints.audio).toEqual({
+        autoGainControl: true,
+        echoCancellation: true,
+        noiseSuppression: true,
+      });
       expect(constraints.video.deviceId).toBeUndefined();
       expect(constraints.video).toEqual(
         expect.objectContaining({
@@ -135,18 +139,9 @@ describe('MediaConstraintsHandler', () => {
     });
 
     describe('Audio Constraints', () => {
-      it('keeps legacy audio constraints when enhanced call audio processing is disabled and no AGC preference is stored', () => {
+      it('uses enhanced audio constraints when no AGC preference is stored', () => {
         createAvailableDevices({audio: defaultId});
-        const constraintsHandler = createConstraintsHandler(createUuid(), false);
-
-        const constraints = constraintsHandler.getMediaStreamConstraints(true, false) as ExtendedMediaTrackConstraints;
-
-        expect(constraints.audio).toEqual({autoGainControl: false});
-      });
-
-      it('applies enhanced audio constraints when enhanced call audio processing is enabled and no AGC preference is stored', () => {
-        createAvailableDevices({audio: defaultId});
-        const constraintsHandler = createConstraintsHandler(createUuid(), true);
+        const constraintsHandler = createConstraintsHandler();
 
         const constraints = constraintsHandler.getMediaStreamConstraints(true, false) as ExtendedMediaTrackConstraints;
 
@@ -157,10 +152,10 @@ describe('MediaConstraintsHandler', () => {
         });
       });
 
-      it('respects a stored disabled AGC preference when enhanced call audio processing is enabled', () => {
+      it('respects a stored disabled AGC preference', () => {
         createAvailableDevices({audio: defaultId});
         const selfUserId = createUuid();
-        const constraintsHandler = createConstraintsHandler(selfUserId, true);
+        const constraintsHandler = createConstraintsHandler(selfUserId);
         localStorage.setItem(`agc_enabled_${selfUserId}`, 'false');
 
         const constraints = constraintsHandler.getMediaStreamConstraints(true, false) as ExtendedMediaTrackConstraints;
@@ -172,10 +167,10 @@ describe('MediaConstraintsHandler', () => {
         });
       });
 
-      it('respects a stored enabled AGC preference when enhanced call audio processing is enabled', () => {
+      it('respects a stored enabled AGC preference', () => {
         createAvailableDevices({audio: defaultId});
         const selfUserId = createUuid();
-        const constraintsHandler = createConstraintsHandler(selfUserId, true);
+        const constraintsHandler = createConstraintsHandler(selfUserId);
         localStorage.setItem(`agc_enabled_${selfUserId}`, 'true');
 
         const constraints = constraintsHandler.getMediaStreamConstraints(true, false) as ExtendedMediaTrackConstraints;
@@ -187,10 +182,10 @@ describe('MediaConstraintsHandler', () => {
         });
       });
 
-      it('treats a stored non-boolean AGC preference as missing when enhanced call audio processing is enabled', () => {
+      it('treats a stored non-boolean AGC preference as missing', () => {
         createAvailableDevices({audio: defaultId});
         const selfUserId = createUuid();
-        const constraintsHandler = createConstraintsHandler(selfUserId, true);
+        const constraintsHandler = createConstraintsHandler(selfUserId);
         localStorage.setItem(`agc_enabled_${selfUserId}`, '"not-a-boolean"');
 
         const constraints = constraintsHandler.getMediaStreamConstraints(true, false) as ExtendedMediaTrackConstraints;
@@ -202,10 +197,10 @@ describe('MediaConstraintsHandler', () => {
         });
       });
 
-      it('treats a malformed stored AGC preference as missing when enhanced call audio processing is enabled', () => {
+      it('treats a malformed stored AGC preference as missing', () => {
         createAvailableDevices({audio: defaultId});
         const selfUserId = createUuid();
-        const constraintsHandler = createConstraintsHandler(selfUserId, true);
+        const constraintsHandler = createConstraintsHandler(selfUserId);
         localStorage.setItem(`agc_enabled_${selfUserId}`, 'not-json');
 
         const constraints = constraintsHandler.getMediaStreamConstraints(true, false) as ExtendedMediaTrackConstraints;
@@ -237,9 +232,9 @@ describe('MediaConstraintsHandler', () => {
         expect(constraints.audio.deviceId.exact).toBe('specific-mic-id');
       });
 
-      it('keeps exact deviceId when enhanced call audio processing is enabled', () => {
+      it('keeps exact deviceId with enhanced audio constraints', () => {
         createAvailableDevices({audio: 'specific-mic-id'});
-        const constraintsHandler = createConstraintsHandler(createUuid(), true);
+        const constraintsHandler = createConstraintsHandler();
 
         const constraints = constraintsHandler.getMediaStreamConstraints(true, false) as ExtendedMediaTrackConstraints;
 
@@ -354,30 +349,37 @@ describe('MediaConstraintsHandler', () => {
       expect(getItemSpy).toHaveBeenCalledWith(expect.stringContaining(selfUserId));
     });
 
-    it('defaults AGC to disabled when enhanced call audio processing is disabled and no AGC preference is stored', () => {
+    it('defaults AGC to enabled when no AGC preference is stored', () => {
       spyOn(Object.getPrototypeOf(localStorage), 'getItem').and.returnValue(null);
-      const constraintsHandler = createConstraintsHandler(createUuid(), false);
-
-      expect(constraintsHandler.getAgcPreference()).toEqual(false);
-    });
-
-    it('defaults AGC to enabled when enhanced call audio processing is enabled and no AGC preference is stored', () => {
-      spyOn(Object.getPrototypeOf(localStorage), 'getItem').and.returnValue(null);
-      const constraintsHandler = createConstraintsHandler(createUuid(), true);
+      const constraintsHandler = createConstraintsHandler();
 
       expect(constraintsHandler.getAgcPreference()).toEqual(true);
     });
 
-    it('keeps AGC disabled when enhanced call audio processing is enabled and AGC is stored as disabled', () => {
+    it('keeps AGC disabled when AGC is stored as disabled', () => {
       spyOn(Object.getPrototypeOf(localStorage), 'getItem').and.returnValue('false');
-      const constraintsHandler = createConstraintsHandler(createUuid(), true);
+      const constraintsHandler = createConstraintsHandler();
 
       expect(constraintsHandler.getAgcPreference()).toEqual(false);
     });
 
-    it('keeps AGC enabled when enhanced call audio processing is enabled and AGC is stored as enabled', () => {
+    it('keeps AGC enabled when AGC is stored as enabled', () => {
       spyOn(Object.getPrototypeOf(localStorage), 'getItem').and.returnValue('true');
-      const constraintsHandler = createConstraintsHandler(createUuid(), true);
+      const constraintsHandler = createConstraintsHandler();
+
+      expect(constraintsHandler.getAgcPreference()).toEqual(true);
+    });
+
+    it('defaults AGC to enabled when the stored AGC preference is malformed', () => {
+      spyOn(Object.getPrototypeOf(localStorage), 'getItem').and.returnValue('not-json');
+      const constraintsHandler = createConstraintsHandler();
+
+      expect(constraintsHandler.getAgcPreference()).toEqual(true);
+    });
+
+    it('defaults AGC to enabled when the stored AGC preference is not boolean', () => {
+      spyOn(Object.getPrototypeOf(localStorage), 'getItem').and.returnValue('"not-a-boolean"');
+      const constraintsHandler = createConstraintsHandler();
 
       expect(constraintsHandler.getAgcPreference()).toEqual(true);
     });

--- a/apps/webapp/src/script/repositories/media/MediaConstraintsHandler.ts
+++ b/apps/webapp/src/script/repositories/media/MediaConstraintsHandler.ts
@@ -101,10 +101,7 @@ export class MediaConstraintsHandler {
     };
   }
 
-  constructor(
-    private readonly userState = container.resolve(UserState),
-    readonly isEnhancedCallAudioProcessingEnabled: boolean = false,
-  ) {
+  constructor(private readonly userState = container.resolve(UserState)) {
     this.logger = getLogger('MediaConstraintsHandler');
   }
 
@@ -117,7 +114,7 @@ export class MediaConstraintsHandler {
   }
 
   getAgcPreference(): boolean {
-    return this.getStoredAgcPreference().unwrapOr(this.isEnhancedCallAudioProcessingEnabled);
+    return this.getStoredAgcPreference().unwrapOr(true);
   }
 
   getMediaStreamConstraints(
@@ -208,17 +205,12 @@ export class MediaConstraintsHandler {
   }
 
   private getAudioStreamConstraints(mediaDeviceId: string = ''): MediaTrackConstraints & {autoGainControl: boolean} {
-    const autoGainControl = this.getStoredAgcPreference().unwrapOr(this.isEnhancedCallAudioProcessingEnabled);
-    const enhancedAudioProcessingConstraints = this.isEnhancedCallAudioProcessingEnabled
-      ? {
-          echoCancellation: true,
-          noiseSuppression: true,
-        }
-      : {};
+    const autoGainControl = this.getStoredAgcPreference().unwrapOr(true);
 
     return {
       autoGainControl,
-      ...enhancedAudioProcessingConstraints,
+      echoCancellation: true,
+      noiseSuppression: true,
       ...this.getDeviceConstraint(mediaDeviceId),
     };
   }

--- a/apps/webapp/src/script/repositories/media/MediaStreamHandler.test.ts
+++ b/apps/webapp/src/script/repositories/media/MediaStreamHandler.test.ts
@@ -24,6 +24,11 @@ import {MediaStreamHandler} from './MediaStreamHandler';
 
 describe('MediaStreamHandler', () => {
   let streamHandler: MediaStreamHandler;
+  const enhancedAudioConstraints = {
+    autoGainControl: true,
+    echoCancellation: true,
+    noiseSuppression: true,
+  };
 
   const userState = {
     self: () => ({id: ''}),
@@ -42,7 +47,7 @@ describe('MediaStreamHandler', () => {
       await streamHandler.requestMediaStream(true, false, false, true);
 
       expect(window.navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith(
-        jasmine.objectContaining({audio: {autoGainControl: false}, video: undefined}),
+        jasmine.objectContaining({audio: enhancedAudioConstraints, video: undefined}),
       );
     });
 
@@ -62,7 +67,7 @@ describe('MediaStreamHandler', () => {
       await streamHandler.requestMediaStream(true, true, false, true);
 
       expect(window.navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith(
-        jasmine.objectContaining({audio: {autoGainControl: false}, video: jasmine.any(Object)}),
+        jasmine.objectContaining({audio: enhancedAudioConstraints, video: jasmine.any(Object)}),
       );
     });
   });

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -42,6 +42,7 @@ const ignores = [
   'apps/webapp/*.config.*',
   'apps/webapp/src/sw.js',
   'apps/server/bin/',
+  'apps/server/coverage/',
   'apps/server/dist/',
   'apps/server/node_modules/',
   'apps/webapp/src/ext/',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26722" title="WPB-26722" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26722</a>  [Web] Add enhanced call audio processing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Intent

The enhanced call audio processing experiment has worked well internally, so this pull request removes the startup feature flag and enables the behavior by default for all users.

The goal is to improve outgoing microphone consistency without changing `@wireapp/avs`