### PR TITLE
Use GitHub artifacts for unit test reports [WPB-26883] [WPB-26883]

### DIFF
--- a/.github/workflows/generate_test_report.yml
+++ b/.github/workflows/generate_test_report.yml
@@ -55,15 +55,6 @@ jobs:
           BRANCH: ${{ github.ref_name }}
         run: ./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/generateUnitTestReports.ts
 
-      - name: Upload unit-tests.log to S3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: eu-west-1
-        run: |
-          TIMESTAMP=$(date -u +'%Y%m%dT%H%M%SZ')
-          aws s3 cp ${{ env.UNIT_TEST_REPORT_FILE }} s3://wire-webapp/unit-tests-${TIMESTAMP}-${TESTED_COMMIT_SHA}.log
-
       - name: Upload complete unit test reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -74,6 +65,7 @@ jobs:
             ${{ env.UNIT_TEST_REPORTS_DIRECTORY }}/manifest.json
             ${{ env.UNIT_TEST_REPORTS_DIRECTORY }}/*.log
           if-no-files-found: error
+          retention-days: 1
 
       - name: Fail when manifest contains failed projects
         if: always()


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26883" title="WPB-26883" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26883</a>  [Web] Adjust unit test logs for web-packages for bund deliveries
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

Store generated unit test reports exclusively as a GitHub Actions artifact.

The artifact contains the combined `unit-tests.log`, the report manifest, and all per-project test reports. It is retained for one day.

## Why

The GitHub Actions artifact already contains the complete report set and is attached to the exact workflow run that generated it.

Storing an additional copy in S3 provided no benefit for this workflow and introduced another storage location, separate credentials, and additional lifecycle management.
