### PR TITLE
Introduce Deployoholics notification action [WPB-22420]

### DIFF
--- a/.github/actions/notify-deployoholics/action.yml
+++ b/.github/actions/notify-deployoholics/action.yml
@@ -1,0 +1,26 @@
+---
+name: Notify Deployoholics
+description: Send a message to the Deployoholics Wire channel.
+
+inputs:
+  webhook-url:
+    description: Deployoholics Wire webhook URL.
+    required: true
+  text:
+    description: Wire message text.
+    required: true
+  status:
+    description: Wire notification status.
+    required: false
+    default: failure
+
+runs:
+  using: composite
+  steps:
+    - name: Send Wire notification
+      uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook-url }}
+      with:
+        status: ${{ inputs.status }}
+        text: ${{ inputs.text }}

--- a/.github/workflows/precommit-slot-run.yml
+++ b/.github/workflows/precommit-slot-run.yml
@@ -128,10 +128,9 @@ jobs:
 
     steps:
       - name: Announce failed critical flow
-        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+        uses: ./.github/actions/notify-deployoholics
         with:
+          webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
           status: failure
           text: |
             ❌ Playwright Critical Flow failed ❌

--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -261,10 +261,9 @@ jobs:
 
     steps:
       - name: Announce wire-builds bump failure
-        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+        uses: ./.github/actions/notify-deployoholics
         with:
+          webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
           status: failure
           text: |
             ❌ wire-builds chart bump failed for ${{ needs.build.outputs.release_name }} ❌
@@ -389,10 +388,9 @@ jobs:
 
     steps:
       - name: Announce deployment failure
-        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+        uses: ./.github/actions/notify-deployoholics
         with:
+          webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
           status: failure
           text: |
             ❌ Deployment failed for ${{ needs.build.outputs.release_name }} ❌

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -150,10 +150,9 @@ jobs:
 
     steps:
       - name: Announce production redeploy failure
-        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+        uses: ./.github/actions/notify-deployoholics
         with:
+          webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
           status: failure
           text: |
             ❌ Production redeploy failed for tag ${{ needs.validate_request.outputs.tag }} ❌

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -545,10 +545,9 @@ jobs:
 
     steps:
       - name: Announce release failure
-        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+        uses: ./.github/actions/notify-deployoholics
         with:
+          webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
           status: failure
           text: |
             Release Cloud failed for ${{ needs.build_artifact.outputs.release_branch || inputs.release_branch }} (${{ needs.build_artifact.outputs.release_identifier || needs.build_artifact.outputs.release_branch || inputs.release_branch }})

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -249,10 +249,9 @@ jobs:
 
     steps:
       - name: Announce Production rollback failure
-        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+        uses: ./.github/actions/notify-deployoholics
         with:
+          webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
           status: failure
           text: |
             Production rollback failed for tag ${{ needs.validate_request.outputs.production_tag || inputs.production_tag }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Add a small local composite action for Deployoholics notifications
- Replace repeated `8398a7/action-slack` wiring in deployment and release workflows
- Keep workflow-specific `if` conditions, `needs`, and message text unchanged

## Why

Several workflows used the same pinned Slack action setup with the Deployoholics webhook. This change centralizes the transport detail in one local composite action without turning the workflow-specific notification messages into a generic framework.