### PR TITLE
Publish Docker, Helm, and wire-builds from Release Cloud [WPB-26469]

### DIFF
--- a/.github/workflows/publish-production-distribution.yml
+++ b/.github/workflows/publish-production-distribution.yml
@@ -1,0 +1,172 @@
+---
+name: Publish Production distribution
+
+on:
+  workflow_call:
+    inputs:
+      production_tag:
+        description: 'Verified immutable Production tag'
+        required: true
+        type: string
+      expected_commit_sha:
+        description: 'Release commit expected by the Production tag'
+        required: true
+        type: string
+      source_run_id:
+        description: 'Release Cloud run that created the distribution artifact'
+        required: true
+        type: string
+      distribution_artifact_name:
+        description: 'Exact distribution context artifact from Release Cloud'
+        required: true
+        type: string
+    outputs:
+      docker_image_tag:
+        description: 'Immutable Quay image tag'
+        value: ${{ jobs.publish_distribution.outputs.docker_image_tag }}
+      helm_chart_version:
+        description: 'Selected WebApp Helm chart version'
+        value: ${{ jobs.publish_distribution.outputs.helm_chart_version }}
+      wire_builds_commit_sha:
+        description: 'Verified wire-builds/main commit'
+        value: ${{ jobs.publish_distribution.outputs.wire_builds_commit_sha }}
+      distribution_result:
+        description: 'Distribution result'
+        value: ${{ jobs.publish_distribution.outputs.distribution_result }}
+    secrets:
+      WEBTEAM_QUAY_USERNAME:
+        required: true
+      WEBTEAM_QUAY_PASSWORD:
+        required: true
+      CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID:
+        required: true
+      CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY:
+        required: true
+      WIRE_BUILDS_WRITE_ACCESS_GH_TOKEN:
+        required: true
+
+permissions: {}
+
+env:
+  CHART_REPOSITORY_NAME: charts-webapp
+  CHART_REPOSITORY_URL: s3://public.wire.com/charts-webapp
+  DOCKER_REPOSITORY: quay.io/wire/webapp
+  DISTRIBUTION_CONTEXT_PATH: distribution-context
+  WIRE_BUILDS_REPOSITORY: wireapp/wire-builds
+
+jobs:
+  publish_distribution:
+    name: Publish Docker, Helm, and wire-builds distribution
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      docker_image_tag: ${{ steps.publish_docker.outputs.docker_image_tag }}
+      helm_chart_version: ${{ steps.publish_helm.outputs.helm_chart_version }}
+      wire_builds_commit_sha: ${{ steps.update_wire_builds.outputs.wire_builds_commit_sha }}
+      distribution_result: ${{ steps.distribution_result.outputs.distribution_result }}
+
+    steps:
+      - name: Checkout exact Production tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ inputs.production_tag }}
+
+      - name: Download exact distribution context
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ inputs.distribution_artifact_name }}
+          path: ${{ env.DISTRIBUTION_CONTEXT_PATH }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install exact release dependencies
+        run: ./bin/yarn --immutable
+
+      - name: Validate Production tag and distribution manifest
+        id: validate_identity
+        env:
+          DISTRIBUTION_CONTEXT_PATH: ${{ env.DISTRIBUTION_CONTEXT_PATH }}
+          EXPECTED_COMMIT_SHA: ${{ inputs.expected_commit_sha }}
+          PRODUCTION_TAG: ${{ inputs.production_tag }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: ./bin/validate-production-distribution.sh
+
+      - name: Setup Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
+        with:
+          version: '3.21.3'
+
+      - name: Publish or reuse Docker image
+        id: publish_docker
+        env:
+          DOCKER_PASSWORD: ${{ secrets.WEBTEAM_QUAY_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.WEBTEAM_QUAY_USERNAME }}
+          DOCKER_REPOSITORY: ${{ env.DOCKER_REPOSITORY }}
+          PRODUCTION_IMAGE_TAG_OUTPUT_PATH: ${{ runner.temp }}/production-image-tag.txt
+          PRODUCTION_TAG: ${{ inputs.production_tag }}
+          RELEASE_COMMIT_SHA: ${{ steps.validate_identity.outputs.production_tag_commit_sha }}
+          WIRE_WEBAPP_DOCKER_CONTEXT_PATH: ${{ env.DISTRIBUTION_CONTEXT_PATH }}
+          WIRE_WEBAPP_RELEASE_COMMIT_SHA: ${{ steps.validate_identity.outputs.production_tag_commit_sha }}
+        run: ./bin/publish-production-docker.sh
+
+      - name: Publish or reuse Helm chart
+        id: publish_helm
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY }}
+          DOCKER_IMAGE_TAG: ${{ steps.publish_docker.outputs.docker_image_tag }}
+          CHART_REPOSITORY_NAME: ${{ env.CHART_REPOSITORY_NAME }}
+          CHART_REPOSITORY_URL: ${{ env.CHART_REPOSITORY_URL }}
+        run: ./bin/publish-production-helm.sh
+
+      - name: Check out wire-builds main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: ${{ env.WIRE_BUILDS_REPOSITORY }}
+          token: ${{ secrets.WIRE_BUILDS_WRITE_ACCESS_GH_TOKEN }}
+          ref: main
+          path: wire-builds
+          fetch-depth: 1
+
+      - name: Update wire-builds main idempotently
+        id: update_wire_builds
+        env:
+          DOCKER_IMAGE_TAG: ${{ steps.publish_docker.outputs.docker_image_tag }}
+          HELM_CHART_VERSION: ${{ steps.publish_helm.outputs.helm_chart_version }}
+          RELEASE_COMMIT_SHA: ${{ steps.validate_identity.outputs.production_tag_commit_sha }}
+        working-directory: wire-builds
+        run: ../bin/update-wire-builds.sh
+
+      - name: Mark distribution complete
+        id: distribution_result
+        env:
+          DOCKER_IMAGE_TAG: ${{ steps.publish_docker.outputs.docker_image_tag }}
+          HELM_CHART_VERSION: ${{ steps.publish_helm.outputs.helm_chart_version }}
+          WIRE_BUILDS_COMMIT_SHA: ${{ steps.update_wire_builds.outputs.wire_builds_commit_sha }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo 'distribution_result=success'
+          } >> "${GITHUB_OUTPUT}"
+
+          {
+            echo '## Production distribution'
+            echo "- Docker image: ${DOCKER_IMAGE_TAG}"
+            echo "- Helm chart: ${HELM_CHART_VERSION}"
+            echo "- wire-builds/main commit: ${WIRE_BUILDS_COMMIT_SHA}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -26,7 +26,7 @@ on:
         type: string
 
 concurrency:
-  group: release-cloud-beta-${{ inputs.release_branch }}
+  group: ${{ inputs.promote_to_production && 'release-cloud-production' || format('release-cloud-beta-{0}', inputs.release_branch) }}
   cancel-in-progress: false
 
 permissions: {}
@@ -89,6 +89,7 @@ jobs:
       artifact_checksum: ${{ steps.artifact_metadata.outputs.artifact_checksum }}
       artifact_name: ${{ steps.artifact_metadata.outputs.artifact_name }}
       artifact_version: ${{ steps.artifact_metadata.outputs.artifact_version }}
+      distribution_artifact_name: ${{ steps.distribution_artifact.outputs.distribution_artifact_name }}
       release_branch: ${{ steps.release_metadata.outputs.release_branch }}
       release_commit_sha: ${{ steps.release_metadata.outputs.release_commit_sha }}
       release_identifier: ${{ steps.release_metadata.outputs.release_identifier }}
@@ -156,6 +157,59 @@ jobs:
             echo "artifact_checksum=${artifact_checksum}"
             echo "artifact_version=${artifact_version}"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Prepare exact public Docker distribution context
+        if: ${{ inputs.promote_to_production }}
+        id: distribution_artifact
+        env:
+          ARTIFACT_CHECKSUM: ${{ steps.artifact_metadata.outputs.artifact_checksum }}
+          ARTIFACT_VERSION: ${{ steps.artifact_metadata.outputs.artifact_version }}
+          RELEASE_COMMIT_SHA: ${{ steps.release_metadata.outputs.release_commit_sha }}
+          RELEASE_IDENTIFIER: ${{ steps.release_metadata.outputs.release_identifier }}
+        run: |
+          set -euo pipefail
+
+          distribution_artifact_name="release-cloud-distribution-context-${RELEASE_IDENTIFIER}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          distribution_context_directory="${RUNNER_TEMP}/${distribution_artifact_name}"
+          mkdir -p \
+            "${distribution_context_directory}/apps/server" \
+            "${distribution_context_directory}/libraries/config" \
+            "${distribution_context_directory}/bin"
+
+          cp -a package.json yarn.lock .yarnrc.yml .npmrc run.sh .env.defaults "${distribution_context_directory}/"
+          cp -a .yarn "${distribution_context_directory}/.yarn"
+          cp -a bin/yarn "${distribution_context_directory}/bin/yarn"
+          cp -a apps/server/Dockerfile apps/server/package.json "${distribution_context_directory}/apps/server/"
+          cp -a apps/server/dist "${distribution_context_directory}/apps/server/dist"
+          cp -a libraries/config/package.json libraries/config/lib "${distribution_context_directory}/libraries/config/"
+
+          jq -n \
+            --arg release_identifier "${RELEASE_IDENTIFIER}" \
+            --arg release_commit_sha "${RELEASE_COMMIT_SHA}" \
+            --arg artifact_version "${ARTIFACT_VERSION}" \
+            --arg cloud_artifact_checksum "${ARTIFACT_CHECKSUM}" \
+            --arg source_run_id "${GITHUB_RUN_ID}" \
+            --arg source_run_attempt "${GITHUB_RUN_ATTEMPT}" \
+            '{
+              productionTag: null,
+              releaseIdentifier: $release_identifier,
+              releaseCommitSha: $release_commit_sha,
+              artifactVersion: $artifact_version,
+              cloudArtifactChecksum: $cloud_artifact_checksum,
+              sourceRunId: $source_run_id,
+              sourceRunAttempt: $source_run_attempt
+            }' > "${distribution_context_directory}/distribution-manifest.json"
+
+          echo "distribution_artifact_name=${distribution_artifact_name}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload exact public Docker distribution context
+        if: ${{ inputs.promote_to_production }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ steps.distribution_artifact.outputs.distribution_artifact_name }}
+          path: ${{ runner.temp }}/${{ steps.distribution_artifact.outputs.distribution_artifact_name }}
+          if-no-files-found: error
+          include-hidden-files: true
 
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -344,7 +398,7 @@ jobs:
 
     steps:
       - name: Checkout release commit
