### PR TITLE
Make reliable message status handling permanent [WPB-27032]

### DIFF
--- a/apps/webapp/src/script/components/appContainer/appContainer.tsx
+++ b/apps/webapp/src/script/components/appContainer/appContainer.tsx
@@ -45,7 +45,6 @@ import {useTheme} from './hooks/useTheme';
 import {runClientVersionCheck} from '../../applicationPeriodicChecks/runClientVersionCheck';
 import {startApplicationPeriodicChecks} from '../../applicationPeriodicChecks/startApplicationPeriodicChecks';
 import {Config, Configuration} from '../../Config';
-import {messageSendingStatusFixFeatureToggleName} from '../../featureToggles/startupFeatureToggleNames';
 import {StartupFeatureToggleName} from '../../featureToggles/startupFeatureToggles';
 import {setAppLocale} from '../../localization/Localizer';
 import {App} from '../../main/app';
@@ -87,10 +86,8 @@ export const AppContainer = (properties: AppProps) => {
   } = properties;
   setAppLocale();
   const app = useMemo(() => {
-    return new App(container.resolve(Core), container.resolve(APIClient), config, translate, {
-      isMessageSendingStatusFixEnabled: isFeatureToggleEnabled(messageSendingStatusFixFeatureToggleName),
-    });
-  }, [config, isFeatureToggleEnabled, translate]);
+    return new App(container.resolve(Core), container.resolve(APIClient), config, translate);
+  }, [config, translate]);
   const enableAutoLogin = Config.getConfig().FEATURE.ENABLE_AUTO_LOGIN;
 
   // Publishing application on the global scope for debug and testing purposes.

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -20,13 +20,11 @@
 export const applockRefactoredFeatureToggleName = 'applock-refactored';
 export const sharedDriveSearchAndFiltersFeatureToggleName = 'shared-drive-search-and-filters';
 export const meetingsFeatureToggleName = 'meetings';
-export const messageSendingStatusFixFeatureToggleName = 'message-sending-status-fix';
 
 export const startupFeatureToggleNames = [
   applockRefactoredFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   meetingsFeatureToggleName,
-  messageSendingStatusFixFeatureToggleName,
 ] as const;
 
 export type StartupFeatureToggleName = (typeof startupFeatureToggleNames)[number];

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -24,7 +24,6 @@ import {
 } from './startupFeatureToggles';
 import {
   applockRefactoredFeatureToggleName,
-  messageSendingStatusFixFeatureToggleName,
   meetingsFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   startupFeatureToggleNames,
@@ -34,7 +33,6 @@ const featureToggleNamesWithDedicatedExistenceTests = [
   applockRefactoredFeatureToggleName,
   sharedDriveSearchAndFiltersFeatureToggleName,
   meetingsFeatureToggleName,
-  messageSendingStatusFixFeatureToggleName,
 ] as const;
 
 describe('startupFeatureToggles', function () {
@@ -103,14 +101,6 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.isFeatureToggleEnabled(meetingsFeatureToggleName)).toBe(true);
   });
 
-  it('enables the message sending status fix feature toggle when present in the query parameter', () => {
-    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=${messageSendingStatusFixFeatureToggleName}`,
-    );
-
-    expect(startupFeatureToggles.isFeatureToggleEnabled(messageSendingStatusFixFeatureToggleName)).toBe(true);
-  });
-
   it('trims whitespace around feature toggle names', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}= ${applockRefactoredFeatureToggleName} `,
@@ -152,7 +142,6 @@ describe('startupFeatureToggles', function () {
       applockRefactoredFeatureToggleName,
       sharedDriveSearchAndFiltersFeatureToggleName,
       meetingsFeatureToggleName,
-      messageSendingStatusFixFeatureToggleName,
     ]);
   });
 

--- a/apps/webapp/src/script/main/app.ts
+++ b/apps/webapp/src/script/main/app.ts
@@ -52,7 +52,7 @@ import {ConversationService} from 'Repositories/conversation/ConversationService
 import {ConversationVerificationState} from 'Repositories/conversation/ConversationVerificationState';
 import {OnConversationE2EIVerificationStateChange} from 'Repositories/conversation/ConversationVerificationStateHandler/shared';
 import {EventBuilder} from 'Repositories/conversation/EventBuilder';
-import {MessageRepository, MessageRepositoryOptions} from 'Repositories/conversation/MessageRepository';
+import {MessageRepository} from 'Repositories/conversation/MessageRepository';
 import {CryptographyRepository} from 'Repositories/cryptography/CryptographyRepository';
 import {User} from 'Repositories/entity/User';
 import {EventRepository} from 'Repositories/event/EventRepository';
