### PR TITLE
Strip Datadog SDK from public production bundle [WPB-26956]

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -438,7 +438,7 @@ jobs:
             lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-
 
       - name: Build and package
-        run: ./bin/yarn nx run server:package
+        run: ./bin/yarn build:prod
 
       - name: Verify Quay credentials availability
         env:
@@ -458,3 +458,51 @@ jobs:
           GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
         # The third and fourth positional parameters are uniqueTagOut and commitSha; they are intentionally left empty here.
         run: ./bin/yarn docker "$PR_TAG" "" "" --pr
+
+  public-production-package:
+    runs-on: ubuntu-24.04
+    name: Public production package verification
+    if: ${{ github.event_name == 'pull_request' }}
+    needs:
+      - generated-artifacts
+      - build-libraries
+      - type-check
+      - lint-file-names
+      - lint
+      - unit-tests
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout (pull_request)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          # Uses the head commit, not the merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: ./bin/yarn --immutable
+
+      - name: Restore Nx and ESLint caches
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            .nx/cache
+            node_modules/.cache/eslint
+          key: lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-${{ github.sha }}
+          restore-keys: |
+            lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-
+
+      - name: Build and verify public production package
+        run: ./bin/yarn build:prod:public

--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -58,8 +58,13 @@ jobs:
           echo -e "SHORT COMMIT SHA = ${SHORT_COMMIT_SHA}" >> ${{ env.UNIT_TEST_REPORT_FILE }}
           echo -e "TEST RUN DATE = $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${{ env.UNIT_TEST_REPORT_FILE }}
 
-      - name: Build and package
-        run: ./bin/yarn nx run server:package
+      - name: Build and package public production
+        if: ${{ contains(inputs.tag, 'production') }}
+        run: ./bin/yarn build:prod:public
+
+      - name: Build and package internal production
+        if: ${{ !contains(inputs.tag, 'production') }}
+        run: ./bin/yarn build:prod
 
       - name: Push Docker image
         env:

--- a/.github/workflows/deploy-edge.yml
+++ b/.github/workflows/deploy-edge.yml
@@ -86,7 +86,7 @@ jobs:
         run: ./bin/yarn nx run webapp:configure
 
       - name: Build and package application
-        run: ./bin/yarn nx run server:package
+        run: ./bin/yarn build:prod
 
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -51,7 +51,7 @@ jobs:
         run: ./bin/yarn --immutable
 
       - name: Build and package
-        run: ./bin/yarn nx run server:package
+        run: ./bin/yarn build:prod
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37

--- a/.github/workflows/precommit-e2e-tests.yml
+++ b/.github/workflows/precommit-e2e-tests.yml
@@ -54,7 +54,7 @@ jobs:
 
       - run: ./bin/yarn --immutable
       - run: ./bin/yarn nx run webapp:configure
-      - run: ./bin/yarn nx run server:package
+      - run: ./bin/yarn build:prod
 
       - name: Compute target EB environment
         id: slot

--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -74,8 +74,13 @@ jobs:
       - name: Update configuration
         run: ./bin/yarn nx run webapp:configure
 
-      - name: Build and package
-        run: ./bin/yarn nx run server:package
+      - name: Build and package public production
+        if: ${{ github.ref == 'refs/heads/master' || contains(github.ref_name, 'production') }}
+        run: ./bin/yarn build:prod:public
+
+      - name: Build and package internal production
+        if: ${{ github.ref != 'refs/heads/master' && !contains(github.ref_name, 'production') }}
+        run: ./bin/yarn build:prod
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -100,7 +100,7 @@ jobs:
         run: ./bin/yarn nx run webapp:configure
 
       - name: Build and package
-        run: ./bin/yarn nx run server:package
+        run: ./bin/yarn build:prod:public
 
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -123,8 +123,13 @@ jobs:
       - name: Update configuration
         run: ./bin/yarn nx run webapp:configure
 
-      - name: Build and package
-        run: ./bin/yarn nx run server:package
+      - name: Build and package public production
+        if: ${{ inputs.promote_to_production }}
+        run: ./bin/yarn build:prod:public
+
+      - name: Build and package internal production
+        if: ${{ !inputs.promote_to_production }}
+        run: ./bin/yarn build:prod
 
       - name: Compute artifact metadata
         id: artifact_metadata

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -144,7 +144,7 @@ jobs:
       # Interim limitation: until durable release artifact storage exists, this
       # workflow rebuilds the deployable artifact from the selected Production tag.
       - name: Build and package
