### PR TITLE
Fix stale webapp Jest report config [WPB-26883]

### DIFF
--- a/apps/webapp/jest.report.config.cjs
+++ b/apps/webapp/jest.report.config.cjs
@@ -24,6 +24,7 @@ module.exports = {
   collectCoverageFrom: ['src/script/**/*.{ts,tsx}', '!src/script/util/test/**/*.*'],
   moduleDirectories: ['node_modules', __dirname],
   moduleNameMapper: {
+    '^@enormora/wall-clock/(.*)$': '<rootDir>/../../node_modules/@enormora/wall-clock/$1.js',
     'Components/(.*)': '<rootDir>/src/script/components/$1',
     'Hooks/(.*)': '<rootDir>/src/script/hooks/$1',
     'I18n/(.*)': '<rootDir>/src/i18n/$1',
@@ -34,14 +35,17 @@ module.exports = {
     '.*\\.glsl': 'jest-transform-stub',
   },
   reporters: ['default'],
+  resolver: '<rootDir>/jest.resolver.cjs',
   setupFilesAfterEnv: ['<rootDir>/setupTests.js'],
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
-    customExportConditions: ['node', 'node-addons'],
+    customExportConditions: ['node', 'node-addons', 'require', 'import', 'default'],
   },
   testPathIgnorePatterns: ['<rootDir>/server', '<rootDir>/.yalc', '<rootDir>/test/e2e_tests'],
   testRunner: 'jest-jasmine2',
-  transformIgnorePatterns: ['/node_modules/(?!(true-myth|p-timeout|p-cancelable|noop-esm|uuid|@enormora/objectory)/)'],
+  transformIgnorePatterns: [
+    '/node_modules/(?!(true-myth|p-timeout|p-cancelable|noop-esm|uuid|@enormora/objectory|@enormora/wall-clock)/)',
+  ],
   transform: {
     '^.+\\.[tj]sx?$': 'babel-jest',
   },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26883" title="WPB-26883" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26883</a>  [Web] Adjust unit test logs for web-packages for bund deliveries
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
- Align the webapp Jest report config with the normal app Jest config for `@enormora/wall-clock`
- Add the custom Jest resolver used by the normal app test config
- Use the same custom export conditions needed for package resolution
- Keep `@enormora/objectory` in the ESM transform allowlist