### PR TITLE
Extend Production runtime verification timeout [WPB-26469]

### DIFF
--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -496,7 +496,7 @@ jobs:
     needs: [build_artifact, deploy_to_production]
     if: ${{ needs.deploy_to_production.result == 'success' }}
     permissions: {}
-    timeout-minutes: 2
+    timeout-minutes: 10
 
     steps:
       - name: Verify live Production runtime


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Allows the Production runtime-verification job enough time to complete its
existing bounded retry policy.

## Problem

The job performs three bounded HTTP requests per attempt across up to ten attempts, but the job itself was limited to two minutes.

GitHub could therefore terminate it before the configured retry policy completed.

## Change

The job timeout is increased from two minutes to ten minutes.

No retry, verification, deployment, tagging, approval, or E2E behavior changes.

## Tracking

Part of #21597