### PR TITLE
Fix stale outgoing text message status behind a startup feature toggle [WPB-27032]

### DIFF
--- a/apps/webapp/src/script/components/appContainer/appContainer.tsx
+++ b/apps/webapp/src/script/components/appContainer/appContainer.tsx
@@ -45,6 +45,7 @@ import {useTheme} from './hooks/useTheme';
 import {runClientVersionCheck} from '../../applicationPeriodicChecks/runClientVersionCheck';
 import {startApplicationPeriodicChecks} from '../../applicationPeriodicChecks/startApplicationPeriodicChecks';
 import {Config, Configuration} from '../../Config';
+import {messageSendingStatusFixFeatureToggleName} from '../../featureToggles/startupFeatureToggleNames';
 import {StartupFeatureToggleName} from '../../featureToggles/startupFeatureToggles';
 import {setAppLocale} from '../../localization/Localizer';
 import {App} from '../../main/app';
@@ -86,8 +87,10 @@ export const AppContainer = (properties: AppProps) => {
   } = properties;
   setAppLocale();
   const app = useMemo(() => {
-    return new App(container.resolve(Core), container.resolve(APIClient), config, translate);
-  }, [config, translate]);
+    return new App(container.resolve(Core), container.resolve(APIClient), config, translate, {
+      isMessageSendingStatusFixEnabled: isFeatureToggleEnabled(messageSendingStatusFixFeatureToggleName),
+    });
+  }, [config, isFeatureToggleEnabled, translate]);
   const enableAutoLogin = Config.getConfig().FEATURE.ENABLE_AUTO_LOGIN;
 
   // Publishing application on the global scope for debug and testing purposes.

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -20,11 +20,13 @@
 export const applockRefactoredFeatureToggleName = 'applock-refactored';
 export const sharedDriveSearchAndFiltersFeatureToggleName = 'shared-drive-search-and-filters';
 export const meetingsFeatureToggleName = 'meetings';
+export const messageSendingStatusFixFeatureToggleName = 'message-sending-status-fix';
 
 export const startupFeatureToggleNames = [
   applockRefactoredFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   meetingsFeatureToggleName,
+  messageSendingStatusFixFeatureToggleName,
 ] as const;
 
 export type StartupFeatureToggleName = (typeof startupFeatureToggleNames)[number];

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -24,6 +24,7 @@ import {
 } from './startupFeatureToggles';
 import {
   applockRefactoredFeatureToggleName,
+  messageSendingStatusFixFeatureToggleName,
   meetingsFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   startupFeatureToggleNames,
@@ -33,6 +34,7 @@ const featureToggleNamesWithDedicatedExistenceTests = [
   applockRefactoredFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   meetingsFeatureToggleName,
+  messageSendingStatusFixFeatureToggleName,
 ] as const;
 
 describe('startupFeatureToggles', function () {
@@ -101,6 +103,14 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.isFeatureToggleEnabled(meetingsFeatureToggleName)).toBe(true);
   });
 
+  it('enables the message sending status fix feature toggle when present in the query parameter', () => {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${messageSendingStatusFixFeatureToggleName}`,
+    );
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(messageSendingStatusFixFeatureToggleName)).toBe(true);
+  });
+
   it('trims whitespace around feature toggle names', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}= ${applockRefactoredFeatureToggleName} `,
@@ -142,6 +152,7 @@ describe('startupFeatureToggles', function () {
       applockRefactoredFeatureToggleName,
       sharedDriveSearchAndFiltersFeatureToggleName,
       meetingsFeatureToggleName,
+      messageSendingStatusFixFeatureToggleName,
     ]);
   });
 

--- a/apps/webapp/src/script/main/app.ts
+++ b/apps/webapp/src/script/main/app.ts
@@ -52,7 +52,7 @@ import {ConversationService} from 'Repositories/conversation/ConversationService
 import {ConversationVerificationState} from 'Repositories/conversation/ConversationVerificationState';
 import {OnConversationE2EIVerificationStateChange} from 'Repositories/conversation/ConversationVerificationStateHandler/shared';
 import {EventBuilder} from 'Repositories/conversation/EventBuilder';
-import {MessageRepository} from 'Repositories/conversation/MessageRepository';
+import {MessageRepository, MessageRepositoryOptions} from 'Repositories/conversation/MessageRepository';
 import {CryptographyRepository} from 'Repositories/cryptography/CryptographyRepository';
 import {User} from 'Repositories/entity/User';
 import {EventRepository} from 'Repositories/event/EventRepository';
