### PR TITLE
fix(core): throttle and deduplicate focus-triggered backend sync tasks [WPB-23080]

### DIFF
--- a/libraries/core/src/account.ts
+++ b/libraries/core/src/account.ts
@@ -94,11 +94,11 @@ import {createCustomEncryptedStore, createEncryptedStore, EncryptedStore} from '
 import {generateSecretKey} from './secretStore/secretKeyGenerator';
 import {SelfService} from './self/';
 import {CoreDatabase, deleteDB, openDB} from './storage/coreDb';
+import {createFireAndForgetInvoker} from './taskExecution/fireAndForgetInvoker/fireAndForgetInvoker';
 import {TeamService} from './team/';
 import {UserService} from './user/';
 import {LocalStorageStore} from './util/localStorageStore';
 import {RecurringTaskScheduler} from './util/recurringTaskScheduler';
-import {createFireAndForgetInvoker} from './taskExecution/fireAndForgetInvoker/fireAndForgetInvoker';
 
 export type ProcessedEventPayload = HandledEventPayload;
 export type WebSocketConnectionContext = Pick<WebSocketReconnectContext, 'attemptId' | 'wrapperGeneration'>;

--- a/libraries/core/src/account.ts
+++ b/libraries/core/src/account.ts
@@ -98,6 +98,7 @@ import {TeamService} from './team/';
 import {UserService} from './user/';
 import {LocalStorageStore} from './util/localStorageStore';
 import {RecurringTaskScheduler} from './util/recurringTaskScheduler';
+import {createFireAndForgetInvoker} from './taskExecution/fireAndForgetInvoker/fireAndForgetInvoker';
 
 export type ProcessedEventPayload = HandledEventPayload;
 export type WebSocketConnectionContext = Pick<WebSocketReconnectContext, 'attemptId' | 'wrapperGeneration'>;
