### PR TITLE
build: envoy gateway support (helm) [WPB-24493]

### DIFF
--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire webapp in Kubernetes
 name: webapp
-version: 0.5.0
+version: 0.6.0

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire webapp in Kubernetes
 name: webapp
-version: 0.8.2
+version: 0.6.0

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire webapp in Kubernetes
 name: webapp
-version: 0.8.1
+version: 0.8.2

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire webapp in Kubernetes
 name: webapp
-version: 0.8.0
+version: 0.8.1

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire webapp in Kubernetes
 name: webapp
-version: 0.6.0
+version: 0.7.0

--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the Wire webapp in Kubernetes
 name: webapp
-version: 0.7.0
+version: 0.8.0

--- a/charts/webapp/templates/_helpers.tpl
+++ b/charts/webapp/templates/_helpers.tpl
@@ -42,7 +42,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "webapp.validateDomainConfig" -}}
   {{- $routingMode := default "nginx" .Values.routing.mode | lower -}}
-  {{- if or .Values.routing.enabled .Values.tls.enabled }}
+  {{- $routingEnabled := eq (include "webapp.routingEnabled" . | trim) "true" -}}
+  {{- if or $routingEnabled .Values.tls.enabled }}
     {{- if not .Values.webappDomain }}
       {{- fail "webappDomain must be set when enabling routing or tls" }}
     {{- end }}
@@ -50,24 +51,28 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- if and (ne $routingMode "nginx") (ne $routingMode "envoy") (ne $routingMode "migration") }}
     {{- fail "routing.mode must be one of nginx, envoy, or migration" }}
   {{- end }}
-  {{- if and (or (eq $routingMode "envoy") (eq $routingMode "migration")) (not .Values.routing.enabled) }}
+  {{- if and (or (eq $routingMode "envoy") (eq $routingMode "migration")) (not $routingEnabled) }}
     {{- fail "routing.enabled must be true when routing.mode is envoy or migration" }}
   {{- end }}
-  {{- if and .Values.routing.enabled (or (eq $routingMode "envoy") (eq $routingMode "migration")) (empty .Values.gateway.name) }}
+  {{- if and $routingEnabled (or (eq $routingMode "envoy") (eq $routingMode "migration")) (empty .Values.gateway.name) }}
     {{- fail "gateway.name must be set when routing.mode is envoy or migration" }}
   {{- end }}
-  {{- if and .Values.routing.enabled (eq $routingMode "migration") (and (ne (default "nginx" .Values.routing.migration.primary | lower) "nginx") (ne (default "nginx" .Values.routing.migration.primary | lower) "envoy")) }}
+  {{- if and $routingEnabled (eq $routingMode "migration") (and (ne (default "nginx" .Values.routing.migration.primary | lower) "nginx") (ne (default "nginx" .Values.routing.migration.primary | lower) "envoy")) }}
     {{- fail "routing.migration.primary must be one of nginx or envoy" }}
   {{- end }}
   {{- if and .Values.ingress.renderCSPInIngress (eq $routingMode "envoy") }}
     {{- fail "ingress.renderCSPInIngress only works with routing.mode=nginx or migration" }}
   {{- end }}
-  {{- if and .Values.tls.enabled (not .Values.routing.enabled) }}
+  {{- if and .Values.tls.enabled (not $routingEnabled) }}
     {{- fail "routing.enabled must be true when tls.enabled is true" }}
   {{- end }}
   {{- if and .Values.tls.enabled (not .Values.tls.useCertManager) (empty .Values.tls.existingSecretName) }}
     {{- fail "When tls.enabled is true, either tls.useCertManager must be true or tls.existingSecretName must be set" }}
   {{- end }}
+{{- end -}}
+
+{{- define "webapp.routingEnabled" -}}
+{{- or .Values.routing.enabled .Values.ingress.enabled -}}
 {{- end -}}
 
 {{- define "webapp.routingMode" -}}

