### PR TITLE
ci: suppress ESLint warnings in GitHub Actions logs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -252,6 +252,8 @@ jobs:
     name: lint
     permissions:
       contents: read
+    env:
+      ESLINT_QUIET: --quiet
 
     steps:
       - name: Checkout (pull_request)

--- a/.github/workflows/publish-libraries.yml
+++ b/.github/workflows/publish-libraries.yml
@@ -49,6 +49,8 @@ jobs:
         run: ./bin/yarn --immutable
 
       - name: Lint libraries
+        env:
+          ESLINT_QUIET: --quiet
         run: ./bin/yarn nx run-many -t lint --projects=tag:type:lib
 
       - name: Test libraries

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -76,7 +76,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --cache --cache-location node_modules/.cache/eslint/server --max-warnings=1289 --ext .js,.ts {projectRoot}"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --cache --cache-location node_modules/.cache/eslint/server --max-warnings=1289 --ext .js,.ts {projectRoot}"
       }
     },
     "type-check": {

--- a/apps/webapp/project.json
+++ b/apps/webapp/project.json
@@ -83,7 +83,7 @@
       "executor": "nx:run-commands",
       "dependsOn": [],
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=758 --cache --cache-location node_modules/.cache/eslint/webapp --ext .js,.ts,.tsx {projectRoot}/src"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=758 --cache --cache-location node_modules/.cache/eslint/webapp --ext .js,.ts,.tsx {projectRoot}/src"
       }
     },
     "lint:full": {

--- a/libraries/api-client/project.json
+++ b/libraries/api-client/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --cache --cache-location node_modules/.cache/eslint/api-client --max-warnings=1289 --ext .js,.ts {projectRoot}"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --cache --cache-location node_modules/.cache/eslint/api-client --max-warnings=1289 --ext .js,.ts {projectRoot}"
       }
     },
     "type-check": {

--- a/libraries/bazinga64/project.json
+++ b/libraries/bazinga64/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/bazinga64 --ext .js,.ts,.tsx --ignore-pattern '**/test/**' {projectRoot}/src"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/bazinga64 --ext .js,.ts,.tsx --ignore-pattern '**/test/**' {projectRoot}/src"
       }
     },
     "type-check": {

--- a/libraries/certificate-check/project.json
+++ b/libraries/certificate-check/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/certificate-check --ext .js,.ts,.tsx {projectRoot}/src"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/certificate-check --ext .js,.ts,.tsx {projectRoot}/src"
       }
     },
     "type-check": {

--- a/libraries/commons/project.json
+++ b/libraries/commons/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/commons --ext .js,.ts,.tsx {projectRoot}/src"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/commons --ext .js,.ts,.tsx {projectRoot}/src"
       }
     },
     "type-check": {

--- a/libraries/config/project.json
+++ b/libraries/config/project.json
@@ -50,7 +50,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --cache --cache-location node_modules/.cache/eslint/config --max-warnings=1289 --ext .js,.ts {projectRoot}"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --cache --cache-location node_modules/.cache/eslint/config --max-warnings=1289 --ext .js,.ts {projectRoot}"
       }
     }
   },

--- a/libraries/copy-config/project.json
+++ b/libraries/copy-config/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/copy-config --ext .js,.ts,.tsx {projectRoot}/src"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/copy-config --ext .js,.ts,.tsx {projectRoot}/src"
       }
     },
     "type-check": {

--- a/libraries/core/project.json
+++ b/libraries/core/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --cache --cache-location node_modules/.cache/eslint/core --max-warnings=1289 --ext .js,.ts {projectRoot}"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --cache --cache-location node_modules/.cache/eslint/core --max-warnings=1289 --ext .js,.ts {projectRoot}"
       }
     },
     "type-check": {

--- a/libraries/eslint-config/project.json
+++ b/libraries/eslint-config/project.json
@@ -14,7 +14,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --cache --cache-location node_modules/.cache/eslint/eslint-config --max-warnings=1289 --ext .js,.ts {projectRoot} --ignore-pattern '**/eslintrc.js' --no-error-on-unmatched-pattern --no-warn-ignored"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --cache --cache-location node_modules/.cache/eslint/eslint-config --max-warnings=1289 --ext .js,.ts {projectRoot} --ignore-pattern '**/eslintrc.js' --no-error-on-unmatched-pattern --no-warn-ignored"
       }
     }
   },

