### PR TITLE
Restore hosted Dev deployment from main [WPB-26469]

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Optional reason for manually delivering main to Edge and the development channel'
+        description: 'Optional reason for manually delivering main to Edge, hosted Dev, and the development channel'
         required: false
         type: string
       confirm_main_publish:
-        description: 'Confirm that this will deploy Edge and publish the dev Docker image, Helm chart, and wire-builds/dev channel'
+        description: 'Confirm that this will deploy Edge and hosted Dev, then publish the dev Docker image, Helm chart, and wire-builds/dev channel'
         required: true
         default: false
         type: boolean
@@ -20,6 +20,10 @@ env:
   AWS_REGION: eu-central-1
   BUILD_ARTIFACT_PATH: apps/server/dist/s3/ebs.zip
   EDGE_ENVIRONMENT_NAME: wire-webapp-edge
+  DEV_ELASTIC_BEANSTALK_ENVIRONMENT_NAME: wire-webapp-dev
+  DEV_WEBAPP_URL: https://wire-webapp-dev.zinfra.io/
+  DEV_RUNTIME_BACKEND_REST: https://staging-nginz-https.zinfra.io/
+  DEV_RUNTIME_BACKEND_WS: wss://staging-nginz-ssl.zinfra.io/
   DOCKER_REPOSITORY: quay.io/wire/webapp
   CHART_REPOSITORY_NAME: charts-webapp
   CHART_REPOSITORY_URL: s3://public.wire.com/charts-webapp
@@ -69,7 +73,8 @@ jobs:
     permissions:
       contents: read
     outputs:
-      edge_artifact_name: ${{ steps.artifact_metadata.outputs.edge_artifact_name }}
+      main_artifact_name: ${{ steps.artifact_metadata.outputs.main_artifact_name }}
+      artifact_version: ${{ steps.artifact_metadata.outputs.artifact_version }}
       development_context_artifact_name: ${{ steps.artifact_metadata.outputs.development_context_artifact_name }}
 
     steps:
@@ -98,7 +103,7 @@ jobs:
       - name: Build and package internal application
         run: ./bin/yarn build:prod
 
-      - name: Prepare exact development Docker context
+      - name: Prepare shared main artifact metadata and exact development Docker context
         id: artifact_metadata
         shell: bash
         env:
@@ -106,8 +111,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          edge_artifact_name="main-edge-artifact-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          main_artifact_name="main-artifact-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           development_context_artifact_name="main-development-context-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_version="$(unzip -p "${BUILD_ARTIFACT_PATH}" version.json | jq --exit-status --raw-output '.version | strings | select(length > 0)')"
+          test -n "${artifact_version}"
           development_context_directory="${RUNNER_TEMP}/${development_context_artifact_name}"
 
           mkdir -p \