@@ -197,9 +197,6 @@ export class App {
     private readonly apiClient: APIClient,
     private readonly config: Configuration,
     private readonly translate: Translate,
-    private readonly messageRepositoryOptions: MessageRepositoryOptions = {
-      isMessageSendingStatusFixEnabled: false,
-    },
   ) {
     this.config = config;
     this.apiClient.on(APIClient.TOPIC.ON_LOGOUT, () =>
@@ -301,7 +298,6 @@ export class App {
       repositories.asset,
       repositories.audio,
       this.translate,
-      this.messageRepositoryOptions,
     );
 
     repositories.calling = new CallingRepository(

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -56,7 +56,7 @@ import {createUuid} from 'Util/uuid';
 
 import {ConversationRepository} from './ConversationRepository';
 import {ConversationState} from './ConversationState';
-import {MessageRepository, MessageRepositoryOptions} from './MessageRepository';
+import {MessageRepository} from './MessageRepository';
 import {ConversationVerificationState} from './ConversationVerificationState';
 
 import {StatusType} from '../../message/statusType';
@@ -77,7 +77,6 @@ type MessageRepositoryDependencies = {
   core: Account;
   cryptographyRepository: CryptographyRepository;
   eventRepository: EventRepository;
-  messageRepositoryOptions: MessageRepositoryOptions;
   propertiesRepository: PropertiesRepository;
   serverTimeHandler: ServerTimeHandler;
   translate: Translate;
@@ -94,7 +93,6 @@ type MessageRepositoryPrivateMethodsForTest = {
 
 async function buildMessageRepository(
   translate: Translate,
-  messageRepositoryOptions: MessageRepositoryOptions = {isMessageSendingStatusFixEnabled: false},
 ): Promise<[MessageRepository, MessageRepositoryDependencies]> {
   const userState = new UserState();
   userState.self(selfUser);
@@ -122,7 +120,6 @@ async function buildMessageRepository(
     assetRepository: {} as AssetRepository,
     audioRepository: new AudioRepository(),
     translate,
-    messageRepositoryOptions,
     userState,
     clientState,
     conversationState,
@@ -523,52 +520,8 @@ describe('MessageRepository', () => {
       });
     });
 
-    it('does not wait for an added message when the status fix is disabled', async () => {
-      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest);
-      clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
-      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
-      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
-      const sendAndInjectMessageSpy = jest
-        .spyOn(messageRepositoryPrivateMethods, 'sendAndInjectMessage')
-        .mockResolvedValue(successPayload);
-      const conversation = generateConversation();
-
-      await messageRepository.sendTextWithLinkPreview({conversation, textMessage: 'hello there', mentions: []});
-
-      expect(sendAndInjectMessageSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('preserves post-send failure behavior when the status fix is disabled', async () => {
-      const [messageRepository, {clientState, core, eventRepository, propertiesRepository}] =
-        await buildMessageRepository(translateForTest);
-      clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
-      spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
-      jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
-      const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
-      const expectedError = new Error('post-send status handling failed');
-      const updateMessageAsFailedSpy = jest
-        .spyOn(messageRepositoryPrivateMethods, 'updateMessageAsFailed')
-        .mockResolvedValue(undefined);
-      jest.spyOn(messageRepositoryPrivateMethods, 'updateMessageAsSent').mockRejectedValue(expectedError);
-      const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
-      const conversation = generateConversation();
-
-      const sendResult = await messageRepository.sendTextWithLinkPreview({
-        conversation,
-        textMessage: 'hello there',
-        mentions: [],
-      });
-
-      expect(sendResult).toBe(MessageSendingState.FAILED);
-      expect(updateMessageAsFailedSpy).toHaveBeenCalledTimes(1);
-      expect(unsubscribeSpy).not.toHaveBeenCalled();
-    });
-
     it('does not wait for an added message when an existing message id is provided', async () => {
-      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest, {
-        isMessageSendingStatusFixEnabled: true,
-      });
+      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest);
       clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
@@ -588,9 +541,7 @@ describe('MessageRepository', () => {
     });
 
     it('does not create a message-added waiter when there is no current client id', async () => {
-      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest, {
-        isMessageSendingStatusFixEnabled: true,
-      });
+      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest);
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       clientState.currentClient = undefined;
       const subscribeSpy = jest.spyOn(amplify, 'subscribe');
@@ -608,13 +559,9 @@ describe('MessageRepository', () => {
       expect(unsubscribeSpy).not.toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
     });
 
-    it('waits for and repairs the exact added message when the status fix is enabled', async () => {
-      const [messageRepository, {clientState, eventRepository, propertiesRepository}] = await buildMessageRepository(
-        translateForTest,
-        {
-          isMessageSendingStatusFixEnabled: true,
-        },
-      );
+    it('waits for and repairs the exact added message for a new text message', async () => {
+      const [messageRepository, {clientState, eventRepository, propertiesRepository}] =
+        await buildMessageRepository(translateForTest);
       clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const subscribeSpy = jest.spyOn(amplify, 'subscribe');
@@ -648,9 +595,9 @@ describe('MessageRepository', () => {
       expect(updateEventSpy).not.toHaveBeenCalled();
     });
 
-    it('does not downgrade an already delivered added message when the status fix is enabled', async () => {
+    it('does not downgrade an already delivered added message', async () => {
       const [messageRepository, {clientState, conversationRepository, propertiesRepository}] =
-        await buildMessageRepository(translateForTest, {isMessageSendingStatusFixEnabled: true});
+        await buildMessageRepository(translateForTest);
       clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
@@ -688,9 +635,7 @@ describe('MessageRepository', () => {
     });
 
     it('removes the listener when sending is canceled', async () => {
-      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest, {
-        isMessageSendingStatusFixEnabled: true,
-      });
+      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest);
       clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
@@ -708,7 +653,7 @@ describe('MessageRepository', () => {
 
     it('removes the listener when the backend send fails', async () => {
       const [messageRepository, {clientState, core, eventRepository, propertiesRepository}] =
-        await buildMessageRepository(translateForTest, {isMessageSendingStatusFixEnabled: true});
+        await buildMessageRepository(translateForTest);
       clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       jest.spyOn(core.service!.conversation, 'send').mockRejectedValue(new Error('backend send failed'));
@@ -728,10 +673,8 @@ describe('MessageRepository', () => {
       expect(unsubscribeSpy).toHaveBeenCalledWith(WebAppEvents.CONVERSATION.MESSAGE.ADDED, expect.any(Function));
     });
 
-    it('removes the listener when the legacy send throws', async () => {
-      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest, {
-        isMessageSendingStatusFixEnabled: true,
-      });
+    it('removes the listener when sending throws', async () => {
+      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest);
       clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const unsubscribeSpy = jest.spyOn(amplify, 'unsubscribe');
@@ -752,9 +695,7 @@ describe('MessageRepository', () => {
     });
 
     it('ignores added messages from another conversation or with another message id', async () => {
-      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest, {
-        isMessageSendingStatusFixEnabled: true,
-      });
+      const [messageRepository, {clientState, propertiesRepository}] = await buildMessageRepository(translateForTest);
       clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
       const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -122,10 +122,6 @@ export interface MessageSendingOptions {
   recipients?: QualifiedId[] | QualifiedUserClients;
 }
 
-export type MessageRepositoryOptions = {
-  readonly isMessageSendingStatusFixEnabled: boolean;
-};
-
 type AddedMessageWaiter = {
   readonly messagePromise: Promise<Message>;
   readonly dispose: () => void;
@@ -192,9 +188,6 @@ export class MessageRepository {
     private readonly assetRepository: AssetRepository,
     private readonly audioRepository: AudioRepository,
     private readonly translate: Translate,
-    private readonly messageRepositoryOptions: MessageRepositoryOptions = {
-      isMessageSendingStatusFixEnabled: false,
-    },
     private readonly userState = container.resolve(UserState),
     private readonly clientState = container.resolve(ClientState),
     private readonly conversationState = container.resolve(ConversationState),
@@ -295,16 +288,11 @@ export class MessageRepository {
       messageId,
     );
 
-    const currentClientId = this.clientState.currentClient?.id;
-    const canInjectOptimisticMessage = is.nonEmptyString(currentClientId);
-    const shouldRepairOptimisticMessageStatus =
-      this.messageRepositoryOptions.isMessageSendingStatusFixEnabled && isNewTextMessage && canInjectOptimisticMessage;
-
-    if (!shouldRepairOptimisticMessageStatus) {
+    if (!isNewTextMessage || !is.nonEmptyString(this.clientState.currentClient?.id)) {
       return this.sendAndInjectMessage(textMessage, conversation, {...options, enableEphemeral: true});
     }
 
-    return this.sendNewTextMessageWithReliableInMemoryStatus(textMessage, conversation, {
+    return this.sendTextWithReliableInMemoryStatus(textMessage, conversation, {
       ...options,
       enableEphemeral: true,
     });
@@ -339,7 +327,7 @@ export class MessageRepository {
     return {dispose, messagePromise};
   }
 
-  private async sendNewTextMessageWithReliableInMemoryStatus(
+  private async sendTextWithReliableInMemoryStatus(
     textMessage: GenericMessage,
     conversation: Conversation,
     options: MessageSendingOptions & {enableEphemeral: true; syncTimestamp?: boolean},

--- a/apps/webapp/test/helper/TestFactory.js
+++ b/apps/webapp/test/helper/TestFactory.js
@@ -287,9 +287,6 @@ export class TestFactory {
       this.assetRepository,
       new AudioRepository(),
       translate,
-      {
-        isMessageSendingStatusFixEnabled: false,
-      },
       this.user_repository['userState'],
       clientState,
     );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27032" title="WPB-27032" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27032</a>  [Web] Outgoing messages can remain grey until the conversation is reopened
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Intent

The reliable message-status implementation is now the permanent production behavior. This removes the temporary rollout flag and its obsolete code paths.

## Changes

- Remove the `message-sending-status-fix` startup feature flag.
- Remove `MessageRepositoryOptions` and all related wiring.
- Use reliable status handling by default for eligible new text messages.
- Retain shared sending logic for edits, attachments, retries, and other non-optimistic message flows.
- Remove obsolete flag-specific tests and test setup.

See also https://github.com/wireapp/wire-webapp/pull/21827