### PR TITLE
Adopt the canonical Beta URL and complete main cutover follow-ups [WPB-26469]

### DIFF
--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -1,10 +1,18 @@
 name: E2E Tests Nightly
 
 on:
+  # Scheduled nightly testing is paused until the canonical Edge URL and TLS
+  # configuration are available. Beta validation continues through release-cloud;
+  # this workflow remains available for manual regression runs.
   workflow_dispatch:
-  schedule:
-    # we want to run this nightly on dev
-    - cron: '0 02 * * 1-5'
+    inputs:
+      webappUrl:
+        description: Choose the canonical Beta URL for release-candidate validation or QA for manual regression
+        required: true
+        type: choice
+        options:
+          - https://wire-webapp-beta.wire.com/
+          - https://wire-webapp-qa.zinfra.io/
 
 # Only allow one instance of this workflow to run per branch at a time
 concurrency:
@@ -16,7 +24,7 @@ jobs:
     name: Run e2e tests
     uses: ./.github/workflows/e2e-tests.yml
     with:
-      webappUrl: https://wire-webapp-dev.zinfra.io/
+      webappUrl: ${{ inputs.webappUrl }}
       backendUrl: https://staging-nginz-https.zinfra.io/
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,11 +7,10 @@ on:
     inputs:
       webappUrl:
         type: choice
-        description: Define which stage to run the tests against
+        description: Choose the canonical Beta release-candidate URL or QA
         required: true
         options:
-          - https://wire-webapp-dev.zinfra.io/
-          - https://wire-webapp-master.zinfra.io/
+          - https://wire-webapp-beta.wire.com/
           - https://wire-webapp-qa.zinfra.io/
       backendUrl:
         type: choice

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -39,7 +39,7 @@ env:
   # ADR 0002 calls this target Beta. During the transition, Beta maps to the
   # existing wire-webapp-staging Elastic Beanstalk environment and URL.
   BETA_ENVIRONMENT_NAME: wire-webapp-staging
-  BETA_WEBAPP_URL: https://wire-webapp-staging.zinfra.io/
+  BETA_WEBAPP_URL: https://wire-webapp-beta.wire.com/
   PRODUCTION_ENVIRONMENT_NAME: wire-webapp-prod
 
 jobs:
@@ -157,7 +157,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build_artifact
     permissions: {}
-    environment: wire-webapp-staging
+    environment:
+      name: wire-webapp-staging
+      url: https://wire-webapp-beta.wire.com/
 
     steps:
       - name: Download build artifact
@@ -241,7 +243,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/e2e-tests.yml
     with:
-      webappUrl: https://wire-webapp-staging.zinfra.io/
+      webappUrl: https://wire-webapp-beta.wire.com/
       backendUrl: https://staging-nginz-https.zinfra.io/
       grep: '@regression|@crit-flow-web'
       testinyRunName: Release ${{ needs.build_artifact.outputs.release_identifier }} ${{ needs.create_beta_tag.outputs.beta_tag_name }}

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Other useful tasks:
 
 ## CI Status
 
