### PR TITLE
Fix E2E login when extra client entropy is required [WPB-23926]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/infoHistory.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/infoHistory.page.ts
@@ -27,6 +27,11 @@ export class HistoryInfoPage {
     this.page = page;
     this.continueButton = this.page.getByTestId('do-history-confirm');
   }
+
+  async waitForConfirmButton(timeoutMilliseconds: number): Promise<void> {
+    await this.continueButton.waitFor({state: 'visible', timeout: timeoutMilliseconds});
+  }
+
   async isButtonVisible(timeout = 3_000) {
     try {
       await this.continueButton.waitFor({state: 'visible', timeout});

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/login.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/login.page.ts
@@ -18,33 +18,60 @@
  */
 
 import type {Page, Locator} from '@playwright/test';
+import is from '@sindresorhus/is';
+
 import type {User} from 'test/e2e_tests/data/user';
 
 export class LoginPage {
+  private readonly page: Page;
+
   readonly signInButton: Locator;
   readonly emailInput: Locator;
   readonly passwordInput: Locator;
   readonly loginErrorText: Locator;
   readonly publicComputerCheckbox: Locator;
   readonly header: Locator;
+  readonly entropyCanvas: Locator;
+  readonly entropyConfirmButton: Locator;
 
   constructor(page: Page) {
+    this.page = page;
     this.signInButton = page.locator('[data-uie-name="do-sign-in"]');
     this.emailInput = page.locator('[data-uie-name="enter-email"]');
     this.passwordInput = page.locator('[data-uie-name="enter-password"]');
     this.loginErrorText = page.locator('[data-uie-name="error-message"]');
     this.publicComputerCheckbox = page.getByText('This is a public computer');
     this.header = page.getByRole('heading');
+    this.entropyCanvas = page.locator('[data-uie-name="element-entropy-canvas"]');
+    this.entropyConfirmButton = page.locator('[data-uie-name="do-entropy-confirm"]');
   }
 
-  async login(user: Pick<User, 'email' | 'password'>, options?: {publicComputer?: boolean}) {
+  async login(user: Pick<User, 'email' | 'password'>, options?: {publicComputer?: boolean}): Promise<void> {
     await this.emailInput.fill(user.email);
     await this.passwordInput.fill(user.password);
 
-    if (options?.publicComputer) {
+    if (options?.publicComputer === true) {
       await this.publicComputerCheckbox.click();
     }
 
     await this.signInButton.click();
+  }
+
+  async completeEntropyCollection(): Promise<void> {
+    const boundingBox = await this.entropyCanvas.boundingBox();
+
+    if (is.nullOrUndefined(boundingBox)) {
+      throw new Error('Entropy canvas is visible but has no bounding box');
+    }
+
+    for (let index = 0; index < 1_500; index += 1) {
+      const x = boundingBox.x + 8 + ((index * 37) % Math.max(1, boundingBox.width - 16));
+      const y = boundingBox.y + 8 + ((index * 53) % Math.max(1, boundingBox.height - 16));
+
+      await this.page.mouse.move(x, y);
+    }
+
+    await this.entropyConfirmButton.waitFor({state: 'visible', timeout: 5_000});
+    await this.entropyConfirmButton.click();
   }
 }

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -141,6 +141,50 @@ export const test = baseTest.extend<Fixtures>({
 /** Max time the login is allowed to take before the application needs to be useable */
 export const LOGIN_TIMEOUT = 40_000;
 
+type LoginCompletionResult = 'sidebar' | 'entropy';
+type LoginCompletionWaitResult =
+  | {type: 'success'; loginCompletionResult: LoginCompletionResult}
+  | {type: 'failure'; loginCompletionResult: LoginCompletionResult};
+
+async function waitForLoginCompletion(pageManager: PageManager): Promise<LoginCompletionResult> {
+  const waitForSidebar = waitForLoginCompletionSignal('sidebar', () => {
+    return pageManager.webapp.components
+      .conversationSidebar()
+      .sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
+  });
+
+  const waitForEntropy = waitForLoginCompletionSignal('entropy', () => {
+    return pageManager.webapp.pages.login().entropyCanvas.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
+  });
+
+  const firstLoginCompletionWaitResult = await Promise.race([waitForSidebar, waitForEntropy]);
+
+  if (firstLoginCompletionWaitResult.type === 'success') {
+    return firstLoginCompletionWaitResult.loginCompletionResult;
+  }
+
+  const secondLoginCompletionWaitResult =
+    firstLoginCompletionWaitResult.loginCompletionResult === 'sidebar' ? await waitForEntropy : await waitForSidebar;
+
+  if (secondLoginCompletionWaitResult.type === 'success') {
+    return secondLoginCompletionWaitResult.loginCompletionResult;
+  }
+
+  throw new Error('Login did not reach either the conversation sidebar or the entropy screen');
+}
+
+async function waitForLoginCompletionSignal(
+  loginCompletionResult: LoginCompletionResult,
+  waitForLoginCompletionSignalToAppear: () => Promise<void>,
+): Promise<LoginCompletionWaitResult> {
+  try {
+    await waitForLoginCompletionSignalToAppear();
+
+    return {type: 'success', loginCompletionResult};
+  } catch {
+    return {type: 'failure', loginCompletionResult};
+  }
+}
 /** PagePlugin to log in as the given user */
 export const withLogin =
   (user: User | Promise<User>, options?: {baseUrl?: string; confirmNewHistory?: boolean}): PagePlugin =>
@@ -157,6 +201,14 @@ export const withLogin =
      * Since the login may take up to 40s we manually wait for it to finish here instead of increasing the timeout on all actions / assertions after this util
      * This is an exception to the general best practice of using playwrights web assertions. (See: https://playwright.dev/docs/best-practices#use-web-first-assertions)
      */
+    const loginCompletionResult = await waitForLoginCompletion(pageManager);
+
+    if (loginCompletionResult === 'sidebar') {
+      return;
+    }
+
+    await pageManager.webapp.pages.login().completeEntropyCollection();
+
     await pageManager.webapp.components
       .conversationSidebar()
       .sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -141,50 +141,73 @@ export const test = baseTest.extend<Fixtures>({
 /** Max time the login is allowed to take before the application needs to be useable */
 export const LOGIN_TIMEOUT = 40_000;
 
-type LoginCompletionResult = 'sidebar' | 'entropy';
-type LoginCompletionWaitResult =
-  | {type: 'success'; loginCompletionResult: LoginCompletionResult}
-  | {type: 'failure'; loginCompletionResult: LoginCompletionResult};
+type LoginStep = 'sidebar' | 'entropy' | 'historyInfo';
+type LoginStepWaitResult = {type: 'success'; loginStep: LoginStep} | {type: 'failure'; loginStep: LoginStep};
 
-async function waitForLoginCompletion(pageManager: PageManager): Promise<LoginCompletionResult> {
-  const waitForSidebar = waitForLoginCompletionSignal('sidebar', () => {
-    return pageManager.webapp.components
-      .conversationSidebar()
-      .sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
-  });
+async function waitForLoginStep(pageManager: PageManager, options: {confirmNewHistory: boolean}): Promise<LoginStep> {
+  const loginStepWaits = [
+    waitForLoginStepSignal('sidebar', () => {
+      return pageManager.webapp.components
+        .conversationSidebar()
+        .sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
+    }),
+    waitForLoginStepSignal('entropy', () => {
+      return pageManager.webapp.pages.login().entropyCanvas.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
+    }),
+  ];
 
-  const waitForEntropy = waitForLoginCompletionSignal('entropy', () => {
-    return pageManager.webapp.pages.login().entropyCanvas.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
-  });
-
-  const firstLoginCompletionWaitResult = await Promise.race([waitForSidebar, waitForEntropy]);
-
-  if (firstLoginCompletionWaitResult.type === 'success') {
-    return firstLoginCompletionWaitResult.loginCompletionResult;
+  if (options.confirmNewHistory === true) {
+    loginStepWaits.push(
+      waitForLoginStepSignal('historyInfo', () => {
+        return pageManager.webapp.pages.historyInfo().waitForConfirmButton(LOGIN_TIMEOUT);
+      }),
+    );
   }
 
-  const secondLoginCompletionWaitResult =
-    firstLoginCompletionWaitResult.loginCompletionResult === 'sidebar' ? await waitForEntropy : await waitForSidebar;
-
-  if (secondLoginCompletionWaitResult.type === 'success') {
-    return secondLoginCompletionWaitResult.loginCompletionResult;
-  }
-
-  throw new Error('Login did not reach either the conversation sidebar or the entropy screen');
+  return waitForFirstSuccessfulLoginStep(loginStepWaits);
 }
 
-async function waitForLoginCompletionSignal(
-  loginCompletionResult: LoginCompletionResult,
-  waitForLoginCompletionSignalToAppear: () => Promise<void>,
-): Promise<LoginCompletionWaitResult> {
+async function waitForFirstSuccessfulLoginStep(loginStepWaits: Promise<LoginStepWaitResult>[]): Promise<LoginStep> {
+  const pendingLoginStepWaits = [...loginStepWaits];
+
+  while (pendingLoginStepWaits.length > 0) {
+    const nextLoginStepWaitResult = await waitForNextLoginStepResult(pendingLoginStepWaits);
+
+    pendingLoginStepWaits.splice(nextLoginStepWaitResult.index, 1);
+
+    if (nextLoginStepWaitResult.result.type === 'success') {
+      return nextLoginStepWaitResult.result.loginStep;
+    }
+  }
+
+  throw new Error('Login did not reach the conversation sidebar, entropy screen, or history info confirmation');
+}
+
+async function waitForNextLoginStepResult(
+  pendingLoginStepWaits: Promise<LoginStepWaitResult>[],
+): Promise<{index: number; result: LoginStepWaitResult}> {
+  return Promise.race(
+    pendingLoginStepWaits.map(async (loginStepWait, index) => {
+      const result = await loginStepWait;
+
+      return {index, result};
+    }),
+  );
+}
+
+async function waitForLoginStepSignal(
+  loginStep: LoginStep,
+  waitForLoginStepSignalToAppear: () => Promise<void>,
+): Promise<LoginStepWaitResult> {
   try {
-    await waitForLoginCompletionSignalToAppear();
+    await waitForLoginStepSignalToAppear();
 
-    return {type: 'success', loginCompletionResult};
+    return {type: 'success', loginStep};
   } catch {
-    return {type: 'failure', loginCompletionResult};
+    return {type: 'failure', loginStep};
   }
 }
+
 /** PagePlugin to log in as the given user */
 export const withLogin =
   (user: User | Promise<User>, options?: {baseUrl?: string; confirmNewHistory?: boolean}): PagePlugin =>
@@ -193,25 +216,31 @@ export const withLogin =
     await pageManager.openLoginPage(options?.baseUrl);
     await pageManager.webapp.pages.login().login(await user);
 
-    if (options?.confirmNewHistory) {
-      await pageManager.webapp.pages.historyInfo().clickConfirmButton();
-    }
-
     /**
      * Since the login may take up to 40s we manually wait for it to finish here instead of increasing the timeout on all actions / assertions after this util
      * This is an exception to the general best practice of using playwrights web assertions. (See: https://playwright.dev/docs/best-practices#use-web-first-assertions)
      */
-    const loginCompletionResult = await waitForLoginCompletion(pageManager);
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const loginStep = await waitForLoginStep(pageManager, {
+        confirmNewHistory: options?.confirmNewHistory === true,
+      });
 
-    if (loginCompletionResult === 'sidebar') {
-      return;
+      if (loginStep === 'sidebar') {
+        return;
+      }
+
+      if (loginStep === 'entropy') {
+        await pageManager.webapp.pages.login().completeEntropyCollection();
+        continue;
+      }
+
+      if (loginStep === 'historyInfo') {
+        await pageManager.webapp.pages.historyInfo().clickConfirmButton();
+        continue;
+      }
     }
 
-    await pageManager.webapp.pages.login().completeEntropyCollection();
-
-    await pageManager.webapp.components
-      .conversationSidebar()
-      .sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
+    throw new Error('Login did not reach the conversation sidebar after handling entropy/history info steps');
   };
 
 /** PagePlugin to open a guest user link and join the group chat as temporary member */


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23926" title="WPB-23926" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23926</a>  [Web] Adjust copy for entropy mouse feature
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## What changed

The Playwright login helper now handles the extra client entropy step when it appears during login.

If the entropy canvas is shown, the helper moves the mouse inside the canvas until entropy collection completes, confirms the step, and then continues with the existing login flow.

If the entropy screen does not appear, the helper behaves exactly as before.

## Why

Several E2E tests were failing while waiting for `.conversations-sidebar-items` after login (see also https://github.com/wireapp/wire-webapp/pull/21710)

The sidebar was only the symptom. The tests were stuck before reaching the authenticated app because login could stop on the extra client entropy screen. Since the shared login helper only filled email/password and clicked sign in, it never completed entropy collection and the sidebar never became visible.

This fixes the shared login path instead of changing sidebar selectors, message list code, or disabling the entropy feature.

## Root cause

The E2E login helper assumed that submitting credentials always leads directly to the app shell.

That assumption is no longer always true. When extra client entropy is required, the login flow waits for manual entropy collection before the authenticated app can load.