@@ -128,14 +135,15 @@ jobs:
           test -d "${development_context_directory}/libraries/config/lib"
 
           {
-            echo "edge_artifact_name=${edge_artifact_name}"
+            echo "main_artifact_name=${main_artifact_name}"
+            echo "artifact_version=${artifact_version}"
             echo "development_context_artifact_name=${development_context_artifact_name}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Upload Edge artifact
+      - name: Upload shared main artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: ${{ steps.artifact_metadata.outputs.edge_artifact_name }}
+          name: ${{ steps.artifact_metadata.outputs.main_artifact_name }}
           path: ${{ env.BUILD_ARTIFACT_PATH }}
           if-no-files-found: error
 
@@ -203,7 +211,7 @@ jobs:
         if: ${{ steps.check_latest_main.outputs.deploy_allowed == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: ${{ needs.build_main_artifacts.outputs.edge_artifact_name }}
+          name: ${{ needs.build_main_artifacts.outputs.main_artifact_name }}
           path: edge-artifact
 
       - name: Configure AWS credentials
@@ -257,6 +265,188 @@ jobs:
             if [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' && -n "${WORKFLOW_DISPATCH_REASON}" ]]; then
               echo "- Manual reason: ${WORKFLOW_DISPATCH_REASON}"
             fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy_to_dev:
+    name: Deploy to hosted Dev
+    runs-on: ubuntu-24.04
+    needs: build_main_artifacts
+    permissions:
+      contents: read
+    concurrency:
+      group: deploy-dev
+      cancel-in-progress: true
+    outputs:
+      superseded: ${{ steps.check_latest_main.outputs.superseded }}
+    environment:
+      name: wire-webapp-dev
+      url: ${{ env.DEV_WEBAPP_URL }}
+
+    steps:
+      - name: Check whether this hosted Dev deployment is current
+        id: check_latest_main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          latest_main_sha="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" \
+              --jq '.object.sha'
+          )"
+
+          if [[ -z "${latest_main_sha}" ]]; then
+            echo 'Unable to resolve the current main SHA.' >&2
+            exit 1
+          fi
+
+          if [[ "${GITHUB_SHA}" != "${latest_main_sha}" ]]; then
+            echo "Skipping hosted Dev deployment because ${GITHUB_SHA} was superseded by ${latest_main_sha}."
+
+            {
+              echo '## Hosted Dev deployment'
+              echo "- Skipped as superseded: \`${GITHUB_SHA}\`"
+              echo "- Current main commit: \`${latest_main_sha}\`"
+            } >> "${GITHUB_STEP_SUMMARY}"
+
+            echo 'superseded=true' >> "${GITHUB_OUTPUT}"
+            echo 'deploy_allowed=false' >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo 'superseded=false' >> "${GITHUB_OUTPUT}"
+          echo 'deploy_allowed=true' >> "${GITHUB_OUTPUT}"
+
+      - name: Download shared main artifact
+        if: ${{ steps.check_latest_main.outputs.deploy_allowed == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ needs.build_main_artifacts.outputs.main_artifact_name }}
+          path: dev-artifact
+
+      - name: Configure AWS credentials
+        if: ${{ steps.check_latest_main.outputs.deploy_allowed == 'true' }}
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
+        with:
+          aws-access-key-id: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy to wire-webapp-dev
+        id: deploy
+        if: ${{ steps.check_latest_main.outputs.deploy_allowed == 'true' }}
+        uses: aws-actions/aws-elasticbeanstalk-deploy@1f56e4e813ae4eb167e69ca324234c336c1df573
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          application-name: Webapp
+          environment-name: ${{ env.DEV_ELASTIC_BEANSTALK_ENVIRONMENT_NAME }}
+          version-label: ${{ github.run_id }}-${{ github.run_attempt }}-dev
+          deployment-package-path: dev-artifact/ebs.zip
+          wait-for-deployment: true
+          wait-for-environment-recovery: true
+          deployment-timeout: 150
+          use-existing-application-version-if-available: true
+
+      - name: Verify hosted Dev runtime
+        id: verify_runtime
+        if: ${{ steps.check_latest_main.outputs.deploy_allowed == 'true' }}
+        env:
+          EXPECTED_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_version }}
+          EXPECTED_COMMIT: ${{ github.sha }}
+          EXPECTED_BACKEND_REST: ${{ env.DEV_RUNTIME_BACKEND_REST }}
+          EXPECTED_BACKEND_WS: ${{ env.DEV_RUNTIME_BACKEND_WS }}
+          DEV_WEBAPP_URL: ${{ env.DEV_WEBAPP_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${EXPECTED_VERSION}" || -z "${EXPECTED_COMMIT}" || -z "${EXPECTED_BACKEND_REST}" || -z "${EXPECTED_BACKEND_WS}" ]]; then
+            echo 'Hosted Dev runtime verification requires all expected values.' >&2
+            exit 1
+          fi
+
+          normalize_url() {
+            local normalized_url="${1}"
+
+            while [[ "${normalized_url}" == */ ]]; do
+              normalized_url="${normalized_url%/}"
+            done
+
+            printf '%s' "${normalized_url}"
+          }
+
+          expected_backend_rest="$(normalize_url "${EXPECTED_BACKEND_REST}")"
+          expected_backend_ws="$(normalize_url "${EXPECTED_BACKEND_WS}")"
+
+          for attempt_number in {1..10}; do
+            version_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${DEV_WEBAPP_URL}version" || true)"
+            commit_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${DEV_WEBAPP_URL}commit" || true)"
+            runtime_config="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${DEV_WEBAPP_URL}config.js" || true)"
+
+            actual_version="$(
+              printf '%s' "${version_response}" |
+                jq --exit-status --raw-output '.version | strings | select(length > 0)'
+            )" || actual_version=''
+            actual_commit="$(
+              printf '%s' "${commit_response}" |
+                tr -d '\r\n'
+            )"
+            actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
+            actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
+
+            if [[
+              "${actual_version}" == "${EXPECTED_VERSION}" &&
+              "${actual_commit}" == "${EXPECTED_COMMIT}" &&
+              "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" &&
+              "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}"
+            ]]; then
+              echo "Hosted Dev runtime verification succeeded on attempt ${attempt_number}: VERSION=${actual_version}, COMMIT=${actual_commit}, REST=$(normalize_url "${actual_backend_rest}"), WS=$(normalize_url "${actual_backend_ws}")."
+              exit 0
+            fi
+
+            echo "Hosted Dev runtime configuration mismatch on attempt ${attempt_number}." >&2
+            echo "Expected: VERSION=${EXPECTED_VERSION}, COMMIT=${EXPECTED_COMMIT}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
+            echo "Observed: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
+
+            if [[ "${attempt_number}" -lt 10 ]]; then
+              sleep 6
+            fi
+          done
+
+          echo 'Hosted Dev runtime verification failed after 10 attempts.' >&2
+          echo "Expected: VERSION=${EXPECTED_VERSION}, COMMIT=${EXPECTED_COMMIT}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
+          echo "Observed: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
+          exit 1
+
+      - name: Summarize hosted Dev deployment
+        if: always()
+        env:
+          DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+          VERIFY_OUTCOME: ${{ steps.verify_runtime.outcome }}
+          SUPERSEDED: ${{ steps.check_latest_main.outputs.superseded }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${SUPERSEDED:-false}" == 'true' ]]; then
+            dev_result='skipped as superseded'
+          elif [[ "${DEPLOY_OUTCOME:-}" == 'success' && "${VERIFY_OUTCOME:-}" == 'success' ]]; then
+            dev_result='deployed and verified successfully'
+          else
+            dev_result='failed'
+          fi
+
+          {
+            echo '## Hosted Dev deployment'
+            echo "- Result: ${dev_result}"
+            echo "- Deployed ref: ${GITHUB_REF}"
+            echo "- Commit SHA: ${GITHUB_SHA}"
+            echo "- Target environment: ${DEV_ELASTIC_BEANSTALK_ENVIRONMENT_NAME}"
+            echo "- Hosted Dev URL: ${DEV_WEBAPP_URL}"
+            echo "- Expected REST backend: ${DEV_RUNTIME_BACKEND_REST}"
+            echo "- Expected WebSocket backend: ${DEV_RUNTIME_BACKEND_WS}"
+            echo "- Workflow run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   publish_to_development_channel:
@@ -403,6 +593,7 @@ jobs:
     needs:
       - build_main_artifacts
       - deploy_to_edge
+      - deploy_to_dev
       - publish_to_development_channel
     if: >-
       ${{
@@ -410,6 +601,7 @@ jobs:
         (
           needs.build_main_artifacts.result == 'failure' ||
           needs.deploy_to_edge.result == 'failure' ||
+          needs.deploy_to_dev.result == 'failure' ||
           needs.publish_to_development_channel.result == 'failure'
         )
       }}
@@ -432,8 +624,9 @@ jobs:
           text: |
             ❌ Main delivery failed ❌
             **Main commit:** ${{ github.sha }}
-            **Build:** ${{ needs.build_main_artifacts.result }}
+            **Shared artifact build:** ${{ needs.build_main_artifacts.result }}
             **Edge deployment:** ${{ needs.deploy_to_edge.result }}
+            **Hosted Dev deployment:** ${{ needs.deploy_to_dev.result }}
             **Development channel:** ${{ needs.publish_to_development_channel.result }}
             **Docker image:** ${{ needs.publish_to_development_channel.outputs.docker_image_tag || 'not published' }}
             **Helm chart:** ${{ needs.publish_to_development_channel.outputs.helm_chart_version || 'not published' }}
@@ -443,7 +636,14 @@ jobs:
   summarize_main_delivery:
     name: Summarize main delivery
     runs-on: ubuntu-24.04
-    needs: [build_main_artifacts, deploy_to_edge, publish_to_development_channel, notify_main_delivery_failure]
+    needs:
+      [
+        build_main_artifacts,
+        deploy_to_edge,
+        deploy_to_dev,
+        publish_to_development_channel,
+        notify_main_delivery_failure,
+      ]
     if: always()
     permissions: {}
 
@@ -452,6 +652,11 @@ jobs:
         env:
           EDGE_RESULT: ${{ needs.deploy_to_edge.result }}
           EDGE_SUPERSEDED: ${{ needs.deploy_to_edge.outputs.superseded }}
+          DEV_RESULT: ${{ needs.deploy_to_dev.result }}
+          DEV_SUPERSEDED: ${{ needs.deploy_to_dev.outputs.superseded }}
+          DEV_WEBAPP_URL: ${{ env.DEV_WEBAPP_URL }}
+          DEV_RUNTIME_BACKEND_REST: ${{ env.DEV_RUNTIME_BACKEND_REST }}
+          DEV_RUNTIME_BACKEND_WS: ${{ env.DEV_RUNTIME_BACKEND_WS }}
           DOCKER_IMAGE_TAG: ${{ needs.publish_to_development_channel.outputs.docker_image_tag }}
           HELM_CHART_VERSION: ${{ needs.publish_to_development_channel.outputs.helm_chart_version }}
           WIRE_BUILDS_COMMIT_SHA: ${{ needs.publish_to_development_channel.outputs.wire_builds_commit_sha }}
@@ -469,10 +674,25 @@ jobs:
             edge_result='Edge failed'
           fi
 
+          if [[ "${DEV_SUPERSEDED:-false}" == 'true' ]]; then
+            dev_result='hosted Dev skipped as superseded'
+          elif [[ "${DEV_RESULT:-}" == 'success' ]]; then
+            dev_result='hosted Dev deployed and verified successfully'
+          elif [[ "${DEV_RESULT:-}" == 'skipped' ]]; then
+            dev_result='hosted Dev did not run'
+          else
+            dev_result='hosted Dev failed'
+          fi
+
           {
             echo '## Main delivery'
             echo "- Main commit SHA: ${GITHUB_SHA}"
             echo "- Edge deployment: ${edge_result}"
+            echo "- Hosted Dev deployment: ${dev_result}"
+            echo "- Hosted Dev skipped as superseded: ${DEV_SUPERSEDED:-false}"
+            echo "- Hosted Dev URL: ${DEV_WEBAPP_URL}"
+            echo "- Expected hosted Dev REST backend: ${DEV_RUNTIME_BACKEND_REST}"
+            echo "- Expected hosted Dev WebSocket backend: ${DEV_RUNTIME_BACKEND_WS}"
             echo "- Docker image: ${DOCKER_IMAGE_TAG:-not published}"
             echo "- Helm chart: ${HELM_CHART_VERSION:-not published}"
             echo "- wire-builds/dev: ${WIRE_BUILDS_COMMIT_SHA:-not updated}"

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -25,6 +25,8 @@ Today, `dev` and `master` both carry release meaning. That creates avoidable com
 flowchart LR
   mainBranch[main]
   edgeEnvironment[Edge]
+  hostedDevEnvironment[Hosted Dev<br/>Staging backend]
+  developmentDistribution[Publish dev Docker image and Helm chart<br/>Update wire-builds/dev]
   releaseBranch[release/YYYY-MM-DD.N]
   releaseArtifact[Release artifact]
   betaEnvironment[Beta company validation<br/>Production backend]
@@ -39,7 +41,9 @@ flowchart LR
   maintenanceBranch[maintenance/maintenance-line-key]
   maintenanceTag[maintenance-line-key-maintenance.X]
 
-  mainBranch -->|Every merge deploys| edgeEnvironment
+  mainBranch -->|Every eligible delivery deploys| edgeEnvironment
+  mainBranch -->|Every eligible delivery deploys| hostedDevEnvironment
+  mainBranch -->|Publish development distribution| developmentDistribution
   mainBranch -->|Create release branch| releaseBranch
   releaseBranch -->|Build once| releaseArtifact
   releaseArtifact -->|Deploy| betaEnvironment
@@ -75,6 +79,8 @@ We will adopt a trunk-based, GitHub-driven release process with automatic beta d
 
 Edge is the Web team's immediate dogfooding environment. Every eligible change merged to `main` may appear on Edge. Because Edge continuously follows trunk, it provides no stability guarantee and may include incomplete, experimental, or recently merged changes protected by feature flags. It is not intended to be stable enough for broader company-wide daily use.
 
+Hosted Dev is the historical hosted development frontend at `https://wire-webapp-dev.zinfra.io/`. Every eligible `main` delivery deploys the same internal artifact to Hosted Dev that it deploys to Edge. Hosted Dev connects to the Staging REST and WebSocket backend services at `https://staging-nginz-https.zinfra.io/` and `wss://staging-nginz-ssl.zinfra.io/`, respectively.
+
 Beta is the logical release stage for company-wide internal release-candidate validation. It follows an active release branch rather than trunk and should be stable enough for broader daily internal use. Beta represents the current candidate for the next Production release. Beta uses the `wire-webapp-beta` GitHub Environment and its canonical company-facing URL is `https://wire-webapp-beta.wire.com/`. Beta continues to deploy physically to the existing `wire-webapp-staging` Elastic Beanstalk environment. The physical AWS environment name is retained temporarily and is separate from the GitHub Environment name.
 
 Beta preserves the previous company-facing Staging release-candidate behavior: it connects to Production backend services, and employees validate it with their normal Production accounts and data. The legacy physical name `wire-webapp-staging` describes infrastructure only; it does not mean that the company-facing Beta frontend uses Staging backend services.
@@ -85,7 +91,7 @@ A Beta candidate may be promoted when validation is complete and no known releas
 
 The branch model is:
 
-- `main` is the single trunk branch and the source for Edge deployments.
+- `main` is the single trunk branch and the source for Edge and hosted Dev deployments.
 - During the migration, `main` was established from the active `dev` history because `dev` contained the current development history at cutover time.
 - `dev` and `master` are legacy branches retained temporarily for compatibility and old release-path retirement; normal development no longer targets either branch.
 - Release branches are cut from `main` as `release/YYYY-MM-DD.N`.
@@ -96,12 +102,14 @@ The release identifier uses the release branch name: `YYYY-MM-DD.N`. The full id
 
 The cloud release process is:
 
-- `publish-main.yml` owns delivery of every `main` commit. It builds the internal application exactly once, then feeds the exact build outputs to both the Edge deployment and the development distribution.
+- `publish-main.yml` owns delivery of every eligible `main` commit. It builds the internal application exactly once, then deploys that same internal artifact to Edge and hosted Dev. Edge remains the immediate trunk dogfooding environment.
 - The development distribution retains the external channel name `dev`: it publishes the Docker image and a matching prerelease Helm chart, then updates `wire-builds/dev`.
-- Internal integration environments consume `wire-builds/dev` downstream. The legacy `wire-webapp-dev` deployment is not restored.
+- `wire-builds/dev` remains the development distribution consumed by downstream internal integration environments; it is separate from the hosted Dev frontend deployment.
+- The legacy `publish-and-deploy-webapp.yml` workflow no longer owns `dev`; its `dev` branch trigger is not restored.
 - `wire-builds/main` remains Production-only and is never updated by an ordinary `main` push.
 - Development and Production distributions share the same Helm repository and prerelease version namespace. Their Docker, Helm, and `wire-builds` publications use one shared, non-cancellable distribution lock.
 - Edge verifies that its artifact still belongs to the current `main` commit after acquiring the deployment slot; stale Edge builds skip instead of moving Edge backwards.
+- Hosted Dev verifies that its artifact still belongs to the current `main` commit after acquiring its deployment slot; stale Hosted Dev builds skip instead of moving Hosted Dev backwards.
 - Development, verified Production, and remaining legacy distribution paths share one non-cancellable queued publication group with `queue: max`, which preserves pending publications until the legacy workflow is deleted.
 - Every merge to `main` deploys continuously to Edge without an approval gate. A newer `main` commit may supersede an in-progress Edge deployment.
 - A stale queued main publication checks the current `main` commit after acquiring the shared distribution lock and skips before external publication instead of regressing the shared `dev` channel.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Restore the hosted `wire-webapp-dev` deployment in the new trunk-based main delivery pipeline.

Every eligible `main` delivery now uses the same internal WebApp artifact for:

* the Edge deployment;
* the hosted Dev deployment;
* the development Docker distribution.

The hosted Dev deployment is verified against the Staging backend before the workflow succeeds.

## Historical behavior

Before the trunk-based pipeline migration, a push to `dev` deployed the WebApp to both:

* `wire-webapp-dev`;
* `wire-webapp-edge`.

The hosted Dev frontend at `https://wire-webapp-dev.zinfra.io/` connected to the Staging backend.

Pull request #21879 transferred development ownership from the legacy `dev` workflow to `publish-main.yml`. It preserved the `dev` Docker image, Helm chart, and `wire-builds/dev` publication, but intentionally did not restore the hosted `wire-webapp-dev` deployment.

That left the development distribution available for downstream environments while removing the existing hosted Dev frontend.
