### PR TITLE
refactor: refactor background renderer to support reusable segmentation masks [WPB-26366]

### DIFF
--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/renderer.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/renderer.ts
@@ -20,7 +20,12 @@
 import {getSafeLogger} from 'Repositories/media/backgroundEffects/helper/logger';
 import {BackgroundSource} from 'Repositories/media/VideoBackgroundEffects';
 
-export type ImageTexture = {texture: WebGLTexture; width: number; height: number; url: string};
+export type ImageTexture = {
+  texture: WebGLTexture;
+  width: number;
+  height: number;
+  url: string;
+};
 
 type ImageInfo = {
   type: 'image';
@@ -38,10 +43,21 @@ type ColorInfo = {
 
 type BackgroundRenderInfo = ImageInfo | ColorInfo;
 
+type RenderOptions = {
+  smoothing: number;
+  smoothstepMin: number;
+  smoothstepMax: number;
+  backgroundSource?: BackgroundSource | null;
+  borderSmooth: number;
+  bgBlur: number;
+  bgBlurRadius: number;
+};
+
 export class WebGLRenderer {
   readonly logger = getSafeLogger('WebGLRenderer');
   readonly canvas: OffscreenCanvas;
   readonly gl: WebGL2RenderingContext;
+
   readonly blendProgram: WebGLProgram;
   readonly blendLocations: {
     position: number;
@@ -56,6 +72,7 @@ export class WebGLRenderer {
     bgBlurRadius: WebGLUniformLocation | null;
     enabled: WebGLUniformLocation | null;
   };
+
   readonly stateUpdateProgram: WebGLProgram;
   readonly stateUpdateLocations: {
     position: number;
@@ -68,66 +85,113 @@ export class WebGLRenderer {
     smoothstepMax: WebGLUniformLocation | null;
     selfieModel: WebGLUniformLocation | null;
   };
+
   readonly positionBuffer: WebGLBuffer | null;
   readonly texCoordBuffer: WebGLBuffer | null;
-  storedStateTextures: (WebGLTexture | null)[];
   readonly fbo: WebGLFramebuffer | null;
 
+  storedStateTextures: (WebGLTexture | null)[];
+
   private running = false;
-  private static readonly DEFAULT_BG_COLOR: readonly [number, number, number, number] = [33, 150, 243, 255];
   private currentStateIndex = 0;
+  private hasStoredMask = false;
+
   private backgroundRenderInfo: BackgroundRenderInfo | null = null;
   private activeBackgroundSourceIdentifier: string | null = null;
 
+  private static readonly DEFAULT_BG_COLOR: readonly [number, number, number, number] = [33, 150, 243, 255];
+
   constructor(canvas: OffscreenCanvas) {
     this.canvas = canvas;
+
     const gl = this.canvas.getContext('webgl2', {
       alpha: false,
       antialias: false,
       desynchronized: true,
     });
+
     if (!gl) {
       throw new Error('WebGL2 not supported');
     }
+
     this.gl = gl;
 
-    // State Update Shader
-    const stateUpdateVertexShaderSource = `attribute vec2 a_position; attribute vec2 a_texCoord; varying vec2 v_texCoord; void main() { gl_Position = vec4(a_position, 0.0, 1.0); v_texCoord = a_texCoord; }`;
+    const vertexShaderSource = `
+      attribute vec2 a_position;
+      attribute vec2 a_texCoord;
+
+      varying vec2 v_texCoord;
+
+      void main() {
+        gl_Position = vec4(a_position, 0.0, 1.0);
+        v_texCoord = a_texCoord;
+      }
+    `;
+
     const stateUpdateFragmentShaderSource = `
-            precision mediump float;
-            varying vec2 v_texCoord;
-            uniform sampler2D u_categoryTexture;    // Current category mask
-            uniform sampler2D u_confidenceTexture; // Current confidence mask
-            uniform sampler2D u_prevStateTexture;  // Previous frame's averaged state
-            uniform float u_smoothingFactor;     // Alpha for moving average
-            uniform float u_smoothstepMin;       // Lower edge for smoothstep
-            uniform float u_smoothstepMax;       // Upper edge for smoothstep
-            uniform int u_selfieModel;
+      precision mediump float;
 
-            void main() {
-                vec2 prevCoord = vec2(v_texCoord.x, 1.0 - v_texCoord.y);
-                float categoryValue = texture2D(u_categoryTexture, v_texCoord).r;
-                float confidenceValue = texture2D(u_confidenceTexture, v_texCoord).r;
+      varying vec2 v_texCoord;
 
-                if (u_selfieModel == 1) {
-                    categoryValue = 1.0 - categoryValue;
-                    confidenceValue = 1.0 - confidenceValue;
-                }
+      uniform sampler2D u_categoryTexture;
+      uniform sampler2D u_confidenceTexture;
+      uniform sampler2D u_prevStateTexture;
 
-                if (categoryValue > 0.0) {
-                    categoryValue = 1.0;
-                    confidenceValue = 1.0 - confidenceValue;
-                }
+      uniform float u_smoothingFactor;
+      uniform float u_smoothstepMin;
+      uniform float u_smoothstepMax;
 
-                float nonLinearConfidence = smoothstep(u_smoothstepMin, u_smoothstepMax, confidenceValue);
-                float prevCategoryValue = texture2D(u_prevStateTexture, prevCoord).r;
-                float alpha = u_smoothingFactor * nonLinearConfidence;
-                float newCategoryValue = alpha * categoryValue + (1.0 - alpha) * prevCategoryValue;
+      uniform int u_selfieModel;
 
-                gl_FragColor = vec4(newCategoryValue, 0.0, 0.0, 0.0);
-            }
-        `;
-    this.stateUpdateProgram = this.createAndLinkProgram(stateUpdateVertexShaderSource, stateUpdateFragmentShaderSource);
+      void main() {
+        vec2 prevCoord = vec2(
+          v_texCoord.x,
+          1.0 - v_texCoord.y
+        );
+
+        float categoryValue =
+          texture2D(u_categoryTexture, v_texCoord).r;
+
+        float confidenceValue =
+          texture2D(u_confidenceTexture, v_texCoord).r;
+
+        if (u_selfieModel == 1) {
+          categoryValue = 1.0 - categoryValue;
+          confidenceValue = 1.0 - confidenceValue;
+        }
+
+        if (categoryValue > 0.0) {
+          categoryValue = 1.0;
+          confidenceValue = 1.0 - confidenceValue;
+        }
+
+        float nonLinearConfidence = smoothstep(
+          u_smoothstepMin,
+          u_smoothstepMax,
+          confidenceValue
+        );
+
+        float prevCategoryValue =
+          texture2D(u_prevStateTexture, prevCoord).r;
+
+        float alpha =
+          u_smoothingFactor * nonLinearConfidence;
+
+        float newCategoryValue =
+          alpha * categoryValue +
+          (1.0 - alpha) * prevCategoryValue;
+
+        gl_FragColor = vec4(
+          newCategoryValue,
+          0.0,
+          0.0,
+          0.0
+        );
+      }
+    `;
+
+    this.stateUpdateProgram = this.createAndLinkProgram(vertexShaderSource, stateUpdateFragmentShaderSource);
+
     this.stateUpdateLocations = {
       position: gl.getAttribLocation(this.stateUpdateProgram, 'a_position'),
       texCoord: gl.getAttribLocation(this.stateUpdateProgram, 'a_texCoord'),
@@ -140,105 +204,208 @@ export class WebGLRenderer {
       selfieModel: gl.getUniformLocation(this.stateUpdateProgram, 'u_selfieModel'),
     };
 
-    // Blending Shader
-    const blendVertexShaderSource = stateUpdateVertexShaderSource; // Reuse vertex shader
     const blendFragmentShaderSource = `
-            precision mediump float;
-            varying vec2 v_texCoord;
+      precision mediump float;
 
-            uniform sampler2D u_frameTexture;
-            uniform sampler2D u_currentStateTexture; // Reads the UPDATED state
-            uniform sampler2D u_backgroundTexture; // Use background texture
-            uniform vec2 u_bgImageDimensions;   // Dimensions of the background image
-            uniform vec2 u_canvasDimensions;    // Dimensions of the canvas
-            uniform float u_borderSmooth;
-            uniform float u_bgBlur;
-            uniform float u_bgBlurRadius;
-            uniform int u_enabled;
+      varying vec2 v_texCoord;
 
-            const float PI = 3.141592653589793;
+      uniform sampler2D u_frameTexture;
+      uniform sampler2D u_currentStateTexture;
+      uniform sampler2D u_backgroundTexture;
 
-            float gaussianWeight(float offset, float sigma) {
-                return exp(-(offset * offset) / (2.0 * sigma * sigma));
+      uniform vec2 u_bgImageDimensions;
+      uniform vec2 u_canvasDimensions;
+
+      uniform float u_borderSmooth;
+      uniform float u_bgBlur;
+      uniform float u_bgBlurRadius;
+
+      uniform int u_enabled;
+
+      const float PI = 3.141592653589793;
+
+      float gaussianWeight(float offset, float sigma) {
+        return exp(
+          -(offset * offset) /
+          (2.0 * sigma * sigma)
+        );
+      }
+
+      vec4 getMixedFragColor(
+        vec2 bgTexCoord,
+        vec2 categoryCoord,
+        vec2 offset
+      ) {
+        vec4 backgroundColor = texture2D(
+          u_backgroundTexture,
+          bgTexCoord + offset
+        );
+
+        vec4 frameColor = texture2D(
+          u_frameTexture,
+          v_texCoord + offset
+        );
+
+        float categoryValue = texture2D(
+          u_currentStateTexture,
+          categoryCoord + offset
+        ).r;
+
+        return mix(
+          backgroundColor,
+          frameColor,
+          categoryValue
+        );
+      }
+
+      vec4 blurColor(
+        float blur,
+        float radius,
+        bool mixed
+      ) {
+        vec2 categoryCoord = vec2(
+          v_texCoord.x,
+          1.0 - v_texCoord.y
+        );
+
+        vec2 texelSize =
+          1.0 / u_canvasDimensions;
+
+        vec4 blurredColor = vec4(0.0);
+        float totalWeight = 0.0;
+
+        for (
+          float angle = 0.0;
+          angle <= 2.0 * PI;
+          angle += PI / 12.0
+        ) {
+          vec2 direction = vec2(
+            cos(angle),
+            sin(angle)
+          );
+
+          for (int i = -10; i <= 10; i++) {
+            float offset =
+              float(i) * (radius / 10.0);
+
+            float weight =
+              gaussianWeight(offset, blur);
+
+            vec2 v_offset =
+              direction * texelSize * offset;
+
+            if (mixed) {
+              blurredColor += getMixedFragColor(
+                v_texCoord,
+                categoryCoord,
+                v_offset
+              ) * weight;
+            } else {
+              blurredColor += texture2D(
+                u_frameTexture,
+                v_texCoord + v_offset
+              ) * weight;
             }
 
-            vec4 getMixedFragColor(vec2 bgTexCoord, vec2 categoryCoord, vec2 offset) {
-                vec4 backgroundColor = texture2D(u_backgroundTexture, bgTexCoord + offset);
-                vec4 frameColor = texture2D(u_frameTexture, v_texCoord + offset);
-                float categoryValue = texture2D(u_currentStateTexture, categoryCoord + offset).r;
-                return mix(backgroundColor, frameColor, categoryValue);
-            }
+            totalWeight += weight;
+          }
+        }
 
-            vec4 blurColor(float blur, float radius, bool mixed) {
-                vec2 categoryCoord = vec2(v_texCoord.x, 1.0 - v_texCoord.y);
-                vec2 texelSize = 1.0 / u_canvasDimensions;
-                vec4 blurredColor = vec4(0.0);
-                float totalWeight = 0.0;
-                for (float angle = 0.0; angle <= 2.0 * PI; angle += PI / 12.0) {
-                    vec2 direction = vec2(cos(angle), sin(angle));
-                    for (int i = -10; i <= 10; i++) {
-                        float offset = float(i) * (radius / 10.0);
-                        float weight = gaussianWeight(offset, blur);
-                        vec2 v_offset = direction * texelSize * offset;
-                        if (mixed) {
-                            blurredColor += getMixedFragColor(v_texCoord, categoryCoord, v_offset) * weight;
-                        } else {
-                            blurredColor += texture2D(u_frameTexture, v_texCoord + v_offset) * weight;
-                        }
-                        totalWeight += weight;
-                    }
-                }
-                return blurredColor / totalWeight;
-            }
+        return blurredColor / totalWeight;
+      }
 
-            void main() {
-                if (u_enabled == 0) {
-                    gl_FragColor = texture2D(u_frameTexture, v_texCoord);
-                    return;
-                }
+      void main() {
+        if (u_enabled == 0) {
+          gl_FragColor = texture2D(
+            u_frameTexture,
+            v_texCoord
+          );
 
-                vec2 categoryCoord = vec2(v_texCoord.x, 1.0 - v_texCoord.y);
-                float categoryValue = texture2D(u_currentStateTexture, categoryCoord).r;
+          return;
+        }
 
-                if (u_bgBlur > 0.0 && u_bgBlurRadius > 0.0) {
-                    if (categoryValue < 0.3) {
-                        gl_FragColor = blurColor(u_bgBlur, u_bgBlurRadius, false);
-                    } else {
-                        gl_FragColor = texture2D(u_frameTexture, v_texCoord);
-                    }
-                    return;
-                }
+        vec2 categoryCoord = vec2(
+          v_texCoord.x,
+          1.0 - v_texCoord.y
+        );
 
-                // Calculate tex coords for "cover" effect
-                float canvasAspect = u_canvasDimensions.x / u_canvasDimensions.y;
-                float bgAspect = u_bgImageDimensions.x / u_bgImageDimensions.y;
+        float categoryValue = texture2D(
+          u_currentStateTexture,
+          categoryCoord
+        ).r;
 
-                vec2 bgTexCoord = v_texCoord;
-                float scaleX = 1.0;
-                float scaleY = 1.0;
-                float offsetX = 0.0;
-                float offsetY = 0.0;
+        if (
+          u_bgBlur > 0.0 &&
+          u_bgBlurRadius > 0.0
+        ) {
+          if (categoryValue < 0.3) {
+            gl_FragColor = blurColor(
+              u_bgBlur,
+              u_bgBlurRadius,
+              false
+            );
+          } else {
+            gl_FragColor = texture2D(
+              u_frameTexture,
+              v_texCoord
+            );
+          }
 
-                if (canvasAspect < bgAspect) {
-                    scaleY = 1.0;
-                    scaleX = bgAspect / canvasAspect;
-                    offsetX = (1.0 - scaleX) / 2.0;
-                } else {
-                    scaleX = 1.0;
-                    scaleY = canvasAspect / bgAspect;
-                    offsetY = (1.0 - scaleY) / 2.0;
-                }
-                bgTexCoord = vec2( (v_texCoord.x - offsetX) / scaleX, (v_texCoord.y - offsetY) / scaleY );
+          return;
+        }
 
-                // Apply border smoothing
-                if (u_borderSmooth > 0.0 && categoryValue > 0.1 && categoryValue < 0.9) {
-                    gl_FragColor = blurColor(u_borderSmooth, u_bgBlurRadius, false);
-                } else {
-                    gl_FragColor = getMixedFragColor(bgTexCoord, categoryCoord, vec2(0.0, 0.0));
-                }
-            }
-        `;
-    this.blendProgram = this.createAndLinkProgram(blendVertexShaderSource, blendFragmentShaderSource);
+        float canvasAspect =
+          u_canvasDimensions.x /
+          u_canvasDimensions.y;
+
+        float bgAspect =
+          u_bgImageDimensions.x /
+          u_bgImageDimensions.y;
+
+        vec2 bgTexCoord = v_texCoord;
+
+        float scaleX = 1.0;
+        float scaleY = 1.0;
+        float offsetX = 0.0;
+        float offsetY = 0.0;
+
+        if (canvasAspect < bgAspect) {
+          scaleY = 1.0;
+          scaleX = bgAspect / canvasAspect;
+          offsetX = (1.0 - scaleX) / 2.0;
+        } else {
+          scaleX = 1.0;
+          scaleY = canvasAspect / bgAspect;
+          offsetY = (1.0 - scaleY) / 2.0;
+        }
+
+        bgTexCoord = vec2(
+          (v_texCoord.x - offsetX) / scaleX,
+          (v_texCoord.y - offsetY) / scaleY
+        );
+
+        if (
+          u_borderSmooth > 0.0 &&
+          categoryValue > 0.1 &&
+          categoryValue < 0.9
+        ) {
+          gl_FragColor = blurColor(
+            u_borderSmooth,
+            u_bgBlurRadius,
+            false
+          );
+        } else {
+          gl_FragColor = getMixedFragColor(
+            bgTexCoord,
+            categoryCoord,
+            vec2(0.0, 0.0)
+          );
+        }
+      }
+    `;
+
+    this.blendProgram = this.createAndLinkProgram(vertexShaderSource, blendFragmentShaderSource);
+
     this.blendLocations = {
       position: gl.getAttribLocation(this.blendProgram, 'a_position'),
       texCoord: gl.getAttribLocation(this.blendProgram, 'a_texCoord'),
@@ -253,115 +420,461 @@ export class WebGLRenderer {
       enabled: gl.getUniformLocation(this.blendProgram, 'u_enabled'),
     };
 
-    // Buffers for fullscreen quad
     this.positionBuffer = gl.createBuffer();
+
     gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]), gl.STATIC_DRAW);
 
     this.texCoordBuffer = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
-    gl.bufferData(
-      gl.ARRAY_BUFFER,
-      new Float32Array([
-        0,
-        1,
-        1,
-        1,
-        0,
-        0,
-        0,
-        0,
-        1,
-        1,
-        1,
-        0, // Flipped Y for WebGL texture coordinates
-      ]),
-      gl.STATIC_DRAW,
-    );
 
-    // Create Textures for Storing State (Ping-Pong)
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
+
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0]), gl.STATIC_DRAW);
+
     this.storedStateTextures = Array.from({length: 2}, () => {
-      const tex = gl.createTexture();
-      gl.bindTexture(gl.TEXTURE_2D, tex);
+      const texture = gl.createTexture();
+
+      gl.bindTexture(gl.TEXTURE_2D, texture);
+
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 255]));
+
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-      return tex;
+
+      return texture;
     });
