### PR TITLE
chore: Disabling TC-3477 test depending on Okta [WPB-26999]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Guestroom/guestroom.spec.ts
@@ -586,7 +586,8 @@ test.describe('Guestroom', () => {
     password: process.env.SCIM_USER_PASSWORD,
   });
 
-  test(
+  // Todo: This test is skipped because of disabled Okta account [WPB-26999]
+  test.skip(
     'I want to join guestroom invite with enterprise login',
     {tag: ['@TC-3477', '@regression']},
     async ({context, createPage}) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26999" title="WPB-26999" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26999</a>  [Plaform] Create and configure Okta instance to be used for automated (e2e) and manual testing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-26999

Disabling the test until we have new tool for SCIM-managed users.