### PR TITLE
fix: e2e test with tag TC-60 [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/.env.staging.tpl
+++ b/apps/webapp/test/e2e_tests/.env.staging.tpl
@@ -30,10 +30,6 @@ CALLING_SERVICE_INSTANCE_VERSION=op://Test Automation/CALLINGSERVICE_BASIC_AUTH/
 
 ENV_NAME=staging
 
-# SCIM user for e2e tests
-SCIM_USER_EMAIL=op://Test Automation/Staging SCIM user/okta username
-SCIM_USER_PASSWORD="{{ op://Test Automation/Staging SCIM user/okta password }}"
-SCIM_USER_SSO_CODE=op://Test Automation/Staging SCIM user/SSO code
 
 SSO_CLAIMED_USER_EMAIL=op://Test Automation/Staging Claimed Domain User/email
 SSO_CLAIMED_USER_PASSWORD=op://Test Automation/Staging Claimed Domain User/password

--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -80,9 +80,9 @@ test.describe('account settings', () => {
   );
 
   const ssoUser = getUser({
-    email: process.env.SCIM_USER_SSO_CODE,
-    username: process.env.SCIM_USER_EMAIL,
-    password: process.env.SCIM_USER_PASSWORD,
+    email: process.env.SSO_CLAIMED_USER_EMAIL,
+    username: process.env.SSO_CLAIMED_USER_EMAIL,
+    password: process.env.SSO_CLAIMED_USER_PASSWORD,
   });
 
   test(
@@ -107,7 +107,11 @@ test.describe('account settings', () => {
 
       await test.step('Remove an existing device and confirm new history', async () => {
         // Since this test re-uses the same user over and over again we need to always remove one of the previously registered devices
-        await page.getByRole('button', {name: 'Remove device'}).first().click({timeout: LOGIN_TIMEOUT});
+        const removeDeviceButton = page.getByRole('button', {name: 'Remove device'}).first();
+        const isRemoveDeviceButtonVisible = await removeDeviceButton.isVisible({timeout: 3_000}).catch(() => false);
+        if (isRemoveDeviceButtonVisible) {
+          await removeDeviceButton.click({timeout: LOGIN_TIMEOUT});
+        }
         // We will also always be prompted to confirm the new history on this device
         await pages.historyInfo().clickConfirmButton();
         await expect(components.conversationSidebar().sidebar, 'Login took more than 60s').toBeVisible({

--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -581,9 +581,9 @@ test.describe('Guestroom', () => {
   );
 
   const ssoUser = getUser({
-    email: process.env.SCIM_USER_SSO_CODE,
-    username: process.env.SCIM_USER_EMAIL,
-    password: process.env.SCIM_USER_PASSWORD,
+    email: process.env.SSO_CLAIMED_USER_EMAIL,
+    username: process.env.SSO_CLAIMED_USER_EMAIL,
+    password: process.env.SSO_CLAIMED_USER_PASSWORD,
   });
 
   test(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Description

This PR updates the E2E tests to use the claimed domain SSO user instead of the removed SCIM user credentials. It also makes the account settings device removal step more robust by checking whether the Remove device button is visible before clicking it, preventing unnecessary test failures.