+
     gl.bindTexture(gl.TEXTURE_2D, null);
 
     this.fbo = gl.createFramebuffer();
-
     this.running = true;
   }
 
-  private createAndLinkProgram(vsSource: string, fsSource: string): WebGLProgram {
-    const vs = this.createShader(this.gl.VERTEX_SHADER, vsSource);
-    const fs = this.createShader(this.gl.FRAGMENT_SHADER, fsSource);
-    const prog = this.gl.createProgram();
-    if (!prog) {
+  /**
+   * Renders the frame with new MediaPipe masks.
+   *
+   * This updates the stored ping-pong state and then
+   * renders the frame using the newly calculated state.
+   */
+  public renderWithNewMasks(
+    videoFrame: VideoFrame,
+    options: RenderOptions,
+    categoryTexture: WebGLTexture,
+    confidenceTexture: WebGLTexture,
+    useSelfieModel = false,
+  ): void {
+    if (!this.running) {
+      return;
+    }
+
+    const stateTexture = this.updateMaskState(options, categoryTexture, confidenceTexture, useSelfieModel);
+
+    if (!stateTexture) {
+      this.logger.warn('Unable to update segmentation mask state.');
+
+      this.renderPassthrough(videoFrame);
+      return;
+    }
+
+    this.hasStoredMask = true;
+
+    this.renderWithMaskTexture(videoFrame, options, stateTexture);
+  }
+
+  /**
+   * Renders the frame using the most recently stored mask.
+   *
+   * MediaPipe is not called and the state-update shader
+   * is not executed.
+   */
+  public renderWithPreviousMask(videoFrame: VideoFrame, options: RenderOptions): void {
+    if (!this.running) {
+      return;
+    }
+
+    if (!this.hasStoredMask) {
+      this.logger.warn('No previous segmentation mask is available.');
+
+      this.renderPassthrough(videoFrame);
+      return;
+    }
+
+    const stateTexture = this.storedStateTextures[this.currentStateIndex];
+
+    if (!stateTexture) {
+      this.logger.warn('Stored segmentation texture is missing.');
+
+      this.renderPassthrough(videoFrame);
+      return;
+    }
+
+    this.renderWithMaskTexture(videoFrame, options, stateTexture);
+  }
+
+  /**
+   * Renders the original frame without applying a
+   * background effect.
+   */
+  public renderPassthrough(videoFrame: VideoFrame): void {
+    if (!this.running) {
+      return;
+    }
+
+    const {gl, blendProgram, blendLocations} = this;
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+    gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+
+    gl.useProgram(blendProgram);
+
+    const frameTexture = this.createFrameTexture(videoFrame);
+
+    if (!frameTexture) {
+      this.logger.warn('Unable to create frame texture.');
+
+      return;
+    }
+
+    gl.activeTexture(gl.TEXTURE0);
+
+    gl.bindTexture(gl.TEXTURE_2D, frameTexture);
+
+    gl.uniform1i(blendLocations.frameTexture, 0);
+
+    gl.uniform1i(blendLocations.enabled, 0);
+
+    this.bindVertexAttributes(blendLocations.position, blendLocations.texCoord);
+
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+    gl.deleteTexture(frameTexture);
+
+    this.unbindTextures(1);
+  }
+
+  /**
+   * Updates the smoothed mask state using the current
+   * MediaPipe category and confidence textures.
+   */
+  private updateMaskState(
+    options: RenderOptions,
+    categoryTexture: WebGLTexture,
+    confidenceTexture: WebGLTexture,
+    useSelfieModel: boolean,
+  ): WebGLTexture | null {
+    const {gl, fbo, storedStateTextures, stateUpdateProgram, stateUpdateLocations} = this;
+
+    if (!fbo) {
+      return null;
+    }
+
+    const width = this.canvas.width;
+    const height = this.canvas.height;
+
+    const readStateIndex = this.currentStateIndex;
+
+    const writeStateIndex = (this.currentStateIndex + 1) % 2;
+
+    const previousStateTexture = storedStateTextures[readStateIndex];
+
+    const newStateTexture = storedStateTextures[writeStateIndex];
+
+    if (!previousStateTexture || !newStateTexture) {
+      return null;
+    }
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, newStateTexture, 0);
+
+    gl.bindTexture(gl.TEXTURE_2D, newStateTexture);
+
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
+    gl.viewport(0, 0, width, height);
+
+    gl.useProgram(stateUpdateProgram);
+
+    gl.activeTexture(gl.TEXTURE0);
+
+    gl.bindTexture(gl.TEXTURE_2D, categoryTexture);
+
+    gl.uniform1i(stateUpdateLocations.categoryTexture, 0);
+
+    gl.activeTexture(gl.TEXTURE1);
+
+    gl.bindTexture(gl.TEXTURE_2D, confidenceTexture);
+
+    gl.uniform1i(stateUpdateLocations.confidenceTexture, 1);
+
+    gl.activeTexture(gl.TEXTURE2);
+
+    gl.bindTexture(gl.TEXTURE_2D, previousStateTexture);
+
+    gl.uniform1i(stateUpdateLocations.prevStateTexture, 2);
+
+    gl.uniform1f(stateUpdateLocations.smoothingFactor, options.smoothing);
+
+    gl.uniform1f(stateUpdateLocations.smoothstepMin, options.smoothstepMin);
+
+    gl.uniform1f(stateUpdateLocations.smoothstepMax, options.smoothstepMax);
+
+    gl.uniform1i(stateUpdateLocations.selfieModel, useSelfieModel ? 1 : 0);
+
+    this.bindVertexAttributes(stateUpdateLocations.position, stateUpdateLocations.texCoord);
+
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+    this.currentStateIndex = writeStateIndex;
+
+    return newStateTexture;
+  }
+
+  /**
+   * Performs the final frame/background blend using
+   * the supplied mask-state texture.
+   */
+  private renderWithMaskTexture(videoFrame: VideoFrame, options: RenderOptions, stateTexture: WebGLTexture): void {
+    const {gl, blendProgram, blendLocations} = this;
+
+    const width = this.canvas.width;
+    const height = this.canvas.height;
+
+    this.updateBackgroundIfNeeded(options.backgroundSource);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+    gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+
+    gl.useProgram(blendProgram);
+
+    const frameTexture = this.createFrameTexture(videoFrame);
+
+    if (!frameTexture) {
+      this.logger.warn('Unable to create frame texture.');
+
+      return;
+    }
+
+    gl.activeTexture(gl.TEXTURE0);
+
+    gl.bindTexture(gl.TEXTURE_2D, frameTexture);
+
+    gl.uniform1i(blendLocations.frameTexture, 0);
+
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, stateTexture);
+
+    gl.uniform1i(blendLocations.currentStateTexture, 1);
+
+    if (this.backgroundRenderInfo) {
+      gl.activeTexture(gl.TEXTURE2);
+
+      gl.bindTexture(gl.TEXTURE_2D, this.backgroundRenderInfo.texture);
+
+      let backgroundWidth = 1;
+      let backgroundHeight = 1;
+
+      if (this.backgroundRenderInfo.type === 'image') {
+        backgroundWidth = this.backgroundRenderInfo.width;
+
+        backgroundHeight = this.backgroundRenderInfo.height;
+      }
+
+      gl.uniform1i(blendLocations.backgroundTexture, 2);
+
+      gl.uniform2f(
+        blendLocations.bgImageDimensions,
+        backgroundWidth > 0 ? backgroundWidth : 1,
+        backgroundHeight > 0 ? backgroundHeight : 1,
+      );
+    } else {
+      this.logger.warn('Background render information is missing.');
+    }
+
+    gl.uniform2f(blendLocations.canvasDimensions, width, height);
+
+    gl.uniform1f(blendLocations.borderSmooth, options.borderSmooth);
+
+    gl.uniform1f(blendLocations.bgBlur, options.bgBlur);
+
+    gl.uniform1f(blendLocations.bgBlurRadius, options.bgBlurRadius);
+
+    gl.uniform1i(blendLocations.enabled, 1);
+
+    this.bindVertexAttributes(blendLocations.position, blendLocations.texCoord);
+
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+    gl.deleteTexture(frameTexture);
+
+    this.unbindTextures(3);
+  }
+
+  private createFrameTexture(videoFrame: VideoFrame): WebGLTexture | null {
+    const {gl} = this;
+
+    const frameTexture = gl.createTexture();
+
+    if (!frameTexture) {
+      return null;
+    }
+
+    gl.activeTexture(gl.TEXTURE0);
+
+    gl.bindTexture(gl.TEXTURE_2D, frameTexture);
+
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, videoFrame);
+
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+
+    return frameTexture;
+  }
+
+  private bindVertexAttributes(positionLocation: number, texCoordLocation: number): void {
+    const {gl} = this;
+
+    gl.enableVertexAttribArray(positionLocation);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+
+    gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
+
+    gl.enableVertexAttribArray(texCoordLocation);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
+
+    gl.vertexAttribPointer(texCoordLocation, 2, gl.FLOAT, false, 0, 0);
+  }
+
+  private unbindTextures(numberOfTextureUnits: number): void {
+    const {gl} = this;
+
+    for (let textureUnit = 0; textureUnit < numberOfTextureUnits; textureUnit++) {
+      gl.activeTexture(gl.TEXTURE0 + textureUnit);
+
+      gl.bindTexture(gl.TEXTURE_2D, null);
+    }
+
+    gl.activeTexture(gl.TEXTURE0);
+  }
+
+  private createAndLinkProgram(vertexShaderSource: string, fragmentShaderSource: string): WebGLProgram {
+    const vertexShader = this.createShader(this.gl.VERTEX_SHADER, vertexShaderSource);
+
+    const fragmentShader = this.createShader(this.gl.FRAGMENT_SHADER, fragmentShaderSource);
+
+    const program = this.gl.createProgram();
+
+    if (!program) {
       throw new Error('Failed to create program');
     }
-    this.gl.attachShader(prog, vs);
-    this.gl.attachShader(prog, fs);
-    this.gl.linkProgram(prog);
-    if (!this.gl.getProgramParameter(prog, this.gl.LINK_STATUS)) {
-      this.logger.error('Program link error:', this.gl.getProgramInfoLog(prog));
-      this.gl.deleteProgram(prog);
+
+    this.gl.attachShader(program, vertexShader);
+
+    this.gl.attachShader(program, fragmentShader);
+
+    this.gl.linkProgram(program);
+
+    if (!this.gl.getProgramParameter(program, this.gl.LINK_STATUS)) {
+      this.logger.error('Program link error:', this.gl.getProgramInfoLog(program));
+
+      this.gl.deleteProgram(program);
+
       throw new Error('Link fail');
     }
-    this.gl.detachShader(prog, vs);
-    this.gl.detachShader(prog, fs);
-    this.gl.deleteShader(vs);
-    this.gl.deleteShader(fs);
-    return prog;
+
+    this.gl.detachShader(program, vertexShader);
+
+    this.gl.detachShader(program, fragmentShader);
+
+    this.gl.deleteShader(vertexShader);
+    this.gl.deleteShader(fragmentShader);
+
+    return program;
   }
 
   private createShader(type: number, source: string): WebGLShader {
     const shader = this.gl.createShader(type);
+
     if (!shader) {
       throw new Error(`Failed to create shader type: ${type}`);
     }
+
     this.gl.shaderSource(shader, source);
+
     this.gl.compileShader(shader);
+
     if (!this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)) {
       this.logger.error('Shader compile error:', this.gl.getShaderInfoLog(shader));
+
       this.gl.deleteShader(shader);
+
       throw new Error('Failed to compile shader');
     }
+
     return shader;
   }
 
   private createColorTexture(
-    r: number,
-    g: number,
-    b: number,
-    a: number,
-  ): {texture: WebGLTexture; color: readonly [number, number, number, number]} {
+    red: number,
+    green: number,
+    blue: number,
+    alpha: number,
+  ): {
+    texture: WebGLTexture;
+    color: readonly [number, number, number, number];
+  } {
     const texture = this.gl.createTexture();
+
     if (!texture) {
       throw new Error('Failed to create texture for color');
     }
+
     this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
-    const pixel = new Uint8Array([r, g, b, a]);
+
+    const pixel = new Uint8Array([red, green, blue, alpha]);
+
     this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, 1, 1, 0, this.gl.RGBA, this.gl.UNSIGNED_BYTE, pixel);
