### PR TITLE
Fix stale outgoing message status behind a startup feature toggle [WPB-27032]

### DIFF
--- a/apps/webapp/jest.config.ts
+++ b/apps/webapp/jest.config.ts
@@ -35,6 +35,7 @@ const esmPackagesToTransform = [
   'uuid',
   '@enormora/objectory',
   '@enormora/wall-clock',
+  'p-defer',
 ];
 
 const config: Config = {

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -73,6 +73,7 @@
     "murmurhash": "2.0.1",
     "noop-esm": "1.1.0",
     "oidc-client-ts": "3.5.0",
+    "p-defer": "4.0.1",
     "p-wait-for": "6.0.0",
     "path-to-regexp": "8.4.2",
     "platform": "1.3.6",

--- a/apps/webapp/src/script/components/appContainer/appContainer.tsx
+++ b/apps/webapp/src/script/components/appContainer/appContainer.tsx
@@ -45,6 +45,7 @@ import {useTheme} from './hooks/useTheme';
 import {runClientVersionCheck} from '../../applicationPeriodicChecks/runClientVersionCheck';
 import {startApplicationPeriodicChecks} from '../../applicationPeriodicChecks/startApplicationPeriodicChecks';
 import {Config, Configuration} from '../../Config';
+import {messageSendingStatusFixFeatureToggleName} from '../../featureToggles/startupFeatureToggleNames';
 import {StartupFeatureToggleName} from '../../featureToggles/startupFeatureToggles';
 import {setAppLocale} from '../../localization/Localizer';
 import {App} from '../../main/app';
@@ -85,9 +86,12 @@ export const AppContainer = (properties: AppProps) => {
     wallClock,
   } = properties;
   setAppLocale();
+  const isMessageSendingStatusFixEnabled = isFeatureToggleEnabled(messageSendingStatusFixFeatureToggleName);
   const app = useMemo(() => {
-    return new App(container.resolve(Core), container.resolve(APIClient), config, translate);
-  }, [config, translate]);
+    return new App(container.resolve(Core), container.resolve(APIClient), config, translate, {
+      isMessageSendingStatusFixEnabled,
+    });
+  }, [config, isMessageSendingStatusFixEnabled, translate]);
   const enableAutoLogin = Config.getConfig().FEATURE.ENABLE_AUTO_LOGIN;
 
   // Publishing application on the global scope for debug and testing purposes.

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -20,11 +20,13 @@
 export const applockRefactoredFeatureToggleName = 'applock-refactored';
 export const sharedDriveSearchAndFiltersFeatureToggleName = 'shared-drive-search-and-filters';
 export const meetingsFeatureToggleName = 'meetings';
+export const messageSendingStatusFixFeatureToggleName = 'message-sending-status-fix';
 
 export const startupFeatureToggleNames = [
   applockRefactoredFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   meetingsFeatureToggleName,
+  messageSendingStatusFixFeatureToggleName,
 ] as const;
 
 export type StartupFeatureToggleName = (typeof startupFeatureToggleNames)[number];

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -24,6 +24,7 @@ import {
 } from './startupFeatureToggles';
 import {
   applockRefactoredFeatureToggleName,
+  messageSendingStatusFixFeatureToggleName,
   meetingsFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   startupFeatureToggleNames,
@@ -33,6 +34,7 @@ const featureToggleNamesWithDedicatedExistenceTests = [
   applockRefactoredFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   meetingsFeatureToggleName,
+  messageSendingStatusFixFeatureToggleName,
 ] as const;
 
 describe('startupFeatureToggles', function () {
@@ -101,6 +103,23 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.isFeatureToggleEnabled(meetingsFeatureToggleName)).toBe(true);
   });
 
