### PR TITLE
Fix TC-60 by removing condition from test flow [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -107,13 +107,10 @@ test.describe('account settings', () => {
 
       await test.step('Remove an existing device and confirm new history', async () => {
         // Since this test re-uses the same user over and over again we need to always remove one of the previously registered devices
-        const removeDeviceButton = page.getByRole('button', {name: 'Remove device'}).first();
-        const isRemoveDeviceButtonVisible = await removeDeviceButton.isVisible({timeout: 3_000}).catch(() => false);
-        if (isRemoveDeviceButtonVisible) {
-          await removeDeviceButton.click({timeout: LOGIN_TIMEOUT});
-        }
+        await page.getByRole('button', {name: 'Remove device'}).first().click({timeout: 10_000});
+
         // We will also always be prompted to confirm the new history on this device
-        await pages.historyInfo().clickConfirmButton();
+        await pages.historyInfo().continueButton.click({timeout: 10_000});
         await expect(components.conversationSidebar().sidebar, 'Login took more than 60s').toBeVisible({
           timeout: 60_000, // The login for this user may take some time since it's persisted and checking for messages takes extra time
         });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is a partial revert of #21790 which introduced a condition only removing a device from the list of devices in some cases. Tests depending on this user rely on the fact that it's re-used and always contains to many devices. It's a trade off, but much more reliable than using conditions within tests to tailor to different scenarios. The modified test already failed as part of the CI of #21790


