### PR TITLE
Fix main development Docker publication [WPB-26469]

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -13,7 +13,8 @@ COPY apps/server/package.json ./apps/server/package.json
 COPY libraries/config/package.json ./libraries/config/package.json
 
 # Install only server production deps
-RUN ./bin/yarn workspaces focus @wireapp/server --production
+# Artifact downloads do not preserve executable file permissions.
+RUN chmod +x ./bin/yarn && ./bin/yarn workspaces focus @wireapp/server --production
 
 # Copy built config library artifacts
 COPY libraries/config/lib ./libraries/config/lib

--- a/bin/push_docker.test.ts
+++ b/bin/push_docker.test.ts
@@ -18,6 +18,7 @@
  */
 
 import assert from 'node:assert';
+import {readFileSync} from 'node:fs';
 import path from 'node:path';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -86,6 +87,16 @@ describe('push_docker metadata', () => {
     const expectedImageTag = 'dev-v0.34.9-0-1234567';
 
     assert.equal(actualImageTag, expectedImageTag);
+  });
+
+  it('makes the Yarn wrapper executable after artifact download before invoking it', () => {
+    const dockerfilePath = path.join(process.cwd(), 'apps/server/Dockerfile');
+    const dockerfileContents = readFileSync(dockerfilePath, 'utf8');
+
+    assert.match(
+      dockerfileContents,
+      /RUN chmod \+x \.\/bin\/yarn && \.\/bin\/yarn workspaces focus @wireapp\/server --production/,
+    );
   });
 
   it('uses the working directory when no custom Docker context is configured', () => {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Root cause

The first real Publish main run failed in **Publish or reuse dev Docker image** while building the immutable image. The exact failing command was:

`RUN ./bin/yarn workspaces focus @wireapp/server --production`

The first relevant error was:

`/bin/sh: ./bin/yarn: Permission denied`

The exact Docker context was downloaded successfully, but the artifact transfer did not preserve the executable mode of the tracked `bin/yarn` wrapper. The failure occurred during Docker build, before runtime `.env.defaults` validation, tagging, pushing, or manifest verification.

## Fix

Make `bin/yarn` executable inside the image immediately before the existing production dependency focus command. The shared Dockerfile is used by both development and Production publication contexts, so this repairs the transfer-boundary mode loss without changing application builds or release ownership.

Edge was unaffected because it consumes the successful `build:prod` EBS artifact and does not execute this Dockerfile command. Helm publication and `wire-builds/dev` correctly remained unchanged because the workflow gates them on successful Docker publication.