@@ -215,18 +216,22 @@ export class Account extends TypedEventEmitter<Events> {
     super();
     this.apiClient = apiClient;
     this.backendFeatures = this.apiClient.backendFeatures;
-    this.recurringTaskScheduler = new RecurringTaskScheduler({
-      get: async key => {
-        const task = await this.db?.get('recurringTasks', key);
-        return task?.firingDate;
+    this.logger = LogFactory.getLogger('@wireapp/core/Account');
+    this.recurringTaskScheduler = new RecurringTaskScheduler(
+      {
+        get: async key => {
+          const task = await this.db?.get('recurringTasks', key);
+          return task?.firingDate;
+        },
+        set: async (key, timestamp) => {
+          await this.db?.put('recurringTasks', {key, firingDate: timestamp}, key);
+        },
+        delete: async key => {
+          await this.db?.delete('recurringTasks', key);
+        },
       },
-      set: async (key, timestamp) => {
-        await this.db?.put('recurringTasks', {key, firingDate: timestamp}, key);
-      },
-      delete: async key => {
-        await this.db?.delete('recurringTasks', key);
-      },
-    });
+      createFireAndForgetInvoker({logger: this.logger}),
+    );
 
     apiClient.on(APIClient.TOPIC.COOKIE_REFRESH, async (cookie?: Cookie) => {
       if (cookie !== undefined && this.storeEngine !== undefined) {
@@ -238,7 +243,6 @@ export class Account extends TypedEventEmitter<Events> {
       }
     });
 
-    this.logger = LogFactory.getLogger('@wireapp/core/Account');
     this.initialisePendingProposalsTasksOnce = this.createInitialisePendingProposalsTasksOnce();
   }
 

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/e2eiServiceExternal.test.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/e2eiServiceExternal.test.ts
@@ -28,6 +28,7 @@ import {openDB} from '../../../storage/coreDb';
 import {getUUID} from '../../../test/payloadHelper';
 import {stringifyQualifiedId} from '../../../util/qualifiedIdUtil';
 import {RecurringTaskScheduler} from '../../../util/recurringTaskScheduler';
+import {createFireAndForgetInvoker} from '../../../taskExecution/fireAndForgetInvoker/fireAndForgetInvoker';
 import {MLSService} from '../mlsService';
 
 async function buildE2EIService(dbName = 'core-test-db') {
@@ -54,13 +55,16 @@ async function buildE2EIService(dbName = 'core-test-db') {
     conversationExists: jest.fn(),
   } as unknown as MLSService;
 
-  const recurringTaskScheduler = new RecurringTaskScheduler({
-    delete: key => mockedDb.delete('recurringTasks', key),
-    get: async key => (await mockedDb.get('recurringTasks', key))?.firingDate,
-    set: async (key, timestamp) => {
-      await mockedDb.put('recurringTasks', {key, firingDate: timestamp}, key);
+  const recurringTaskScheduler = new RecurringTaskScheduler(
+    {
+      delete: key => mockedDb.delete('recurringTasks', key),
+      get: async key => (await mockedDb.get('recurringTasks', key))?.firingDate,
+      set: async (key, timestamp) => {
+        await mockedDb.put('recurringTasks', {key, firingDate: timestamp}, key);
+      },
     },
-  });
+    createFireAndForgetInvoker({logger: {error: jest.fn()}}),
+  );
 
   return [
     new E2EIServiceExternal(coreCrypto, mockedDb, recurringTaskScheduler, clientService, mockedMLSService),

--- a/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.test.ts
+++ b/libraries/core/src/messagingProtocols/mls/mlsService/mlsService.test.ts
@@ -45,6 +45,7 @@ import {InitClientOptions, MLSService} from './mlsService';
 import {AddUsersFailure, AddUsersFailureReasons} from '../../../conversation';
 import {openDB} from '../../../storage/coreDb';
 import {RecurringTaskScheduler} from '../../../util/recurringTaskScheduler';
+import {createFireAndForgetInvoker} from '../../../taskExecution/fireAndForgetInvoker/fireAndForgetInvoker';
 import {TaskScheduler} from '../../../util/taskScheduler';
 import * as Helper from '../e2eIdentityService/helper';
 
@@ -100,13 +101,16 @@ const createMLSService = async () => {
   } as unknown as jest.Mocked<CoreCrypto>;
 
   const mockedDb = await openDB('core-test-db');
-  const recurringTaskScheduler = new RecurringTaskScheduler({
-    delete: key => mockedDb.delete('recurringTasks', key),
-    get: async key => (await mockedDb.get('recurringTasks', key))?.firingDate,
-    set: async (key, timestamp) => {
-      await mockedDb.put('recurringTasks', {key, firingDate: timestamp}, key);
+  const recurringTaskScheduler = new RecurringTaskScheduler(
+    {
+      delete: key => mockedDb.delete('recurringTasks', key),
+      get: async key => (await mockedDb.get('recurringTasks', key))?.firingDate,
+      set: async (key, timestamp) => {
+        await mockedDb.put('recurringTasks', {key, firingDate: timestamp}, key);
+      },
     },
-  });
+    createFireAndForgetInvoker({logger: {error: jest.fn()}}),
+  );
 
   const mlsService = new MLSService(apiClient, mockCoreCrypto, mockedDb, recurringTaskScheduler);
 

--- a/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.test.ts
+++ b/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.test.ts
@@ -21,6 +21,7 @@ import {advanceJestTimersWithPromise} from '@wireapp/commons/lib/util/testUtils'
 
 import {TimeUtil} from '@wireapp/commons';
 
+import {createFireAndForgetInvoker} from '../../taskExecution/fireAndForgetInvoker/fireAndForgetInvoker';
 import {RecurringTaskScheduler} from './recurringTaskScheduler';
 
 const mockedStore = {
@@ -39,7 +40,16 @@ const mockedStore = {
   },
 };
 
-const recurringTaskScheduler = new RecurringTaskScheduler(mockedStore);
+const createRecurringTaskSchedulerForTest = () => {
+  const fireAndForgetInvoker = createFireAndForgetInvoker({logger: {error: jest.fn()}});
+
+  return {
+    fireAndForgetInvoker,
+    recurringTaskScheduler: new RecurringTaskScheduler(mockedStore, fireAndForgetInvoker),
+  };
+};
+
+const {recurringTaskScheduler} = createRecurringTaskSchedulerForTest();
 
 describe('RecurringTaskScheduler', () => {
   beforeEach(() => {
@@ -128,6 +138,7 @@ describe('RecurringTaskScheduler', () => {
 
   describe('window focus tasks', () => {
     let focusTaskScheduler: RecurringTaskScheduler;
+    let fireAndForgetInvoker: ReturnType<typeof createFireAndForgetInvoker>;
     let addEventListenerSpy: jest.Mock;
     let removeEventListenerSpy: jest.Mock;
     let originalWindow: typeof globalThis.window | undefined;
@@ -140,14 +151,14 @@ describe('RecurringTaskScheduler', () => {
 
     const runFocusHandler = async (handler: () => void): Promise<void> => {
       handler();
-      await Promise.resolve();
+      await fireAndForgetInvoker.waitUntilAllSettled();
       await Promise.resolve();
       await Promise.resolve();
     };
 
     beforeEach(async () => {
       await mockedStore.clearAll();
-      focusTaskScheduler = new RecurringTaskScheduler(mockedStore);
+      ({fireAndForgetInvoker, recurringTaskScheduler: focusTaskScheduler} = createRecurringTaskSchedulerForTest());
       addEventListenerSpy = jest.fn();
       removeEventListenerSpy = jest.fn();
       originalWindow = globalThis.window;

--- a/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.test.ts
+++ b/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.test.ts
@@ -217,6 +217,33 @@ describe('RecurringTaskScheduler', () => {
       expect(task).toHaveBeenCalledTimes(2);
     });
 
+    it('does not run a focus task while it is already executing', async () => {
+      let resolveTask: () => void = () => undefined;
+      const task = jest.fn().mockImplementation(
+        () =>
+          new Promise<void>(resolve => {
+            resolveTask = resolve;
+          }),
+      );
+
+      await focusTaskScheduler.registerTask({
+        every: TimeUtil.TimeInMillis.DAY,
+        task,
+        key: 'concurrent-focus-task',
+        addTaskOnWindowFocusEvent: true,
+      });
+
+      const focusHandler = getFocusHandler();
+      focusHandler();
+      await Promise.resolve();
+
+      focusHandler();
+      expect(task).toHaveBeenCalledTimes(1);
+
+      resolveTask();
+      await fireAndForgetInvoker.waitUntilAllSettled();
+    });
+
     it('removes the focus listener when a focus task is cancelled', async () => {
       const task = jest.fn();
       const taskKey = 'cancel-focus-task';

--- a/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.test.ts
+++ b/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.test.ts
@@ -125,4 +125,102 @@ describe('RecurringTaskScheduler', () => {
     expect(mockedTask1).toHaveBeenCalledTimes(2);
     expect(mockedTask2).toHaveBeenCalledTimes(1);
   });
+
+  describe('window focus tasks', () => {
+    let focusTaskScheduler: RecurringTaskScheduler;
+    let addEventListenerSpy: jest.Mock;
+    let removeEventListenerSpy: jest.Mock;
+    let originalWindow: typeof globalThis.window | undefined;
+
+    const getFocusHandler = (): (() => void) => {
+      const focusCalls = addEventListenerSpy.mock.calls.filter(([eventName]) => eventName === 'focus');
+      expect(focusCalls.length).toBeGreaterThan(0);
+      return focusCalls[focusCalls.length - 1]?.[1] as () => void;
+    };
+
+    const runFocusHandler = async (handler: () => void): Promise<void> => {
+      handler();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    };
+
+    beforeEach(async () => {
+      await mockedStore.clearAll();
+      focusTaskScheduler = new RecurringTaskScheduler(mockedStore);
+      addEventListenerSpy = jest.fn();
+      removeEventListenerSpy = jest.fn();
+      originalWindow = globalThis.window;
+      globalThis.window = {
+        addEventListener: addEventListenerSpy,
+        removeEventListener: removeEventListenerSpy,
+      } as unknown as Window & typeof globalThis;
+    });
+
+    afterEach(() => {
+      if (originalWindow === undefined) {
+        // @ts-expect-error restoring test environment without window
+        delete globalThis.window;
+      } else {
+        globalThis.window = originalWindow;
+      }
+    });
+
+    it('replaces the focus listener when a focus task is re-registered', async () => {
+      const task = jest.fn();
+      await focusTaskScheduler.registerTask({
+        every: TimeUtil.TimeInMillis.DAY,
+        task,
+        key: 'focus-task',
+        addTaskOnWindowFocusEvent: true,
+      });
+
+      const initialFocusHandler = getFocusHandler();
+      await runFocusHandler(initialFocusHandler);
+
+      expect(task).toHaveBeenCalledTimes(1);
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('focus', initialFocusHandler);
+
+      const focusAddCalls = addEventListenerSpy.mock.calls.filter(([eventName]) => eventName === 'focus');
+      expect(focusAddCalls).toHaveLength(2);
+    });
+
+    it('does not run a focus task again within the minimum interval', async () => {
+      const task = jest.fn();
+      await focusTaskScheduler.registerTask({
+        every: TimeUtil.TimeInMillis.DAY,
+        task,
+        key: 'throttle-task',
+        addTaskOnWindowFocusEvent: true,
+      });
+
+      await runFocusHandler(getFocusHandler());
+      expect(task).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(5 * TimeUtil.TimeInMillis.MINUTE);
+      await runFocusHandler(getFocusHandler());
+      expect(task).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(11 * TimeUtil.TimeInMillis.MINUTE);
+      await runFocusHandler(getFocusHandler());
+      expect(task).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes the focus listener when a focus task is cancelled', async () => {
+      const task = jest.fn();
+      const taskKey = 'cancel-focus-task';
+
+      await focusTaskScheduler.registerTask({
+        every: TimeUtil.TimeInMillis.DAY,
+        task,
+        key: taskKey,
+        addTaskOnWindowFocusEvent: true,
+      });
+
+      const focusHandler = getFocusHandler();
+      await focusTaskScheduler.cancelTask(taskKey);
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('focus', focusHandler);
+    });
+  });
 });

--- a/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.ts
+++ b/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.ts
@@ -19,6 +19,7 @@
 
 import {TimeUtil} from '@wireapp/commons';
 
+import {type FireAndForgetInvoker} from '../../taskExecution/fireAndForgetInvoker/fireAndForgetInvoker';
 import {LowPrecisionTaskScheduler} from '../lowPrecisionTaskScheduler';
 import {TaskScheduler} from '../taskScheduler';
 
@@ -42,7 +43,10 @@ export class RecurringTaskScheduler {
   private readonly lastExecutedAt = new Map<string, number>();
   private readonly windowFocusTaskKeys = new Set<string>();
 
-  constructor(private readonly storage: RecurringTaskSchedulerStorage) {}
+  constructor(
+    private readonly storage: RecurringTaskSchedulerStorage,
+    private readonly fireAndForgetInvoker: FireAndForgetInvoker,
+  ) {}
 
   public readonly registerTask = async ({
     every,
@@ -95,7 +99,7 @@ export class RecurringTaskScheduler {
           return;
         }
 
-        void executeTask();
+        this.fireAndForgetInvoker.fireAndForget(executeTask);
       };
 
       this.focusListeners.set(key, focusHandler);

--- a/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.ts
+++ b/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.ts
@@ -41,6 +41,7 @@ const WINDOW_FOCUS_MIN_INTERVAL_MS = 15 * TimeUtil.TimeInMillis.MINUTE;
 export class RecurringTaskScheduler {
   private readonly focusListeners = new Map<string, () => void>();
   private readonly lastExecutedAt = new Map<string, number>();
+  private readonly executingTaskKeys = new Set<string>();
   private readonly windowFocusTaskKeys = new Set<string>();
 
   constructor(
@@ -62,10 +63,17 @@ export class RecurringTaskScheduler {
     await this.storage.set(key, firingDate);
 
     const executeTask = async () => {
+      if (this.executingTaskKeys.has(key) === true) {
+        return;
+      }
+
+      this.executingTaskKeys.add(key);
+
       await this.storage.delete(key);
       try {
         await task();
       } finally {
+        this.executingTaskKeys.delete(key);
         this.lastExecutedAt.set(key, Date.now());
         await this.registerTask({
           every,
@@ -94,6 +102,10 @@ export class RecurringTaskScheduler {
       this.removeWindowFocusListener(key);
 
       const focusHandler = () => {
+        if (this.executingTaskKeys.has(key) === true) {
+          return;
+        }
+
         const lastRun = this.lastExecutedAt.get(key);
         if (lastRun !== undefined && Date.now() - lastRun < WINDOW_FOCUS_MIN_INTERVAL_MS) {
           return;
@@ -111,6 +123,7 @@ export class RecurringTaskScheduler {
     this.windowFocusTaskKeys.delete(taskKey);
     this.removeWindowFocusListener(taskKey);
     this.lastExecutedAt.delete(taskKey);
+    this.executingTaskKeys.delete(taskKey);
     await this.storage.delete(taskKey);
     TaskScheduler.cancelTask(taskKey);
     LowPrecisionTaskScheduler.cancelTask({intervalDelay: TimeUtil.TimeInMillis.MINUTE, key: taskKey});

--- a/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.ts
+++ b/libraries/core/src/util/recurringTaskScheduler/recurringTaskScheduler.ts
@@ -35,7 +35,13 @@ export interface TaskParams {
   addTaskOnWindowFocusEvent?: boolean;
 }
 
+const WINDOW_FOCUS_MIN_INTERVAL_MS = 15 * TimeUtil.TimeInMillis.MINUTE;
+
 export class RecurringTaskScheduler {
+  private readonly focusListeners = new Map<string, () => void>();
+  private readonly lastExecutedAt = new Map<string, number>();
+  private readonly windowFocusTaskKeys = new Set<string>();
+
   constructor(private readonly storage: RecurringTaskSchedulerStorage) {}
 
   public readonly registerTask = async ({
@@ -44,20 +50,32 @@ export class RecurringTaskScheduler {
     key,
     addTaskOnWindowFocusEvent = false,
   }: TaskParams): Promise<void> => {
+    if (addTaskOnWindowFocusEvent === true) {
+      this.windowFocusTaskKeys.add(key);
+    }
+
     const firingDate = (await this.storage.get(key)) ?? Date.now() + every;
     await this.storage.set(key, firingDate);
+
+    const executeTask = async () => {
+      await this.storage.delete(key);
+      try {
+        await task();
+      } finally {
+        this.lastExecutedAt.set(key, Date.now());
+        await this.registerTask({
+          every,
+          task,
+          key,
+          addTaskOnWindowFocusEvent: this.windowFocusTaskKeys.has(key),
+        });
+      }
+    };
 
     const taskConfig = {
       firingDate,
       key,
-      task: async () => {
-        await this.storage.delete(key);
-        try {
-          await task();
-        } finally {
-          await this.registerTask({every, task, key});
-        }
-      },
+      task: executeTask,
     };
 
     if (every > TimeUtil.TimeInMillis.DAY * 20) {
@@ -68,14 +86,27 @@ export class RecurringTaskScheduler {
       TaskScheduler.addTask(taskConfig);
     }
 
-    // If the task should be added on window focus event, we add it here
+    if (this.windowFocusTaskKeys.has(key) === true && typeof window !== 'undefined') {
+      this.removeWindowFocusListener(key);
 
-    if (addTaskOnWindowFocusEvent === true && typeof window !== 'undefined') {
-      window.addEventListener('focus', taskConfig.task);
+      const focusHandler = () => {
+        const lastRun = this.lastExecutedAt.get(key);
+        if (lastRun !== undefined && Date.now() - lastRun < WINDOW_FOCUS_MIN_INTERVAL_MS) {
+          return;
+        }
+
+        void executeTask();
+      };
+
+      this.focusListeners.set(key, focusHandler);
+      window.addEventListener('focus', focusHandler);
     }
   };
 
   public readonly cancelTask = async (taskKey: string): Promise<void> => {
+    this.windowFocusTaskKeys.delete(taskKey);
+    this.removeWindowFocusListener(taskKey);
+    this.lastExecutedAt.delete(taskKey);
     await this.storage.delete(taskKey);
     TaskScheduler.cancelTask(taskKey);
     LowPrecisionTaskScheduler.cancelTask({intervalDelay: TimeUtil.TimeInMillis.MINUTE, key: taskKey});
@@ -83,5 +114,15 @@ export class RecurringTaskScheduler {
 
   public readonly hasTask = async (taskKey: string): Promise<boolean> => {
     return (await this.storage.get(taskKey)) !== undefined;
+  };
+
+  private readonly removeWindowFocusListener = (key: string): void => {
+    const handler = this.focusListeners.get(key);
+    if (handler === undefined || typeof window === 'undefined') {
+      return;
+    }
+
+    window.removeEventListener('focus', handler);
+    this.focusListeners.delete(key);
   };
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23080" title="WPB-23080" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23080</a>  [Web] Performance - webapp makes at least 5 calls to the backend on any click I do
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Returning focus to the webapp triggers several REST calls (`api-version`, `feature-configs`, team data, MLS key package count) via `RecurringTaskScheduler` tasks with `addTaskOnWindowFocusEvent`. This is intentional, but every refocus issued the full request burst with no cooldown.
- Throttle focus-triggered runs to at most once every 15 minutes, while keeping existing 24-hour scheduled syncs unchanged.
- Track focus listeners per task key so re-registration and cancellation replace the previous handler instead of accumulating duplicate `window` focus listeners.

## Test plan

- [x] `yarn nx run core-lib:test --testFile=src/util/recurringTaskScheduler/recurringTaskScheduler.test.ts`
- [x] Alt-tab away from the webapp and back within 15 minutes — no focus-triggered REST burst in Network tab
- [x] Alt-tab away and back after 15+ minutes — focus-triggered sync runs as before
- [x] Verify scheduled daily syncs still run (no change to timer-based behavior)