### PR TITLE
feat: add applock override through MDM [WPB-26671]

### DIFF
--- a/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences/privacySection.test.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences/privacySection.test.tsx
@@ -1,0 +1,544 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, screen} from '@testing-library/react';
+
+import {PropertiesRepository} from 'Repositories/properties/propertiesRepository';
+import {AppLockRepository} from 'Repositories/user/appLockRepository';
+import {AppLockState} from 'Repositories/user/appLockState';
+import {Config} from 'src/script/Config';
+import {withTheme} from 'src/script/auth/util/test/testUtil';
+import {translateForTest} from 'Util/test/translateForTest';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import ko from 'knockout';
+
+import {PrivacySection} from './privacySection';
+
+const createMockAppLockState = (overrides?: Partial<AppLockState>): AppLockState => {
+  const hasPassphrase = ko.observable(false);
+  const isActivatedInPreferences = ko.observable(false);
+  
+  // Create observables for computed values that can be overridden
+  const isAppLockEnforcedValue = ko.observable(overrides?.isAppLockEnforced?.() ?? false);
+  const isAppLockAvailableValue = ko.observable(overrides?.isAppLockAvailable?.() ?? true);
+  const isAppLockEnabledValue = ko.observable(overrides?.isAppLockEnabled?.() ?? false);
+  const appLockInactivityTimeoutSecsValue = ko.observable(overrides?.appLockInactivityTimeoutSecs?.() ?? 10);
+  const isAppLockDisabledOnTeamValue = ko.observable(overrides?.isAppLockDisabledOnTeam?.() ?? false);
+  const isAppLockActivatedValue = ko.observable(overrides?.isAppLockActivated?.() ?? false);
+
+  return {
+    isAppLockEnabled: ko.pureComputed(() => isAppLockEnabledValue()),
+    isAppLockAvailable: ko.pureComputed(() => isAppLockAvailableValue()),
+    isAppLockEnforced: ko.pureComputed(() => isAppLockEnforcedValue()),
+    appLockInactivityTimeoutSecs: ko.pureComputed(() => appLockInactivityTimeoutSecsValue()),
+    isAppLockActivated: ko.pureComputed(() => isAppLockActivatedValue()),
+    hasPassphrase,
+    isActivatedInPreferences,
+    isAppLockDisabledOnTeam: ko.pureComputed(() => isAppLockDisabledOnTeamValue()),
+  };
+};
+
+const createMockPropertiesRepository = (): PropertiesRepository => {
+  return {
+    receiptMode: ko.observable(0),
+    typingIndicatorMode: ko.observable(0),
+  } as any;
+};
+
+const createMockAppLockRepository = (): AppLockRepository => {
+  return {
+    setEnabled: jest.fn(),
+  } as any;
+};
+
+const rootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate: translateForTest}),
+);
+
+describe('PrivacySection', () => {
+  let configSpy: jest.SpyInstance;
+  let desktopConfigSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    configSpy = jest.spyOn(Config, 'getConfig').mockReturnValue({
+      FEATURE: {
+        ENABLE_MDM_CONFIG: false,
+      },
+    } as any);
+    desktopConfigSpy = jest.spyOn(Config, 'getDesktopConfig').mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    configSpy.mockRestore();
+    desktopConfigSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  describe('app lock checkbox', () => {
+    it('should render the app lock checkbox when available', () => {
+      const appLockState = createMockAppLockState({
+        isAppLockAvailable: ko.pureComputed(() => true),
+      });
+      const propertiesRepository = createMockPropertiesRepository();
+      const appLockRepository = createMockAppLockRepository();
+
+      render(
+        withTheme(
+          <PrivacySection
+            appLockRepository={appLockRepository}
+            appLockState={appLockState}
+            propertiesRepository={propertiesRepository}
+          />,
+        ),
+        {wrapper: rootProviderWrapper},
+      );
+
+      expect(screen.getByTestId('status-preference-applock')).toBeInTheDocument();
+    });
+
+    it('should not render the app lock checkbox when not available', () => {
+      const appLockState = createMockAppLockState({
+        isAppLockAvailable: ko.pureComputed(() => false),
+      });
+      const propertiesRepository = createMockPropertiesRepository();
+      const appLockRepository = createMockAppLockRepository();
+
+      render(
+        withTheme(
+          <PrivacySection
+            appLockRepository={appLockRepository}
+            appLockState={appLockState}
+            propertiesRepository={propertiesRepository}
+          />,
+        ),
+        {wrapper: rootProviderWrapper},
+      );
+
+      expect(screen.queryByTestId('status-preference-applock')).not.toBeInTheDocument();
+    });
+
+    describe('when MDM config is enabled', () => {
+      beforeEach(() => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: true,
+          },
+        } as any);
+      });
+
+      describe('and MDM override is enabled', () => {
+        beforeEach(() => {
+          desktopConfigSpy.mockReturnValue({
+            version: '1.0',
+            managedConfig: {
+              applockOverride: true,
+            },
+          } as any);
+        });
+
+        it('should disable the app lock checkbox', () => {
+          const appLockState = createMockAppLockState({
+            isAppLockAvailable: ko.pureComputed(() => true),
+            isAppLockEnabled: ko.pureComputed(() => true),
+          });
+          const propertiesRepository = createMockPropertiesRepository();
+          const appLockRepository = createMockAppLockRepository();
+
+          render(
+            withTheme(
+              <PrivacySection
+                appLockRepository={appLockRepository}
+                appLockState={appLockState}
+                propertiesRepository={propertiesRepository}
+              />,
+            ),
+            {wrapper: rootProviderWrapper},
+          );
+
+          const checkbox = screen.getByRole('checkbox', {name: /applock/i});
+          expect(checkbox).toBeDisabled();
+        });
+
+        it('should uncheck the app lock checkbox when MDM override is active', () => {
+          const appLockState = createMockAppLockState({
+            isAppLockAvailable: ko.pureComputed(() => true),
+            isAppLockEnabled: ko.pureComputed(() => false),
+          });
+          const propertiesRepository = createMockPropertiesRepository();
+          const appLockRepository = createMockAppLockRepository();
+
+          render(
+            withTheme(
+              <PrivacySection
+                appLockRepository={appLockRepository}
+                appLockState={appLockState}
+                propertiesRepository={propertiesRepository}
+              />,
+            ),
+            {wrapper: rootProviderWrapper},
+          );
+
+          const checkbox = screen.getByRole('checkbox', {name: /applock/i});
+          expect(checkbox).not.toBeChecked();
+        });
+      });
+
+      describe('and MDM override is disabled', () => {
+        beforeEach(() => {
+          desktopConfigSpy.mockReturnValue({
+            version: '1.0',
+            managedConfig: {
+              applockOverride: false,
+            },
+          } as any);
+        });
+
+        it('should not disable the app lock checkbox', () => {
+          const appLockState = createMockAppLockState({
+            isAppLockAvailable: ko.pureComputed(() => true),
+            isAppLockEnabled: ko.pureComputed(() => false),
+          });
+          const propertiesRepository = createMockPropertiesRepository();
+          const appLockRepository = createMockAppLockRepository();
+
+          render(
+            withTheme(
+              <PrivacySection
+                appLockRepository={appLockRepository}
+                appLockState={appLockState}
+                propertiesRepository={propertiesRepository}
+              />,
+            ),
+            {wrapper: rootProviderWrapper},
+          );
+
+          const checkbox = screen.getByRole('checkbox', {name: /applock/i});
+          expect(checkbox).not.toBeDisabled();
+        });
+      });
+
+      describe('and managedConfig is missing', () => {
+        beforeEach(() => {
+          desktopConfigSpy.mockReturnValue({
+            version: '1.0',
+          } as any);
+        });
+
+        it('should not disable the app lock checkbox', () => {
+          const appLockState = createMockAppLockState({
+            isAppLockAvailable: ko.pureComputed(() => true),
+            isAppLockEnabled: ko.pureComputed(() => false),
+          });
+          const propertiesRepository = createMockPropertiesRepository();
+          const appLockRepository = createMockAppLockRepository();
+
+          render(
+            withTheme(
+              <PrivacySection
+                appLockRepository={appLockRepository}
+                appLockState={appLockState}
+                propertiesRepository={propertiesRepository}
+              />,
+            ),
+            {wrapper: rootProviderWrapper},
+          );
+
+          const checkbox = screen.getByRole('checkbox', {name: /applock/i});
+          expect(checkbox).not.toBeDisabled();
+        });
+      });
+
+      describe('and desktopConfig is missing entirely', () => {
+        beforeEach(() => {
+          desktopConfigSpy.mockReturnValue(undefined);
+        });
+
+        it('should not disable the app lock checkbox', () => {
+          const appLockState = createMockAppLockState({
+            isAppLockAvailable: ko.pureComputed(() => true),
+            isAppLockEnabled: ko.pureComputed(() => false),
+          });
+          const propertiesRepository = createMockPropertiesRepository();
+          const appLockRepository = createMockAppLockRepository();
+
+          render(
+            withTheme(
+              <PrivacySection
+                appLockRepository={appLockRepository}
+                appLockState={appLockState}
+                propertiesRepository={propertiesRepository}
+              />,
+            ),
+            {wrapper: rootProviderWrapper},
+          );
+
+          const checkbox = screen.getByRole('checkbox', {name: /applock/i});
+          expect(checkbox).not.toBeDisabled();
+        });
+      });
+    });
+
+    describe('when MDM config is disabled', () => {
+      beforeEach(() => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: false,
+          },
+        } as any);
+      });
+
+      it('should not disable the app lock checkbox even if desktopConfig has applockOverride', () => {
+        desktopConfigSpy.mockReturnValue({
+          version: '1.0',
+          managedConfig: {
+            applockOverride: true,
+          },
+        } as any);
+
+        const appLockState = createMockAppLockState({
+          isAppLockAvailable: ko.pureComputed(() => true),
+          isAppLockEnabled: ko.pureComputed(() => true),
+        });
+        const propertiesRepository = createMockPropertiesRepository();
+        const appLockRepository = createMockAppLockRepository();
+
+        render(
+          withTheme(
+            <PrivacySection
+              appLockRepository={appLockRepository}
+              appLockState={appLockState}
+              propertiesRepository={propertiesRepository}
+            />,
+          ),
+          {wrapper: rootProviderWrapper},
+        );
+
+        const checkbox = screen.getByRole('checkbox', {name: /applock/i});
+        expect(checkbox).not.toBeDisabled();
+      });
+    });
+
+    describe('when app lock is enforced by team', () => {
+      it('should disable the app lock checkbox', () => {
+        const appLockState = createMockAppLockState({
+          isAppLockAvailable: ko.pureComputed(() => true),
+          isAppLockEnforced: ko.pureComputed(() => true),
+          isAppLockEnabled: ko.pureComputed(() => true),
+        });
+        const propertiesRepository = createMockPropertiesRepository();
+        const appLockRepository = createMockAppLockRepository();
+
+        render(
+          withTheme(
+            <PrivacySection
+              appLockRepository={appLockRepository}
+              appLockState={appLockState}
+              propertiesRepository={propertiesRepository}
+            />,
+          ),
+          {wrapper: rootProviderWrapper},
+        );
+
+        const checkbox = screen.getByRole('checkbox', {name: /applock/i});
+        expect(checkbox).toBeDisabled();
+      });
+
+      it('should still be disabled if also overridden by MDM', () => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: true,
+          },
+        } as any);
+        desktopConfigSpy.mockReturnValue({
+          version: '1.0',
+          managedConfig: {
+            applockOverride: true,
+          },
+        } as any);
+
+        const appLockState = createMockAppLockState({
+          isAppLockAvailable: ko.pureComputed(() => true),
+          isAppLockEnforced: ko.pureComputed(() => true),
+          isAppLockEnabled: ko.pureComputed(() => true),
+        });
+        const propertiesRepository = createMockPropertiesRepository();
+        const appLockRepository = createMockAppLockRepository();
+
+        render(
+          withTheme(
+            <PrivacySection
+              appLockRepository={appLockRepository}
+              appLockState={appLockState}
+              propertiesRepository={propertiesRepository}
+            />,
+          ),
+          {wrapper: rootProviderWrapper},
+        );
+
+        const checkbox = screen.getByRole('checkbox', {name: /applock/i});
+        expect(checkbox).toBeDisabled();
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle applockOverride as non-boolean value safely', () => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: true,
+          },
+        } as any);
+        desktopConfigSpy.mockReturnValue({
+          version: '1.0',
+          managedConfig: {
+            applockOverride: 1 as any, // Invalid: number instead of boolean
+          },
+        } as any);
+
+        const appLockState = createMockAppLockState({
+          isAppLockAvailable: ko.pureComputed(() => true),
+          isAppLockEnabled: ko.pureComputed(() => true),
+        });
+        const propertiesRepository = createMockPropertiesRepository();
+        const appLockRepository = createMockAppLockRepository();
+
+        render(
+          withTheme(
+            <PrivacySection
+              appLockRepository={appLockRepository}
+              appLockState={appLockState}
+              propertiesRepository={propertiesRepository}
+            />,
+          ),
+          {wrapper: rootProviderWrapper},
+        );
+
+        const checkbox = screen.getByRole('checkbox', {name: /applock/i});
+        // Should not be disabled because 1 !== true (strict comparison)
+        expect(checkbox).not.toBeDisabled();
+      });
+
+      it('should handle stale desktop config gracefully', () => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: true,
+          },
+        } as any);
+        // Old config format without managedConfig
+        desktopConfigSpy.mockReturnValue({
+          version: '0.5',
+          supportsCallingPopoutWindow: true,
+        } as any);
+
+        const appLockState = createMockAppLockState({
+          isAppLockAvailable: ko.pureComputed(() => true),
+          isAppLockEnabled: ko.pureComputed(() => true),
+        });
+        const propertiesRepository = createMockPropertiesRepository();
+        const appLockRepository = createMockAppLockRepository();
+
+        render(
+          withTheme(
+            <PrivacySection
+              appLockRepository={appLockRepository}
+              appLockState={appLockState}
+              propertiesRepository={propertiesRepository}
+            />,
+          ),
+          {wrapper: rootProviderWrapper},
+        );
+
+        const checkbox = screen.getByRole('checkbox', {name: /applock/i});
+        expect(checkbox).not.toBeDisabled();
+      });
+
+      it('should handle applockOverride with undefined value', () => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: true,
+          },
+        } as any);
+        desktopConfigSpy.mockReturnValue({
+          version: '1.0',
+          managedConfig: {
+            applockOverride: undefined,
+          },
+        } as any);
+
+        const appLockState = createMockAppLockState({
+          isAppLockAvailable: ko.pureComputed(() => true),
+          isAppLockEnabled: ko.pureComputed(() => true),
+        });
+        const propertiesRepository = createMockPropertiesRepository();
+        const appLockRepository = createMockAppLockRepository();
+
+        render(
+          withTheme(
+            <PrivacySection
+              appLockRepository={appLockRepository}
+              appLockState={appLockState}
+              propertiesRepository={propertiesRepository}
+            />,
+          ),
+          {wrapper: rootProviderWrapper},
+        );
+
+        const checkbox = screen.getByRole('checkbox', {name: /applock/i});
+        expect(checkbox).not.toBeDisabled();
+      });
+
+      it('should handle applockOverride with null value', () => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: true,
+          },
+        } as any);
+        desktopConfigSpy.mockReturnValue({
+          version: '1.0',
+          managedConfig: {
+            applockOverride: null,
+          },
+        } as any);
+
+        const appLockState = createMockAppLockState({
+          isAppLockAvailable: ko.pureComputed(() => true),
+          isAppLockEnabled: ko.pureComputed(() => true),
+        });
+        const propertiesRepository = createMockPropertiesRepository();
+        const appLockRepository = createMockAppLockRepository();
+
+        render(
+          withTheme(
+            <PrivacySection
+              appLockRepository={appLockRepository}
+              appLockState={appLockState}
+              propertiesRepository={propertiesRepository}
+            />,
+          ),
+          {wrapper: rootProviderWrapper},
+        );
+
+        const checkbox = screen.getByRole('checkbox', {name: /applock/i});
+        expect(checkbox).not.toBeDisabled();
+      });
+    });
+  });
+});

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences/privacySection.test.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences/privacySection.test.tsx
@@ -61,13 +61,13 @@ const createMockPropertiesRepository = (): PropertiesRepository => {
   return {
     receiptMode: ko.observable(0),
     typingIndicatorMode: ko.observable(0),
-  } as any;
+  };
 };
 
 const createMockAppLockRepository = (): AppLockRepository => {
   return {
     setEnabled: jest.fn(),
-  } as any;
+  };
 };
 
 const rootProviderWrapper = createRootProviderWrapperForTest(
@@ -83,7 +83,7 @@ describe('PrivacySection', () => {
       FEATURE: {
         ENABLE_MDM_CONFIG: false,
       },
-    } as any);
+    });
     desktopConfigSpy = jest.spyOn(Config, 'getDesktopConfig').mockReturnValue(undefined);
   });
 
