### PR TITLE
Fix release failure notifications [WPB-26469]

### DIFF
--- a/.github/workflows/precommit-slot-run.yml
+++ b/.github/workflows/precommit-slot-run.yml
@@ -179,8 +179,17 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [deploy_to_aws, e2e_tests]
     if: ${{ always() && inputs.notify_deployoholics_on_failure && needs.e2e_tests.result == 'failure' }}
+    permissions:
+      contents: read
 
     steps:
+      - name: Checkout notification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          sparse-checkout: .github/actions/notify-deployoholics
+
       - name: Announce failed critical flow
         uses: ./.github/actions/notify-deployoholics
         with:

--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -267,8 +267,17 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [build, publish_wire_builds]
     if: ${{ always() && needs.publish_wire_builds.result == 'failure' }}
+    permissions:
+      contents: read
 
     steps:
+      - name: Checkout notification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          sparse-checkout: .github/actions/notify-deployoholics
+
       - name: Announce wire-builds bump failure
         uses: ./.github/actions/notify-deployoholics
         with:
@@ -394,8 +403,17 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [build, deploy_to_aws]
     if: ${{ always() && needs.deploy_to_aws.result == 'failure' }}
+    permissions:
+      contents: read
 
     steps:
+      - name: Checkout notification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          sparse-checkout: .github/actions/notify-deployoholics
+
       - name: Announce deployment failure
         uses: ./.github/actions/notify-deployoholics
         with:

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -147,8 +147,17 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [validate_request, build_artifact, deploy_to_production]
     if: ${{ always() && needs.deploy_to_production.result == 'failure' }}
+    permissions:
+      contents: read
 
     steps:
+      - name: Checkout notification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          sparse-checkout: .github/actions/notify-deployoholics
+
       - name: Announce production redeploy failure
         uses: ./.github/actions/notify-deployoholics
         with:

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -607,6 +607,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       [
+        validate_request,
         build_artifact,
         deploy_to_beta,
         create_beta_tag,
@@ -616,15 +617,39 @@ jobs:
         create_production_tag,
       ]
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
-    permissions: {}
+    permissions:
+      contents: read
 
     steps:
+      - name: Checkout notification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          sparse-checkout: .github/actions/notify-deployoholics
+
       - name: Announce release failure
         uses: ./.github/actions/notify-deployoholics
         with:
           webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
           status: failure
           text: |
-            Release Cloud failed for ${{ needs.build_artifact.outputs.release_branch || inputs.release_branch }} (${{ needs.build_artifact.outputs.release_identifier || needs.build_artifact.outputs.release_branch || inputs.release_branch }})
+            ❌ Release Cloud blocked Production ❌
+
+            Release: ${{ needs.build_artifact.outputs.release_identifier || 'unavailable' }}
+            Branch: ${{ needs.build_artifact.outputs.release_branch || inputs.release_branch || 'unavailable' }}
             Triggered by: ${{ github.actor }}
-            Build log: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Request validation: ${{ needs.validate_request.result }}
+            Build: ${{ needs.build_artifact.result }}
+            Beta deployment: ${{ needs.deploy_to_beta.result }}
+            Beta tag: ${{ needs.create_beta_tag.result }}
+            E2E system gate: ${{ needs.run_e2e.result }}
+            Production preflight: ${{ needs.production_preflight.result }}
+            Production deployment: ${{ needs.deploy_to_production.result }}
+            Production tag: ${{ needs.create_production_tag.result }}
+
+            Playwright report: ${{ needs.run_e2e.outputs.reportUrl || 'unavailable' }}
+            Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Production was blocked because a release gate failed.

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -245,9 +245,17 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [validate_request, build_artifact, deploy_to_production]
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
-    permissions: {}
+    permissions:
+      contents: read
 
     steps:
+      - name: Checkout notification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          sparse-checkout: .github/actions/notify-deployoholics
+
       - name: Announce Production rollback failure
         uses: ./.github/actions/notify-deployoholics
         with:

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -96,7 +96,13 @@ The cloud release process is:
 - After a successful beta deployment, the workflow creates a beta tag such as `YYYY-MM-DD.N-beta.1`, `YYYY-MM-DD.N-beta.2`, and so on.
 - Beta tag numbers are derived from existing beta tags for the release identifier. If concurrent workflows try to create the same tag for different commits, the later workflow must fail and be rerun after fetching the latest tags.
 - The release workflow deploys the Beta artifact to a dedicated E2E validation environment connected to Staging backend services, runs E2E there, and reports the result to Testiny.
+- The complete selected release E2E suite is a blocking full-system Production gate. The suite is not split into blocking and advisory tests, and no selected release E2E test uses `continue-on-error` or a flaky-test quarantine.
+- This gate intentionally validates the complete Wire system: frontend, backend, infrastructure, and integration failures may all block Production because customers consume the whole system.
+- Test implementation defects are fixed as test defects; known instability is not converted into `continue-on-error`.
+- Temporary system outages require investigation and a manual decision on whether to rerun. Failed tests may be manually rerun only after investigation; automatic test reruns are not part of the release decision.
 - Successful E2E and Testiny reporting are required before Production promotion.
+- Production preflight is not allowed after any E2E failure, and QA approval cannot override a technically failed E2E gate in this workflow.
+- Failed release gates notify Deployoholics with stage evidence and Playwright report links when available.
 - The production deployment job waits for GitHub Environment approval on the production environment.
 - GitHub Environment approval means the workflow pauses before using the production environment until configured reviewers approve or reject the deployment in GitHub.
 - Quality assurance owns the go/no-go quality gate.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Makes Deployoholics failure notifications reliable and documents the complete release E2E suite as a full-system Production gate.

## Notification failure

The Release Cloud failure-notification job attempted to use the local `notify-deployoholics` action without first checking out the repository.

GitHub therefore could not find the local action and no webhook request was made.

## Release policy

All selected release E2E tests remain blocking.

A failure in a frontend, backend, infrastructure, or integration component blocks Production because the release validates the complete customer-facing system.

## Tracking

Part of #21597