-[![CI](https://github.com/wireapp/wire-webapp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/wireapp/wire-webapp/actions/workflows/ci.yml) [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+[![CI](https://github.com/wireapp/wire-webapp/actions/workflows/continuous-integration.yml/badge.svg?branch=main)](https://github.com/wireapp/wire-webapp/actions/workflows/continuous-integration.yml) [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 ## Translations
 

--- a/apps/webapp/test/e2e_tests/README.md
+++ b/apps/webapp/test/e2e_tests/README.md
@@ -44,6 +44,8 @@ CI/CD PR git actions job can be found [here](/.github/workflows/precommit-crit-f
 
 ### Running the tests
 
+For hosted manual regression runs, use the logical company-facing Beta environment (`https://wire-webapp-beta.wire.com/`) for release-candidate validation or QA (`https://wire-webapp-qa.zinfra.io/`) for QA validation. Nightly trunk testing will return to Edge once its canonical URL and TLS configuration are confirmed.
+
 E2E tests can be run via
 
 1. Executing `yarn e2e-test` in the root folder of the repo. Running it with `--ui` flag will open Playwright app that can be handy for debugging. Providing `--grep "@{TAG_NAME}"` will result in running only tests with @{TAG_NAME}. For example:

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -63,16 +63,17 @@ We will adopt a trunk-based, GitHub-driven release process with automatic beta d
 
 Edge is the Web team's immediate dogfooding environment. Every eligible change merged to `main` may appear on Edge. Because Edge continuously follows trunk, it provides no stability guarantee and may include incomplete, experimental, or recently merged changes protected by feature flags. It is not intended to be stable enough for broader company-wide daily use.
 
-Beta is the logical release stage for company-wide internal release-candidate validation. It follows an active release branch rather than trunk and should be stable enough for broader daily internal use. Beta represents the current candidate for the next Production release. During the transition, the existing `wire-webapp-staging` environment may continue to serve as Beta's physical target.
+Beta is the logical release stage for company-wide internal release-candidate validation. It follows an active release branch rather than trunk and should be stable enough for broader daily internal use. Beta represents the current candidate for the next Production release. Its canonical company-facing URL is `https://wire-webapp-beta.wire.com/`. Beta continues to deploy physically to the existing `wire-webapp-staging` GitHub and Elastic Beanstalk environment; changing the logical URL does not require renaming that physical environment.
 
 A Beta candidate may be promoted when validation is complete and no known release-blocking issues remain. Production receives only the exact artifact validated on Beta. Production promotion remains an explicit decision through GitHub Environment approval; the absence of reported issues does not automatically deploy Beta to Production.
 
 The branch model is:
 
-- `master` will be renamed to `main`.
-- `dev` will be retired as a long-lived branch after workflows, branch protection rules, documentation, and external integrations are migrated.
 - `main` is the single trunk branch and the source for Edge deployments.
+- During the migration, `main` was established from the active `dev` history because `dev` contained the current development history at cutover time.
+- `dev` and `master` are legacy branches retained temporarily for compatibility and old release-path retirement; normal development no longer targets either branch.
 - Release branches are cut from `main` as `release/YYYY-MM-DD.N`.
+- Removing the legacy branches is a later operational cleanup decision.
 - On-premises maintenance branches are created only when a customer-managed release line needs maintenance after the original production release.
 
 The release identifier uses the release branch name: `YYYY-MM-DD.N`. The full identifier is anchored to the release branch, not to the later deployment date. For example, updates to `release/2026-05-05.1` always create tags in the `2026-05-05.1` family, even if a hotfix is added on a later day.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Completes the remaining repository follow-ups after the `dev` / `master` to `main` cutover and adopts `https://wire-webapp-beta.wire.com/` as the canonical logical Beta URL.

## Changes

- corrects ADR 0002 to reflect the actual branch migration
- documents the logical and physical Beta environment mapping
- updates `release-cloud` to expose and validate the canonical Beta URL
- keeps `wire-webapp-staging` as the physical deployment target
- repairs the README CI badge
- removes stale `dev` and `master` manual E2E targets
- updates manual regression execution to use Beta and QA
- pauses scheduled nightly testing until the canonical Edge URL is available
- updates active E2E documentation
- retargets PR #21813 to `main`

## Beta mapping

- Logical stage: Beta
- Canonical URL: `https://wire-webapp-beta.wire.com/`
- Physical GitHub/Elastic Beanstalk environment: `wire-webapp-staging`
- Backend: `https://staging-nginz-https.zinfra.io/`

The physical environment is not renamed by this pull request.

## Release behavior

This pull request intentionally does not:

- enable automatic `release/**` deployment
- change Production promotion or approval
- retire the legacy release path
- remove old release tags or commands
- delete `dev` or `master`
- change rollback behavior

`release-cloud` remains manual-only.

## Follow-ups

- resolve the canonical Edge URL and TLS configuration
- verify required reviewers on the `wire-webapp-prod` GitHub Environment
- resolve the post-retargeting conflicts in PR #21813
- complete one controlled Beta-to-Production release
- enable automatic release-branch deployment separately after validation

## Tracking

Part of #21597.
