### PR TITLE
Hide "Does not repeat" badge on meeting list items

### DIFF
--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingListItem.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingListItem.tsx
@@ -103,7 +103,7 @@ const MeetingListItemComponent = ({nowMs, ...meeting}: MeetingListItemProps) => 
           <div css={metaStyles}>
             {showCalendarIcon && <CalendarIcon css={{marginRight: '4px'}} height={12} />}
             {time}
-            {recurrence && (
+            {recurrence && recurrence !== 'doesNotRepeat' && (
               <div css={badgeWrapperStyles}>
                 <span>{translate(SCHEDULE_MEETING_RECURRENCE_TRANSLATION_KEYS[recurrence])}</span>
               </div>


### PR DESCRIPTION
## Summary
- Stop showing a recurrence badge for non-recurring meetings in the meeting list
- Keep recurrence badges for recurring meetings (daily, weekly, every two weeks, monthly)

Addresses design review feedback: "Does not repeat" should not be rendered as a label on list items.

## Test plan
- [ ] Open the meetings list with a non-recurring upcoming meeting and confirm no "Does not repeat" badge appears
- [ ] Confirm recurring meetings still show their recurrence badge (e.g. Daily, Weekly)
- [ ] Verify ongoing and past meetings are unaffected