--- a/charts/webapp/templates/_helpers.tpl
+++ b/charts/webapp/templates/_helpers.tpl
@@ -95,6 +95,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{- define "webapp.externalDnsSetIdentifier" -}}
+{{- $ctx := .ctx -}}
+{{- $kind := .kind -}}
+{{- if eq (include "webapp.routingMode" $ctx) "migration" -}}
+{{- printf "%s-%s" (include "webapp.baseName" $ctx) $kind -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "webapp.listenerSetName" -}}
 {{- printf "%s-listeners" (include "webapp.baseName" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/webapp/templates/_helpers.tpl
+++ b/charts/webapp/templates/_helpers.tpl
@@ -41,43 +41,43 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "webapp.validateDomainConfig" -}}
-  {{- $ingressMode := default "nginx" .Values.ingress.mode | lower -}}
-  {{- if or .Values.ingress.enabled .Values.tls.enabled }}
+  {{- $routingMode := default "nginx" .Values.routing.mode | lower -}}
+  {{- if or .Values.routing.enabled .Values.tls.enabled }}
     {{- if not .Values.webappDomain }}
-      {{- fail "webappDomain must be set when enabling ingress or tls" }}
+      {{- fail "webappDomain must be set when enabling routing or tls" }}
     {{- end }}
   {{- end }}
-  {{- if and (ne $ingressMode "nginx") (ne $ingressMode "envoy") (ne $ingressMode "migration") }}
-    {{- fail "ingress.mode must be one of nginx, envoy, or migration" }}
+  {{- if and (ne $routingMode "nginx") (ne $routingMode "envoy") (ne $routingMode "migration") }}
+    {{- fail "routing.mode must be one of nginx, envoy, or migration" }}
   {{- end }}
-  {{- if and (or (eq $ingressMode "envoy") (eq $ingressMode "migration")) (not .Values.ingress.enabled) }}
-    {{- fail "ingress.enabled must be true when ingress.mode is envoy or migration" }}
+  {{- if and (or (eq $routingMode "envoy") (eq $routingMode "migration")) (not .Values.routing.enabled) }}
+    {{- fail "routing.enabled must be true when routing.mode is envoy or migration" }}
   {{- end }}
-  {{- if and .Values.ingress.enabled (or (eq $ingressMode "envoy") (eq $ingressMode "migration")) (empty .Values.ingress.gateway.name) }}
-    {{- fail "ingress.gateway.name must be set when ingress.mode is envoy or migration" }}
+  {{- if and .Values.routing.enabled (or (eq $routingMode "envoy") (eq $routingMode "migration")) (empty .Values.gateway.name) }}
+    {{- fail "gateway.name must be set when routing.mode is envoy or migration" }}
   {{- end }}
-  {{- if and .Values.ingress.enabled (eq $ingressMode "migration") (and (ne (default "nginx" .Values.ingress.migration.primary | lower) "nginx") (ne (default "nginx" .Values.ingress.migration.primary | lower) "envoy")) }}
-    {{- fail "ingress.migration.primary must be one of nginx or envoy" }}
+  {{- if and .Values.routing.enabled (eq $routingMode "migration") (and (ne (default "nginx" .Values.routing.migration.primary | lower) "nginx") (ne (default "nginx" .Values.routing.migration.primary | lower) "envoy")) }}
+    {{- fail "routing.migration.primary must be one of nginx or envoy" }}
   {{- end }}
-  {{- if and .Values.ingress.renderCSPInIngress (eq $ingressMode "envoy") }}
-    {{- fail "ingress.renderCSPInIngress only works with ingress.mode=nginx or migration" }}
+  {{- if and .Values.ingress.renderCSPInIngress (eq $routingMode "envoy") }}
+    {{- fail "ingress.renderCSPInIngress only works with routing.mode=nginx or migration" }}
   {{- end }}
-  {{- if and .Values.tls.enabled (not .Values.ingress.enabled) }}
-    {{- fail "ingress.enabled must be true when tls.enabled is true" }}
+  {{- if and .Values.tls.enabled (not .Values.routing.enabled) }}
+    {{- fail "routing.enabled must be true when tls.enabled is true" }}
   {{- end }}
   {{- if and .Values.tls.enabled (not .Values.tls.useCertManager) (empty .Values.tls.existingSecretName) }}
     {{- fail "When tls.enabled is true, either tls.useCertManager must be true or tls.existingSecretName must be set" }}
   {{- end }}
 {{- end -}}
 
-{{- define "webapp.ingressMode" -}}
-{{- default "nginx" .Values.ingress.mode | lower -}}
+{{- define "webapp.routingMode" -}}
+{{- default "nginx" .Values.routing.mode | lower -}}
 {{- end -}}
 
-{{- define "webapp.ingressPrimaryController" -}}
-{{- $mode := include "webapp.ingressMode" . -}}
+{{- define "webapp.routingPrimaryController" -}}
+{{- $mode := include "webapp.routingMode" . -}}
 {{- if eq $mode "migration" -}}
-{{- default "nginx" .Values.ingress.migration.primary | lower -}}
+{{- default "nginx" .Values.routing.migration.primary | lower -}}
 {{- else -}}
 {{- $mode -}}
 {{- end -}}
@@ -86,8 +86,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "webapp.externalDnsWeight" -}}
 {{- $ctx := .ctx -}}
 {{- $kind := .kind -}}
-{{- if eq (include "webapp.ingressMode" $ctx) "migration" -}}
-{{- if eq (include "webapp.ingressPrimaryController" $ctx) $kind -}}
+{{- if eq (include "webapp.routingMode" $ctx) "migration" -}}
+{{- if eq (include "webapp.routingPrimaryController" $ctx) $kind -}}
 100
 {{- else -}}
 0
@@ -100,8 +100,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "webapp.listenerName" -}}
-{{- if .Values.ingress.gateway.sectionName -}}
-{{- .Values.ingress.gateway.sectionName -}}
+{{- if .Values.gateway.sectionName -}}
+{{- .Values.gateway.sectionName -}}
 {{- else if .Values.tls.enabled -}}
 https
 {{- else -}}

--- a/charts/webapp/templates/_helpers.tpl
+++ b/charts/webapp/templates/_helpers.tpl
@@ -41,10 +41,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "webapp.validateDomainConfig" -}}
+  {{- $ingressMode := default "nginx" .Values.ingress.mode | lower -}}
   {{- if or .Values.ingress.enabled .Values.tls.enabled }}
     {{- if not .Values.webappDomain }}
       {{- fail "webappDomain must be set when enabling ingress or tls" }}
     {{- end }}
+  {{- end }}
+  {{- if and (ne $ingressMode "nginx") (ne $ingressMode "envoy") (ne $ingressMode "migration") }}
+    {{- fail "ingress.mode must be one of nginx, envoy, or migration" }}
+  {{- end }}
+  {{- if and .Values.ingress.enabled (or (eq $ingressMode "envoy") (eq $ingressMode "migration")) (empty .Values.ingress.gateway.name) }}
+    {{- fail "ingress.gateway.name must be set when ingress.mode is envoy or migration" }}
+  {{- end }}
+  {{- if and .Values.ingress.enabled (eq $ingressMode "migration") (and (ne (default "nginx" .Values.ingress.migration.primary | lower) "nginx") (ne (default "nginx" .Values.ingress.migration.primary | lower) "envoy")) }}
+    {{- fail "ingress.migration.primary must be one of nginx or envoy" }}
+  {{- end }}
+  {{- if and .Values.ingress.renderCSPInIngress (eq $ingressMode "envoy") }}
+    {{- fail "ingress.renderCSPInIngress only works with ingress.mode=nginx or migration" }}
   {{- end }}
   {{- if and .Values.tls.enabled (not .Values.ingress.enabled) }}
     {{- fail "ingress.enabled must be true when tls.enabled is true" }}
@@ -52,6 +65,31 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- if and .Values.tls.enabled (not .Values.tls.useCertManager) (empty .Values.tls.existingSecretName) }}
     {{- fail "When tls.enabled is true, either tls.useCertManager must be true or tls.existingSecretName must be set" }}
   {{- end }}
