### PR TITLE
bug: fixed rendering bug for images sent from services (WPB-26424)

### DIFF
--- a/apps/webapp/src/script/repositories/cryptography/CryptographyMapper.ts
+++ b/apps/webapp/src/script/repositories/cryptography/CryptographyMapper.ts
@@ -368,11 +368,9 @@ export class CryptographyMapper {
 
   private _mapAsset(asset: Asset) {
     const {original, preview, uploaded, notUploaded} = asset;
-    let data: AssetData = {
-      content_length: 0,
-      content_type: '',
-      info: {},
-    };
+
+    // Initializing this with empty values breaks rendering of images of services
+    let data = {} as AssetData;
 
     if (original !== null && original !== undefined) {
       data = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26424" title="WPB-26424" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26424</a>  [Web] [Assets] Asset previews are not displayed when sent by Bots (or old clients)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Description

This commit fixes a bug with image assets sent by services.
Initializing the AssetData with empty values breaks a condition somewhere in the app that leads to the image not being rendered and showing as having 0 Bytes.

To fix this the initialization of the AssetData object was skipped so only the properties that are actually required are part of the resulting object.