### PR TITLE
Fix loading of default configuration in Docker deployments [WPB-26336]

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -21,6 +21,7 @@ COPY libraries/config/lib ./libraries/config/lib
 # Copy built server artifacts and runtime files
 COPY apps/server/dist /dist
 COPY run.sh .env.defaults ./
+COPY .env.defaults /dist/.env.defaults
 
 ENV NODE_PATH=/app/node_modules
 ENV PATH=/app/node_modules/.bin:$PATH

--- a/bin/push_docker.js
+++ b/bin/push_docker.js
@@ -54,6 +54,13 @@ const dockerRegistryDomain = 'quay.io';
 const repository = `${dockerRegistryDomain}/wire/webapp`;
 
 const tags = [];
+const requiredEnvironmentDefaultKeys = ['BACKEND_NAME', 'BRAND_NAME', 'URL_ACCOUNT_BASE', 'BACKEND_REST', 'BACKEND_WS'];
+const environmentDefaultsSmokeCheckCommand = [
+  'test -s /dist/.env.defaults',
+  ...requiredEnvironmentDefaultKeys.map(requiredEnvironmentDefaultKey => {
+    return `grep -q "^${requiredEnvironmentDefaultKey}=" /dist/.env.defaults`;
+  }),
+].join(' && ');
 
 /** One Docker image can have multiple tags, e.g. "production" (links always to the latest production build) & "2021-08-30-production.0-v0.28.25-0-1240cfd" (links to a fixed production build) */
 tags.push(`${repository}:${versionTag}`);
@@ -79,6 +86,7 @@ if (isPR) {
 const dockerCommands = [
   `echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin ${dockerRegistryDomain}`,
   `docker build . --file apps/server/Dockerfile --tag ${commitShortSha}`,
+  `docker run --rm --entrypoint sh ${commitShortSha} -c ${JSON.stringify(environmentDefaultsSmokeCheckCommand)}`,
   `if [ "${uniqueTagOut}" != "" ]; then echo -n "${uniqueTag}" > "${uniqueTagOut}"; fi`,
 ];
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26336" title="WPB-26336" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26336</a>  [Web] [Registration] Incorrect welcome text and SSO code prompt are displayed on registration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Docker deployments were not loading `.env.defaults` after the monorepo migration https://github.com/wireapp/wire-webapp/commit/fcca1234cf29a44653fbaa71daf994de6ac5db9d.

The server resolves configuration relative to its deployment directory (`/dist`), while the Docker image copied `.env.defaults` to `/app`. As a result, default configuration values were silently ignored.

This affected much more than the original registration issue, including backend/brand names, account URLs, backup functionality and other configuration values.

## Changes

- copy `.env.defaults` into the location expected by the server
- add a Docker regression check to prevent publishing broken images