### PR TITLE
Verify Production before tagging [WPB-26469]

### DIFF
--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -37,6 +37,9 @@ env:
   BETA_ARTIFACT_NAME_PREFIX: release-cloud-ebs
   BETA_RUNTIME_BACKEND_REST: https://prod-nginz-https.wire.com
   BETA_RUNTIME_BACKEND_WS: wss://prod-nginz-ssl.wire.com
+  PRODUCTION_WEBAPP_URL: https://app.wire.com/
+  PRODUCTION_RUNTIME_BACKEND_REST: https://prod-nginz-https.wire.com
+  PRODUCTION_RUNTIME_BACKEND_WS: wss://prod-nginz-ssl.wire.com
   # ADR 0002 calls this logical release stage Beta. Its GitHub Environment and
   # canonical company-facing URL use wire-webapp-beta, while deployments retain
   # the existing wire-webapp-staging Elastic Beanstalk environment.
@@ -467,11 +470,65 @@ jobs:
           deployment-timeout: 150
           use-existing-application-version-if-available: true
 
+  verify_production_runtime:
+    name: Verify Production runtime
+    runs-on: ubuntu-24.04
+    needs: [build_artifact, deploy_to_production]
+    if: ${{ needs.deploy_to_production.result == 'success' }}
+    permissions: {}
+    timeout-minutes: 2
+
+    steps:
+      - name: Verify live Production runtime
+        env:
+          EXPECTED_BACKEND_REST: ${{ env.PRODUCTION_RUNTIME_BACKEND_REST }}
+          EXPECTED_BACKEND_WS: ${{ env.PRODUCTION_RUNTIME_BACKEND_WS }}
+          EXPECTED_VERSION: ${{ needs.build_artifact.outputs.artifact_version }}
+          PRODUCTION_WEBAPP_URL: ${{ env.PRODUCTION_WEBAPP_URL }}
+        run: |
+          set -euo pipefail
+
+          normalize_url() {
+            printf '%s' "${1%/}"
+          }
+
+          expected_backend_rest="$(normalize_url "${EXPECTED_BACKEND_REST}")"
+          expected_backend_ws="$(normalize_url "${EXPECTED_BACKEND_WS}")"
+
+          for attempt_number in {1..10}; do
+            runtime_config=''
+            if ! runtime_config="$(curl --fail --silent --show-error "${PRODUCTION_WEBAPP_URL}config.js")"; then
+              echo "Unable to fetch Production runtime configuration on attempt ${attempt_number}: URL=${PRODUCTION_WEBAPP_URL}config.js." >&2
+            fi
+
+            actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
+            actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
+            actual_version="$(printf '%s' "${runtime_config}" | sed -n 's/.*"VERSION":"\([^"]*\)".*/\1/p')"
+
+            if [[ "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" && "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}" && "${actual_version}" == "${EXPECTED_VERSION}" ]]; then
+              echo "Production runtime verification succeeded on attempt ${attempt_number}: URL=${PRODUCTION_WEBAPP_URL}config.js, VERSION=${actual_version}, REST=$(normalize_url "${actual_backend_rest}"), WS=$(normalize_url "${actual_backend_ws}")."
+              exit 0
+            fi
+
+            echo "Production runtime configuration mismatch on attempt ${attempt_number}." >&2
+            echo "Expected: VERSION=${EXPECTED_VERSION}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
+            echo "Observed: VERSION=${actual_version:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
+
+            if [[ "${attempt_number}" -lt 10 ]]; then
+              sleep 6
+            fi
+          done
+
+          echo "Production runtime verification failed after 10 attempts." >&2
+          echo "Expected: VERSION=${EXPECTED_VERSION}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
+          echo "Observed: VERSION=${actual_version:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
+          exit 1
+
   create_production_tag:
     name: Create Production tag
     runs-on: ubuntu-24.04
-    needs: [build_artifact, production_preflight, deploy_to_production]
-    if: ${{ needs.production_preflight.outputs.should_deploy == 'true' && needs.deploy_to_production.result == 'success' }}
+    needs: [build_artifact, production_preflight, deploy_to_production, verify_production_runtime]
+    if: ${{ needs.production_preflight.outputs.should_deploy == 'true' && needs.deploy_to_production.result == 'success' && needs.verify_production_runtime.result == 'success' }}
     permissions:
       contents: write
     outputs:
@@ -518,6 +575,7 @@ jobs:
         run_e2e,
         production_preflight,
         deploy_to_production,
+        verify_production_runtime,
         create_production_tag,
       ]
     if: ${{ always() }}
@@ -544,6 +602,11 @@ jobs:
           PRODUCTION_ENVIRONMENT_NAME: ${{ env.PRODUCTION_ENVIRONMENT_NAME }}
           PRODUCTION_PREFLIGHT_RESULT: ${{ needs.production_preflight.outputs.production_preflight_result }}
           PRODUCTION_PROMOTION_REQUESTED: ${{ inputs.promote_to_production }}
+          PRODUCTION_RUNTIME_VERIFICATION_RESULT: ${{ needs.verify_production_runtime.result }}
+          PRODUCTION_RUNTIME_BACKEND_REST: ${{ env.PRODUCTION_RUNTIME_BACKEND_REST }}
+          PRODUCTION_RUNTIME_BACKEND_WS: ${{ env.PRODUCTION_RUNTIME_BACKEND_WS }}
+          PRODUCTION_WEBAPP_URL: ${{ env.PRODUCTION_WEBAPP_URL }}
+          PRODUCTION_ARTIFACT_VERSION: ${{ needs.build_artifact.outputs.artifact_version }}
           PRODUCTION_SKIPPED_REASON: ${{ needs.production_preflight.outputs.production_skipped_reason }}
           PRODUCTION_TAG_CREATION_RESULT: ${{ needs.create_production_tag.result }}
           PRODUCTION_TAG_NAME: ${{ needs.production_preflight.outputs.production_tag_name }}
@@ -595,6 +658,11 @@ jobs:
             fi
 
             echo "- Production deployment result: ${PRODUCTION_DEPLOYMENT_RESULT}"
+            echo "- Production runtime verification result: ${PRODUCTION_RUNTIME_VERIFICATION_RESULT}"
+            echo "- Production URL: ${PRODUCTION_WEBAPP_URL}"
+            echo "- Expected Production artifact version: ${PRODUCTION_ARTIFACT_VERSION}"
+            echo "- Expected Production REST backend: ${PRODUCTION_RUNTIME_BACKEND_REST}"
+            echo "- Expected Production WebSocket backend: ${PRODUCTION_RUNTIME_BACKEND_WS}"
             echo "- Production tag creation result: ${PRODUCTION_TAG_CREATION_RESULT}"
             echo "- Production environment: ${PRODUCTION_ENVIRONMENT_NAME}"
             echo "- Production artifact name: ${PRODUCTION_ARTIFACT_NAME}"
@@ -614,6 +682,7 @@ jobs:
         run_e2e,
         production_preflight,
         deploy_to_production,
+        verify_production_runtime,
         create_production_tag,
       ]
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
@@ -647,9 +716,11 @@ jobs:
             E2E system gate: ${{ needs.run_e2e.result }}
             Production preflight: ${{ needs.production_preflight.result }}
             Production deployment: ${{ needs.deploy_to_production.result }}