@@ -197,6 +197,9 @@ export class App {
     private readonly apiClient: APIClient,
     private readonly config: Configuration,
     private readonly translate: Translate,
+    private readonly messageRepositoryOptions: MessageRepositoryOptions = {
+      isMessageSendingStatusFixEnabled: false,
+    },
   ) {
     this.config = config;
     this.apiClient.on(APIClient.TOPIC.ON_LOGOUT, () =>
@@ -298,6 +301,7 @@ export class App {
       repositories.asset,
       repositories.audio,
       this.translate,
+      this.messageRepositoryOptions,
     );
 
     repositories.calling = new CallingRepository(

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -54,7 +54,7 @@ import {createUuid} from 'Util/uuid';
 
 import {ConversationRepository} from './ConversationRepository';
 import {ConversationState} from './ConversationState';
-import {MessageRepository} from './MessageRepository';
+import {MessageRepository, MessageRepositoryOptions} from './MessageRepository';
 import {ConversationVerificationState} from './ConversationVerificationState';
 
 import {StatusType} from '../../message/statusType';
@@ -75,6 +75,7 @@ type MessageRepositoryDependencies = {
   core: Account;
   cryptographyRepository: CryptographyRepository;
   eventRepository: EventRepository;
+  messageRepositoryOptions: MessageRepositoryOptions;
   propertiesRepository: PropertiesRepository;
   serverTimeHandler: ServerTimeHandler;
   translate: Translate;
@@ -111,6 +112,7 @@ async function buildMessageRepository(
     assetRepository: {} as AssetRepository,
     audioRepository: new AudioRepository(),
     translate,
+    messageRepositoryOptions: {isMessageSendingStatusFixEnabled: false},
     userState,
     clientState,
     conversationState,

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -524,7 +524,8 @@ describe('MessageRepository', () => {
     });
 
     it('does not wait for an added message when the status fix is disabled', async () => {
-      const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest);
+      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest);
+      clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
       const sendAndInjectMessageSpy = jest
@@ -538,8 +539,9 @@ describe('MessageRepository', () => {
     });
 
     it('preserves post-send failure behavior when the status fix is disabled', async () => {
-      const [messageRepository, {core, eventRepository, propertiesRepository}] =
+      const [messageRepository, {clientState, core, eventRepository, propertiesRepository}] =
         await buildMessageRepository(translateForTest);
+      clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
@@ -564,9 +566,10 @@ describe('MessageRepository', () => {
     });
 
     it('does not wait for an added message when an existing message id is provided', async () => {
-      const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest, {
+      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest, {
         isMessageSendingStatusFixEnabled: true,
       });
+      clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
       const sendAndInjectMessageSpy = jest
@@ -584,14 +587,37 @@ describe('MessageRepository', () => {
       expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('does not create a message-added waiter when there is no current client id', async () => {
+      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest, {
+        isMessageSendingStatusFixEnabled: true,
+      });
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      clientState.currentClient = undefined;
+      const subscribeSpy = jest.spyOn(amplify, 'subscribe');
+      const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
+      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
+      const sendAndInjectMessageSpy = jest
+        .spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage')
+        .mockResolvedValue(successPayload);
+      const conversation = generateConversation();
+
+      await messageRepository.sendTextWithLinkPreview({conversation, textMessage: 'hello there', mentions: []});
+
+      expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
+      expect(subscribeSpy).not.toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
+      expect(unsubscribeSpy).not.toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
+    });
+
     it('waits for and repairs the exact added message when the status fix is enabled', async () => {
-      const [messageRepository, {eventRepository, propertiesRepository}] = await buildMessageRepository(
+      const [messageRepository, {clientState, eventRepository, propertiesRepository}] = await buildMessageRepository(
         translateForTest,
         {
           isMessageSendingStatusFixEnabled: true,
         },
       );
+      clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const subscribeSpy = jest.spyOn(amplify, 'subscribe');
       const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
       const updateEventSpy = jest.spyOn(eventRepository.eventService, 'updateEvent');
       const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
@@ -617,15 +643,15 @@ describe('MessageRepository', () => {
 
       expect(addedMessageEntity.status()).toBe(StatusType.SENT);
       expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
+      expect(subscribeSpy).toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
       expect(unsubscribeSpy).toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
       expect(updateEventSpy).not.toHaveBeenCalled();
     });
 
     it('does not downgrade an already delivered added message when the status fix is enabled', async () => {
-      const [messageRepository, {conversationRepository, propertiesRepository}] = await buildMessageRepository(
-        translateForTest,
-        {isMessageSendingStatusFixEnabled: true},
-      );
+      const [messageRepository, {clientState, conversationRepository, propertiesRepository}] =
+        await buildMessageRepository(translateForTest, {isMessageSendingStatusFixEnabled: true});
+      clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
       const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
@@ -633,9 +659,6 @@ describe('MessageRepository', () => {
         .spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage')
         .mockResolvedValue(successPayload);
       const conversation = generateConversation();
-      const updateTimestampServerSpy = jest.spyOn(conversation, 'updateTimestampServer');
-      const updateTimestampsSpy = jest.spyOn(conversation, 'updateTimestamps');
-      const checkMessageTimerSpy = jest.spyOn(conversationRepository(), 'checkMessageTimer');
       const sendPromise = messageRepository.sendTextWithLinkPreview({
         conversation,
         textMessage: 'hello there',
@@ -648,8 +671,11 @@ describe('MessageRepository', () => {
       const addedMessageEntity = new Message(sentTextMessage.messageId, undefined, translateForTest);
       addedMessageEntity.conversation_id = conversation.id;
       addedMessageEntity.status(StatusType.DELIVERED);
-      const timestampSpy = jest.spyOn(addedMessageEntity, 'timestamp');
       conversation.addMessage(addedMessageEntity);
+      const timestampSpy = jest.spyOn(addedMessageEntity, 'timestamp');
+      const updateTimestampServerSpy = jest.spyOn(conversation, 'updateTimestampServer');
+      const updateTimestampsSpy = jest.spyOn(conversation, 'updateTimestamps');
+      const checkMessageTimerSpy = jest.spyOn(conversationRepository(), 'checkMessageTimer');
 
       await sendPromise;
 
@@ -662,9 +688,10 @@ describe('MessageRepository', () => {
     });
 
     it('removes the listener when sending is canceled', async () => {
-      const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest, {
+      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest, {
         isMessageSendingStatusFixEnabled: true,
       });
+      clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
       const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
@@ -680,10 +707,9 @@ describe('MessageRepository', () => {
     });
 
     it('removes the listener when the backend send fails', async () => {
-      const [messageRepository, {core, eventRepository, propertiesRepository}] = await buildMessageRepository(
-        translateForTest,
-        {isMessageSendingStatusFixEnabled: true},
-      );
+      const [messageRepository, {clientState, core, eventRepository, propertiesRepository}] =
+        await buildMessageRepository(translateForTest, {isMessageSendingStatusFixEnabled: true});
+      clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       jest.spyOn(core.service!.conversation, 'send').mockRejectedValue(new Error('backend send failed'));
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
@@ -703,9 +729,10 @@ describe('MessageRepository', () => {
     });
 
     it('removes the listener when the legacy send throws', async () => {
-      const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest, {
+      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest, {
         isMessageSendingStatusFixEnabled: true,
       });
+      clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
       const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
@@ -725,9 +752,10 @@ describe('MessageRepository', () => {
     });
 
     it('ignores added messages from another conversation or with another message id', async () => {
-      const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest, {
+      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest, {
         isMessageSendingStatusFixEnabled: true,
       });
+      clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
       const sendAndInjectMessageSpy = jest

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -582,6 +582,45 @@ describe('MessageRepository', () => {
       expect(addedMessageEntity.status()).toBe(StatusType.SENT);
       expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('ignores added messages from another conversation or with another message id', async () => {
+      const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest, {
+        isMessageSendingStatusFixEnabled: true,
+      });
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
+      const sendAndInjectMessageSpy = jest
+        .spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage')
+        .mockResolvedValue(successPayload);
+      const conversation = generateConversation();
+      const otherConversation = generateConversation();
+      const sendPromise = messageRepository.sendTextWithLinkPreview({
+        conversation,
+        textMessage: 'hello there',
+        mentions: [],
+      });
+
+      await Promise.resolve();
+
+      const sentTextMessage = sendAndInjectMessageSpy.mock.calls[0][0];
+      const messageWithAnotherId = new Message(createUuid(), undefined, translateForTest);
+      messageWithAnotherId.conversation_id = conversation.id;
+      conversation.addMessage(messageWithAnotherId);
+      const messageFromAnotherConversation = new Message(sentTextMessage.messageId, undefined, translateForTest);
+      messageFromAnotherConversation.conversation_id = otherConversation.id;
+      otherConversation.addMessage(messageFromAnotherConversation);
+
+      await Promise.resolve();
+
+      const sendStateBeforeMatchingMessage = await Promise.race([sendPromise, Promise.resolve('pending')]);
+      expect(sendStateBeforeMatchingMessage).toBe('pending');
+
+      const matchingMessageEntity = new Message(sentTextMessage.messageId, undefined, translateForTest);
+      matchingMessageEntity.conversation_id = conversation.id;
+      conversation.addMessage(matchingMessageEntity);
+
+      await sendPromise;
+    });
   });
 
   describe('deleteMessageForEveryone', () => {

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -21,9 +21,11 @@ import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
 import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation/';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 import {MessageSendingState} from '@wireapp/core/lib/conversation';
+import {amplify} from 'amplify';
 
 import {Account} from '@wireapp/core';
 import {GenericMessage, LegalHoldStatus} from '@wireapp/protocol-messaging';
+import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {AssetRepository} from 'Repositories/assets/assetRepository';
 import {AudioRepository} from 'Repositories/audio/audioRepository';
@@ -558,6 +560,7 @@ describe('MessageRepository', () => {
         isMessageSendingStatusFixEnabled: true,
       });
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
       const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
       const sendAndInjectMessageSpy = jest
         .spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage')
@@ -581,6 +584,47 @@ describe('MessageRepository', () => {
 
       expect(addedMessageEntity.status()).toBe(StatusType.SENT);
       expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
+      expect(unsubscribeSpy).toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
+    });
+
+    it('removes the listener when sending is canceled', async () => {
+      const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest, {
+        isMessageSendingStatusFixEnabled: true,
+      });
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
+      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
+      jest.spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage').mockResolvedValue({
+        ...successPayload,
+        state: MessageSendingState.CANCELED,
+      });
+      const conversation = generateConversation();
+
+      await messageRepository.sendTextWithLinkPreview({conversation, textMessage: 'hello there', mentions: []});
+
+      expect(unsubscribeSpy).toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
+    });
+
+    it('removes the listener when the legacy send throws', async () => {
+      const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest, {
+        isMessageSendingStatusFixEnabled: true,
+      });
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
+      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
+      const expectedError = new Error('injection failed');
+      jest.spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage').mockRejectedValue(expectedError);
+      const conversation = generateConversation();
+      let actualError: unknown;
+
+      try {
+        await messageRepository.sendTextWithLinkPreview({conversation, textMessage: 'hello there', mentions: []});
+      } catch (error: unknown) {
+        actualError = error;
+      }
+
+      expect(actualError).toBe(expectedError);
+      expect(unsubscribeSpy).toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
     });
 
     it('ignores added messages from another conversation or with another message id', async () => {

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -108,8 +108,9 @@ async function buildMessageRepository(
   const selfConversation = new Conversation(selfUser.id, '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
   selfConversation.selfUser(selfUser);
   conversationState.conversations([selfConversation]);
+  const conversationRepository = {checkMessageTimer: jest.fn()} as unknown as ConversationRepository;
   const dependencies = {
-    conversationRepository: () => ({checkMessageTimer: jest.fn()}) as unknown as ConversationRepository,
+    conversationRepository: () => conversationRepository,
     cryptographyRepository: new CryptographyRepository({} as any),
     eventRepository: new EventRepository(new EventService({} as any), {} as any, {} as any, {} as any),
     propertiesRepository: new PropertiesRepository({} as any, {} as any, translate),
@@ -618,6 +619,46 @@ describe('MessageRepository', () => {
       expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
       expect(unsubscribeSpy).toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
       expect(updateEventSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not downgrade an already delivered added message when the status fix is enabled', async () => {
+      const [messageRepository, {conversationRepository, propertiesRepository}] = await buildMessageRepository(
+        translateForTest,
+        {isMessageSendingStatusFixEnabled: true},
+      );
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
+      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
+      const sendAndInjectMessageSpy = jest
+        .spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage')
+        .mockResolvedValue(successPayload);
+      const conversation = generateConversation();
+      const updateTimestampServerSpy = jest.spyOn(conversation, 'updateTimestampServer');
+      const updateTimestampsSpy = jest.spyOn(conversation, 'updateTimestamps');
+      const checkMessageTimerSpy = jest.spyOn(conversationRepository(), 'checkMessageTimer');
+      const sendPromise = messageRepository.sendTextWithLinkPreview({
+        conversation,
+        textMessage: 'hello there',
+        mentions: [],
+      });
+
+      await Promise.resolve();
+
+      const sentTextMessage = sendAndInjectMessageSpy.mock.calls[0][0];
+      const addedMessageEntity = new Message(sentTextMessage.messageId, undefined, translateForTest);
+      addedMessageEntity.conversation_id = conversation.id;
+      addedMessageEntity.status(StatusType.DELIVERED);
+      const timestampSpy = jest.spyOn(addedMessageEntity, 'timestamp');
+      conversation.addMessage(addedMessageEntity);
+
+      await sendPromise;
+
+      expect(addedMessageEntity.status()).toBe(StatusType.DELIVERED);
+      expect(timestampSpy).not.toHaveBeenCalled();
+      expect(updateTimestampServerSpy).not.toHaveBeenCalled();
+      expect(updateTimestampsSpy).not.toHaveBeenCalled();
+      expect(checkMessageTimerSpy).not.toHaveBeenCalled();
+      expect(unsubscribeSpy).toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
     });
 
     it('removes the listener when sending is canceled', async () => {

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -556,11 +556,15 @@ describe('MessageRepository', () => {
     });
 
     it('waits for and repairs the exact added message when the status fix is enabled', async () => {
-      const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest, {
-        isMessageSendingStatusFixEnabled: true,
-      });
+      const [messageRepository, {eventRepository, propertiesRepository}] = await buildMessageRepository(
+        translateForTest,
+        {
+          isMessageSendingStatusFixEnabled: true,
+        },
+      );
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
+      const updateEventSpy = jest.spyOn(eventRepository.eventService, 'updateEvent');
       const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
       const sendAndInjectMessageSpy = jest
         .spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage')
@@ -585,6 +589,7 @@ describe('MessageRepository', () => {
       expect(addedMessageEntity.status()).toBe(StatusType.SENT);
       expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
       expect(unsubscribeSpy).toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
+      expect(updateEventSpy).not.toHaveBeenCalled();
     });
 
     it('removes the listener when sending is canceled', async () => {

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -88,6 +88,8 @@ type MessageRepositoryDependencies = {
 
 type MessageRepositoryPrivateMethodsForTest = {
   sendAndInjectMessage: (message: GenericMessage) => Promise<unknown>;
+  updateMessageAsFailed: () => Promise<void>;
+  updateMessageAsSent: () => Promise<void>;
 };
 
 async function buildMessageRepository(
@@ -534,6 +536,32 @@ describe('MessageRepository', () => {
       expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('preserves post-send failure behavior when the status fix is disabled', async () => {
+      const [messageRepository, {core, eventRepository, propertiesRepository}] =
+        await buildMessageRepository(translateForTest);
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
+      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
+      const expectedError = new Error('post-send status handling failed');
+      const updateMessageAsFailedSpy = jest
+        .spyOn(messageRepositoryPrivateMethods, 'updateMessageAsFailed')
+        .mockResolvedValue(undefined);
+      jest.spyOn(messageRepositoryPrivateMethods, 'updateMessageAsSent').mockRejectedValue(expectedError);
+      const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
+      const conversation = generateConversation();
+
+      const sendResult = await messageRepository.sendTextWithLinkPreview({
+        conversation,
+        textMessage: 'hello there',
+        mentions: [],
+      });
+
+      expect(sendResult).toBe(MessageSendingState.FAILED);
+      expect(updateMessageAsFailedSpy).toHaveBeenCalledTimes(1);
+      expect(unsubscribeSpy).not.toHaveBeenCalled();
+    });
+
     it('does not wait for an added message when an existing message id is provided', async () => {
       const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest, {
         isMessageSendingStatusFixEnabled: true,
@@ -607,6 +635,29 @@ describe('MessageRepository', () => {
 
       await messageRepository.sendTextWithLinkPreview({conversation, textMessage: 'hello there', mentions: []});
 
+      expect(unsubscribeSpy).toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
+    });
+
+    it('removes the listener when the backend send fails', async () => {
+      const [messageRepository, {core, eventRepository, propertiesRepository}] = await buildMessageRepository(
+        translateForTest,
+        {isMessageSendingStatusFixEnabled: true},
+      );
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      jest.spyOn(core.service!.conversation, 'send').mockRejectedValue(new Error('backend send failed'));
+      jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
+      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
+      jest.spyOn(messageRepositoryPrivateMethods, 'updateMessageAsFailed').mockResolvedValue(undefined);
+      const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
+      const conversation = generateConversation();
+
+      const sendResult = await messageRepository.sendTextWithLinkPreview({
+        conversation,
+        textMessage: 'hello there',
+        mentions: [],
+      });
+
+      expect(sendResult).toBe(MessageSendingState.FAILED);
       expect(unsubscribeSpy).toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
     });
 

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -23,7 +23,7 @@ import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 import {MessageSendingState} from '@wireapp/core/lib/conversation';
 
 import {Account} from '@wireapp/core';
-import {LegalHoldStatus} from '@wireapp/protocol-messaging';
+import {GenericMessage, LegalHoldStatus} from '@wireapp/protocol-messaging';
 
 import {AssetRepository} from 'Repositories/assets/assetRepository';
 import {AudioRepository} from 'Repositories/audio/audioRepository';
@@ -82,6 +82,10 @@ type MessageRepositoryDependencies = {
   userRepository: UserRepository;
   userState: UserState;
   conversationState: ConversationState;
+};
+
+type MessageRepositoryPrivateMethodsForTest = {
+  sendAndInjectMessage: (message: GenericMessage) => Promise<unknown>;
 };
 
 async function buildMessageRepository(
@@ -383,8 +387,9 @@ describe('MessageRepository', () => {
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
 
       // Spy on the internal method that sendButtonAction actually calls
+      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
       const sendAndInjectMessageSpy = jest
-        .spyOn(messageRepository as any, 'sendAndInjectMessage')
+        .spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage')
         .mockResolvedValue(undefined);
 
       // Create a mock message entity with primary_key for updateEventSequentially
@@ -452,8 +457,9 @@ describe('MessageRepository', () => {
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
 
       // Spy on the internal method that sendButtonAction actually calls
+      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
       const sendAndInjectMessageSpy = jest
-        .spyOn(messageRepository as any, 'sendAndInjectMessage')
+        .spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage')
         .mockResolvedValue(undefined);
 
       // Create a mock message entity with primary_key for updateEventSequentially
@@ -515,12 +521,34 @@ describe('MessageRepository', () => {
     it('does not wait for an added message when the status fix is disabled', async () => {
       const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest);
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
       const sendAndInjectMessageSpy = jest
-        .spyOn(messageRepository as any, 'sendAndInjectMessage')
+        .spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage')
         .mockResolvedValue(successPayload);
       const conversation = generateConversation();
 
       await messageRepository.sendTextWithLinkPreview({conversation, textMessage: 'hello there', mentions: []});
+
+      expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not wait for an added message when an existing message id is provided', async () => {
+      const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest, {
+        isMessageSendingStatusFixEnabled: true,
+      });
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
+      const sendAndInjectMessageSpy = jest
+        .spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage')
+        .mockResolvedValue(successPayload);
+      const conversation = generateConversation();
+
+      await messageRepository.sendTextWithLinkPreview({
+        conversation,
+        textMessage: 'hello there',
+        mentions: [],
+        messageId: createUuid(),
+      });
 
       expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
     });
@@ -530,8 +558,9 @@ describe('MessageRepository', () => {
         isMessageSendingStatusFixEnabled: true,
       });
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
       const sendAndInjectMessageSpy = jest
-        .spyOn(messageRepository as any, 'sendAndInjectMessage')
+        .spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage')
         .mockResolvedValue(successPayload);
       const conversation = generateConversation();
       const sendPromise = messageRepository.sendTextWithLinkPreview({

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -86,6 +86,7 @@ type MessageRepositoryDependencies = {
 
 async function buildMessageRepository(
   translate: Translate,
+  messageRepositoryOptions: MessageRepositoryOptions = {isMessageSendingStatusFixEnabled: false},
 ): Promise<[MessageRepository, MessageRepositoryDependencies]> {
   const userState = new UserState();
   userState.self(selfUser);
@@ -100,7 +101,7 @@ async function buildMessageRepository(
   selfConversation.selfUser(selfUser);
   conversationState.conversations([selfConversation]);
   const dependencies = {
-    conversationRepository: () => ({}) as ConversationRepository,
+    conversationRepository: () => ({checkMessageTimer: jest.fn()}) as unknown as ConversationRepository,
     cryptographyRepository: new CryptographyRepository({} as any),
     eventRepository: new EventRepository(new EventService({} as any), {} as any, {} as any, {} as any),
     propertiesRepository: new PropertiesRepository({} as any, {} as any, translate),
@@ -112,7 +113,7 @@ async function buildMessageRepository(
     assetRepository: {} as AssetRepository,
     audioRepository: new AudioRepository(),
     translate,
-    messageRepositoryOptions: {isMessageSendingStatusFixEnabled: false},
+    messageRepositoryOptions,
     userState,
     clientState,
     conversationState,
@@ -509,6 +510,48 @@ describe('MessageRepository', () => {
         targetMode: undefined,
         userIds: expect.any(Object),
       });
+    });
+
+    it('does not wait for an added message when the status fix is disabled', async () => {
+      const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest);
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const sendAndInjectMessageSpy = jest
+        .spyOn(messageRepository as any, 'sendAndInjectMessage')
+        .mockResolvedValue(successPayload);
+      const conversation = generateConversation();
+
+      await messageRepository.sendTextWithLinkPreview({conversation, textMessage: 'hello there', mentions: []});
+
+      expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('waits for and repairs the exact added message when the status fix is enabled', async () => {
+      const [messageRepository, {propertiesRepository}] = await buildMessageRepository(translateForTest, {
+        isMessageSendingStatusFixEnabled: true,
+      });
+      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
+      const sendAndInjectMessageSpy = jest
+        .spyOn(messageRepository as any, 'sendAndInjectMessage')
+        .mockResolvedValue(successPayload);
+      const conversation = generateConversation();
+      const sendPromise = messageRepository.sendTextWithLinkPreview({
+        conversation,
+        textMessage: 'hello there',
+        mentions: [],
+      });
+
+      await Promise.resolve();
+
+      const sentTextMessage = sendAndInjectMessageSpy.mock.calls[0][0];
+      const addedMessageEntity = new Message(sentTextMessage.messageId, undefined, translateForTest);
+      addedMessageEntity.conversation_id = conversation.id;
+      addedMessageEntity.status(StatusType.SENDING);
+      conversation.addMessage(addedMessageEntity);
+
+      await sendPromise;
+
+      expect(addedMessageEntity.status()).toBe(StatusType.SENT);
+      expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -349,20 +349,22 @@ export class MessageRepository {
 
       if (sendResult.state === MessageSendingState.OUTGOING_SENT) {
         const messageEntity = await addedMessageWaiter.messagePromise;
-        const updatedStatus = messageEntity.readReceipts().length > 0 ? StatusType.SEEN : StatusType.SENT;
-        messageEntity.status(updatedStatus);
+        if (messageEntity.status() === StatusType.SENDING) {
+          const updatedStatus = messageEntity.readReceipts().length > 0 ? StatusType.SEEN : StatusType.SENT;
+          messageEntity.status(updatedStatus);
 
-        const shouldSynchronizeTimestamp = is.undefined(options.syncTimestamp) || options.syncTimestamp;
-        if (shouldSynchronizeTimestamp) {
-          const timestamp = new Date(sendResult.sentAt).getTime();
-          if (!isNaN(timestamp)) {
-            messageEntity.timestamp(timestamp);
-            conversation.updateTimestampServer(timestamp, true);
-            conversation.updateTimestamps(messageEntity);
+          const shouldSynchronizeTimestamp = is.undefined(options.syncTimestamp) || options.syncTimestamp;
+          if (shouldSynchronizeTimestamp) {
+            const timestamp = new Date(sendResult.sentAt).getTime();
+            if (!isNaN(timestamp)) {
+              messageEntity.timestamp(timestamp);
+              conversation.updateTimestampServer(timestamp, true);
+              conversation.updateTimestamps(messageEntity);
+            }
           }
-        }
 
-        this.conversationRepositoryProvider().checkMessageTimer(messageEntity as ContentMessage);
+          this.conversationRepositoryProvider().checkMessageTimer(messageEntity as ContentMessage);
+        }
       }
 
       return sendResult;

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -121,6 +121,10 @@ export interface MessageSendingOptions {
   recipients?: QualifiedId[] | QualifiedUserClients;
 }
 
+export type MessageRepositoryOptions = {
+  readonly isMessageSendingStatusFixEnabled: boolean;
+};
+
 export enum CONSENT_TYPE {
   INCOMING_CALL = 'incoming_call',
   MESSAGE = 'message',
@@ -182,6 +186,9 @@ export class MessageRepository {
     private readonly assetRepository: AssetRepository,
     private readonly audioRepository: AudioRepository,
     private readonly translate: Translate,
+    private readonly messageRepositoryOptions: MessageRepositoryOptions = {
+      isMessageSendingStatusFixEnabled: false,
+    },
     private readonly userState = container.resolve(UserState),
     private readonly clientState = container.resolve(ClientState),
     private readonly conversationState = container.resolve(ConversationState),

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -44,6 +44,7 @@ import {TextContentBuilder} from '@wireapp/core/lib/conversation/message/textCon
 import {isQualifiedUserClients} from '@wireapp/core/lib/util';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
+import is from '@sindresorhus/is';
 import {container} from 'tsyringe';
 import {partition} from 'underscore';
 
@@ -123,6 +124,11 @@ export interface MessageSendingOptions {
 
 export type MessageRepositoryOptions = {
   readonly isMessageSendingStatusFixEnabled: boolean;
+};
+
+type AddedMessageWaiter = {
+  readonly messagePromise: Promise<Message>;
+  readonly dispose: () => void;
 };
 
 export enum CONSENT_TYPE {
@@ -276,6 +282,7 @@ export class MessageRepository {
   private async sendText(
     {conversation, message, mentions = [], linkPreview, quote, messageId}: TextMessagePayload,
     options?: {syncTimestamp?: boolean},
+    isNewTextMessage = false,
   ) {
     const textMessage = MessageBuilder.buildTextMessage(
       this.decorateTextMessage(
@@ -288,7 +295,80 @@ export class MessageRepository {
       messageId,
     );
 
-    return this.sendAndInjectMessage(textMessage, conversation, {...options, enableEphemeral: true});
+    const shouldRepairOptimisticMessageStatus =
+      this.messageRepositoryOptions.isMessageSendingStatusFixEnabled && isNewTextMessage;
+
+    if (!shouldRepairOptimisticMessageStatus) {
+      return this.sendAndInjectMessage(textMessage, conversation, {...options, enableEphemeral: true});
+    }
+
+    return this.sendNewTextMessageWithReliableInMemoryStatus(textMessage, conversation, {
+      ...options,
+      enableEphemeral: true,
+    });
+  }
+
+  private createAddedMessageWaiter(conversation: Conversation, messageId: string): AddedMessageWaiter {
+    let resolveMessage: ((messageEntity: Message) => void) | undefined;
+    let isDisposed = false;
+
+    const messagePromise = new Promise<Message>((resolve): void => {
+      resolveMessage = resolve;
+    });
+
+    function dispose(): void {
+      if (!isDisposed) {
+        isDisposed = true;
+        amplify.unsubscribe(WebAppEvents.CONVERSATION.MESSAGE.ADDED, onMessageAdded);
+      }
+    }
+
+    function onMessageAdded(messageEntity: Message): void {
+      const isMatchingMessage = messageEntity.id === messageId && messageEntity.conversation_id === conversation.id;
+
+      if (isMatchingMessage && !is.undefined(resolveMessage)) {
+        dispose();
+        resolveMessage(messageEntity);
+      }
+    }
+
+    amplify.subscribe(WebAppEvents.CONVERSATION.MESSAGE.ADDED, onMessageAdded);
+
+    return {dispose, messagePromise};
+  }
+
+  private async sendNewTextMessageWithReliableInMemoryStatus(
+    textMessage: GenericMessage,
+    conversation: Conversation,
+    options: MessageSendingOptions & {enableEphemeral: true; syncTimestamp?: boolean},
+  ): Promise<SendAndInjectResult> {
+    const addedMessageWaiter = this.createAddedMessageWaiter(conversation, textMessage.messageId);
+
+    try {
+      const sendResult = await this.sendAndInjectMessage(textMessage, conversation, options);
+
+      if (sendResult.state === MessageSendingState.OUTGOING_SENT) {
+        const messageEntity = await addedMessageWaiter.messagePromise;
+        const updatedStatus = messageEntity.readReceipts().length > 0 ? StatusType.SEEN : StatusType.SENT;
+        messageEntity.status(updatedStatus);
+
+        const shouldSynchronizeTimestamp = is.undefined(options.syncTimestamp) || options.syncTimestamp;
+        if (shouldSynchronizeTimestamp) {
+          const timestamp = new Date(sendResult.sentAt).getTime();
+          if (!isNaN(timestamp)) {
+            messageEntity.timestamp(timestamp);
+            conversation.updateTimestampServer(timestamp, true);
+            conversation.updateTimestamps(messageEntity);
+          }
+        }
+
+        this.conversationRepositoryProvider().checkMessageTimer(messageEntity as ContentMessage);
+      }
+
+      return sendResult;
+    } finally {
+      addedMessageWaiter.dispose();
+    }
   }
 
   /**
@@ -429,7 +509,7 @@ export class MessageRepository {
     if (attachments && attachments.length > 0) {
       state = (await this.sendMultipartText({...textPayload, attachments})).state;
     } else {
-      state = (await this.sendText(textPayload)).state;
+      state = (await this.sendText(textPayload, undefined, is.undefined(messageId))).state;
     }
 
     if (state !== MessageSendingState.CANCELED) {

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import is from '@sindresorhus/is';
 import {AssetAuditData} from '@wireapp/api-client/lib/asset';
 import {MessageSendingStatus, QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http/';
@@ -44,7 +45,6 @@ import {TextContentBuilder} from '@wireapp/core/lib/conversation/message/textCon
 import {isQualifiedUserClients} from '@wireapp/core/lib/util';
 import {amplify} from 'amplify';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
-import is from '@sindresorhus/is';
 import {container} from 'tsyringe';
 import {partition} from 'underscore';
 

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -295,8 +295,10 @@ export class MessageRepository {
       messageId,
     );
 
+    const currentClientId = this.clientState.currentClient?.id;
+    const canInjectOptimisticMessage = is.nonEmptyString(currentClientId);
     const shouldRepairOptimisticMessageStatus =
-      this.messageRepositoryOptions.isMessageSendingStatusFixEnabled && isNewTextMessage;
+      this.messageRepositoryOptions.isMessageSendingStatusFixEnabled && isNewTextMessage && canInjectOptimisticMessage;
 
     if (!shouldRepairOptimisticMessageStatus) {
       return this.sendAndInjectMessage(textMessage, conversation, {...options, enableEphemeral: true});

--- a/apps/webapp/test/helper/TestFactory.js
+++ b/apps/webapp/test/helper/TestFactory.js
@@ -287,6 +287,9 @@ export class TestFactory {
       this.assetRepository,
       new AudioRepository(),
       translate,
+      {
+        isMessageSendingStatusFixEnabled: false,
+      },
       this.user_repository['userState'],
       clientState,
     );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27032" title="WPB-27032" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27032</a>  [Web] Outgoing messages can remain grey until the conversation is reopened
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem

Newly sent text messages can intermittently remain grey even though they were sent successfully.

The persisted message already has the correct `SENT` status, but the message entity currently rendered in the conversation can remain in `StatusType.SENDING`. Switching to another conversation and back reloads the entity from storage, after which it appears correctly as sent.

## Root cause

The optimistic message injection and the successful send-status update can race.

The successful send path may update a message entity loaded from storage before the optimistic entity has been attached to the conversation. The database record is therefore updated correctly, while the later-added in-memory entity can retain its original `SENDING` status.

## Changes

This pull request adds a small, isolated repair for newly created plain text messages.

When the feature is enabled, the text-message send path subscribes to the existing `WebAppEvents.CONVERSATION.MESSAGE.ADDED` event before sending begins. After the unchanged legacy send flow reports success, the new path waits for the exact message entity that was added to the target conversation and updates its in-memory status to `SENT` or `SEEN`.

The persisted event is not updated again. The existing send flow remains responsible for persistence.

The fix intentionally applies only to newly created plain text messages. Message edits, link-preview replacements, multipart messages, assets, reactions, confirmations, deletes, pings, and calling events continue to use the existing behavior.

## Feature toggle

The new behavior is disabled by default and can be enabled with:

```text
?enabled-features=message-sending-status-fix
```