### PR TITLE
test: add regression test for incoming call acceptance behavior [WPB-26929]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -49,6 +49,54 @@ test.describe('Calling', () => {
   });
 
   test(
+    'Verify incoming call acceptance terminates the active call after user confirmation',
+    {tag: ['@TC-11353', '@regression']},
+    async ({createPage}) => {
+      const [userAPage, userBPage, userCPage] = await Promise.all([
+        createPage(withLogin(userA)),
+        createPage(withLogin(userB)),
+        createPage(withLogin(userC)),
+      ]);
+      await connectWithUser(userAPage, userB);
+      await connectWithUser(userAPage, userC);
+
+      const {pages: userAPages, modals: userAModals} = PageManager.from(userAPage).webapp;
+      const {pages: userBPages} = PageManager.from(userBPage).webapp;
+      const {pages: userCPages} = PageManager.from(userCPage).webapp;
+
+      await test.step('User A establishes an active call with User B', async () => {
+        await userAPages.conversationList().getConversation(userB.fullName).open();
+        await userAPages.conversation().clickCallButton();
+        await userBPages.calling().clickAcceptCallButton();
+        await expect(userBPages.calling().callCell).toBeVisible();
+      });
+
+      await test.step('User C calls User A (creating a second incoming call for User A)', async () => {
+        await userCPages.conversationList().getConversation(userA.fullName).open();
+        await userCPages.conversation().clickCallButton();
+      });
+
+      await test.step("User A accepts User C's call and confirms the termination warning", async () => {
+        await expect(userAPages.calling().callCell).toHaveCount(2);
+        const callCellWithUserC = userAPages.calling().callCell.filter({hasText: userC.fullName});
+        await callCellWithUserC.getByRole('button', {name: 'Accept'}).click();
+
+        await expect(userAModals.confirm().modalText).toContainText('Your current call will end.');
+        await userAModals.confirm().clickAction();
+      });
+
+      await test.step('Verify the call with User B is terminated and the call with User C is active', async () => {
+        // The call with user B should be terminated
+        await expect(userBPages.calling().callCell).not.toBeVisible();
+
+        // The call with user C should be established
+        await expect(userAPages.calling().callCell).toHaveCount(1);
+        await expect(userCPages.calling().goFullScreen).toBeVisible();
+      });
+    },
+  );
+
+  test(
     'Verify that current call is terminated if you want to call someone else (as caller)',
     {tag: ['@TC-2802', '@regression']},
     async ({createPage}) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26929" title="WPB-26929" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26929</a>  [Web][QA] Implement missing Calling test about termination of an active call when joining a new one
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Adds automated test case TC-11353 to verify that accepting a second incoming call successfully terminates the current active call after the user confirms the warning modal.