+            Production runtime verification: ${{ needs.verify_production_runtime.result }}
             Production tag: ${{ needs.create_production_tag.result }}
 
             Playwright report: ${{ needs.run_e2e.outputs.reportUrl || 'unavailable' }}
             Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-            Production was blocked because a release gate failed.
+            ${{ needs.verify_production_runtime.result == 'failure' && 'Production deployment completed, but live runtime verification failed.' || 'Production was blocked because a release gate failed.' }}
+            ${{ needs.verify_production_runtime.result == 'failure' && 'No Production tag was created.' || 'Production tag creation was blocked by the failed release gate.' }}

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -8,7 +8,7 @@ Accepted
 
 The current release process is mostly driven by branch and tag pushes, with production deployment triggered by pre-existing production tags. That creates two main problems:
 
-- Production tags are created before production deployment, which makes the tag represent intent rather than a verified deployment result.
+- A successful Production deployment operation alone is not sufficient evidence for an immutable Production tag; without live verification, the tag can represent intent rather than a verified runtime.
 - The process does not provide a clean and auditable promotion flow from beta validation to production deployment.
 
 We want a release process that is fully executable from GitHub Actions without manual release operations on local developer machines. We also want fewer long-lived branches, fewer synchronization steps, and clearer ownership for quality approval, production rollout, observability, rollback, and customer-specific maintenance releases.
@@ -32,6 +32,7 @@ flowchart LR
   productionApproval[Quality assurance approval]
   betaTag[YYYY-MM-DD.N-beta.M]
   productionEnvironment[Production]
