### PR TITLE
Verify deployed version and commit [WPB-26469]

### DIFF
--- a/.github/workflows/precommit-slot-run.yml
+++ b/.github/workflows/precommit-slot-run.yml
@@ -23,6 +23,9 @@ on:
       expectedVersion:
         type: string
         required: false
+      expectedCommit:
+        type: string
+        required: false
       grep:
         type: string
         required: false
@@ -117,11 +120,12 @@ jobs:
           echo "Resolved precommit URL: https://$ENV_NAME.zinfra.io/"
           echo "url=https://$ENV_NAME.zinfra.io/" >> "$GITHUB_OUTPUT"
 
-      - name: Verify precommit runtime backend
-        if: ${{ inputs.expectedBackendRest && inputs.expectedBackendWs }}
+      - name: Verify precommit runtime
+        if: ${{ inputs.expectedVersion || inputs.expectedCommit || inputs.expectedBackendRest || inputs.expectedBackendWs }}
         env:
           EXPECTED_BACKEND_REST: ${{ inputs.expectedBackendRest }}
           EXPECTED_BACKEND_WS: ${{ inputs.expectedBackendWs }}
+          EXPECTED_COMMIT: ${{ inputs.expectedCommit }}
           EXPECTED_VERSION: ${{ inputs.expectedVersion }}
           PRECOMMIT_URL: ${{ steps.fetch_url.outputs.url }}
         run: |
@@ -135,20 +139,38 @@ jobs:
           expected_backend_ws="$(normalize_url "${EXPECTED_BACKEND_WS}")"
 
           for attempt_number in {1..10}; do
-            runtime_config="$(curl --fail --silent --show-error "${PRECOMMIT_URL}config.js" || true)"
+            version_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${PRECOMMIT_URL}version" || true)"
+            commit_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${PRECOMMIT_URL}commit" || true)"
+            runtime_config="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${PRECOMMIT_URL}config.js" || true)"
+
+            actual_version="$(
+              printf '%s' "${version_response}" |
+                jq --raw-output '.version'
+            )" || actual_version=''
+            actual_commit="$(
+              printf '%s' "${commit_response}" |
+                tr -d '\r\n'
+            )"
             actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
             actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
-            actual_version="$(printf '%s' "${runtime_config}" | sed -n 's/.*"VERSION":"\([^"]*\)".*/\1/p')"
 
-            if [[ "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" && "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}" && ( -z "${EXPECTED_VERSION}" || "${actual_version}" == "${EXPECTED_VERSION}" ) ]]; then
+            if [[
+              ( -z "${EXPECTED_VERSION}" || "${actual_version}" == "${EXPECTED_VERSION}" ) &&
+              ( -z "${EXPECTED_COMMIT}" || "${actual_commit}" == "${EXPECTED_COMMIT}" ) &&
+              ( -z "${EXPECTED_BACKEND_REST}" || "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" ) &&
+              ( -z "${EXPECTED_BACKEND_WS}" || "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}" )
+            ]]; then
               exit 0
             fi
 
-            echo "Precommit runtime configuration does not match the current artifact and Staging backend on attempt ${attempt_number}: REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}, VERSION=${actual_version:-missing}." >&2
-            sleep 6
+            echo "Precommit runtime verification mismatch on attempt ${attempt_number}: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}." >&2
+
+            if [[ "${attempt_number}" -lt 10 ]]; then
+              sleep 6
+            fi
           done
 
-          echo "Precommit runtime configuration did not match the expected Staging endpoints and artifact version." >&2
+          echo "Precommit runtime verification failed after 10 attempts." >&2
           exit 1
 
       - name: Deployment Status

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -199,11 +199,12 @@ jobs:
           deployment-timeout: 150
           use-existing-application-version-if-available: true
 
-      - name: Verify Beta runtime backend
+      - name: Verify Beta runtime
         env:
           BETA_WEBAPP_URL: ${{ env.BETA_WEBAPP_URL }}
           EXPECTED_BACKEND_REST: ${{ env.BETA_RUNTIME_BACKEND_REST }}
           EXPECTED_BACKEND_WS: ${{ env.BETA_RUNTIME_BACKEND_WS }}
+          EXPECTED_COMMIT: ${{ needs.build_artifact.outputs.release_commit_sha }}
           EXPECTED_VERSION: ${{ needs.build_artifact.outputs.artifact_version }}
         run: |
           set -euo pipefail
@@ -216,20 +217,38 @@ jobs:
           expected_backend_ws="$(normalize_url "${EXPECTED_BACKEND_WS}")"
 
           for attempt_number in {1..10}; do
-            runtime_config="$(curl --fail --silent --show-error "${BETA_WEBAPP_URL}config.js" || true)"
+            version_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${BETA_WEBAPP_URL}version" || true)"
+            commit_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${BETA_WEBAPP_URL}commit" || true)"
+            runtime_config="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${BETA_WEBAPP_URL}config.js" || true)"
+
+            actual_version="$(
+              printf '%s' "${version_response}" |
+                jq --raw-output '.version'
+            )" || actual_version=''
+            actual_commit="$(
+              printf '%s' "${commit_response}" |
+                tr -d '\r\n'
+            )"
             actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
             actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