-        if: ${{ inputs.promote_to_production == true }}
+        if: ${{ inputs.promote_to_production }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
@@ -352,18 +406,18 @@ jobs:
           ref: ${{ needs.build_artifact.outputs.release_commit_sha }}
 
       - name: Add repository Yarn wrapper to PATH
-        if: ${{ inputs.promote_to_production == true }}
+        if: ${{ inputs.promote_to_production }}
         run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
 
       - name: Setup Node.js
-        if: ${{ inputs.promote_to_production == true }}
+        if: ${{ inputs.promote_to_production }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
       - name: Install dependencies
-        if: ${{ inputs.promote_to_production == true }}
+        if: ${{ inputs.promote_to_production }}
         run: ./bin/yarn --immutable
 
       - name: Check Production promotion eligibility
@@ -459,10 +513,6 @@ jobs:
     permissions: {}
     # Production approval is enforced by the wire-webapp-prod GitHub Environment settings.
     environment: wire-webapp-prod
-    concurrency:
-      group: release-cloud-production
-      cancel-in-progress: false
-
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -596,6 +646,26 @@ jobs:
 
           echo "production_tag_name=${PRODUCTION_TAG_NAME}" >> "$GITHUB_OUTPUT"
 
+  publish_production_distribution:
+    name: Publish Production distribution
+    needs: [build_artifact, create_production_tag]
+    if: ${{ needs.create_production_tag.result == 'success' && inputs.promote_to_production }}
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/publish-production-distribution.yml
+    with:
+      production_tag: ${{ needs.create_production_tag.outputs.production_tag_name }}
+      expected_commit_sha: ${{ needs.build_artifact.outputs.release_commit_sha }}
+      source_run_id: ${{ github.run_id }}
+      distribution_artifact_name: ${{ needs.build_artifact.outputs.distribution_artifact_name }}
+    secrets:
+      WEBTEAM_QUAY_USERNAME: ${{ secrets.WEBTEAM_QUAY_USERNAME }}
+      WEBTEAM_QUAY_PASSWORD: ${{ secrets.WEBTEAM_QUAY_PASSWORD }}
+      CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID }}
+      CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY }}
+      WIRE_BUILDS_WRITE_ACCESS_GH_TOKEN: ${{ secrets.WIRE_BUILDS_WRITE_ACCESS_GH_TOKEN }}
+
   summarize_release:
     name: Summarize release
     runs-on: ubuntu-24.04
@@ -609,6 +679,7 @@ jobs:
         deploy_to_production,
         verify_production_runtime,
         create_production_tag,
+        publish_production_distribution,
       ]
     if: ${{ always() }}
     permissions: {}
@@ -639,6 +710,11 @@ jobs:
           PRODUCTION_RUNTIME_BACKEND_WS: ${{ env.PRODUCTION_RUNTIME_BACKEND_WS }}
           PRODUCTION_WEBAPP_URL: ${{ env.PRODUCTION_WEBAPP_URL }}
           PRODUCTION_ARTIFACT_VERSION: ${{ needs.build_artifact.outputs.artifact_version }}
+          PRODUCTION_DISTRIBUTION_RESULT: ${{ needs.publish_production_distribution.outputs.distribution_result }}
+          PRODUCTION_DISTRIBUTION_JOB_RESULT: ${{ needs.publish_production_distribution.result }}
+          PRODUCTION_DOCKER_IMAGE_TAG: ${{ needs.publish_production_distribution.outputs.docker_image_tag }}
+          PRODUCTION_HELM_CHART_VERSION: ${{ needs.publish_production_distribution.outputs.helm_chart_version }}
+          PRODUCTION_WIRE_BUILDS_COMMIT_SHA: ${{ needs.publish_production_distribution.outputs.wire_builds_commit_sha }}
           PRODUCTION_SKIPPED_REASON: ${{ needs.production_preflight.outputs.production_skipped_reason }}
           PRODUCTION_TAG_CREATION_RESULT: ${{ needs.create_production_tag.result }}
           PRODUCTION_TAG_NAME: ${{ needs.production_preflight.outputs.production_tag_name }}
@@ -710,6 +786,11 @@ jobs:
             echo "- Production artifact name: ${PRODUCTION_ARTIFACT_NAME}"
             echo "- Production artifact checksum: ${PRODUCTION_ARTIFACT_CHECKSUM}"
             echo "- Production approval gate: ${PRODUCTION_ENVIRONMENT_NAME} GitHub Environment settings"
+            echo "- Production distribution job result: ${PRODUCTION_DISTRIBUTION_JOB_RESULT}"
+            echo "- Production distribution result: ${PRODUCTION_DISTRIBUTION_RESULT:-not run}"
+            echo "- Production Docker image tag: ${PRODUCTION_DOCKER_IMAGE_TAG:-unavailable}"
+            echo "- Production Helm chart version: ${PRODUCTION_HELM_CHART_VERSION:-unavailable}"
+            echo "- wire-builds/main commit: ${PRODUCTION_WIRE_BUILDS_COMMIT_SHA:-unavailable}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   notify_release_failure:
@@ -726,6 +807,7 @@ jobs:
         deploy_to_production,
         verify_production_runtime,
         create_production_tag,
+        publish_production_distribution,
       ]
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
     permissions:
@@ -760,13 +842,21 @@ jobs:
             Production deployment: ${{ needs.deploy_to_production.result }}
             Production runtime verification: ${{ needs.verify_production_runtime.result }}
             Production tag: ${{ needs.create_production_tag.result }}
+            Production distribution: ${{ needs.publish_production_distribution.result }}
 
             Production runtime verification result: ${{ needs.verify_production_runtime.result }}
             Expected Production build version: ${{ needs.build_artifact.outputs.artifact_version || 'unavailable' }}
             Expected Production release commit: ${{ needs.build_artifact.outputs.release_commit_sha || 'unavailable' }}
+            Production tag name: ${{ needs.create_production_tag.outputs.production_tag_name || needs.production_preflight.outputs.production_tag_name || 'unavailable' }}
+            Docker image tag: ${{ needs.publish_production_distribution.outputs.docker_image_tag || 'unavailable' }}
+            Helm chart version: ${{ needs.publish_production_distribution.outputs.helm_chart_version || 'unavailable' }}
+            wire-builds result: ${{ needs.publish_production_distribution.outputs.wire_builds_commit_sha || 'publication failed or unavailable' }}
 
             Playwright report: ${{ needs.run_e2e.outputs.reportUrl || 'unavailable' }}
-            Workflow URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            Source workflow URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-            ${{ needs.verify_production_runtime.result == 'failure' && 'Production deployment completed, but live runtime verification failed.' || 'Production was blocked because a release gate failed.' }}
-            ${{ needs.verify_production_runtime.result == 'failure' && 'No Production tag was created.' || 'Production tag creation was blocked by the failed release gate.' }}
+            ${{ needs.publish_production_distribution.result == 'failure' && needs.create_production_tag.result == 'success' && 'Cloud Production deployment and verification succeeded.' || 'Production was blocked because a release gate failed.' }}
+            ${{ needs.publish_production_distribution.result == 'failure' && needs.create_production_tag.result == 'success' && 'The Production tag exists.' || 'Production tag creation was blocked by the failed release gate.' }}
+            ${{ needs.publish_production_distribution.result == 'failure' && needs.create_production_tag.result == 'success' && 'Docker, Helm, or wire-builds publication failed.' || '' }}
+            ${{ needs.publish_production_distribution.result == 'failure' && needs.create_production_tag.result == 'success' && 'The release is incomplete for on-premises distribution.' || '' }}
+            ${{ needs.publish_production_distribution.result == 'failure' && needs.create_production_tag.result == 'success' && 'No Production tag was moved or deleted.' || '' }}