+  productionRuntimeVerification[Verify live Production runtime<br/>Artifact version and Production backends]
   productionTag[YYYY-MM-DD.N-production]
   maintenanceBranch[maintenance/maintenance-line-key]
   maintenanceTag[maintenance-line-key-maintenance.X]
@@ -44,7 +45,8 @@ flowchart LR
   betaTag -->|Deploy same artifact| e2eEnvironment
   e2eEnvironment -->|E2E and Testiny succeed| productionApproval
   productionApproval -->|Approve candidate| productionEnvironment
-  productionEnvironment -->|Successful production deployment creates| productionTag
+  productionEnvironment -->|Deploy promoted artifact| productionRuntimeVerification
+  productionRuntimeVerification -->|Verified runtime creates| productionTag
   productionTag -->|Create only when needed| maintenanceBranch
   maintenanceBranch -->|Validated maintenance artifact creates| maintenanceTag
 
@@ -108,7 +110,9 @@ The cloud release process is:
 - Quality assurance owns the go/no-go quality gate.
 - The engineering release captain owns production rollout, observability, and incident response.
 - The production workflow promotes the beta-tested artifact and does not rebuild from source.
-- After successful production deployment, the workflow creates the production tag `YYYY-MM-DD.N-production`.
+- After Production deployment, the workflow verifies that the live Production endpoint `https://app.wire.com/config.js` exposes the expected artifact version and Production REST and WebSocket backend configuration.
+- A successful deployment operation alone does not create a Production tag. The workflow creates the production tag `YYYY-MM-DD.N-production` only after the live runtime and artifact verification succeeds, so the tag represents a successfully deployed and verified runtime.
+- If Production runtime verification fails, Production remains untagged, the release workflow fails, Deployoholics receives a failure notification, and the release captain performs incident assessment.
 - If the current release branch commit already has the matching production tag, the release workflow must not redeploy that commit.
 - Production tags are immutable release history and are never moved or deleted.
 Release workflows must be serialized:
@@ -135,6 +139,7 @@ flowchart TD
   reportToTestiny[Report result to Testiny]
   productionApproval[GitHub Environment approval<br/>Production]
   deployToProduction[Deploy promoted beta artifact to Production]
+  verifyProductionRuntime[Verify live Production runtime<br/>Artifact version and Production backends]
   createProductionTag[Create YYYY-MM-DD.N-production]
   rollbackWorkflow[Rollback Production workflow_dispatch<br/>optional incident action]
   deployKnownGoodArtifact[Deploy previous known-good production artifact]
@@ -142,7 +147,7 @@ flowchart TD
   mergeToMain --> deployToEdge
   createReleaseBranch --> buildArtifact --> deployToBeta --> verifyBetaRuntime --> createBetaTag
   createBetaTag --> deployToE2E --> verifyE2ERuntime --> runEndToEndTests --> reportToTestiny
-  reportToTestiny --> productionApproval --> deployToProduction --> createProductionTag
+  reportToTestiny --> productionApproval --> deployToProduction --> verifyProductionRuntime --> createProductionTag
   createProductionTag -.-> rollbackWorkflow -.-> deployKnownGoodArtifact
 ```
 
@@ -171,7 +176,7 @@ Branch and tag cleanup follows these rules:
 
 Rollback will be first-class:
 
-- Production rollback is performed through a dedicated GitHub Actions workflow.
+- Production rollback is performed through a dedicated GitHub Actions workflow as a separate explicit operation; runtime verification failure does not automatically roll back.
 - The rollback workflow deploys a previous known-good production tag or artifact.
 - Rollback is owned by engineering release owners, not quality assurance.
 - A rollback requires a reason, a Wire notification, and, when applicable, an incident reference.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Adds live Production verification before creating the immutable Production tag.

## Problem

Release Cloud verified Beta and precommit, but a successful Elastic Beanstalk Production deployment proceeded directly to tag creation.

That did not prove that the public endpoint served the current artifact and Production backend configuration.

## Changes

After Production deployment, the workflow verifies:

- `https://app.wire.com/`
- the artifact version from the current run
- the Production REST backend
- the Production WebSocket backend

The Production tag is created only after this verification succeeds.

## Failure behavior

When Production deployment succeeds but runtime verification fails:

- no Production tag is created
- the release workflow fails
- Deployoholics is notified
- rollback remains an explicit operational decision

## Tracking

Part of #21597