### PR TITLE
fix(meetings): align participant picker with schedule modal design [WPB-25056]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/MeetingParticipantsPicker/MeetingParticipantsPicker.styles.ts
+++ b/apps/webapp/src/script/components/Meeting/MeetingParticipantsPicker/MeetingParticipantsPicker.styles.ts
@@ -118,9 +118,9 @@ export const searchInputStyles: CSSObject = {
 
 export const chevronIconStyles: CSSObject = {
   flexShrink: 0,
-  height: '12px',
+  height: '16px',
   transition: 'transform 0.15s ease',
-  width: '12px',
+  width: '16px',
 };
 
 export const chevronButtonStyles: CSSObject = {
@@ -161,9 +161,29 @@ export const dialogStyles: CSSObject = {
   outline: 'none',
 };
 
+const sectionHeaderBorderStyles: CSSObject = {
+  borderBottom: '1px solid var(--gray-40)',
+  'body.theme-dark &': {
+    borderBottomColor: 'var(--gray-90)',
+  },
+};
+
 export const listContainerStyles: CSSObject = {
   flex: 1,
   overflowY: 'auto',
+
+  '[data-uie-name="do-toggle-selected-search-list"]': sectionHeaderBorderStyles,
+
+  '[data-uie-name="do-toggle-search-list"]': {
+    ...sectionHeaderBorderStyles,
+  },
+
+  '[data-uie-name="do-toggle-selected-search-list"] ~ [data-uie-name="do-toggle-search-list"]': {
+    borderTop: '1px solid var(--gray-40)',
+    'body.theme-dark &': {
+      borderTopColor: 'var(--gray-90)',
+    },
+  },
 };
 
 export const emptyStateStyles: CSSObject = {

--- a/apps/webapp/src/script/components/Meeting/MeetingParticipantsPicker/MeetingParticipantsPicker.styles.ts
+++ b/apps/webapp/src/script/components/Meeting/MeetingParticipantsPicker/MeetingParticipantsPicker.styles.ts
@@ -116,12 +116,14 @@ export const searchInputStyles: CSSObject = {
   },
 };
 
-export const chevronIconStyles: CSSObject = {
+export const chevronIconStyles = (isOpen: boolean): CSSObject => ({
   flexShrink: 0,
   height: '16px',
+  marginTop: isOpen ? 2 : 4,
+  transform: isOpen ? 'rotateX(180deg)' : undefined,
   transition: 'transform 0.15s ease',
   width: '16px',
-};
+});
 
 export const chevronButtonStyles: CSSObject = {
   alignItems: 'center',

--- a/apps/webapp/src/script/components/Meeting/MeetingParticipantsPicker/MeetingParticipantsPicker.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingParticipantsPicker/MeetingParticipantsPicker.tsx
@@ -213,7 +213,7 @@ export const MeetingParticipantsPicker = ({
             aria-hidden="true"
             width={16}
             height={16}
-            css={[chevronIconStyles, isOpen ? {transform: 'rotateX(180deg)', marginTop: 2} : {marginTop: 4}]}
+            css={chevronIconStyles(isOpen)}
           />
         </Button>
       </div>

--- a/apps/webapp/src/script/components/Meeting/MeetingParticipantsPicker/MeetingParticipantsPicker.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingParticipantsPicker/MeetingParticipantsPicker.tsx
@@ -91,7 +91,7 @@ export const MeetingParticipantsPicker = ({
   disabled = false,
   markInvalid = false,
   required = false,
-  noUnderline = true,
+  noUnderline = false,
   popoverPortalContainer,
 }: MeetingParticipantsPickerProps) => {
   const {translate} = useApplicationContext();
@@ -211,9 +211,9 @@ export const MeetingParticipantsPicker = ({
         >
           <ChevronDownIcon
             aria-hidden="true"
-            width={12}
-            height={12}
-            css={[chevronIconStyles, isOpen && {transform: 'rotate(180deg)'}]}
+            width={16}
+            height={16}
+            css={[chevronIconStyles, isOpen ? {transform: 'rotateX(180deg)', marginTop: 2} : {marginTop: 4}]}
           />
         </Button>
       </div>

--- a/apps/webapp/src/script/components/Meeting/MeetingParticipantsPicker/MeetingParticipantsPicker.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingParticipantsPicker/MeetingParticipantsPicker.tsx
@@ -209,12 +209,7 @@ export const MeetingParticipantsPicker = ({
           data-uie-name={`${dataUieName}-toggle`}
           onPress={() => handleOpenChange(!isOpen)}
         >
-          <ChevronDownIcon
-            aria-hidden="true"
-            width={16}
-            height={16}
-            css={chevronIconStyles(isOpen)}
-          />
+          <ChevronDownIcon aria-hidden="true" width={16} height={16} css={chevronIconStyles(isOpen)} />
         </Button>
       </div>
 

--- a/apps/webapp/src/script/components/participantItemContent/participantItem.styles.ts
+++ b/apps/webapp/src/script/components/participantItemContent/participantItem.styles.ts
@@ -27,9 +27,6 @@ export const listWrapper = ({isHighlighted = false, noUnderline = false, noInter
 
   '&:hover, &:focus, &:focus-visible': {
     background: 'var(--app-bg-secondary)',
-    '&::after': {
-      borderBottom: 'none',
-    },
   },
 
   '&:hover [data-hover-class="chevron-icon"], &:focus, &:focus-visible [data-hover-class="chevron-icon"]': {

--- a/apps/webapp/src/script/components/userList/userList.styles.tsx
+++ b/apps/webapp/src/script/components/userList/userList.styles.tsx
@@ -31,8 +31,10 @@ export const collapseButton: CSSObject = {
 };
 
 export const collapseIcon = (isOpen: boolean): CSSObject => ({
-  marginRight: '30px',
-  transform: isOpen ? 'rotate(90deg)' : undefined,
+  display: 'flex',
+  flexShrink: 0,
+  marginRight: '8px',
+  transform: isOpen ? undefined : 'rotate(-90deg)',
 
   '> svg': {
     fill: 'var(--main-color)',

--- a/apps/webapp/src/script/components/userList/userList.tsx
+++ b/apps/webapp/src/script/components/userList/userList.tsx
@@ -22,7 +22,8 @@ import {ChangeEvent, useCallback, useId, useMemo, useState} from 'react';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
-import * as Icon from 'Components/icon';
+import {ChevronDownIcon} from '@wireapp/react-ui-kit';
+
 import {InViewport} from 'Components/inViewport';
 import {collapseButton, collapseIcon} from 'Components/userList/userList.styles';
 import type {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
@@ -266,6 +267,7 @@ export const UserList = ({
 
     const isSelectedContactsOpen = expandedFolders.includes(UserListSections.SELECTED_CONTACTS);
     const isContactsOpen = expandedFolders.includes(UserListSections.CONTACTS);
+    const unselectedUsers = truncatedUsers.slice(0, maxShownUsers).filter(user => !isSelected(user));
 
     content = (
       <>
@@ -277,7 +279,7 @@ export const UserList = ({
               data-uie-name="do-toggle-selected-search-list"
             >
               <span css={collapseIcon(isSelectedContactsOpen)} aria-hidden="true">
-                <Icon.DiscloseIcon width={16} height={16} />
+                <ChevronDownIcon width={16} height={16} />
               </span>
 
               {translate('userListSelectedContacts', {selectedContacts: selectedUsersCount})}
@@ -305,7 +307,7 @@ export const UserList = ({
             data-uie-name="do-toggle-search-list"
           >
             <span css={collapseIcon(isContactsOpen)} aria-hidden="true">
-              <Icon.DiscloseIcon width={16} height={16} />
+              <ChevronDownIcon width={16} height={16} />
             </span>
 
             {translate('userListContacts')}
@@ -314,10 +316,11 @@ export const UserList = ({
 
         <ul className={cx('search-list', cssClasses)} data-uie-name="search-list">
           {isContactsOpen &&
-            truncatedUsers
-              .slice(0, maxShownUsers)
-              .filter(user => !isSelected(user))
-              .map(user => renderListItem(user))}
+            unselectedUsers.map((user, index) => {
+              const isLastItem = index === unselectedUsers.length - 1;
+
+              return renderListItem(user, isLastItem);
+            })}
         </ul>
       </>
     );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25056" title="WPB-25056" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25056</a>  [Web] Schedule a meeting: participants (Wire users)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Add inset row dividers and section header borders to the schedule meeting participant picker dropdown
- Keep row dividers visible on hover instead of hiding them
- Use the same 16px `ChevronDownIcon` for the participants field and Contacts/Selected section headers, matching the time and repeats selects

## Test plan
- [x] Open Schedule New Meeting modal and expand the Participants picker
- [x] Verify row dividers appear between participant rows in Contacts and Selected sections
- [x] Verify section header borders match the Figma design
- [x] Hover participant rows and confirm dividers remain visible
- [x] Confirm chevron icons match the time and repeats dropdown arrows in size and style
- [x] `yarn nx run webapp:test --testFile=src/script/components/Meeting/MeetingParticipantsPicker/MeetingParticipantsPicker.test.tsx`
- [x] `yarn nx run webapp:test --testFile=src/script/components/userList/userList.test.tsx`