--- a/libraries/license-collector/project.json
+++ b/libraries/license-collector/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/license-collector --ext .js,.ts,.tsx {projectRoot}/src"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/license-collector --ext .js,.ts,.tsx {projectRoot}/src"
       }
     },
     "type-check": {

--- a/libraries/prettier-config/project.json
+++ b/libraries/prettier-config/project.json
@@ -14,7 +14,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --cache --cache-location node_modules/.cache/eslint/prettier-config --max-warnings=1289 --no-error-on-unmatched-pattern --ext .js,.ts {projectRoot}"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --cache --cache-location node_modules/.cache/eslint/prettier-config --max-warnings=1289 --no-error-on-unmatched-pattern --ext .js,.ts {projectRoot}"
       }
     }
   },

--- a/libraries/priority-queue/project.json
+++ b/libraries/priority-queue/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/priority-queue --ext .js,.ts,.tsx {projectRoot}/src"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/priority-queue --ext .js,.ts,.tsx {projectRoot}/src"
       }
     },
     "type-check": {

--- a/libraries/react-ui-kit/project.json
+++ b/libraries/react-ui-kit/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/react-ui-kit --ext .js,.ts,.tsx {projectRoot}/src"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/react-ui-kit --ext .js,.ts,.tsx {projectRoot}/src"
       }
     },
     "type-check": {

--- a/libraries/store-engine-dexie/project.json
+++ b/libraries/store-engine-dexie/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/store-engine-dexie --ext .js,.ts,.tsx {projectRoot}/src"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/store-engine-dexie --ext .js,.ts,.tsx {projectRoot}/src"
       }
     },
     "type-check": {

--- a/libraries/store-engine-fs/project.json
+++ b/libraries/store-engine-fs/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/store-engine-fs --ext .js,.ts,.tsx {projectRoot}/src"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/store-engine-fs --ext .js,.ts,.tsx {projectRoot}/src"
       }
     },
     "type-check": {

--- a/libraries/store-engine/project.json
+++ b/libraries/store-engine/project.json
@@ -61,7 +61,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/store-engine --ext .js,.ts,.tsx {projectRoot}/src --ignore-pattern '{projectRoot}/src/test/**'"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/store-engine --ext .js,.ts,.tsx {projectRoot}/src --ignore-pattern '{projectRoot}/src/test/**'"
       }
     },
     "type-check": {

--- a/libraries/telemetry/project.json
+++ b/libraries/telemetry/project.json
@@ -62,7 +62,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/telemetry --ext .js,.ts,.tsx {projectRoot}/src"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/telemetry --ext .js,.ts,.tsx {projectRoot}/src"
       }
     }
   },

--- a/libraries/webapp-events/project.json
+++ b/libraries/webapp-events/project.json
@@ -52,7 +52,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "eslint --config eslint.config.ts --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/webapp-events --ext .js,.ts,.tsx {projectRoot}/src"
+        "command": "eslint --config eslint.config.ts ${ESLINT_QUIET:-} --max-warnings=1289 --cache --cache-location node_modules/.cache/eslint/webapp-events --ext .js,.ts,.tsx {projectRoot}/src"
       }
     },
     "type-check": {


### PR DESCRIPTION
## Summary
- Add optional `${ESLINT_QUIET:-}` placeholder to all Nx ESLint lint targets so CI can pass `--quiet` without changing local behavior.
- Set `ESLINT_QUIET: --quiet` on the CI lint job and library publish lint step so GitHub Actions logs only show ESLint errors.

## Test plan
- [x] Verified locally: `ESLINT_QUIET=--quiet yarn nx run webapp:lint` completes without printing ESLint warnings
- [x] CI lint job shows errors only when lint fails, without flooding logs with pre-existing warnings