### PR TITLE
Ensure 1on1 conversation upgrades don't cause flake [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Conversations/conversations.spec.ts
@@ -140,7 +140,7 @@ test.describe('Conversations', () => {
 
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();
-      await expect(adminPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
+      await expect(adminPages.conversationList().getConversation(guestUser.fullName, {protocol: 'mls'})).toBeAttached();
 
       await createGroup(adminPages, groupName, [userB, guestUser]);
 
@@ -169,7 +169,7 @@ test.describe('Conversations', () => {
 
       await guestPages.conversationList().openPendingConnectionRequest();
       await guestPages.connectRequest().clickConnectButton();
-      await expect(adminPages.conversationList().getConversation(guestUser.fullName)).toBeAttached();
+      await expect(adminPages.conversationList().getConversation(guestUser.fullName, {protocol: 'mls'})).toBeAttached();
 
       await createGroup(adminPages, groupName, [userB, guestUser]);
 

--- a/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ParticipantProfile/participantProfile.spec.ts
@@ -103,8 +103,8 @@ test.describe('Participant Profile', () => {
 
       await sendConnectionRequest(userAPage, userC);
       await acceptConnectionRequest(userCPages);
-      await expect(userAPages.conversationList().getConversation(userC.fullName)).toBeAttached();
-      await expect(userCPages.conversationList().getConversation(userA.fullName)).toBeAttached();
+      await expect(userAPages.conversationList().getConversation(userC.fullName, {protocol: 'mls'})).toBeAttached();
+      await expect(userCPages.conversationList().getConversation(userA.fullName, {protocol: 'mls'})).toBeAttached();
 
       await test.step('User C is in group with User A and B. User C is not connected to user B', async () => {
         await createGroup(userAPages, groupName, [userB, userC]);
@@ -146,7 +146,7 @@ test.describe('Participant Profile', () => {
 
       await sendConnectionRequest(userAPageManager, userC);
       await acceptConnectionRequest(userCPageManager.webapp.pages);
-      await expect(pages.conversationList().getConversation(userC.fullName)).toBeAttached();
+      await expect(pages.conversationList().getConversation(userC.fullName, {protocol: 'mls'})).toBeAttached();
 
       await createGroup(pages, groupName, [userB, userC]);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The new way for unlocking enterprise features revealed a bit of flake in some tests. This PR is a small fix to ensure upgrades of 1on1 conversations don't cause test failures