### PR TITLE
Use workflow branch for test report generation [WPB-26883]

### DIFF
--- a/.github/workflows/generate_test_report.yml
+++ b/.github/workflows/generate_test_report.yml
@@ -2,11 +2,6 @@ name: Generate test reports
 
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Git branch to generate the test report for'
-        required: true
-        type: string
 
 jobs:
   generate_test_report:
@@ -21,7 +16,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-          ref: refs/heads/${{ inputs.branch }}
+          ref: ${{ github.ref }}
 
       - name: Capture checked out commit SHA
         run: echo "TESTED_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
@@ -57,7 +52,7 @@ jobs:
         id: package_unit_test_reports
         continue-on-error: true
         env:
-          BRANCH: ${{ inputs.branch }}
+          BRANCH: ${{ github.ref_name }}
         run: ./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/generateUnitTestReports.ts
 
       - name: Generate app unit test report
@@ -72,7 +67,7 @@ jobs:
             cd ./apps/webapp
             node ../../node_modules/jest/bin/jest.js --config jest.report.config.cjs --coverage --coverageReporters=lcov --verbose
           ) 2>&1 | tee -a ${{ env.UNIT_TEST_REPORT_FILE }}
-          echo -e "BRANCH = ${{ inputs.branch }}" >> ${{ env.UNIT_TEST_REPORT_FILE }}
+          echo -e "BRANCH = ${{ github.ref_name }}" >> ${{ env.UNIT_TEST_REPORT_FILE }}
           echo -e "COMMIT SHA = ${TESTED_COMMIT_SHA}" >> ${{ env.UNIT_TEST_REPORT_FILE }}
           echo -e "TEST RUN DATE = $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${{ env.UNIT_TEST_REPORT_FILE }}
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26883" title="WPB-26883" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26883</a>  [Web] Adjust unit test logs for web-packages for bund deliveries
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

- remove the custom `branch` input from the Generate test reports workflow which was duplicated
- use GitHub's built-in `workflow_dispatch` branch selector as the tested branch
- check out `${{ github.ref }}`
- write `${{ github.ref_name }}` into generated package and app unit test report metadata

---

<img width="670" height="633" alt="2026-07-06 16 29 52 github com 6a5e454fe5f7" src="https://github.com/user-attachments/assets/b4020757-ccdc-4f53-a61b-97e6810585ab" />