+  it('enables the message sending status fix feature toggle when present in the query parameter', () => {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${messageSendingStatusFixFeatureToggleName}`,
+    );
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(messageSendingStatusFixFeatureToggleName)).toBe(true);
+  });
+
+  it('enables the message sending status fix feature toggle when combined with another feature toggle', () => {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${meetingsFeatureToggleName},${messageSendingStatusFixFeatureToggleName}`,
+    );
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(meetingsFeatureToggleName)).toBe(true);
+    expect(startupFeatureToggles.isFeatureToggleEnabled(messageSendingStatusFixFeatureToggleName)).toBe(true);
+  });
+
   it('trims whitespace around feature toggle names', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}= ${applockRefactoredFeatureToggleName} `,
@@ -142,6 +161,7 @@ describe('startupFeatureToggles', function () {
       applockRefactoredFeatureToggleName,
       sharedDriveSearchAndFiltersFeatureToggleName,
       meetingsFeatureToggleName,
+      messageSendingStatusFixFeatureToggleName,
     ]);
   });
 

--- a/apps/webapp/src/script/main/app.ts
+++ b/apps/webapp/src/script/main/app.ts
@@ -53,6 +53,7 @@ import {ConversationVerificationState} from 'Repositories/conversation/Conversat
 import {OnConversationE2EIVerificationStateChange} from 'Repositories/conversation/ConversationVerificationStateHandler/shared';
 import {EventBuilder} from 'Repositories/conversation/EventBuilder';
 import {MessageRepository} from 'Repositories/conversation/MessageRepository';
+import type {MessageRepositoryOptions} from 'Repositories/conversation/MessageRepository';
 import {CryptographyRepository} from 'Repositories/cryptography/CryptographyRepository';
 import {User} from 'Repositories/entity/User';
 import {EventRepository} from 'Repositories/event/EventRepository';
@@ -197,6 +198,9 @@ export class App {
     private readonly apiClient: APIClient,
     private readonly config: Configuration,
     private readonly translate: Translate,
+    private readonly messageRepositoryOptions: MessageRepositoryOptions = {
+      isMessageSendingStatusFixEnabled: false,
+    },
   ) {
     this.config = config;
     this.apiClient.on(APIClient.TOPIC.ON_LOGOUT, () =>
@@ -298,6 +302,7 @@ export class App {
       repositories.asset,
       repositories.audio,
       this.translate,
+      this.messageRepositoryOptions,
     );
 
     repositories.calling = new CallingRepository(

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
@@ -47,6 +47,7 @@ import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import ko from 'knockout';
 import {container} from 'tsyringe';
+import {Maybe} from 'true-myth';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 
@@ -91,6 +92,7 @@ import {ConversationStatus} from './ConversationStatus';
 import {
   ButtonActionConfirmationEvent,
   ButtonActionEvent,
+  type ClientConversationEvent,
   DeleteEvent,
   EventBuilder,
   MessageHiddenEvent,
@@ -102,7 +104,13 @@ import {entities, payload} from '../../../../test/api/payloads';
 import {TestFactory} from '../../../../test/helper/TestFactory';
 import {createMockHttpServer, MockHttpServer} from '../../../../test/helper/mockHttpServer';
 import {generateUser} from '../../../../test/helper/UserGenerator';
+import {StatusType} from '../../message/statusType';
 import {Core} from '../../service/coreSingleton';
+
+type ConversationRepositoryWaiterTestSeam = {
+  readonly handleConversationEvent: (event: ClientConversationEvent) => Promise<unknown>;
+  readonly onConversationEvent: (event: ClientConversationEvent) => Promise<unknown>;
+};
 
 function buildConversationRepository(translate: Translate) {
   const teamState = new TeamState();
@@ -227,6 +235,78 @@ describe('ConversationRepository', () => {
   afterEach(() => {
     const conversationRepository = testFactory.conversation_repository!;
     conversationRepository['conversationState'].conversations.removeAll();
+  });
+
+  describe('injected message event waiters', () => {
+    const createMessageAddEvent = (eventId: string): ClientConversationEvent => {
+      return {
+        conversation: createUuid(),
+        data: {content: 'message', sender: createUuid()},
+        from: createUuid(),
+        id: eventId,
+        status: StatusType.SENDING,
+        time: new Date().toISOString(),
+        type: ClientEvent.CONVERSATION.MESSAGE_ADD,
+      };
+    };
+
+    it('resolves with the entity produced by onConversationEvent and removes the waiter', async () => {
+      const [conversationRepository] = buildConversationRepository(translateForTest);
+      const conversationRepositoryTestSeam = conversationRepository as unknown as ConversationRepositoryWaiterTestSeam;
+      const eventId = createUuid();
+      const messageEntity = new Message(eventId, undefined, translateForTest);
+      const conversationEntity = _generateConversation();
+      jest.spyOn(conversationRepositoryTestSeam, 'handleConversationEvent').mockResolvedValue({
+        conversationEntity,
+        messageEntity,
+      });
+
+      conversationRepository.prepareForInjectedMessageEvent(eventId);
+      const waitingForMessageEntity = conversationRepository.waitForInjectedMessageEvent(eventId);
+
+      await conversationRepositoryTestSeam.onConversationEvent(createMessageAddEvent(eventId));
+
+      await expect(waitingForMessageEntity).resolves.toEqual(Maybe.just(messageEntity));
+      await expect(conversationRepository.waitForInjectedMessageEvent(eventId)).rejects.toThrow(
+        `No completion waiter exists for injected message '${eventId}'`,
+      );
+    });
+
+    it('rejects the waiter and removes it when onConversationEvent fails', async () => {
+      const [conversationRepository] = buildConversationRepository(translateForTest);
+      const conversationRepositoryTestSeam = conversationRepository as unknown as ConversationRepositoryWaiterTestSeam;
+      const eventId = createUuid();
+      const eventHandlingError = new Error('event handling failed');
+      jest
+        .spyOn(conversationRepositoryTestSeam, 'handleConversationEvent')
+        .mockRejectedValue(eventHandlingError);
+
+      conversationRepository.prepareForInjectedMessageEvent(eventId);
+      const waitingForMessageEntity = conversationRepository.waitForInjectedMessageEvent(eventId);
+      const waitingForMessageEntityRejection = expect(waitingForMessageEntity).rejects.toThrow(eventHandlingError);
+
+      await expect(conversationRepositoryTestSeam.onConversationEvent(createMessageAddEvent(eventId))).rejects.toThrow(
+        eventHandlingError,
+      );
+      await waitingForMessageEntityRejection;
+      await expect(conversationRepository.waitForInjectedMessageEvent(eventId)).rejects.toThrow(
+        `No completion waiter exists for injected message '${eventId}'`,
+      );
+    });
+
+    it('resolves with Nothing and removes the waiter when canceled', async () => {
+      const [conversationRepository] = buildConversationRepository(translateForTest);
+      const eventId = createUuid();
+
+      conversationRepository.prepareForInjectedMessageEvent(eventId);
+      const waitingForMessageEntity = conversationRepository.waitForInjectedMessageEvent(eventId);
+      conversationRepository.cancelInjectedMessageEventWait(eventId);
+
+      await expect(waitingForMessageEntity).resolves.toEqual(Maybe.nothing());
+      await expect(conversationRepository.waitForInjectedMessageEvent(eventId)).rejects.toThrow(
+        `No completion waiter exists for injected message '${eventId}'`,
+      );
+    });
   });
 
   describe('translation injection', () => {

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
@@ -277,9 +277,7 @@ describe('ConversationRepository', () => {
       const conversationRepositoryTestSeam = conversationRepository as unknown as ConversationRepositoryWaiterTestSeam;
       const eventId = createUuid();
       const eventHandlingError = new Error('event handling failed');
-      jest
-        .spyOn(conversationRepositoryTestSeam, 'handleConversationEvent')
-        .mockRejectedValue(eventHandlingError);
+      jest.spyOn(conversationRepositoryTestSeam, 'handleConversationEvent').mockRejectedValue(eventHandlingError);
 
       conversationRepository.prepareForInjectedMessageEvent(eventId);
       const waitingForMessageEntity = conversationRepository.waitForInjectedMessageEvent(eventId);

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -58,7 +58,7 @@ import {ClientMLSError, ClientMLSErrorLabel} from '@wireapp/core/lib/messagingPr
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import pDefer, {type DeferredPromise} from 'p-defer';
-import {Task, task} from 'true-myth';
+import {Maybe, Task, task} from 'true-myth';
 import {container} from 'tsyringe';
 import {flatten, isError} from 'underscore';
 
@@ -209,7 +209,7 @@ export class ConversationRepository {
   public readonly proteusVerificationStateHandler: ProteusConversationVerificationStateHandler;
   private mlsConversationVerificationStateHandler?: MLSConversationVerificationStateHandler;
   private initiatingMlsConversationQualifiedIds: QualifiedId[] = [];
-  private readonly injectedMessageEventWaiters = new Map<string, DeferredPromise<Message | undefined>>();
+  private readonly injectedMessageEventWaiters = new Map<string, DeferredPromise<Maybe<Message>>>();
 
   static get CONFIG() {
     return {
@@ -396,10 +396,10 @@ export class ConversationRepository {
       throw new Error(`A completion waiter already exists for injected message '${messageId}'`);
     }
 
-    this.injectedMessageEventWaiters.set(messageId, pDefer<Message | undefined>());
+    this.injectedMessageEventWaiters.set(messageId, pDefer<Maybe<Message>>());
   }
 
-  public async waitForInjectedMessageEvent(messageId: string): Promise<Message | undefined> {
+  public async waitForInjectedMessageEvent(messageId: string): Promise<Maybe<Message>> {
     const messageEventWaiter = this.injectedMessageEventWaiters.get(messageId);
     if (is.undefined(messageEventWaiter)) {
       throw new Error(`No completion waiter exists for injected message '${messageId}'`);
@@ -421,7 +421,7 @@ export class ConversationRepository {
     }
 
     this.injectedMessageEventWaiters.delete(messageId);
-    messageEventWaiter.resolve(undefined);
+    messageEventWaiter.resolve(Maybe.nothing());
   }
 
   private initSubscriptions(): void {
@@ -3628,7 +3628,7 @@ export class ConversationRepository {
         if (is.undefined(messageEntity)) {
           throw new Error(`Injected message '${eventId}' did not produce a message entity`);
         }
-        messageEventWaiter.resolve(messageEntity);
+        messageEventWaiter.resolve(Maybe.just(messageEntity));
       }
 
       return handledConversationEvent;

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -57,6 +57,7 @@ import {AddUsersFailure, BaseCreateConversationResponse} from '@wireapp/core/lib
 import {ClientMLSError, ClientMLSErrorLabel} from '@wireapp/core/lib/messagingProtocols/mls';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
+import pDefer, {type DeferredPromise} from 'p-defer';
 import {Task, task} from 'true-myth';
 import {container} from 'tsyringe';
 import {flatten, isError} from 'underscore';
@@ -208,6 +209,7 @@ export class ConversationRepository {
   public readonly proteusVerificationStateHandler: ProteusConversationVerificationStateHandler;
   private mlsConversationVerificationStateHandler?: MLSConversationVerificationStateHandler;
   private initiatingMlsConversationQualifiedIds: QualifiedId[] = [];
+  private readonly injectedMessageEventWaiters = new Map<string, DeferredPromise<Message | undefined>>();
 
   static get CONFIG() {
     return {
@@ -387,6 +389,39 @@ export class ConversationRepository {
 
   checkMessageTimer(messageEntity: ContentMessage): void {
     this.ephemeralHandler.checkMessageTimer(messageEntity, this.serverTimeHandler.getTimeOffset());
+  }
+
+  public prepareForInjectedMessageEvent(messageId: string): void {
+    if (this.injectedMessageEventWaiters.has(messageId)) {
+      throw new Error(`A completion waiter already exists for injected message '${messageId}'`);
+    }
+
+    this.injectedMessageEventWaiters.set(messageId, pDefer<Message | undefined>());
+  }
+
+  public async waitForInjectedMessageEvent(messageId: string): Promise<Message | undefined> {
+    const messageEventWaiter = this.injectedMessageEventWaiters.get(messageId);
+    if (is.undefined(messageEventWaiter)) {
+      throw new Error(`No completion waiter exists for injected message '${messageId}'`);
+    }
+
+    try {
+      return await messageEventWaiter.promise;
+    } finally {
+      if (this.injectedMessageEventWaiters.get(messageId) === messageEventWaiter) {
+        this.injectedMessageEventWaiters.delete(messageId);
+      }
+    }
+  }
+
+  public cancelInjectedMessageEventWait(messageId: string): void {
+    const messageEventWaiter = this.injectedMessageEventWaiters.get(messageId);
+    if (is.undefined(messageEventWaiter)) {
+      return;
+    }
+
+    this.injectedMessageEventWaiters.delete(messageId);
+    messageEventWaiter.resolve(undefined);
   }
 
   private initSubscriptions(): void {
@@ -3578,13 +3613,29 @@ export class ConversationRepository {
    * @returns Resolves when event was handled
    */
   private readonly onConversationEvent = async (event: IncomingEvent, source = EventRepository.SOURCE.STREAM) => {
-    const start = performance.now();
-    const handledConversations = await this.handleConversationEvent(event, source);
-    const duration = performance.now() - start;
+    const eventId = 'id' in event ? event.id : undefined;
+    const messageEventWaiter = is.undefined(eventId) ? undefined : this.injectedMessageEventWaiters.get(eventId);
 
-    this.logConversationEvent(event, source, duration);
+    try {
+      const start = performance.now();
+      const handledConversationEvent = await this.handleConversationEvent(event, source);
+      const duration = performance.now() - start;
 
-    return handledConversations;
+      this.logConversationEvent(event, source, duration);
+
+      if (!is.undefined(messageEventWaiter)) {
+        const messageEntity = handledConversationEvent?.messageEntity;
+        if (is.undefined(messageEntity)) {
+          throw new Error(`Injected message '${eventId}' did not produce a message entity`);
+        }
+        messageEventWaiter.resolve(messageEntity);
+      }
+
+      return handledConversationEvent;
+    } catch (error: unknown) {
+      messageEventWaiter?.reject(error);
+      throw error;
+    }
   };
 
   private handleConversationEvent(
@@ -3656,9 +3707,10 @@ export class ConversationRepository {
         conversationEntity =>
           this.reactToConversationEvent(conversationEntity, eventJson, eventSource) as Promise<EntityObject>,
       )
-      .then((entityObject = {} as EntityObject) =>
-        this.handleConversationNotification(entityObject as EntityObject, eventSource, type),
-      )
+      .then(async (entityObject = {} as EntityObject) => {
+        await this.handleConversationNotification(entityObject as EntityObject, eventSource, type);
+        return entityObject;
+      })
       .catch((error: unknown) => {
         const ignoredErrorTypes: string[] = [
           ConversationError.TYPE.MESSAGE_NOT_FOUND,

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -671,6 +671,45 @@ describe('MessageRepository', () => {
       expect(conversationRepository.cancelInjectedMessageEventWait).toHaveBeenCalledWith(optimisticMessageEntity.id);
     });
 
+    it('cancels the waiter when optimistic event injection fails', async () => {
+      const injectedMessageEventHandled = pDefer<Maybe<Message>>();
+      const cancelInjectedMessageEventWait = jest.fn();
+      const prepareForInjectedMessageEvent = jest.fn();
+      const waitForInjectedMessageEvent = jest.fn().mockReturnValue(injectedMessageEventHandled.promise);
+      const conversationRepository = {
+        cancelInjectedMessageEventWait,
+        prepareForInjectedMessageEvent,
+        waitForInjectedMessageEvent,
+      } as unknown as ConversationRepository;
+      const [messageRepository, {core, eventRepository, propertiesRepository}] = await buildMessageRepository(
+        translateForTest,
+        {
+          conversationRepository,
+          isMessageSendingStatusFixEnabled: true,
+        },
+      );
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const conversation = generateConversation();
+      const eventInjectionError = new Error('optimistic injection failed');
+      jest.spyOn(eventRepository, 'injectEvent').mockRejectedValue(eventInjectionError);
+      const backendSendSpy = jest.spyOn(core.service!.conversation, 'send');
+
+      const sendingPromise = messageRepository['sendText']({
+        conversation,
+        mentions: [],
+        message: 'hello there',
+      });
+
+      await expect(sendingPromise).rejects.toThrow(eventInjectionError);
+
+      const injectedMessageEventId = prepareForInjectedMessageEvent.mock.calls[0][0];
+      expect(waitForInjectedMessageEvent).toHaveBeenCalledWith(injectedMessageEventId);
+      expect(cancelInjectedMessageEventWait).toHaveBeenCalledWith(injectedMessageEventId);
+      expect(backendSendSpy).not.toHaveBeenCalled();
+
+      injectedMessageEventHandled.resolve(Maybe.nothing());
+    });
+
     it('uses the legacy flow when the message-sending-status-fix toggle is disabled', async () => {
       const conversationRepository = {
         cancelInjectedMessageEventWait: jest.fn(),

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -21,6 +21,8 @@ import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
 import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation/';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 import {MessageSendingState} from '@wireapp/core/lib/conversation';
+import pDefer from 'p-defer';
+import {Maybe} from 'true-myth';
 
 import {Account} from '@wireapp/core';
 import {LegalHoldStatus} from '@wireapp/protocol-messaging';
@@ -40,12 +42,13 @@ import {Message} from 'Repositories/entity/message/message';
 import {Text} from 'Repositories/entity/message/text';
 import {User} from 'Repositories/entity/User';
 import {EventRepository} from 'Repositories/event/EventRepository';
-import {EventService} from 'Repositories/event/EventService';
+import {EventService, type IdentifiedUpdatePayload} from 'Repositories/event/EventService';
 import {PropertiesRepository} from 'Repositories/properties/propertiesRepository';
 import {ReactionMap} from 'Repositories/storage';
 import {TeamState} from 'Repositories/team/TeamState';
 import {UserRepository} from 'Repositories/user/userRepository';
 import {UserState} from 'Repositories/user/userState';
+import {ClientEvent} from 'Repositories/event/Client';
 import {ConversationError} from 'src/script/error/conversationError';
 import {generateQualifiedId} from 'test/helper/UserGenerator';
 import type {Translate} from 'Util/localizerUtil';
@@ -85,13 +88,20 @@ type MessageRepositoryDependencies = {
   conversationState: ConversationState;
 };
 
+type MessageRepositoryTestOptions = {
+  readonly conversationRepository?: ConversationRepository;
+  readonly isMessageSendingStatusFixEnabled?: boolean;
+  readonly shouldStubMessageStatusUpdate?: boolean;
+};
+
 async function buildMessageRepository(
   translate: Translate,
+  options: MessageRepositoryTestOptions = {},
 ): Promise<[MessageRepository, MessageRepositoryDependencies]> {
   const userState = new UserState();
   userState.self(selfUser);
   const clientState = new ClientState();
-  clientState.currentClient = new ClientEntity(true, '');
+  clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
   const core = new Account();
 
   const teamState = new TeamState();
@@ -101,7 +111,9 @@ async function buildMessageRepository(
   selfConversation.selfUser(selfUser);
   conversationState.conversations([selfConversation]);
   const dependencies = {
-    conversationRepository: () => ({}) as ConversationRepository,
+    conversationRepository: () => {
+      return options.conversationRepository ?? ({} as ConversationRepository);
+    },
     cryptographyRepository: new CryptographyRepository({} as any),
     eventRepository: new EventRepository(new EventService({} as any), {} as any, {} as any, {} as any),
     propertiesRepository: new PropertiesRepository({} as any, {} as any, translate),
@@ -114,7 +126,7 @@ async function buildMessageRepository(
     audioRepository: new AudioRepository(),
     translate,
     messageRepositoryOptions: {
-      isMessageSendingStatusFixEnabled: false,
+      isMessageSendingStatusFixEnabled: options.isMessageSendingStatusFixEnabled ?? false,
     },
     userState,
     clientState,
@@ -125,7 +137,9 @@ async function buildMessageRepository(
 
   const deps = Object.values(dependencies) as ConstructorParameters<typeof MessageRepository>;
   const messageRepository = new MessageRepository(...deps);
-  jest.spyOn(messageRepository as any, 'updateMessageAsSent').mockReturnValue(undefined);
+  if (options.shouldStubMessageStatusUpdate ?? true) {
+    jest.spyOn(messageRepository as any, 'updateMessageAsSent').mockReturnValue(undefined);
+  }
   return [messageRepository, dependencies];
 }
 
@@ -512,6 +526,111 @@ describe('MessageRepository', () => {
         targetMode: undefined,
         userIds: expect.any(Object),
       });
+    });
+
+    it('updates the displayed optimistic entity after delayed event handling when the status fix is enabled', async () => {
+      const optimisticMessageEntity = new ContentMessage(createUuid(), translateForTest);
+      optimisticMessageEntity.primary_key = 'optimistic-message-primary-key';
+      optimisticMessageEntity.type = ClientEvent.CONVERSATION.MESSAGE_ADD;
+      optimisticMessageEntity.from = selfUser.id;
+      optimisticMessageEntity.user(selfUser);
+      optimisticMessageEntity.status(StatusType.SENDING);
+
+      const optimisticEventInjected = pDefer<void>();
+      const injectedMessageEventHandled = pDefer<Maybe<Message>>();
+      const sendStarted = pDefer<void>();
+      const waitForInjectedMessageEvent = jest.fn().mockReturnValue(injectedMessageEventHandled.promise);
+      const conversationRepository = {
+        cancelInjectedMessageEventWait: jest.fn(),
+        checkMessageTimer: jest.fn(),
+        prepareForInjectedMessageEvent: jest.fn(),
+        waitForInjectedMessageEvent,
+      } as unknown as ConversationRepository;
+
+      const [messageRepository, {core, eventRepository, propertiesRepository}] = await buildMessageRepository(
+        translateForTest,
+        {
+          conversationRepository,
+          isMessageSendingStatusFixEnabled: true,
+          shouldStubMessageStatusUpdate: false,
+        },
+      );
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const conversation = generateConversation();
+      const sendSpy = jest.spyOn(core.service!.conversation, 'send').mockImplementation(async () => {
+        sendStarted.resolve();
+        return successPayload;
+      });
+      const persistedEventUpdateSpy = jest
+        .spyOn(eventRepository.eventService, 'updateEvent')
+        .mockResolvedValue({primary_key: optimisticMessageEntity.primary_key} as IdentifiedUpdatePayload);
+      const detachedMessageLookupSpy = jest.spyOn(messageRepository, 'getMessageInConversationById');
+
+      jest.spyOn(eventRepository, 'injectEvent').mockImplementation(async event => {
+        optimisticMessageEntity.id = event.id;
+        optimisticEventInjected.resolve();
+      });
+
+      const sendingPromise = messageRepository.sendTextWithLinkPreview({
+        conversation,
+        mentions: [],
+        textMessage: 'hello there',
+      });
+
+      await optimisticEventInjected.promise;
+
+      expect(optimisticMessageEntity.status()).toBe(StatusType.SENDING);
+      expect(conversationRepository.prepareForInjectedMessageEvent).toHaveBeenCalledWith(optimisticMessageEntity.id);
+      expect(waitForInjectedMessageEvent).toHaveBeenCalledWith(optimisticMessageEntity.id);
+      expect(waitForInjectedMessageEvent).toHaveBeenCalledTimes(1);
+      await sendStarted.promise;
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      expect(conversation.messages()).not.toContain(optimisticMessageEntity);
+
+      conversation.addMessage(optimisticMessageEntity);
+      const resolvedMessageEntity = Maybe.just(optimisticMessageEntity);
+      injectedMessageEventHandled.resolve(resolvedMessageEntity);
+      await expect(waitForInjectedMessageEvent.mock.results[0].value).resolves.toBe(resolvedMessageEntity);
+      await sendingPromise;
+
+      expect(optimisticMessageEntity.status()).toBe(StatusType.SENT);
+      expect(conversation.getMessage(optimisticMessageEntity.id)).toBe(optimisticMessageEntity);
+      expect(
+        conversation.messages().filter(messageEntity => messageEntity.id === optimisticMessageEntity.id),
+      ).toHaveLength(1);
+      expect(detachedMessageLookupSpy).not.toHaveBeenCalled();
+      expect(persistedEventUpdateSpy).toHaveBeenCalledWith(
+        optimisticMessageEntity.primary_key,
+        expect.objectContaining({status: StatusType.SENT}),
+      );
+    });
+
+    it('uses the legacy flow when the message-sending-status-fix toggle is disabled', async () => {
+      const conversationRepository = {
+        cancelInjectedMessageEventWait: jest.fn(),
+        prepareForInjectedMessageEvent: jest.fn(),
+        waitForInjectedMessageEvent: jest.fn(),
+      } as unknown as ConversationRepository;
+      const [messageRepository, {core, eventRepository, propertiesRepository}] = await buildMessageRepository(
+        translateForTest,
+        {
+          conversationRepository,
+          isMessageSendingStatusFixEnabled: false,
+        },
+      );
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
+
+      await messageRepository.sendTextWithLinkPreview({
+        conversation: generateConversation(),
+        mentions: [],
+        textMessage: 'hello there',
+      });
+
+      expect(conversationRepository.prepareForInjectedMessageEvent).not.toHaveBeenCalled();
+      expect(conversationRepository.waitForInjectedMessageEvent).not.toHaveBeenCalled();
+      expect(conversationRepository.cancelInjectedMessageEventWait).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -605,6 +605,72 @@ describe('MessageRepository', () => {
       );
     });
 
+    it('updates the displayed optimistic entity as failed after backend send failure when the status fix is enabled', async () => {
+      const optimisticMessageEntity = new ContentMessage(createUuid(), translateForTest);
+      optimisticMessageEntity.primary_key = 'optimistic-message-primary-key';
+      optimisticMessageEntity.type = ClientEvent.CONVERSATION.MESSAGE_ADD;
+      optimisticMessageEntity.from = selfUser.id;
+      optimisticMessageEntity.user(selfUser);
+      optimisticMessageEntity.status(StatusType.SENDING);
+
+      const optimisticEventInjected = pDefer<void>();
+      const injectedMessageEventHandled = pDefer<Maybe<Message>>();
+      const sendStarted = pDefer<void>();
+      const waitForInjectedMessageEvent = jest.fn().mockReturnValue(injectedMessageEventHandled.promise);
+      const conversationRepository = {
+        cancelInjectedMessageEventWait: jest.fn(),
+        checkMessageTimer: jest.fn(),
+        prepareForInjectedMessageEvent: jest.fn(),
+        waitForInjectedMessageEvent,
+      } as unknown as ConversationRepository;
+      const [messageRepository, {core, eventRepository, propertiesRepository}] = await buildMessageRepository(
+        translateForTest,
+        {
+          conversationRepository,
+          isMessageSendingStatusFixEnabled: true,
+          shouldStubMessageStatusUpdate: false,
+        },
+      );
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const conversation = generateConversation();
+      const backendSendError = new Error('backend send failed');
+      jest.spyOn(core.service!.conversation, 'send').mockImplementation(async () => {
+        sendStarted.resolve();
+        throw backendSendError;
+      });
+      const persistedEventUpdateSpy = jest
+        .spyOn(eventRepository.eventService, 'updateEvent')
+        .mockResolvedValue({primary_key: optimisticMessageEntity.primary_key} as IdentifiedUpdatePayload);
+      const detachedMessageLookupSpy = jest.spyOn(messageRepository, 'getMessageInConversationById');
+
+      jest.spyOn(eventRepository, 'injectEvent').mockImplementation(async event => {
+        optimisticMessageEntity.id = event.id;
+        optimisticEventInjected.resolve();
+      });
+
+      const sendingPromise = messageRepository['sendText']({
+        conversation,
+        mentions: [],
+        message: 'hello there',
+      });
+
+      await optimisticEventInjected.promise;
+      await sendStarted.promise;
+
+      conversation.addMessage(optimisticMessageEntity);
+      const resolvedMessageEntity = Maybe.just(optimisticMessageEntity);
+      injectedMessageEventHandled.resolve(resolvedMessageEntity);
+
+      await expect(sendingPromise).resolves.toMatchObject({state: 'FAILED'});
+
+      expect(optimisticMessageEntity.status()).toBe(StatusType.FAILED);
+      expect(detachedMessageLookupSpy).not.toHaveBeenCalled();
+      expect(persistedEventUpdateSpy).toHaveBeenCalledWith(optimisticMessageEntity.primary_key, {
+        status: StatusType.FAILED,
+      });
+      expect(conversationRepository.cancelInjectedMessageEventWait).toHaveBeenCalledWith(optimisticMessageEntity.id);
+    });
+
     it('uses the legacy flow when the message-sending-status-fix toggle is disabled', async () => {
       const conversationRepository = {
         cancelInjectedMessageEventWait: jest.fn(),

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -55,6 +55,7 @@ import {createUuid} from 'Util/uuid';
 import {ConversationRepository} from './ConversationRepository';
 import {ConversationState} from './ConversationState';
 import {MessageRepository} from './MessageRepository';
+import type {MessageRepositoryOptions} from './MessageRepository';
 import {ConversationVerificationState} from './ConversationVerificationState';
 
 import {StatusType} from '../../message/statusType';
@@ -75,6 +76,7 @@ type MessageRepositoryDependencies = {
   core: Account;
   cryptographyRepository: CryptographyRepository;
   eventRepository: EventRepository;
+  messageRepositoryOptions: MessageRepositoryOptions;
   propertiesRepository: PropertiesRepository;
   serverTimeHandler: ServerTimeHandler;
   translate: Translate;
@@ -111,6 +113,9 @@ async function buildMessageRepository(
     assetRepository: {} as AssetRepository,
     audioRepository: new AudioRepository(),
     translate,
+    messageRepositoryOptions: {
+      isMessageSendingStatusFixEnabled: false,
+    },
     userState,
     clientState,
     conversationState,

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -25,7 +25,7 @@ import pDefer from 'p-defer';
 import {Maybe} from 'true-myth';
 
 import {Account} from '@wireapp/core';
-import {LegalHoldStatus} from '@wireapp/protocol-messaging';
+import {Confirmation, LegalHoldStatus} from '@wireapp/protocol-messaging';
 
 import {AssetRepository} from 'Repositories/assets/assetRepository';
 import {AudioRepository} from 'Repositories/audio/audioRepository';
@@ -628,6 +628,47 @@ describe('MessageRepository', () => {
         textMessage: 'hello there',
       });
 
+      expect(conversationRepository.prepareForInjectedMessageEvent).not.toHaveBeenCalled();
+      expect(conversationRepository.waitForInjectedMessageEvent).not.toHaveBeenCalled();
+      expect(conversationRepository.cancelInjectedMessageEventWait).not.toHaveBeenCalled();
+    });
+
+    it('does not register a waiter for edits, reactions, confirmations, or in-call events when the status fix is enabled', async () => {
+      const conversationRepository = {
+        cancelInjectedMessageEventWait: jest.fn(),
+        prepareForInjectedMessageEvent: jest.fn(),
+        waitForInjectedMessageEvent: jest.fn(),
+      } as unknown as ConversationRepository;
+      const [messageRepository, {core, eventRepository}] = await buildMessageRepository(translateForTest, {
+        conversationRepository,
+        isMessageSendingStatusFixEnabled: true,
+      });
+      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
+
+      const conversation = generateConversation();
+      const originalMessage = new ContentMessage(createUuid(), translateForTest);
+      originalMessage.assets.push(new Text(createUuid(), 'old text'));
+      originalMessage.from = selfUser.id;
+      originalMessage.user(selfUser);
+      originalMessage.type = ClientEvent.CONVERSATION.MESSAGE_ADD;
+      conversation.addMessage(originalMessage);
+
+      const confirmationMessage = new ContentMessage(createUuid(), translateForTest);
+      const otherUser = new User(createUuid(), '', translateForTest);
+      otherUser.isMe = false;
+      confirmationMessage.from = otherUser.id;
+      confirmationMessage.user(otherUser);
+      confirmationMessage.type = ClientEvent.CONVERSATION.MESSAGE_ADD;
+      conversation.addMessage(confirmationMessage);
+
+      await messageRepository.sendMessageEdit(conversation, 'new text', originalMessage, []);
+      await messageRepository.toggleReaction(conversation, originalMessage, '👍', selfUser.qualifiedId);
+      await messageRepository.sendConfirmationStatus(conversation, confirmationMessage, Confirmation.Type.READ);
+      await messageRepository.sendInCallEmoji(conversation, {heart: 1});
+      await messageRepository.sendInCallHandRaised(conversation, true);
+
+      expect(core.service!.conversation.send).toHaveBeenCalledTimes(5);
       expect(conversationRepository.prepareForInjectedMessageEvent).not.toHaveBeenCalled();
       expect(conversationRepository.waitForInjectedMessageEvent).not.toHaveBeenCalled();
       expect(conversationRepository.cancelInjectedMessageEventWait).not.toHaveBeenCalled();

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import is from '@sindresorhus/is';
 import {AssetAuditData} from '@wireapp/api-client/lib/asset';
 import {MessageSendingStatus, QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
@@ -149,6 +150,22 @@ type TextMessagePayload = {
 };
 type EditMessagePayload = TextMessagePayload & {originalMessageId: string};
 
+type SendAndInjectMessageOptions = MessageSendingOptions & {
+  enableEphemeral?: boolean;
+  silentDegradationWarning?: boolean;
+  skipInjection?: boolean;
+  skipSelf?: boolean;
+  syncTimestamp?: boolean;
+  targetMode?: MessageTargetMode;
+  consentType?: CONSENT_TYPE;
+};
+
+type MessageSendingEventHandling = {
+  readonly prepareForInjectedMessageEvent: (messageId: string) => void;
+  readonly waitForInjectedMessageEvent: (messageId: string) => Promise<StoredMessage | undefined>;
+  readonly cancelInjectedMessageEventWait: (messageId: string) => void;
+};
+
 type MultipartMessagePayload = TextMessagePayload & {
   attachments: MultiPartContent['attachments'];
 };
@@ -186,7 +203,7 @@ export class MessageRepository {
     private readonly assetRepository: AssetRepository,
     private readonly audioRepository: AudioRepository,
     private readonly translate: Translate,
-    public readonly messageRepositoryOptions: MessageRepositoryOptions = {
+    private readonly messageRepositoryOptions: MessageRepositoryOptions = {
       isMessageSendingStatusFixEnabled: false,
     },
     private readonly userState = container.resolve(UserState),
@@ -923,6 +940,58 @@ export class MessageRepository {
   private async sendAndInjectMessage(
     message: GenericMessage,
     conversation: Conversation,
+    options: SendAndInjectMessageOptions = {
+      syncTimestamp: true,
+    },
+  ): Promise<SendAndInjectResult> {
+    if (this.messageRepositoryOptions.isMessageSendingStatusFixEnabled) {
+      return this.sendAndInjectMessageWithReliableStatusUpdate(message, conversation, options);
+    }
+
+    return this.sendAndInjectMessageUsingLegacyFlow(message, conversation, options);
+  }
+
+  private async sendAndInjectMessageUsingLegacyFlow(
+    message: GenericMessage,
+    conversation: Conversation,
+    options: SendAndInjectMessageOptions,
+  ): Promise<SendAndInjectResult> {
+    return this.sendAndInjectMessageUsingFlow(message, conversation, options, {
+      prepareForInjectedMessageEvent() {},
+      async waitForInjectedMessageEvent() {
+        return undefined;
+      },
+      cancelInjectedMessageEventWait() {},
+    });
+  }
+
+  private async sendAndInjectMessageWithReliableStatusUpdate(
+    message: GenericMessage,
+    conversation: Conversation,
+    options: SendAndInjectMessageOptions,
+  ): Promise<SendAndInjectResult> {
+    const conversationRepository = this.conversationRepositoryProvider();
+
+    return this.sendAndInjectMessageUsingFlow(message, conversation, options, {
+      prepareForInjectedMessageEvent: messageId => {
+        conversationRepository.prepareForInjectedMessageEvent(messageId);
+      },
+      waitForInjectedMessageEvent: async messageId => {
+        const messageEntity = await conversationRepository.waitForInjectedMessageEvent(messageId);
+        if (is.undefined(messageEntity) || is.undefined(messageEntity.primary_key)) {
+          throw new Error(`Injected message '${messageId}' did not produce a stored message entity`);
+        }
+        return messageEntity as StoredMessage;
+      },
+      cancelInjectedMessageEventWait: messageId => {
+        conversationRepository.cancelInjectedMessageEventWait(messageId);
+      },
+    });
+  }
+
+  private async sendAndInjectMessageUsingFlow(
+    message: GenericMessage,
+    conversation: Conversation,
     {
       syncTimestamp = true,
       nativePush = true,
@@ -933,20 +1002,12 @@ export class MessageRepository {
       skipInjection,
       silentDegradationWarning,
       consentType = CONSENT_TYPE.MESSAGE,
-    }: MessageSendingOptions & {
-      enableEphemeral?: boolean;
-      silentDegradationWarning?: boolean;
-      skipInjection?: boolean;
-      skipSelf?: boolean;
-      syncTimestamp?: boolean;
-      targetMode?: MessageTargetMode;
-      consentType?: CONSENT_TYPE;
-    } = {
-      syncTimestamp: true,
-    },
+    }: SendAndInjectMessageOptions,
+    messageSendingEventHandling: MessageSendingEventHandling,
   ): Promise<SendAndInjectResult> {
     const messageTimer = conversation.messageTimer();
     const payload = enableEphemeral && messageTimer ? MessageBuilder.wrapInEphemeral(message, messageTimer) : message;
+    let optimisticMessageEntity: StoredMessage | undefined;
 
     const injectOptimisticEvent = async () => {
       if (!skipInjection) {
@@ -969,7 +1030,14 @@ export class MessageRepository {
           payload,
           optimisticEvent,
         );
-        await this.eventRepository.injectEvent(mappedEvent);
+        messageSendingEventHandling.prepareForInjectedMessageEvent(mappedEvent.id);
+        try {
+          await this.eventRepository.injectEvent(mappedEvent);
+          optimisticMessageEntity = await messageSendingEventHandling.waitForInjectedMessageEvent(mappedEvent.id);
+        } catch (error: unknown) {
+          messageSendingEventHandling.cancelInjectedMessageEventWait(mappedEvent.id);
+          throw error;
+        }
       }
       return silentDegradationWarning ? true : this.requestUserSendingPermission(conversation, false, consentType);
     };
@@ -986,6 +1054,7 @@ export class MessageRepository {
           payload.messageId,
           syncTimestamp ? sentAt : undefined,
           failedToSend,
+          optimisticMessageEntity,
         );
       }
     };
@@ -1434,9 +1503,11 @@ export class MessageRepository {
     eventId: string,
     isoDate?: string,
     failedToSend?: SendResult['failedToSend'],
+    messageEntityFromOptimisticEvent?: StoredMessage,
   ) {
     try {
-      const messageEntity = await this.getMessageInConversationById(conversationEntity, eventId);
+      const messageEntity =
+        messageEntityFromOptimisticEvent ?? (await this.getMessageInConversationById(conversationEntity, eventId));
       const updatedStatus = messageEntity.readReceipts().length ? StatusType.SEEN : StatusType.SENT;
       messageEntity.status(updatedStatus);
       const changes: Pick<Partial<EventRecord>, 'status' | 'time' | 'failedToSend' | 'fileData'> = {
@@ -1453,7 +1524,7 @@ export class MessageRepository {
           conversationEntity.updateTimestamps(messageEntity);
         }
       }
-      this.conversationRepositoryProvider().checkMessageTimer(messageEntity);
+      this.conversationRepositoryProvider().checkMessageTimer(messageEntity as ContentMessage);
       if ((EventTypeHandling.STORE as string[]).includes(messageEntity.type) || messageEntity.hasAssetImage()) {
         return await this.eventService.updateEvent(messageEntity.primary_key, changes);
       }

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -1007,7 +1007,7 @@ export class MessageRepository {
             return Maybe.just(storedMessage as StoredMessage);
           },
           Nothing: () => {
-            throw new Error(`Injected message '${messageId}' did not produce a stored message entity`);
+            return Maybe.nothing<StoredMessage>();
           },
         });
       },
@@ -1036,6 +1036,16 @@ export class MessageRepository {
     const messageTimer = conversation.messageTimer();
     const payload = enableEphemeral && messageTimer ? MessageBuilder.wrapInEphemeral(message, messageTimer) : message;
     let optimisticMessageEntityPromise: Promise<Maybe<StoredMessage>> = Promise.resolve(Maybe.nothing());
+    let optimisticMessageEventId: string | undefined;
+
+    const cancelOptimisticMessageEntityWait = () => {
+      if (is.undefined(optimisticMessageEventId)) {
+        return;
+      }
+
+      messageSendingEventHandling.cancelInjectedMessageEventWait(optimisticMessageEventId);
+      optimisticMessageEventId = undefined;
+    };
 
     const injectOptimisticEvent = async () => {
       if (!skipInjection) {
@@ -1058,13 +1068,13 @@ export class MessageRepository {
           payload,
           optimisticEvent,
         );
-        messageSendingEventHandling.prepareForInjectedMessageEvent(mappedEvent.id);
-        optimisticMessageEntityPromise = messageSendingEventHandling.waitForInjectedMessageEvent(mappedEvent.id);
+        optimisticMessageEventId = mappedEvent.id;
+        messageSendingEventHandling.prepareForInjectedMessageEvent(optimisticMessageEventId);
+        optimisticMessageEntityPromise = messageSendingEventHandling.waitForInjectedMessageEvent(optimisticMessageEventId);
         try {
           await this.eventRepository.injectEvent(mappedEvent);
         } catch (error: unknown) {
-          messageSendingEventHandling.cancelInjectedMessageEventWait(mappedEvent.id);
-          optimisticMessageEntityPromise = Promise.resolve(Maybe.nothing());
+          cancelOptimisticMessageEntityWait();
           throw error;
         }
       }
@@ -1112,11 +1122,12 @@ export class MessageRepository {
 
     const shouldProceedSending = await injectOptimisticEvent();
     if (shouldProceedSending === false) {
-      await optimisticMessageEntityPromise;
+      cancelOptimisticMessageEntityWait();
       this.logger.log('User has canceled sending a message to a degraded conversation.');
       return {id: payload.messageId, sentAt: new Date().toISOString(), state: MessageSendingState.CANCELED};
     }
 
+    let result: SendResult;
     try {
       if (isMLSConversation(conversation)) {
         this.logger.info('Sending message to a MLS conversation, ensuring conversation exists');
@@ -1125,19 +1136,23 @@ export class MessageRepository {
           groupId: conversation.groupId,
         });
       }
-      const result = await this.conversationService.send(sendOptions);
-
-      if (result.state === MessageSendingState.OUTGOING_SENT) {
-        await handleSuccess(result);
-      } else {
-        await optimisticMessageEntityPromise;
-      }
-      return result;
+      result = await this.conversationService.send(sendOptions);
     } catch (error: unknown) {
-      const optimisticMessageEntity = await optimisticMessageEntityPromise;
-      await this.updateMessageAsFailed(conversation, payload.messageId, error, optimisticMessageEntity);
+      try {
+        const optimisticMessageEntity = await optimisticMessageEntityPromise;
+        await this.updateMessageAsFailed(conversation, payload.messageId, error, optimisticMessageEntity);
+      } finally {
+        cancelOptimisticMessageEntityWait();
+      }
       return {id: payload.messageId, sentAt: new Date().toISOString(), state: SendAndInjectSendingState.FAILED};
     }
+
+    if (result.state === MessageSendingState.OUTGOING_SENT) {
+      await handleSuccess(result);
+    } else {
+      await optimisticMessageEntityPromise;
+    }
+    return result;
   }
 
   public updateUserReactions(reactions: ReactionMap, userId: QualifiedId, reaction: ReactionType) {

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -1068,9 +1068,11 @@ export class MessageRepository {
           payload,
           optimisticEvent,
         );
-        optimisticMessageEventId = mappedEvent.id;
-        messageSendingEventHandling.prepareForInjectedMessageEvent(optimisticMessageEventId);
-        optimisticMessageEntityPromise = messageSendingEventHandling.waitForInjectedMessageEvent(optimisticMessageEventId);
+        const injectedMessageEventId = mappedEvent.id;
+        optimisticMessageEventId = injectedMessageEventId;
+        messageSendingEventHandling.prepareForInjectedMessageEvent(injectedMessageEventId);
+        optimisticMessageEntityPromise =
+          messageSendingEventHandling.waitForInjectedMessageEvent(injectedMessageEventId);
         try {
           await this.eventRepository.injectEvent(mappedEvent);
         } catch (error: unknown) {

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -165,6 +165,10 @@ type SendAndInjectResult = Omit<SendResult, 'state'> & {state: MessageSendingSta
 type StoredMessage = Message & {primary_key: string};
 type StoredContentMessage = ContentMessage & {primary_key: string};
 
+export type MessageRepositoryOptions = {
+  readonly isMessageSendingStatusFixEnabled: boolean;
+};
+
 export class MessageRepository {
   private readonly logger: Logger;
   private readonly eventService: EventService;
@@ -182,6 +186,9 @@ export class MessageRepository {
     private readonly assetRepository: AssetRepository,
     private readonly audioRepository: AudioRepository,
     private readonly translate: Translate,
+    public readonly messageRepositoryOptions: MessageRepositoryOptions = {
+      isMessageSendingStatusFixEnabled: false,
+    },
     private readonly userState = container.resolve(UserState),
     private readonly clientState = container.resolve(ClientState),
     private readonly conversationState = container.resolve(ConversationState),

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -153,6 +153,7 @@ type EditMessagePayload = TextMessagePayload & {originalMessageId: string};
 
 type SendAndInjectMessageOptions = MessageSendingOptions & {
   enableEphemeral?: boolean;
+  optimisticMessageEntityHandling?: 'await-created-entity' | 'none';
   silentDegradationWarning?: boolean;
   skipInjection?: boolean;
   skipSelf?: boolean;
@@ -284,7 +285,10 @@ export class MessageRepository {
     });
 
     void this.audioRepository.play(AudioType.OUTGOING_PING);
-    return this.sendAndInjectMessage(ping, conversation, {enableEphemeral: true});
+    return this.sendAndInjectMessage(ping, conversation, {
+      enableEphemeral: true,
+      optimisticMessageEntityHandling: 'await-created-entity',
+    });
   }
 
   /**
@@ -307,7 +311,11 @@ export class MessageRepository {
       messageId,
     );
 
-    return this.sendAndInjectMessage(textMessage, conversation, {...options, enableEphemeral: true});
+    return this.sendAndInjectMessage(textMessage, conversation, {
+      ...options,
+      enableEphemeral: true,
+      optimisticMessageEntityHandling: 'await-created-entity',
+    });
   }
 
   /**
@@ -328,7 +336,11 @@ export class MessageRepository {
     );
     const textMessage = MessageBuilder.buildMultipartMessage(attachments, text, messageId);
 
-    return this.sendAndInjectMessage(textMessage, conversation, {...options, enableEphemeral: true});
+    return this.sendAndInjectMessage(textMessage, conversation, {
+      ...options,
+      enableEphemeral: true,
+      optimisticMessageEntityHandling: 'await-created-entity',
+    });
   }
 
   private async sendEdit({
@@ -842,7 +854,10 @@ export class MessageRepository {
           messageId,
         );
 
-    return this.sendAndInjectMessage(assetMessage, conversation, {enableEphemeral: true});
+    return this.sendAndInjectMessage(assetMessage, conversation, {
+      enableEphemeral: true,
+      optimisticMessageEntityHandling: 'await-created-entity',
+    });
   }
 
   /**
@@ -946,7 +961,11 @@ export class MessageRepository {
       syncTimestamp: true,
     },
   ): Promise<SendAndInjectResult> {
-    if (this.messageRepositoryOptions.isMessageSendingStatusFixEnabled) {
+    const shouldAwaitCreatedOptimisticMessageEntity =
+      this.messageRepositoryOptions.isMessageSendingStatusFixEnabled &&
+      options.optimisticMessageEntityHandling === 'await-created-entity';
+
+    if (shouldAwaitCreatedOptimisticMessageEntity) {
       return this.sendAndInjectMessageWithReliableStatusUpdate(message, conversation, options);
     }
 

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -182,6 +182,7 @@ type SendAndInjectResult = Omit<SendResult, 'state'> & {state: MessageSendingSta
 /** A message that has already been stored in DB and has a primary key */
 type StoredMessage = Message & {primary_key: string};
 type StoredContentMessage = ContentMessage & {primary_key: string};
+type MessageEntityResolver = () => Promise<StoredMessage>;
 
 export type MessageRepositoryOptions = {
   readonly isMessageSendingStatusFixEnabled: boolean;
@@ -979,10 +980,17 @@ export class MessageRepository {
       },
       waitForInjectedMessageEvent: async messageId => {
         const messageEntity = await conversationRepository.waitForInjectedMessageEvent(messageId);
-        if (messageEntity.isNothing || is.undefined(messageEntity.value.primary_key)) {
-          throw new Error(`Injected message '${messageId}' did not produce a stored message entity`);
-        }
-        return Maybe.just(messageEntity.value as StoredMessage);
+        return messageEntity.match({
+          Just: storedMessage => {
+            if (is.undefined(storedMessage.primary_key)) {
+              throw new Error(`Injected message '${messageId}' did not produce a stored message entity`);
+            }
+            return Maybe.just(storedMessage as StoredMessage);
+          },
+          Nothing: () => {
+            throw new Error(`Injected message '${messageId}' did not produce a stored message entity`);
+          },
+        });
       },
       cancelInjectedMessageEventWait: messageId => {
         conversationRepository.cancelInjectedMessageEventWait(messageId);
@@ -1008,7 +1016,7 @@ export class MessageRepository {
   ): Promise<SendAndInjectResult> {
     const messageTimer = conversation.messageTimer();
     const payload = enableEphemeral && messageTimer ? MessageBuilder.wrapInEphemeral(message, messageTimer) : message;
-    let optimisticMessageEntity: Maybe<StoredMessage> = Maybe.nothing();
+    let optimisticMessageEntityPromise: Promise<Maybe<StoredMessage>> = Promise.resolve(Maybe.nothing());
 
     const injectOptimisticEvent = async () => {
       if (!skipInjection) {
@@ -1032,11 +1040,12 @@ export class MessageRepository {
           optimisticEvent,
         );
         messageSendingEventHandling.prepareForInjectedMessageEvent(mappedEvent.id);
+        optimisticMessageEntityPromise = messageSendingEventHandling.waitForInjectedMessageEvent(mappedEvent.id);
         try {
           await this.eventRepository.injectEvent(mappedEvent);
-          optimisticMessageEntity = await messageSendingEventHandling.waitForInjectedMessageEvent(mappedEvent.id);
         } catch (error: unknown) {
           messageSendingEventHandling.cancelInjectedMessageEventWait(mappedEvent.id);
+          optimisticMessageEntityPromise = Promise.resolve(Maybe.nothing());
           throw error;
         }
       }
@@ -1050,6 +1059,7 @@ export class MessageRepository {
       // Trigger an empty mismatch to check for users that have no devices and that could have been removed from the team
       await this.onClientMismatch?.({time: preMessageTimestamp}, conversation, silentDegradationWarning);
       if (!skipInjection) {
+        const optimisticMessageEntity = await optimisticMessageEntityPromise;
         await this.updateMessageAsSent(
           conversation,
           payload.messageId,
@@ -1083,6 +1093,7 @@ export class MessageRepository {
 
     const shouldProceedSending = await injectOptimisticEvent();
     if (shouldProceedSending === false) {
+      await optimisticMessageEntityPromise;
       this.logger.log('User has canceled sending a message to a degraded conversation.');
       return {id: payload.messageId, sentAt: new Date().toISOString(), state: MessageSendingState.CANCELED};
     }
@@ -1099,10 +1110,13 @@ export class MessageRepository {
 
       if (result.state === MessageSendingState.OUTGOING_SENT) {
         await handleSuccess(result);
+      } else {
+        await optimisticMessageEntityPromise;
       }
       return result;
     } catch (error: unknown) {
-      await this.updateMessageAsFailed(conversation, payload.messageId, error);
+      const optimisticMessageEntity = await optimisticMessageEntityPromise;
+      await this.updateMessageAsFailed(conversation, payload.messageId, error, optimisticMessageEntity);
       return {id: payload.messageId, sentAt: new Date().toISOString(), state: SendAndInjectSendingState.FAILED};
     }
   }
@@ -1507,9 +1521,19 @@ export class MessageRepository {
     messageEntityFromOptimisticEvent: Maybe<StoredMessage> = Maybe.nothing(),
   ) {
     try {
-      const messageEntity = messageEntityFromOptimisticEvent.isJust
-        ? messageEntityFromOptimisticEvent.value
-        : await this.getMessageInConversationById(conversationEntity, eventId);
+      const resolveMessageEntity: MessageEntityResolver = messageEntityFromOptimisticEvent.match({
+        Just: storedMessage => {
+          return () => {
+            return Promise.resolve(storedMessage);
+          };
+        },
+        Nothing: () => {
+          return () => {
+            return this.getMessageInConversationById(conversationEntity, eventId);
+          };
+        },
+      });
+      const messageEntity = await resolveMessageEntity();
       const updatedStatus = messageEntity.readReceipts().length ? StatusType.SEEN : StatusType.SENT;
       messageEntity.status(updatedStatus);
       const changes: Pick<Partial<EventRecord>, 'status' | 'time' | 'failedToSend' | 'fileData'> = {
@@ -1538,9 +1562,26 @@ export class MessageRepository {
     return undefined;
   }
 
-  private async updateMessageAsFailed(conversationEntity: Conversation, eventId: string, error: unknown) {
+  private async updateMessageAsFailed(
+    conversationEntity: Conversation,
+    eventId: string,
+    error: unknown,
+    messageEntityFromOptimisticEvent: Maybe<StoredMessage> = Maybe.nothing(),
+  ) {
     try {
-      const messageEntity = await this.getMessageInConversationById(conversationEntity, eventId);
+      const resolveMessageEntity: MessageEntityResolver = messageEntityFromOptimisticEvent.match({
+        Just: storedMessage => {
+          return () => {
+            return Promise.resolve(storedMessage);
+          };
+        },
+        Nothing: () => {
+          return () => {
+            return this.getMessageInConversationById(conversationEntity, eventId);
+          };
+        },
+      });
+      const messageEntity = await resolveMessageEntity();
       const errorStatus =
         isBackendError(error) &&
         error.label ===

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -45,6 +45,7 @@ import {TextContentBuilder} from '@wireapp/core/lib/conversation/message/textCon
 import {isQualifiedUserClients} from '@wireapp/core/lib/util';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
+import {Maybe} from 'true-myth';
 import {container} from 'tsyringe';
 import {partition} from 'underscore';
 
@@ -162,7 +163,7 @@ type SendAndInjectMessageOptions = MessageSendingOptions & {
 
 type MessageSendingEventHandling = {
   readonly prepareForInjectedMessageEvent: (messageId: string) => void;
-  readonly waitForInjectedMessageEvent: (messageId: string) => Promise<StoredMessage | undefined>;
+  readonly waitForInjectedMessageEvent: (messageId: string) => Promise<Maybe<StoredMessage>>;
   readonly cancelInjectedMessageEventWait: (messageId: string) => void;
 };
 
@@ -959,7 +960,7 @@ export class MessageRepository {
     return this.sendAndInjectMessageUsingFlow(message, conversation, options, {
       prepareForInjectedMessageEvent() {},
       async waitForInjectedMessageEvent() {
-        return undefined;
+        return Maybe.nothing<StoredMessage>();
       },
       cancelInjectedMessageEventWait() {},
     });
@@ -978,10 +979,10 @@ export class MessageRepository {
       },
       waitForInjectedMessageEvent: async messageId => {
         const messageEntity = await conversationRepository.waitForInjectedMessageEvent(messageId);
-        if (is.undefined(messageEntity) || is.undefined(messageEntity.primary_key)) {
+        if (messageEntity.isNothing || is.undefined(messageEntity.value.primary_key)) {
           throw new Error(`Injected message '${messageId}' did not produce a stored message entity`);
         }
-        return messageEntity as StoredMessage;
+        return Maybe.just(messageEntity.value as StoredMessage);
       },
       cancelInjectedMessageEventWait: messageId => {
         conversationRepository.cancelInjectedMessageEventWait(messageId);
@@ -1007,7 +1008,7 @@ export class MessageRepository {
   ): Promise<SendAndInjectResult> {
     const messageTimer = conversation.messageTimer();
     const payload = enableEphemeral && messageTimer ? MessageBuilder.wrapInEphemeral(message, messageTimer) : message;
-    let optimisticMessageEntity: StoredMessage | undefined;
+    let optimisticMessageEntity: Maybe<StoredMessage> = Maybe.nothing();
 
     const injectOptimisticEvent = async () => {
       if (!skipInjection) {
@@ -1503,11 +1504,12 @@ export class MessageRepository {
     eventId: string,
     isoDate?: string,
     failedToSend?: SendResult['failedToSend'],
-    messageEntityFromOptimisticEvent?: StoredMessage,
+    messageEntityFromOptimisticEvent: Maybe<StoredMessage> = Maybe.nothing(),
   ) {
     try {
-      const messageEntity =
-        messageEntityFromOptimisticEvent ?? (await this.getMessageInConversationById(conversationEntity, eventId));
+      const messageEntity = messageEntityFromOptimisticEvent.isJust
+        ? messageEntityFromOptimisticEvent.value
+        : await this.getMessageInConversationById(conversationEntity, eventId);
       const updatedStatus = messageEntity.readReceipts().length ? StatusType.SEEN : StatusType.SENT;
       messageEntity.status(updatedStatus);
       const changes: Pick<Partial<EventRecord>, 'status' | 'time' | 'failedToSend' | 'fileData'> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12008,6 +12008,7 @@ __metadata:
     noop-esm: "npm:1.1.0"
     oidc-client-ts: "npm:3.5.0"
     os-browserify: "npm:0.3.0"
+    p-defer: "npm:4.0.1"
     p-wait-for: "npm:6.0.0"
     path-browserify: "npm:1.0.1"
     path-to-regexp: "npm:8.4.2"
@@ -24274,6 +24275,13 @@ __metadata:
     object-keys: "npm:^1.1.1"
     safe-push-apply: "npm:^1.0.0"
   checksum: 10/ab4bb3b8636908554fc19bf899e225444195092864cb61503a0d048fdaf662b04be2605b636a4ffeaf6e8811f6fcfa8cbb210ec964c0eb1a41eb853e1d5d2f41
+  languageName: node
+  linkType: hard
+
+"p-defer@npm:4.0.1":
+  version: 4.0.1
+  resolution: "p-defer@npm:4.0.1"
+  checksum: 10/a561e7b581b76e6dce8ae763b4980004dbc795781de327d0b760e5341f035b0fa2c14e892a66d6d8122e2e114815a26f5ad154061374df84f88e75405ea4b0bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27032" title="WPB-27032" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27032</a>  [Web] Outgoing messages can remain grey until the conversation is reopened
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Problem

Outgoing messages can intermittently remain grey after they have been sent successfully.

The message is persisted and delivered, but the message entity currently rendered in the conversation can remain in `StatusType.SENDING`. Switching to another conversation and back reloads the message from storage, after which it appears correctly as sent.

## Root cause

The optimistic message injection and the successful send-status update can race.

The successful send path may update a message entity loaded from storage before the optimistic entity has been attached to the conversation. The database record is therefore updated to `SENT`, while the in-memory entity rendered by the UI can remain `SENDING`.

## Changes

This pull request ensures that the successful send result updates the authoritative in-memory message entity used by the conversation.

The new behavior is protected by the existing startup feature-toggle mechanism and is disabled by default.

Enable it with:

```text
?enabled-features=message-sending-status-fix
```

## Side note: Why `Promise<Maybe<Message>>`?

Using `Promise<Maybe<Message>>` here is intentional.

`Task` is not a drop-in replacement in this part of the codebase. The completion boundary is already based on promises through `p-defer`, while `EventRepository` and `ConversationRepository` rely on standard `async` functions, rejected promises, and `try`/`catch` for error propagation.

Introducing `Task` would therefore change more than the return type. Because a `Task` resolves to a `Result`, it would require refactoring the waiter API, stored resolvers, rejection handling, and all affected callers. That would expand this bug fix into a broader migration of the asynchronous error model.