-        run: ./bin/yarn nx run server:package
+        run: ./bin/yarn build:prod:public
 
       - name: Compute artifact metadata
         id: artifact_metadata

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,4 +1,8 @@
 ls:
+  bin/verifyPublicProductionBundle.ts:
+    .ts: camelCase
+  bin/verifyPublicProductionBundle.test.ts:
+    .test.ts: camelCase
   libraries/config/src:
     .dir: camelCase
     .ts: camelCase

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -31,6 +31,15 @@
         "parallel": false
       }
     },
+    "package-public": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["^build"],
+      "outputs": ["{projectRoot}/dist/s3"],
+      "options": {
+        "commands": ["rimraf {projectRoot}/dist", "nx run server:build", "nx run webapp:build:production-public", "yarn verify:bundle:prod:public", "node bin/zip.js"],
+        "parallel": false
+      }
+    },
     "serve": {
       "continuous": true,
       "dependsOn": ["config-lib:build", "webapp:build-libs", "webapp:watch-deps-dynamic"],

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -8,6 +8,7 @@
     "build": "nx build webapp",
     "build:dev": "webpack --config webpack.config.dev.js --progress",
     "build:prod": "webpack --config webpack.config.js",
+    "build:prod:public": "webpack --config webpack.config.public.js",
     "test": "nx test webapp",
     "test:verbose": "nx test webapp --verbose",
     "test:watch": "nx test webapp --watch",

--- a/apps/webapp/project.json
+++ b/apps/webapp/project.json
@@ -19,6 +19,9 @@
         },
         "production": {
           "command": "yarn build:prod"
+        },
+        "production-public": {
+          "command": "yarn build:prod:public"
         }
       }
     },

