### PR TITLE
Render messages before latest missed call on conversation open [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/MessagesList/VirtualizedMessagesList/VirtualizedMessagesList.tsx
+++ b/apps/webapp/src/script/components/MessagesList/VirtualizedMessagesList/VirtualizedMessagesList.tsx
@@ -19,6 +19,7 @@
 
 import {MutableRefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 
+import is from '@sindresorhus/is';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import cx from 'classnames';
 
@@ -32,7 +33,11 @@ import {verticallyCenterMessage} from 'Components/MessagesList/utils/helpers';
 import {filterMessages} from 'Components/MessagesList/utils/messagesFilter';
 import {useLoadConversation} from 'Components/MessagesList/utils/useLoadConversation';
 import {useScrollToLastUnreadMessage} from 'Components/MessagesList/utils/useScrollToLastUnreadMessage';
-import {groupMessagesBySenderAndTime, isMarker} from 'Components/MessagesList/utils/virtualizedMessagesGroup';
+import {
+  getVirtualizedMessagesGroupItemKey,
+  groupMessagesBySenderAndTime,
+  isMarker,
+} from 'Components/MessagesList/utils/virtualizedMessagesGroup';
 import {useLoadMessages} from 'Components/MessagesList/VirtualizedMessagesList/useLoadMessages';
 import {useScrollMessages} from 'Components/MessagesList/VirtualizedMessagesList/useScrollMessages';
 import {useRoveFocus} from 'Hooks/useRoveFocus';
@@ -137,7 +142,18 @@ export const VirtualizedMessagesList = ({
 
   const shouldShowInvitePeople = isActiveParticipant && inTeam && (isGuestRoom || isGuestAndServicesRoom);
 
-  const getItemKey = useCallback((index: number) => index, [groupedMessages]);
+  const getItemKey = useCallback(
+    (index: number) => {
+      const item = groupedMessages[index];
+
+      if (is.undefined(item)) {
+        return `missing-message-list-item-${index}`;
+      }
+
+      return getVirtualizedMessagesGroupItemKey(item);
+    },
+    [groupedMessages],
+  );
 
   const virtualizer = useVirtualizer({
     count: groupedMessages.length,

--- a/apps/webapp/src/script/components/MessagesList/VirtualizedMessagesList/useScrollMessages.test.ts
+++ b/apps/webapp/src/script/components/MessagesList/VirtualizedMessagesList/useScrollMessages.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createFactory} from '@enormora/objectory';
+import {renderHook, act} from '@testing-library/react';
+import {Virtualizer} from '@tanstack/react-virtual';
+
+import {StatusType} from '../../../message/statusType';
+import {Message} from 'Repositories/entity/message/message';
+import {GroupedMessage} from '../utils/virtualizedMessagesGroup';
+
+import {useScrollMessages} from './useScrollMessages';
+
+const messageFactory = createFactory<Message>(() => {
+  return {
+    id: 'message-id',
+    status: () => StatusType.SENT,
+    user: () => ({id: 'sender-id'}),
+  } as Message;
+});
+
+const groupedMessageFactory = createFactory<GroupedMessage>(() => {
+  return {
+    messageType: 'message',
+    message: messageFactory.build(),
+    timestamp: 1,
+    sender: 'sender-id',
+    firstMessageTimestamp: 1,
+    lastMessageTimestamp: 1,
+    shouldGroup: false,
+  };
+});
+
+function createGroupedMessage(messageId: string): GroupedMessage {
+  return groupedMessageFactory.build({
+    message: messageFactory.build({id: messageId}),
+  });
+}
+
+describe('useScrollMessages', () => {
+  it('does not scroll to the bottom for the initial loaded message range', () => {
+    const scrollElement = {
+      clientHeight: 500,
+    } as HTMLDivElement;
+    const scrollToIndex = jest.fn();
+    const virtualizer = {
+      getTotalSize: () => 1000,
+      options: {
+        getScrollElement: () => scrollElement,
+      },
+      scrollOffset: 500,
+      scrollToIndex,
+    } as unknown as Virtualizer<HTMLDivElement, Element>;
+
+    renderHook(() => {
+      return useScrollMessages(virtualizer, {
+        messages: [createGroupedMessage('older-message'), createGroupedMessage('newest-message')],
+        userId: 'self-user-id',
+        isConversationLoaded: true,
+      });
+    });
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it('keeps sticking to the bottom for later new messages', () => {
+    let animationFrameCallback: FrameRequestCallback = () => 0;
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      animationFrameCallback = callback;
+      return 1;
+    });
+
+    const scrollElement = {
+      clientHeight: 500,
+    } as HTMLDivElement;
+    const scrollToIndex = jest.fn();
+    const virtualizer = {
+      getTotalSize: () => 1000,
+      options: {
+        getScrollElement: () => scrollElement,
+      },
+      scrollOffset: 500,
+      scrollToIndex,
+    } as unknown as Virtualizer<HTMLDivElement, Element>;
+
+    const renderedHook = renderHook(
+      properties => {
+        return useScrollMessages(virtualizer, properties);
+      },
+      {
+        initialProps: {
+          messages: [createGroupedMessage('older-message')],
+          userId: 'self-user-id',
+          isConversationLoaded: true,
+        },
+      },
+    );
+
+    renderedHook.rerender({
+      messages: [createGroupedMessage('older-message'), createGroupedMessage('newest-message')],
+      userId: 'self-user-id',
+      isConversationLoaded: true,
+    });
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+
+    act(() => {
+      animationFrameCallback(0);
+    });
+
+    expect(scrollToIndex).toHaveBeenCalledWith(1, {align: 'end'});
+  });
+});

--- a/apps/webapp/src/script/components/MessagesList/VirtualizedMessagesList/useScrollMessages.ts
+++ b/apps/webapp/src/script/components/MessagesList/VirtualizedMessagesList/useScrollMessages.ts
@@ -55,7 +55,9 @@ export const useScrollMessages = (
   const prevTotalSizeRef = useRef(0);
 
   useLayoutEffect(() => {
-    if (!isConversationLoaded && messages.length === 0) {
+    if (!isConversationLoaded || messages.length === 0) {
+      prevNbMessages.current = messages.length;
+      prevTotalSizeRef.current = virtualizer.getTotalSize();
       return;
     }
 
@@ -68,17 +70,19 @@ export const useScrollMessages = (
     const lastMessage = lastMessageItem?.message;
 
     const shouldStickToBottom = shouldStickToBottomFromPrev(virtualizer, prevTotalSizeRef.current, 100);
+    const nbNewMessages = messages.length - prevNbMessages.current;
+
+    if (prevNbMessages.current === 0 || nbNewMessages <= 0) {
+      prevNbMessages.current = messages.length;
+      prevTotalSizeRef.current = virtualizer.getTotalSize();
+      return;
+    }
 
     if (shouldStickToBottom) {
       // We only want to animate the scroll if there are new messages in the list
-      const nbNewMessages = messages.length - prevNbMessages.current;
-
-      if (nbNewMessages >= 1) {
-        // Simple content update, we just scroll to bottom if we are in the stick to bottom threshold
-        requestAnimationFrame(() => {
-          virtualizer.scrollToIndex(messages.length - 1, {align: 'end'});
-        });
-      }
+      requestAnimationFrame(() => {
+        virtualizer.scrollToIndex(messages.length - 1, {align: 'end'});
+      });
     } else if (lastMessage.status() === StatusType.SENDING && lastMessage.user().id === userId) {
       // The self user just sent a message, we scroll straight to the bottom
       const index = messages.findIndex(message => !isMarker(message) && message.message.id === lastMessage.id);

--- a/apps/webapp/src/script/components/MessagesList/utils/useScrollToLastUnreadMessage.test.ts
+++ b/apps/webapp/src/script/components/MessagesList/utils/useScrollToLastUnreadMessage.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createRef} from 'react';
+
+import {createFactory} from '@enormora/objectory';
+import {renderHook, act} from '@testing-library/react';
+import {Virtualizer} from '@tanstack/react-virtual';
+
+import {Message} from 'Repositories/entity/message/message';
+
+import {GroupedMessage, Marker} from './virtualizedMessagesGroup';
+import {getInitialScrollPosition, useScrollToLastUnreadMessage} from './useScrollToLastUnreadMessage';
+
+const messageFactory = createFactory<Message>(() => {
+  return {
+    id: 'message-id',
+  } as Message;
+});
+
+const groupedMessageFactory = createFactory<GroupedMessage>(() => {
+  return {
+    messageType: 'message',
+    message: messageFactory.build(),
+    timestamp: 1,
+    sender: 'sender-id',
+    firstMessageTimestamp: 1,
+    lastMessageTimestamp: 1,
+    shouldGroup: false,
+  };
+});
+
+function createGroupedMessage(messageId: string, timestamp: number): GroupedMessage {
+  return groupedMessageFactory.build({
+    message: messageFactory.build({id: messageId}),
+    timestamp,
+    firstMessageTimestamp: timestamp,
+    lastMessageTimestamp: timestamp,
+  });
+}
+
+function createUnreadMarker(timestamp: number): Marker {
+  return {
+    messageType: 'marker',
+    type: 'unread',
+    timestamp,
+    firstMessageTimestamp: timestamp,
+    lastMessageTimestamp: timestamp,
+  };
+}
+
+describe('useScrollToLastUnreadMessage', () => {
+  it('bottom-aligns the newest message when a missed call is the final item', () => {
+    const groupedMessages = [
+      createGroupedMessage('older-message-1', 10),
+      createGroupedMessage('older-message-2', 20),
+      createGroupedMessage('missed-call-message', 30),
+    ];
+
+    const actualScrollPosition = getInitialScrollPosition(groupedMessages, 30);
+
+    expect(actualScrollPosition.isJust).toBe(true);
+    expect(actualScrollPosition.value).toEqual({
+      scrollAlign: 'end',
+      scrollIndex: 2,
+    });
+  });
+
+  it('scrolls to the unread marker before the first unread message', () => {
+    const groupedMessages = [
+      createGroupedMessage('read-message', 10),
+      createUnreadMarker(20),
+      createGroupedMessage('first-unread-message', 20),
+      createGroupedMessage('second-unread-message', 30),
+    ];
+
+    const actualScrollPosition = getInitialScrollPosition(groupedMessages, 10);
+
+    expect(actualScrollPosition.isJust).toBe(true);
+    expect(actualScrollPosition.value).toEqual({
+      scrollAlign: 'start',
+      scrollIndex: 1,
+    });
+  });
+
+  it('waits for grouped messages before measuring and scrolling the loaded conversation', () => {
+    let animationFrameCallback: FrameRequestCallback = () => 0;
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      animationFrameCallback = callback;
+      return 1;
+    });
+
+    const scrollToIndex = jest.fn();
+    const measure = jest.fn();
+    const virtualizer = {
+      measure,
+      scrollToIndex,
+    } as unknown as Virtualizer<HTMLDivElement, Element>;
+    const conversationLastReadTimestamp = createRef<number>();
+    conversationLastReadTimestamp.current = 30;
+    const groupedMessages = [
+      createGroupedMessage('older-message-1', 10),
+      createGroupedMessage('older-message-2', 20),
+      createGroupedMessage('missed-call-message', 30),
+    ];
+
+    const renderedHook = renderHook(
+      properties => {
+        return useScrollToLastUnreadMessage(virtualizer, properties);
+      },
+      {
+        initialProps: {
+          isConversationLoaded: true,
+          groupedMessages: [],
+          conversationLastReadTimestamp,
+        },
+      },
+    );
+
+    expect(measure).not.toHaveBeenCalled();
+    expect(scrollToIndex).not.toHaveBeenCalled();
+
+    renderedHook.rerender({
+      isConversationLoaded: true,
+      groupedMessages,
+      conversationLastReadTimestamp,
+    });
+
+    expect(measure).toHaveBeenCalledTimes(1);
+    expect(scrollToIndex).not.toHaveBeenCalled();
+
+    act(() => {
+      animationFrameCallback(0);
+    });
+
+    expect(measure).toHaveBeenCalledTimes(2);
+    expect(scrollToIndex).toHaveBeenCalledWith(2, {align: 'end'});
+  });
+});

--- a/apps/webapp/src/script/components/MessagesList/utils/useScrollToLastUnreadMessage.ts
+++ b/apps/webapp/src/script/components/MessagesList/utils/useScrollToLastUnreadMessage.ts
@@ -17,11 +17,19 @@
  *
  */
 
-import {MutableRefObject, useEffect} from 'react';
+import {MutableRefObject, useLayoutEffect, useRef} from 'react';
 
 import {Virtualizer} from '@tanstack/react-virtual';
+import {Maybe} from 'true-myth';
 
 import {GroupedMessage, isMarker, Marker} from 'Components/MessagesList/utils/virtualizedMessagesGroup';
+
+type ScrollAlign = 'start' | 'center' | 'end';
+
+type InitialScrollPosition = {
+  scrollAlign: ScrollAlign;
+  scrollIndex: number;
+};
 
 interface Props {
   isConversationLoaded: boolean;
@@ -29,30 +37,60 @@ interface Props {
   conversationLastReadTimestamp: MutableRefObject<number>;
 }
 
+export function getInitialScrollPosition(
+  groupedMessages: (Marker | GroupedMessage)[],
+  lastReadTimestamp: number,
+): Maybe<InitialScrollPosition> {
+  if (groupedMessages.length === 0) {
+    return Maybe.nothing();
+  }
+
+  const firstUnreadMessageIndex = groupedMessages.findIndex(
+    message => !isMarker(message) && message.timestamp > lastReadTimestamp,
+  );
+
+  if (firstUnreadMessageIndex !== -1) {
+    return Maybe.just({
+      scrollAlign: 'start',
+      scrollIndex: Math.max(0, firstUnreadMessageIndex - 1),
+    });
+  }
+
+  return Maybe.just({
+    scrollAlign: 'end',
+    scrollIndex: groupedMessages.length - 1,
+  });
+}
+
 export const useScrollToLastUnreadMessage = (
   virtualizer: Virtualizer<HTMLDivElement, Element>,
   {isConversationLoaded, groupedMessages, conversationLastReadTimestamp}: Props,
 ) => {
-  useEffect(() => {
-    if (isConversationLoaded) {
-      let scrollAlign: 'start' | 'center' | 'end' = 'center';
+  const hasScrolledToInitialPosition = useRef(false);
 
-      const firstUnreadMessageIndex = groupedMessages.findIndex(
-        message => !isMarker(message) && message.timestamp > conversationLastReadTimestamp.current,
-      );
-
-      let nextScrollIndex = groupedMessages.length - 1; // Default to the last message
-
-      if (firstUnreadMessageIndex !== -1) {
-        nextScrollIndex = firstUnreadMessageIndex - 1;
-        scrollAlign = 'start';
-      }
-
-      const scrollIndex = nextScrollIndex;
-
-      requestAnimationFrame(() => {
-        virtualizer.scrollToIndex(scrollIndex, {align: scrollAlign});
-      });
+  useLayoutEffect(() => {
+    if (!isConversationLoaded) {
+      hasScrolledToInitialPosition.current = false;
+      return;
     }
-  }, [isConversationLoaded]);
+
+    if (hasScrolledToInitialPosition.current) {
+      return;
+    }
+
+    const initialScrollPosition = getInitialScrollPosition(groupedMessages, conversationLastReadTimestamp.current);
+
+    if (initialScrollPosition.isNothing) {
+      return;
+    }
+
+    virtualizer.measure();
+    hasScrolledToInitialPosition.current = true;
+    const {scrollAlign, scrollIndex} = initialScrollPosition.value;
+
+    requestAnimationFrame(() => {
+      virtualizer.measure();
+      virtualizer.scrollToIndex(scrollIndex, {align: scrollAlign});
+    });
+  }, [conversationLastReadTimestamp, groupedMessages, isConversationLoaded, virtualizer]);
 };

--- a/apps/webapp/src/script/components/MessagesList/utils/virtualizedMessagesGroup.test.ts
+++ b/apps/webapp/src/script/components/MessagesList/utils/virtualizedMessagesGroup.test.ts
@@ -27,7 +27,12 @@ import {translate} from 'Util/localizerUtil';
 import {getRandomNumber} from 'Util/numberUtil';
 import {createUuid} from 'Util/uuid';
 
-import {GroupedMessage, groupMessagesBySenderAndTime, isMarker} from './virtualizedMessagesGroup';
+import {
+  getVirtualizedMessagesGroupItemKey,
+  GroupedMessage,
+  groupMessagesBySenderAndTime,
+  isMarker,
+} from './virtualizedMessagesGroup';
 import {translateForTest} from 'Util/test/translateForTest';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 
@@ -167,5 +172,25 @@ describe('MessagesGroup', () => {
     expect(groupReadMessages).toHaveLength(nbReadMessages);
     expect(isMarker(groupedMessages[firstReadIndex])).toBeTruthy();
     expect(groupUnReadMessages).toHaveLength(nbUnreadMessages);
+  });
+
+  it('uses stable virtualized item keys for messages and markers', () => {
+    const lastReadTimestamp = 10;
+    const readMessageEvent = createMessageAddEvent({overrides: {time: new Date(lastReadTimestamp).toISOString()}});
+    const unreadMessageEvent = createMessageAddEvent({
+      overrides: {time: new Date(lastReadTimestamp + 1).toISOString()},
+    });
+
+    const allMessages = [readMessageEvent, unreadMessageEvent].map(
+      event => eventMapper.mapJsonEvent(event, conversation) as Message,
+    );
+
+    const groupedMessages = groupMessagesBySenderAndTime(allMessages, lastReadTimestamp);
+
+    expect(getVirtualizedMessagesGroupItemKey(groupedMessages[0])).toBe(`message-${allMessages[0].id}`);
+    expect(getVirtualizedMessagesGroupItemKey(groupedMessages[1])).toBe(
+      `marker-unread-${lastReadTimestamp + 1}-${lastReadTimestamp + 1}-${lastReadTimestamp + 1}`,
+    );
+    expect(getVirtualizedMessagesGroupItemKey(groupedMessages[2])).toBe(`message-${allMessages[1].id}`);
   });
 });

--- a/apps/webapp/src/script/components/MessagesList/utils/virtualizedMessagesGroup.ts
+++ b/apps/webapp/src/script/components/MessagesList/utils/virtualizedMessagesGroup.ts
@@ -75,6 +75,14 @@ export function isMarker(object: any): object is Marker {
   return object?.messageType === 'marker';
 }
 
+export function getVirtualizedMessagesGroupItemKey(item: Marker | GroupedMessage): string {
+  if (isMarker(item)) {
+    return `marker-${item.type}-${item.timestamp}-${item.firstMessageTimestamp}-${item.lastMessageTimestamp}`;
+  }
+
+  return `message-${item.message.id}`;
+}
+
 /**
  * Determines whether a message should be grouped with a previous one based on timestamp,
  * a message should be grouped if it's sent within the same minute on the clock than the first message in the group


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## What changed

This fixes an initial rendering issue in the virtualized message list.

When the newest item in a conversation was a missed call, opening the conversation could show only the missed-call row with a large empty area below it. The previous messages were already loaded, but they only became visible after the user scrolled a little bit.

The message list now renders the correct initial range immediately when the conversation is opened.

## Why

A missed call as the latest item exposed a timing / measurement issue in the virtualized list. The virtualizer could start from an incomplete initial range and only recover after a scroll event triggered recalculation.

This made the conversation look empty even though older messages were present.