--- a/.github/workflows/repair-production-distribution.yml
+++ b/.github/workflows/repair-production-distribution.yml
@@ -1,0 +1,143 @@
+---
+name: Repair Production distribution
+
+on:
+  workflow_dispatch:
+    inputs:
+      production_tag:
+        description: 'Existing verified immutable Production tag to repair'
+        required: true
+        type: string
+      source_run_id:
+        description: 'Release Cloud run containing the distribution artifact'
+        required: true
+        type: string
+      distribution_artifact_name:
+        description: 'Exact distribution context artifact from Release Cloud'
+        required: true
+        type: string
+      confirm_repair:
+        description: 'Confirm repair publication for the existing Production release'
+        required: true
+        default: false
+        type: boolean
+      reason:
+        description: 'Reason for repairing the incomplete distribution'
+        required: true
+        type: string
+
+concurrency:
+  group: release-cloud-production
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  validate_repair:
+    name: Validate Production repair request
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      production_tag: ${{ steps.resolve_tag.outputs.production_tag }}
+      expected_commit_sha: ${{ steps.resolve_tag.outputs.expected_commit_sha }}
+
+    steps:
+      - name: Checkout repository for tag validation
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: main
+
+      - name: Validate repair confirmation and resolve annotated tag
+        id: resolve_tag
+        env:
+          CONFIRM_REPAIR: ${{ inputs.confirm_repair }}
+          PRODUCTION_TAG: ${{ inputs.production_tag }}
+          REASON: ${{ inputs.reason }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${CONFIRM_REPAIR}" != 'true' ]]; then
+            echo 'confirm_repair must be true for a manual distribution repair.' >&2
+            exit 1
+          fi
+
+          if [[ -z "${REASON//[[:space:]]/}" ]]; then
+            echo 'reason must explain the manual distribution repair.' >&2
+            exit 1
+          fi
+
+          if [[ ! "${PRODUCTION_TAG}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\.[1-9][0-9]*-production$ ]]; then
+            echo "production_tag must match YYYY-MM-DD.N-production: ${PRODUCTION_TAG}" >&2
+            exit 1
+          fi
+
+          git ls-remote --exit-code --tags origin "refs/tags/${PRODUCTION_TAG}" >/dev/null
+          git fetch --no-tags origin "refs/tags/${PRODUCTION_TAG}:refs/tags/${PRODUCTION_TAG}"
+
+          if [[ "$(git cat-file -t "refs/tags/${PRODUCTION_TAG}")" != 'tag' ]]; then
+            echo "Production tag ${PRODUCTION_TAG} is not annotated." >&2
+            exit 1
+          fi
+
+          expected_commit_sha="$(git rev-parse "refs/tags/${PRODUCTION_TAG}^{commit}")"
+          {
+            echo "production_tag=${PRODUCTION_TAG}"
+            echo "expected_commit_sha=${expected_commit_sha}"
+          } >> "${GITHUB_OUTPUT}"
+
+  publish_distribution:
+    name: Publish Production distribution repair
+    needs: validate_repair
+    if: ${{ needs.validate_repair.result == 'success' }}
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/publish-production-distribution.yml
+    with:
+      production_tag: ${{ needs.validate_repair.outputs.production_tag }}
+      expected_commit_sha: ${{ needs.validate_repair.outputs.expected_commit_sha }}
+      source_run_id: ${{ inputs.source_run_id }}
+      distribution_artifact_name: ${{ inputs.distribution_artifact_name }}
+    secrets:
+      WEBTEAM_QUAY_USERNAME: ${{ secrets.WEBTEAM_QUAY_USERNAME }}
+      WEBTEAM_QUAY_PASSWORD: ${{ secrets.WEBTEAM_QUAY_PASSWORD }}
+      CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID }}
+      CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY }}
+      WIRE_BUILDS_WRITE_ACCESS_GH_TOKEN: ${{ secrets.WIRE_BUILDS_WRITE_ACCESS_GH_TOKEN }}
+
+  notify_repair_failure:
+    name: Notify Production repair failure
+    runs-on: ubuntu-24.04
+    needs: [validate_repair, publish_distribution]
+    if: ${{ always() && (needs.validate_repair.result == 'failure' || needs.publish_distribution.result == 'failure') }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout notification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: main
+          sparse-checkout: .github/actions/notify-deployoholics
+
+      - name: Announce Production repair failure
+        uses: ./.github/actions/notify-deployoholics
+        with:
+          webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+          status: failure
+          text: |
+            ❌ Production distribution repair failed ❌
+
+            Production tag: ${{ inputs.production_tag }}
+            Expected release commit: ${{ needs.validate_repair.outputs.expected_commit_sha || 'unresolved' }}
+            Docker image tag: ${{ needs.publish_distribution.outputs.docker_image_tag || 'unavailable' }}
+            Helm chart version: ${{ needs.publish_distribution.outputs.helm_chart_version || 'unavailable' }}
+            wire-builds commit: ${{ needs.publish_distribution.outputs.wire_builds_commit_sha || 'publication failed or unavailable' }}
+            Source workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ inputs.source_run_id }}
+            Repair reason: ${{ inputs.reason }}
+            Workflow URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/bin/productionDistribution.test.ts
+++ b/bin/productionDistribution.test.ts
@@ -1,0 +1,275 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+import {execFileSync} from 'node:child_process';
+
+import {
+  hasExpectedWireBuildsWebappFields,
+  selectHelmChartVersion,
+  validateProductionDistributionManifest,
+} from './productionDistribution';
+import type {WireBuildsWebappFields} from './productionDistribution';
+
+const expectedProductionTag = '2026-07-15.1-production';
+const expectedReleaseCommitSha = '1234567890abcdef1234567890abcdef12345678';
+const expectedWireBuildsFields: WireBuildsWebappFields = {
+  version: '0.8.0-pre.3175',
+  repo: 'https://s3-eu-west-1.amazonaws.com/public.wire.com/charts-webapp',
+  appVersion: '2026-07-15.1-production-v0.34.9-0-1234567',
+  commitUrl: `https://github.com/wireapp/wire-webapp/commit/${expectedReleaseCommitSha}`,
+  commit: expectedReleaseCommitSha,
+};
+
+function createValidDistributionManifest(): Record<string, unknown> {
+  return {
+    productionTag: null,
+    releaseIdentifier: '2026-07-15.1',
+    releaseCommitSha: expectedReleaseCommitSha,
+    artifactVersion: '2026.07.15.12.00',
+    cloudArtifactChecksum: 'a'.repeat(64),
+    sourceRunId: '12345',
+    sourceRunAttempt: '1',
+  };
+}
+
+function getUnrelatedWireBuildsState(buildJson: Record<string, unknown>): string {
+  return execFileSync('jq', ['-S', '-c', 'del(.version, .helmCharts.webapp)'], {
+    encoding: 'utf8',
+    input: `${JSON.stringify(buildJson)}\n`,
+  }).trim();
+}
+
+describe('production distribution decisions', () => {
+  it('validates the Production identity and distribution manifest together', () => {
+    const actualManifest = validateProductionDistributionManifest({
+      manifest: createValidDistributionManifest(),
+      productionTag: expectedProductionTag,
+      productionTagCommitSha: expectedReleaseCommitSha,
+      expectedCommitSha: expectedReleaseCommitSha,
+      sourceRunId: '12345',
+    });
+
+    assert(actualManifest.isOk);
+
+    expect(actualManifest.value.releaseCommitSha).toBe(expectedReleaseCommitSha);
+    expect(actualManifest.value.cloudArtifactChecksum).toHaveLength(64);
+  });
+
+  it('rejects a manifest for a non-ADR Production tag', () => {
+    const actualValidation = validateProductionDistributionManifest({
+      manifest: createValidDistributionManifest(),
+      productionTag: '2026-07-15-production.1',
+      productionTagCommitSha: expectedReleaseCommitSha,
+      sourceRunId: '12345',
+    });
+
+    expect(actualValidation.isErr).toBe(true);
+  });
+
+  it('rejects a manifest whose release commit differs from the tag commit', () => {
+    const manifest = createValidDistributionManifest();
+    manifest.releaseCommitSha = 'fedcba0987654321fedcba0987654321fedcba09';
+
+    const actualValidation = validateProductionDistributionManifest({
+      manifest,
+      productionTag: expectedProductionTag,
+      productionTagCommitSha: expectedReleaseCommitSha,
+      sourceRunId: '12345',
+    });
+
+    expect(actualValidation.isErr).toBe(true);
+  });
+
+  it('rejects an empty expected commit when the caller supplies one', () => {
+    const actualValidation = validateProductionDistributionManifest({
+      manifest: createValidDistributionManifest(),
+      productionTag: expectedProductionTag,
+      productionTagCommitSha: expectedReleaseCommitSha,
+      expectedCommitSha: '',
+      sourceRunId: '12345',
+    });
+
+    expect(actualValidation.isErr).toBe(true);
+  });
+
+  it('rejects an expected commit that differs from the Production tag', () => {
+    const actualValidation = validateProductionDistributionManifest({
+      manifest: createValidDistributionManifest(),
+      productionTag: expectedProductionTag,
+      productionTagCommitSha: expectedReleaseCommitSha,
+      expectedCommitSha: 'fedcba0987654321fedcba0987654321fedcba09',
+      sourceRunId: '12345',
+    });
+
+    expect(actualValidation.isErr).toBe(true);
+  });
+
+  it('rejects a manifest from a different source workflow run', () => {
+    const actualValidation = validateProductionDistributionManifest({
+      manifest: createValidDistributionManifest(),
+      productionTag: expectedProductionTag,
+      productionTagCommitSha: expectedReleaseCommitSha,
+      expectedCommitSha: expectedReleaseCommitSha,
+      sourceRunId: '67890',
+    });
+
+    expect(actualValidation.isErr).toBe(true);
+  });
+
+  it('reuses the only Helm chart with the immutable image tag as appVersion', () => {
+    const actualSelection = selectHelmChartVersion(
+      [
+        {version: '0.8.0-pre.3174', appVersion: 'old-image'},
+        {version: expectedWireBuildsFields.version, appVersion: expectedWireBuildsFields.appVersion},
+      ],
+      expectedWireBuildsFields.appVersion,
+    );
+
+    assert(actualSelection.isOk);
+
+    expect(actualSelection.value).toEqual({kind: 'reuse', version: expectedWireBuildsFields.version});
+  });
+
+  it('requires a fresh Helm chart when no published chart matches', () => {
+    const actualSelection = selectHelmChartVersion(
+      [{version: '0.8.0-pre.3174', appVersion: 'old-image'}],
+      expectedWireBuildsFields.appVersion,
+    );
+
+    assert(actualSelection.isOk);
+
+    expect(actualSelection.value).toEqual({kind: 'publish'});
+  });
+
+  it('rejects ambiguous Helm publication state', () => {
+    const actualSelection = selectHelmChartVersion(
+      [
+        {version: '0.8.0-pre.3174', appVersion: expectedWireBuildsFields.appVersion},
+        {version: '0.8.0-pre.3175', appVersion: expectedWireBuildsFields.appVersion},
+      ],
+      expectedWireBuildsFields.appVersion,
+    );
+
+    expect(actualSelection.isErr).toBe(true);
+  });
+
+  it('detects an exact wire-builds idempotent no-op without considering the top-level version', () => {
+    const currentBuildJson = {
+      version: '1.0.0-154',
+      helmCharts: {
+        webapp: {
+          repo: expectedWireBuildsFields.repo,
+          version: expectedWireBuildsFields.version,
+          meta: {
+            appVersion: expectedWireBuildsFields.appVersion,
+            commitURL: expectedWireBuildsFields.commitUrl,
+            commit: expectedWireBuildsFields.commit,
+          },
+        },
+        'wire-server': {
+          version: '5.34.0',
+        },
+      },
+    };
+
+    const actualIsCurrent = hasExpectedWireBuildsWebappFields(currentBuildJson, expectedWireBuildsFields);
+
+    expect(actualIsCurrent).toBe(true);
+  });
+
+  it('rejects a build.json without helmCharts', () => {
+    const actualIsCurrent = hasExpectedWireBuildsWebappFields({version: '1.0.0-154'}, expectedWireBuildsFields);
+
+    expect(actualIsCurrent).toBe(false);
+  });
+
+  it('rejects a build.json without a WebApp entry', () => {
+    const actualIsCurrent = hasExpectedWireBuildsWebappFields(
+      {version: '1.0.0-154', helmCharts: {'wire-server': {version: '5.34.0'}}},
+      expectedWireBuildsFields,
+    );
+
+    expect(actualIsCurrent).toBe(false);
+  });
+
+  it('rejects a build.json with incorrect nested WebApp metadata', () => {
+    const currentBuildJson = {
+      version: '1.0.0-154',
+      helmCharts: {
+        webapp: {
+          repo: expectedWireBuildsFields.repo,
+          version: expectedWireBuildsFields.version,
+          meta: {
+            appVersion: expectedWireBuildsFields.appVersion,
+            commitURL: 'https://example.com/commit',
+            commit: expectedWireBuildsFields.commit,
+          },
+        },
+        'wire-server': {
+          version: '5.34.0',
+        },
+      },
+    };
+
+    const actualIsCurrent = hasExpectedWireBuildsWebappFields(currentBuildJson, expectedWireBuildsFields);
+
+    expect(actualIsCurrent).toBe(false);
+  });
+
+  it('allows only the build version and WebApp chart entry to change', () => {
+    const currentBuildJson = {
+      version: '1.0.0-154',
+      helmCharts: {
+        webapp: {version: '0.8.0-pre.3174'},
+        'wire-server': {version: '5.34.0'},
+      },
+      metadata: {releaseChannel: 'production'},
+    };
+    const generatedBuildJson = {
+      version: '1.0.0-155',
+      helmCharts: {
+        webapp: {version: expectedWireBuildsFields.version},
+        'wire-server': {version: '5.34.0'},
+      },
+      metadata: {releaseChannel: 'production'},
+    };
+
+    expect(getUnrelatedWireBuildsState(generatedBuildJson)).toBe(getUnrelatedWireBuildsState(currentBuildJson));
+  });
+
+  it('detects an unrelated wire-builds change', () => {
+    const currentBuildJson = {
+      version: '1.0.0-154',
+      helmCharts: {
+        webapp: {version: '0.8.0-pre.3174'},
+        'wire-server': {version: '5.34.0'},
+      },
+    };
+    const generatedBuildJson = {
+      version: '1.0.0-155',
+      helmCharts: {
+        webapp: {version: expectedWireBuildsFields.version},
+        'wire-server': {version: '5.34.1'},
+      },
+    };
+
+    expect(getUnrelatedWireBuildsState(generatedBuildJson)).not.toBe(getUnrelatedWireBuildsState(currentBuildJson));
+  });
+});