+{{- end -}}
+
+{{- define "webapp.ingressMode" -}}
+{{- default "nginx" .Values.ingress.mode | lower -}}
+{{- end -}}
+
+{{- define "webapp.ingressPrimaryController" -}}
+{{- $mode := include "webapp.ingressMode" . -}}
+{{- if eq $mode "migration" -}}
+{{- default "nginx" .Values.ingress.migration.primary | lower -}}
+{{- else -}}
+{{- $mode -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "webapp.externalDnsWeight" -}}
+{{- $ctx := .ctx -}}
+{{- $kind := .kind -}}
+{{- if eq (include "webapp.ingressMode" $ctx) "migration" -}}
+{{- if eq (include "webapp.ingressPrimaryController" $ctx) $kind -}}
+100
+{{- else -}}
+0
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "webapp.certificateSecretName" -}}

--- a/charts/webapp/templates/_helpers.tpl
+++ b/charts/webapp/templates/_helpers.tpl
@@ -50,6 +50,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- if and (ne $ingressMode "nginx") (ne $ingressMode "envoy") (ne $ingressMode "migration") }}
     {{- fail "ingress.mode must be one of nginx, envoy, or migration" }}
   {{- end }}
+  {{- if and (or (eq $ingressMode "envoy") (eq $ingressMode "migration")) (not .Values.ingress.enabled) }}
+    {{- fail "ingress.enabled must be true when ingress.mode is envoy or migration" }}
+  {{- end }}
   {{- if and .Values.ingress.enabled (or (eq $ingressMode "envoy") (eq $ingressMode "migration")) (empty .Values.ingress.gateway.name) }}
     {{- fail "ingress.gateway.name must be set when ingress.mode is envoy or migration" }}
   {{- end }}
@@ -89,6 +92,36 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- else -}}
 0
 {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "webapp.listenerSetName" -}}
