### PR TITLE
fix: Prevent conversation list avatars from showing the wrong user [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/avatar/avatarImage.test.tsx
+++ b/apps/webapp/src/script/components/avatar/avatarImage.test.tsx
@@ -137,4 +137,45 @@ describe('AvatarImage', () => {
 
     await waitFor(() => expect(assetRepoSpy.getObjectUrl).not.toHaveBeenCalled());
   });
+
+  it('clears a previously loaded avatar when the picture resource is removed', async () => {
+    const avatarUrl = 'blob:avatar-image';
+    const assetRepoSpy = {
+      getObjectUrl: jasmine.createSpy().and.returnValue(Promise.resolve(avatarUrl)),
+    };
+    const assetRepo = assetRepoSpy as unknown as AssetRepository;
+    const participant = new User('id', '', translateForTest);
+    const resource = {
+      downloadProgress: 0,
+    } as AssetRemoteData;
+    participant.previewPictureResource(resource);
+
+    const {rerender} = render(
+      <AvatarImage
+        assetRepository={assetRepo}
+        avatarAlt={participant.name()}
+        avatarSize={AVATAR_SIZE.SMALL}
+        mediumPicture={participant.mediumPictureResource()}
+        previewPicture={participant.previewPictureResource()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('img')).toHaveAttribute('src', avatarUrl);
+    });
+
+    rerender(
+      <AvatarImage
+        assetRepository={assetRepo}
+        avatarAlt={participant.name()}
+        avatarSize={AVATAR_SIZE.SMALL}
+        mediumPicture={undefined}
+        previewPicture={undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('img')).toHaveAttribute('src', '');
+    });
+  });
 });

--- a/apps/webapp/src/script/components/avatar/avatarImage.tsx
+++ b/apps/webapp/src/script/components/avatar/avatarImage.tsx
@@ -55,38 +55,41 @@ const AvatarImage: React.FunctionComponent<AvatarImageProps> = ({
 }) => {
   const [avatarImage, setAvatarImage] = useState('');
   const [showTransition, setShowTransition] = useState(false);
-  const [avatarLoadingBlocked, setAvatarLoadingBlocked] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
-    if (!avatarLoadingBlocked && isVisible) {
-      setAvatarLoadingBlocked(true);
-
-      const isSmall = ![AVATAR_SIZE.LARGE, AVATAR_SIZE.X_LARGE].includes(avatarSize);
-      const loadHiRes = !isSmall && devicePixelRatio > 1;
-      const pictureResource: AssetRemoteData | undefined = loadHiRes
-        ? (mediumPicture ?? previewPicture)
-        : previewPicture;
-
-      (async () => {
-        if (pictureResource !== undefined) {
-          const isCached = pictureResource.downloadProgress === 100;
-          setShowTransition(!isCached && !isSmall);
-          try {
-            const url = await assetRepository.getObjectUrl(pictureResource);
-            if (url) {
-              setAvatarImage(url);
-            }
-            setAvatarLoadingBlocked(false);
-          } catch (error: unknown) {
-            console.warn('Failed to load avatar picture.', error);
-          }
-        } else {
-          setAvatarLoadingBlocked(false);
-        }
-      })();
+    if (!isVisible) {
+      return undefined;
     }
-  }, [previewPicture, mediumPicture, avatarSize, isVisible]);
+
+    const isSmall = ![AVATAR_SIZE.LARGE, AVATAR_SIZE.X_LARGE].includes(avatarSize);
+    const loadHiRes = !isSmall && devicePixelRatio > 1;
+    const pictureResource: AssetRemoteData | undefined = loadHiRes ? (mediumPicture ?? previewPicture) : previewPicture;
+
+    if (pictureResource === undefined) {
+      setAvatarImage('');
+      return undefined;
+    }
+
+    let cancelled = false;
+    const isCached = pictureResource.downloadProgress === 100;
+    setShowTransition(!isCached && !isSmall);
+
+    void (async () => {
+      try {
+        const url = await assetRepository.getObjectUrl(pictureResource);
+        if (!cancelled && url) {
+          setAvatarImage(url);
+        }
+      } catch (error: unknown) {
+        console.warn('Failed to load avatar picture.', error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [previewPicture, mediumPicture, avatarSize, isVisible, assetRepository, devicePixelRatio]);
 
   const transitionImageStyles: Record<string, CSSObject> = {
     entered: {opacity: 1, transform: 'scale(1)'},

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationsList.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationsList.tsx
@@ -152,10 +152,28 @@ export const ConversationsList = ({
 
   const parentRef = useRef(null);
 
+  const getItemKey = useCallback(
+    (index: number) => {
+      const item = conversationsToDisplay[index];
+
+      if (isConversationEntity(item)) {
+        return item.id;
+      }
+
+      if (item && 'heading' in item) {
+        return `heading-${item.heading}`;
+      }
+
+      return index;
+    },
+    [conversationsToDisplay],
+  );
+
   const rowVirtualizer = useVirtualizer({
     count: conversationsToDisplay.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => CONVERSATION_ROW_HEIGHT,
+    getItemKey,
   });
 
   const debouncedOnConversationClick = useDebouncedCallback(


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary
- Restore stable TanStack Virtual item keys (`conversation.id`) so conversation list rows are not reused across different conversations when the list reorders after send/receive.
- Clear stale `AvatarImage` URLs when a user has no picture resource, and ignore cancelled async loads, so initials avatars cannot keep another user’s photo.

<img width="762" height="332" alt="image" src="https://github.com/user-attachments/assets/7ce2c66e-cf29-4b19-8817-ec5e5a9b0d61" />

## Test plan
- [x] Open a conversation list with at least one 1:1 contact without a profile picture (initials only) and one with a photo
- [x] Send a message to the initials-only contact, or receive a message in another conversation so the list reorders
- [x] Confirm the initials-only contact still shows initials (not another user’s photo)
- [x] Confirm contacts with photos still show the correct avatars after reordering
- [x] `yarn nx run webapp:test --testFile=src/script/components/avatar/avatarImage.test.tsx`