@@ -142,7 +142,7 @@ describe('PrivacySection', () => {
           FEATURE: {
             ENABLE_MDM_CONFIG: true,
           },
-        } as any);
+        });
       });
 
       describe('and MDM override is enabled', () => {
@@ -152,7 +152,7 @@ describe('PrivacySection', () => {
             managedConfig: {
               applockOverride: true,
             },
-          } as any);
+          });
         });
 
         it('should disable the app lock checkbox', () => {
@@ -209,7 +209,7 @@ describe('PrivacySection', () => {
             managedConfig: {
               applockOverride: false,
             },
-          } as any);
+          });
         });
 
         it('should not disable the app lock checkbox', () => {
@@ -240,7 +240,7 @@ describe('PrivacySection', () => {
         beforeEach(() => {
           desktopConfigSpy.mockReturnValue({
             version: '1.0',
-          } as any);
+          });
         });
 
         it('should not disable the app lock checkbox', () => {
@@ -303,7 +303,7 @@ describe('PrivacySection', () => {
           FEATURE: {
             ENABLE_MDM_CONFIG: false,
           },
-        } as any);
+        });
       });
 
       it('should not disable the app lock checkbox even if desktopConfig has applockOverride', () => {
@@ -312,7 +312,7 @@ describe('PrivacySection', () => {
           managedConfig: {
             applockOverride: true,
           },
-        } as any);
+        });
 
         const appLockState = createMockAppLockState({
           isAppLockAvailable: ko.pureComputed(() => true),
@@ -367,13 +367,13 @@ describe('PrivacySection', () => {
           FEATURE: {
             ENABLE_MDM_CONFIG: true,
           },
-        } as any);
+        });
         desktopConfigSpy.mockReturnValue({
           version: '1.0',
           managedConfig: {
             applockOverride: true,
           },
-        } as any);
+        });
 
         const appLockState = createMockAppLockState({
           isAppLockAvailable: ko.pureComputed(() => true),
@@ -405,13 +405,13 @@ describe('PrivacySection', () => {
           FEATURE: {
             ENABLE_MDM_CONFIG: true,
           },
-        } as any);
+        });
         desktopConfigSpy.mockReturnValue({
           version: '1.0',
           managedConfig: {
-            applockOverride: 1 as any, // Invalid: number instead of boolean
+            applockOverride: 1, // Invalid: number instead of boolean
           },
-        } as any);
+        });
 
         const appLockState = createMockAppLockState({
           isAppLockAvailable: ko.pureComputed(() => true),
@@ -441,12 +441,12 @@ describe('PrivacySection', () => {
           FEATURE: {
             ENABLE_MDM_CONFIG: true,
           },
-        } as any);
+        });
         // Old config format without managedConfig
         desktopConfigSpy.mockReturnValue({
           version: '0.5',
           supportsCallingPopoutWindow: true,
-        } as any);
+        });
 
         const appLockState = createMockAppLockState({
           isAppLockAvailable: ko.pureComputed(() => true),
@@ -475,13 +475,13 @@ describe('PrivacySection', () => {
           FEATURE: {
             ENABLE_MDM_CONFIG: true,
           },
-        } as any);
+        });
         desktopConfigSpy.mockReturnValue({
           version: '1.0',
           managedConfig: {
             applockOverride: undefined,
           },
-        } as any);
+        });
 
         const appLockState = createMockAppLockState({
           isAppLockAvailable: ko.pureComputed(() => true),
@@ -510,13 +510,13 @@ describe('PrivacySection', () => {
           FEATURE: {
             ENABLE_MDM_CONFIG: true,
           },
-        } as any);
+        });
         desktopConfigSpy.mockReturnValue({
           version: '1.0',
           managedConfig: {
             applockOverride: null,
           },
-        } as any);
+        });
 
         const appLockState = createMockAppLockState({
           isAppLockAvailable: ko.pureComputed(() => true),

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences/privacySection.test.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences/privacySection.test.tsx
@@ -36,7 +36,7 @@ import {PrivacySection} from './privacySection';
 const createMockAppLockState = (overrides?: Partial<AppLockState>): AppLockState => {
   const hasPassphrase = ko.observable(false);
   const isActivatedInPreferences = ko.observable(false);
-  
+
   // Create observables for computed values that can be overridden
   const isAppLockEnforcedValue = ko.observable(overrides?.isAppLockEnforced?.() ?? false);
   const isAppLockAvailableValue = ko.observable(overrides?.isAppLockAvailable?.() ?? true);

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences/privacySection.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences/privacySection.tsx
@@ -28,6 +28,7 @@ import {PropertiesRepository} from 'Repositories/properties/propertiesRepository
 import {AppLockRepository} from 'Repositories/user/appLockRepository';
 import {AppLockState} from 'Repositories/user/appLockState';
 import {CONVERSATION_TYPING_INDICATOR_MODE} from 'Repositories/user/typingIndicatorMode';
+import {Config} from 'src/script/Config';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {formatDurationCaption, TIME_IN_MILLIS} from 'Util/timeUtil';
@@ -53,6 +54,10 @@ const PrivacySection = ({
       'isAppLockEnforced',
       'appLockInactivityTimeoutSecs',
     ]);
+
+  const enableMdmConfig = Config.getConfig().FEATURE.ENABLE_MDM_CONFIG;
+  const appLockOverride = Boolean(Config.getDesktopConfig()?.managedConfig?.applockOverride);
+  const isMdmAppLockDisabled = enableMdmConfig && appLockOverride;
 
   const {receiptMode, typingIndicatorMode} = useKoSubscribableChildren(propertiesRepository, [
     'receiptMode',
@@ -112,7 +117,6 @@ const PrivacySection = ({
           {translate('preferencesAccountTypingIndicatorsDetail')}
         </p>
       </div>
-
       {isAppLockAvailable && (
         <div className="checkbox-margin">
           <Checkbox
@@ -120,7 +124,7 @@ const PrivacySection = ({
               appLockRepository.setEnabled(event.target.checked);
             }}
             checked={isAppLockEnabled}
-            disabled={isAppLockEnforced}
+            disabled={isAppLockEnforced || isMdmAppLockDisabled}
             data-uie-name="status-preference-applock"
           >
             <CheckboxLabel htmlFor="status-preference-applock">

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences/privacySection.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences/privacySection.tsx
@@ -56,7 +56,7 @@ const PrivacySection = ({
     ]);
 
   const enableMdmConfig = Config.getConfig().FEATURE.ENABLE_MDM_CONFIG;
-  const appLockOverride = Boolean(Config.getDesktopConfig()?.managedConfig?.applockOverride);
+  const appLockOverride = Config.getDesktopConfig()?.managedConfig?.applockOverride === true;
   const isMdmAppLockDisabled = enableMdmConfig && appLockOverride;
 
   const {receiptMode, typingIndicatorMode} = useKoSubscribableChildren(propertiesRepository, [

--- a/apps/webapp/src/script/repositories/conversation/linkPreviews/index.ts
+++ b/apps/webapp/src/script/repositories/conversation/linkPreviews/index.ts
@@ -51,7 +51,11 @@ type LinkPreviewContent = {
 declare global {
   interface Window {
     openGraphAsync?: (url: string) => Promise<OpenGraphResult>;
-    desktopAppConfig?: {version: string; supportsCallingPopoutWindow?: boolean};
+    desktopAppConfig?: {
+      version: string;
+      supportsCallingPopoutWindow?: boolean;
+      managedConfig?: {applockOverride: boolean};
+    };
   }
 }
 const logger = getLogger('LinkPreviewRepository');

--- a/apps/webapp/src/script/repositories/user/appLockState.test.ts
+++ b/apps/webapp/src/script/repositories/user/appLockState.test.ts
@@ -1,0 +1,324 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {FEATURE_STATUS} from '@wireapp/api-client/lib/team/feature/';
+import {container} from 'tsyringe';
+import ko from 'knockout';
+
+import {TeamState} from 'Repositories/team/TeamState';
+import {Config} from 'src/script/Config';
+import {AppLockState} from './appLockState';
+
+describe('AppLockState', () => {
+  let appLockState: AppLockState;
+  let teamState: TeamState;
+  let configSpy: jest.SpyInstance;
+  let desktopConfigSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    teamState = container.resolve(TeamState);
+    appLockState = new AppLockState(teamState);
+    configSpy = jest.spyOn(Config, 'getConfig').mockReturnValue({
+      FEATURE: {
+        ENABLE_MDM_CONFIG: false,
+      },
+    });
+    desktopConfigSpy = jest.spyOn(Config, 'getDesktopConfig').mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    configSpy.mockRestore();
+    desktopConfigSpy.mockRestore();
+    jest.restoreAllMocks();
+  });
+
+  describe('isAppLockEnabled', () => {
+    describe('when MDM config is disabled', () => {
+      beforeEach(() => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: false,
+          },
+        });
+      });
+
+      it('should return false when app lock is not enforced and not activated in preferences', () => {
+        expect(appLockState.isAppLockEnabled()).toBe(false);
+      });
+
+      it('should return true when app lock is activated in preferences', () => {
+        appLockState.isActivatedInPreferences(true);
+
+        expect(appLockState.isAppLockEnabled()).toBe(true);
+      });
+    });
+
+    describe('when MDM config is enabled', () => {
+      beforeEach(() => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: true,
+          },
+        });
+      });
+
+      describe('and MDM override is enabled', () => {
+        beforeEach(() => {
+          desktopConfigSpy.mockReturnValue({
+            version: '1.0',
+            managedConfig: {
+              applockOverride: true,
+            },
+          });
+          // Mock teamState for this group
+          jest.spyOn(teamState, 'isTeam').mockReturnValue(true);
+          jest.spyOn(teamState, 'teamFeatures').mockReturnValue({
+            appLock: {
+              status: FEATURE_STATUS.ENABLED,
+              config: {
+                enforceAppLock: false,
+              },
+            },
+          });
+        });
+
+        it('should force app lock to be disabled regardless of preferences', () => {
+          appLockState.isActivatedInPreferences(true);
+
+          expect(appLockState.isAppLockEnabled()).toBe(false);
+        });
+
+        it('should disable app lock even when enforced by team', () => {
+          // Override enforceAppLock for this specific test
+          jest.spyOn(teamState, 'teamFeatures').mockReturnValue({
+            appLock: {
+              status: FEATURE_STATUS.ENABLED,
+              config: {
+                enforceAppLock: true,
+              },
+            },
+          });
+
+          expect(appLockState.isAppLockEnabled()).toBe(false);
+        });
+      });
+
+      describe('and MDM override is disabled', () => {
+        beforeEach(() => {
+          desktopConfigSpy.mockReturnValue({
+            version: '1.0',
+            managedConfig: {
+              applockOverride: false,
+            },
+          });
+          // Ensure teamState is properly mocked
+          jest.spyOn(teamState, 'isTeam').mockReturnValue(false);
+          jest.spyOn(teamState, 'teamFeatures').mockReturnValue({
+            appLock: {
+              status: FEATURE_STATUS.DISABLED,
+              config: {},
+            },
+          });
+        });
+
+        it('should allow app lock to be controlled by preferences', () => {
+          appLockState.isActivatedInPreferences(true);
+
+          expect(appLockState.isAppLockEnabled()).toBe(true);
+        });
+
+        it('should return false when not activated in preferences', () => {
+          appLockState.isActivatedInPreferences(false);
+
+          expect(appLockState.isAppLockEnabled()).toBe(false);
+        });
+      });
+
+      describe('and managedConfig is missing', () => {
+        beforeEach(() => {
+          desktopConfigSpy.mockReturnValue({
+            version: '1.0',
+          }); // Ensure teamState is properly mocked
+          jest.spyOn(teamState, 'isTeam').mockReturnValue(false);
+          jest.spyOn(teamState, 'teamFeatures').mockReturnValue({
+            appLock: {
+              status: FEATURE_STATUS.DISABLED,
+              config: {},
+            },
+          });
+        });
+
+        it('should allow app lock to be controlled by preferences', () => {
+          appLockState.isActivatedInPreferences(true);
+
+          expect(appLockState.isAppLockEnabled()).toBe(true);
+        });
+      });
+
+      describe('and desktopConfig is missing entirely', () => {
+        beforeEach(() => {
+          desktopConfigSpy.mockReturnValue(undefined);
+          // Ensure teamState is properly mocked
+          jest.spyOn(teamState, 'isTeam').mockReturnValue(false);
+          jest.spyOn(teamState, 'teamFeatures').mockReturnValue({
+            appLock: {
+              status: FEATURE_STATUS.DISABLED,
+              config: {},
+            },
+          });
+        });
+
+        it('should allow app lock to be controlled by preferences', () => {
+          appLockState.isActivatedInPreferences(true);
+
+          expect(appLockState.isAppLockEnabled()).toBe(true);
+        });
+      });
+    });
+
+    describe('edge cases', () => {
+      beforeEach(() => {
+        // Ensure teamState is properly mocked for all edge case tests
+        jest.spyOn(teamState, 'isTeam').mockReturnValue(false);
+        jest.spyOn(teamState, 'teamFeatures').mockReturnValue({
+          appLock: {
+            status: FEATURE_STATUS.DISABLED,
+            config: {},
+          },
+        });
+      });
+
+      it('should handle applockOverride as non-boolean value safely', () => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: true,
+          },
+        });
+        desktopConfigSpy.mockReturnValue({
+          version: '1.0',
+          managedConfig: {
+            applockOverride: 1, // Invalid: number instead of boolean
+          },
+        });
+
+        appLockState.isActivatedInPreferences(true);
+
+        // Should still work with strict comparison
+        expect(appLockState.isAppLockEnabled()).toBe(true);
+      });
+
+      it('should handle stale desktop config gracefully', () => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: true,
+          },
+        });
+        // Old config format without managedConfig
+        desktopConfigSpy.mockReturnValue({
+          version: '0.5',
+          supportsCallingPopoutWindow: true,
+        });
+
+        appLockState.isActivatedInPreferences(true);
+
+        expect(appLockState.isAppLockEnabled()).toBe(true);
+      });
+
+      it('should handle applockOverride with undefined value', () => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: true,
+          },
+        });
+        desktopConfigSpy.mockReturnValue({
+          version: '1.0',
+          managedConfig: {
+            applockOverride: undefined,
+          },
+        });
+
+        appLockState.isActivatedInPreferences(true);
+
+        expect(appLockState.isAppLockEnabled()).toBe(true);
+      });
+
+      it('should handle applockOverride with null value', () => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: true,
+          },
+        });
+        desktopConfigSpy.mockReturnValue({
+          version: '1.0',
+          managedConfig: {
+            applockOverride: null,
+          },
+        });
+
+        appLockState.isActivatedInPreferences(true);
+
+        expect(appLockState.isAppLockEnabled()).toBe(true);
+      });
+    });
+
+    describe('isAppLockActivated', () => {
+      beforeEach(() => {
+        // Ensure teamState is properly mocked
+        jest.spyOn(teamState, 'isTeam').mockReturnValue(false);
+        jest.spyOn(teamState, 'teamFeatures').mockReturnValue({
+          appLock: {
+            status: FEATURE_STATUS.DISABLED,
+            config: {},
+          },
+        });
+      });
+
+      it('should return true when app lock is enabled and passphrase is set', () => {
+        appLockState.isActivatedInPreferences(true);
+        appLockState.hasPassphrase(true);
+
+        expect(appLockState.isAppLockActivated()).toBe(true);
+      });
+
+      it('should return false when app lock is disabled even if passphrase is set', () => {
+        appLockState.hasPassphrase(true);
+
+        expect(appLockState.isAppLockActivated()).toBe(false);
+      });
+
+      it('should return false when MDM overrides app lock even with passphrase', () => {
+        configSpy.mockReturnValue({
+          FEATURE: {
+            ENABLE_MDM_CONFIG: true,
+          },
+        });
+        desktopConfigSpy.mockReturnValue({
+          version: '1.0',
+          managedConfig: {
+            applockOverride: true,
+          },
+        });
+        appLockState.isActivatedInPreferences(true);
+        appLockState.hasPassphrase(true);
+
+        expect(appLockState.isAppLockActivated()).toBe(false);
+      });
+    });
+  });
+});