--- a/bin/productionDistribution.ts
+++ b/bin/productionDistribution.ts
@@ -1,0 +1,182 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import is from '@sindresorhus/is';
+import {Result} from 'true-myth';
+
+import {validateProductionTagName} from './releaseMetadata';
+
+export type ProductionDistributionManifest = {
+  readonly productionTag: null;
+  readonly releaseIdentifier: string;
+  readonly releaseCommitSha: string;
+  readonly artifactVersion: string;
+  readonly cloudArtifactChecksum: string;
+  readonly sourceRunId: string;
+  readonly sourceRunAttempt: string;
+};
+
+export type DistributionManifestValidationParameters = {
+  readonly manifest: unknown;
+  readonly productionTag: string;
+  readonly productionTagCommitSha: string;
+  readonly expectedCommitSha?: string;
+  readonly sourceRunId: string;
+};
+
+export type PublishedHelmChart = {
+  readonly version: string;
+  readonly appVersion: string;
+};
+
+export type HelmChartVersionSelection = {readonly kind: 'reuse'; readonly version: string} | {readonly kind: 'publish'};
+
+export type WireBuildsWebappFields = {
+  readonly version: string;
+  readonly repo: string;
+  readonly appVersion: string;
+  readonly commitUrl: string;
+  readonly commit: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return is.plainObject(value);
+}
+
+function getNonEmptyString(value: unknown): string | undefined {
+  if (!is.nonEmptyString(value)) {
+    return undefined;
+  }
+
+  return value;
+}
+
+export function validateProductionDistributionManifest(
+  parameters: DistributionManifestValidationParameters,
+): Result<ProductionDistributionManifest, Error> {
+  const productionTagResult = validateProductionTagName(parameters.productionTag);
+
+  if (productionTagResult.isErr) {
+    return Result.err(productionTagResult.error);
+  }
+
+  if (parameters.productionTagCommitSha.length === 0) {
+    return Result.err(new Error('Production tag commit SHA must not be empty'));
+  }
+
+  if (parameters.expectedCommitSha !== undefined) {
+    if (
+      parameters.expectedCommitSha.length === 0 ||
+      parameters.expectedCommitSha !== parameters.productionTagCommitSha
+    ) {
+      return Result.err(new Error('Production tag commit does not match the expected commit SHA'));
+    }
+  }
+
+  if (!isRecord(parameters.manifest)) {
+    return Result.err(new Error('Distribution manifest must be a JSON object'));
+  }
+
+  const releaseIdentifier = productionTagResult.value.replace(/-production$/, '');
+  const manifestReleaseIdentifier = getNonEmptyString(parameters.manifest.releaseIdentifier);
+  const manifestReleaseCommitSha = getNonEmptyString(parameters.manifest.releaseCommitSha);
+  const artifactVersion = getNonEmptyString(parameters.manifest.artifactVersion);
+  const cloudArtifactChecksum = getNonEmptyString(parameters.manifest.cloudArtifactChecksum);
+  const sourceRunId = getNonEmptyString(parameters.manifest.sourceRunId);
+  const sourceRunAttempt = getNonEmptyString(parameters.manifest.sourceRunAttempt);
+
+  if (parameters.manifest.productionTag !== null) {
+    return Result.err(new Error('Distribution manifest productionTag must be null before publication'));
+  }
+
+  if (manifestReleaseIdentifier !== releaseIdentifier) {
+    return Result.err(new Error('Distribution manifest release identifier does not match the Production tag'));
+  }
+
+  if (manifestReleaseCommitSha !== parameters.productionTagCommitSha) {
+    return Result.err(new Error('Distribution manifest release commit does not match the Production tag commit'));
+  }
+
+  if (artifactVersion === undefined) {
+    return Result.err(new Error('Distribution manifest artifact version must not be empty'));
+  }
+
+  if (cloudArtifactChecksum === undefined) {
+    return Result.err(new Error('Distribution manifest cloud artifact checksum must not be empty'));
+  }
+
+  if (sourceRunId !== parameters.sourceRunId) {
+    return Result.err(new Error('Distribution manifest source run ID does not match the supplied source run ID'));
+  }
+
+  if (sourceRunAttempt === undefined) {
+    return Result.err(new Error('Distribution manifest source run attempt must not be empty'));
+  }
+
+  return Result.ok({
+    productionTag: null,
+    releaseIdentifier,
+    releaseCommitSha: parameters.productionTagCommitSha,
+    artifactVersion,
+    cloudArtifactChecksum,
+    sourceRunId,
+    sourceRunAttempt,
+  });
+}
+
+export function selectHelmChartVersion(
+  publishedCharts: readonly PublishedHelmChart[],
+  immutableImageTag: string,
+): Result<HelmChartVersionSelection, Error> {
+  const matchingChartVersions = publishedCharts
+    .filter(publishedChart => {
+      return publishedChart.appVersion === immutableImageTag;
+    })
+    .map(publishedChart => publishedChart.version);
+
+  if (matchingChartVersions.length > 1) {
+    return Result.err(new Error(`More than one Helm chart matches image tag ${immutableImageTag}`));
+  }
+
+  if (matchingChartVersions.length === 1) {
+    return Result.ok({kind: 'reuse', version: matchingChartVersions[0]});
+  }
+
+  return Result.ok({kind: 'publish'});
+}
+
+export function hasExpectedWireBuildsWebappFields(buildJson: unknown, expectedFields: WireBuildsWebappFields): boolean {
+  if (!isRecord(buildJson) || !isRecord(buildJson.helmCharts)) {
+    return false;
+  }
+
+  const webappEntry = buildJson.helmCharts.webapp;
+
+  if (!isRecord(webappEntry) || !isRecord(webappEntry.meta)) {
+    return false;
+  }
+
+  return (
+    webappEntry.repo === expectedFields.repo &&
+    webappEntry.version === expectedFields.version &&
+    webappEntry.meta.appVersion === expectedFields.appVersion &&
+    webappEntry.meta.commitURL === expectedFields.commitUrl &&
+    webappEntry.meta.commit === expectedFields.commit
+  );
+}

