### PR TITLE
Enable strict boolean expressions for core [WPB-22420]

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -253,6 +253,7 @@ const config: Linter.Config[] = [
       'libraries/api-client/**/*.{ts,tsx}',
       'libraries/commons/**/*.{ts,tsx}',
       'libraries/certificate-check/**/*.{ts,tsx}',
+      'libraries/core/**/*.{ts,tsx}',
       'libraries/copy-config/**/*.{ts,tsx}',
       'libraries/license-collector/**/*.{ts,tsx}',
       'libraries/store-engine/**/*.{ts,tsx}',

--- a/libraries/core/src/account.ts
+++ b/libraries/core/src/account.ts
@@ -220,7 +220,7 @@ export class Account extends TypedEventEmitter<Events> {
     });
 
     apiClient.on(APIClient.TOPIC.COOKIE_REFRESH, async (cookie?: Cookie) => {
-      if (cookie && this.storeEngine) {
+      if (cookie !== undefined && this.storeEngine !== undefined) {
         try {
           await this.persistCookie(this.storeEngine, cookie);
         } catch (error: unknown) {
@@ -293,7 +293,7 @@ export class Account extends TypedEventEmitter<Events> {
     const context = this.apiClient.context;
     const domain = context?.domain ?? '';
 
-    if (!this.currentClient) {
+    if (this.currentClient === undefined) {
       throw new Error('Client has not been initialized - please login first');
     }
 
@@ -376,7 +376,7 @@ export class Account extends TypedEventEmitter<Events> {
     entropyData?: Uint8Array,
     clientInfo: ClientInfo = coreDefaultClient,
   ): Promise<RegisteredClient> => {
-    if (!this.service || !this.apiClient.context || !this.storeEngine) {
+    if (this.service === undefined || this.apiClient.context === undefined || this.storeEngine === undefined) {
       throw new Error('Services are not set or context not initialized.');
     }
 
@@ -414,7 +414,7 @@ export class Account extends TypedEventEmitter<Events> {
    * @returns The local existing client or undefined if the client does not exist or is not valid (non existing on backend)
    */
   public initClient = async (client: RegisteredClient, mlsConfig?: InitClientOptions) => {
-    if (!this.service || !this.apiClient.context || !this.storeEngine) {
+    if (this.service === undefined || this.apiClient.context === undefined || this.storeEngine === undefined) {
       throw new Error('Services are not set.');
     }
     this.apiClient.context.clientId = client.id;
@@ -424,7 +424,7 @@ export class Account extends TypedEventEmitter<Events> {
 
     await this.service.proteus.initClient(this.apiClient.context);
 
-    if ((await this.isMLSActiveForClient()) && this.service.mls && mlsConfig) {
+    if ((await this.isMLSActiveForClient()) && this.service.mls !== undefined && mlsConfig !== undefined) {
       const {userId, domain = ''} = this.apiClient.context;
       await this.service.mls.initClient({id: userId, domain}, client, mlsConfig);
 
@@ -486,9 +486,10 @@ export class Account extends TypedEventEmitter<Events> {
 
   private readonly initServices = async (context: Context): Promise<void> => {
     const encryptedStoreName = this.generateEncryptedDbName(context);
-    this.encryptedDb = this.options.systemCrypto
-      ? await createCustomEncryptedStore(encryptedStoreName, this.options.systemCrypto)
-      : await createEncryptedStore(encryptedStoreName);
+    this.encryptedDb =
+      this.options.systemCrypto !== undefined
+        ? await createCustomEncryptedStore(encryptedStoreName, this.options.systemCrypto)
+        : await createEncryptedStore(encryptedStoreName);
     this.db = await openDB(this.generateCoreDbName(context));
     this.storeEngine = await this.initEngine(context, this.encryptedDb);
 
@@ -601,7 +602,7 @@ export class Account extends TypedEventEmitter<Events> {
     }
 
     try {
-      if (this.storeEngine) {
+      if (this.storeEngine !== undefined) {
         await wipeCoreCryptoDb(this.storeEngine);
       }
     } catch (error: unknown) {
@@ -621,7 +622,7 @@ export class Account extends TypedEventEmitter<Events> {
    */
   private readonly wipeAllData = async (): Promise<void> => {
     try {
-      if (this.storeEngine) {
+      if (this.storeEngine !== undefined) {
         await deleteIdentity(this.storeEngine, false);
       }
     } catch (error: unknown) {
@@ -629,7 +630,7 @@ export class Account extends TypedEventEmitter<Events> {
     }
 
     try {
-      if (this.db) {
+      if (this.db !== undefined) {
         await deleteDB(this.db);
       }
     } catch (error: unknown) {
@@ -645,7 +646,7 @@ export class Account extends TypedEventEmitter<Events> {
    */
   private readonly wipeCryptoData = async (): Promise<void> => {
     try {
-      if (this.storeEngine) {
+      if (this.storeEngine !== undefined) {
         await deleteIdentity(this.storeEngine, true);
       }
     } catch (error: unknown) {
@@ -713,7 +714,7 @@ export class Account extends TypedEventEmitter<Events> {
      */
     dryRun?: boolean;
   } = {}): Promise<() => void> => {
-    if (!this.currentClient) {
+    if (this.currentClient === undefined) {
       throw new Error('Client has not been initialized - please login first');
     }
 
@@ -894,9 +895,8 @@ export class Account extends TypedEventEmitter<Events> {
           try {
             const start = Date.now();
             const firstNotificationPayload = notification.payload[0];
-            const notificationTime = firstNotificationPayload
-              ? this.getNotificationEventTime(firstNotificationPayload)
-              : null;
+            const notificationTime =
+              firstNotificationPayload !== undefined ? this.getNotificationEventTime(firstNotificationPayload) : null;
             this.logger.info(`Processing legacy notification "${notification.id}" at ${notificationTime}`);
             this.logger.info(`Total notifications queue length: ${this.notificationProcessingQueue.getLength()}`);
             this.logger.info(`Total pending proposals queue length: ${getProposalQueueLength()}`);
@@ -1031,7 +1031,8 @@ export class Account extends TypedEventEmitter<Events> {
       const payloads = this.service!.notification.handleNotification(notification.data.event, source);
 
       const firstEventPayload = notification.data.event.payload[0];
-      const notificationTime = firstEventPayload ? this.getNotificationEventTime(firstEventPayload) : null;
+      const notificationTime =
+        firstEventPayload !== undefined ? this.getNotificationEventTime(firstEventPayload) : null;
       if (!this.isConnectionLive() && is.nonEmptyString(notificationTime)) {
         onNotificationStreamProgress(notificationTime);
       }
@@ -1244,7 +1245,7 @@ export class Account extends TypedEventEmitter<Events> {
   };
 
   public getClientCapabilities = () => {
-    return this.currentClient?.capabilities || [];
+    return this.currentClient?.capabilities ?? [];
   };
 
   public static checkIsConsumable = (
@@ -1278,7 +1279,7 @@ export class Account extends TypedEventEmitter<Events> {
     const openDb = async () => {
       const dbKey = await generateSecretKey({keyId: 'db-key', keySize: 32, secretsDb: encryptedStore});
       const initializedDb = await this.options.createStore?.(dbName, dbKey.key);
-      if (initializedDb) {
+      if (initializedDb !== undefined) {
         this.logger.debug(`Initialized store with existing engine "${dbName}".`);
         return initializedDb;
       }
@@ -1289,7 +1290,7 @@ export class Account extends TypedEventEmitter<Events> {
     };
     const storeEngine = await openDb();
     const cookie = CookieStore.getCookie();
-    if (cookie) {
+    if (cookie !== undefined) {
       await this.persistCookie(storeEngine, cookie);
     }
     return storeEngine;

--- a/libraries/core/src/client/clientService.ts
+++ b/libraries/core/src/client/clientService.ts
@@ -167,7 +167,7 @@ export class ClientService {
     {prekeys, lastPrekey}: InitialPrekeys,
     useLegacyNotificationStream: boolean = true,
   ): Promise<RegisteredClient> {
-    if (!this.apiClient.context) {
+    if (this.apiClient.context === undefined) {
       throw new Error('Context is not set.');
     }
 

--- a/libraries/core/src/conversation/conversationService/conversationService.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.ts
@@ -117,7 +117,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     this.messageTimer = new MessageTimer();
 
     // Make MLS recovery orchestrator mandatory in this service
-    if (!this._mlsService) {
+    if (this._mlsService === undefined) {
       throw new Error('MLSService is required to construct ConversationService with MLS capabilities');
     }
 
@@ -147,7 +147,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
   }
 
   get mlsService(): MLSService {
-    if (!this._mlsService) {
+    if (this._mlsService === undefined) {
       throw new Error('Cannot do MLS operations on a non-mls environment');
     }
     return this._mlsService;
@@ -211,7 +211,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
   }
 
   public async getConversations(conversationIds?: QualifiedId[]): Promise<RemoteConversations> {
-    if (!conversationIds) {
+    if (conversationIds === undefined) {
       const conversationIdsToSkip = await this.coreDatabase.getAll('conversationBlacklist');
       return this.apiClient.api.conversation.getConversationList(conversationIdsToSkip);
     }
@@ -471,7 +471,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     const sentAt = response.time?.length > 0 ? response.time : new Date().toISOString();
 
     const failedToSend =
-      response?.failed || (response?.failed_to_send ?? []).length > 0
+      response.failed !== undefined || (response.failed_to_send ?? []).length > 0
         ? {
             queued: response?.failed_to_send,
             failed: response?.failed,
@@ -482,7 +482,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
       id: payload.messageId,
       sentAt,
       failedToSend,
-      state: sentAt ? MessageSendingState.OUTGOING_SENT : MessageSendingState.CANCELED,
+      state: sentAt.length > 0 ? MessageSendingState.OUTGOING_SENT : MessageSendingState.CANCELED,
     };
   }
 
@@ -642,7 +642,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
     const conversation = await this.getConversationByGroupId(groupId);
 
-    if (!conversation) {
+    if (conversation === undefined) {
       this.logger.warn(`No conversation found for group ${groupId}`, {error});
       return;
     }
@@ -799,7 +799,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
     //fetch all the mls conversations from backend
     const conversations = await this.apiClient.api.conversation.getConversationList();
-    const foundConversations = conversations.found || [];
+    const foundConversations = conversations.found ?? [];
 
     const mlsConversations = foundConversations.filter(isMLSConversation);
 
@@ -1098,7 +1098,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
   private async handleMLSMessageAddEvent(event: ConversationMLSMessageAddEvent): Promise<HandledEventPayload | null> {
     try {
       const {qualified_conversation: qualifiedConversationId, subconv} = event;
-      if (!qualifiedConversationId) {
+      if (qualifiedConversationId === undefined) {
         throw new Error('Qualified conversation id is missing in the MLS message-add event');
       }
       return await this.MLSRecoveryOrchestrator.execute<HandledEventPayload | null>({
@@ -1226,7 +1226,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
   private async isConversationBlacklisted(conversationId: string): Promise<boolean> {
     const foundEntry = await this.coreDatabase.get('conversationBlacklist', conversationId);
-    return !!foundEntry;
+    return foundEntry !== undefined;
   }
 
   /**

--- a/libraries/core/src/conversation/conversationService/utility/getConversationQualifiedMembers.ts
+++ b/libraries/core/src/conversation/conversationService/utility/getConversationQualifiedMembers.ts
@@ -33,10 +33,10 @@ const getConversationQualifiedMembers = async ({apiClient, conversationId}: Para
    * other clients.
    */
   const filteredConversations = conversation.members.others
-    .filter(member => !!member.qualified_id)
-    .map(member => member.qualified_id!);
+    .filter((member): member is typeof member & {qualified_id: QualifiedId} => member.qualified_id !== undefined)
+    .map(member => member.qualified_id);
 
-  if (conversation.members.self?.qualified_id) {
+  if (conversation.members.self?.qualified_id !== undefined) {
     filteredConversations.push(conversation.members.self.qualified_id);
   }
 

--- a/libraries/core/src/conversation/message/messageToProtoMapper.ts
+++ b/libraries/core/src/conversation/message/messageToProtoMapper.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import is from '@sindresorhus/is';
+
 import {Article, Asset, LinkPreview, Mention, Quote, Text, Tweet} from '@wireapp/protocol-messaging';
 
 import {EditedTextContent, LinkPreviewUploadedContent, TextContent} from '../content';
@@ -35,7 +37,7 @@ export class MessageToProtoMapper {
         urlOffset: linkPreview.urlOffset,
       });
 
-      if (linkPreview.tweet) {
+      if (!is.nullOrUndefined(linkPreview.tweet)) {
         linkPreviewMessage.tweet = Tweet.create({
           author: linkPreview.tweet.author,
           username: linkPreview.tweet.username,
@@ -43,7 +45,7 @@ export class MessageToProtoMapper {
         linkPreviewMessage.metaData = 'tweet';
       }
 
-      if (linkPreview.imageUploaded) {
+      if (linkPreview.imageUploaded !== undefined) {
         const {asset, image} = linkPreview.imageUploaded;
 
         const imageMetadata = Asset.ImageMetaData.create({
@@ -103,7 +105,7 @@ export class MessageToProtoMapper {
       textMessage.mentions = mentions.map(mention => Mention.create(mention));
     }
 
-    if (quote) {
+    if (quote !== undefined) {
       textMessage.quote = Quote.create({
         quotedMessageId: quote.quotedMessageId,
         quotedMessageSha256: quote.quotedMessageSha256,

--- a/libraries/core/src/conversation/message/textContentBuilder.ts
+++ b/libraries/core/src/conversation/message/textContentBuilder.ts
@@ -54,7 +54,7 @@ export class TextContentBuilder<T extends TextContent | EditedTextContent> {
   }
 
   withQuote(quote?: QuoteContent) {
-    if (quote) {
+    if (quote !== undefined) {
       this.content.quote = quote as QuoteContent;
     }
 

--- a/libraries/core/src/conversation/message/userClientsUtil.ts
+++ b/libraries/core/src/conversation/message/userClientsUtil.ts
@@ -43,7 +43,7 @@ export function flattenUserMap<T = unknown>(userMap: QualifiedUserMap<T>): {data
  */
 export function nestUsersList<T = unknown>(users: {data: T; userId: QualifiedId}[]): QualifiedUserMap<T> {
   return users.reduce((users, {data, userId: {domain, id}}) => {
-    if (!users[domain]) {
+    if (users[domain] === undefined) {
       users[domain] = {};
     }
     users[domain][id] = data;

--- a/libraries/core/src/conversation/subconversationService/subconversationService.ts
+++ b/libraries/core/src/conversation/subconversationService/subconversationService.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import is from '@sindresorhus/is';
 import {SUBCONVERSATION_ID, Subconversation} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
@@ -54,7 +55,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
   }
 
   get mlsService(): MLSService {
-    if (!this._mlsService) {
+    if (this._mlsService === undefined) {
       throw new Error('MLSService was not initialised!');
     }
     return this._mlsService;
@@ -268,7 +269,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
       if (groupId !== subconversationGroupId) {
         // if the epoch update did not happen in the subconversation directly, check if it happened in the parent conversation
         const parentConversationId = findConversationByGroupId(groupId);
-        if (!parentConversationId) {
+        if (parentConversationId === undefined) {
           this.logger.debug('Ignoring NEW_EPOCH event: could not map to parent conversation');
           return;
         }
@@ -294,7 +295,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
         parentConversationGroupId,
       );
 
-      if (!subconversationEpochInfo) {
+      if (is.nullOrUndefined(subconversationEpochInfo)) {
         this.logger.debug('No subconversation epoch info available; skipping callback', {
           parentConversationId,
           parentConversationGroupId,

--- a/libraries/core/src/cryptography/messageHashService.ts
+++ b/libraries/core/src/cryptography/messageHashService.ts
@@ -63,7 +63,7 @@ export class MessageHashService {
   }
 
   private getAssetBytes(content: AssetContent): Buffer {
-    if (content.uploaded) {
+    if (content.uploaded !== undefined) {
       const assetId = content.uploaded.assetId;
       return this.convertToUtf16BE(assetId);
     }

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/e2eiServiceExternal.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/e2eiServiceExternal.ts
@@ -73,7 +73,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
   // If we have a handle in the local storage, we are in the enrollment process (this handle is saved before oauth redirect)
   public async isEnrollmentInProgress(): Promise<boolean> {
     const data = await this.enrollmentStorage.getPendingEnrollmentData();
-    return !!data;
+    return data !== undefined;
   }
 
   public clearAllProgress() {
@@ -138,7 +138,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
 
     const mappedUserIdentities = new Map<StringifiedQualifiedId, DeviceIdentity[]>();
     for (const userId of userIds) {
-      const identities = (userIdentities.get(userId.id) || []).map(identity => ({
+      const identities = (userIdentities.get(userId.id) ?? []).map(identity => ({
         ...identity,
         deviceId: parseFullQualifiedClientId(identity.clientId).client,
         qualifiedUserId: userId,
@@ -205,7 +205,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
 
   public async isFreshMLSSelfClient(): Promise<boolean> {
     const client = await this.clientService.loadClient();
-    return !client || !this.mlsService.isInitializedMLSClient(client);
+    return client === undefined || !this.mlsService.isInitializedMLSClient(client);
   }
 
   private async registerLocalCertificateRoot(acmeService: AcmeService): Promise<string> {
@@ -249,7 +249,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
   }
 
   private get acmeService(): AcmeService {
-    if (!this._acmeService) {
+    if (this._acmeService === undefined) {
       throw new Error('AcmeService not initialized');
     }
     return this._acmeService;

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/e2eiServiceInternal.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/e2eiServiceInternal.ts
@@ -78,10 +78,10 @@ export class E2EIServiceInternal {
   ) {
     const stashedEnrollmentData = await this.enrollmentStorage.getPendingEnrollmentData();
 
-    if (stashedEnrollmentData !== undefined) {
+    if (!is.undefined(stashedEnrollmentData)) {
       // In case we have stashed data, we continue the enrollment flow (we are coming back from a redirect)
       const oAuthToken = await getOAuthToken();
-      if (oAuthToken === undefined || oAuthToken.length === 0) {
+      if (is.undefined(oAuthToken) || is.emptyString(oAuthToken)) {
         throw new Error('No OAuthToken received for in progress enrollment process');
       }
       return this.continueCertificateGeneration(oAuthToken, stashedEnrollmentData, getAllConversations, ciphersuite);
@@ -104,7 +104,7 @@ export class E2EIServiceInternal {
 
     // At this point we might be redirected to the identity provider. We have
     const oAuthToken = await getOAuthToken(challengeData);
-    if (oAuthToken === undefined || oAuthToken.length === 0) {
+    if (is.undefined(oAuthToken) || is.emptyString(oAuthToken)) {
       throw new Error('No OAuthToken received for in initial enrollment process');
     }
     return this.continueCertificateGeneration(oAuthToken, enrollmentData, getAllConversations, ciphersuite);
@@ -138,7 +138,7 @@ export class E2EIServiceInternal {
   private async getDirectory(identity: E2eiEnrollment, connection: AcmeService): Promise<AcmeDirectory | undefined> {
     const directory = await connection.getDirectory();
 
-    if (directory !== undefined) {
+    if (!is.undefined(directory)) {
       const parsedDirectory = identity.directoryResponse(directory);
       return parsedDirectory;
     }
@@ -147,7 +147,7 @@ export class E2EIServiceInternal {
 
   private async getInitialNonce(directory: AcmeDirectory, connection: AcmeService): Promise<string> {
     const nonce = await connection.getInitialNonce(directory.newNonce);
-    if (nonce === undefined || nonce.length === 0) {
+    if (is.undefined(nonce) || is.emptyString(nonce)) {
       throw new Error('No initial-nonce received');
     }
     return nonce;
@@ -163,13 +163,13 @@ export class E2EIServiceInternal {
     // Get the directory
     const {acmeService: acmeService} = this;
     const directory = await this.getDirectory(identity, acmeService);
-    if (directory === undefined) {
+    if (is.undefined(directory)) {
       throw new Error('Error while trying to start OAuth flow. No directory received');
     }
 
     // Step 1: Get a new nonce from ACME server
     const nonce = await this.getInitialNonce(directory, acmeService);
-    if (nonce.length === 0) {
+    if (is.emptyString(nonce)) {
       throw new Error('Error while trying to start OAuth flow. No nonce received');
     }
 
@@ -255,7 +255,7 @@ export class E2EIServiceInternal {
       orderUrl: enrollmentData.orderUrl,
     });
 
-    if (!finalizeOrderData.certificateUrl) {
+    if (is.emptyString(finalizeOrderData.certificateUrl)) {
       throw new Error('Error while trying to continue OAuth flow. No certificateUrl received');
     }
 
@@ -267,7 +267,7 @@ export class E2EIServiceInternal {
       identity,
     });
 
-    if (!certificate) {
+    if (is.emptyString(certificate)) {
       throw new Error('Error while trying to continue OAuth flow. No certificate received');
     }
 

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/authorization.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/authorization.ts
@@ -56,7 +56,7 @@ export const getAuthorizationChallenges = async ({
   const {challenge: oidcChallenge} = challenges.find(challenge => challenge.type.includes('oidc')) ?? {};
   const {challenge: dpopChallenge} = challenges.find(challenge => challenge.type.includes('dpop')) ?? {};
 
-  if (!dpopChallenge || !oidcChallenge) {
+  if (dpopChallenge === undefined || oidcChallenge === undefined) {
     throw new Error('missing dpop or oidc challenge');
   }
   // manual copy of the wasm data because of a problem while cloning it

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/certificate.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/certificate.ts
@@ -31,7 +31,7 @@ export const getCertificate = async ({certificateUrl, connection, identity, nonc
 
   const certificateResponse = await connection.getCertificate(certificateUrl, reqBody);
 
-  if (certificateResponse?.data) {
+  if (certificateResponse?.data !== undefined && certificateResponse.data.length > 0) {
     return {
       certificate: certificateResponse.data,
       nonce: certificateResponse.nonce,

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/dpopChallenge/dpopChallenge.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/dpopChallenge/dpopChallenge.ts
@@ -24,7 +24,7 @@ import {DoWireDpopChallengeParams, GetClientNonceParams} from './dpopChallenge.t
 const getClientNonce = async ({apiClient, clientId}: GetClientNonceParams) => {
   try {
     const nonce = await apiClient.api.client.getNonce(clientId);
-    if (nonce) {
+    if (nonce.length > 0) {
       return nonce;
     }
     throw new Error('No client-nonce received');

--- a/libraries/core/src/messagingProtocols/mls/eventHandler/events/messageAdd/messageAdd.ts
+++ b/libraries/core/src/messagingProtocols/mls/eventHandler/events/messageAdd/messageAdd.ts
@@ -67,14 +67,14 @@ export const handleMLSMessageAdd = async ({
     qualifiedConversationId,
   );
 
-  if (!decryptedMessage) {
+  if (decryptedMessage === undefined) {
     // If the message is not decrypted, we return null
     return null;
   }
 
   const {message, commitDelay, senderClientId: encodedSenderClientId} = decryptedMessage;
 
-  if (encodedSenderClientId) {
+  if (encodedSenderClientId !== undefined) {
     const decoder = new TextDecoder();
     const senderClientId = decoder.decode(optionalToUint8Array(encodedSenderClientId.copyBytes()));
     event.senderClientId = senderClientId;
@@ -95,5 +95,5 @@ export const handleMLSMessageAdd = async ({
     });
   }
 
-  return message ? {event, decryptedData: GenericMessage.decode(message)} : null;
+  return message !== undefined ? {event, decryptedData: GenericMessage.decode(message)} : null;
 };

--- a/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.ts
+++ b/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.ts
@@ -172,11 +172,11 @@ export class MLSService extends TypedEventEmitter<Events> {
    * return true if the MLS service if configured and ready to be used
    */
   get isEnabled() {
-    return !!this._config;
+    return this._config !== undefined;
   }
 
   get config() {
-    if (!this._config) {
+    if (this._config === undefined) {
       throw new Error('mls config is not set, did you forget to call initClient?');
     }
     return this._config;
@@ -262,12 +262,12 @@ export class MLSService extends TypedEventEmitter<Events> {
     const bundlePayload = new Uint8Array([
       ...commit,
       ...groupInfo.payload.copyBytes(),
-      ...(welcome?.copyBytes() || []),
+      ...(welcome?.copyBytes() ?? []),
     ]);
     try {
       const response = await this.apiClient.api.conversation.postMlsCommitBundle(bundlePayload);
 
-      if (response.failed_to_send) {
+      if (response.failed_to_send !== undefined) {
         this.logger.warn(`Failed to send commit bundle to backend`);
         return 'retry';
       }
@@ -532,7 +532,7 @@ export class MLSService extends TypedEventEmitter<Events> {
   }
 
   private dispatchNewCrlDistributionPoints(crlNewDistributionPoints: NewCrlDistributionPoints) {
-    if (crlNewDistributionPoints && crlNewDistributionPoints.length > 0) {
+    if (crlNewDistributionPoints !== undefined && crlNewDistributionPoints.length > 0) {
       this.emit(MLSServiceEvents.NEW_CRL_DISTRIBUTION_POINTS, crlNewDistributionPoints);
     }
   }

--- a/libraries/core/src/messagingProtocols/mls/recovery/mlsRecoveryOrchestrator.ts
+++ b/libraries/core/src/messagingProtocols/mls/recovery/mlsRecoveryOrchestrator.ts
@@ -226,7 +226,7 @@ export class MlsRecoveryOrchestratorImpl implements MlsRecoveryOrchestrator {
   /** Resolve the effective policy for the mapped error and operation. Supports per-operation policies. */
   private getPolicyFor = (err: DomainMlsError, ctx: OperationContext): RecoveryPolicy => {
     const entry = this.policies[err.type];
-    if (!entry) {
+    if (entry === undefined) {
       return {action: RecoveryActionKind.Unknown, retryConfig: {maxAttempts: 0}};
     }
 
@@ -249,7 +249,7 @@ export class MlsRecoveryOrchestratorImpl implements MlsRecoveryOrchestrator {
     recoveryKey: string,
   ) {
     const id = context.qualifiedConversationId;
-    if (!id) {
+    if (id === undefined) {
       const errorMessage = `Missing conversationId for recovery action ${policy.action}`;
       this.logger.error(errorMessage);
       throw new Error(errorMessage);

--- a/libraries/core/src/messagingProtocols/proteus/eventHandler/events/otrMessageAdd/otrMessageAdd.ts
+++ b/libraries/core/src/messagingProtocols/proteus/eventHandler/events/otrMessageAdd/otrMessageAdd.ts
@@ -45,7 +45,7 @@ export const handleOtrMessageAdd = async ({
       qualified_from,
       data: {sender: clientId, text: encodedCiphertext},
     } = event;
-    const userId = qualified_from || {id: from, domain: ''};
+    const userId = qualified_from ?? {id: from, domain: ''};
     const messageBytes = Decoder.fromBase64(encodedCiphertext).asBytes;
     const now = Date.now();
     logger.info('Decrypting OTR message', {userId, clientId});

--- a/libraries/core/src/messagingProtocols/proteus/proteusService/cryptoClient/coreCryptoWrapper/coreCryptoWrapper.ts
+++ b/libraries/core/src/messagingProtocols/proteus/proteusService/cryptoClient/coreCryptoWrapper/coreCryptoWrapper.ts
@@ -209,7 +209,7 @@ export class CoreCryptoWrapper implements CryptoClient {
   }
 
   async create(nbPrekeys: number, entropy?: Uint8Array) {
-    if (entropy) {
+    if (entropy !== undefined) {
       await this.coreCrypto.reseedRng(entropy);
     }
     await this.init();

--- a/libraries/core/src/messagingProtocols/proteus/proteusService/cryptoClient/cryptoboxWrapper.ts
+++ b/libraries/core/src/messagingProtocols/proteus/proteusService/cryptoClient/cryptoboxWrapper.ts
@@ -79,7 +79,7 @@ export class CryptoboxWrapper implements CryptoClient {
         }
         return {id: -1, key: ''};
       })
-      .filter(serializedPreKey => serializedPreKey.key);
+      .filter(serializedPreKey => serializedPreKey.key.length > 0);
 
     return {
       prekeys,

--- a/libraries/core/src/messagingProtocols/proteus/utility/getGenericMessageParams.ts
+++ b/libraries/core/src/messagingProtocols/proteus/utility/getGenericMessageParams.ts
@@ -56,7 +56,7 @@ const getGenericMessageParams = async ({
   apiClient,
 }: GetGenericMessageParamsParams): GetGenericMessageParamsReturnType => {
   const plainText = GenericMessage.encode(genericMessage).finish();
-  if (targetMode !== MessageTargetMode.NONE && !userIds) {
+  if (targetMode !== MessageTargetMode.NONE && userIds === undefined) {
     throw new Error('Cannot send targetted message when no userIds are given');
   }
 

--- a/libraries/core/src/messagingProtocols/proteus/utility/sessionHandler/sessionHandler.ts
+++ b/libraries/core/src/messagingProtocols/proteus/utility/sessionHandler/sessionHandler.ts
@@ -68,7 +68,7 @@ const parseSessionId = (sessionId: string): SessionId => {
   // see https://regex101.com/r/c8FtCw/1
   const regex = /((?<domain>.+)@)?(?<userId>.+)@(?<clientId>.+)$/g;
   const match = regex.exec(sessionId);
-  if (!match || !isSessionId(match.groups)) {
+  if (match === null || !isSessionId(match.groups)) {
     throw new Error(`given session id "${sessionId}" has wrong format`);
   }
   return match.groups;
@@ -92,7 +92,7 @@ const initSession = async (
   {userId, clientId, initialPrekey}: {userId: QualifiedId; clientId: string; initialPrekey?: PreKey},
   {cryptoClient, apiClient}: {apiClient: APIClient; cryptoClient: CryptoClient},
 ): Promise<string> => {
-  const recipients = initialPrekey
+  const recipients = !is.undefined(initialPrekey)
     ? {[userId.domain]: {[userId.id]: {[clientId]: initialPrekey}}}
     : {[userId.domain]: {[userId.id]: [clientId]}};
   const {sessions} = await initSessions({
@@ -102,7 +102,7 @@ const initSession = async (
   });
   const sessionId = sessions[0];
 
-  if (sessionId === undefined) {
+  if (is.undefined(sessionId)) {
     throw new Error('Expected a session to be initialized.');
   }
 
@@ -124,7 +124,7 @@ const createSessions = async ({recipients, apiClient, cryptoClient}: CreateSessi
 
   return {
     ...result,
-    failed: failed !== undefined && failed.length > 0 ? failed : undefined,
+    failed: is.nonEmptyArray(failed) ? failed : undefined,
   };
 };
 
@@ -163,7 +163,7 @@ const initSessions = async ({
         const userPrekeys = domainMissingWithPrekey[userId.id] ?? {};
         const prekey = data[clientId];
 
-        if (prekey === undefined) {
+        if (is.nullOrUndefined(prekey)) {
           continue;
         }
 
@@ -181,19 +181,20 @@ const initSessions = async ({
     }
   }
 
-  const {sessions: prekeyCreated, unknowns: prekeyUnknows} =
-    Object.keys(missingClientsWithPrekeys).length > 0
-      ? await createSessionsFromPreKeys({
-          recipients: missingClientsWithPrekeys,
-          cryptoClient,
-        })
-      : {sessions: [], unknowns: {}};
+  const hasMissingClientsWithPrekeys = is.nonEmptyArray(Object.keys(missingClientsWithPrekeys));
+  const {sessions: prekeyCreated, unknowns: prekeyUnknows} = hasMissingClientsWithPrekeys
+    ? await createSessionsFromPreKeys({
+        recipients: missingClientsWithPrekeys,
+        cryptoClient,
+      })
+    : {sessions: [], unknowns: {}};
 
+  const hasMissingClients = is.nonEmptyArray(Object.keys(missingClients));
   const {
     sessions: created,
     failed,
     unknowns,
-  } = Object.keys(missingClients).length > 0
+  } = hasMissingClients
     ? await createSessions({
         recipients: missingClients,
         apiClient,
@@ -206,7 +207,7 @@ const initSessions = async ({
   return {
     sessions: [...existingSessions, ...prekeyCreated, ...created],
     failed,
-    unknowns: Object.keys(allUnknowns).length > 0 ? allUnknowns : undefined,
+    unknowns: is.nonEmptyArray(Object.keys(allUnknowns)) ? allUnknowns : undefined,
   };
 };
 
@@ -241,7 +242,7 @@ const createSessionsFromPreKeys = async ({
         const sessionId = constructSessionId({userId: {id: userId, domain}, clientId});
         const prekey = userClients[clientId];
 
-        if (!prekey) {
+        if (is.nullOrUndefined(prekey)) {
           const domainUnknowns = unknowns[domain] ?? {};
           domainUnknowns[userId] = domainUnknowns[userId] ?? [];
           domainUnknowns[userId].push(clientId);
@@ -269,7 +270,7 @@ type EncryptedPayloads<T> = Record<string, Record<string, Record<string, T>>>;
 const buildEncryptedPayloads = <T>(payloads: Map<string, T>): EncryptedPayloads<T> => {
   return [...payloads].reduce((acc, [sessionId, payload]) => {
     const {userId, domain, clientId} = parseSessionId(sessionId);
-    if (domain === undefined || domain.length === 0) {
+    if (is.undefined(domain) || is.emptyString(domain)) {
       throw new Error('Invalid session ID');
     }
     const domainPayloads = acc[domain] ?? {};

--- a/libraries/core/src/notification/notificationService.ts
+++ b/libraries/core/src/notification/notificationService.ts
@@ -103,7 +103,7 @@ export class NotificationService extends TypedEventEmitter<Events> {
 
   public async hasHistory(): Promise<boolean> {
     const notificationEvents = await this.getNotificationEventList();
-    return !!notificationEvents.length;
+    return notificationEvents.length > 0;
   }
 
   public getNotificationEventList(): Promise<BackendEvent[]> {

--- a/libraries/core/src/secretStore/encryptedStore.ts
+++ b/libraries/core/src/secretStore/encryptedStore.ts
@@ -62,7 +62,7 @@ export class EncryptedStore<EncryptedPayload = unknown> {
 
   async getSecretValue(primaryKey: string) {
     const result = await this.db.get('secrets', primaryKey);
-    if (!result) {
+    if (result === undefined) {
       return undefined;
     }
     return this.#decrypt(result);
@@ -123,7 +123,7 @@ export async function createEncryptedStore(dbName: string): Promise<EncryptedSto
 
   const keyPrimaryKey = 'dbKey';
   let key = await db.get('key', keyPrimaryKey);
-  if (!key) {
+  if (key === undefined) {
     key = await generateKey();
     await db.put('key', key, keyPrimaryKey);
   }

--- a/libraries/core/src/secretStore/secretKeyGenerator.ts
+++ b/libraries/core/src/secretStore/secretKeyGenerator.ts
@@ -51,12 +51,12 @@ export async function generateSecretKey({
       await secretsDb.deleteSecretValue(keyId);
       throw new CorruptedKeyError('Could not decrypt key');
     }
-    if (key && key.length !== keySize) {
+    if (key !== undefined && key.length !== keySize) {
       // If the key size is not correct, we have a corrupted key in the DB. This is unrecoverable.
       await secretsDb.deleteSecretValue(keyId);
       throw new CorruptedKeyError('Invalid key');
     }
-    if (!key) {
+    if (key === undefined) {
       key = await crypto.subtle.generateKey(
         {
           name: 'AES-GCM',

--- a/libraries/core/src/user/userService.ts
+++ b/libraries/core/src/user/userService.ts
@@ -41,7 +41,7 @@ export class UserService {
   }
 
   public async getUsers(userIds: QualifiedId[]): Promise<User[] | UsersResponse> {
-    if (!userIds.length) {
+    if (userIds.length === 0) {
       return [];
     }
     return this.apiClient.api.user.postListUsers({qualified_ids: userIds});

--- a/libraries/core/src/util/lowPrecisionTaskScheduler/lowPrecisionTaskScheduler.ts
+++ b/libraries/core/src/util/lowPrecisionTaskScheduler/lowPrecisionTaskScheduler.ts
@@ -39,11 +39,11 @@ const intervals: Record<number, {timeoutId: NodeJS.Timeout; tasks: Record<string
 
 const addTask = ({key, firingDate, task, intervalDelay}: ScheduleLowPrecisionTaskParams) => {
   const existingIntervalId = intervals[intervalDelay]?.timeoutId;
-  if (existingIntervalId) {
+  if (existingIntervalId !== undefined) {
     clearInterval(existingIntervalId);
   }
 
-  const tasks = intervals[intervalDelay]?.tasks || {};
+  const tasks = intervals[intervalDelay]?.tasks ?? {};
 
   tasks[key] = {firingDate, task};
 

--- a/libraries/core/src/util/taskScheduler/taskScheduler.ts
+++ b/libraries/core/src/util/taskScheduler/taskScheduler.ts
@@ -47,7 +47,7 @@ const addTask = ({task, firingDate, key, persist = false}: ScheduleTaskParams) =
   if (TaskSchedulerStore.has(key)) {
     TaskSchedulerStore.remove(key);
   }
-  if (activeTimeouts[key]) {
+  if (activeTimeouts[key] !== undefined) {
     cancelTask(key);
   }
 
@@ -77,7 +77,7 @@ const addTask = ({task, firingDate, key, persist = false}: ScheduleTaskParams) =
  */
 const cancelTask = (key: string) => {
   const timeout = activeTimeouts[key];
-  if (timeout) {
+  if (timeout !== undefined) {
     clearTimeout(timeout);
     delete activeTimeouts[key];
     logger.info(`Scheduled task with key "${key}" prematurely cleared`);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Add `libraries/core/**/*.{ts,tsx}` to the existing `@typescript-eslint/strict-boolean-expressions` override.
- Replace implicit truthiness checks in `libraries/core` with explicit nullish, empty string, and length checks.
- Preserve existing behavior for nullable protocol shapes, including deleted clients represented by `null` prekeys.