+{{- printf "%s-listeners" (include "webapp.baseName" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "webapp.listenerName" -}}
+{{- if .Values.ingress.gateway.sectionName -}}
+{{- .Values.ingress.gateway.sectionName -}}
+{{- else if .Values.tls.enabled -}}
+https
+{{- else -}}
+http
+{{- end -}}
+{{- end -}}
+
+{{- define "webapp.listenerProtocol" -}}
+{{- if .Values.tls.enabled -}}
+HTTPS
+{{- else -}}
+HTTP
+{{- end -}}
+{{- end -}}
+
+{{- define "webapp.listenerPort" -}}
+{{- if .Values.tls.enabled -}}
+443
+{{- else -}}
+80
 {{- end -}}
 {{- end -}}
 

--- a/charts/webapp/templates/certificate.yaml
+++ b/charts/webapp/templates/certificate.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.routing.enabled (empty .Values.tls.existingSecretName) }}
+{{- $routingEnabled := eq (include "webapp.routingEnabled" . | trim) "true" -}}
+{{- if and .Values.tls.enabled .Values.tls.useCertManager $routingEnabled (empty .Values.tls.existingSecretName) }}
 {{- include "webapp.validateDomainConfig" . }}
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/webapp/templates/certificate.yaml
+++ b/charts/webapp/templates/certificate.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.ingress.enabled (empty .Values.tls.existingSecretName) }}
+{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.routing.enabled (empty .Values.tls.existingSecretName) }}
 {{- include "webapp.validateDomainConfig" . }}
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/webapp/templates/httproute.yaml
+++ b/charts/webapp/templates/httproute.yaml
@@ -1,5 +1,5 @@
-{{- $ingressMode := include "webapp.ingressMode" . -}}
-{{- if and .Values.ingress.enabled (or (eq $ingressMode "envoy") (eq $ingressMode "migration")) }}
+{{- $routingMode := include "webapp.routingMode" . -}}
+{{- if and .Values.routing.enabled (or (eq $routingMode "envoy") (eq $routingMode "migration")) }}
 {{- include "webapp.validateDomainConfig" . }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -10,9 +10,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  {{- if or .Values.ingress.httpRouteAnnotations (eq $ingressMode "migration") }}
+  {{- if or .Values.gateway.httpRouteAnnotations (eq $routingMode "migration") }}
   annotations:
-    {{- range $key, $val := .Values.ingress.httpRouteAnnotations }}
+    {{- range $key, $val := .Values.gateway.httpRouteAnnotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
     {{- $weight := include "webapp.externalDnsWeight" (dict "ctx" . "kind" "envoy") | trim -}}

--- a/charts/webapp/templates/httproute.yaml
+++ b/charts/webapp/templates/httproute.yaml
@@ -10,19 +10,16 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  {{- if or .Values.gateway.httpRouteAnnotations (eq $routingMode "migration") (eq $routingMode "envoy") }}
+  {{- $setIdentifier := include "webapp.externalDnsSetIdentifier" (dict "ctx" . "kind" "envoy") | trim -}}
+  {{- $weight := include "webapp.externalDnsWeight" (dict "ctx" . "kind" "envoy") | trim -}}
+  {{- if or .Values.gateway.httpRouteAnnotations $setIdentifier $weight }}
   annotations:
     {{- range $key, $val := .Values.gateway.httpRouteAnnotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
-    {{- $setIdentifier := include "webapp.externalDnsSetIdentifier" (dict "ctx" . "kind" "envoy") | trim -}}
     {{- if $setIdentifier }}
     external-dns.alpha.kubernetes.io/set-identifier: {{ $setIdentifier | quote }}
     {{- end }}
-    {{- if not (hasKey .Values.gateway.httpRouteAnnotations "external-dns.alpha.kubernetes.io/hostname") }}
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.webappDomain | quote }}
-    {{- end }}
-    {{- $weight := include "webapp.externalDnsWeight" (dict "ctx" . "kind" "envoy") | trim -}}
     {{- if $weight }}
     external-dns.alpha.kubernetes.io/aws-weight: {{ $weight | quote }}
     {{- end }}

--- a/charts/webapp/templates/httproute.yaml
+++ b/charts/webapp/templates/httproute.yaml
@@ -22,14 +22,10 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
-    - name: {{ required "ingress.gateway.name must be set when ingress.mode is envoy or migration" .Values.ingress.gateway.name | quote }}
-      {{- if .Values.ingress.gateway.namespace }}
-      namespace: {{ .Values.ingress.gateway.namespace | quote }}
-      {{- else }}
-      namespace: {{ .Release.Namespace | quote }}
-      {{- end }}
-      kind: Gateway
-      sectionName: {{ default "https" .Values.ingress.gateway.sectionName | quote }}
+    - name: {{ include "webapp.listenerSetName" . | quote }}
+      kind: ListenerSet
+      group: gateway.networking.k8s.io
+      sectionName: {{ include "webapp.listenerName" . | quote }}
   hostnames:
     - {{ .Values.webappDomain | quote }}
   rules:

--- a/charts/webapp/templates/httproute.yaml
+++ b/charts/webapp/templates/httproute.yaml
@@ -15,6 +15,10 @@ metadata:
     {{- range $key, $val := .Values.gateway.httpRouteAnnotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+    {{- $setIdentifier := include "webapp.externalDnsSetIdentifier" (dict "ctx" . "kind" "envoy") | trim -}}
+    {{- if $setIdentifier }}
+    external-dns.alpha.kubernetes.io/set-identifier: {{ $setIdentifier | quote }}
+    {{- end }}
     {{- if not (hasKey .Values.gateway.httpRouteAnnotations "external-dns.alpha.kubernetes.io/hostname") }}
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.webappDomain | quote }}
     {{- end }}

--- a/charts/webapp/templates/httproute.yaml
+++ b/charts/webapp/templates/httproute.yaml
@@ -15,6 +15,9 @@ metadata:
     {{- range $key, $val := .Values.gateway.httpRouteAnnotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+    {{- if not (hasKey .Values.gateway.httpRouteAnnotations "external-dns.alpha.kubernetes.io/hostname") }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.webappDomain | quote }}
+    {{- end }}
     {{- $weight := include "webapp.externalDnsWeight" (dict "ctx" . "kind" "envoy") | trim -}}
     {{- if $weight }}
     external-dns.alpha.kubernetes.io/aws-weight: {{ $weight | quote }}

--- a/charts/webapp/templates/httproute.yaml
+++ b/charts/webapp/templates/httproute.yaml
@@ -1,5 +1,6 @@
 {{- $routingMode := include "webapp.routingMode" . -}}
-{{- if and .Values.routing.enabled (or (eq $routingMode "envoy") (eq $routingMode "migration")) }}
+{{- $routingEnabled := eq (include "webapp.routingEnabled" . | trim) "true" -}}
+{{- if and $routingEnabled (or (eq $routingMode "envoy") (eq $routingMode "migration")) }}
 {{- include "webapp.validateDomainConfig" . }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/charts/webapp/templates/httproute.yaml
+++ b/charts/webapp/templates/httproute.yaml
@@ -10,7 +10,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  {{- if or .Values.gateway.httpRouteAnnotations (eq $routingMode "migration") }}
+  {{- if or .Values.gateway.httpRouteAnnotations (eq $routingMode "migration") (eq $routingMode "envoy") }}
   annotations:
     {{- range $key, $val := .Values.gateway.httpRouteAnnotations }}
     {{ $key }}: {{ $val | quote }}

--- a/charts/webapp/templates/httproute.yaml
+++ b/charts/webapp/templates/httproute.yaml
@@ -1,0 +1,44 @@
+{{- $ingressMode := include "webapp.ingressMode" . -}}
+{{- if and .Values.ingress.enabled (or (eq $ingressMode "envoy") (eq $ingressMode "migration")) }}
+{{- include "webapp.validateDomainConfig" . }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "webapp.baseName" . }}
+  labels:
+    app: {{ include "webapp.baseName" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- if or .Values.ingress.httpRouteAnnotations (eq $ingressMode "migration") }}
+  annotations:
+    {{- range $key, $val := .Values.ingress.httpRouteAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- $weight := include "webapp.externalDnsWeight" (dict "ctx" . "kind" "envoy") | trim -}}
+    {{- if $weight }}
+    external-dns.alpha.kubernetes.io/aws-weight: {{ $weight | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  parentRefs:
+    - name: {{ required "ingress.gateway.name must be set when ingress.mode is envoy or migration" .Values.ingress.gateway.name | quote }}
+      {{- if .Values.ingress.gateway.namespace }}
+      namespace: {{ .Values.ingress.gateway.namespace | quote }}
+      {{- else }}
+      namespace: {{ .Release.Namespace | quote }}
+      {{- end }}
+      kind: Gateway
+      sectionName: {{ default "https" .Values.ingress.gateway.sectionName | quote }}
+  hostnames:
+    - {{ .Values.webappDomain | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "webapp.httpServiceName" . }}
+          port: {{ .Values.service.http.port | default .Values.service.http.internalPort }}
+          kind: Service
+{{- end }}

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- $routingMode := include "webapp.routingMode" . -}}
-{{- if and .Values.routing.enabled (or (eq $routingMode "nginx") (eq $routingMode "migration")) }}
+{{- $routingEnabled := eq (include "webapp.routingEnabled" . | trim) "true" -}}
+{{- if and $routingEnabled (or (eq $routingMode "nginx") (eq $routingMode "migration")) }}
 {{- include "webapp.validateDomainConfig" . }}
 {{- $ingressClass := default "nginx" .Values.ingress.className -}}
 {{- $backendDomain := "" -}}

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.ingress.enabled }}
+{{- $ingressMode := include "webapp.ingressMode" . -}}
+{{- if and .Values.ingress.enabled (or (eq $ingressMode "nginx") (eq $ingressMode "migration")) }}
 {{- include "webapp.validateDomainConfig" . }}
 {{- $ingressClass := default "nginx" .Values.ingress.className -}}
 {{- $backendDomain := "" -}}
@@ -17,6 +18,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if or .Values.ingress.annotations .Values.ingress.renderCSPInIngress (eq $ingressMode "migration") }}
   annotations:
     {{- range $key, $val := .Values.ingress.annotations }}
     {{ $key }}: {{ $val | quote }}
@@ -50,6 +52,11 @@ metadata:
         more_set_headers "content-security-policy: $CSP";
       }
     {{- end }}