--- a/apps/webapp/src/script/publicBuild/noopDataDog.test.ts
+++ b/apps/webapp/src/script/publicBuild/noopDataDog.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {initializeDataDog, isDataDogEnabled} from './noopDataDog';
+import {datadogLogs} from './noopDataDogBrowserLogs';
+import {datadogRum} from './noopDataDogBrowserRum';
+
+describe('public build DataDog no-ops', (): void => {
+  it('keeps DataDog disabled', (): void => {
+    expect(isDataDogEnabled()).toBe(false);
+  });
+
+  it('accepts the DataDog initialization calls used by the application', async (): Promise<void> => {
+    await expect(
+      initializeDataDog({} as never, {
+        domain: 'example.com',
+        id: 'user-id',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect((): void => {
+      datadogRum.init({});
+      datadogRum.setUser({id: 'user-id'});
+      datadogLogs.init({});
+      datadogLogs.setUser({id: 'user-id'});
+      datadogLogs.logger.info('message', {field: 'value'});
+    }).not.toThrow();
+  });
+});

--- a/apps/webapp/src/script/publicBuild/noopDataDog.ts
+++ b/apps/webapp/src/script/publicBuild/noopDataDog.ts
@@ -1,0 +1,29 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {Configuration} from '../Config';
+
+export function isDataDogEnabled(): boolean {
+  return false;
+}
+
+export async function initializeDataDog(config: Configuration, user: {id?: string; domain: string}): Promise<void> {
+  void config;
+  void user;
+}

--- a/apps/webapp/src/script/publicBuild/noopDataDogBrowserLogs.ts
+++ b/apps/webapp/src/script/publicBuild/noopDataDogBrowserLogs.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+function ignoreDataDogCall(...values: readonly unknown[]): void {
+  void values;
+}
+
+export const datadogLogs = {
+  init: ignoreDataDogCall,
+  logger: {
+    info: ignoreDataDogCall,
+  },
+  setUser: ignoreDataDogCall,
+};

--- a/apps/webapp/src/script/publicBuild/noopDataDogBrowserRum.ts
+++ b/apps/webapp/src/script/publicBuild/noopDataDogBrowserRum.ts
@@ -1,0 +1,27 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+function ignoreDataDogCall(...values: readonly unknown[]): void {
+  void values;
+}
+
+export const datadogRum = {
+  init: ignoreDataDogCall,
+  setUser: ignoreDataDogCall,
+};

--- a/apps/webapp/src/script/publicBuild/noopDataDogLogsApplicationObservability.ts
+++ b/apps/webapp/src/script/publicBuild/noopDataDogLogsApplicationObservability.ts
@@ -1,0 +1,55 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {ApplicationObservability} from '../observability/applicationObservability';
+import type {ApplicationStartupReport} from '../observability/applicationStartupReport';
+import {createNoopApplicationObservability} from '../observability/createNoopApplicationObservability';
+
+export const dataDogApplicationStartupLogMessage = 'wire_app_startup';
+
+type NoopDataDogBrowserLogs = {
+  readonly datadogLogs: {
+    readonly logger: {
+      readonly info: (...values: readonly unknown[]) => void;
+    };
+  };
+};
+
+export function createDataDogApplicationStartupLogContext(
+  report: ApplicationStartupReport,
+): Readonly<Record<string, number | string>> {
+  void report;
+  return {};
+}
+
+export function createDataDogLogsApplicationObservability(): ApplicationObservability {
+  return createNoopApplicationObservability();
+}
+
+export function importDataDogBrowserLogs(): Promise<NoopDataDogBrowserLogs> {
+  return Promise.resolve({
+    datadogLogs: {
+      logger: {
+        info(...values: readonly unknown[]): void {
+          void values;
+        },
+      },
+    },
+  });
+}

--- a/apps/webapp/webpack.config.public.js
+++ b/apps/webapp/webpack.config.public.js
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+const path = require('path');
+
+const productionConfig = require('./webpack.config');
+
+const publicBuildPath = path.resolve(__dirname, 'src/script/publicBuild');
+
+module.exports = {
+  ...productionConfig,
+  cache: {
+    ...productionConfig.cache,
+    buildDependencies: {
+      ...productionConfig.cache.buildDependencies,
+      config: [...productionConfig.cache.buildDependencies.config, __filename],
+    },
+    name: 'production-public',
+  },
+  output: {
+    ...productionConfig.output,
+    clean: true,
+  },
+  resolve: {
+    ...productionConfig.resolve,
+    alias: {
+      './createDataDogLogsApplicationObservability$': path.resolve(
+        publicBuildPath,
+        'noopDataDogLogsApplicationObservability.ts',
+      ),
+      '@datadog/browser-logs$': path.resolve(publicBuildPath, 'noopDataDogBrowserLogs.ts'),
+      '@datadog/browser-rum$': path.resolve(publicBuildPath, 'noopDataDogBrowserRum.ts'),
+      'Util/dataDog$': path.resolve(publicBuildPath, 'noopDataDog.ts'),
+      ...productionConfig.resolve.alias,
+    },
+    fallback: {
+      ...productionConfig.resolve.fallback,
+    },
+    modules: [...productionConfig.resolve.modules],
+  },
+};

--- a/bin/verifyPublicProductionBundle.test.ts
+++ b/bin/verifyPublicProductionBundle.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+
+import {
+  getDatadogReferencesInFile,
+  getPublicProductionArtifactFilePaths,
+  verifyPublicProductionBundle,
+} from './verifyPublicProductionBundle';
+
+function createTemporaryDirectory(): string {
+  return mkdtempSync(join(tmpdir(), 'wire-public-production-bundle-'));
+}
+
+describe('verifyPublicProductionBundle', (): void => {
+  it('recursively scans JavaScript files and source maps', (): void => {
+    const temporaryDirectory = createTemporaryDirectory();
+
+    try {
+      const nestedDirectory = join(temporaryDirectory, 'min', 'nested');
+      mkdirSync(nestedDirectory, {recursive: true});
+      writeFileSync(join(temporaryDirectory, 'index.html'), 'ignored html file');
+      writeFileSync(join(temporaryDirectory, 'min', 'app.js'), 'console.log("app");');
+      writeFileSync(join(nestedDirectory, 'chunk.js.map'), '{"sources":["chunk.ts"]}');
+
+      const actualFilePaths = getPublicProductionArtifactFilePaths(temporaryDirectory);
+
+      expect(actualFilePaths).toEqual([
+        join(temporaryDirectory, 'min', 'app.js'),
+        join(nestedDirectory, 'chunk.js.map'),
+      ]);
+    } finally {
+      rmSync(temporaryDirectory, {force: true, recursive: true});
+    }
+  });
+
+  it('finds Datadog references in source maps', (): void => {
+    const temporaryDirectory = createTemporaryDirectory();
+
+    try {
+      const sourceMapFilePath = join(temporaryDirectory, 'app.js.map');
+      writeFileSync(sourceMapFilePath, '{"sources":["../../node_modules/@datadog/browser-rum/index.js"]}');
+
+      const actualReferences = getDatadogReferencesInFile(sourceMapFilePath);
+
+      expect(actualReferences).toEqual([
+        {
+          filePath: sourceMapFilePath,
+          lineNumber: 1,
+          matchedText: '@datadog/browser-rum',
+        },
+      ]);
+    } finally {
+      rmSync(temporaryDirectory, {force: true, recursive: true});
+    }
+  });
+
+  it('fails verification when Datadog references exist in shipped artifacts', (): void => {
+    const temporaryDirectory = createTemporaryDirectory();
+
+    try {
+      writeFileSync(join(temporaryDirectory, 'app.js'), 'fetch("https://browser-intake-datadoghq.eu");');
+
+      const actualResult = verifyPublicProductionBundle(temporaryDirectory);
+
+      expect(actualResult).toEqual({
+        references: [
+          {
+            filePath: join(temporaryDirectory, 'app.js'),
+            lineNumber: 1,
+            matchedText: 'datadoghq.eu',
+          },
+        ],
+        status: 'failed',
+      });
+    } finally {
+      rmSync(temporaryDirectory, {force: true, recursive: true});
+    }
+  });
+});

--- a/bin/verifyPublicProductionBundle.ts
+++ b/bin/verifyPublicProductionBundle.ts
@@ -1,0 +1,145 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as nodeFileSystem from 'node:fs';
+import * as nodePath from 'node:path';
+
+export type DatadogReference = {
+  readonly filePath: string;
+  readonly lineNumber: number;
+  readonly matchedText: string;
+};
+
+export type VerificationResult =
+  | {
+      readonly references: readonly DatadogReference[];
+      readonly status: 'failed';
+    }
+  | {
+      readonly checkedFileCount: number;
+      readonly status: 'passed';
+    };
+
+const datadogReferencePattern = /@datadog\/browser-logs|@datadog\/browser-rum|datadoghq\.eu/g;
+const publicProductionArtifactDirectory = 'apps/server/dist/static';
+
+function isScannedPublicProductionArtifactFile(filePath: string): boolean {
+  return filePath.endsWith('.js') || filePath.endsWith('.js.map');
+}
+
+export function getPublicProductionArtifactFilePaths(artifactDirectory: string): readonly string[] {
+  if (!nodeFileSystem.existsSync(artifactDirectory)) {
+    return [];
+  }
+
+  const artifactFilePaths: string[] = [];
+
+  for (const directoryEntry of nodeFileSystem.readdirSync(artifactDirectory, {withFileTypes: true})) {
+    const directoryEntryPath = nodePath.join(artifactDirectory, directoryEntry.name);
+
+    if (directoryEntry.isDirectory()) {
+      artifactFilePaths.push(...getPublicProductionArtifactFilePaths(directoryEntryPath));
+    } else if (directoryEntry.isFile() && isScannedPublicProductionArtifactFile(directoryEntryPath)) {
+      artifactFilePaths.push(directoryEntryPath);
+    }
+  }
+
+  return artifactFilePaths.sort();
+}
+
+export function getDatadogReferencesInFile(filePath: string): readonly DatadogReference[] {
+  const fileContent = nodeFileSystem.readFileSync(filePath, 'utf8');
+  const references: DatadogReference[] = [];
+  const fileLines = fileContent.split('\n');
+
+  for (const [lineIndex, lineContent] of fileLines.entries()) {
+    const matches = lineContent.matchAll(datadogReferencePattern);
+
+    for (const match of matches) {
+      references.push({
+        filePath,
+        lineNumber: lineIndex + 1,
+        matchedText: match[0],
+      });
+    }
+  }
+
+  return references;
+}
+
+export function verifyPublicProductionBundle(artifactDirectory: string): VerificationResult {
+  const artifactFilePaths = getPublicProductionArtifactFilePaths(artifactDirectory);
+
+  if (artifactFilePaths.length === 0) {
+    throw new Error(`No public production JavaScript artifact files found in ${artifactDirectory}.`);
+  }
+
+  const references: DatadogReference[] = [];
+
+  for (const filePath of artifactFilePaths) {
+    references.push(...getDatadogReferencesInFile(filePath));
+  }
+
+  if (references.length > 0) {
+    return {
+      references,
+      status: 'failed',
+    };
+  }
+
+  return {
+    checkedFileCount: artifactFilePaths.length,
+    status: 'passed',
+  };
+}
+
+function printVerificationResult(result: VerificationResult): void {
+  if (result.status === 'passed') {
+    console.log(`No Datadog SDK references found in ${result.checkedFileCount} public production artifact files.`);
+    return;
+  }
+
+  for (const reference of result.references) {
+    console.log(`${reference.filePath}:${reference.lineNumber}: ${reference.matchedText}`);
+  }
+
+  console.error('Datadog SDK references were found in the public production bundle.');
+  process.exitCode = 1;
+}
+
+function main(): void {
+  try {
+    const result = verifyPublicProductionBundle(publicProductionArtifactDirectory);
+    printVerificationResult(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+function isCurrentProcessEntryPoint(executableScriptPath: string | undefined): boolean {
+  return (
+    executableScriptPath !== undefined && nodePath.basename(executableScriptPath) === 'verifyPublicProductionBundle.ts'
+  );
+}
+
+if (isCurrentProcessEntryPoint(process.argv[1])) {
+  main();
+}

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "build:libs": "nx run-many -t build --projects=tag:type:lib",
     "bundle:dev": "nx build webapp --configuration=development",
     "bundle:prod": "nx build webapp --configuration=production",
+    "bundle:prod:public": "nx build webapp --configuration=production-public",
     "clean:jest": "nx reset && nx run workspace-tools:clean-jest",
     "clean:yarn": "find . -name node_modules -type d -prune -exec rm -rf '{}' + && ./bin/yarn cache clean",
     "changelog:production": "nx run workspace-tools:changelog-production 2>&1 | grep -v '\\[dotenv@'",
@@ -125,6 +126,8 @@
     "e2e-test": "nx e2e webapp",
     "e2e-ui": "nx e2e webapp --ui",
     "build:prod": "nx run server:package",
+    "build:prod:public": "nx run server:package-public",
+    "verify:bundle:prod:public": "node bin/verifyPublicProductionBundle.ts",
     "test": "nx run-many -t test --all",
     "type-check": "nx run-many -t type-check --all"
   },


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26956" title="WPB-26956" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26956</a>  Do not ship Datadog SDK in customer-facing production bundles
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Why

Customer-facing production builds must not ship Datadog code at all.

This is stricter than disabling Datadog through runtime configuration. A runtime guard is not enough, because the Datadog SDK could still be part of the delivered JavaScript artifact or emitted as a dynamically loadable chunk.

The requirement is:

Customer-facing production artifacts must not contain the Datadog browser SDK, even if it would never be initialized at runtime.

## What changed

This pull request adds an explicit public production build variant that strips the Datadog browser SDK from the generated JavaScript bundle.

The existing internal production build remains unchanged and keeps the current Datadog behavior for internal/dev deployments.

This keeps the distinction explicit:

* internal production build: Datadog kept
* public production build: Datadog stripped

The application code does not infer this behavior from branch names. The build and deployment pipeline decides which build command to run.

## Build behavior

The public production build aliases Datadog-related modules to no-op implementations so that the real Datadog browser SDK is not included in the emitted customer-facing artifact.

This includes both the direct SDK packages and the app-level Datadog integration modules.

The existing production build continues to use the current Datadog implementation.

## Verification

This pull request adds an artifact-level verification step for the public production build.

The verification scans the generated static artifact under `apps/server/dist/static` and fails when Datadog SDK indicators are found in shipped JavaScript files or source maps.

The public production package flow now runs:

```sh
yarn build:prod:public
```

which builds the public production artifact, verifies that Datadog SDK references are absent, and only then creates the deployable package.

Pull request CI also runs the public production package verification, so the customer-facing build path is checked before merge.

## Important detail

This is intentionally a build-time concern.

We do not want customer-facing production builds to contain inactive Datadog code, dynamically loaded Datadog chunks, or Datadog SDK modules that are merely guarded by configuration.

The final customer-facing JavaScript artifact should be free of Datadog SDK code.