+
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
+
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
+
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.NEAREST);
+
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.NEAREST);
+
     this.gl.bindTexture(this.gl.TEXTURE_2D, null);
-    return {texture, color: [r, g, b, a] as const};
+
+    return {
+      texture,
+      color: [red, green, blue, alpha] as const,
+    };
   }
 
-  private updateBackgroundIfNeeded(newSource?: BackgroundSource | null) {
-    const gl = this.gl;
+  private updateBackgroundIfNeeded(newSource?: BackgroundSource | null): void {
+    const {gl} = this;
+
     let newIdentifier: string;
 
     if (!newSource) {
-      const [r, g, b, a] = WebGLRenderer.DEFAULT_BG_COLOR;
-      newIdentifier = `color(${r},${g},${b},${a})`;
+      const [red, green, blue, alpha] = WebGLRenderer.DEFAULT_BG_COLOR;
+
+      newIdentifier = `color(${red},${green},${blue},${alpha})`;
     } else {
       newIdentifier = newSource.url;
     }
@@ -372,32 +885,47 @@ export class WebGLRenderer {
 
     if (this.backgroundRenderInfo) {
       gl.deleteTexture(this.backgroundRenderInfo.texture);
+
       this.backgroundRenderInfo = null;
     }
+
     this.activeBackgroundSourceIdentifier = newIdentifier;
 
     if (!newSource) {
-      const [r, g, b, a] = WebGLRenderer.DEFAULT_BG_COLOR;
-      const colorTexData = this.createColorTexture(r, g, b, a);
+      const [red, green, blue, alpha] = WebGLRenderer.DEFAULT_BG_COLOR;
+
+      const colorTexture = this.createColorTexture(red, green, blue, alpha);
+
       this.backgroundRenderInfo = {
         type: 'color',
-        texture: colorTexData.texture,
-        color: colorTexData.color,
+        texture: colorTexture.texture,
+        color: colorTexture.color,
       };
-      this.activeBackgroundSourceIdentifier = `color(${r},${g},${b},${a})`;
     } else if (newSource.type === 'image') {
-      const {media, url} = newSource as {media: ImageBitmap; url: string};
-      const texture = this.gl.createTexture();
+      const {media, url} = newSource as {
+        media: ImageBitmap;
+        url: string;
+      };
+
+      const texture = gl.createTexture();
+
       if (!texture) {
         throw new Error('Failed to create texture object for image.');
       }
-      this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
-      this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, this.gl.RGBA, this.gl.UNSIGNED_BYTE, media);
-      this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
-      this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
-      this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.LINEAR);
-      this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.LINEAR);
-      this.gl.bindTexture(this.gl.TEXTURE_2D, null);
+
+      gl.bindTexture(gl.TEXTURE_2D, texture);
+
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, media);
+
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+
+      gl.bindTexture(gl.TEXTURE_2D, null);
 
       this.backgroundRenderInfo = {
         type: 'image',
@@ -409,213 +937,58 @@ export class WebGLRenderer {
     }
 
     if (!this.backgroundRenderInfo) {
-      this.logger.error('Critical: backgroundRenderInfo is null after processing new source. Setting default color.');
-      const [r, g, b, a] = WebGLRenderer.DEFAULT_BG_COLOR;
-      const colorTexData = this.createColorTexture(r, g, b, a);
+      this.logger.error('Background information is missing. Using the default color.');
+
+      const [red, green, blue, alpha] = WebGLRenderer.DEFAULT_BG_COLOR;
+
+      const colorTexture = this.createColorTexture(red, green, blue, alpha);
+
       this.backgroundRenderInfo = {
         type: 'color',
-        texture: colorTexData.texture,
-        color: colorTexData.color,
+        texture: colorTexture.texture,
+        color: colorTexture.color,
       };
-      this.activeBackgroundSourceIdentifier = `color(${r},${g},${b},${a})`;
+
+      this.activeBackgroundSourceIdentifier = `color(${red},${green},${blue},${alpha})`;
     }
   }
 
