### PR TITLE
Prevent ADR production tags from triggering legacy deployment [WPB-26469]

### DIFF
--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -7,8 +7,8 @@ on:
     tags:
       - '*q1-2024*'
       - '*q2-2025*'
-      - '*staging*'
-      - '*production*'
+      - '*-staging.*'
+      - '*-production.*'
 
 concurrency:
   group: publish-${{ github.ref }}
@@ -17,6 +17,10 @@ concurrency:
 jobs:
   build:
     name: Build Docker image and Helm Chart
+    # ADR Production tags end in -production after the new workflow has already
+    # deployed the Beta-tested artifact. Keep legacy *-production.N tags working
+    # temporarily, but never rebuild and redeploy for ADR Production tags.
+    if: ${{ !(github.ref_type == 'tag' && endsWith(github.ref_name, '-production')) }}
     runs-on: ubuntu-24.04
 
     outputs:

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -36,8 +36,9 @@ env:
   ARTIFACT_PATH: apps/server/dist/s3/ebs.zip
   BETA_ARTIFACT_NAME_PREFIX: release-cloud-ebs
   BETA_BACKEND_URL: https://staging-nginz-https.zinfra.io/
-  # ADR 0002 calls this target Beta. During the transition, Beta maps to the
-  # existing wire-webapp-staging Elastic Beanstalk environment and URL.
+  # ADR 0002 calls this logical release stage Beta. Beta deploys to the existing
+  # wire-webapp-staging GitHub and Elastic Beanstalk environment, while its
+  # canonical company-facing URL is https://wire-webapp-beta.wire.com/.
   BETA_ENVIRONMENT_NAME: wire-webapp-staging
   BETA_WEBAPP_URL: https://wire-webapp-beta.wire.com/
   PRODUCTION_ENVIRONMENT_NAME: wire-webapp-prod


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Prevents Production tags created by the ADR 0002 release workflow from triggering the legacy tag-driven deployment workflow.

## Problem

The new release workflow creates YYYY-MM-DD.N-production only after successfully deploying the Beta-tested artifact to Production.

The legacy workflow currently listens to every tag containing production. Without this change, the new Production tag would trigger a second workflow that rebuilds from source and could redeploy Production.

## Changes

- narrows legacy staging and Production tag triggers to their legacy formats
- explicitly prevents ADR Production tags ending in -production from running the legacy build
- keeps legacy *-production.N and *-staging.N tags working
- keeps release-branch Docker and Helm publication unchanged
- corrects the Beta environment comment in release-cloud

## Intentionally unchanged

This pull request does not:

- enable automatic release branch deployment
- remove the legacy workflow
- remove the release branch legacy trigger
- change Docker or Helm publication
- change wire-builds
- change Beta or Production behavior in the new workflow
- change tags
- perform a deployment

## Tracking

Part of #21597.

This compatibility fix is required before the first controlled Beta-to-Production release.