--- a/apps/webapp/src/script/repositories/user/appLockState.ts
+++ b/apps/webapp/src/script/repositories/user/appLockState.ts
@@ -67,7 +67,7 @@ export class AppLockState {
     this.isAppLockEnabled = ko.pureComputed(() => {
       const isMdmAppLockDisabled =
         Config.getConfig().FEATURE.ENABLE_MDM_CONFIG &&
-        Boolean(Config.getDesktopConfig()?.managedConfig?.applockOverride);
+        Config.getDesktopConfig()?.managedConfig?.applockOverride === true;
       if (isMdmAppLockDisabled) {
         return false;
       }

--- a/apps/webapp/src/script/repositories/user/appLockState.ts
+++ b/apps/webapp/src/script/repositories/user/appLockState.ts
@@ -22,6 +22,7 @@ import ko from 'knockout';
 import {container, singleton} from 'tsyringe';
 
 import {TeamState} from 'Repositories/team/TeamState';
+import {Config} from 'src/script/Config';
 
 const defaultEnabled = true;
 const defaultEnforced = false;
@@ -63,6 +64,14 @@ export class AppLockState {
     this.isAppLockActivated = ko.pureComputed(() => this.isAppLockEnabled() && this.hasPassphrase());
     this.hasPassphrase = ko.observable(false);
     this.isActivatedInPreferences = ko.observable(false);
-    this.isAppLockEnabled = ko.pureComputed(() => this.isAppLockEnforced() || this.isActivatedInPreferences());
+    this.isAppLockEnabled = ko.pureComputed(() => {
+      const isMdmAppLockDisabled =
+        Config.getConfig().FEATURE.ENABLE_MDM_CONFIG &&
+        Boolean(Config.getDesktopConfig()?.managedConfig?.applockOverride);
+      if (isMdmAppLockDisabled) {
+        return false;
+      }
+      return this.isAppLockEnforced() || this.isActivatedInPreferences();
+    });
   }
 }

--- a/libraries/config/src/client.config.ts
+++ b/libraries/config/src/client.config.ts
@@ -54,6 +54,7 @@ export function generateConfig(params: ConfigGeneratorParams, env: Env) {
       APPLOCK_SCHEDULED_TIMEOUT: env.FEATURE_APPLOCK_SCHEDULED_TIMEOUT
         ? Number(env.FEATURE_APPLOCK_SCHEDULED_TIMEOUT)
         : null,
+      ENABLE_MDM_CONFIG: env.FEATURE_ENABLE_MDM_CONFIG == 'true',
       ENABLE_CELLS: env.FEATURE_ENABLE_CELLS == 'true',
       CELLS_INIT_WITH_ZAUTH_TOKEN: env.FEATURE_CELLS_INIT_WITH_ZAUTH_TOKEN == 'true',
       CHECK_CONSENT: env.FEATURE_CHECK_CONSENT != 'false',

--- a/libraries/config/src/env.ts
+++ b/libraries/config/src/env.ts
@@ -169,6 +169,9 @@ export type Env = {
   /** Time in seconds after the last unlock which forces the app to lock */
   FEATURE_APPLOCK_SCHEDULED_TIMEOUT: string;
 
+  /** Feature toggle to enable MDM config support for app lock */
+  FEATURE_ENABLE_MDM_CONFIG: string;
+
   /** Feature toggle to automatically mute when accepting incoming conference calls */
   FEATURE_CONFERENCE_AUTO_MUTE: string;
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26671" title="WPB-26671" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26671</a>  [Web] Bypass Applock using MDM config for Managed devices
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Description

Allow app to consume MDM config and influence app lock functionality.
There is an env veraible to control the behaviour