### PR TITLE
Fix wire-builds chart bump push authentication [WPB-26802]

### DIFF
--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -248,6 +248,27 @@ jobs:
               exit 1
           fi
 
+  notify_wire_builds_failure:
+    name: 'Notify wire-builds bump failure to Deployoholics'
+    runs-on: ubuntu-24.04
+    needs: [build, publish_wire_builds]
+    if: ${{ always() && needs.publish_wire_builds.result == 'failure' }}
+
+    steps:
+      - name: Announce wire-builds bump failure
+        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+        with:
+          status: failure
+          text: |
+            ❌ wire-builds chart bump failed for ${{ needs.build.outputs.release_name }} ❌
+            **Triggered by:** ${{ github.actor }}
+            **Ref:** ${{ github.ref_name }}
+            **Chart version:** ${{ needs.build.outputs.chart_version }}
+            **Image tag:** ${{ needs.build.outputs.image_tag }}
+            **Build log:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
   set_deployment_targets:
     name: 'Set deployment targets'
     runs-on: ubuntu-24.04

--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -196,7 +196,7 @@ jobs:
           ref: ${{matrix.target_branch}}
           fetch-depth: 1
 
-      - name: Create new build in wire-build
+      - name: Create new build in wire-builds
         shell: bash
         run: |
           set -eo pipefail
@@ -207,43 +207,43 @@ jobs:
           git config --global user.email "zebot@users.noreply.github.com"
           git config --global user.name "Zebot"
 
+          push_succeeded=false
+
           for retry in $(seq 3); do
-            set +e
-            (
-            set -e
+            if (
+              set -e
 
-            if (( retry > 1 )); then
-              echo "Retrying..."
-            fi
+              if (( retry > 1 )); then
+                echo "Retrying..."
+              fi
 
-            git fetch --depth 1 origin "${{ matrix.target_branch }}"
-            git checkout "${{ matrix.target_branch }}"
-            git reset --hard @{upstream}
+              git fetch --depth 1 origin "${{ matrix.target_branch }}"
+              git checkout "${{ matrix.target_branch }}"
+              git reset --hard @{upstream}
 
-            build_json=$(cat ./build.json | \
-              ./bin/set-chart-fields webapp \
-              "version=$chart_version" \
-              "repo=https://s3-eu-west-1.amazonaws.com/public.wire.com/charts-webapp" \
-              "meta.appVersion=$image_tag" \
-              "meta.commitURL=${{github.event.head_commit.url}}" \
-              "meta.commit=${{github.event.head_commit.id}}" \
-              | ./bin/bump-prerelease )
-            echo "$build_json" > ./build.json
+              build_json=$(cat ./build.json | \
+                ./bin/set-chart-fields webapp \
+                "version=$chart_version" \
+                "repo=https://s3-eu-west-1.amazonaws.com/public.wire.com/charts-webapp" \
+                "meta.appVersion=$image_tag" \
+                "meta.commitURL=${{github.event.head_commit.url}}" \
+                "meta.commit=${{github.event.head_commit.id}}" \
+                | ./bin/bump-prerelease )
+              echo "$build_json" > ./build.json
 
-            git add build.json
-            git commit -m "Bump webapp to $chart_version"
-            git push origin "${{ matrix.target_branch }}"
-
-            )
-            if [ $? -eq 0 ]; then
+              git add build.json
+              git commit -m "Bump webapp to $chart_version"
+              git push origin "${{ matrix.target_branch }}"
+            ); then
               echo "pushing to wire-builds succeeded"
+              push_succeeded=true
               break
-            else
-              echo "pushing to wire-builds FAILED (in retry $retry)"
             fi
-            set -e
+
+            echo "pushing to wire-builds FAILED (retry $retry)"
           done
-          if (( $? != 0 )); then
+
+          if [[ "$push_succeeded" != "true" ]]; then
               echo "Retrying didn't help. Failing the step."
               exit 1
           fi

--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -191,7 +191,6 @@ jobs:
       - name: Check out wire-builds
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          persist-credentials: false
           repository: wireapp/wire-builds
           token: ${{secrets.WIRE_BUILDS_WRITE_ACCESS_GH_TOKEN}}
           ref: ${{matrix.target_branch}}

--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -210,12 +210,13 @@ jobs:
           push_succeeded=false
 
           for retry in $(seq 3); do
-            if (
-              set -e
+            if (( retry > 1 )); then
+              echo "Retrying..."
+            fi
 
-              if (( retry > 1 )); then
-                echo "Retrying..."
-              fi
+            set +e
+            (
+              set -eo pipefail
 
               git fetch --depth 1 origin "${{ matrix.target_branch }}"
               git checkout "${{ matrix.target_branch }}"
@@ -234,7 +235,11 @@ jobs:
               git add build.json
               git commit -m "Bump webapp to $chart_version"
               git push origin "${{ matrix.target_branch }}"
-            ); then
+            )
+            attempt_exit_code=$?
+            set -e
+
+            if [[ "$attempt_exit_code" -eq 0 ]]; then
               echo "pushing to wire-builds succeeded"
               push_succeeded=true
               break
@@ -244,8 +249,8 @@ jobs:
           done
 
           if [[ "$push_succeeded" != "true" ]]; then
-              echo "Retrying didn't help. Failing the step."
-              exit 1
+            echo "Retrying didn't help. Failing the step."
+            exit 1
           fi
 
   notify_wire_builds_failure:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26802" title="WPB-26802" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26802</a>  [Web] Fix wire-builds chart bump push authentication and failure reporting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## What happened

The `Bump webapp chart in wire-builds (dev)` job failed while trying to push the generated `wire-builds` commit:

https://github.com/wireapp/wire-webapp/actions/runs/28646436439/job/84954935712

The workflow checked out `wireapp/wire-builds` with `WIRE_BUILDS_WRITE_ACCESS_GH_TOKEN`, but also used `persist-credentials: false`. Because of that, `actions/checkout` removed the Git credentials after checkout. The later `git push origin dev` then tried to push via HTTPS without credentials and failed with:

```text
fatal: could not read Username for 'https://github.com': No such device or address
```

## What changed

* Remove `persist-credentials: false` from the `wire-builds` checkout step.
* Keep using `WIRE_BUILDS_WRITE_ACCESS_GH_TOKEN` for the checkout and later push.
* Make the retry loop track push success explicitly.
* Fail the workflow when all push attempts fail, instead of accidentally masking the failure.

## Why

The job needs to write to `wireapp/wire-builds`. Passing the token to `actions/checkout` is not enough if the credentials are removed before the later `git push`.

The retry loop also needs an explicit success state because the previous final `$?` check could become unreliable after the loop body had already handled the failed command.