-            actual_version="$(printf '%s' "${runtime_config}" | sed -n 's/.*"VERSION":"\([^"]*\)".*/\1/p')"
 
-            if [[ "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" && "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}" && "${actual_version}" == "${EXPECTED_VERSION}" ]]; then
+            if [[
+              "${actual_version}" == "${EXPECTED_VERSION}" &&
+              "${actual_commit}" == "${EXPECTED_COMMIT}" &&
+              "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" &&
+              "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}"
+            ]]; then
               exit 0
             fi
 
-            echo "Beta runtime configuration does not match the current artifact and Production backend on attempt ${attempt_number}: REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}, VERSION=${actual_version:-missing}." >&2
-            sleep 6
+            echo "Beta runtime verification mismatch on attempt ${attempt_number}: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}." >&2
+
+            if [[ "${attempt_number}" -lt 10 ]]; then
+              sleep 6
+            fi
           done
 
-          echo "Beta runtime configuration did not match the expected Production endpoints and artifact version." >&2
+          echo "Beta runtime verification failed after 10 attempts." >&2
           exit 1
 
   create_beta_tag:
@@ -302,6 +321,7 @@ jobs:
       expectedBackendRest: https://staging-nginz-https.zinfra.io/
       expectedBackendWs: wss://staging-nginz-ssl.zinfra.io/
       expectedVersion: ${{ needs.build_artifact.outputs.artifact_version }}
+      expectedCommit: ${{ needs.build_artifact.outputs.release_commit_sha }}
       grep: '@regression|@crit-flow-web'
       testinyRunName: Release ${{ needs.build_artifact.outputs.release_identifier }} ${{ needs.create_beta_tag.outputs.beta_tag_name }}
     secrets:
@@ -483,6 +503,7 @@ jobs:
         env:
           EXPECTED_BACKEND_REST: ${{ env.PRODUCTION_RUNTIME_BACKEND_REST }}
           EXPECTED_BACKEND_WS: ${{ env.PRODUCTION_RUNTIME_BACKEND_WS }}
+          EXPECTED_COMMIT: ${{ needs.build_artifact.outputs.release_commit_sha }}
           EXPECTED_VERSION: ${{ needs.build_artifact.outputs.artifact_version }}
           PRODUCTION_WEBAPP_URL: ${{ env.PRODUCTION_WEBAPP_URL }}
         run: |
@@ -496,23 +517,34 @@ jobs:
           expected_backend_ws="$(normalize_url "${EXPECTED_BACKEND_WS}")"
 
           for attempt_number in {1..10}; do
-            runtime_config=''
-            if ! runtime_config="$(curl --fail --silent --show-error "${PRODUCTION_WEBAPP_URL}config.js")"; then
-              echo "Unable to fetch Production runtime configuration on attempt ${attempt_number}: URL=${PRODUCTION_WEBAPP_URL}config.js." >&2
-            fi
+            version_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${PRODUCTION_WEBAPP_URL}version" || true)"
+            commit_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${PRODUCTION_WEBAPP_URL}commit" || true)"
+            runtime_config="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${PRODUCTION_WEBAPP_URL}config.js" || true)"
 
+            actual_version="$(
+              printf '%s' "${version_response}" |
+                jq --raw-output '.version'
+            )" || actual_version=''
+            actual_commit="$(
+              printf '%s' "${commit_response}" |
+                tr -d '\r\n'
+            )"
             actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
             actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
