### PR TITLE
Optimize Beta tag checkout [WPB-26469]

### DIFF
--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -242,7 +242,8 @@ jobs:
       - name: Checkout release commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: false
           ref: ${{ needs.build_artifact.outputs.release_commit_sha }}
 
       - name: Add repository Yarn wrapper to PATH
@@ -265,9 +266,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch --tags origin
-
-          mapfile -t existing_beta_tag_names < <(git tag --list "${RELEASE_IDENTIFIER}-beta.*")
+          mapfile -t existing_beta_tag_names < <(
+            git ls-remote \
+              --tags \
+              --refs \
+              origin \
+              "${RELEASE_IDENTIFIER}-beta.*" |
+              awk '{
+                sub("^refs/tags/", "", $2);
+                print $2;
+              }'
+          )
           beta_tag_name="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts next-beta-tag "${RELEASE_IDENTIFIER}" "${existing_beta_tag_names[@]}")"
 
           git config user.email "zebot@users.noreply.github.com"


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

Reduces the repository data fetched by the `Create Beta tag` release job.

## Problem

The job checked out the complete history for every branch and tag using `fetch-depth: 0`, then fetched every tag again before selecting the tags for one release family.

The job only needs the release commit and the names of matching Beta tags.

## Changes

- checks out only the exact release commit with depth one
- keeps automatic tag fetching disabled
- queries only matching remote Beta tag names with `git ls-remote`
- keeps `releaseMetadataCli.ts` responsible for choosing the next tag
- keeps annotated tag creation and safe push behavior unchanged

## Safety

This pull request does not:

- create or modify a tag
- dispatch a release
- change release numbering
- change Beta, E2E, or Production deployment behavior
- change artifact creation or promotion
- introduce new credentials

A concurrent workflow creating the same Beta tag still causes the later push to fail rather than overwrite the tag.

## Tracking

Part of #21597.
