### PR TITLE
Restore Beta and E2E runtime separation [WPB-26469]

### DIFF
--- a/.github/workflows/precommit-slot-run.yml
+++ b/.github/workflows/precommit-slot-run.yml
@@ -10,7 +10,20 @@ on:
       backendUrl:
         type: string
         required: true
+      artifact_name:
+        type: string
+        required: false
+        default: build-artifact
+      expectedBackendRest:
+        type: string
+        required: false
+      expectedBackendWs:
+        type: string
+        required: false
       grep:
+        type: string
+        required: false
+      testinyRunName:
         type: string
         required: false
       notify_deployoholics_on_failure:
@@ -25,6 +38,8 @@ on:
       WEBTEAM_AWS_SECRET_ACCESS_KEY:
         required: true
       WIRE_DEPLOYOHOLICS_WEBHOOK_URL:
+        required: false
+      TESTINY_API_KEY:
         required: false
     outputs:
       precommit_url:
@@ -55,7 +70,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: build-artifact
+          name: ${{ inputs.artifact_name }}
 
       - name: Validate precommit environment
         env:
@@ -99,6 +114,38 @@ jobs:
           echo "Resolved precommit URL: https://$ENV_NAME.zinfra.io/"
           echo "url=https://$ENV_NAME.zinfra.io/" >> "$GITHUB_OUTPUT"
 
+      - name: Verify precommit runtime backend
+        if: ${{ inputs.expectedBackendRest && inputs.expectedBackendWs }}
+        env:
+          EXPECTED_BACKEND_REST: ${{ inputs.expectedBackendRest }}
+          EXPECTED_BACKEND_WS: ${{ inputs.expectedBackendWs }}
+          PRECOMMIT_URL: ${{ steps.fetch_url.outputs.url }}
+        run: |
+          set -euo pipefail
+
+          normalize_url() {
+            printf '%s' "${1%/}"
+          }
+
+          expected_backend_rest="$(normalize_url "${EXPECTED_BACKEND_REST}")"
+          expected_backend_ws="$(normalize_url "${EXPECTED_BACKEND_WS}")"
+
+          for attempt_number in {1..10}; do
+            runtime_config="$(curl --fail --silent --show-error "${PRECOMMIT_URL}config.js" || true)"
+            actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
+            actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
+
+            if [[ "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" && "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}" ]]; then
+              exit 0
+            fi
+
+            echo "Precommit runtime backend does not match Staging on attempt ${attempt_number}: REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}." >&2
+            sleep 6
+          done
+
+          echo "Precommit runtime backend did not match the expected Staging endpoints." >&2
+          exit 1
+
       - name: Deployment Status
         if: ${{ always() }}
         run: |
@@ -117,8 +164,10 @@ jobs:
       webappUrl: ${{ needs.deploy_to_aws.outputs.precommit_url }}
       backendUrl: ${{ inputs.backendUrl }}
       grep: ${{ inputs.grep }}
+      testinyRunName: ${{ inputs.testinyRunName }}
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
 
   notify_deployoholics:
     name: Notify Deployoholics about failed critical flow

--- a/.github/workflows/precommit-slot-run.yml
+++ b/.github/workflows/precommit-slot-run.yml
@@ -20,6 +20,9 @@ on:
       expectedBackendWs:
         type: string
         required: false
+      expectedVersion:
+        type: string
+        required: false
       grep:
         type: string
         required: false
@@ -99,7 +102,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           application-name: Webapp
           environment-name: ${{ inputs.env_name }}
-          version-label: ${{ github.run_id }}
+          version-label: ${{ github.run_id }}-${{ github.run_attempt }}
           deployment-package-path: ebs.zip
           wait-for-deployment: true
           wait-for-environment-recovery: true
@@ -119,6 +122,7 @@ jobs:
         env:
           EXPECTED_BACKEND_REST: ${{ inputs.expectedBackendRest }}
           EXPECTED_BACKEND_WS: ${{ inputs.expectedBackendWs }}
+          EXPECTED_VERSION: ${{ inputs.expectedVersion }}
           PRECOMMIT_URL: ${{ steps.fetch_url.outputs.url }}
         run: |
           set -euo pipefail