-            actual_version="$(printf '%s' "${runtime_config}" | sed -n 's/.*"VERSION":"\([^"]*\)".*/\1/p')"
 
-            if [[ "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" && "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}" && "${actual_version}" == "${EXPECTED_VERSION}" ]]; then
-              echo "Production runtime verification succeeded on attempt ${attempt_number}: URL=${PRODUCTION_WEBAPP_URL}config.js, VERSION=${actual_version}, REST=$(normalize_url "${actual_backend_rest}"), WS=$(normalize_url "${actual_backend_ws}")."
+            if [[
+              "${actual_version}" == "${EXPECTED_VERSION}" &&
+              "${actual_commit}" == "${EXPECTED_COMMIT}" &&
+              "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" &&
+              "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}"
+            ]]; then
+              echo "Production runtime verification succeeded on attempt ${attempt_number}: VERSION=${actual_version}, COMMIT=${actual_commit}, REST=$(normalize_url "${actual_backend_rest}"), WS=$(normalize_url "${actual_backend_ws}")."
               exit 0
             fi
 
             echo "Production runtime configuration mismatch on attempt ${attempt_number}." >&2
-            echo "Expected: VERSION=${EXPECTED_VERSION}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
-            echo "Observed: VERSION=${actual_version:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
+            echo "Expected: VERSION=${EXPECTED_VERSION}, COMMIT=${EXPECTED_COMMIT}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
+            echo "Observed: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
 
             if [[ "${attempt_number}" -lt 10 ]]; then
               sleep 6
@@ -520,8 +552,8 @@ jobs:
           done
 
           echo "Production runtime verification failed after 10 attempts." >&2
-          echo "Expected: VERSION=${EXPECTED_VERSION}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
-          echo "Observed: VERSION=${actual_version:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
+          echo "Expected: VERSION=${EXPECTED_VERSION}, COMMIT=${EXPECTED_COMMIT}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
+          echo "Observed: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
           exit 1
 
   create_production_tag:
@@ -628,6 +660,9 @@ jobs:
             echo "- Public Beta URL: ${BETA_WEBAPP_URL}"
             echo "- Beta runtime backend: ${BETA_RUNTIME_BACKEND_REST}"
             echo "- Beta runtime WebSocket backend: ${BETA_RUNTIME_BACKEND_WS}"
+            echo '- Beta artifact version verification: /version'
+            echo '- Beta source commit verification: /commit'
+            echo '- Beta backend verification: /config.js'
             echo "- Artifact name: ${ARTIFACT_NAME}"
             echo "- Artifact checksum: ${ARTIFACT_CHECKSUM}"
             echo "- Beta tag: ${BETA_TAG_NAME}"
@@ -635,6 +670,9 @@ jobs:
             echo "- E2E Elastic Beanstalk environment: ${E2E_ELASTIC_BEANSTALK_ENVIRONMENT_NAME}"
             echo "- E2E URL: ${E2E_WEBAPP_URL}"
             echo "- E2E backend: ${E2E_BACKEND_URL}"
+            echo '- Precommit artifact version verification: /version'
+            echo '- Precommit source commit verification: /commit'
+            echo '- Precommit backend verification: /config.js'
 
             if [[ -n "${E2E_REPORT_URL}" ]]; then
               echo "- E2E report URL: ${E2E_REPORT_URL}"
@@ -660,7 +698,11 @@ jobs:
             echo "- Production deployment result: ${PRODUCTION_DEPLOYMENT_RESULT}"
             echo "- Production runtime verification result: ${PRODUCTION_RUNTIME_VERIFICATION_RESULT}"
             echo "- Production URL: ${PRODUCTION_WEBAPP_URL}"
+            echo '- Production artifact version verification: /version'
+            echo '- Production source commit verification: /commit'
+            echo '- Production backend verification: /config.js'
             echo "- Expected Production artifact version: ${PRODUCTION_ARTIFACT_VERSION}"
+            echo "- Expected Production release commit: ${RELEASE_COMMIT_SHA}"
             echo "- Expected Production REST backend: ${PRODUCTION_RUNTIME_BACKEND_REST}"
             echo "- Expected Production WebSocket backend: ${PRODUCTION_RUNTIME_BACKEND_WS}"
             echo "- Production tag creation result: ${PRODUCTION_TAG_CREATION_RESULT}"
@@ -719,8 +761,12 @@ jobs:
             Production runtime verification: ${{ needs.verify_production_runtime.result }}
             Production tag: ${{ needs.create_production_tag.result }}
 
+            Production runtime verification result: ${{ needs.verify_production_runtime.result }}
+            Expected Production build version: ${{ needs.build_artifact.outputs.artifact_version || 'unavailable' }}
+            Expected Production release commit: ${{ needs.build_artifact.outputs.release_commit_sha || 'unavailable' }}
+
             Playwright report: ${{ needs.run_e2e.outputs.reportUrl || 'unavailable' }}
-            Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            Workflow URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ${{ needs.verify_production_runtime.result == 'failure' && 'Production deployment completed, but live runtime verification failed.' || 'Production was blocked because a release gate failed.' }}
             ${{ needs.verify_production_runtime.result == 'failure' && 'No Production tag was created.' || 'Production tag creation was blocked by the failed release gate.' }}

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -110,8 +110,10 @@ The cloud release process is:
 - Quality assurance owns the go/no-go quality gate.
 - The engineering release captain owns production rollout, observability, and incident response.
 - The production workflow promotes the beta-tested artifact and does not rebuild from source.
-- After Production deployment, the workflow verifies that the live Production endpoint `https://app.wire.com/config.js` exposes the expected artifact version and Production REST and WebSocket backend configuration.
-- A successful deployment operation alone does not create a Production tag. The workflow creates the production tag `YYYY-MM-DD.N-production` only after the live runtime and artifact verification succeeds, so the tag represents a successfully deployed and verified runtime.
+- Live deployment verification uses `/version` to identify the deployed build, `/commit` to identify its source revision, and `/config.js` to verify the active environment-specific REST and WebSocket backend configuration.
+- Build version and source commit are separate evidence: the same source commit can produce different builds, so `/commit` proves the source revision while `/version` identifies the particular build generated and promoted by the current workflow.
+- Backend configuration is runtime state and is not inferred from build identity. Beta, precommit, and Production must each satisfy their expected combination of build version, source commit, REST backend, and WebSocket backend.
+- A successful deployment operation alone does not create a Production tag. The workflow creates the production tag `YYYY-MM-DD.N-production` only after all Production runtime assertions pass, so the tag represents a successfully deployed and verified runtime.
 - If Production runtime verification fails, Production remains untagged, the release workflow fails, Deployoholics receives a failure notification, and the release captain performs incident assessment.
 - If the current release branch commit already has the matching production tag, the release workflow must not redeploy that commit.
 - Production tags are immutable release history and are never moved or deleted.
@@ -131,15 +133,15 @@ flowchart TD
   createReleaseBranch[Create or update release/YYYY-MM-DD.N]
   buildArtifact[Build release artifact once]
   deployToBeta[Deploy artifact to Beta<br/>Production backend]
-  verifyBetaRuntime[Verify Beta runtime backend]
+  verifyBetaRuntime[Verify Beta runtime<br/>Build version, source commit, and Production backends]
   createBetaTag[Create YYYY-MM-DD.N-beta.M]
   deployToE2E[Deploy same artifact to E2E slot<br/>Staging backend]
-  verifyE2ERuntime[Verify E2E runtime backend]
+  verifyE2ERuntime[Verify E2E runtime<br/>Build version, source commit, and Staging backends]
   runEndToEndTests[Run end-to-end tests against E2E slot]
   reportToTestiny[Report result to Testiny]
   productionApproval[GitHub Environment approval<br/>Production]
   deployToProduction[Deploy promoted beta artifact to Production]
-  verifyProductionRuntime[Verify live Production runtime<br/>Artifact version and Production backends]
+  verifyProductionRuntime[Verify live Production runtime<br/>Build version, source commit, and Production backends]
   createProductionTag[Create YYYY-MM-DD.N-production]
   rollbackWorkflow[Rollback Production workflow_dispatch<br/>optional incident action]
   deployKnownGoodArtifact[Deploy previous known-good production artifact]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Uses the dedicated runtime endpoints for deployment verification.

## Verification responsibilities

```text
/version   → deployed build version
/commit    → deployed source commit
/config.js → active REST and WebSocket backend configuration
````

## Changes

Beta, precommit, and Production now verify:

* the artifact version generated by the current workflow
* the release commit packaged into the artifact
* the expected environment-specific REST backend
* the expected environment-specific WebSocket backend

The Production tag remains blocked until all Production assertions succeed.

## Why both version and commit?

The same source commit can produce multiple builds.

`/commit` proves the source revision, while `/version` identifies the particular build generated and promoted by the current workflow.

`/config.js` remains responsible only for runtime environment configuration.

## Release policy

The complete selected E2E suite remains a blocking full-system Production gate.

No failed test is ignored or rerun automatically.

## Tracking

Part of #21597