### PR TITLE
fix: update the HistoryImport and HistoryExport modal re-render issue [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/historyExport/historyExport.test.tsx
+++ b/apps/webapp/src/script/components/historyExport/historyExport.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, waitFor} from '@testing-library/react';
+
+import {PrimaryModal, removeCurrentModal} from 'Components/Modals/PrimaryModal';
+import {ClientState} from 'Repositories/client/ClientState';
+import {User} from 'Repositories/entity/User';
+import * as RootProvider from 'src/script/page/rootProvider';
+import {RootContextValue} from 'src/script/page/rootProvider';
+import {MainViewModel} from 'src/script/view_model/MainViewModel';
+
+import {HistoryExport} from './historyExport';
+import {translateForTest} from 'Util/test/translateForTest';
+
+describe('HistoryExport', () => {
+  beforeEach(() => {
+    removeCurrentModal();
+  });
+
+  afterEach(() => {
+    removeCurrentModal();
+    jest.restoreAllMocks();
+  });
+
+  it('uses a stable modal id so rerenders do not queue duplicate password modals', async () => {
+    const showSpy = jest.spyOn(PrimaryModal, 'show').mockImplementation(() => {});
+    const user = new User('', '', translateForTest);
+    const switchContent = jest.fn();
+    const clientState = new ClientState();
+    const mainViewModel = {content: {repositories: {backup: {}}}} as unknown as MainViewModel;
+
+    jest.spyOn(RootProvider, 'useApplicationContext').mockImplementation(
+      () =>
+        ({
+          mainViewModel,
+          translate: translateForTest,
+        }) as unknown as RootContextValue,
+    );
+
+    const {rerender} = render(<HistoryExport switchContent={switchContent} user={user} clientState={clientState} />);
+
+    await waitFor(() => {
+      expect(showSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(showSpy.mock.calls[0]?.[2]).toBe('history-export-password-modal');
+
+    rerender(<HistoryExport switchContent={switchContent} user={user} clientState={clientState} />);
+
+    await waitFor(() => {
+      expect(showSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/webapp/src/script/components/historyExport/historyExport.tsx
+++ b/apps/webapp/src/script/components/historyExport/historyExport.tsx
@@ -49,6 +49,8 @@ enum ExportState {
 
 const MILLISECONDS_PER_SECOND = 1000;
 const PERCENTAGE_MULTIPLIER = 100;
+const HISTORY_EXPORT_MODAL_ID = 'history-export-password-modal';
+const logger = getLogger('HistoryExport');
 
 export const CONFIG = {
   LEGACY_FILE_EXTENSION: 'desktop_wbu',
@@ -62,7 +64,6 @@ interface HistoryExportProps {
 }
 
 const HistoryExport = ({switchContent, user, clientState = container.resolve(ClientState)}: HistoryExportProps) => {
-  const logger = getLogger('HistoryExport');
   const {mainViewModel, translate} = useApplicationContext();
 
   const [historyState, setHistoryState] = useState<ExportState>(ExportState.PREPARING);
@@ -123,7 +124,7 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
       setHasError(true);
       logger.error(`Failed to export history: ${error.message}`, error);
     },
-    [dismissExport, logger],
+    [dismissExport],
   );
 
   const downloadArchiveFile = () => {
@@ -197,7 +198,7 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
         onError(error as Error);
       }
     },
-    [backupRepository, clientState.currentClient, logger, onError, onProgress, onSuccess, user],
+    [backupRepository, clientState.currentClient, onError, onProgress, onSuccess, user],
   );
 
   const showBackupModal = useCallback(() => {
@@ -225,15 +226,14 @@ const HistoryExport = ({switchContent, user, clientState = container.resolve(Cli
           title: translate('backupEncryptionModalTitle'),
         },
       },
-      undefined,
+      HISTORY_EXPORT_MODAL_ID,
       translate,
     );
   }, [exportHistory, onClose, translate]);
 
   useEffect(() => {
     showBackupModal();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [showBackupModal]);
 
   return (
     <div id="history-export">

--- a/apps/webapp/src/script/components/historyImport/historyImport.test.tsx
+++ b/apps/webapp/src/script/components/historyImport/historyImport.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, waitFor} from '@testing-library/react';
+
+import {PrimaryModal, removeCurrentModal} from 'Components/Modals/PrimaryModal';
+import {BackupRepository} from 'Repositories/backup/backupRepository';
+import {User} from 'Repositories/entity/User';
+import * as RootProvider from 'src/script/page/rootProvider';
+import {RootContextValue} from 'src/script/page/rootProvider';
+import * as BackupUtil from 'Util/backupUtil';
+import * as Util from 'Util/util';
+
+import {HistoryImport} from './historyImport';
+
+describe('HistoryImport', () => {
+  const createFile = (content = 'backup', name = 'backup.wbu') => new File([content], name);
+
+  const setup = ({file = createFile(), isEncrypted = false}: {file?: File; isEncrypted?: boolean} = {}) => {
+    const translate = jest.fn((translationKey: string) => translationKey);
+
+    jest.spyOn(RootProvider, 'useApplicationContext').mockImplementation(
+      () =>
+        ({
+          translate,
+        }) as unknown as RootContextValue,
+    );
+
+    jest.spyOn(BackupUtil, 'checkBackupEncryption').mockResolvedValue(isEncrypted);
+    jest.spyOn(Util, 'loadFileBuffer').mockResolvedValue(new ArrayBuffer(8));
+
+    const backupRepository = {
+      cancelAction: jest.fn(),
+      importHistory: jest.fn().mockResolvedValue(undefined),
+    } as unknown as BackupRepository;
+
+    const user = {id: 'user-1'} as unknown as User;
+    const switchContent = jest.fn();
+
+    const view = render(
+      <HistoryImport backupRepository={backupRepository} file={file} switchContent={switchContent} user={user} />,
+    );
+
+    return {
+      ...view,
+      backupRepository,
+      file,
+      switchContent,
+      user,
+    };
+  };
+
+  beforeEach(() => {
+    removeCurrentModal();
+  });
+
+  afterEach(() => {
+    removeCurrentModal();
+    jest.restoreAllMocks();
+  });
+
+  it('uses a stable modal id for the password prompt', async () => {
+    const showSpy = jest.spyOn(PrimaryModal, 'show');
+
+    setup({isEncrypted: true});
+
+    await waitFor(() => {
+      expect(showSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(showSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'history-import-password-modal',
+      expect.any(Function),
+    );
+  });
+
+  it('starts a fresh import when a new file is uploaded, but not when the same file re-renders', async () => {
+    const {backupRepository, file, rerender, switchContent, user} = setup();
+
+    await waitFor(() => {
+      expect(backupRepository.importHistory).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <HistoryImport backupRepository={backupRepository} file={file} switchContent={switchContent} user={user} />,
+    );
+
+    await waitFor(() => {
+      expect(backupRepository.importHistory).toHaveBeenCalledTimes(1);
+    });
+
+    const nextFile = createFile('backup-2', 'backup-2.wbu');
+
+    rerender(
+      <HistoryImport backupRepository={backupRepository} file={nextFile} switchContent={switchContent} user={user} />,
+    );
+
+    await waitFor(() => {
+      expect(backupRepository.importHistory).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/webapp/src/script/components/historyImport/historyImport.tsx
+++ b/apps/webapp/src/script/components/historyImport/historyImport.tsx
@@ -51,7 +51,9 @@ export enum HistoryImportState {
 }
 
 const HISTORY_IMPORT_DISMISS_DELAY_MULTIPLIER = 2;
+const HISTORY_IMPORT_PASSWORD_MODAL_ID = 'history-import-password-modal';
 const PERCENTAGE_MULTIPLIER = 100;
+const logger = getLogger('HistoryImportViewModel');
 
 interface HistoryImportProps {
   readonly backupRepository: BackupRepository;
@@ -61,7 +63,6 @@ interface HistoryImportProps {
 }
 
 const HistoryImport = ({user, backupRepository, file, switchContent}: HistoryImportProps) => {
-  const logger = getLogger('HistoryImportViewModel');
   const {translate} = useApplicationContext();
 
   const [historyImportState, setHistoryImportState] = useState(HistoryImportState.PREPARING);
@@ -146,7 +147,7 @@ const HistoryImport = ({user, backupRepository, file, switchContent}: HistoryImp
         setErrorSecondary(translate('backupImportGenericErrorSecondary'));
       }
     },
-    [dismissImport, logger, translate],
+    [dismissImport, translate],
   );
 
   const getBackUpPassword = useCallback((): Promise<string> => {
@@ -177,7 +178,7 @@ const HistoryImport = ({user, backupRepository, file, switchContent}: HistoryImp
             title: translate('backupDecryptionModalTitle'),
           },
         },
-        undefined,
+        HISTORY_IMPORT_PASSWORD_MODAL_ID,
         translate,
       );
     });
@@ -219,8 +220,7 @@ const HistoryImport = ({user, backupRepository, file, switchContent}: HistoryImp
 
   useEffect(() => {
     void importHistory(file);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [file]);
+  }, [file, importHistory]);
 
   const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add tests to ensure stable modal behavior

Remove eslint-disable-next-line which was introduced in [this PR](https://github.com/wireapp/wire-webapp/pull/21730) 