### PR TITLE
Verify authenticated session before WebSocket reconnect [WPB-21916]

### DIFF
--- a/libraries/api-client/src/tcp/webSocketClient.test.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.test.ts
@@ -44,6 +44,7 @@ const fakeHttpClient: any = {
   },
   refreshAccessToken: () => Promise.resolve(accessTokenPayload),
   hasValidAccessToken: () => true,
+  sendRequest: () => Promise.resolve({data: {}}),
 };
 
 const invalidTokenHttpClient: any = {
@@ -52,6 +53,7 @@ const invalidTokenHttpClient: any = {
   },
   refreshAccessToken: () => Promise.reject(new InvalidTokenError('Invalid token')),
   hasValidAccessToken: () => true,
+  sendRequest: () => Promise.resolve({data: {}}),
 };
 
 const fakeSocket = {
@@ -87,11 +89,11 @@ const testWallClock: ReconnectingWebsocketWallClock = {
 type WebSocketHttpClient = ConstructorParameters<typeof WebSocketClient>[1];
 type WebSocketReconnectHttpClient = Pick<
   WebSocketHttpClient,
-  'accessTokenStore' | 'refreshAccessToken' | 'hasValidAccessToken'
+  'accessTokenStore' | 'refreshAccessToken' | 'hasValidAccessToken' | 'sendRequest'
 >;
 type WebSocketReconnectHttpClientOptions = Pick<
   WebSocketReconnectHttpClient,
-  'refreshAccessToken' | 'hasValidAccessToken'
+  'refreshAccessToken' | 'hasValidAccessToken' | 'sendRequest'
 >;
 type RetryDelayCallback = () => void;
 type ManualRetryWallClock = {
@@ -122,6 +124,7 @@ function createWebSocketReconnectHttpClient(
     accessTokenStore: fakeHttpClient.accessTokenStore,
     refreshAccessToken: webSocketReconnectHttpClient.refreshAccessToken,
     hasValidAccessToken: webSocketReconnectHttpClient.hasValidAccessToken,
+    sendRequest: webSocketReconnectHttpClient.sendRequest,
   };
 
   return httpClient as WebSocketHttpClient;
@@ -288,6 +291,7 @@ describe('WebSocketClient', () => {
       const httpClient = createWebSocketReconnectHttpClient({
         refreshAccessToken,
         hasValidAccessToken: () => accessTokenIsValid,
+        sendRequest: jest.fn().mockResolvedValue({data: {}}),
       });
       const websocketClient = createWebSocketClientWithTestWallClock('ws://url', httpClient);
       webSocketClients.push(websocketClient);
@@ -324,6 +328,7 @@ describe('WebSocketClient', () => {
       const httpClient = createWebSocketReconnectHttpClient({
         refreshAccessToken,
         hasValidAccessToken: () => accessTokenIsValid,
+        sendRequest: jest.fn().mockResolvedValue({data: {}}),
       });
       const websocketClient = createWebSocketClient('ws://url', httpClient, manualRetryWallClock.wallClock);
       webSocketClients.push(websocketClient);
@@ -347,11 +352,13 @@ describe('WebSocketClient', () => {
       expect(buildWebSocketUrl).toHaveBeenCalledTimes(1);
     });
 
-    it('emits invalid-token event, rejects reconnect, and does not build a WebSocket URL when refresh fails with invalid token', async () => {
+    it('does not run authenticated HTTP preflight when token refresh fails with invalid token', async () => {
       const invalidTokenError = new InvalidTokenError('Invalid token');
+      const sendRequest = jest.fn();
       const httpClient = createWebSocketReconnectHttpClient({
         refreshAccessToken: jest.fn().mockRejectedValue(invalidTokenError),
         hasValidAccessToken: () => false,
+        sendRequest,
       });
       const websocketClient = createWebSocketClientWithTestWallClock('ws://url', httpClient);
       webSocketClients.push(websocketClient);
@@ -364,14 +371,17 @@ describe('WebSocketClient', () => {
 
       expect(invalidTokenListener).toHaveBeenCalledTimes(1);
       expect(invalidTokenListener).toHaveBeenCalledWith(invalidTokenError);
+      expect(sendRequest).not.toHaveBeenCalled();
       expect(buildWebSocketUrl).not.toHaveBeenCalled();
     });
 
-    it('builds a WebSocket URL without refreshing when the access token is already valid', async () => {
+    it('runs authenticated HTTP preflight before building WebSocket URL', async () => {
       const refreshAccessToken = jest.fn().mockResolvedValue(accessTokenPayload);
+      const sendRequest = jest.fn().mockResolvedValue({data: {}});
       const httpClient = createWebSocketReconnectHttpClient({
         refreshAccessToken,
         hasValidAccessToken: () => true,
+        sendRequest,
       });
       const websocketClient = createWebSocketClientWithTestWallClock('ws://url', httpClient);
       webSocketClients.push(websocketClient);
@@ -380,6 +390,71 @@ describe('WebSocketClient', () => {
       await expect(websocketClient['onReconnect']()).resolves.toBe('ws://url/await');
 
       expect(refreshAccessToken).not.toHaveBeenCalled();
+      expect(sendRequest).toHaveBeenCalledTimes(1);
+      expect(sendRequest).toHaveBeenCalledWith({
+        method: 'get',
+        url: '/cookies',
+      });
+      expect(buildWebSocketUrl).toHaveBeenCalledTimes(1);
+      expect(sendRequest.mock.invocationCallOrder[0]).toBeLessThan(buildWebSocketUrl.mock.invocationCallOrder[0]);
+    });
+
+    it('refreshes invalid local token before running authenticated HTTP preflight', async () => {
+      const refreshAccessToken = jest.fn().mockResolvedValue(accessTokenPayload);
+      const hasValidAccessToken = jest.fn().mockReturnValueOnce(false).mockReturnValue(true);
+      const sendRequest = jest.fn().mockResolvedValue({data: {}});
+      const httpClient = createWebSocketReconnectHttpClient({
+        refreshAccessToken,
+        hasValidAccessToken,
+        sendRequest,
+      });
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', httpClient);
+      webSocketClients.push(websocketClient);
+      const buildWebSocketUrl = jest.spyOn(websocketClient, 'buildWebSocketUrl').mockReturnValue('ws://url/await');
+
+      await expect(websocketClient['onReconnect']()).resolves.toBe('ws://url/await');
+
+      expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+      expect(sendRequest).toHaveBeenCalledTimes(1);
+      expect(buildWebSocketUrl).toHaveBeenCalledTimes(1);
+      expect(refreshAccessToken.mock.invocationCallOrder[0]).toBeLessThan(sendRequest.mock.invocationCallOrder[0]);
+      expect(sendRequest.mock.invocationCallOrder[0]).toBeLessThan(buildWebSocketUrl.mock.invocationCallOrder[0]);
+    });
+
+    it('does not build WebSocket URL when authenticated HTTP preflight fails', async () => {
+      const preflightError = new Error('Authenticated session verification failed');
+      const sendRequest = jest.fn().mockRejectedValue(preflightError);
+      const httpClient = createWebSocketReconnectHttpClient({
+        refreshAccessToken: jest.fn().mockResolvedValue(accessTokenPayload),
+        hasValidAccessToken: () => true,
+        sendRequest,
+      });
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', httpClient);
+      webSocketClients.push(websocketClient);
+      const buildWebSocketUrl = jest.spyOn(websocketClient, 'buildWebSocketUrl').mockReturnValue('ws://url/await');
+
+      await expect(websocketClient['onReconnect']()).rejects.toBe(preflightError);
+
+      expect(sendRequest).toHaveBeenCalledTimes(1);
+      expect(buildWebSocketUrl).not.toHaveBeenCalled();
+    });
+
+    it('builds a WebSocket URL without refreshing when the access token is already valid', async () => {
+      const refreshAccessToken = jest.fn().mockResolvedValue(accessTokenPayload);
+      const sendRequest = jest.fn().mockResolvedValue({data: {}});
+      const httpClient = createWebSocketReconnectHttpClient({
+        refreshAccessToken,
+        hasValidAccessToken: () => true,
+        sendRequest,
+      });
+      const websocketClient = createWebSocketClientWithTestWallClock('ws://url', httpClient);
+      webSocketClients.push(websocketClient);
+      const buildWebSocketUrl = jest.spyOn(websocketClient, 'buildWebSocketUrl').mockReturnValue('ws://url/await');
+
+      await expect(websocketClient['onReconnect']()).resolves.toBe('ws://url/await');
+
+      expect(refreshAccessToken).not.toHaveBeenCalled();
+      expect(sendRequest).toHaveBeenCalledTimes(1);
       expect(buildWebSocketUrl).toHaveBeenCalledTimes(1);
     });
   });

--- a/libraries/api-client/src/tcp/webSocketClient.ts
+++ b/libraries/api-client/src/tcp/webSocketClient.ts
@@ -34,7 +34,7 @@ import {
   WEBSOCKET_STATE,
 } from './reconnectingWebsocket';
 
-import {InvalidTokenError, MissingCookieAndTokenError, MissingCookieError} from '../auth/';
+import {AuthAPI, InvalidTokenError, MissingCookieAndTokenError, MissingCookieError} from '../auth/';
 import {MINIMUM_API_VERSION} from '../config';
 import {HttpClient, NetworkError} from '../http/';
 import {Notification} from '../notification';
@@ -151,6 +151,7 @@ export class WebSocketClient extends EventEmitter {
 
   private readonly onReconnect = async () => {
     await this.waitForValidAccessTokenBeforeReconnect();
+    await this.verifyAuthenticatedSessionBeforeReconnect();
 
     return this.buildWebSocketUrl();
   };
@@ -250,6 +251,17 @@ export class WebSocketClient extends EventEmitter {
       );
       await this.waitForNextAccessTokenRefreshRetry(nextRetryDelayInMilliseconds);
     }
+  }
+
+  private async verifyAuthenticatedSessionBeforeReconnect(): Promise<void> {
+    this.logger.info('Verifying authenticated HTTP session before WebSocket reconnect');
+
+    await this.client.sendRequest({
+      method: 'get',
+      url: AuthAPI.URL.COOKIES,
+    });
+
+    this.logger.info('Authenticated HTTP session verified before WebSocket reconnect');
   }
 
   private isInvalidSessionError(error: unknown): boolean {

--- a/libraries/core/src/account.test.ts
+++ b/libraries/core/src/account.test.ts
@@ -173,6 +173,8 @@ describe('Account', () => {
         domain: 'zinfra.io',
       });
 
+    nock(MOCK_BACKEND.rest).get(`/v${MINIMUM_API_VERSION}${AuthAPI.URL.COOKIES}`).reply(HTTP_STATUS.OK, {}).persist();
+
     nock(MOCK_BACKEND.rest)
       .get(NotificationAPI.URL.NOTIFICATION)
       .query({client: CLIENT_ID, size: 10000})


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21916" title="WPB-21916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21916</a>  [Web/Desktop] : Missing messages in Web - Prod
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add an authenticated HTTP preflight to WebSocket reconnects using the existing /cookies endpoint. The reconnect flow now waits for a valid local token, verifies the backend accepts the authenticated HTTP request, and only then builds the WebSocket URL.

Add coverage for preflight ordering, token refresh sequencing, and failure paths.


