### PR TITLE
Use refresh event for WebApp updates [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/main/app.ts
+++ b/apps/webapp/src/script/main/app.ts
@@ -100,6 +100,7 @@ import {getLogger, Logger} from 'Util/logger';
 import {durationFrom, formatCoarseDuration, TIME_IN_MILLIS} from 'Util/timeUtil';
 import {AppInitializationStep, checkIndexedDb, InitializationEventLogger} from 'Util/util';
 
+import {refreshApplication} from './applicationRefresh';
 import {reportStartupFailure} from './reportStartupFailure';
 
 import '../../style/default.less';
@@ -924,14 +925,18 @@ export class App {
    * Refresh the web app or desktop wrapper
    */
   readonly refresh = (): void => {
-    if (Runtime.isDesktopApp()) {
-      // if we are in a desktop env, we just warn the wrapper that we need to reload. It then decide what should be done
-      amplify.publish(WebAppEvents.LIFECYCLE.RESTART);
-      return;
-    }
-
-    window.location.reload();
-    window.focus();
+    refreshApplication({
+      isDesktopApplication: Runtime.isDesktopApp,
+      publishLifecycleEvent: lifecycleEventName => {
+        amplify.publish(lifecycleEventName);
+      },
+      reloadWindowLocation: () => {
+        window.location.reload();
+      },
+      focusWindow: () => {
+        window.focus();
+      },
+    });
   };
 
   /**

--- a/apps/webapp/src/script/main/applicationRefresh.test.ts
+++ b/apps/webapp/src/script/main/applicationRefresh.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {WebAppEvents} from '@wireapp/webapp-events';
+
+import {refreshApplication} from './applicationRefresh';
+
+describe('refreshApplication', () => {
+  it('publishes refresh rather than restart in the desktop application', () => {
+    const publishedLifecycleEvents: string[] = [];
+    let reloadWindowLocationCallCount = 0;
+    let focusWindowCallCount = 0;
+
+    function publishLifecycleEvent(lifecycleEventName: string): void {
+      publishedLifecycleEvents.push(lifecycleEventName);
+    }
+
+    function reloadWindowLocation(): void {
+      reloadWindowLocationCallCount += 1;
+    }
+
+    function focusWindow(): void {
+      focusWindowCallCount += 1;
+    }
+
+    refreshApplication({
+      isDesktopApplication: () => {
+        return true;
+      },
+      publishLifecycleEvent,
+      reloadWindowLocation,
+      focusWindow,
+    });
+
+    expect(publishedLifecycleEvents).toEqual([WebAppEvents.LIFECYCLE.REFRESH]);
+    expect(publishedLifecycleEvents).not.toContain(WebAppEvents.LIFECYCLE.RESTART);
+    expect(reloadWindowLocationCallCount).toBe(0);
+    expect(focusWindowCallCount).toBe(0);
+  });
+
+  it('reloads and focuses the browser window outside the desktop application', () => {
+    const publishedLifecycleEvents: string[] = [];
+    let reloadWindowLocationCallCount = 0;
+    let focusWindowCallCount = 0;
+
+    function publishLifecycleEvent(lifecycleEventName: string): void {
+      publishedLifecycleEvents.push(lifecycleEventName);
+    }
+
+    function reloadWindowLocation(): void {
+      reloadWindowLocationCallCount += 1;
+    }
+
+    function focusWindow(): void {
+      focusWindowCallCount += 1;
+    }
+
+    refreshApplication({
+      isDesktopApplication: () => {
+        return false;
+      },
+      publishLifecycleEvent,
+      reloadWindowLocation,
+      focusWindow,
+    });
+
+    expect(publishedLifecycleEvents).toEqual([]);
+    expect(reloadWindowLocationCallCount).toBe(1);
+    expect(focusWindowCallCount).toBe(1);
+  });
+});

--- a/apps/webapp/src/script/main/applicationRefresh.ts
+++ b/apps/webapp/src/script/main/applicationRefresh.ts
@@ -1,0 +1,39 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {WebAppEvents} from '@wireapp/webapp-events';
+
+type ApplicationRefreshDependencies = {
+  readonly isDesktopApplication: () => boolean;
+  readonly publishLifecycleEvent: (lifecycleEventName: string) => void;
+  readonly reloadWindowLocation: () => void;
+  readonly focusWindow: () => void;
+};
+
+export function refreshApplication(dependencies: ApplicationRefreshDependencies): void {
+  const {focusWindow, isDesktopApplication, publishLifecycleEvent, reloadWindowLocation} = dependencies;
+
+  if (isDesktopApplication()) {
+    publishLifecycleEvent(WebAppEvents.LIFECYCLE.REFRESH);
+    return;
+  }
+
+  reloadWindowLocation();
+  focusWindow();
+}


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Context

When the “Update now” banner is used inside Wire Desktop, the WebApp currently publishes `WebAppEvents.LIFECYCLE.RESTART`.

Wire Desktop interprets this as a request to relaunch the Electron application. During that relaunch, the WebApp URL is reconstructed from the configured environment, so query parameters such as `enabled-features` are lost.

A WebApp update only requires the existing WebViews to be refreshed. It does not require the Electron application itself to restart.

## Changes

This changes `App.refresh()` to publish `WebAppEvents.LIFECYCLE.REFRESH` in desktop environments.

The browser behavior remains unchanged and still reloads the current page directly.

Existing uses of `WebAppEvents.LIFECYCLE.RESTART` are intentionally unchanged because they represent operations that may require a real desktop application restart.

## Result

Wire Desktop can now distinguish between refreshing the WebApp and restarting the Electron application.

This allows the desktop client to reload the existing WebView while preserving its current URL, including startup feature-toggle query parameters.

See also https://github.com/wireapp/wire-desktop/pull/9696