### PR TITLE
Remove meeting starting-soon countdown from list [WPB-20286]

### DIFF
--- a/apps/webapp/src/i18n/ar-SA.json
+++ b/apps/webapp/src/i18n/ar-SA.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/bg-BG.json
+++ b/apps/webapp/src/i18n/bg-BG.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/bn-BD.json
+++ b/apps/webapp/src/i18n/bn-BD.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/bs-BA.json
+++ b/apps/webapp/src/i18n/bs-BA.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/ca-ES.json
+++ b/apps/webapp/src/i18n/ca-ES.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/cs-CZ.json
+++ b/apps/webapp/src/i18n/cs-CZ.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/da-DK.json
+++ b/apps/webapp/src/i18n/da-DK.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/de-DE.json
+++ b/apps/webapp/src/i18n/de-DE.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Morgen",
   "meetings.meetingStatus.participating": "Anwesend",
   "meetings.meetingStatus.startedAt": "Begann {time}",
-  "meetings.meetingStatus.startingIn": "Beginnt in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/el-CY.json
+++ b/apps/webapp/src/i18n/el-CY.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/el-GR.json
+++ b/apps/webapp/src/i18n/el-GR.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/es-ES.json
+++ b/apps/webapp/src/i18n/es-ES.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/et-EE.json
+++ b/apps/webapp/src/i18n/et-EE.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/fa-IR.json
+++ b/apps/webapp/src/i18n/fa-IR.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/fi-FI.json
+++ b/apps/webapp/src/i18n/fi-FI.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/fr-FR.json
+++ b/apps/webapp/src/i18n/fr-FR.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/ga-IE.json
+++ b/apps/webapp/src/i18n/ga-IE.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/he-IL.json
+++ b/apps/webapp/src/i18n/he-IL.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/hi-IN.json
+++ b/apps/webapp/src/i18n/hi-IN.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/hr-HR.json
+++ b/apps/webapp/src/i18n/hr-HR.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/hu-HU.json
+++ b/apps/webapp/src/i18n/hu-HU.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/id-ID.json
+++ b/apps/webapp/src/i18n/id-ID.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/is-IS.json
+++ b/apps/webapp/src/i18n/is-IS.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/it-IT.json
+++ b/apps/webapp/src/i18n/it-IT.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/ja-JP.json
+++ b/apps/webapp/src/i18n/ja-JP.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/lb-LU.json
+++ b/apps/webapp/src/i18n/lb-LU.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/lt-LT.json
+++ b/apps/webapp/src/i18n/lt-LT.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/lv-LV.json
+++ b/apps/webapp/src/i18n/lv-LV.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/me-ME.json
+++ b/apps/webapp/src/i18n/me-ME.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/mk-MK.json
+++ b/apps/webapp/src/i18n/mk-MK.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/ms-MY.json
+++ b/apps/webapp/src/i18n/ms-MY.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/mt-MT.json
+++ b/apps/webapp/src/i18n/mt-MT.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/nl-NL.json
+++ b/apps/webapp/src/i18n/nl-NL.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/no-NO.json
+++ b/apps/webapp/src/i18n/no-NO.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/pl-PL.json
+++ b/apps/webapp/src/i18n/pl-PL.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/pt-BR.json
+++ b/apps/webapp/src/i18n/pt-BR.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/pt-PT.json
+++ b/apps/webapp/src/i18n/pt-PT.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/ro-RO.json
+++ b/apps/webapp/src/i18n/ro-RO.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/ru-RU.json
+++ b/apps/webapp/src/i18n/ru-RU.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Завтра",
   "meetings.meetingStatus.participating": "Участвует",
   "meetings.meetingStatus.startedAt": "Начата в {time}",
-  "meetings.meetingStatus.startingIn": "Начало в {countdown}",
   "meetings.navigation.label": "Встречи",
   "meetings.navigation.parent.label": "Встречи",
   "meetings.navigation.title": "Встречи",

--- a/apps/webapp/src/i18n/si-LK.json
+++ b/apps/webapp/src/i18n/si-LK.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/sk-SK.json
+++ b/apps/webapp/src/i18n/sk-SK.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/sl-SI.json
+++ b/apps/webapp/src/i18n/sl-SI.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/sq-AL.json
+++ b/apps/webapp/src/i18n/sq-AL.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/sr-Cyrl-ME.json
+++ b/apps/webapp/src/i18n/sr-Cyrl-ME.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/sr-SP.json
+++ b/apps/webapp/src/i18n/sr-SP.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/sv-SE.json
+++ b/apps/webapp/src/i18n/sv-SE.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/th-TH.json
+++ b/apps/webapp/src/i18n/th-TH.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/tr-CY.json
+++ b/apps/webapp/src/i18n/tr-CY.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/tr-TR.json
+++ b/apps/webapp/src/i18n/tr-TR.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/uk-UA.json
+++ b/apps/webapp/src/i18n/uk-UA.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/uz-UZ.json
+++ b/apps/webapp/src/i18n/uz-UZ.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/vi-VN.json
+++ b/apps/webapp/src/i18n/vi-VN.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/zh-CN.json
+++ b/apps/webapp/src/i18n/zh-CN.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/zh-HK.json
+++ b/apps/webapp/src/i18n/zh-HK.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/i18n/zh-TW.json
+++ b/apps/webapp/src/i18n/zh-TW.json
@@ -1274,7 +1274,6 @@
   "meetings.list.tomorrow": "Tomorrow",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