-  public render(
-    videoFrame: VideoFrame,
-    options: {
-      smoothing: number;
-      smoothstepMin: number;
-      smoothstepMax: number;
-      backgroundSource?: BackgroundSource | null;
-      borderSmooth: number;
-      bgBlur: number;
-      bgBlurRadius: number;
-    },
-    categoryTexture?: WebGLTexture,
-    confidenceTexture?: WebGLTexture,
-    useSelfieModel?: boolean,
-  ) {
+  public close(): void {
     if (!this.running) {
       return;
     }
-    const {gl, fbo, storedStateTextures, stateUpdateProgram, stateUpdateLocations, blendProgram, blendLocations} = this;
 
-    const width = this.canvas.width;
-    const height = this.canvas.height;
-
-    if (!categoryTexture || !confidenceTexture) {
-      gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-      gl.useProgram(blendProgram);
-
-      const frameTexture = gl.createTexture();
-      gl.activeTexture(gl.TEXTURE0);
-      gl.bindTexture(gl.TEXTURE_2D, frameTexture);
-      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, videoFrame);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-      gl.uniform1i(blendLocations.frameTexture, 0);
-      gl.uniform1i(blendLocations.enabled, 0);
-
-      gl.enableVertexAttribArray(blendLocations.position);
-      gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
-      gl.vertexAttribPointer(blendLocations.position, 2, gl.FLOAT, false, 0, 0);
-      gl.enableVertexAttribArray(blendLocations.texCoord);
-      gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
-      gl.vertexAttribPointer(blendLocations.texCoord, 2, gl.FLOAT, false, 0, 0);
-
-      gl.drawArrays(gl.TRIANGLES, 0, 6);
-
-      gl.deleteTexture(frameTexture);
-      gl.activeTexture(gl.TEXTURE0);
-      gl.bindTexture(gl.TEXTURE_2D, null);
-
-      return;
-    }
-
-    // Determine read/write indices for state ping-pong
-    const readStateIndex = this.currentStateIndex;
-    const writeStateIndex = (this.currentStateIndex + 1) % 2;
-    const prevStateTexture = storedStateTextures[readStateIndex];
-    const newStateTexture = storedStateTextures[writeStateIndex];
-
-    this.updateBackgroundIfNeeded(options.backgroundSource);
-
-    // --- 1. State Update Pass (Calculates Moving Average) ---
-    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, newStateTexture, 0);
-
-    // Ensure state texture is correctly sized
-    gl.bindTexture(gl.TEXTURE_2D, newStateTexture);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-
-    gl.viewport(0, 0, width, height);
-    gl.useProgram(stateUpdateProgram);
-
-    // Bind inputs: Current Cat (0), Current Conf (1), Prev State (2)
-    gl.activeTexture(gl.TEXTURE0);
-    gl.bindTexture(gl.TEXTURE_2D, categoryTexture);
-    gl.uniform1i(stateUpdateLocations.categoryTexture, 0);
-    gl.activeTexture(gl.TEXTURE1);
-    gl.bindTexture(gl.TEXTURE_2D, confidenceTexture);
-    gl.uniform1i(stateUpdateLocations.confidenceTexture, 1);
-    gl.activeTexture(gl.TEXTURE2);
-    gl.bindTexture(gl.TEXTURE_2D, prevStateTexture); // Read previous state
-    gl.uniform1i(stateUpdateLocations.prevStateTexture, 2);
-
-    // Set smoothing factors from sliders
-    gl.uniform1f(stateUpdateLocations.smoothingFactor, options.smoothing);
-    gl.uniform1f(stateUpdateLocations.smoothstepMin, options.smoothstepMin);
-    gl.uniform1f(stateUpdateLocations.smoothstepMax, options.smoothstepMax);
-
-    // Set selfie model flag
-    gl.uniform1i(stateUpdateLocations.selfieModel, useSelfieModel ? 1 : 0);
-
-    // Set vertex attributes
-    gl.enableVertexAttribArray(stateUpdateLocations.position);
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
-    gl.vertexAttribPointer(stateUpdateLocations.position, 2, gl.FLOAT, false, 0, 0);
-    gl.enableVertexAttribArray(stateUpdateLocations.texCoord);
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
-    gl.vertexAttribPointer(stateUpdateLocations.texCoord, 2, gl.FLOAT, false, 0, 0);
-
-    // Draw quad to calculate and write the new state
-    gl.drawArrays(gl.TRIANGLES, 0, 6);
-
-    // --- 2. Blending Pass (Uses the NEW state) ---
-    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-    gl.useProgram(blendProgram);
-
-    // Bind Frame Texture (Unit 0)
-    const frameTexture = gl.createTexture();
-    gl.activeTexture(gl.TEXTURE0);
-    gl.bindTexture(gl.TEXTURE_2D, frameTexture);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, videoFrame);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.uniform1i(blendLocations.frameTexture, 0);
-    gl.uniform1f(blendLocations.borderSmooth, options.borderSmooth);
-    gl.uniform1f(blendLocations.bgBlur, options.bgBlur);
-    gl.uniform1f(blendLocations.bgBlurRadius, options.bgBlurRadius);
-    gl.uniform1i(blendLocations.enabled, 1);
-
-    // Bind Current State Texture (Unit 1)
-    const currentStateTexture = storedStateTextures[writeStateIndex]; // Use the *newly written* state
-    gl.activeTexture(gl.TEXTURE1);
-    gl.bindTexture(gl.TEXTURE_2D, currentStateTexture);
-    gl.uniform1i(blendLocations.currentStateTexture, 1);
-
-    // Bind Background Texture (Unit 2)
-    if (this.backgroundRenderInfo) {
-      gl.activeTexture(gl.TEXTURE2);
-      gl.bindTexture(gl.TEXTURE_2D, this.backgroundRenderInfo.texture);
-
-      let bgHeight = 1;
-      let bgWidth = 1; // Default for color type
-
-      if (this.backgroundRenderInfo.type === 'image') {
-        bgWidth = this.backgroundRenderInfo.width;
-        bgHeight = this.backgroundRenderInfo.height;
-      }
-      gl.uniform1i(blendLocations.backgroundTexture, 2);
-      gl.uniform2f(blendLocations.bgImageDimensions, bgWidth > 0 ? bgWidth : 1, bgHeight > 0 ? bgHeight : 1);
-      gl.uniform2f(blendLocations.canvasDimensions, width, height);
-    } else {
-      this.logger.warn('backgroundRenderInfo is null in render loop. Background may not render correctly.');
-    }
-
-    // Set vertex attributes
-    gl.enableVertexAttribArray(blendLocations.position);
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
-    gl.vertexAttribPointer(blendLocations.position, 2, gl.FLOAT, false, 0, 0);
-    gl.enableVertexAttribArray(blendLocations.texCoord);
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
-    gl.vertexAttribPointer(blendLocations.texCoord, 2, gl.FLOAT, false, 0, 0);
-
-    // Draw quad to blend onto canvas
-    gl.drawArrays(gl.TRIANGLES, 0, 6);
-
-    // --- 3. Cleanup ---
-    gl.deleteTexture(frameTexture);
-    // Unbind textures (Units 0, 1, 2 used)
-    for (let i = 0; i < 3; ++i) {
-      gl.activeTexture(gl.TEXTURE0 + i);
-      gl.bindTexture(gl.TEXTURE_2D, null);
-    }
-
-    // Swap state index for next frame
-    this.currentStateIndex = writeStateIndex;
-  }
-
-  public close() {
-    if (!this.running) {
-      return;
-    }
     this.running = false;
+    this.hasStoredMask = false;
+    this.currentStateIndex = 0;
+
     const {gl, fbo} = this;
+
     gl.clearColor(0, 0, 0, 0);
     gl.clear(gl.COLOR_BUFFER_BIT);
+
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
     gl.deleteFramebuffer(fbo);
     gl.deleteProgram(this.stateUpdateProgram);
     gl.deleteProgram(this.blendProgram);
     gl.deleteBuffer(this.positionBuffer);
     gl.deleteBuffer(this.texCoordBuffer);
+
     this.storedStateTextures.forEach(texture => {
       if (texture) {
         gl.deleteTexture(texture);
       }
     });
-    this.storedStateTextures = this.storedStateTextures.toSpliced(0, this.storedStateTextures.length);
+
+    this.storedStateTextures = [];
+
     if (this.backgroundRenderInfo?.texture) {
       gl.deleteTexture(this.backgroundRenderInfo.texture);
+
       this.backgroundRenderInfo = null;
     }
+
     this.activeBackgroundSourceIdentifier = null;
   }
 }

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/segmenter.test.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/segmenter.test.ts
@@ -40,7 +40,9 @@ jest.mock('@enormora/wall-clock/wall-clock', () => ({
 
 jest.mock('./renderer', () => ({
   WebGLRenderer: jest.fn().mockImplementation(() => ({
-    render: jest.fn(),
+    renderWithNewMasks: jest.fn(),
+    renderWithPreviousMask: jest.fn(),
+    renderPassthrough: jest.fn(),
     close: jest.fn(),
   })),
 }));
@@ -352,6 +354,231 @@ describe('segmenter tests', () => {
       expect(ImageSegmenter.createFromOptions).toHaveBeenCalledTimes(2);
 
       expect(firstSegmenter.close).toHaveBeenCalled();
+    });
+  });
+
+  describe('runSegmenter rendering', () => {
+    it('renders the original frame when background effects are disabled', async () => {
+      const segmenter = {
+        close: jest.fn(),
+        setOptions: jest.fn(),
+        segmentForVideo: jest.fn(),
+      };
+
+      (ImageSegmenter.createFromOptions as jest.Mock).mockResolvedValueOnce(segmenter);
+
+      let writerSink!: UnderlyingSink<VideoFrame>;
+
+      const readable = {
+        pipeTo: jest.fn(writer => {
+          writerSink = (writer as any).sink;
+          return Promise.resolve();
+        }),
+      } as unknown as ReadableStream;
+
+      const canvas = {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      } as unknown as OffscreenCanvas;
+
+      await runSegmenter(
+        canvas,
+        readable,
+        {
+          enabled: false,
+          quality: 'bypass',
+          modelPath: 'model-a.tflite',
+          wasmLoaderPath: '/mock/vision_wasm_internal.js',
+          wasmBinaryPath: '/mock/vision_wasm_internal.wasm',
+        } as any,
+        jest.fn(),
+        jest.fn(),
+      );
+
+      const frame = {
+        codedWidth: 640,
+        codedHeight: 480,
+        displayWidth: 640,
+        displayHeight: 480,
+        timestamp: 1,
+        close: jest.fn(),
+      } as unknown as VideoFrame;
+
+      await writerSink.write!(frame, {} as WritableStreamDefaultController);
+
+      const {WebGLRenderer} = await import('./renderer');
+
+      const renderer = (WebGLRenderer as unknown as jest.Mock).mock.results[0].value;
+
+      expect(renderer.renderPassthrough).toHaveBeenCalledWith(frame);
+      expect(renderer.renderWithNewMasks).not.toHaveBeenCalled();
+      expect(renderer.renderWithPreviousMask).not.toHaveBeenCalled();
+      expect(segmenter.segmentForVideo).not.toHaveBeenCalled();
+      expect(frame.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders with new segmentation masks when background effects are enabled', async () => {
+      const categoryTexture = {} as WebGLTexture;
+      const confidenceTexture = {} as WebGLTexture;
+
+      const categoryMask = {
+        getAsWebGLTexture: jest.fn(() => categoryTexture),
+        close: jest.fn(),
+      };
+
+      const confidenceMask = {
+        getAsWebGLTexture: jest.fn(() => confidenceTexture),
+        close: jest.fn(),
+      };
+
+      const segmenter = {
+        close: jest.fn(),
+        setOptions: jest.fn(),
+        segmentForVideo: jest.fn(
+          (
+            _source: VideoFrame,
+            _timestamp: number,
+            callback: (result: {
+              categoryMask: typeof categoryMask;
+              confidenceMasks: Array<typeof confidenceMask>;
+            }) => void,
+          ) => {
+            callback({
+              categoryMask,
+              confidenceMasks: [confidenceMask],
+            });
+          },
+        ),
+      };
+
+      (ImageSegmenter.createFromOptions as jest.Mock).mockResolvedValueOnce(segmenter);
+
+      let writerSink!: UnderlyingSink<VideoFrame>;
+
+      const readable = {
+        pipeTo: jest.fn(writer => {
+          writerSink = (writer as any).sink;
+          return Promise.resolve();
+        }),
+      } as unknown as ReadableStream;
+
+      const canvas = {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      } as unknown as OffscreenCanvas;
+
+      const options = {
+        enabled: true,
+        quality: 'auto',
+        enableFilters: false,
+        modelPath: 'model-a.tflite',
+        wasmLoaderPath: '/mock/vision_wasm_internal.js',
+        wasmBinaryPath: '/mock/vision_wasm_internal.wasm',
+      };
+
+      await runSegmenter(canvas, readable, options as any, jest.fn(), jest.fn());
+
+      const frame = {
+        codedWidth: 640,
+        codedHeight: 480,
+        displayWidth: 640,
+        displayHeight: 480,
+        timestamp: 1,
+        close: jest.fn(),
+      } as unknown as VideoFrame;
+
+      await writerSink.write!(frame, {} as WritableStreamDefaultController);
+
+      const {WebGLRenderer} = await import('./renderer');
+
+      const renderer = (WebGLRenderer as unknown as jest.Mock).mock.results[0].value;
+
+      expect(segmenter.segmentForVideo).toHaveBeenCalledWith(frame, 1000, expect.any(Function));
+
+      expect(renderer.renderWithNewMasks).toHaveBeenCalledWith(
+        frame,
+        expect.objectContaining(options),
+        categoryTexture,
+        confidenceTexture,
+        false,
+      );
+
+      expect(renderer.renderPassthrough).not.toHaveBeenCalled();
+      expect(renderer.renderWithPreviousMask).not.toHaveBeenCalled();
+
+      expect(categoryMask.close).toHaveBeenCalledTimes(1);
+      expect(confidenceMask.close).toHaveBeenCalledTimes(1);
+      expect(frame.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to passthrough when the first segmentation result has no masks', async () => {
+      const segmenter = {
+        close: jest.fn(),
+        setOptions: jest.fn(),
+        segmentForVideo: jest.fn(
+          (
+            _source: VideoFrame,
+            _timestamp: number,
+            callback: (result: {categoryMask?: undefined; confidenceMasks?: undefined}) => void,
+          ) => {
+            callback({
+              categoryMask: undefined,
+              confidenceMasks: undefined,
+            });
+          },
+        ),
+      };
+
+      (ImageSegmenter.createFromOptions as jest.Mock).mockResolvedValueOnce(segmenter);
+
+      let writerSink!: UnderlyingSink<VideoFrame>;
+
+      const readable = {
+        pipeTo: jest.fn(writer => {
+          writerSink = (writer as any).sink;
+          return Promise.resolve();
+        }),
+      } as unknown as ReadableStream;
+
+      const canvas = {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      } as unknown as OffscreenCanvas;
+
+      await runSegmenter(
+        canvas,
+        readable,
+        {
+          enabled: true,
+          quality: 'auto',
+          enableFilters: false,
+          modelPath: 'model-a.tflite',
+          wasmLoaderPath: '/mock/vision_wasm_internal.js',
+          wasmBinaryPath: '/mock/vision_wasm_internal.wasm',
+        } as any,
+        jest.fn(),
+        jest.fn(),
+      );
+
+      const frame = {
+        codedWidth: 640,
+        codedHeight: 480,
+        displayWidth: 640,
+        displayHeight: 480,
+        timestamp: 1,
+        close: jest.fn(),
+      } as unknown as VideoFrame;
+
+      await writerSink.write!(frame, {} as WritableStreamDefaultController);
+
+      const {WebGLRenderer} = await import('./renderer');
+
+      const renderer = (WebGLRenderer as unknown as jest.Mock).mock.results[0].value;
+
+      expect(renderer.renderPassthrough).toHaveBeenCalledWith(frame);
+      expect(renderer.renderWithNewMasks).not.toHaveBeenCalled();
+      expect(renderer.renderWithPreviousMask).not.toHaveBeenCalled();
+      expect(frame.close).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/segmenter.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/segmenter.ts
@@ -36,28 +36,39 @@ import {WebGLRenderer} from './renderer';
 
 let segmenterOptions: WorkerProcessVideoTrackOptions = {} as WorkerProcessVideoTrackOptions;
 
+const SEGMENTATION_FRAME_INTERVAL = 1;
+
 export function updateSegmenterOptions(opts: WorkerProcessVideoTrackOptions) {
-  // Keep the references stable, this allows us to do option changes on segmenter runtime.
+  // Keep the reference stable so that runtime option changes
+  // are immediately visible inside the processing loop.
   Object.assign(segmenterOptions, opts);
 }
 
 async function createSegmenter(canvas: OffscreenCanvas) {
   const logger = getSafeLogger('segmenter:createSegmenter');
+
   const {wasmLoaderPath, wasmBinaryPath, modelPath} = segmenterOptions;
+
   if (!wasmLoaderPath || !wasmBinaryPath) {
     logger.error('wasmLoaderPath and wasmBinaryPath must be provided');
+
     throw new Error('wasmLoaderPath and wasmBinaryPath must be provided');
   }
 
-  const fileset = {wasmLoaderPath, wasmBinaryPath};
-  logger.log(`[virtual-background] createSegmenter`);
-
   if (!modelPath) {
     logger.error('Model path must be provided');
+
     throw new Error('Model path must be provided');
   }
 
-  const segmenter = await ImageSegmenter.createFromOptions(fileset, {
+  const fileset = {
+    wasmLoaderPath,
+    wasmBinaryPath,
+  };
+
+  logger.log('[virtual-background] createSegmenter');
+
+  return ImageSegmenter.createFromOptions(fileset, {
     baseOptions: {
       modelAssetPath: modelPath,
       delegate: 'GPU',
@@ -67,7 +78,6 @@ async function createSegmenter(canvas: OffscreenCanvas) {
     outputConfidenceMasks: true,
     canvas,
   });
-  return segmenter;
 }
 
 export function getSegmenterModelUpdatedOptions(
@@ -93,25 +103,33 @@ export async function runSegmenter(
   onPerformanceSample: (sample: PerformanceSample, mode: Mode) => void,
 ) {
   const logger = getSafeLogger('segmenter:runSegmenter');
-  logger.log(`[virtual-background] runSegmenter`);
+
+  logger.log('[virtual-background] runSegmenter');
+
   segmenterOptions = opts;
 
   let webGLRenderer: WebGLRenderer | null = new WebGLRenderer(canvas);
 
   function onContextLost(event: Event) {
     logger.log(`[virtual-background] webglcontextlost (${!!webGLRenderer})`);
+
     event.preventDefault();
+
     webGLRenderer?.close();
     webGLRenderer = null;
   }
 
   function onContextRestored() {
     logger.log(`[virtual-background] webglcontextrestored (${!!webGLRenderer})`);
+
     if (!webGLRenderer) {
       const timer = createWallClock();
+
       timer.setTimeout(() => {
         logger.log('[virtual-background] restart segmenter onContextRestored');
+
         webGLRenderer = new WebGLRenderer(canvas);
+
         restartSegmenter();
         attachCanvasEvents();
       }, 1000);
@@ -120,12 +138,27 @@ export async function runSegmenter(
 
   function attachCanvasEvents() {
     canvas.addEventListener('webglcontextlost', onContextLost, {once: true});
+
     canvas.addEventListener('webglcontextrestored', onContextRestored, {once: true});
   }
+
   attachCanvasEvents();
 
   let segmenter = await createSegmenter(canvas);
+
   let currentModelPath = segmenterOptions.modelPath;
+
+  /*
+   * This tracks whether the current renderer already has
+   * a valid stored mask that can be reused.
+   */
+  let hasSegmentationMask = false;
+
+  /*
+   * Used to decide whether the current frame should be
+   * segmented or rendered with the previous mask.
+   */
+  let segmentationFrameCounter = 0;
 
   const restartSegmenter = createRestartQueue(restartSegmenterSequentially);
 
@@ -136,9 +169,18 @@ export async function runSegmenter(
       const newSegmenter = await createSegmenter(canvas);
 
       const oldSegmenter = segmenter;
+
       segmenter = newSegmenter;
       currentModelPath = targetModelPath;
+
       oldSegmenter.close();
+
+      /*
+       * The renderer may have been recreated after a context
+       * loss. Force the next frame to generate a new mask.
+       */
+      hasSegmentationMask = false;
+      segmentationFrameCounter = 0;
     } catch (error: unknown) {
       logger.error('Error restarting segmenter:', error);
     }
@@ -146,6 +188,7 @@ export async function runSegmenter(
 
   async function updateSegmenterModel() {
     const targetModelPath = segmenterOptions.modelPath;
+
     const nextOptions = getSegmenterModelUpdatedOptions(targetModelPath, currentModelPath);
 
     if (nextOptions === null) {
@@ -154,56 +197,86 @@ export async function runSegmenter(
 
     try {
       logger.log(`[virtual-background] model is changed to ${nextOptions.baseOptions.modelAssetPath}`);
+
       await segmenter.setOptions(nextOptions);
+
       currentModelPath = targetModelPath;
+
+      /*
+       * A different model may produce masks with different
+       * semantics. Do not reuse the previous model's state.
+       */
+      hasSegmentationMask = false;
+      segmentationFrameCounter = 0;
     } catch (error: unknown) {
       logger.error('[virtual-background] Error updating segmenter model:', error);
     }
   }
 
-  // Filters.
   const effectsCanvas = new OffscreenCanvas(1, 1);
+
   const videoFilter = new VideoFilter(effectsCanvas);
 
-  // Metrics
   const metricsWindow = createMetricsWindow(60);
 
   let lastStatsTime = performance.now();
+
   let totalMsSum = 0;
   let segmentationMsSum = 0;
   let gpuMsSum = 0;
   let filterMsSum = 0;
+
   let frames = 0;
   let totalFrames = 0;
+
   const droppedFrames = 0;
 
   function updateMetrics(totalMs: number, segmentationMs: number, gpuMs: number) {
-    pushMetricsSample(metricsWindow, {totalMs, segmentationMs, gpuMs});
+    pushMetricsSample(metricsWindow, {
+      totalMs,
+      segmentationMs,
+      gpuMs,
+    });
 
     const quality = segmenterOptions.quality ?? 'auto';
+
     const tier = quality === 'auto' ? 'fhd' : quality;
 
     onMetrics(buildMetrics(metricsWindow, droppedFrames, tier, 'GPU'));
 
     const mode: Mode =
       segmenterOptions.mode === 'passthrough' || segmenterOptions.mode === undefined ? 'blur' : segmenterOptions.mode;
-    onPerformanceSample({totalMs, segmentationMs, gpuMs}, mode);
+
+    onPerformanceSample(
+      {
+        totalMs,
+        segmentationMs,
+        gpuMs,
+      },
+      mode,
+    );
   }
 
   function close() {
     segmenter.close();
+
     webGLRenderer?.close();
     webGLRenderer = null;
-    videoFilter?.destroy();
+
+    videoFilter.destroy();
+
     canvas.removeEventListener('webglcontextlost', onContextLost);
+
     canvas.removeEventListener('webglcontextrestored', onContextRestored);
   }
 
   let lastFrameTs = performance.now();
+
   const writer = new WritableStream(
     {
       async write(videoFrame: VideoFrame) {
         const {codedWidth, codedHeight, timestamp} = videoFrame;
+
         if (!codedWidth || !codedHeight) {
           videoFrame.close();
           return;
@@ -213,73 +286,144 @@ export async function runSegmenter(
 
         const useSelfieModel = currentModelPath?.includes('selfie_segmenter');
 
-        // start to process the frame
         const frameStart = performance.now();
+
         const frameDeltaMs = frameStart - lastFrameTs;
+
         lastFrameTs = frameStart;
 
         let filterMs = 0;
         let segmentationMs = 0;
         let gpuMs = 0;
-        const logger = getSafeLogger('segmenter:WritableStream::write');
+
+        const frameLogger = getSafeLogger('segmenter:WritableStream::write');
 
         try {
-          if (segmenterOptions.enabled && segmenterOptions.quality !== 'bypass') {
-            if (segmenterOptions.enableFilters) {
-              const filterStart = performance.now();
-              videoFilter.render(
-                videoFrame,
-                segmenterOptions.blur,
-                segmenterOptions.brightness,
-                segmenterOptions.contrast,
-                segmenterOptions.gamma,
-              );
-              filterMs = performance.now() - filterStart;
-            }
+          const backgroundEffectEnabled = segmenterOptions.enabled && segmenterOptions.quality !== 'bypass';
 
-            const segStart = performance.now();
-
-            await new Promise<void>(resolve => {
-              segmenter.segmentForVideo(
-                segmenterOptions.enableFilters ? effectsCanvas : videoFrame,
-                timestamp * 1000,
-                result => {
-                  segmentationMs = performance.now() - segStart;
-
-                  const categoryMask = result.categoryMask;
-                  const confidenceMask = result.confidenceMasks?.[0];
-
-                  try {
-                    if (!categoryMask || !confidenceMask) {
-                      logger.warn('Skipping frame: Missing masks or WebGL data.');
-                      return;
-                    }
-
-                    const categoryTextureMP = categoryMask.getAsWebGLTexture();
-                    const confidenceTextureMP = confidenceMask.getAsWebGLTexture();
-                    const gpuStart = performance.now();
-                    webGLRenderer?.render(
-                      videoFrame,
-                      segmenterOptions,
-                      categoryTextureMP,
-                      confidenceTextureMP,
-                      useSelfieModel,
-                    );
-                    gpuMs = performance.now() - gpuStart;
-                  } catch (e) {
-                    logger.error('Error in videoCallback:', e);
-                  } finally {
-                    categoryMask?.close();
-                    confidenceMask?.close();
-                    resolve();
-                  }
-                },
-              );
-            });
-          } else {
+          if (!backgroundEffectEnabled) {
+            /*
+             * Background effect disabled:
+             * render the original video frame.
+             */
             const gpuStart = performance.now();
-            webGLRenderer?.render(videoFrame, segmenterOptions);
+
+            webGLRenderer?.renderPassthrough(videoFrame);
+
             gpuMs = performance.now() - gpuStart;
+
+            /*
+             * The next enabled frame should run segmentation
+             * immediately rather than reusing an old state.
+             */
+            hasSegmentationMask = false;
+            segmentationFrameCounter = 0;
+          } else {
+            /*
+             * Always segment the first frame.
+             *
+             * Afterwards, only segment according to the
+             * configured interval.
+             */
+            const shouldRunSegmentation =
+              !hasSegmentationMask || segmentationFrameCounter % SEGMENTATION_FRAME_INTERVAL === 0;
+
+            segmentationFrameCounter++;
+
+            if (!shouldRunSegmentation) {
+              /*
+               * Skip MediaPipe and use the last stored mask.
+               */
+              const gpuStart = performance.now();
+
+              webGLRenderer?.renderWithPreviousMask(videoFrame, segmenterOptions);
+
+              gpuMs = performance.now() - gpuStart;
+            } else {
+              /*
+               * Filters only need to run on frames that are
+               * passed into MediaPipe.
+               */
+              if (segmenterOptions.enableFilters) {
+                const filterStart = performance.now();
+
+                videoFilter.render(
+                  videoFrame,
+                  segmenterOptions.blur,
+                  segmenterOptions.brightness,
+                  segmenterOptions.contrast,
+                  segmenterOptions.gamma,
+                );
+
+                filterMs = performance.now() - filterStart;
+              }
+
+              const segmentationStart = performance.now();
+
+              await new Promise<void>(resolve => {
+                segmenter.segmentForVideo(
+                  segmenterOptions.enableFilters ? effectsCanvas : videoFrame,
+                  timestamp * 1000,
+                  result => {
+                    segmentationMs = performance.now() - segmentationStart;
+
+                    const categoryMask = result.categoryMask;
+
+                    const confidenceMask = result.confidenceMasks?.[0];
+
+                    try {
+                      if (!categoryMask || !confidenceMask) {
+                        frameLogger.warn('Missing segmentation masks.');
+
+                        const gpuStart = performance.now();
+
+                        if (hasSegmentationMask) {
+                          webGLRenderer?.renderWithPreviousMask(videoFrame, segmenterOptions);
+                        } else {
+                          webGLRenderer?.renderPassthrough(videoFrame);
+                        }
+
+                        gpuMs = performance.now() - gpuStart;
+
+                        return;
+                      }
+
+                      const categoryTexture = categoryMask.getAsWebGLTexture();
+
+                      const confidenceTexture = confidenceMask.getAsWebGLTexture();
+
+                      const gpuStart = performance.now();
+
+                      webGLRenderer?.renderWithNewMasks(
+                        videoFrame,
+                        segmenterOptions,
+                        categoryTexture,
+                        confidenceTexture,
+                        useSelfieModel,
+                      );
+
+                      gpuMs = performance.now() - gpuStart;
+
+                      hasSegmentationMask = true;
+                    } catch (error) {
+                      frameLogger.error('Error processing segmentation result:', error);
+
+                      /*
+                       * If rendering the new mask failed,
+                       * force another segmentation attempt
+                       * on the next frame.
+                       */
+                      hasSegmentationMask = false;
+                    } finally {
+                      categoryMask?.close();
+                      confidenceMask?.close();
+
+                      resolve();
+                    }
+                  },
+                );
+              });
+            }
           }
         } finally {
           videoFrame.close();
@@ -292,6 +436,12 @@ export async function runSegmenter(
         gpuMsSum += gpuMs;
         filterMsSum += filterMs;
 
+        /*
+         * Keep the existing metric meaning:
+         * frameDeltaMs represents the time between frames.
+         *
+         * Skipped segmentation frames report segmentationMs = 0.
+         */
         updateMetrics(frameDeltaMs, segmentationMs, gpuMs);
 
         frames++;
@@ -301,27 +451,34 @@ export async function runSegmenter(
 
         if (now - lastStatsTime > 2000) {
           lastStatsTime = now;
+
           totalMsSum = 0;
           segmentationMsSum = 0;
           gpuMsSum = 0;
           filterMsSum = 0;
+
           frames = 0;
         }
       },
 
       close() {
         logger.log('[virtual-background] runSegmenter close');
+
         close();
       },
+
       abort(reason) {
         logger.log('[virtual-background] runSegmenter abort', reason);
+
         close();
       },
     },
-    new CountQueuingStrategy({highWaterMark: 1}),
+    new CountQueuingStrategy({
+      highWaterMark: 1,
+    }),
   );
 
-  readable.pipeTo(writer).catch((err: unknown) => {
-    logger.error(`[virtual-background] video error: ${(err as Error).message}`);
+  readable.pipeTo(writer).catch((error: unknown) => {
+    logger.error(`[virtual-background] video error: ${(error as Error).message}`);
   });
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26366" title="WPB-26366" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-26366</a>  High CPU and GPU utilization when enabling Blur Background effect causes fan activation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

The goal is to make the rendering pipeline more flexible and allow future performance optimizations by reusing previously generated segmentation masks instead of running MediaPipe on every frame.

At the moment, this PR mainly introduces the required infrastructure. The quality/performance trade-offs of mask reuse are still being evaluated.

This PR refactors the background effects rendering pipeline to support rendering with either:

- newly generated segmentation masks,
- previously generated segmentation masks, or
- no segmentation (passthrough).

The renderer now exposes three dedicated rendering paths:

- `renderWithNewMasks()`
- `renderWithPreviousMask()`
- `renderPassthrough()`

This separation removes the previous conditional rendering logic and prepares the renderer for experiments where segmentation is not executed for every frame.

## Notes

Reusing segmentation masks can reduce segmentation workload, but early testing shows noticeable mask lag during movement. Further investigation is required before enabling this optimization by default.
