### PR TITLE
Fix accumulated window title event subscriptions [WPB-27018]

### DIFF
--- a/apps/webapp/src/script/page/components/windowTitleUpdater.test.tsx
+++ b/apps/webapp/src/script/page/components/windowTitleUpdater.test.tsx
@@ -17,16 +17,177 @@
  *
  */
 
-import {render} from '@testing-library/react';
+import {act, render} from '@testing-library/react';
+import {amplify} from 'amplify';
 
+import {WebAppEvents} from '@wireapp/webapp-events';
+
+import {NOTIFICATION_HANDLING_STATE} from 'Repositories/event/NotificationHandlingState';
+import {useKoSubscribableChildren} from 'Util/componentUtil';
+import {getLogger} from 'Util/logger';
 import {translateForTest} from 'Util/test/translateForTest';
 
+import {ContentState, useAppState} from '../useAppState';
 import {WindowTitleUpdater} from './windowTitleUpdater';
 
+jest.mock('amplify');
+jest.mock('tsyringe', () => {
+  const actualTsyringeModule = jest.requireActual('tsyringe');
+
+  return {
+    ...actualTsyringeModule,
+    container: {
+      resolve: jest.fn(),
+    },
+  };
+});
+jest.mock('Util/componentUtil');
+jest.mock('Util/logger', () => {
+  return {
+    getLogger: jest.fn(() => {
+      return {debug: jest.fn()};
+    }),
+  };
+});
+
+const mockWindowTitleLoggerDebug = (getLogger as jest.Mock).mock.results[0].value.debug as jest.Mock;
+jest.mock('../../Config', () => {
+  return {
+    Config: {
+      getConfig: jest.fn(() => {
+        return {BRAND_NAME: 'Wire'};
+      }),
+    },
+  };
+});
+jest.mock('../useAppState', () => {
+  const actualUseAppStateModule = jest.requireActual('../useAppState');
+
+  return {
+    ...actualUseAppStateModule,
+    useAppState: jest.fn(),
+  };
+});
+
 describe('WindowTitleUpdater', () => {
-  it('can render outside RootProvider when translate is injected', () => {
-    expect(() => render(<WindowTitleUpdater translate={translateForTest} />)).not.toThrow(
-      'RootContext has not been set',
+  const activeNotificationStateHandlers = new Set<(notificationState: NOTIFICATION_HANDLING_STATE) => void>();
+  const setUnreadMessagesCount = jest.fn();
+  let connectionRequests: unknown[];
+  let unreadConversations: unknown[];
+
+  const renderWindowTitleUpdater = () => {
+    return render(<WindowTitleUpdater translate={translateForTest} />);
+  };
+
+  const latestNotificationStateHandler = (): ((notificationState: NOTIFICATION_HANDLING_STATE) => void) => {
+    const subscribeCalls = (amplify.subscribe as jest.Mock).mock.calls;
+    const latestSubscribeCall = subscribeCalls.at(-1);
+
+    return latestSubscribeCall[1];
+  };
+
+  const publishNotificationState = (notificationState: NOTIFICATION_HANDLING_STATE) => {
+    act(() => {
+      activeNotificationStateHandlers.forEach(notificationStateHandler => {
+        notificationStateHandler(notificationState);
+      });
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    activeNotificationStateHandlers.clear();
+    connectionRequests = [];
+    unreadConversations = [];
+
+    (amplify.subscribe as jest.Mock).mockImplementation(
+      (_eventName: string, notificationStateHandler: (notificationState: NOTIFICATION_HANDLING_STATE) => void) => {
+        activeNotificationStateHandlers.add(notificationStateHandler);
+      },
     );
+    (amplify.unsubscribe as jest.Mock).mockImplementation(
+      (_eventName: string, notificationStateHandler: (notificationState: NOTIFICATION_HANDLING_STATE) => void) => {
+        activeNotificationStateHandlers.delete(notificationStateHandler);
+      },
+    );
+    (useAppState as jest.Mock).mockImplementation(selector => {
+      return selector({contentState: ContentState.CONVERSATION, setUnreadMessagesCount});
+    });
+    (useKoSubscribableChildren as jest.Mock).mockImplementation((_state: unknown, properties: string[]) => {
+      if (properties.includes('connectRequests')) {
+        return {connectRequests: connectionRequests};
+      }
+
+      return {activeConversation: undefined, unreadConversations};
+    });
+  });
+
+  it('keeps one active subscription across rerenders and uses the same handler to unsubscribe', () => {
+    const {rerender, unmount} = renderWindowTitleUpdater();
+    const firstNotificationStateHandler = latestNotificationStateHandler();
+
+    rerender(<WindowTitleUpdater translate={translateForTest} />);
+
+    expect(activeNotificationStateHandlers).toEqual(new Set([firstNotificationStateHandler]));
+
+    publishNotificationState(NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
+
+    expect(mockWindowTitleLoggerDebug).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(amplify.unsubscribe).toHaveBeenLastCalledWith(
+      WebAppEvents.EVENT.NOTIFICATION_HANDLING_STATE,
+      firstNotificationStateHandler,
+    );
+  });
+
+  it('does not transition state or log again when an event resolves to the current state', () => {
+    renderWindowTitleUpdater();
+
+    publishNotificationState(NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
+
+    expect(mockWindowTitleLoggerDebug).not.toHaveBeenCalled();
+    expect(amplify.subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables title updates and logs the state being applied', () => {
+    renderWindowTitleUpdater();
+
+    publishNotificationState(NOTIFICATION_HANDLING_STATE.STREAM);
+
+    expect(mockWindowTitleLoggerDebug).toHaveBeenCalledWith("Set window title update state to 'false'");
+    expect(activeNotificationStateHandlers).toEqual(new Set([latestNotificationStateHandler()]));
+  });
+
+  it('does not update the title while disabled and updates it again when websocket handling resumes', () => {
+    const {rerender} = renderWindowTitleUpdater();
+    const titleBeforeDisablingUpdates = document.title;
+
+    expect(amplify.publish).toHaveBeenCalledWith(WebAppEvents.LIFECYCLE.UNREAD_COUNT, 0);
+
+    publishNotificationState(NOTIFICATION_HANDLING_STATE.STREAM);
+    connectionRequests = [{}];
+    unreadConversations = [{}];
+    rerender(<WindowTitleUpdater translate={translateForTest} />);
+
+    expect(amplify.publish).toHaveBeenCalledTimes(1);
+    expect(document.title).toBe(titleBeforeDisablingUpdates);
+
+    publishNotificationState(NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
+
+    expect(amplify.publish).toHaveBeenLastCalledWith(WebAppEvents.LIFECYCLE.UNREAD_COUNT, 2);
+    expect(document.title).toBe('(2) Wire');
+  });
+
+  it('does not invoke stale handlers after a state transition and rerender', () => {
+    const {rerender} = renderWindowTitleUpdater();
+
+    publishNotificationState(NOTIFICATION_HANDLING_STATE.STREAM);
+    rerender(<WindowTitleUpdater translate={translateForTest} />);
+    publishNotificationState(NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
+
+    expect(mockWindowTitleLoggerDebug).toHaveBeenCalledTimes(2);
+    expect(mockWindowTitleLoggerDebug).toHaveBeenLastCalledWith("Set window title update state to 'true'");
   });
 });

--- a/apps/webapp/src/script/page/components/windowTitleUpdater.ts
+++ b/apps/webapp/src/script/page/components/windowTitleUpdater.ts
@@ -19,7 +19,9 @@
 
 import {useCallback, useEffect, useState} from 'react';
 
+import is from '@sindresorhus/is';
 import {amplify} from 'amplify';
+import {match} from 'ts-pattern';
 import {container} from 'tsyringe';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
@@ -43,10 +45,14 @@ const useWindowTitle = (translate: Translate) => {
   const userState = container.resolve(UserState);
   const conversationState = container.resolve(ConversationState);
 
-  const contentState = useAppState(state => state.contentState);
-  const setUnreadMessagesCount = useAppState(state => state.setUnreadMessagesCount);
+  const contentState = useAppState(state => {
+    return state.contentState;
+  });
+  const setUnreadMessagesCount = useAppState(state => {
+    return state.setUnreadMessagesCount;
+  });
 
-  const [updateWindowTitle, setUpdateWindowTitle] = useState(false);
+  const [shouldUpdateWindowTitle, setShouldUpdateWindowTitle] = useState(true);
 
   const {connectRequests: connectionRequests} = useKoSubscribableChildren(userState, ['connectRequests']);
   const {activeConversation, unreadConversations} = useKoSubscribableChildren(conversationState, [
@@ -59,8 +65,10 @@ const useWindowTitle = (translate: Translate) => {
       setUnreadMessagesCount(unreadCount);
 
       const iconBadge = unreadCount ? '-badge' : '';
-      const link: HTMLLinkElement =
-        document.querySelector("link[rel*='shortcut icon']") || document.createElement('link');
+      const existingIconLink = document.querySelector<HTMLLinkElement>("link[rel*='shortcut icon']");
+      const link: HTMLLinkElement = is.nullOrUndefined(existingIconLink)
+        ? document.createElement('link')
+        : existingIconLink;
       link.type = 'image/x-icon';
       link.rel = 'shortcut icon';
       link.href = `/image/favicon${iconBadge}.ico`;
@@ -69,85 +77,89 @@ const useWindowTitle = (translate: Translate) => {
     [setUnreadMessagesCount],
   );
 
-  const updateNotificationState = useCallback(
-    (handlingNotifications: NOTIFICATION_HANDLING_STATE) => {
-      const shouldUpdateWindowTitle = handlingNotifications === NOTIFICATION_HANDLING_STATE.WEB_SOCKET;
-      const isStateChange = updateWindowTitle !== shouldUpdateWindowTitle;
+  const handleNotificationStateChange = useCallback(
+    (notificationState: NOTIFICATION_HANDLING_STATE) => {
+      const nextShouldUpdateWindowTitle = notificationState === NOTIFICATION_HANDLING_STATE.WEB_SOCKET;
 
-      if (isStateChange) {
-        setUpdateWindowTitle(shouldUpdateWindowTitle);
-        windowTitleLogger.debug(`Set window title update state to '${updateWindowTitle}'`);
+      if (shouldUpdateWindowTitle === nextShouldUpdateWindowTitle) {
+        return;
       }
+
+      setShouldUpdateWindowTitle(nextShouldUpdateWindowTitle);
+      windowTitleLogger.debug(`Set window title update state to '${nextShouldUpdateWindowTitle}'`);
     },
-    [updateWindowTitle],
+    [shouldUpdateWindowTitle],
   );
 
-  const initiateTitleUpdates = useCallback(() => {
-    setUpdateWindowTitle(true);
+  useEffect(() => {
+    amplify.subscribe(WebAppEvents.EVENT.NOTIFICATION_HANDLING_STATE, handleNotificationStateChange);
 
-    if (updateWindowTitle) {
-      const unreadConversationsCount = unreadConversations.length;
-      const connectionRequestsCount = connectionRequests.length;
-      const unreadCount = connectionRequestsCount + unreadConversationsCount;
-      let specificTitle = unreadCount > MIN_UNREAD_COUNT ? `(${unreadCount}) ` : '';
+    return () => {
+      amplify.unsubscribe(WebAppEvents.EVENT.NOTIFICATION_HANDLING_STATE, handleNotificationStateChange);
+    };
+  }, [handleNotificationStateChange]);
 
-      amplify.publish(WebAppEvents.LIFECYCLE.UNREAD_COUNT, unreadCount);
-      updateFavicon(unreadCount);
-
-      switch (contentState) {
-        case ContentState.CONNECTION_REQUESTS: {
-          const multipleRequests = connectionRequestsCount > MIN_CONNECTION_REQUEST_COUNT;
-          const requestsString = multipleRequests
-            ? translate('conversationsConnectionRequestMany', {number: connectionRequestsCount})
-            : translate('conversationsConnectionRequestOne');
-          specificTitle += requestsString;
-          break;
-        }
-
-        case ContentState.CONVERSATION: {
-          if (activeConversation) {
-            specificTitle += activeConversation.display_name();
-          }
-          break;
-        }
-
-        case ContentState.PREFERENCES_ABOUT: {
-          specificTitle += translate('preferencesAbout');
-          break;
-        }
-
-        case ContentState.PREFERENCES_ACCOUNT: {
-          specificTitle += translate('preferencesAccount');
-          break;
-        }
-
-        case ContentState.PREFERENCES_AV: {
-          specificTitle += translate('preferencesAV');
-          break;
-        }
-
-        case ContentState.PREFERENCES_DEVICE_DETAILS: {
-          specificTitle += translate('preferencesDeviceDetails');
-          break;
-        }
-
-        case ContentState.PREFERENCES_DEVICES: {
-          specificTitle += translate('preferencesDevices');
-          break;
-        }
-
-        case ContentState.PREFERENCES_OPTIONS: {
-          specificTitle += translate('preferencesOptions');
-          break;
-        }
-
-        default:
-          break;
-      }
-
-      const isTitleSet = specificTitle !== '' && !specificTitle.endsWith(' ');
-      window.document.title = `${specificTitle}${isTitleSet ? ' · ' : ''}${Config.getConfig().BRAND_NAME}`;
+  useEffect(() => {
+    if (!shouldUpdateWindowTitle) {
+      return;
     }
+
+    const unreadConversationsCount = unreadConversations.length;
+    const connectionRequestsCount = connectionRequests.length;
+    const unreadCount = connectionRequestsCount + unreadConversationsCount;
+    let specificTitle = unreadCount > MIN_UNREAD_COUNT ? `(${unreadCount}) ` : '';
+
+    amplify.publish(WebAppEvents.LIFECYCLE.UNREAD_COUNT, unreadCount);
+    updateFavicon(unreadCount);
+
+    const contentSpecificTitle = match(contentState)
+      .with(ContentState.CONNECTION_REQUESTS, () => {
+        const multipleRequests = connectionRequestsCount > MIN_CONNECTION_REQUEST_COUNT;
+        const requestsString = multipleRequests
+          ? translate('conversationsConnectionRequestMany', {number: connectionRequestsCount})
+          : translate('conversationsConnectionRequestOne');
+        return requestsString;
+      })
+
+      .with(ContentState.CONVERSATION, () => {
+        if (!is.nullOrUndefined(activeConversation)) {
+          return activeConversation.display_name();
+        }
+        return '';
+      })
+
+      .with(ContentState.PREFERENCES_ABOUT, () => {
+        return translate('preferencesAbout');
+      })
+
+      .with(ContentState.PREFERENCES_ACCOUNT, () => {
+        return translate('preferencesAccount');
+      })
+
+      .with(ContentState.PREFERENCES_AV, () => {
+        return translate('preferencesAV');
+      })
+
+      .with(ContentState.PREFERENCES_DEVICE_DETAILS, () => {
+        return translate('preferencesDeviceDetails');
+      })
+
+      .with(ContentState.PREFERENCES_DEVICES, () => {
+        return translate('preferencesDevices');
+      })
+
+      .with(ContentState.PREFERENCES_OPTIONS, () => {
+        return translate('preferencesOptions');
+      })
+
+      .otherwise(() => {
+        return '';
+      });
+
+    specificTitle += contentSpecificTitle;
+
+    const isTitleSet = is.nonEmptyString(specificTitle) && !specificTitle.endsWith(' ');
+    window.document.title = `${specificTitle}${isTitleSet ? ' · ' : ''}${Config.getConfig().BRAND_NAME}`;
   }, [
     activeConversation,
     connectionRequests.length,
@@ -155,13 +167,8 @@ const useWindowTitle = (translate: Translate) => {
     translate,
     unreadConversations.length,
     updateFavicon,
-    updateWindowTitle,
+    shouldUpdateWindowTitle,
   ]);
-
-  useEffect(() => {
-    amplify.subscribe(WebAppEvents.EVENT.NOTIFICATION_HANDLING_STATE, updateNotificationState);
-    initiateTitleUpdates();
-  }, [initiateTitleUpdates, updateNotificationState]);
 };
 
 type WindowTitleUpdaterProps = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27018" title="WPB-27018" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27018</a>  [Web] Window title event subscriptions accumulate and flood application logs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem

`WindowTitleUpdater` subscribes to `WebAppEvents.EVENT.NOTIFICATION_HANDLING_STATE` from a React effect, but the subscription is never removed.

The effect reruns whenever its callback dependencies change. Each rerender therefore adds another listener while the previous listeners remain active. Those listeners also retain stale React state.

After the application has been running for some time, a single notification handling state change can invoke thousands of callbacks. This floods the logs with repeated messages such as:

```text
@wireapp/webapp/WindowTitlesViewModel Set window title update state to 'true'
```

This is not only a logging issue. Every stale callback can also attempt to update the component state.

The title update callback additionally enables title updates on every execution, which can overwrite the state derived from the current notification handling state.

## Solution

This change separates notification state handling from document title updates.

The notification subscription now has an explicit cleanup function that unsubscribes the same handler when the effect reruns or the component unmounts. This ensures that only one active listener exists.

The title update effect no longer enables title updates itself. Whether title updates are allowed is controlled exclusively by the current notification handling state.

The debug message also reports the new state being applied rather than the previous React state value.

## Result

Notification state transitions invoke a single handler, stale listeners no longer accumulate, and `WindowTitlesViewModel` no longer floods the logs with duplicate messages.
