### PR TITLE
Remove message list width transition [WPB-22420]

### DIFF
--- a/apps/webapp/src/style/foundation/framework.less
+++ b/apps/webapp/src/style/foundation/framework.less
@@ -72,13 +72,17 @@
     #conversation-title-bar,
     #message-list {
       width: 100%;
-      transition: width var(--animation-timing-fast) var(--ease-out-quart);
 
       @media (min-width: 1000px) {
         &.is-right-panel-open {
           width: calc(100% - var(--right-width));
         }
       }
+    }
+
+    #conversation-input-bar,
+    #conversation-title-bar {
+      transition: width var(--animation-timing-fast) var(--ease-out-quart);
     }
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Stop animating the width of the large message-list container when the right sidebar changes state. This avoids repeatedly relaying out and repainting complex message content while preserving the existing title and input bar transitions.