-  "meetings.meetingStatus.startingIn": "Starting in {countdown}",
   "meetings.navigation.label": "Meetings",
   "meetings.navigation.parent.label": "Meetings",
   "meetings.navigation.title": "Meetings",

--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingStatus/MeetingStatus.styles.ts
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingStatus/MeetingStatus.styles.ts
@@ -27,12 +27,6 @@ export const participatingStatusStyles = {
   alignItems: 'center',
 };
 
-export const startingSoonStatusStyles: CSSObject = {
-  color: 'var(--accent-color)',
-  textTransform: 'uppercase',
-  fontWeight: 'var(--font-weight-semibold)',
-};
-
 export const participatingStatusIconStyles = {
   marginRight: '8px',
   fill: 'var(--accent-color)',

--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingStatus/MeetingStatus.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingStatus/MeetingStatus.tsx
@@ -27,11 +27,9 @@ import {
   joinButtonStyles,
   participatingStatusIconStyles,
   participatingStatusStyles,
-  startingSoonStatusStyles,
 } from 'Components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingStatus/MeetingStatus.styles';
-import {getCountdownSeconds, getMeetingStatusAt, MeetingStatuses} from 'Components/Meeting/utils/MeetingStatusUtil';
+import {getMeetingStatusAt, MeetingStatuses} from 'Components/Meeting/utils/MeetingStatusUtil';
 import {useApplicationContext} from 'src/script/page/rootProvider';
-import {formatSeconds} from 'Util/timeUtil';
 
 export interface MeetingStatusProps {
   start_date: string;
@@ -65,15 +63,6 @@ const MeetingStatusComponent = ({start_date, end_date, attending, nowMs}: Meetin
         </Button>
       </div>
     );
-  }
-
-  if (meetingStatus === MeetingStatuses.STARTING_SOON) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const countdown = useMemo(() => {
-      const seconds = getCountdownSeconds(timestamp, start_date);
-      return formatSeconds(seconds);
-    }, [timestamp, start_date]);
-    return <div css={startingSoonStatusStyles}>{translate('meetings.meetingStatus.startingIn', {countdown})}</div>;
   }
 
   return null;

--- a/apps/webapp/src/script/components/Meeting/utils/MeetingStatusUtil.ts
+++ b/apps/webapp/src/script/components/Meeting/utils/MeetingStatusUtil.ts
@@ -18,25 +18,13 @@
  */
 
 import {Meeting} from 'Components/Meeting/MeetingList/MeetingList';
-import {TIME_IN_MILLIS} from 'Util/timeUtil';
 
 export enum MeetingStatuses {
   ON_GOING = 'on_going',
-  STARTING_SOON = 'starting_soon',
   PARTICIPATING = 'participating',
   UPCOMING = 'upcoming',
   PAST = 'past',
 }
-
-/**
- * Threshold in minutes to determine if a meeting is starting soon.
- */
-const STARTING_SOON_THRESHOLD_MINUTES = 5;
-
-/**
- * Threshold in milliseconds to determine if a meeting is starting soon.
- */
-export const STARTING_SOON_THRESHOLD_MS = STARTING_SOON_THRESHOLD_MINUTES * TIME_IN_MILLIS.MINUTE;
 
 /**
  * Filters the list of meetings to return only those that are ongoing at the specified time.
@@ -78,21 +66,5 @@ export const getMeetingStatusAt = (
     return attending ? MeetingStatuses.PARTICIPATING : MeetingStatuses.ON_GOING;
   }
 
-  if (startMs <= nowMs + STARTING_SOON_THRESHOLD_MS) {
-    return MeetingStatuses.STARTING_SOON;
-  }
-
   return MeetingStatuses.UPCOMING;
-};
-
-/**
- * Calculates the countdown in seconds until a meeting starts.
- *
- * @param {number} nowMs - The current time in milliseconds.
- * @param {string} start_date - The start date of the meeting in ISO format.
- * @returns {number} - The countdown in seconds, or 0 if the meeting has already started.
- */
-export const getCountdownSeconds = (nowMs: number, start_date: string): number => {
-  const startMs = new Date(start_date).getTime();
-  return Math.max(0, Math.ceil((startMs - nowMs) / TIME_IN_MILLIS.SECOND));
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20286" title="WPB-20286" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20286</a>  [Web] Meeting options menu
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Remove the "Starting in {countdown}" status from meeting list items
- Remove `STARTING_SOON` meeting status, countdown helpers, and related styles
- Remove the unused `meetings.meetingStatus.startingIn` translation key from all locales

## Test plan
- [x] `yarn nx run webapp:test --testFile=src/script/components/Meeting/MeetingList/MeetingList.test.tsx`
- [x] Open the meetings list with an upcoming meeting starting within 5 minutes and confirm no "Starting in X" label is shown