### PR TITLE
Do not cache runtime configuration [WPB-26469]

### DIFF
--- a/apps/server/Server.test.ts
+++ b/apps/server/Server.test.ts
@@ -1,0 +1,242 @@
+import http from 'http';
+import type {Express} from 'express';
+
+import {createFactory} from '@enormora/objectory';
+import is from '@sindresorhus/is';
+import type {ClientConfig, ServerConfig} from '@wireapp/config';
+
+import {Server} from './Server';
+
+type HttpResponse = {
+  readonly body: string;
+  readonly headers: http.IncomingHttpHeaders;
+  readonly statusCode: number | undefined;
+};
+
+type ServerInternals = {
+  readonly app: Express;
+};
+
+const nonCacheHeaders = {
+  cacheControl: 'no-store, no-cache, must-revalidate, proxy-revalidate',
+  expires: '0',
+  pragma: 'no-cache',
+  surrogateControl: 'no-store',
+};
+
+type ServerResponseTestCase = {
+  readonly expectedBody?: string;
+  readonly expectedContentType?: string;
+  readonly requestPath: string;
+};
+
+const nonCacheableResponseTestCaseFactory = createFactory<ServerResponseTestCase>(() => {
+  return {
+    expectedContentType: 'application/javascript',
+    requestPath: '/config.js',
+  };
+});
+
+const metadataResponseTestCaseFactory = createFactory<ServerResponseTestCase>(() => {
+  return {
+    expectedBody: 'abc123',
+    requestPath: '/commit',
+  };
+});
+
+function createServerConfiguration(): ServerConfig {
+  return {
+    APP_BASE: 'https://app.example.com',
+    BACKEND_REST: 'https://backend.example.com',
+    BACKEND_WS: 'wss://backend.example.com',
+    CACHE_DURATION_SECONDS: 300,
+    COMMIT: 'abc123',
+    CSP: {},
+    DEVELOPMENT: false,
+    DEVELOPMENT_ENABLE_TLS: false,
+    ENABLE_CLIENT_VERSION_ENFORCEMENT: false,
+    ENABLE_DYNAMIC_HOSTNAME: false,
+    ENFORCE_HTTPS: false,
+    ENVIRONMENT: 'production',
+    GOOGLE_WEBMASTER_ID: '',
+    OPEN_GRAPH: {
+      DESCRIPTION: '',
+      IMAGE_URL: '',
+      TITLE: '',
+    },
+    PORT_HTTP: 0,
+    ROBOTS: {
+      ALLOW: 'allow',
+      ALLOWED_HOSTS: ['app.wire.com'],
+      DISALLOW: 'disallow',
+    },
+    SSL_CERTIFICATE_KEY_PATH: '/tmp/key.pem',
+    SSL_CERTIFICATE_PATH: '/tmp/cert.pem',
+    VERSION: '2026.03.16.10.30.00',
+  };
+}
+
+function createClientConfiguration(): ClientConfig {
+  return {
+    BACKEND_REST: 'https://backend.example.com',
+    BACKEND_WS: 'wss://backend.example.com',
+    FEATURE: {
+      ENABLE_CHANNELS: true,
+    },
+  } as unknown as ClientConfig;
+}
+
+function getServerApplication(server: Server): Express {
+  return (server as unknown as ServerInternals).app;
+}
+
+function openHttpServer(httpServer: http.Server): Promise<string> {
+  return new Promise((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(0, '127.0.0.1', () => {
+      const address = httpServer.address();
+      if (is.nullOrUndefined(address) || is.string(address)) {
+        reject(new Error('Expected the test HTTP server to listen on a TCP port.'));
+        return;
+      }
+
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+function closeHttpServer(httpServer: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    httpServer.close(error => {
+      if (is.error(error)) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function withHttpServer(
+  clientConfiguration: ClientConfig,
+  runTest: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+  const server = new Server(createServerConfiguration(), clientConfiguration);
+  const httpServer = http.createServer(getServerApplication(server));
+  let serverIsListening = false;
+
+  try {
+    const baseUrl = await openHttpServer(httpServer);
+    serverIsListening = true;
+    await runTest(baseUrl);
+  } finally {
+    if (serverIsListening) {
+      await closeHttpServer(httpServer);
+    }
+  }
+}
+
+function requestHttpResponse(baseUrl: string, requestPath: string): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const request = http.get(`${baseUrl}${requestPath}`, response => {
+      const responseBodyChunks: Buffer[] = [];
+
+      response.on('data', responseBodyChunk => {
+        responseBodyChunks.push(Buffer.from(responseBodyChunk));
+      });
+      response.on('end', () => {
+        resolve({
+          body: Buffer.concat(responseBodyChunks).toString('utf8'),
+          headers: response.headers,
+          statusCode: response.statusCode,
+        });
+      });
+    });
+
+    request.on('error', reject);
+  });
+}
+
+function getResponseHeader(response: HttpResponse, headerName: string): string {
+  const headerValue = response.headers[headerName];
+  if (!is.string(headerValue)) {
+    throw new Error(`Expected response header '${headerName}' to be a string.`);
+  }
+
+  return headerValue;
+}
+
+function expectNonCacheableResponse(response: HttpResponse): void {
+  if (!is.number(response.statusCode)) {
+    throw new Error('Expected the HTTP response to have a status code.');
+  }
+
+  expect(response.statusCode).toBe(200);
+  expect(getResponseHeader(response, 'cache-control')).toBe(nonCacheHeaders.cacheControl);
+  expect(getResponseHeader(response, 'pragma')).toBe(nonCacheHeaders.pragma);
+  expect(getResponseHeader(response, 'expires')).toBe(nonCacheHeaders.expires);
+  expect(getResponseHeader(response, 'surrogate-control')).toBe(nonCacheHeaders.surrogateControl);
+}
+
+describe('server response caching', () => {
+  function createServerResponseTest(testCase: ServerResponseTestCase): () => Promise<void> {
+    return async () => {
+      const clientConfiguration = createClientConfiguration();
+
+      await withHttpServer(clientConfiguration, async baseUrl => {
+        const response = await requestHttpResponse(baseUrl, testCase.requestPath);
+
+        if (testCase.expectedBody !== undefined) {
+          expect(response.body).toContain(testCase.expectedBody);
+        }
+
+        if (is.nonEmptyString(testCase.expectedContentType)) {
+          expect(getResponseHeader(response, 'content-type')).toContain(testCase.expectedContentType);
+        }
+
+        expectNonCacheableResponse(response);
+      });
+    };
+  }
+
+  [
+    nonCacheableResponseTestCaseFactory.build(),
+    nonCacheableResponseTestCaseFactory.build({requestPath: '/config.js?v=immutable-looking-value'}),
+  ].forEach(testCase => {
+    it(`returns non-cache headers for ${testCase.requestPath}`, createServerResponseTest(testCase));
+  });
+
+  it('returns the serialized runtime configuration from /config.js', async () => {
+    const clientConfiguration = createClientConfiguration();
+
+    await withHttpServer(clientConfiguration, async baseUrl => {
+      const response = await requestHttpResponse(baseUrl, '/config.js');
+
+      expect(response.body).toContain(`window.wire.env = ${JSON.stringify(clientConfiguration)};`);
+    });
+  });
+
+  [
+    metadataResponseTestCaseFactory.build({
+      expectedBody: JSON.stringify({version: '2026.03.16.10.30.00'}),
+      requestPath: '/version',
+    }),
+    metadataResponseTestCaseFactory.build(),
+  ].forEach(testCase => {
+    it(`keeps non-cache headers for ${testCase.requestPath}`, createServerResponseTest(testCase));
+  });
+
+  it('keeps the public cache policy for ordinary responses', async () => {
+    await withHttpServer(createClientConfiguration(), async baseUrl => {
+      const response = await requestHttpResponse(baseUrl, '/_health');
+
+      if (!is.number(response.statusCode)) {
+        throw new Error('Expected the HTTP response to have a status code.');
+      }
+
+      expect(response.statusCode).toBe(200);
+      expect(getResponseHeader(response, 'cache-control')).toBe('public, max-age=300');
+    });
+  });
+});

--- a/apps/server/http/setNonCacheHeaders.test.ts
+++ b/apps/server/http/setNonCacheHeaders.test.ts
@@ -1,0 +1,42 @@
+import type {Response} from 'express';
+
+import {setNonCacheHeaders} from './setNonCacheHeaders';
+
+type HeaderValueMap = Record<string, string>;
+
+type ResponseWithHeaderCapture = {
+  readonly headerValues: HeaderValueMap;
+  readonly response: Response;
+};
+
+function createResponseWithHeaderCapture(): ResponseWithHeaderCapture {
+  const headerValues: HeaderValueMap = {};
+  const response = {
+    set(name: string, value: string) {
+      headerValues[name] = value;
+
+      return this;
+    },
+  } as unknown as Response;
+
+  return {
+    headerValues,
+    response,
+  };
+}
+
+describe('setNonCacheHeaders', () => {
+  it('sets the non-cache response headers and returns the response', () => {
+    const {headerValues, response} = createResponseWithHeaderCapture();
+
+    const returnedResponse = setNonCacheHeaders(response);
+
+    expect(returnedResponse).toBe(response);
+    expect(headerValues).toEqual({
+      'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+      Expires: '0',
+      Pragma: 'no-cache',
+      'Surrogate-Control': 'no-store',
+    });
+  });
+});

--- a/apps/server/http/setNonCacheHeaders.ts
+++ b/apps/server/http/setNonCacheHeaders.ts
@@ -1,0 +1,29 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {Response} from 'express';
+
+export function setNonCacheHeaders(response: Response): Response {
+  response.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+  response.set('Pragma', 'no-cache');
+  response.set('Expires', '0');
+  response.set('Surrogate-Control', 'no-store');
+
+  return response;
+}

--- a/apps/server/jest.config.js
+++ b/apps/server/jest.config.js
@@ -42,10 +42,13 @@ module.exports = {
   },
   coverageReporters: isContinuousIntegrationEnvironment ? ['html', 'lcov', 'text-summary'] : undefined,
   moduleDirectories: ['node_modules', __dirname],
+  moduleNameMapper: {
+    '^@enormora/objectory$': '<rootDir>/../../node_modules/@enormora/objectory/main.js',
+  },
   reporters: isContinuousIntegrationEnvironment ? ['github-actions', 'summary'] : ['default'],
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/dist'],
-  transformIgnorePatterns: ['/node_modules/(?!(true-myth|@sindresorhus/is)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(true-myth|@sindresorhus/is|@enormora/objectory)/)'],
   transform: {
     '^.+\\.(ts|tsx)$': 'babel-jest',
     '^.+\\.(js|jsx)$': 'babel-jest',

--- a/apps/server/routes/clientVersionCheck/clientVersionCheckRoute.ts
+++ b/apps/server/routes/clientVersionCheck/clientVersionCheckRoute.ts
@@ -22,7 +22,7 @@ import {Router} from 'express';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {result, type Result} from 'true-myth';
 
-import {setNonCacheHeaders} from '../redirectRoutes';
+import {setNonCacheHeaders} from '../../http/setNonCacheHeaders';
 
 type ClientVersionCheckRouteDependencies = {
   readonly router: ReturnType<typeof Router>;

--- a/apps/server/routes/config/configRoute.ts
+++ b/apps/server/routes/config/configRoute.ts
@@ -21,6 +21,7 @@ import {Router} from 'express';
 
 import type {ClientConfig, ServerConfig} from '@wireapp/config';
 
+import {setNonCacheHeaders} from '../../http/setNonCacheHeaders';
 import {replaceHostname} from '../../util/hostnameReplacer';
 
 export const ConfigRoute = (serverConfig: ServerConfig, clientConfig: ClientConfig) =>
@@ -30,5 +31,7 @@ export const ConfigRoute = (serverConfig: ServerConfig, clientConfig: ClientConf
       ? // In case we want URLs that depends on the the hostname, we need to replace the placeholder with the actual hostname.
         replaceHostname(serializedConfig, request)
       : serializedConfig;
-    res.type('application/javascript').send(payload);
+    const response = setNonCacheHeaders(res);
+
+    return response.type('application/javascript').send(payload);
   });

--- a/apps/server/routes/redirectRoutes.test.ts
+++ b/apps/server/routes/redirectRoutes.test.ts
@@ -2,36 +2,13 @@ import {type Request, type Response} from 'express';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {Maybe} from 'true-myth';
 
-import {createJoinConversationRedirectUrl, redirectToJoinConversation, setNonCacheHeaders} from './redirectRoutes';
-
-type HeaderValueMap = Record<string, string>;
-
-type ResponseWithHeaderCapture = {
-  readonly headerValues: HeaderValueMap;
-  readonly response: Response;
-};
+import {createJoinConversationRedirectUrl, redirectToJoinConversation} from './redirectRoutes';
 
 type JoinRedirectResponse = {
   readonly response: Response;
   readonly redirect: jest.Mock;
   readonly sendStatus: jest.Mock;
 };
-
-function createResponseWithHeaderCapture(): ResponseWithHeaderCapture {
-  const headerValues: HeaderValueMap = {};
-  const response = {
-    set(name: string, value: string) {
-      headerValues[name] = value;
-
-      return this;
-    },
-  } as unknown as Response;
-
-  return {
-    headerValues,
-    response,
-  };
-}
 
 function createJoinRedirectResponse(): JoinRedirectResponse {
   const redirect = jest.fn();
@@ -124,21 +101,5 @@ describe('RedirectRoutes join redirect', () => {
       '/auth/?join_key=key&join_code=code#/join-conversation',
     );
     expect(sendStatus).not.toHaveBeenCalled();
-  });
-});
-
-describe('RedirectRoutes response caching', () => {
-  it('sets non-cache headers for version metadata responses', () => {
-    const {headerValues, response} = createResponseWithHeaderCapture();
-
-    const returnedResponse = setNonCacheHeaders(response);
-
-    expect(returnedResponse).toBe(response);
-    expect(headerValues).toEqual({
-      'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
-      Expires: '0',
-      Pragma: 'no-cache',
-      'Surrogate-Control': 'no-store',
-    });
   });
 });

--- a/apps/server/routes/redirectRoutes.ts
+++ b/apps/server/routes/redirectRoutes.ts
@@ -24,6 +24,7 @@ import {Maybe, maybe} from 'true-myth';
 
 import type {ServerConfig} from '@wireapp/config';
 
+import {setNonCacheHeaders} from '../http/setNonCacheHeaders';
 import * as BrowserUtil from '../util/browserUtil';
 
 const router = express.Router();
@@ -62,15 +63,6 @@ export function redirectToJoinConversation(request: Request, response: Response)
     },
     redirectUrl,
   );
-}
-
-export function setNonCacheHeaders(response: Response): Response {
-  response.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
-  response.set('Pragma', 'no-cache');
-  response.set('Expires', '0');
-  response.set('Surrogate-Control', 'no-store');
-
-  return response;
 }
 
 export const RedirectRoutes = (config: ServerConfig) => [

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -5,6 +5,9 @@
     "module": "commonjs",
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
+    "paths": {
+      "@enormora/objectory": ["node_modules/@enormora/objectory/main.d.ts"]
+    },
     "removeComments": true,
     "lib": ["esnext"],
     "noEmitOnError": true,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Makes the dynamically generated `/config.js` response explicitly non-cacheable.

## Problem

The global server cache policy also applied to `/config.js`, allowing runtime configuration from an earlier deployment to remain cached for up to five minutes.

This can combine newly deployed application code with stale backend URLs or environment configuration.

## Changes

`/config.js` now uses the same non-cache policy as `/version` and `/commit`:

```text
Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate
Pragma: no-cache
Expires: 0
Surrogate-Control: no-store
````

The policy applies regardless of query parameters.

The existing cache behavior for all other responses remains unchanged.

## Tracking

Part of #21597