### PR TITLE
Remove unimplemented meeting create conversation action [WPB-20286]

### DIFF
--- a/apps/webapp/src/i18n/ar-SA.json
+++ b/apps/webapp/src/i18n/ar-SA.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/bg-BG.json
+++ b/apps/webapp/src/i18n/bg-BG.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/bn-BD.json
+++ b/apps/webapp/src/i18n/bn-BD.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/bs-BA.json
+++ b/apps/webapp/src/i18n/bs-BA.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/ca-ES.json
+++ b/apps/webapp/src/i18n/ca-ES.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/cs-CZ.json
+++ b/apps/webapp/src/i18n/cs-CZ.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/da-DK.json
+++ b/apps/webapp/src/i18n/da-DK.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/de-DE.json
+++ b/apps/webapp/src/i18n/de-DE.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Wiedergabe",
   "meetings.action.copyLink": "Link kopieren",
-  "meetings.action.createConversation": "Unterhaltung erstellen",
   "meetings.action.createMeeting": "Meeting erstellen",
   "meetings.action.deleteMeetingForAll": "Meeting für alle löschen",
   "meetings.action.deleteMeetingForMe": "Meeting für mich löschen",

--- a/apps/webapp/src/i18n/el-CY.json
+++ b/apps/webapp/src/i18n/el-CY.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/el-GR.json
+++ b/apps/webapp/src/i18n/el-GR.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/es-ES.json
+++ b/apps/webapp/src/i18n/es-ES.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/et-EE.json
+++ b/apps/webapp/src/i18n/et-EE.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/fa-IR.json
+++ b/apps/webapp/src/i18n/fa-IR.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/fi-FI.json
+++ b/apps/webapp/src/i18n/fi-FI.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/fr-FR.json
+++ b/apps/webapp/src/i18n/fr-FR.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/ga-IE.json
+++ b/apps/webapp/src/i18n/ga-IE.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/he-IL.json
+++ b/apps/webapp/src/i18n/he-IL.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/hi-IN.json
+++ b/apps/webapp/src/i18n/hi-IN.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/hr-HR.json
+++ b/apps/webapp/src/i18n/hr-HR.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/hu-HU.json
+++ b/apps/webapp/src/i18n/hu-HU.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/id-ID.json
+++ b/apps/webapp/src/i18n/id-ID.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/is-IS.json
+++ b/apps/webapp/src/i18n/is-IS.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/it-IT.json
+++ b/apps/webapp/src/i18n/it-IT.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/ja-JP.json
+++ b/apps/webapp/src/i18n/ja-JP.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/lb-LU.json
+++ b/apps/webapp/src/i18n/lb-LU.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/lt-LT.json
+++ b/apps/webapp/src/i18n/lt-LT.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/lv-LV.json
+++ b/apps/webapp/src/i18n/lv-LV.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/me-ME.json
+++ b/apps/webapp/src/i18n/me-ME.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/mk-MK.json
+++ b/apps/webapp/src/i18n/mk-MK.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/ms-MY.json
+++ b/apps/webapp/src/i18n/ms-MY.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/mt-MT.json
+++ b/apps/webapp/src/i18n/mt-MT.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/nl-NL.json
+++ b/apps/webapp/src/i18n/nl-NL.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/no-NO.json
+++ b/apps/webapp/src/i18n/no-NO.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/pl-PL.json
+++ b/apps/webapp/src/i18n/pl-PL.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/pt-BR.json
+++ b/apps/webapp/src/i18n/pt-BR.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pausar",
   "mediaBtnPlay": "Reproduzir",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/pt-PT.json
+++ b/apps/webapp/src/i18n/pt-PT.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/ro-RO.json
+++ b/apps/webapp/src/i18n/ro-RO.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/ru-RU.json
+++ b/apps/webapp/src/i18n/ru-RU.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Пауза",
   "mediaBtnPlay": "Воспроизвести",
   "meetings.action.copyLink": "Скопировать ссылку",
-  "meetings.action.createConversation": "Создать беседу",
   "meetings.action.createMeeting": "Создать встречу",
   "meetings.action.deleteMeetingForAll": "Удалить встречу для всех",
   "meetings.action.deleteMeetingForMe": "Удалить встречу для меня",

--- a/apps/webapp/src/i18n/si-LK.json
+++ b/apps/webapp/src/i18n/si-LK.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "විරාමය",
   "mediaBtnPlay": "වාදනය",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/sk-SK.json
+++ b/apps/webapp/src/i18n/sk-SK.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/sl-SI.json
+++ b/apps/webapp/src/i18n/sl-SI.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/sq-AL.json
+++ b/apps/webapp/src/i18n/sq-AL.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/sr-Cyrl-ME.json
+++ b/apps/webapp/src/i18n/sr-Cyrl-ME.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/sr-SP.json
+++ b/apps/webapp/src/i18n/sr-SP.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/sv-SE.json
+++ b/apps/webapp/src/i18n/sv-SE.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/th-TH.json
+++ b/apps/webapp/src/i18n/th-TH.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/tr-CY.json
+++ b/apps/webapp/src/i18n/tr-CY.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/tr-TR.json
+++ b/apps/webapp/src/i18n/tr-TR.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/uk-UA.json
+++ b/apps/webapp/src/i18n/uk-UA.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/uz-UZ.json
+++ b/apps/webapp/src/i18n/uz-UZ.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/vi-VN.json
+++ b/apps/webapp/src/i18n/vi-VN.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/zh-CN.json
+++ b/apps/webapp/src/i18n/zh-CN.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/zh-HK.json
+++ b/apps/webapp/src/i18n/zh-HK.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/i18n/zh-TW.json
+++ b/apps/webapp/src/i18n/zh-TW.json
@@ -1261,7 +1261,6 @@
   "mediaBtnPause": "Pause",
   "mediaBtnPlay": "Play",
   "meetings.action.copyLink": "Copy link",
-  "meetings.action.createConversation": "Create conversation",
   "meetings.action.createMeeting": "Create meeting",
   "meetings.action.deleteMeetingForAll": "Delete meeting for everyone",
   "meetings.action.deleteMeetingForMe": "Delete meeting for me",

--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingAction/getMeetingActionEntries.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingAction/getMeetingActionEntries.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {CallIcon, CirclePlusIcon, CloseIcon, EditIcon, ShareLinkIcon, TrashIcon} from '@wireapp/react-ui-kit';
+import {CallIcon, CloseIcon, EditIcon, ShareLinkIcon, TrashIcon} from '@wireapp/react-ui-kit';
 
 import type {Meeting} from 'Components/Meeting/MeetingList/MeetingList';
 import {
@@ -54,10 +54,6 @@ export const getMeetingActionEntries = ({
     {
       icon: () => <CallIcon />,
       label: translate('meetings.action.startMeeting'),
-    },
-    {
-      icon: () => <CirclePlusIcon />,
-      label: translate('meetings.action.createConversation'),
     },
     {
       icon: () => <ShareLinkIcon />,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20286" title="WPB-20286" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20286</a>  [Web] Meeting options menu
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Remove the placeholder "Create conversation" entry from the meeting context menu
- Remove the unused `meetings.action.createConversation` translation key from all locales

## Test plan
- [x] `yarn nx run webapp:test --testFile=src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingAction/getMeetingActionEntries.test.tsx`
- [x] Open a meeting context menu and confirm "Create conversation" is no longer shown