+    {{- $weight := include "webapp.externalDnsWeight" (dict "ctx" . "kind" "nginx") | trim -}}
+    {{- if $weight }}
+    external-dns.alpha.kubernetes.io/aws-weight: {{ $weight | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   ingressClassName: {{ $ingressClass | quote }}
   {{- if .Values.tls.enabled }}

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -23,6 +23,10 @@ metadata:
     {{- range $key, $val := .Values.ingress.annotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+    {{- $setIdentifier := include "webapp.externalDnsSetIdentifier" (dict "ctx" . "kind" "nginx") | trim -}}
+    {{- if $setIdentifier }}
+    external-dns.alpha.kubernetes.io/set-identifier: {{ $setIdentifier | quote }}
+    {{- end }}
     {{- if .Values.ingress.renderCSPInIngress }}
     {{- if not (contains $ingressClass "nginx") }}
         {{- fail "In ingress CSP header setting only works with a 'nginx' controller. (Rename it to 'nginx-*' if it is one.)" }}

--- a/charts/webapp/templates/ingress.yaml
+++ b/charts/webapp/templates/ingress.yaml
@@ -1,5 +1,5 @@
-{{- $ingressMode := include "webapp.ingressMode" . -}}
-{{- if and .Values.ingress.enabled (or (eq $ingressMode "nginx") (eq $ingressMode "migration")) }}
+{{- $routingMode := include "webapp.routingMode" . -}}
+{{- if and .Values.routing.enabled (or (eq $routingMode "nginx") (eq $routingMode "migration")) }}
 {{- include "webapp.validateDomainConfig" . }}
 {{- $ingressClass := default "nginx" .Values.ingress.className -}}
 {{- $backendDomain := "" -}}
@@ -18,7 +18,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  {{- if or .Values.ingress.annotations .Values.ingress.renderCSPInIngress (eq $ingressMode "migration") }}
+  {{- if or .Values.ingress.annotations .Values.ingress.renderCSPInIngress (eq $routingMode "migration") }}
   annotations:
     {{- range $key, $val := .Values.ingress.annotations }}
     {{ $key }}: {{ $val | quote }}

--- a/charts/webapp/templates/issuer.yaml
+++ b/charts/webapp/templates/issuer.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.tls.createIssuer .Values.ingress.enabled (empty .Values.tls.existingSecretName) }}
 {{- include "webapp.validateDomainConfig" . }}
+{{- $solverController := include "webapp.ingressPrimaryController" . -}}
 apiVersion: cert-manager.io/v1
 {{- if or (eq .Values.tls.issuer.kind "Issuer") (eq .Values.tls.issuer.kind "ClusterIssuer") }}
 kind: "{{ .Values.tls.issuer.kind }}"
@@ -25,8 +26,17 @@ spec:
 {{- if .Values.certManager.customSolvers }}
 {{ toYaml .Values.certManager.customSolvers | indent 6 }}
 {{- else }}
+{{- if eq $solverController "envoy" }}
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: {{ required "ingress.gateway.name must be set when ingress.mode is envoy or migration" .Values.ingress.gateway.name | quote }}
+                namespace: {{ default .Release.Namespace .Values.ingress.gateway.namespace | quote }}
+                kind: Gateway
+{{- else }}
       - http01:
           ingress:
             class: {{ default "nginx" .Values.ingress.className }}
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/webapp/templates/issuer.yaml
+++ b/charts/webapp/templates/issuer.yaml
@@ -1,6 +1,6 @@
-{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.tls.createIssuer .Values.ingress.enabled (empty .Values.tls.existingSecretName) }}
+{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.tls.createIssuer .Values.routing.enabled (empty .Values.tls.existingSecretName) }}
 {{- include "webapp.validateDomainConfig" . }}
-{{- $solverController := include "webapp.ingressPrimaryController" . -}}
+{{- $solverController := include "webapp.routingPrimaryController" . -}}
 apiVersion: cert-manager.io/v1
 {{- if or (eq .Values.tls.issuer.kind "Issuer") (eq .Values.tls.issuer.kind "ClusterIssuer") }}
 kind: "{{ .Values.tls.issuer.kind }}"
@@ -30,8 +30,8 @@ spec:
       - http01:
           gatewayHTTPRoute:
             parentRefs:
-              - name: {{ required "ingress.gateway.name must be set when ingress.mode is envoy or migration" .Values.ingress.gateway.name | quote }}
-                namespace: {{ default .Release.Namespace .Values.ingress.gateway.namespace | quote }}
+              - name: {{ required "gateway.name must be set when routing.mode is envoy or migration" .Values.gateway.name | quote }}
+                namespace: {{ default .Release.Namespace .Values.gateway.namespace | quote }}
                 kind: Gateway
 {{- else }}
       - http01:

--- a/charts/webapp/templates/issuer.yaml
+++ b/charts/webapp/templates/issuer.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.tls.createIssuer .Values.routing.enabled (empty .Values.tls.existingSecretName) }}
+{{- $routingEnabled := eq (include "webapp.routingEnabled" . | trim) "true" -}}
+{{- if and .Values.tls.enabled .Values.tls.useCertManager .Values.tls.createIssuer $routingEnabled (empty .Values.tls.existingSecretName) }}
 {{- include "webapp.validateDomainConfig" . }}
 {{- $solverController := include "webapp.routingPrimaryController" . -}}
 apiVersion: cert-manager.io/v1

