### PR TITLE
Correct release branch checkout credentials [WPB-26469]

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          persist-credentials: true
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Add repository Yarn wrapper to PATH
@@ -122,7 +122,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          persist-credentials: false
+          persist-credentials: true
           fetch-depth: 1
 
       - name: Create and push release branch


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

Corrects the checkout credential configuration in the release-branch creation workflow.

## Problem

The previous authentication fix applied the settings to the wrong jobs:

- the read-only validation job persisted credentials
- the write-enabled branch-creation job disabled credentials

As a result, the real branch-creation run would still be unable to push.

## Changes

- disables persisted credentials in `validate_request`
- enables persisted credentials in `create_release_branch`
- keeps the existing `contents: read` and `contents: write` job permissions
- changes no other workflow behavior

## Safety

This pull request does not:

- create a release branch
- create or modify tags
- deploy Beta or Production
- change GitHub settings
- add credentials or secrets
- enable automatic release execution

## Verification after merge

After this pull request is merged, start a fresh Create Release Branch workflow for the already confirmed release identifier:

`2026-07-15.1`

The release branch must be created from the then-current `main` commit. Do not expect the earlier `31e8e8c...` SHA because merging this corrective pull request will advance `main`.

## Tracking

Part of #21597.