### PR TITLE
Hide "Does not repeat" badge on meeting list items [WPB-25055]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingListItem.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingListItem.tsx
@@ -103,7 +103,7 @@ const MeetingListItemComponent = ({nowMs, ...meeting}: MeetingListItemProps) => 
           <div css={metaStyles}>
             {showCalendarIcon && <CalendarIcon css={{marginRight: '4px'}} height={12} />}
             {time}
-            {recurrence && (
+            {recurrence !== 'doesNotRepeat' && (
               <div css={badgeWrapperStyles}>
                 <span>{translate(SCHEDULE_MEETING_RECURRENCE_TRANSLATION_KEYS[recurrence])}</span>
               </div>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25055" title="WPB-25055" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25055</a>  [Web] Schedule a meeting: setup date and Repeat options
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Hide the recurrence badge for non-repeating meetings in the meeting list UI
- Repeating meetings (daily, weekly, every two weeks, monthly) continue to show their recurrence label

Addresses design review feedback: "Does not repeat" should not be displayed as a label on list items.

## Test plan

- [ ] Open the meetings list with a non-repeating meeting and confirm no recurrence badge is shown
- [ ] Open the meetings list with repeating meetings and confirm their recurrence badges still appear
- [ ] Verify ongoing and past meetings are unaffected