--- a/charts/webapp/templates/listenerset.yaml
+++ b/charts/webapp/templates/listenerset.yaml
@@ -1,5 +1,5 @@
-{{- $ingressMode := include "webapp.ingressMode" . -}}
-{{- if and .Values.ingress.enabled (or (eq $ingressMode "envoy") (eq $ingressMode "migration")) }}
+{{- $routingMode := include "webapp.routingMode" . -}}
+{{- if and .Values.routing.enabled (or (eq $routingMode "envoy") (eq $routingMode "migration")) }}
 {{- include "webapp.validateDomainConfig" . }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: ListenerSet
@@ -12,9 +12,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   parentRef:
-    name: {{ required "ingress.gateway.name must be set when ingress.mode is envoy or migration" .Values.ingress.gateway.name | quote }}
-    {{- if .Values.ingress.gateway.namespace }}
-    namespace: {{ .Values.ingress.gateway.namespace | quote }}
+    name: {{ required "gateway.name must be set when routing.mode is envoy or migration" .Values.gateway.name | quote }}
+    {{- if .Values.gateway.namespace }}
+    namespace: {{ .Values.gateway.namespace | quote }}
     {{- else }}
     namespace: {{ .Release.Namespace | quote }}
     {{- end }}

--- a/charts/webapp/templates/listenerset.yaml
+++ b/charts/webapp/templates/listenerset.yaml
@@ -1,5 +1,6 @@
 {{- $routingMode := include "webapp.routingMode" . -}}
-{{- if and .Values.routing.enabled (or (eq $routingMode "envoy") (eq $routingMode "migration")) }}
+{{- $routingEnabled := eq (include "webapp.routingEnabled" . | trim) "true" -}}
+{{- if and $routingEnabled (or (eq $routingMode "envoy") (eq $routingMode "migration")) }}
 {{- include "webapp.validateDomainConfig" . }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: ListenerSet

--- a/charts/webapp/templates/listenerset.yaml
+++ b/charts/webapp/templates/listenerset.yaml
@@ -1,0 +1,35 @@
+{{- $ingressMode := include "webapp.ingressMode" . -}}
+{{- if and .Values.ingress.enabled (or (eq $ingressMode "envoy") (eq $ingressMode "migration")) }}
+{{- include "webapp.validateDomainConfig" . }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: {{ include "webapp.listenerSetName" . }}
+  labels:
+    app: {{ include "webapp.baseName" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  parentRef:
+    name: {{ required "ingress.gateway.name must be set when ingress.mode is envoy or migration" .Values.ingress.gateway.name | quote }}
+    {{- if .Values.ingress.gateway.namespace }}
+    namespace: {{ .Values.ingress.gateway.namespace | quote }}
+    {{- else }}
+    namespace: {{ .Release.Namespace | quote }}
+    {{- end }}
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+    - name: {{ include "webapp.listenerName" . | quote }}
+      hostname: {{ .Values.webappDomain | quote }}
+      protocol: {{ include "webapp.listenerProtocol" . | quote }}
+      port: {{ include "webapp.listenerPort" . }}
+      {{- if .Values.tls.enabled }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: {{ include "webapp.tlsSecretName" . | quote }}
+      {{- end }}
+{{- end }}

--- a/charts/webapp/templates/service.yaml
+++ b/charts/webapp/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled }}
+{{- if .Values.routing.enabled }}
 {{- $appName := include "webapp.baseName" . -}}
 apiVersion: v1
 kind: Service

--- a/charts/webapp/templates/service.yaml
+++ b/charts/webapp/templates/service.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.routing.enabled }}
+{{- $routingEnabled := eq (include "webapp.routingEnabled" . | trim) "true" -}}
+{{- if $routingEnabled }}
 {{- $appName := include "webapp.baseName" . -}}
 apiVersion: v1
 kind: Service

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -19,6 +19,10 @@ appendReleaseNameToResources: false
 # webappDomain: webapp.example.com
 
 routing:
+  # `routing.enabled` controls whether the chart renders the shared HTTP Service
+  # plus either an Ingress (nginx mode) or Gateway API resources (envoy or
+  # migration mode). `ingress.enabled` remains a deprecated alias for one
+  # release so older values files keep working during the rename.
   enabled: false
   # Controller mode for web traffic:
   # - nginx: render only a Kubernetes Ingress
@@ -52,6 +56,11 @@ gateway:
   # - spec.gatewayClassName must point at the Envoy Gateway GatewayClass.
   # - spec.allowedListeners must allow ListenerSet attachments from this chart's namespace.
   #   `namespaces.from: All` is the broadest choice if you want to permit any namespace.
+  # - ExternalDNS must run with `--gateway-listener-sets` so it follows the ListenerSet
+  #   parentRef and publishes DNS targets for envoy or migration mode. Without it,
+  #   Envoy may accept the route while ExternalDNS emits no target, which breaks the
+  #   weighted migration path. That flag is disabled by default and requires Gateway
+  #   API v1.5+ CRDs.
   # Example:
   # apiVersion: gateway.networking.k8s.io/v1
   # kind: Gateway
@@ -67,11 +76,16 @@ gateway:
   #     - name: http
   #       protocol: HTTP
   #       port: 80
+  #       allowedRoutes:
+  #         namespaces:
+  #           from: All
   # - This chart creates a ListenerSet in the release namespace and an HTTPRoute that
   #   attaches to it. When using a shared Gateway namespace, set `gateway.namespace`
   #   to that namespace.
-  # - If tls.useCertManager=true and you rely on the default HTTP01 solver, the Gateway
-  #   must also expose an HTTP listener on port 80, or you must provide custom solvers.
+  # - If tls.useCertManager=true and you rely on the default HTTP01 solver, cert-manager's
+  #   Gateway API integration must be enabled. When `gateway.namespace` differs from the
+  #   release namespace, the port 80 listener must also allow routes from the Certificate
+  #   namespace, for example with `allowedRoutes.namespaces.from: All`.
   # Gateway name used when routing.mode is envoy or migration.
   name: ""
   # Optional namespace of the Gateway. Defaults to the release namespace.
@@ -86,6 +100,10 @@ gateway:
 
 tls:
   enabled: false
+  # Set this to true when cert-manager should provision the certificate using
+  # its Gateway API HTTP-01 solver. This requires cert-manager's Gateway API
+  # integration to be enabled, and the Gateway listener must allow the solver
+  # namespace when the Gateway lives outside the release namespace.
   useCertManager: false
   createIssuer: false
   # existingSecretName: "" # set this if you created e.g. a wildcard cert outside this chart

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -46,6 +46,9 @@ gateway:
   # - If you are running an older Envoy Gateway release, check that release's docs for
   #   any feature gate or compatibility notes before enabling this chart.
   # - A Gateway (gateway.networking.k8s.io/v1) must already exist, or be created separately.
+  # - In the shared setup we use in staging, the Gateway lives in a dedicated
+  #   namespace such as `web-gateway` and the chart's ListenerSet points there
+  #   via `gateway.namespace`.
   # - spec.gatewayClassName must point at the Envoy Gateway GatewayClass.
   # - spec.allowedListeners must allow ListenerSet attachments from this chart's namespace.
   #   `namespaces.from: All` is the broadest choice if you want to permit any namespace.
@@ -53,19 +56,27 @@ gateway:
   # apiVersion: gateway.networking.k8s.io/v1
   # kind: Gateway
   # metadata:
-  #   name: envoy-gateway
+  #   name: webapp-gateway
+  #   namespace: web-gateway
   # spec:
-  #   gatewayClassName: envoy-gateway # use the GatewayClass installed by Envoy Gateway
+  #   gatewayClassName: envoy # use the GatewayClass installed by Envoy Gateway
   #   allowedListeners:
   #     namespaces:
   #       from: All
+  #   listeners:
+  #     - name: http
+  #       protocol: HTTP
+  #       port: 80
   # - This chart creates a ListenerSet in the release namespace and an HTTPRoute that
-  #   attaches to it.
+  #   attaches to it. When using a shared Gateway namespace, set `gateway.namespace`
+  #   to that namespace.
   # - If tls.useCertManager=true and you rely on the default HTTP01 solver, the Gateway
   #   must also expose an HTTP listener on port 80, or you must provide custom solvers.
   # Gateway name used when routing.mode is envoy or migration.
   name: ""
   # Optional namespace of the Gateway. Defaults to the release namespace.
+  # Set this to a shared Gateway namespace like `web-gateway` when you keep the
+  # Envoy Gateway entrypoint separate from the application namespace.
   namespace: ""
   # Listener section name used by the ListenerSet and HTTPRoute parentRef.
   # Defaults to https when tls.enabled=true, otherwise http.

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -27,12 +27,39 @@ ingress:
   mode: nginx
   className: nginx
   gateway:
+    # Envoy Gateway / Gateway API expectations when ingress.mode is envoy or migration:
+    # - Envoy Gateway v1.7.0 or newer is required for ListenerSet support.
+    # - ListenerSet is experimental in Envoy Gateway and must be enabled with the
+    #   `XListenerSet` feature flag in the EnvoyGateway configuration.
+    # - A Gateway (gateway.networking.k8s.io/v1) must already exist, or be created separately.
+    # - spec.gatewayClassName must point at the Envoy Gateway GatewayClass.
+    # - spec.allowedListeners must allow ListenerSet attachments from this chart's namespace.
+    #   `namespaces.from: All` is the broadest choice if you want to permit any namespace.
+    # Example:
+    # apiVersion: gateway.networking.k8s.io/v1
+    # kind: Gateway
+    # metadata:
+    #   name: envoy-gateway
+    # spec:
+    #   gatewayClassName: envoy-gateway # use the GatewayClass installed by Envoy Gateway
+    #   allowedListeners:
+    #     namespaces:
+    #       from: All
+    #   listeners:
+    #     - name: http
+    #       protocol: HTTP
+    #       port: 80
+    # - This chart creates a ListenerSet in the release namespace and an HTTPRoute that
+    #   attaches to it.
+    # - If tls.useCertManager=true and you rely on the default HTTP01 solver, the Gateway
+    #   must also expose an HTTP listener on port 80, or you must provide custom solvers.
     # Gateway name used when ingress.mode is envoy or migration.
     name: ""
     # Optional namespace of the Gateway. Defaults to the release namespace.
     namespace: ""
-    # Listener section name used by the HTTPRoute parentRef.
-    sectionName: https
+    # Listener section name used by the ListenerSet and HTTPRoute parentRef.
+    # Defaults to https when tls.enabled=true, otherwise http.
+    sectionName: ""
   migration:
     # Which controller should receive external-dns weight 100 during migration.
     # The other resource receives weight 0.

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -20,8 +20,27 @@ appendReleaseNameToResources: false
 
 ingress:
   enabled: false
+  # Controller mode for web traffic:
+  # - nginx: render only a Kubernetes Ingress
+  # - envoy: render only a Gateway API HTTPRoute
+  # - migration: render both and split external-dns weights between them
+  mode: nginx
   className: nginx
+  gateway:
+    # Gateway name used when ingress.mode is envoy or migration.
+    name: ""
+    # Optional namespace of the Gateway. Defaults to the release namespace.
+    namespace: ""
+    # Listener section name used by the HTTPRoute parentRef.
+    sectionName: https
+  migration:
+    # Which controller should receive external-dns weight 100 during migration.
+    # The other resource receives weight 0.
+    primary: nginx
+  # Ingress-specific annotations.
   annotations: {}
+  # HTTPRoute-specific annotations.
+  httpRouteAnnotations: {}
   renderCSPInIngress: false
 
 tls:

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -41,6 +41,8 @@ ingress:
   annotations: {}
   # HTTPRoute-specific annotations.
   httpRouteAnnotations: {}
+  # nginx-only override for proxy-side CSP injection. The webapp server already
+  # emits CSP headers itself, so Envoy mode does not need a proxy-side CSP path.
   renderCSPInIngress: false
 
 tls:

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -18,59 +18,60 @@ appendReleaseNameToResources: false
 
 # webappDomain: webapp.example.com
 
-ingress:
+routing:
   enabled: false
   # Controller mode for web traffic:
   # - nginx: render only a Kubernetes Ingress
   # - envoy: render only a Gateway API HTTPRoute
   # - migration: render both and split external-dns weights between them
   mode: nginx
-  className: nginx
-  gateway:
-    # Envoy Gateway / Gateway API expectations when ingress.mode is envoy or migration:
-    # - Envoy Gateway v1.7.0 or newer is required for ListenerSet support.
-    # - ListenerSet is experimental in Envoy Gateway and must be enabled with the
-    #   `XListenerSet` feature flag in the EnvoyGateway configuration.
-    # - A Gateway (gateway.networking.k8s.io/v1) must already exist, or be created separately.
-    # - spec.gatewayClassName must point at the Envoy Gateway GatewayClass.
-    # - spec.allowedListeners must allow ListenerSet attachments from this chart's namespace.
-    #   `namespaces.from: All` is the broadest choice if you want to permit any namespace.
-    # Example:
-    # apiVersion: gateway.networking.k8s.io/v1
-    # kind: Gateway
-    # metadata:
-    #   name: envoy-gateway
-    # spec:
-    #   gatewayClassName: envoy-gateway # use the GatewayClass installed by Envoy Gateway
-    #   allowedListeners:
-    #     namespaces:
-    #       from: All
-    #   listeners:
-    #     - name: http
-    #       protocol: HTTP
-    #       port: 80
-    # - This chart creates a ListenerSet in the release namespace and an HTTPRoute that
-    #   attaches to it.
-    # - If tls.useCertManager=true and you rely on the default HTTP01 solver, the Gateway
-    #   must also expose an HTTP listener on port 80, or you must provide custom solvers.
-    # Gateway name used when ingress.mode is envoy or migration.
-    name: ""
-    # Optional namespace of the Gateway. Defaults to the release namespace.
-    namespace: ""
-    # Listener section name used by the ListenerSet and HTTPRoute parentRef.
-    # Defaults to https when tls.enabled=true, otherwise http.
-    sectionName: ""
   migration:
     # Which controller should receive external-dns weight 100 during migration.
     # The other resource receives weight 0.
     primary: nginx
-  # Ingress-specific annotations.
+
+ingress:
+  # nginx Ingress settings.
+  className: nginx
   annotations: {}
-  # HTTPRoute-specific annotations.
-  httpRouteAnnotations: {}
   # nginx-only override for proxy-side CSP injection. The webapp server already
   # emits CSP headers itself, so Envoy mode does not need a proxy-side CSP path.
   renderCSPInIngress: false
+
+gateway:
+  # Envoy Gateway / Gateway API expectations when routing.mode is envoy or migration:
+  # - ListenerSet is a Gateway API standard-channel resource as of Gateway API v1.5.0.
+  # - Use an Envoy Gateway release that supports ListenerSet in your cluster; recent
+  #   Envoy Gateway 1.8.x release notes and tests use the stable `ListenerSet` API.
+  # - If you are running an older Envoy Gateway release, check that release's docs for
+  #   any feature gate or compatibility notes before enabling this chart.
+  # - A Gateway (gateway.networking.k8s.io/v1) must already exist, or be created separately.
+  # - spec.gatewayClassName must point at the Envoy Gateway GatewayClass.
+  # - spec.allowedListeners must allow ListenerSet attachments from this chart's namespace.
+  #   `namespaces.from: All` is the broadest choice if you want to permit any namespace.
+  # Example:
+  # apiVersion: gateway.networking.k8s.io/v1
+  # kind: Gateway
+  # metadata:
+  #   name: envoy-gateway
+  # spec:
+  #   gatewayClassName: envoy-gateway # use the GatewayClass installed by Envoy Gateway
+  #   allowedListeners:
+  #     namespaces:
+  #       from: All
+  # - This chart creates a ListenerSet in the release namespace and an HTTPRoute that
+  #   attaches to it.
+  # - If tls.useCertManager=true and you rely on the default HTTP01 solver, the Gateway
+  #   must also expose an HTTP listener on port 80, or you must provide custom solvers.
+  # Gateway name used when routing.mode is envoy or migration.
+  name: ""
+  # Optional namespace of the Gateway. Defaults to the release namespace.
+  namespace: ""
+  # Listener section name used by the ListenerSet and HTTPRoute parentRef.
+  # Defaults to https when tls.enabled=true, otherwise http.
+  sectionName: ""
+  # HTTPRoute-specific annotations.
+  httpRouteAnnotations: {}
 
 tls:
   enabled: false


### PR DESCRIPTION




<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24493" title="WPB-24493" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24493</a>  add gateway support to webapp ingress (part of webapp helm chart)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->




In general we wish to switch from ingress-nginx to envoy-gateway. This has already been added as an option when the webapp is installed as part of the wire-server bundle (see https://github.com/wireapp/wire-server/pull/5150
 and related PRs). But when using this chart standalone, it also needs to be added here.

Ticket: https://wearezeta.atlassian.net/browse/WPB-24493

This PR goes beyond the minimal needed work though, and also does these things:

1. Introduces `ListenerSet`s. It's a newer object available since a few months, that makes it easier to share one gateway and EnvoyProxy for different domains, and define the ListernerSet / domains in the chart / overrides, without having to touch any infra.
2. Tests this thoroughly with three argocd-based deployments on three different domains:

## Deployments

- [x] Regression deployment: The default nginx-ingress helm chart is being deployed through argo
https://argocd.apps-staging.ops.zinfra.io/applications/argo-cd/webapp-pr-21860 using [these overrides](https://github.com/wireapp/argocd-web/blob/main/values/webapp/pr/nginx.yaml) and is available under https://webapp-pr-21860.apps-staging.wire.link
    - the only helm change is from `ingress: enabled: true` to `routing: enabled: true / mode: nginx` but I believe the standalone webapp is not being used/deployed anywhere except through argo manifests (which is updated alongside this PR)
- [x] Envoy based deployment: Using [these overrides](https://github.com/wireapp/argocd-web/blob/main/values/webapp/pr/envoy-gateway.yaml) this gets deployed with Argo and is available under https://webapp-pr-21860-envoy.apps-staging.wire.link and hinges on some extra infra in cailleach [this](https://github.com/zinfra/cailleach/pull/4612) and [this one](https://github.com/zinfra/cailleach/pull/4645)

Based on the the two modes there's a second "migration" mode which sets two extra annotations and then allows for a weighted DNS cutover without downtime:

- [x] Migration deployment online under https://webapp-pr-21860-migration.apps-staging.wire.link. See also [this confluence page](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/3095527493/How+to+cut+traffic+from+nginx-ingress+to+envoy-gateway+without+downtime+on+the+example+of+a+standalone+webapp) for more details. TL;DR: you can toggle/revert [this commit](https://github.com/wireapp/argocd-web/commit/72c75df65d2711d835ad451703ea68aea22a6f33) to switch incoming traffic for that url to either go through envoy-gateway or through ingress-nginx.


