### PR TITLE
Prepare workflows for main branch cutover [WPB-26469]

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,14 +4,14 @@ name: Continuous integration
 on:
   pull_request:
     # we want to run the CI on every PR targetting those branches
-    branches: [master, dev, release/*]
+    branches: [main, master, dev, release/*]
 
   merge_group:
-    branches: [master, dev, release/*]
+    branches: [main, master, dev, release/*]
 
   push:
     # We also run CI on dev in order to update the coverage monitoring
-    branches: [dev]
+    branches: [main, dev]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/jira-lint-and-link.yml
+++ b/.github/workflows/jira-lint-and-link.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
   merge_group:
-    branches: [dev]
+    branches: [main, dev]
 jobs:
   add-jira-description:
     # On merge_group there is no pull request payload; keep the required check green there.
@@ -26,5 +26,5 @@ jobs:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-base-url: https://wearezeta.atlassian.net
           custom-issue-number-regexp: '(WPB-\d+)'
-          skip-branches: '^(dev|master|release\/*)$'
+          skip-branches: '^(main|dev|master|release\/*)$'
           fail-when-jira-issue-not-found: true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Prepares the repository for the planned `dev` / `master` to `main` branch-model cutover defined by ADR 0002.

This adds transitional `main` branch compatibility while retaining the existing `dev` and `master` behavior until the coordinated cutover is complete.

## Details

The changes prepare branch-dependent workflows and repository configuration to recognize the future `main` trunk branch.

During this transition:

* `main` can be introduced and verified before becoming the default branch
* existing pull requests targeting `dev` or `master` continue to work
* existing CI and release behavior remains available
* the dedicated `main` to Edge workflow can run once `main` exists
* no branch operation is performed by this pull request

## Why this is separate

Changing repository files and changing GitHub branch settings at the same time would make the migration difficult to review and roll back.

This pull request establishes compatibility first. The actual branch creation or rename, default-branch switch, branch protection migration, and external integration updates will happen as a coordinated operational step.

## Intentionally unchanged

This pull request does not:

* rename `master` to `main`
* delete or retire `dev`
* change the GitHub default branch
* change branch protection or merge queue settings
* enable automatic `release/**` deployments
* change the current release branch creation default
* retire the old tag-driven release path
* change Production promotion or rollback behavior
* remove old release scripts
* add maintenance release automation

Those changes belong to later cutover and cleanup steps.

## Follow-up

After this pull request is merged:

1. Create or establish `main` at the current `dev` commit.
2. Copy and verify branch protection and required status checks.
3. Change the GitHub default branch to `main`.
4. Verify CI and the dedicated Edge deployment.
5. Update repository defaults from `dev` to `main`.
6. Enable automatic release-branch deployment after the new release path has been operationally verified.
7. Retire the old tag-driven release path separately.

## Tracking

Part of https://github.com/wireapp/wire-webapp/issues/21597.

Implements the pre-cutover compatibility part of Phase 9:

* Cut over the branch model from `dev` / `master` to `main`