@@ -134,16 +138,17 @@ jobs:
             runtime_config="$(curl --fail --silent --show-error "${PRECOMMIT_URL}config.js" || true)"
             actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
             actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
+            actual_version="$(printf '%s' "${runtime_config}" | sed -n 's/.*"VERSION":"\([^"]*\)".*/\1/p')"
 
-            if [[ "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" && "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}" ]]; then
+            if [[ "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" && "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}" && ( -z "${EXPECTED_VERSION}" || "${actual_version}" == "${EXPECTED_VERSION}" ) ]]; then
               exit 0
             fi
 
-            echo "Precommit runtime backend does not match Staging on attempt ${attempt_number}: REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}." >&2
+            echo "Precommit runtime configuration does not match the current artifact and Staging backend on attempt ${attempt_number}: REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}, VERSION=${actual_version:-missing}." >&2
             sleep 6
           done
 
-          echo "Precommit runtime backend did not match the expected Staging endpoints." >&2
+          echo "Precommit runtime configuration did not match the expected Staging endpoints and artifact version." >&2
           exit 1
 
       - name: Deployment Status

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -35,12 +35,16 @@ env:
   AWS_REGION: eu-central-1
   ARTIFACT_PATH: apps/server/dist/s3/ebs.zip
   BETA_ARTIFACT_NAME_PREFIX: release-cloud-ebs
-  BETA_BACKEND_URL: https://staging-nginz-https.zinfra.io/
+  BETA_RUNTIME_BACKEND_REST: https://prod-nginz-https.wire.com
+  BETA_RUNTIME_BACKEND_WS: wss://prod-nginz-ssl.wire.com
   # ADR 0002 calls this logical release stage Beta. Its GitHub Environment and
   # canonical company-facing URL use wire-webapp-beta, while deployments retain
   # the existing wire-webapp-staging Elastic Beanstalk environment.
   BETA_ELASTIC_BEANSTALK_ENVIRONMENT_NAME: wire-webapp-staging
   BETA_WEBAPP_URL: https://wire-webapp-beta.wire.com/
+  E2E_BACKEND_URL: https://staging-nginz-https.zinfra.io/
+  E2E_ELASTIC_BEANSTALK_ENVIRONMENT_NAME: wire-webapp-precommit-3
+  E2E_WEBAPP_URL: https://wire-webapp-precommit-3.zinfra.io/
   PRODUCTION_ENVIRONMENT_NAME: wire-webapp-prod
 
 jobs:
@@ -189,6 +193,37 @@ jobs:
           deployment-timeout: 150
           use-existing-application-version-if-available: true
 
+      - name: Verify Beta runtime backend
+        env:
+          BETA_WEBAPP_URL: ${{ env.BETA_WEBAPP_URL }}
+          EXPECTED_BACKEND_REST: ${{ env.BETA_RUNTIME_BACKEND_REST }}
+          EXPECTED_BACKEND_WS: ${{ env.BETA_RUNTIME_BACKEND_WS }}
+        run: |
+          set -euo pipefail
+
+          normalize_url() {
+            printf '%s' "${1%/}"
+          }
+
+          expected_backend_rest="$(normalize_url "${EXPECTED_BACKEND_REST}")"
+          expected_backend_ws="$(normalize_url "${EXPECTED_BACKEND_WS}")"
+
+          for attempt_number in {1..10}; do
+            runtime_config="$(curl --fail --silent --show-error "${BETA_WEBAPP_URL}config.js" || true)"
+            actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
+            actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
+
+            if [[ "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" && "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}" ]]; then
+              exit 0
+            fi
+
+            echo "Beta runtime backend does not match Production on attempt ${attempt_number}: REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}." >&2
+            sleep 6
+          done
+
+          echo "Beta runtime backend did not match the expected Production endpoints." >&2
+          exit 1
+
   create_beta_tag:
     name: Create Beta tag
     runs-on: ubuntu-24.04
@@ -238,18 +273,23 @@ jobs:
           echo "beta_tag_name=${beta_tag_name}" >> "$GITHUB_OUTPUT"
 
   run_e2e:
-    name: Run E2E against Beta
+    name: Deploy to precommit and run E2E
     needs: [build_artifact, create_beta_tag]
     permissions:
       contents: read
-    uses: ./.github/workflows/e2e-tests.yml
+    uses: ./.github/workflows/precommit-slot-run.yml
     with:
-      webappUrl: https://wire-webapp-beta.wire.com/
+      env_name: wire-webapp-precommit-3
       backendUrl: https://staging-nginz-https.zinfra.io/
+      artifact_name: ${{ needs.build_artifact.outputs.artifact_name }}
+      expectedBackendRest: https://staging-nginz-https.zinfra.io/
+      expectedBackendWs: wss://staging-nginz-ssl.zinfra.io/
       grep: '@regression|@crit-flow-web'
       testinyRunName: Release ${{ needs.build_artifact.outputs.release_identifier }} ${{ needs.create_beta_tag.outputs.beta_tag_name }}
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      WEBTEAM_AWS_ACCESS_KEY_ID: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+      WEBTEAM_AWS_SECRET_ACCESS_KEY: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
       TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
 
   production_preflight:
@@ -474,9 +514,14 @@ jobs:
           ARTIFACT_CHECKSUM: ${{ needs.build_artifact.outputs.artifact_checksum }}
           ARTIFACT_NAME: ${{ needs.build_artifact.outputs.artifact_name }}
           BETA_ELASTIC_BEANSTALK_ENVIRONMENT_NAME: ${{ env.BETA_ELASTIC_BEANSTALK_ENVIRONMENT_NAME }}
+          BETA_RUNTIME_BACKEND_REST: ${{ env.BETA_RUNTIME_BACKEND_REST }}
+          BETA_RUNTIME_BACKEND_WS: ${{ env.BETA_RUNTIME_BACKEND_WS }}
           BETA_TAG_NAME: ${{ needs.create_beta_tag.outputs.beta_tag_name }}
+          E2E_BACKEND_URL: ${{ env.E2E_BACKEND_URL }}
+          E2E_ELASTIC_BEANSTALK_ENVIRONMENT_NAME: ${{ env.E2E_ELASTIC_BEANSTALK_ENVIRONMENT_NAME }}
           E2E_REPORT_URL: ${{ needs.run_e2e.outputs.reportUrl }}
           E2E_RESULT: ${{ needs.run_e2e.result }}
+          E2E_WEBAPP_URL: ${{ env.E2E_WEBAPP_URL }}
           PRODUCTION_ARTIFACT_CHECKSUM: ${{ needs.build_artifact.outputs.artifact_checksum }}
           PRODUCTION_ARTIFACT_NAME: ${{ needs.build_artifact.outputs.artifact_name }}
           PRODUCTION_DEPLOYMENT_RESULT: ${{ needs.deploy_to_production.result }}
@@ -503,10 +548,15 @@ jobs:
             echo '- GitHub Environment: wire-webapp-beta'
             echo "- Elastic Beanstalk environment: ${BETA_ELASTIC_BEANSTALK_ENVIRONMENT_NAME}"
             echo "- Public Beta URL: ${BETA_WEBAPP_URL}"
+            echo "- Beta runtime backend: ${BETA_RUNTIME_BACKEND_REST}"
+            echo "- Beta runtime WebSocket backend: ${BETA_RUNTIME_BACKEND_WS}"
             echo "- Artifact name: ${ARTIFACT_NAME}"
             echo "- Artifact checksum: ${ARTIFACT_CHECKSUM}"
             echo "- Beta tag: ${BETA_TAG_NAME}"
             echo "- E2E result: ${E2E_RESULT}"
+            echo "- E2E Elastic Beanstalk environment: ${E2E_ELASTIC_BEANSTALK_ENVIRONMENT_NAME}"
+            echo "- E2E URL: ${E2E_WEBAPP_URL}"
+            echo "- E2E backend: ${E2E_BACKEND_URL}"
 
             if [[ -n "${E2E_REPORT_URL}" ]]; then
               echo "- E2E report URL: ${E2E_REPORT_URL}"

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -85,6 +85,7 @@ jobs:
     outputs:
       artifact_checksum: ${{ steps.artifact_metadata.outputs.artifact_checksum }}
       artifact_name: ${{ steps.artifact_metadata.outputs.artifact_name }}
+      artifact_version: ${{ steps.artifact_metadata.outputs.artifact_version }}
       release_branch: ${{ steps.release_metadata.outputs.release_branch }}
       release_commit_sha: ${{ steps.release_metadata.outputs.release_commit_sha }}
       release_identifier: ${{ steps.release_metadata.outputs.release_identifier }}
@@ -145,10 +146,12 @@ jobs:
 
           artifact_name="${BETA_ARTIFACT_NAME_PREFIX}-${RELEASE_IDENTIFIER}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           artifact_checksum="$(sha256sum "${ARTIFACT_PATH}" | awk '{print $1}')"
+          artifact_version="$(unzip -p "${ARTIFACT_PATH}" version.json | jq --raw-output '.version')"
 
           {
             echo "artifact_name=${artifact_name}"
             echo "artifact_checksum=${artifact_checksum}"
+            echo "artifact_version=${artifact_version}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Upload build artifact
@@ -198,6 +201,7 @@ jobs:
           BETA_WEBAPP_URL: ${{ env.BETA_WEBAPP_URL }}
           EXPECTED_BACKEND_REST: ${{ env.BETA_RUNTIME_BACKEND_REST }}
           EXPECTED_BACKEND_WS: ${{ env.BETA_RUNTIME_BACKEND_WS }}
+          EXPECTED_VERSION: ${{ needs.build_artifact.outputs.artifact_version }}
         run: |
           set -euo pipefail
 
@@ -212,16 +216,17 @@ jobs:
             runtime_config="$(curl --fail --silent --show-error "${BETA_WEBAPP_URL}config.js" || true)"
             actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
             actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
+            actual_version="$(printf '%s' "${runtime_config}" | sed -n 's/.*"VERSION":"\([^"]*\)".*/\1/p')"
 
-            if [[ "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" && "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}" ]]; then
+            if [[ "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" && "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}" && "${actual_version}" == "${EXPECTED_VERSION}" ]]; then
               exit 0
             fi
 
-            echo "Beta runtime backend does not match Production on attempt ${attempt_number}: REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}." >&2
+            echo "Beta runtime configuration does not match the current artifact and Production backend on attempt ${attempt_number}: REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}, VERSION=${actual_version:-missing}." >&2
             sleep 6
           done
 
-          echo "Beta runtime backend did not match the expected Production endpoints." >&2
+          echo "Beta runtime configuration did not match the expected Production endpoints and artifact version." >&2
           exit 1
 
   create_beta_tag:
@@ -284,6 +289,7 @@ jobs:
       artifact_name: ${{ needs.build_artifact.outputs.artifact_name }}
       expectedBackendRest: https://staging-nginz-https.zinfra.io/
       expectedBackendWs: wss://staging-nginz-ssl.zinfra.io/
+      expectedVersion: ${{ needs.build_artifact.outputs.artifact_version }}
       grep: '@regression|@crit-flow-web'
       testinyRunName: Release ${{ needs.build_artifact.outputs.release_identifier }} ${{ needs.create_beta_tag.outputs.beta_tag_name }}
     secrets:

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -26,7 +26,9 @@ flowchart LR
   mainBranch[main]
   edgeEnvironment[Edge]
   releaseBranch[release/YYYY-MM-DD.N]
-  betaEnvironment[Beta]
+  releaseArtifact[Release artifact]
+  betaEnvironment[Beta company validation<br/>Production backend]
+  e2eEnvironment[E2E validation slot<br/>Staging backend]
   betaTag[YYYY-MM-DD.N-beta.M]
   productionEnvironment[Production]
   productionTag[YYYY-MM-DD.N-production]
@@ -35,9 +37,11 @@ flowchart LR
 
   mainBranch -->|Every merge deploys| edgeEnvironment
   mainBranch -->|Create release branch| releaseBranch
-  releaseBranch -->|Every update deploys| betaEnvironment
-  betaEnvironment -->|Successful beta deployment creates| betaTag
-  betaEnvironment -->|Quality assurance approves| productionEnvironment
+  releaseBranch -->|Build once| releaseArtifact
+  releaseArtifact -->|Deploy| betaEnvironment
+  betaEnvironment -->|Verify Production runtime| betaTag
+  betaTag -->|Deploy same artifact| e2eEnvironment
+  e2eEnvironment -->|E2E and Testiny succeed| productionEnvironment
   productionEnvironment -->|Successful production deployment creates| productionTag
   productionTag -->|Create only when needed| maintenanceBranch
   maintenanceBranch -->|Validated maintenance artifact creates| maintenanceTag
@@ -65,6 +69,10 @@ Edge is the Web team's immediate dogfooding environment. Every eligible change m
 
 Beta is the logical release stage for company-wide internal release-candidate validation. It follows an active release branch rather than trunk and should be stable enough for broader daily internal use. Beta represents the current candidate for the next Production release. Beta uses the `wire-webapp-beta` GitHub Environment and its canonical company-facing URL is `https://wire-webapp-beta.wire.com/`. Beta continues to deploy physically to the existing `wire-webapp-staging` Elastic Beanstalk environment. The physical AWS environment name is retained temporarily and is separate from the GitHub Environment name.
 
+Beta preserves the previous company-facing Staging release-candidate behavior: it connects to Production backend services, and employees validate it with their normal Production accounts and data. The legacy physical name `wire-webapp-staging` describes infrastructure only; it does not mean that the company-facing Beta frontend uses Staging backend services.
+
+Automated E2E must never run against Production backend services or create test users in Production. The release workflow deploys the exact Beta artifact to the dedicated `wire-webapp-precommit-3` validation environment, verifies that its runtime configuration uses Staging backend services, then runs E2E there with disposable Staging users and test data. Beta, precommit validation, and Production use the same built artifact; their differences are runtime environment configuration, not rebuilt application artifacts.
+
 A Beta candidate may be promoted when validation is complete and no known release-blocking issues remain. Production receives only the exact artifact validated on Beta. Production promotion remains an explicit decision through GitHub Environment approval; the absence of reported issues does not automatically deploy Beta to Production.
 
 The branch model is:
@@ -85,7 +93,8 @@ The cloud release process is:
 - The release workflow deploys the release branch to Beta.
 - After a successful beta deployment, the workflow creates a beta tag such as `YYYY-MM-DD.N-beta.1`, `YYYY-MM-DD.N-beta.2`, and so on.
 - Beta tag numbers are derived from existing beta tags for the release identifier. If concurrent workflows try to create the same tag for different commits, the later workflow must fail and be rerun after fetching the latest tags.
-- The release workflow runs end-to-end tests against Beta and reports the result to Testiny.
+- The release workflow deploys the Beta artifact to a dedicated E2E validation environment connected to Staging backend services, runs E2E there, and reports the result to Testiny.
+- Successful E2E and Testiny reporting are required before Production promotion.
 - The production deployment job waits for GitHub Environment approval on the production environment.
 - GitHub Environment approval means the workflow pauses before using the production environment until configured reviewers approve or reject the deployment in GitHub.
 - Quality assurance owns the go/no-go quality gate.
@@ -108,9 +117,13 @@ flowchart TD
   mergeToMain[Merge to main]
   deployToEdge[Deploy to Edge]
   createReleaseBranch[Create or update release/YYYY-MM-DD.N]
-  deployToBeta[Deploy release branch to Beta]
+  buildArtifact[Build release artifact once]
+  deployToBeta[Deploy artifact to Beta<br/>Production backend]
+  verifyBetaRuntime[Verify Beta runtime backend]
   createBetaTag[Create YYYY-MM-DD.N-beta.M]
-  runEndToEndTests[Run end-to-end tests against Beta]
+  deployToE2E[Deploy same artifact to E2E slot<br/>Staging backend]
+  verifyE2ERuntime[Verify E2E runtime backend]
+  runEndToEndTests[Run end-to-end tests against E2E slot]
   reportToTestiny[Report result to Testiny]
   productionApproval[GitHub Environment approval<br/>Production]
   deployToProduction[Deploy promoted beta artifact to Production]
@@ -119,8 +132,8 @@ flowchart TD
   deployKnownGoodArtifact[Deploy previous known-good production artifact]
 
   mergeToMain --> deployToEdge
-  createReleaseBranch --> deployToBeta --> createBetaTag
-  createBetaTag --> runEndToEndTests --> reportToTestiny
+  createReleaseBranch --> buildArtifact --> deployToBeta --> verifyBetaRuntime --> createBetaTag
+  createBetaTag --> deployToE2E --> verifyE2ERuntime --> runEndToEndTests --> reportToTestiny
   reportToTestiny --> productionApproval --> deployToProduction --> createProductionTag
   createProductionTag -.-> rollbackWorkflow -.-> deployKnownGoodArtifact
 ```

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -29,6 +29,7 @@ flowchart LR
   releaseArtifact[Release artifact]
   betaEnvironment[Beta company validation<br/>Production backend]
   e2eEnvironment[E2E validation slot<br/>Staging backend]
+  productionApproval[Quality assurance approval]
   betaTag[YYYY-MM-DD.N-beta.M]
   productionEnvironment[Production]
   productionTag[YYYY-MM-DD.N-production]
@@ -41,7 +42,8 @@ flowchart LR
   releaseArtifact -->|Deploy| betaEnvironment
   betaEnvironment -->|Verify Production runtime| betaTag
   betaTag -->|Deploy same artifact| e2eEnvironment
-  e2eEnvironment -->|E2E and Testiny succeed| productionEnvironment
+  e2eEnvironment -->|E2E and Testiny succeed| productionApproval
+  productionApproval -->|Approve candidate| productionEnvironment
   productionEnvironment -->|Successful production deployment creates| productionTag
   productionTag -->|Create only when needed| maintenanceBranch
   maintenanceBranch -->|Validated maintenance artifact creates| maintenanceTag


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Summary

Restores the historical separation between company release-candidate testing and automated E2E validation.

## Problem

The first ADR 0002 Beta run deployed the company-facing Beta frontend successfully.

That frontend correctly retained the legacy runtime configuration and connected to Production services.

The new release workflow then created test users in the Staging backend but attempted to log them in through the company-facing Beta frontend connected to Production. This caused systematic HTTP 403 login failures across the E2E matrix.

The failures were not flaky tests.

## Changes

- keeps `wire-webapp-beta.wire.com` connected to Production services
- deploys the exact same artifact to `wire-webapp-precommit-3`
- runs automated E2E there against the Staging backend
- passes the release Testiny run through the reusable precommit workflow
- verifies the Beta and precommit runtime backend configuration before
  continuing
- updates the release summary with both validation environments
- documents the runtime and testing boundaries in ADR 0002

## Preserved behavior

Company validation:

`wire-webapp-beta.wire.com` → Production backend

Automated validation:

`wire-webapp-precommit-3.zinfra.io` → Staging backend

This matches the behavior of the previous release process while retaining the new Beta naming and GitHub-driven artifact promotion.

## Artifact integrity

The release artifact is built once.

The same artifact is deployed to:

1. company-facing Beta
2. the E2E precommit slot
3. Production after approval

No rebuild occurs between those stages.

## Safety

This pull request does not:

- change DNS or Terraform
- modify Elastic Beanstalk runtime settings
- deploy any environment
- create or modify tags
- run tests against Production
- enable automatic release-branch triggering
- change Production approval or rollback behavior

## Failed candidate

`2026-07-15.1-beta.1` remains immutable and represents the failed workflow validation attempt.

After this pull request is merged, a fresh Release Cloud run for `release/2026-07-15.1` should create `2026-07-15.1-beta.2`.

## Workflow reruns

Precommit Elastic Beanstalk application versions include both the GitHub Actions run ID and run attempt.

This prevents a workflow rerun from reusing an application version created by an earlier attempt and ensures E2E validates the artifact built by the current attempt.

## Tracking

Part of #21597.
