### PR TITLE
Fix release branch workflow authentication [WPB-26469]

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          persist-credentials: false
+          persist-credentials: true
           fetch-depth: 1
 
       - name: Add repository Yarn wrapper to PATH
@@ -128,7 +128,6 @@ jobs:
       - name: Create and push release branch
         id: create_release_branch
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCH: ${{ needs.validate_request.outputs.release_branch }}
           SOURCE_REF: ${{ needs.validate_request.outputs.source_ref }}
         run: |
@@ -150,7 +149,7 @@ jobs:
           fi
 
           git branch "${RELEASE_BRANCH}" "${source_commit_sha}"
-          git -c http.extraheader="AUTHORIZATION: bearer ${GITHUB_TOKEN}" push origin "refs/heads/${RELEASE_BRANCH}:refs/heads/${RELEASE_BRANCH}"
+          git push origin "refs/heads/${RELEASE_BRANCH}:refs/heads/${RELEASE_BRANCH}"
 
           echo "source_commit_sha=${source_commit_sha}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

Fixes authentication for the GitHub Actions workflow that creates release branches.

## Problem

The first controlled branch-creation run validated `release/2026-07-15.1`, but its push failed with:

`fatal: could not read Username for 'https://github.com': No such device or address`

The job had `contents: write`, but checkout credentials were disabled and the manually supplied Bearer header did not authenticate the Git push.

## Changes

- keeps the validation job read-only
- lets `actions/checkout` configure the scoped credential in the branch-creation job
- removes the custom token environment variable
- removes the custom HTTP authorization header
- keeps all branch validation and release behavior unchanged

## Workflow-trigger behavior

The push uses the repository `GITHUB_TOKEN`, so it does not start another push-triggered workflow.

That is intentional for the current transition because `Release Cloud` remains manual-only. Automatic release execution will be handled separately by either explicitly dispatching `Release Cloud` or using a GitHub App installation token.

## Safety

This pull request does not:

- create a release branch
- create or modify tags
- deploy Beta or Production
- enable automatic release execution
- modify branch protection
- add secrets or long-lived credentials

## Verification after merge

After this pull request is merged, start a fresh Create Release Branch run for:

- release identifier: `2026-07-15.1`
- source ref: `main`
- expected source commit: current `main`

Do not rerun the old failed attempt.

## Tracking

Part of #21597.