--- a/bin/productionDistributionCli.ts
+++ b/bin/productionDistributionCli.ts
@@ -1,0 +1,180 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as nodeFileSystem from 'node:fs';
+
+import is from '@sindresorhus/is';
+
+import {
+  hasExpectedWireBuildsWebappFields,
+  selectHelmChartVersion,
+  validateProductionDistributionManifest,
+} from './productionDistribution';
+import type {PublishedHelmChart, WireBuildsWebappFields} from './productionDistribution';
+
+type CommandLineOptions = ReadonlyMap<string, string>;
+
+function parseCommandLineOptions(commandLineArguments: readonly string[]): CommandLineOptions {
+  const optionValues = new Map<string, string>();
+
+  for (let argumentIndex = 0; argumentIndex < commandLineArguments.length; argumentIndex += 2) {
+    const optionName = commandLineArguments[argumentIndex];
+    const optionValue = commandLineArguments[argumentIndex + 1];
+
+    if (!is.nonEmptyString(optionName) || !optionName.startsWith('--') || !is.nonEmptyString(optionValue)) {
+      throw new Error('Options must be supplied as non-empty --name value pairs.');
+    }
+
+    optionValues.set(optionName.slice(2), optionValue);
+  }
+
+  return optionValues;
+}
+
+function getRequiredOption(optionValues: CommandLineOptions, optionName: string): string {
+  const optionValue = optionValues.get(optionName);
+
+  if (!is.nonEmptyString(optionValue)) {
+    throw new Error(`Missing required option: --${optionName}`);
+  }
+
+  return optionValue;
+}
+
+function parseJson(jsonText: string): unknown {
+  try {
+    return JSON.parse(jsonText);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid JSON: ${errorMessage}`);
+  }
+}
+
+function readJsonFile(filePath: string): unknown {
+  return parseJson(nodeFileSystem.readFileSync(filePath, 'utf8'));
+}
+
+function readJsonFromStandardInput(): unknown {
+  return parseJson(nodeFileSystem.readFileSync(0, 'utf8'));
+}
+
+function readWireBuildsFields(optionValues: CommandLineOptions): WireBuildsWebappFields {
+  return {
+    version: getRequiredOption(optionValues, 'version'),
+    repo: getRequiredOption(optionValues, 'repo'),
+    appVersion: getRequiredOption(optionValues, 'app-version'),
+    commitUrl: getRequiredOption(optionValues, 'commit-url'),
+    commit: getRequiredOption(optionValues, 'commit'),
+  };
+}
+
+function readPublishedHelmCharts(value: unknown): readonly PublishedHelmChart[] {
+  if (!is.array(value)) {
+    throw new Error('Published Helm chart search results must be an array.');
+  }
+
+  return value.map((publishedChart, chartIndex) => {
+    if (!is.plainObject(publishedChart)) {
+      throw new Error(`Published Helm chart at index ${chartIndex} must be an object.`);
+    }
+
+    if (!is.nonEmptyString(publishedChart.version) || !is.string(publishedChart.app_version)) {
+      throw new Error(`Published Helm chart at index ${chartIndex} has invalid version metadata.`);
+    }
+
+    return {
+      version: publishedChart.version,
+      appVersion: publishedChart.app_version,
+    };
+  });
+}
+
+function runCommand(commandName: string, optionValues: CommandLineOptions): void {
+  switch (commandName) {
+    case 'validate-manifest': {
+      const expectedCommitSha = optionValues.get('expected-commit-sha');
+      const validationResult = validateProductionDistributionManifest({
+        manifest: readJsonFile(getRequiredOption(optionValues, 'manifest-path')),
+        productionTag: getRequiredOption(optionValues, 'production-tag'),
+        productionTagCommitSha: getRequiredOption(optionValues, 'production-tag-commit-sha'),
+        expectedCommitSha,
+        sourceRunId: getRequiredOption(optionValues, 'source-run-id'),
+      });
+
+      if (validationResult.isErr) {
+        throw validationResult.error;
+      }
+
+      return;
+    }
+
+    case 'select-helm-chart': {
+      const publishedCharts = readPublishedHelmCharts(readJsonFile(getRequiredOption(optionValues, 'charts-path')));
+      const selectionResult = selectHelmChartVersion(publishedCharts, getRequiredOption(optionValues, 'image-tag'));
+
+      if (selectionResult.isErr) {
+        throw selectionResult.error;
+      }
+
+      if (selectionResult.value.kind === 'reuse') {
+        console.log(`reuse:${selectionResult.value.version}`);
+      } else {
+        console.log('publish');
+      }
+
+      return;
+    }
+
+    case 'wire-builds-fields-match': {
+      const fieldsMatch = hasExpectedWireBuildsWebappFields(
+        readJsonFromStandardInput(),
+        readWireBuildsFields(optionValues),
+      );
+
+      if (!fieldsMatch) {
+        process.exitCode = 1;
+      }
+
+      return;
+    }
+
+    default:
+      throw new Error(`Unknown production distribution command: ${commandName}`);
+  }
+}
+
+function main(): void {
+  try {
+    const commandName = process.argv[2];
+
+    if (!is.nonEmptyString(commandName)) {
+      throw new Error('A production distribution command is required.');
+    }
+
+    runCommand(commandName, parseCommandLineOptions(process.argv.slice(3)));
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(errorMessage);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1]?.endsWith('productionDistributionCli.ts')) {
+  main();
+}

--- a/bin/publish-production-docker.sh
+++ b/bin/publish-production-docker.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${DOCKER_PASSWORD:?DOCKER_PASSWORD is required}"
+: "${DOCKER_USERNAME:?DOCKER_USERNAME is required}"
+: "${DOCKER_REPOSITORY:?DOCKER_REPOSITORY is required}"
+: "${PRODUCTION_IMAGE_TAG_OUTPUT_PATH:?PRODUCTION_IMAGE_TAG_OUTPUT_PATH is required}"
+: "${PRODUCTION_TAG:?PRODUCTION_TAG is required}"
+: "${RELEASE_COMMIT_SHA:?RELEASE_COMMIT_SHA is required}"
+
+expected_image_tag="$(node ./bin/push_docker.js "${PRODUCTION_TAG}" --print-image-tag)"
+expected_release_commit_short_sha="${RELEASE_COMMIT_SHA:0:7}"
+if [[ "${expected_image_tag}" != *"${expected_release_commit_short_sha}"* ]]; then
+  echo "Expected immutable image tag does not contain ${expected_release_commit_short_sha}: ${expected_image_tag}" >&2
+  exit 1
+fi
+
+immutable_image_reference="${DOCKER_REPOSITORY}:${expected_image_tag}"
+stable_image_reference="${DOCKER_REPOSITORY}:${PRODUCTION_TAG}"
+
+echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin quay.io
+
+if docker manifest inspect "${immutable_image_reference}" >/dev/null 2>&1; then
+  echo "Reusing existing immutable image ${immutable_image_reference}."
+  docker manifest inspect "${immutable_image_reference}" >/dev/null
+  docker pull "${immutable_image_reference}"
+  docker tag "${immutable_image_reference}" "${stable_image_reference}"
+  docker push "${stable_image_reference}"
+else
+  echo "Building immutable image ${immutable_image_reference} from the downloaded context."
+  rm -f "${PRODUCTION_IMAGE_TAG_OUTPUT_PATH}"
+  node ./bin/push_docker.js "${PRODUCTION_TAG}" "${PRODUCTION_IMAGE_TAG_OUTPUT_PATH}"
+  captured_image_tag="$(<"${PRODUCTION_IMAGE_TAG_OUTPUT_PATH}")"
+
+  if [[ "${captured_image_tag}" != "${expected_image_tag}" ]]; then
+    echo "Docker script produced ${captured_image_tag}, expected ${expected_image_tag}." >&2
+    exit 1
+  fi
+fi
+
+docker manifest inspect "${immutable_image_reference}" >/dev/null
+docker logout quay.io
+
+echo "docker_image_tag=${expected_image_tag}" >> "${GITHUB_OUTPUT}"

--- a/bin/publish-production-helm.sh
+++ b/bin/publish-production-helm.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${CHART_REPOSITORY_NAME:?CHART_REPOSITORY_NAME is required}"
+: "${CHART_REPOSITORY_URL:?CHART_REPOSITORY_URL is required}"
+: "${DOCKER_IMAGE_TAG:?DOCKER_IMAGE_TAG is required}"
+
+helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.15.1
+helm repo add "${CHART_REPOSITORY_NAME}" "${CHART_REPOSITORY_URL}"
+helm repo update
+
+published_charts_path="${RUNNER_TEMP}/published-webapp-charts.json"
+helm search repo "${CHART_REPOSITORY_NAME}/webapp" --devel --versions --output json > "${published_charts_path}"
+
+helm_action="$(
+  ./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/productionDistributionCli.ts \
+    select-helm-chart --charts-path "${published_charts_path}" --image-tag "${DOCKER_IMAGE_TAG}"
+)"
+
+case "${helm_action}" in
+  reuse:*)
+    chart_version="${helm_action#reuse:}"
+  echo "Reusing existing Helm chart version ${chart_version}."
+  ;;
+  publish)
+    # Keep the current WebApp distribution policy: wire-builds/main consumes prerelease chart versions.
+    chart_version="$(./bin/chart-next-version.sh prerelease)"
+    CHART_VERSION="${chart_version}" IMAGE_TAG="${DOCKER_IMAGE_TAG}" \
+      yq -i '.version = strenv(CHART_VERSION) | .appVersion = strenv(IMAGE_TAG)' charts/webapp/Chart.yaml
+    chart_package_directory="${RUNNER_TEMP}/webapp-chart"
+    mkdir -p "${chart_package_directory}"
+    helm package ./charts/webapp --destination "${chart_package_directory}"
+    helm s3 push --relative "${chart_package_directory}/webapp-${chart_version}.tgz" "${CHART_REPOSITORY_NAME}"
+    ;;
+  *)
+    echo "Unknown Helm publication action: ${helm_action}" >&2
+    exit 1
+    ;;
+esac
+
+helm repo update
+helm search repo "${CHART_REPOSITORY_NAME}/webapp" --devel --versions --output json |
+  jq -e --arg chart_version "${chart_version}" --arg image_tag "${DOCKER_IMAGE_TAG}" \
+    'any(.[]; .version == $chart_version and .app_version == $image_tag)' >/dev/null
+
+echo "helm_chart_version=${chart_version}" >> "${GITHUB_OUTPUT}"

--- a/bin/push_docker.js
+++ b/bin/push_docker.js
@@ -20,6 +20,8 @@
  */
 
 const child = require('child_process');
+const nodeFileSystem = require('fs');
+const path = require('path');
 const appConfigPkg = require('../apps/webapp/app-config/package.json');
 
 require('dotenv').config({quiet: true});
@@ -37,68 +39,212 @@ require('dotenv').config({quiet: true});
  * ./bin/yarn docker staging '2021-08-25' '1240cfda9e609470cf1154e18f5bc582ca8907ff' --pr
  */
 
-/** Version tag of webapp (e.g. "2023-11-09-staging.0", "dev", "pr-123") */
-const versionTag = process.argv[2].replace('/', '-');
-const uniqueTagOut = process.argv[3] || '';
-/** Commit ID of https://github.com/wireapp/wire-webapp (i.e. "1240cfda9e609470cf1154e18f5bc582ca8907ff") */
-let commitSha = process.env.GITHUB_SHA || process.argv[4];
-/** Flag to indicate if this is a PR build */
-const isPR = process.argv.includes('--pr');
-
-if (isPR) {
-  /** on PRs, use the SHA from the head commit (not the merge commit) for tagging purposes */
-  commitSha = child.execSync('git rev-parse HEAD').toString().trim();
-}
-const commitShortSha = commitSha.substring(0, 7);
-const dockerRegistryDomain = 'quay.io';
-const repository = `${dockerRegistryDomain}/wire/webapp`;
-
-const tags = [];
-const requiredEnvironmentDefaultKeys = ['BACKEND_NAME', 'BRAND_NAME', 'URL_ACCOUNT_BASE', 'BACKEND_REST', 'BACKEND_WS'];
-const environmentDefaultsSmokeCheckCommand = [
-  'test -s /dist/.env.defaults',
-  ...requiredEnvironmentDefaultKeys.map(requiredEnvironmentDefaultKey => {
-    return `grep -q "^${requiredEnvironmentDefaultKey}=" /dist/.env.defaults`;
-  }),
-].join(' && ');
-
-/** One Docker image can have multiple tags, e.g. "production" (links always to the latest production build) & "2021-08-30-production.0-v0.28.25-0-1240cfd" (links to a fixed production build) */
-tags.push(`${repository}:${versionTag}`);
-
-/** Defines which config version (listed in "app-config/package.json") is going to be used */
-
-var configurationEntry;
-if (versionTag.includes('production')) {
-  configurationEntry = 'wire-web-config-default-master';
-} else {
-  configurationEntry = 'wire-web-config-default-staging';
-}
-const configVersion = appConfigPkg.dependencies[configurationEntry].split('#')[1];
-const uniqueTag = `${versionTag}-${configVersion}-${commitShortSha}`;
-if (!isPR) {
-  tags.push(`${repository}:${uniqueTag}`);
+function selectReleaseCommit({releaseCommitSha, commandLineCommitSha, pullRequestCommitSha, githubSha}) {
+  return releaseCommitSha || commandLineCommitSha || pullRequestCommitSha || githubSha;
 }
 
-if (isPR) {
-  tags.push(`${repository}:${versionTag}-${commitShortSha}`);
+function createUniqueImageTag({versionTag, configurationVersion, releaseCommitSha}) {
+  return versionTag.replace('/', '-') + '-' + configurationVersion + '-' + releaseCommitSha.substring(0, 7);
 }
 
-const dockerCommands = [
-  `echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin ${dockerRegistryDomain}`,
-  `docker build . --file apps/server/Dockerfile --tag ${commitShortSha}`,
-  `docker run --rm --entrypoint sh ${commitShortSha} -c ${JSON.stringify(environmentDefaultsSmokeCheckCommand)}`,
-  `if [ "${uniqueTagOut}" != "" ]; then echo -n "${uniqueTag}" > "${uniqueTagOut}"; fi`,
-];
+function runProcess(command, commandArguments, processOptions, spawnProcess = child.spawnSync) {
+  const result = spawnProcess(command, commandArguments, {
+    ...processOptions,
+    shell: false,
+  });
 
-tags.forEach(containerImageTagValue => {
-  dockerCommands.push(
-    `docker tag ${commitShortSha} ${containerImageTagValue}`,
-    `docker push ${containerImageTagValue}`,
+  if (result.error) {
+    throw new Error(`${command} failed with status ${result.status ?? 'unknown'}: ${result.error.message}`, {
+      cause: result.error,
+    });
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`${command} exited with status ${result.status}`);
+  }
+
+  return result;
+}
+
+function getCurrentCommitSha() {
+  return child.execFileSync('git', ['rev-parse', 'HEAD']).toString().trim();
+}
+
+function resolveDockerContextPath(configuredPath, workingDirectory) {
+  if (!configuredPath) {
+    return workingDirectory;
+  }
+
+  if (configuredPath.includes('\0')) {
+    throw new Error('Docker context path must not contain null bytes');
+  }
+
+  const resolvedWorkingDirectory = path.resolve(workingDirectory);
+  const resolvedDockerContextPath = path.resolve(resolvedWorkingDirectory, configuredPath);
+  const relativeDockerContextPath = path.relative(resolvedWorkingDirectory, resolvedDockerContextPath);
+  const escapesWorkingDirectory =
+    relativeDockerContextPath === '..' ||
+    relativeDockerContextPath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeDockerContextPath);
+
+  if (escapesWorkingDirectory) {
+    throw new Error('Docker context path must remain inside the working directory');
+  }
+
+  return resolvedDockerContextPath;
+}
+
+function requireDockerBuildPaths(dockerContextPath, dockerfilePath) {
+  if (!nodeFileSystem.existsSync(dockerContextPath)) {
+    throw new Error(`Docker context directory does not exist: ${dockerContextPath}`);
+  }
+
+  if (!nodeFileSystem.statSync(dockerContextPath).isDirectory()) {
+    throw new Error(`Docker context path is not a directory: ${dockerContextPath}`);
+  }
+
+  if (!nodeFileSystem.existsSync(dockerfilePath)) {
+    throw new Error(`Dockerfile does not exist: ${dockerfilePath}`);
+  }
+
+  if (!nodeFileSystem.statSync(dockerfilePath).isFile()) {
+    throw new Error(`Dockerfile path is not a file: ${dockerfilePath}`);
+  }
+}
+
+function writeImageTag(outputPath, imageTag) {
+  if (outputPath) {
+    nodeFileSystem.writeFileSync(outputPath, imageTag);
+  }
+}
+
+function runDockerPublication(
+  commandLineArguments,
+  environment,
+  {
+    runProcess: executeProcess = runProcess,
+    getCurrentCommitSha: readCurrentCommitSha = getCurrentCommitSha,
+    writeFile = writeImageTag,
+  } = {},
+) {
+  /** Version tag of webapp (e.g. "2023-11-09-staging.0", "dev", "pr-123") */
+  const versionTag = commandLineArguments[0].replace('/', '-');
+  const uniqueTagOut = commandLineArguments[1] || '';
+  /** Flag to indicate if this is a PR build */
+  const isPullRequest = commandLineArguments.includes('--pr');
+  const commandLineCommitSha = commandLineArguments[2]?.startsWith('--') ? undefined : commandLineArguments[2];
+  /** Commit ID of https://github.com/wireapp/wire-webapp (i.e. "1240cfda9e609470cf1154e18f5bc582ca8907ff") */
+  const releaseCommitSha = selectReleaseCommit({
+    releaseCommitSha: environment.WIRE_WEBAPP_RELEASE_COMMIT_SHA,
+    commandLineCommitSha,
+    pullRequestCommitSha:
+      isPullRequest && !environment.WIRE_WEBAPP_RELEASE_COMMIT_SHA && !commandLineCommitSha
+        ? readCurrentCommitSha()
+        : undefined,
+    githubSha: environment.GITHUB_SHA,
+  });
+  const printImageTagOnly = commandLineArguments.includes('--print-image-tag');
+
+  if (!releaseCommitSha) {
+    throw new Error(
+      'A release commit SHA is required through WIRE_WEBAPP_RELEASE_COMMIT_SHA, an argument, or GITHUB_SHA',
+    );
+  }
+
+  const commitShortSha = releaseCommitSha.substring(0, 7);
+  const dockerRegistryDomain = 'quay.io';
+  const repository = dockerRegistryDomain + '/wire/webapp';
+  const containerImageTags = [];
+  const requiredEnvironmentDefaultKeys = [
+    'BACKEND_NAME',
+    'BRAND_NAME',
+    'URL_ACCOUNT_BASE',
+    'BACKEND_REST',
+    'BACKEND_WS',
+  ];
+  const environmentDefaultsSmokeCheckCommand = [
+    'test -s /dist/.env.defaults',
+    ...requiredEnvironmentDefaultKeys.map(requiredEnvironmentDefaultKey => {
+      return 'grep -q "^' + requiredEnvironmentDefaultKey + '=" /dist/.env.defaults';
+    }),
+  ].join(' && ');
+
+  /** Defines which config version (listed in "app-config/package.json") is going to be used */
+  const configurationEntry = versionTag.includes('production')
+    ? 'wire-web-config-default-master'
+    : 'wire-web-config-default-staging';
+  const configurationVersion = appConfigPkg.dependencies[configurationEntry].split('#')[1];
+  const uniqueImageTag = createUniqueImageTag({versionTag, configurationVersion, releaseCommitSha});
+
+  if (printImageTagOnly) {
+    console.log(uniqueImageTag);
+    return uniqueImageTag;
+  }
+
+  /** One Docker image can have multiple tags, e.g. "production" (links always to the latest production build) & "2021-08-30-production.0-v0.28.25-0-1240cfd" (links to a fixed production build) */
+  containerImageTags.push(repository + ':' + versionTag);
+
+  if (!isPullRequest) {
+    containerImageTags.push(repository + ':' + uniqueImageTag);
+  }
+
+  if (isPullRequest) {
+    containerImageTags.push(repository + ':' + versionTag + '-' + commitShortSha);
+  }
+
+  const dockerUsername = environment.DOCKER_USERNAME;
+  const dockerPassword = environment.DOCKER_PASSWORD;
+  if (!dockerUsername || !dockerPassword) {
+    throw new Error('DOCKER_USERNAME and DOCKER_PASSWORD are required');
+  }
+
+  const dockerContextPath = resolveDockerContextPath(environment.WIRE_WEBAPP_DOCKER_CONTEXT_PATH, process.cwd());
+  const dockerfilePath = path.join(dockerContextPath, 'apps/server/Dockerfile');
+  requireDockerBuildPaths(dockerContextPath, dockerfilePath);
+
+  executeProcess('docker', ['login', '--username', dockerUsername, '--password-stdin', dockerRegistryDomain], {
+    env: environment,
+    input: `${dockerPassword}\n`,
+    stdio: ['pipe', 'inherit', 'inherit'],
+  });
+  executeProcess('docker', ['build', dockerContextPath, '--file', dockerfilePath, '--tag', commitShortSha], {
+    stdio: 'inherit',
+    env: environment,
+  });
+  executeProcess(
+    'docker',
+    ['run', '--rm', '--entrypoint', 'sh', commitShortSha, '-c', environmentDefaultsSmokeCheckCommand],
+    {stdio: 'inherit', env: environment},
   );
-});
+  writeFile(uniqueTagOut, uniqueImageTag);
 
-dockerCommands.push(`docker logout ${dockerRegistryDomain}`);
+  containerImageTags.forEach(containerImageTagValue => {
+    executeProcess('docker', ['tag', commitShortSha, containerImageTagValue], {
+      stdio: 'inherit',
+      env: environment,
+    });
+    executeProcess('docker', ['push', containerImageTagValue], {
+      stdio: 'inherit',
+      env: environment,
+    });
+  });
 
-dockerCommands.forEach(command => {
-  child.execSync(command, {stdio: 'inherit'});
-});
+  executeProcess('docker', ['logout', dockerRegistryDomain], {
+    stdio: 'inherit',
+    env: environment,
+  });
+
+  return uniqueImageTag;
+}
+
+if (require.main === module) {
+  runDockerPublication(process.argv.slice(2), process.env);
+}
+
+module.exports = {
+  createUniqueImageTag,
+  resolveDockerContextPath,
+  runDockerPublication,
+  runProcess,
+  selectReleaseCommit,
+};

--- a/bin/push_docker.test.ts
+++ b/bin/push_docker.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+import path from 'node:path';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const {
+  createUniqueImageTag,
+  resolveDockerContextPath,
+  runDockerPublication,
+  runProcess,
+  selectReleaseCommit,
+} = require('./push_docker');
+
+describe('push_docker metadata', () => {
+  it('prefers the explicit release environment over the caller SHA and argument', () => {
+    const actualReleaseCommitSha = selectReleaseCommit({
+      releaseCommitSha: 'release-commit-sha',
+      commandLineCommitSha: 'argument-commit-sha',
+      githubSha: 'caller-commit-sha',
+    });
+
+    expect(actualReleaseCommitSha).toBe('release-commit-sha');
+  });
+
+  it('uses the explicit release argument before GITHUB_SHA', () => {
+    const actualReleaseCommitSha = selectReleaseCommit({
+      commandLineCommitSha: 'argument-commit-sha',
+      githubSha: 'caller-commit-sha',
+    });
+
+    expect(actualReleaseCommitSha).toBe('argument-commit-sha');
+  });
+
+  it('falls back to GITHUB_SHA for legacy callers without an explicit release commit', () => {
+    const actualReleaseCommitSha = selectReleaseCommit({githubSha: 'caller-commit-sha'});
+
+    expect(actualReleaseCommitSha).toBe('caller-commit-sha');
+  });
+
+  it('uses the pull request head commit before GITHUB_SHA for legacy pull request callers', () => {
+    const actualReleaseCommitSha = selectReleaseCommit({
+      pullRequestCommitSha: 'pull-request-head-sha',
+      githubSha: 'caller-commit-sha',
+    });
+
+    expect(actualReleaseCommitSha).toBe('pull-request-head-sha');
+  });
+
+  it('generates immutable image metadata from the config version and short release commit', () => {
+    const actualImageTag = createUniqueImageTag({
+      versionTag: '2026-07-15.1-production',
+      configurationVersion: 'v0.34.9-0',
+      releaseCommitSha: '1234567890abcdef',
+    });
+
+    const expectedImageTag = '2026-07-15.1-production-v0.34.9-0-1234567';
+
+    assert.equal(actualImageTag, expectedImageTag);
+  });
+
+  it('uses the working directory when no custom Docker context is configured', () => {
+    const workingDirectory = '/workspace/wire-webapp';
+
+    const actualContextPath = resolveDockerContextPath(undefined, workingDirectory);
+
+    expect(actualContextPath).toBe(workingDirectory);
+  });
+
+  it('resolves a relative Docker context inside the working directory', () => {
+    const workingDirectory = '/workspace/wire-webapp';
+
+    const actualContextPath = resolveDockerContextPath('distribution-context', workingDirectory);
+
+    expect(actualContextPath).toBe(path.join(workingDirectory, 'distribution-context'));
+  });
+
+  it('rejects a Docker context outside the working directory', () => {
+    const workingDirectory = '/workspace/wire-webapp';
+
+    assert.throws(
+      () => resolveDockerContextPath('../outside', workingDirectory),
+      /Docker context path must remain inside the working directory/,
+    );
+    assert.throws(
+      () => resolveDockerContextPath('/tmp/outside', workingDirectory),
+      /Docker context path must remain inside the working directory/,
+    );
+  });
+
+  it('rejects a Docker context containing a null byte', () => {
+    assert.throws(
+      () => resolveDockerContextPath('distribution\0context', '/workspace/wire-webapp'),
+      /Docker context path must not contain null bytes/,
+    );
+  });
+
+  it('invokes Docker with separate arguments and writes the image tag without a shell', () => {
+    const events: Array<Record<string, unknown>> = [];
+    const environment = {
+      DOCKER_PASSWORD: 'secret-password',
+      DOCKER_USERNAME: 'docker-user',
+      WIRE_WEBAPP_RELEASE_COMMIT_SHA: '1234567890abcdef',
+    };
+    const outputPath = '/tmp/production-image-tag.txt';
+    const actualImageTag = runDockerPublication(['2026-07-15.1-production', outputPath], environment, {
+      runProcess(command: string, commandArguments: string[], processOptions: Record<string, unknown>) {
+        events.push({kind: 'process', command, commandArguments, processOptions});
+      },
+      writeFile(filePath: string, fileContents: string) {
+        events.push({kind: 'write', filePath, fileContents});
+      },
+    });
+
+    const processEvents = events.filter(event => event.kind === 'process');
+    const loginEvent = processEvents.find(event => event.commandArguments[0] === 'login');
+    const buildEvent = processEvents.find(event => event.commandArguments[0] === 'build');
+    const runEvent = processEvents.find(event => event.commandArguments[0] === 'run');
+    const tagEvents = processEvents.filter(event => event.commandArguments[0] === 'tag');
+    const pushEvents = processEvents.filter(event => event.commandArguments[0] === 'push');
+    const writeEvent = events.find(event => event.kind === 'write');
+
+    expect(loginEvent.commandArguments).toEqual(['login', '--username', 'docker-user', '--password-stdin', 'quay.io']);
+    expect(loginEvent.processOptions.input).toBe('secret-password\n');
+    expect(buildEvent.commandArguments).toEqual([
+      'build',
+      process.cwd(),
+      '--file',
+      path.join(process.cwd(), 'apps/server/Dockerfile'),
+      '--tag',
+      '1234567',
+    ]);
+    expect(runEvent.commandArguments.slice(0, 6)).toEqual(['run', '--rm', '--entrypoint', 'sh', '1234567', '-c']);
+    expect(tagEvents.every(event => event.commandArguments.length === 3)).toBe(true);
+    expect(tagEvents.every(event => event.commandArguments[1] === '1234567')).toBe(true);
+    expect(pushEvents.every(event => event.commandArguments.length === 2)).toBe(true);
+    expect(pushEvents.every(event => typeof event.commandArguments[1] === 'string')).toBe(true);
+    expect(events.map(event => event.kind).slice(0, 4)).toEqual(['process', 'process', 'process', 'write']);
+    expect(writeEvent).toEqual({kind: 'write', filePath: outputPath, fileContents: actualImageTag});
+  });
+
+  it('always disables the shell at the process boundary', () => {
+    let actualProcessOptions: Record<string, unknown> | undefined;
+
+    runProcess(
+      'docker',
+      ['push', 'quay.io/wire/webapp:production'],
+      {stdio: 'inherit'},
+      (_command: string, _commandArguments: string[], processOptions: Record<string, unknown>) => {
+        actualProcessOptions = processOptions;
+        return {error: undefined, status: 0};
+      },
+    );
+
+    expect(actualProcessOptions?.shell).toBe(false);
+  });
+
+  it('reports process failures with the executable and status', () => {
+    assert.throws(
+      () => runProcess('docker', ['push', 'quay.io/wire/webapp:production'], {}, () => ({error: undefined, status: 7})),
+      /docker exited with status 7/,
+    );
+  });
+
+  it('reports process startup errors without exposing unrelated input', () => {
+    assert.throws(
+      () =>
+        runProcess('docker', ['login', '--username', 'docker-user', '--password-stdin', 'quay.io'], {}, () => ({
+          error: new Error('not found'),
+          status: null,
+        })),
+      /docker failed with status unknown: not found/,
+    );
+  });
+});

--- a/bin/update-wire-builds.sh
+++ b/bin/update-wire-builds.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${DOCKER_IMAGE_TAG:?DOCKER_IMAGE_TAG is required}"
+: "${HELM_CHART_VERSION:?HELM_CHART_VERSION is required}"
+: "${RELEASE_COMMIT_SHA:?RELEASE_COMMIT_SHA is required}"
+
+webapp_repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+chart_repository='https://s3-eu-west-1.amazonaws.com/public.wire.com/charts-webapp'
+commit_url="https://github.com/wireapp/wire-webapp/commit/${RELEASE_COMMIT_SHA}"
+wire_builds_field_options=(
+  --version "${HELM_CHART_VERSION}"
+  --repo "${chart_repository}"
+  --app-version "${DOCKER_IMAGE_TAG}"
+  --commit-url "${commit_url}"
+  --commit "${RELEASE_COMMIT_SHA}"
+)
+
+run_distribution_cli() {
+  (
+    cd "${webapp_repository_root}"
+    ./bin/yarn ts-node \
+      --project ./tsconfig.bin.json \
+      ./bin/productionDistributionCli.ts \
+      "$@"
+  )
+}
+
+wire_builds_fields_match() {
+  run_distribution_cli wire-builds-fields-match "${wire_builds_field_options[@]}" < build.json
+}
+
+build_version_before="$(jq --raw-output '.version' build.json)"
+if wire_builds_fields_match; then
+  build_version_after="$(jq --raw-output '.version' build.json)"
+  if [[ "${build_version_before}" != "${build_version_after}" ]]; then
+    echo 'The wire-builds no-op changed the top-level build version.' >&2
+    exit 1
+  fi
+
+  echo 'wire-builds already contains the exact WebApp distribution fields.'
+  echo "wire_builds_commit_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+push_succeeded=false
+for retry_number in 1 2 3; do
+  if [[ "${retry_number}" -gt 1 ]]; then
+    echo 'Retrying wire-builds/main update.'
+  fi
+
+  set +e
+  (
+    set -euo pipefail
+
+    git fetch --depth 1 origin main
+    git reset --hard origin/main
+
+    build_version_before="$(jq --raw-output '.version' build.json)"
+    if wire_builds_fields_match; then
+      build_version_after="$(jq --raw-output '.version' build.json)"
+      if [[ "${build_version_before}" != "${build_version_after}" ]]; then
+        echo 'The wire-builds no-op changed the top-level build version.' >&2
+        exit 1
+      fi
+
+      exit 0
+    fi
+
+    unrelated_build_state_before="$(jq -S -c 'del(.version, .helmCharts.webapp)' build.json)"
+    updated_build_json="$(
+      ./bin/set-chart-fields webapp \
+        "version=${HELM_CHART_VERSION}" \
+        "repo=${chart_repository}" \
+        "meta.appVersion=${DOCKER_IMAGE_TAG}" \
+        "meta.commitURL=${commit_url}" \
+        "meta.commit=${RELEASE_COMMIT_SHA}" < build.json |
+        ./bin/bump-prerelease
+    )"
+    printf '%s\n' "${updated_build_json}" > build.json
+
+    unrelated_build_state_after="$(jq -S -c 'del(.version, .helmCharts.webapp)' build.json)"
+    if [[ "${unrelated_build_state_before}" != "${unrelated_build_state_after}" ]]; then
+      echo 'The wire-builds update changed a chart other than webapp.' >&2
+      exit 1
+    fi
+
+    build_version_after="$(jq --raw-output '.version' build.json)"
+    if [[ "${build_version_before}" == "${build_version_after}" ]]; then
+      echo 'The wire-builds update did not bump the top-level build version.' >&2
+      exit 1
+    fi
+
+    if ! wire_builds_fields_match; then
+      echo 'The generated wire-builds WebApp fields are not exact.' >&2
+      exit 1
+    fi
+
+    git config user.email 'zebot@users.noreply.github.com'
+    git config user.name 'Zebot'
+    git add build.json
+    git commit -m "Bump webapp to ${HELM_CHART_VERSION}"
+    git push origin main
+  )
+  attempt_exit_code=$?
+  set -e
+
+  if [[ "${attempt_exit_code}" -eq 0 ]]; then
+    push_succeeded=true
+    break
+  fi
+
+  echo "wire-builds/main update failed on attempt ${retry_number}." >&2
+done
+
+if [[ "${push_succeeded}" != 'true' ]]; then
+  echo 'Unable to update wire-builds/main after three attempts.' >&2
+  exit 1
+fi
+
+git fetch --depth 1 origin main
+git reset --hard origin/main
+if ! wire_builds_fields_match; then
+  echo 'wire-builds/main does not contain the expected final WebApp fields.' >&2
+  exit 1
+fi
+
+echo "wire_builds_commit_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"

--- a/bin/validate-production-distribution.sh
+++ b/bin/validate-production-distribution.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${DISTRIBUTION_CONTEXT_PATH:?DISTRIBUTION_CONTEXT_PATH is required}"
+: "${EXPECTED_COMMIT_SHA:?EXPECTED_COMMIT_SHA is required}"
+: "${PRODUCTION_TAG:?PRODUCTION_TAG is required}"
+: "${SOURCE_RUN_ID:?SOURCE_RUN_ID is required}"
+
+if [[ ! "${PRODUCTION_TAG}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\.[1-9][0-9]*-production$ ]]; then
+  echo "Production tag does not match YYYY-MM-DD.N-production: ${PRODUCTION_TAG}" >&2
+  exit 1
+fi
+
+git ls-remote --exit-code --tags origin "refs/tags/${PRODUCTION_TAG}" >/dev/null
+git fetch --no-tags origin "refs/tags/${PRODUCTION_TAG}:refs/tags/${PRODUCTION_TAG}"
+
+if [[ "$(git cat-file -t "refs/tags/${PRODUCTION_TAG}")" != 'tag' ]]; then
+  echo "Production tag ${PRODUCTION_TAG} is not an annotated tag." >&2
+  exit 1
+fi
+
+production_tag_commit_sha="$(git rev-parse "refs/tags/${PRODUCTION_TAG}^{commit}")"
+manifest_path="${DISTRIBUTION_CONTEXT_PATH}/distribution-manifest.json"
+
+validation_options=(
+  --manifest-path "${manifest_path}"
+  --production-tag "${PRODUCTION_TAG}"
+  --production-tag-commit-sha "${production_tag_commit_sha}"
+  --source-run-id "${SOURCE_RUN_ID}"
+)
+
+if [[ -n "${EXPECTED_COMMIT_SHA}" ]]; then
+  validation_options+=(--expected-commit-sha "${EXPECTED_COMMIT_SHA}")
+fi
+
+./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/productionDistributionCli.ts \
+  validate-manifest "${validation_options[@]}"
+
+for required_context_path in \
+  "${DISTRIBUTION_CONTEXT_PATH}/apps/server/Dockerfile" \
+  "${DISTRIBUTION_CONTEXT_PATH}/apps/server/dist" \
+  "${DISTRIBUTION_CONTEXT_PATH}/libraries/config/lib" \
+  "${DISTRIBUTION_CONTEXT_PATH}/package.json" \
+  "${DISTRIBUTION_CONTEXT_PATH}/yarn.lock" \
+  "${DISTRIBUTION_CONTEXT_PATH}/.yarnrc.yml" \
+  "${DISTRIBUTION_CONTEXT_PATH}/.npmrc" \
+  "${DISTRIBUTION_CONTEXT_PATH}/.yarn" \
+  "${DISTRIBUTION_CONTEXT_PATH}/bin/yarn" \
+  "${DISTRIBUTION_CONTEXT_PATH}/apps/server/package.json" \
+  "${DISTRIBUTION_CONTEXT_PATH}/libraries/config/package.json" \
+  "${DISTRIBUTION_CONTEXT_PATH}/run.sh" \
+  "${DISTRIBUTION_CONTEXT_PATH}/.env.defaults"; do
+  if [[ ! -e "${required_context_path}" ]]; then
+    echo "Required Docker context path is missing: ${required_context_path}" >&2
+    exit 1
+  fi
+done
+
+cloud_artifact_checksum="$(jq --raw-output '.cloudArtifactChecksum' "${manifest_path}")"
+actual_cloud_artifact_checksum="$(sha256sum "${DISTRIBUTION_CONTEXT_PATH}/apps/server/dist/s3/ebs.zip" | awk '{print $1}')"
+if [[ "${actual_cloud_artifact_checksum}" != "${cloud_artifact_checksum}" ]]; then
+  echo 'The distribution context EBS checksum does not match its manifest.' >&2
+  exit 1
+fi
+
+artifact_version="$(jq --raw-output '.artifactVersion' "${manifest_path}")"
+actual_artifact_version="$(jq --raw-output '.version' "${DISTRIBUTION_CONTEXT_PATH}/apps/server/dist/version.json")"
+if [[ "${actual_artifact_version}" != "${artifact_version}" ]]; then
+  echo 'The distribution context version does not match its manifest.' >&2
+  exit 1
+fi
+
+echo "production_tag_commit_sha=${production_tag_commit_sha}" >> "${GITHUB_OUTPUT}"

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -34,6 +34,8 @@ flowchart LR
   productionEnvironment[Production]
   productionRuntimeVerification[Verify live Production runtime<br/>Artifact version and Production backends]
   productionTag[YYYY-MM-DD.N-production]
+  productionDistribution[Publish Docker image and Helm chart<br/>Update wire-builds/main]
+  manualDistributionRepair[Manual distribution repair<br/>Validate confirmation, reason, and tag]
   maintenanceBranch[maintenance/maintenance-line-key]
   maintenanceTag[maintenance-line-key-maintenance.X]
 
@@ -47,6 +49,8 @@ flowchart LR
   productionApproval -->|Approve candidate| productionEnvironment
   productionEnvironment -->|Deploy promoted artifact| productionRuntimeVerification
   productionRuntimeVerification -->|Verified runtime creates| productionTag
+  productionTag -->|Explicit reusable workflow| productionDistribution
+  manualDistributionRepair -->|Explicit reusable workflow| productionDistribution
   productionTag -->|Create only when needed| maintenanceBranch
   maintenanceBranch -->|Validated maintenance artifact creates| maintenanceTag
 
@@ -93,7 +97,7 @@ The release identifier uses the release branch name: `YYYY-MM-DD.N`. The full id
 The cloud release process is:
 
 - Every merge to `main` deploys continuously to Edge without an approval gate.
-- Creating or updating `release/YYYY-MM-DD.N` automatically starts the release workflow.
+- The release workflow is explicitly dispatched for `release/YYYY-MM-DD.N`; automatic release-branch triggering remains disabled during the transition.
 - The release workflow deploys the release branch to Beta.
 - After a successful beta deployment, the workflow creates a beta tag such as `YYYY-MM-DD.N-beta.1`, `YYYY-MM-DD.N-beta.2`, and so on.
 - Beta tag numbers are derived from existing beta tags for the release identifier. If concurrent workflows try to create the same tag for different commits, the later workflow must fail and be rerun after fetching the latest tags.
@@ -114,6 +118,16 @@ The cloud release process is:
 - Build version and source commit are separate evidence: the same source commit can produce different builds, so `/commit` proves the source revision while `/version` identifies the particular build generated and promoted by the current workflow.
 - Backend configuration is runtime state and is not inferred from build identity. Beta, precommit, and Production must each satisfy their expected combination of build version, source commit, REST backend, and WebSocket backend.
 - A successful deployment operation alone does not create a Production tag. The workflow creates the production tag `YYYY-MM-DD.N-production` only after all Production runtime assertions pass, so the tag represents a successfully deployed and verified runtime.
+- The cloud EBS artifact is built once and promoted unchanged through Beta, E2E, and Production.
+- A Production-capable run also preserves the exact public build outputs needed by the Dockerfile. The public Docker image is built from those outputs, from the same release commit, without rebuilding the application.
+- Docker and Helm publication starts only after Production deployment and runtime verification succeed and the immutable Production tag has been created.
+- `wire-builds/main` is updated only after the immutable image and Helm chart have been published or reused and verified.
+- A Production tag represents verified cloud deployment. The release is fully distributed only after the `wire-builds/main` update succeeds.
+- A distribution failure does not move or delete the Production tag. The Release Cloud run remains failed and identifies the release as incomplete for on-premises distribution.
+- A dedicated reusable distribution workflow is called explicitly by Release Cloud after the immutable Production tag exists. A separate manual repair workflow validates confirmation, reason, and the existing annotated Production tag before calling the same reusable workflow for a partial distribution failure. Publication is not triggered by a tag listener.
+- Docker, Helm, and `wire-builds/main` publication is retry-safe and idempotent. Existing immutable image and chart identities are reused, and an exact `wire-builds` entry is a no-op.
+- The current WebApp distribution policy is preserved: when no matching chart exists, Helm publication uses the prerelease chart version sequence consumed by `wire-builds/main`.
+- A `wire-builds/main` update may change only the top-level `version` and `helmCharts.webapp`; every other field and chart entry must remain byte-for-byte equivalent after normalized JSON comparison.
 - If Production runtime verification fails, Production remains untagged, the release workflow fails, Deployoholics receives a failure notification, and the release captain performs incident assessment.
 - If the current release branch commit already has the matching production tag, the release workflow must not redeploy that commit.
 - Production tags are immutable release history and are never moved or deleted.
@@ -123,6 +137,7 @@ Release workflows must be serialized:
 - A newer Beta run for the same release branch may cancel an older in-progress Beta run before deployment starts.
 - Only one Production deployment may run at a time for the repository.
 - Production deployments must not be cancelled automatically.
+- The repository-wide Production lock covers deployment, runtime verification, Production tag creation, Docker publication, Helm publication, and the `wire-builds/main` update. Manual distribution repairs use the same lock.
 
 - Release workflow failures and stalled approvals are monitored by the engineering release captain and announced in Wire.
 
@@ -143,6 +158,11 @@ flowchart TD
   deployToProduction[Deploy promoted beta artifact to Production]
   verifyProductionRuntime[Verify live Production runtime<br/>Build version, source commit, and Production backends]
   createProductionTag[Create YYYY-MM-DD.N-production]
+  publishDocker[Publish or reuse immutable Docker image]
+  publishHelm[Publish or reuse Helm chart<br/>Verify appVersion]
+  updateWireBuilds[Update or reuse wire-builds/main<br/>Verify exact WebApp fields]
+  repairDistribution[workflow_dispatch repair<br/>Validate reason, confirmation, and annotated tag]
+  distributionFailure[Distribution failure<br/>Production tag remains immutable]
   rollbackWorkflow[Rollback Production workflow_dispatch<br/>optional incident action]
   deployKnownGoodArtifact[Deploy previous known-good production artifact]
 
@@ -150,6 +170,11 @@ flowchart TD
   createReleaseBranch --> buildArtifact --> deployToBeta --> verifyBetaRuntime --> createBetaTag
   createBetaTag --> deployToE2E --> verifyE2ERuntime --> runEndToEndTests --> reportToTestiny
   reportToTestiny --> productionApproval --> deployToProduction --> verifyProductionRuntime --> createProductionTag
+  createProductionTag --> publishDocker --> publishHelm --> updateWireBuilds
+  repairDistribution -->|same reusable distribution workflow| publishDocker
+  updateWireBuilds -.-> distributionFailure
+  publishDocker -.-> distributionFailure
+  publishHelm -.-> distributionFailure
   createProductionTag -.-> rollbackWorkflow -.-> deployKnownGoodArtifact
 ```
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

Integrates the WebApp Docker image, Helm chart, and
`wireapp/wire-builds/main` update into the ADR 0002 Production release path.

## Release order

The normal Release Cloud flow is:

1. build the public cloud artifact once
2. deploy the artifact to Beta
3. verify Beta runtime identity and configuration
4. create the immutable Beta tag
5. deploy the same artifact to the E2E environment
6. run the complete blocking full-system E2E suite
7. wait for Production approval
8. deploy the same cloud artifact to Production
9. verify the live Production version, commit, and backend configuration
10. create the immutable Production tag
11. publish or reuse the immutable Docker image
12. publish or reuse the Helm chart
13. update `wireapp/wire-builds/main/build.json`

The release is fully distributed only after the `wire-builds` update succeeds.

## Architecture

The implementation uses two explicit entry points.

### Normal release

```text
Release Cloud
→ calls the reusable Production distribution workflow
```

`.github/workflows/publish-production-distribution.yml` supports
`workflow_call` only.

It receives an already verified Production tag, release commit, source workflow
run, and exact distribution artifact.

### Manual repair

```text
Repair Production distribution
→ validates confirmation, reason, and the existing annotated Production tag
→ calls the same reusable Production distribution workflow
```

Manual repair is handled by:

```text
.github/workflows/repair-production-distribution.yml
```

The reusable workflow does not inspect `github.event_name` to infer whether it
is running as a normal release or a repair.

## Serialization

Production-capable Release Cloud runs and manual distribution repairs share the
same global concurrency lock:

```text
release-cloud-production
```

Production operations are never cancelled automatically.

Beta-only runs retain branch-specific concurrency.

## Artifact integrity

The public cloud artifact is built once and promoted unchanged through Beta,
E2E, and Production.

The Docker image is built from the exact public build outputs created by the
same Production-capable Release Cloud run.

The distribution workflow verifies:

* the Production tag is an annotated ADR tag
* the Production tag points to the expected release commit
* the downloaded distribution manifest belongs to the expected workflow run
* the manifest commit matches the Production tag commit
* the generated application version matches the manifest
* the EBS artifact checksum matches the manifest
* the immutable Docker image tag contains the release commit identity
* the Helm chart `appVersion` matches the immutable Docker image
* the final `wire-builds` WebApp entry contains the exact expected values

The uploaded Docker context explicitly includes required hidden files such as:

```text
.yarn
.yarnrc.yml
.npmrc
.env.defaults
```

## Idempotency

The distribution path is safe to retry.

* an existing immutable Docker image is reused
* an existing single Helm chart with the expected `appVersion` is reused
* multiple matching Helm charts fail explicitly
* an already correct `wire-builds` WebApp entry is treated as a no-op
* a no-op does not bump the top-level `wire-builds` version again
* concurrent `wire-builds/main` updates use bounded retry behavior

## Helm policy

This change preserves the existing WebApp distribution policy by publishing
prerelease Helm chart versions.

It does not introduce a new stable-chart versioning policy.

## wire-builds safety

The `wire-builds` update may change only:

```text
.version
.helmCharts.webapp
```

Every other field and chart entry must remain unchanged.

The WebApp entry is verified against:

```text
repo
version
meta.appVersion
meta.commitURL
meta.commit
```

The complete `build.json` document is passed to the validator, which explicitly
reads:

```text
helmCharts.webapp
```

## Failure behavior

When a release gate fails before Production:

* Production is not deployed
* no Production tag is created
* Release Cloud fails
* Deployoholics is notified

When cloud Production succeeds but Docker, Helm, or `wire-builds` publication
fails:

* Production remains deployed
* the immutable Production tag remains unchanged
* Release Cloud fails
* Deployoholics is notified
* the release is marked incomplete for on-premises distribution
* the dedicated repair workflow can resume the idempotent publication

No failure path moves or deletes a Production tag.

## Transition

The legacy publication workflow remains available for existing legacy,
development, and maintenance paths.

This pull request does not retire the old workflow.

Retirement happens only after the new complete release path has been validated
successfully.

## Safety

This pull request does not:

* weaken the blocking E2E gate
* change Production approval rules
* rebuild the cloud artifact between Beta and Production
* publish before Production verification
* update `wire-builds` before the Production tag exists
* move or delete release tags
* enable automatic release-branch execution
* remove the legacy publication workflow
* change infrastructure

## Tracking

Part of #21597.
