### PR TITLE
Standardize deployment summaries in the Deliver main workflow [WPB-26469]

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Optional reason for manually delivering main to Edge, hosted Dev, and the development channel'
+        description: 'Optional reason for manually delivering main to Edge, Hosted Dev, and the development channel'
         required: false
         type: string
       confirm_main_publish:
-        description: 'Confirm that this will deploy Edge and hosted Dev, then publish the dev Docker image, Helm chart, and wire-builds/dev channel'
+        description: 'Confirm that this will deploy Edge and Hosted Dev, then publish the dev Docker image, Helm chart, and wire-builds/dev channel'
         required: true
         default: false
         type: boolean
@@ -20,6 +20,9 @@ env:
   AWS_REGION: eu-central-1
   BUILD_ARTIFACT_PATH: apps/server/dist/s3/ebs.zip
   EDGE_ENVIRONMENT_NAME: wire-webapp-edge
+  EDGE_WEBAPP_URL: https://wire-webapp-edge.wire.com/
+  EDGE_RUNTIME_BACKEND_REST: https://prod-nginz-https.wire.com
+  EDGE_RUNTIME_BACKEND_WS: wss://prod-nginz-ssl.wire.com
   DEV_ELASTIC_BEANSTALK_ENVIRONMENT_NAME: wire-webapp-dev
   DEV_WEBAPP_URL: https://wire-webapp-dev.zinfra.io/
   DEV_RUNTIME_BACKEND_REST: https://staging-nginz-https.zinfra.io/
@@ -168,7 +171,9 @@ jobs:
       superseded: ${{ steps.check_latest_main.outputs.superseded }}
     # ADR 0002 requires Edge to deploy without an approval gate, so the
     # wire-webapp-edge repository environment must not require reviewers.
-    environment: wire-webapp-edge
+    environment:
+      name: wire-webapp-edge
+      url: ${{ env.EDGE_WEBAPP_URL }}
 
     steps:
       - name: Check whether this Edge deployment is current
@@ -192,12 +197,6 @@ jobs:
 
           if [[ "${GITHUB_SHA}" != "${latest_main_sha}" ]]; then
             echo "Skipping Edge deployment because ${GITHUB_SHA} was superseded by ${latest_main_sha}."
-
-            {
-              echo '## Edge deployment'
-              echo "- Skipped as superseded: \`${GITHUB_SHA}\`"
-              echo "- Current main commit: \`${latest_main_sha}\`"
-            } >> "${GITHUB_STEP_SUMMARY}"
 
             echo 'superseded=true' >> "${GITHUB_OUTPUT}"
             echo 'deploy_allowed=false' >> "${GITHUB_OUTPUT}"
@@ -240,7 +239,11 @@ jobs:
       - name: Summarize Edge deployment
         if: always()
         env:
+          ARTIFACT_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_version }}
           DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+          EDGE_RUNTIME_BACKEND_REST: ${{ env.EDGE_RUNTIME_BACKEND_REST }}
+          EDGE_RUNTIME_BACKEND_WS: ${{ env.EDGE_RUNTIME_BACKEND_WS }}
+          EDGE_WEBAPP_URL: ${{ env.EDGE_WEBAPP_URL }}
           SUPERSEDED: ${{ steps.check_latest_main.outputs.superseded }}
           WORKFLOW_DISPATCH_REASON: ${{ inputs.reason }}
         run: |
@@ -254,13 +257,21 @@ jobs:
             edge_result='failed'
           fi
 
+          commit_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+          workflow_run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
           {
             echo '## Edge deployment'
+            echo
             echo "- Result: ${edge_result}"
-            echo "- Deployed ref: ${GITHUB_REF}"
-            echo "- Commit SHA: ${GITHUB_SHA}"
+            echo "- Ref: ${GITHUB_REF}"
+            echo "- Commit SHA: [${GITHUB_SHA}](${commit_url})"
+            echo "- Artifact version: ${ARTIFACT_VERSION:-not available}"
             echo "- Target environment: ${EDGE_ENVIRONMENT_NAME}"
-            echo "- Workflow run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Frontend URL: [${EDGE_WEBAPP_URL}](${EDGE_WEBAPP_URL})"
+            echo "- REST backend URL: ${EDGE_RUNTIME_BACKEND_REST}"
+            echo "- WebSocket backend URL: ${EDGE_RUNTIME_BACKEND_WS}"
+            echo "- Workflow run URL: [${workflow_run_url}](${workflow_run_url})"
 
             if [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' && -n "${WORKFLOW_DISPATCH_REASON}" ]]; then
               echo "- Manual reason: ${WORKFLOW_DISPATCH_REASON}"
@@ -283,7 +294,7 @@ jobs:
       url: ${{ env.DEV_WEBAPP_URL }}
 
     steps:
-      - name: Check whether this hosted Dev deployment is current
+      - name: Check whether this Hosted Dev deployment is current
         id: check_latest_main
         env:
           GH_TOKEN: ${{ github.token }}
@@ -303,13 +314,7 @@ jobs:
           fi
 
           if [[ "${GITHUB_SHA}" != "${latest_main_sha}" ]]; then
-            echo "Skipping hosted Dev deployment because ${GITHUB_SHA} was superseded by ${latest_main_sha}."
-
-            {
-              echo '## Hosted Dev deployment'
-              echo "- Skipped as superseded: \`${GITHUB_SHA}\`"
-              echo "- Current main commit: \`${latest_main_sha}\`"
-            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "Skipping Hosted Dev deployment because ${GITHUB_SHA} was superseded by ${latest_main_sha}."
 
             echo 'superseded=true' >> "${GITHUB_OUTPUT}"
             echo 'deploy_allowed=false' >> "${GITHUB_OUTPUT}"
@@ -349,7 +354,7 @@ jobs:
           deployment-timeout: 150
           use-existing-application-version-if-available: true
 
-      - name: Verify hosted Dev runtime
+      - name: Verify Hosted Dev runtime
         id: verify_runtime
         if: ${{ steps.check_latest_main.outputs.deploy_allowed == 'true' }}
         env:
@@ -420,12 +425,17 @@ jobs:
           echo "Observed: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
           exit 1
 
-      - name: Summarize hosted Dev deployment
+      - name: Summarize Hosted Dev deployment
         if: always()
         env:
+          ARTIFACT_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_version }}
           DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+          DEV_RUNTIME_BACKEND_REST: ${{ env.DEV_RUNTIME_BACKEND_REST }}
+          DEV_RUNTIME_BACKEND_WS: ${{ env.DEV_RUNTIME_BACKEND_WS }}
+          DEV_WEBAPP_URL: ${{ env.DEV_WEBAPP_URL }}
           VERIFY_OUTCOME: ${{ steps.verify_runtime.outcome }}
           SUPERSEDED: ${{ steps.check_latest_main.outputs.superseded }}
+          WORKFLOW_DISPATCH_REASON: ${{ inputs.reason }}
         run: |
           set -euo pipefail
 
@@ -437,16 +447,25 @@ jobs:
             dev_result='failed'
           fi
 
+          commit_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+          workflow_run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
           {
             echo '## Hosted Dev deployment'
+            echo
             echo "- Result: ${dev_result}"
-            echo "- Deployed ref: ${GITHUB_REF}"
-            echo "- Commit SHA: ${GITHUB_SHA}"
+            echo "- Ref: ${GITHUB_REF}"
+            echo "- Commit SHA: [${GITHUB_SHA}](${commit_url})"
+            echo "- Artifact version: ${ARTIFACT_VERSION:-not available}"
             echo "- Target environment: ${DEV_ELASTIC_BEANSTALK_ENVIRONMENT_NAME}"
-            echo "- Hosted Dev URL: ${DEV_WEBAPP_URL}"
-            echo "- Expected REST backend: ${DEV_RUNTIME_BACKEND_REST}"
-            echo "- Expected WebSocket backend: ${DEV_RUNTIME_BACKEND_WS}"
-            echo "- Workflow run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Frontend URL: [${DEV_WEBAPP_URL}](${DEV_WEBAPP_URL})"
+            echo "- REST backend URL: ${DEV_RUNTIME_BACKEND_REST}"
+            echo "- WebSocket backend URL: ${DEV_RUNTIME_BACKEND_WS}"
+            echo "- Workflow run URL: [${workflow_run_url}](${workflow_run_url})"
+
+            if [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' && -n "${WORKFLOW_DISPATCH_REASON}" ]]; then
+              echo "- Manual reason: ${WORKFLOW_DISPATCH_REASON}"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   publish_to_development_channel:
@@ -511,11 +530,6 @@ jobs:
 
           if [[ "${GITHUB_SHA}" != "${latest_main_sha}" ]]; then
             echo "Skipping development channel delivery because ${GITHUB_SHA} was superseded by ${latest_main_sha}."
-            {
-              echo '### Development channel'
-              echo "- Skipped as superseded: \`${GITHUB_SHA}\`"
-              echo "- Current origin/main: \`${latest_main_sha}\`"
-            } >> "${GITHUB_STEP_SUMMARY}"
             echo 'superseded=true' >> "$GITHUB_OUTPUT"
             echo 'publish_allowed=false' >> "$GITHUB_OUTPUT"
             exit 0
@@ -570,21 +584,66 @@ jobs:
       - name: Summarize development channel
         if: always()
         env:
+          ARTIFACT_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_version }}
+          CHART_REPOSITORY_URL: ${{ env.CHART_REPOSITORY_URL }}
+          DOCKER_IMAGE_OUTCOME: ${{ steps.publish_docker.outcome }}
           DOCKER_IMAGE_TAG: ${{ steps.publish_docker.outputs.docker_image_tag }}
+          DOCKER_REPOSITORY: ${{ env.DOCKER_REPOSITORY }}
+          HELM_CHART_OUTCOME: ${{ steps.publish_helm.outcome }}
           HELM_CHART_VERSION: ${{ steps.publish_helm.outputs.helm_chart_version }}
+          WIRE_BUILDS_COMMIT_OUTCOME: ${{ steps.update_wire_builds.outcome }}
           WIRE_BUILDS_COMMIT_SHA: ${{ steps.update_wire_builds.outputs.wire_builds_commit_sha }}
+          WIRE_BUILDS_REPOSITORY: ${{ env.WIRE_BUILDS_REPOSITORY }}
           SUPERSEDED: ${{ steps.check_latest_main.outputs.superseded }}
+          WORKFLOW_DISPATCH_REASON: ${{ inputs.reason }}
         run: |
           set -euo pipefail
 
+          if [[ "${SUPERSEDED:-false}" == 'true' ]]; then
+            channel_result='skipped as superseded'
+          elif [[
+            "${DOCKER_IMAGE_OUTCOME:-}" == 'success' &&
+            "${HELM_CHART_OUTCOME:-}" == 'success' &&
+            "${WIRE_BUILDS_COMMIT_OUTCOME:-}" == 'success'
+          ]]; then
+            channel_result='published successfully'
+          else
+            channel_result='failed'
+          fi
+
+          if [[ -n "${DOCKER_IMAGE_TAG:-}" ]]; then
+            docker_image_reference="${DOCKER_REPOSITORY}:${DOCKER_IMAGE_TAG}"
+          else
+            docker_image_reference='not published'
+          fi
+
+          if [[ -n "${WIRE_BUILDS_COMMIT_SHA:-}" ]]; then
+            wire_builds_commit_url="${GITHUB_SERVER_URL}/${WIRE_BUILDS_REPOSITORY}/commit/${WIRE_BUILDS_COMMIT_SHA}"
+            wire_builds_commit="[${WIRE_BUILDS_COMMIT_SHA}](${wire_builds_commit_url})"
+          else
+            wire_builds_commit='not updated'
+          fi
+
+          commit_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+          workflow_run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
           {
             echo '## Development channel'
-            echo "- Main commit SHA: ${GITHUB_SHA}"
-            echo "- Superseded: ${SUPERSEDED:-false}"
-            echo "- Docker image: ${DOCKER_IMAGE_TAG:-not published}"
-            echo "- Helm chart: ${HELM_CHART_VERSION:-not published}"
-            echo "- wire-builds/dev commit: ${WIRE_BUILDS_COMMIT_SHA:-not updated}"
-            echo "- Workflow run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo
+            echo "- Result: ${channel_result}"
+            echo "- Ref: ${GITHUB_REF}"
+            echo "- Commit SHA: [${GITHUB_SHA}](${commit_url})"
+            echo "- Artifact version: ${ARTIFACT_VERSION:-not available}"
+            echo '- Target channel: dev'
+            echo "- Docker image: ${docker_image_reference}"
+            echo "- Helm chart repository: ${CHART_REPOSITORY_URL}"
+            echo "- Helm chart version: ${HELM_CHART_VERSION:-not published}"
+            echo "- wire-builds/dev commit: ${wire_builds_commit}"
+            echo "- Workflow run URL: [${workflow_run_url}](${workflow_run_url})"
+
+            if [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' && -n "${WORKFLOW_DISPATCH_REASON}" ]]; then
+              echo "- Manual reason: ${WORKFLOW_DISPATCH_REASON}"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   notify_main_delivery_failure:
@@ -650,52 +709,145 @@ jobs:
     steps:
       - name: Write main delivery summary
         env:
+          ARTIFACT_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_version }}
           EDGE_RESULT: ${{ needs.deploy_to_edge.result }}
+          EDGE_RUNTIME_BACKEND_REST: ${{ env.EDGE_RUNTIME_BACKEND_REST }}
+          EDGE_RUNTIME_BACKEND_WS: ${{ env.EDGE_RUNTIME_BACKEND_WS }}
+          EDGE_WEBAPP_URL: ${{ env.EDGE_WEBAPP_URL }}
           EDGE_SUPERSEDED: ${{ needs.deploy_to_edge.outputs.superseded }}
           DEV_RESULT: ${{ needs.deploy_to_dev.result }}
           DEV_SUPERSEDED: ${{ needs.deploy_to_dev.outputs.superseded }}
+          DEV_ELASTIC_BEANSTALK_ENVIRONMENT_NAME: ${{ env.DEV_ELASTIC_BEANSTALK_ENVIRONMENT_NAME }}
           DEV_WEBAPP_URL: ${{ env.DEV_WEBAPP_URL }}
           DEV_RUNTIME_BACKEND_REST: ${{ env.DEV_RUNTIME_BACKEND_REST }}
           DEV_RUNTIME_BACKEND_WS: ${{ env.DEV_RUNTIME_BACKEND_WS }}
+          DOCKER_REPOSITORY: ${{ env.DOCKER_REPOSITORY }}
           DOCKER_IMAGE_TAG: ${{ needs.publish_to_development_channel.outputs.docker_image_tag }}
+          DEVELOPMENT_CHANNEL_RESULT: ${{ needs.publish_to_development_channel.result }}
           HELM_CHART_VERSION: ${{ needs.publish_to_development_channel.outputs.helm_chart_version }}
+          CHART_REPOSITORY_URL: ${{ env.CHART_REPOSITORY_URL }}
           WIRE_BUILDS_COMMIT_SHA: ${{ needs.publish_to_development_channel.outputs.wire_builds_commit_sha }}
-          SUPERSEDED: ${{ needs.publish_to_development_channel.outputs.superseded }}
+          WIRE_BUILDS_REPOSITORY: ${{ env.WIRE_BUILDS_REPOSITORY }}
+          DEVELOPMENT_CHANNEL_SUPERSEDED: ${{ needs.publish_to_development_channel.outputs.superseded }}
+          WORKFLOW_DISPATCH_REASON: ${{ inputs.reason }}
         run: |
           set -euo pipefail
 
           if [[ "${EDGE_SUPERSEDED:-false}" == 'true' ]]; then
-            edge_result='Edge skipped as superseded'
-          elif [[ "${EDGE_RESULT}" == 'success' ]]; then
-            edge_result='Edge deployed successfully'
-          elif [[ "${EDGE_RESULT}" == 'skipped' ]]; then
-            edge_result='Edge did not run'
+            edge_result='skipped as superseded'
+          elif [[ "${EDGE_RESULT:-}" == 'success' ]]; then
+            edge_result='deployed successfully'
+          elif [[ "${EDGE_RESULT:-}" == 'skipped' ]]; then
+            edge_result='did not run'
+          elif [[ "${EDGE_RESULT:-}" == 'cancelled' ]]; then
+            edge_result='cancelled'
+          elif [[ "${EDGE_RESULT:-}" == 'failure' ]]; then
+            edge_result='failed'
           else
-            edge_result='Edge failed'
+            edge_result='unknown result'
           fi
 
           if [[ "${DEV_SUPERSEDED:-false}" == 'true' ]]; then
-            dev_result='hosted Dev skipped as superseded'
+            dev_result='skipped as superseded'
           elif [[ "${DEV_RESULT:-}" == 'success' ]]; then
-            dev_result='hosted Dev deployed and verified successfully'
+            dev_result='deployed and verified successfully'
           elif [[ "${DEV_RESULT:-}" == 'skipped' ]]; then
-            dev_result='hosted Dev did not run'
+            dev_result='did not run'
+          elif [[ "${DEV_RESULT:-}" == 'cancelled' ]]; then
+            dev_result='cancelled'
+          elif [[ "${DEV_RESULT:-}" == 'failure' ]]; then
+            dev_result='failed'
           else
-            dev_result='hosted Dev failed'
+            dev_result='unknown result'
           fi
+
+          if [[ "${DEVELOPMENT_CHANNEL_SUPERSEDED:-false}" == 'true' ]]; then
+            channel_result='skipped as superseded'
+          elif [[ "${DEVELOPMENT_CHANNEL_RESULT:-}" == 'success' ]]; then
+            channel_result='published successfully'
+          elif [[ "${DEVELOPMENT_CHANNEL_RESULT:-}" == 'skipped' ]]; then
+            channel_result='did not run'
+          elif [[ "${DEVELOPMENT_CHANNEL_RESULT:-}" == 'cancelled' ]]; then
+            channel_result='cancelled'
+          elif [[ "${DEVELOPMENT_CHANNEL_RESULT:-}" == 'failure' ]]; then
+            channel_result='failed'
+          else
+            channel_result='unknown result'
+          fi
+
+          if [[ -n "${DOCKER_IMAGE_TAG:-}" ]]; then
+            docker_image_reference="${DOCKER_REPOSITORY}:${DOCKER_IMAGE_TAG}"
+          else
+            docker_image_reference='not published'
+          fi
+
+          if [[ -n "${WIRE_BUILDS_COMMIT_SHA:-}" ]]; then
+            wire_builds_commit_url="${GITHUB_SERVER_URL}/${WIRE_BUILDS_REPOSITORY}/commit/${WIRE_BUILDS_COMMIT_SHA}"
+            wire_builds_commit="[${WIRE_BUILDS_COMMIT_SHA}](${wire_builds_commit_url})"
+          else
+            wire_builds_commit='not updated'
+          fi
+
+          commit_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+          workflow_run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
           {
             echo '## Main delivery'
-            echo "- Main commit SHA: ${GITHUB_SHA}"
-            echo "- Edge deployment: ${edge_result}"
-            echo "- Hosted Dev deployment: ${dev_result}"
-            echo "- Hosted Dev skipped as superseded: ${DEV_SUPERSEDED:-false}"
-            echo "- Hosted Dev URL: ${DEV_WEBAPP_URL}"
-            echo "- Expected hosted Dev REST backend: ${DEV_RUNTIME_BACKEND_REST}"
-            echo "- Expected hosted Dev WebSocket backend: ${DEV_RUNTIME_BACKEND_WS}"
-            echo "- Docker image: ${DOCKER_IMAGE_TAG:-not published}"
-            echo "- Helm chart: ${HELM_CHART_VERSION:-not published}"
-            echo "- wire-builds/dev: ${WIRE_BUILDS_COMMIT_SHA:-not updated}"
-            echo "- Development channel skipped as superseded: ${SUPERSEDED:-false}"
-            echo "- Workflow URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo
+            echo "- Ref: ${GITHUB_REF}"
+            echo "- Commit SHA: [${GITHUB_SHA}](${commit_url})"
+            echo "- Artifact version: ${ARTIFACT_VERSION:-not available}"
+            echo "- Workflow run URL: [${workflow_run_url}](${workflow_run_url})"
+
+            echo
+            echo '### Edge deployment'
+            echo
+            echo "- Result: ${edge_result}"
+            echo "- Ref: ${GITHUB_REF}"
+            echo "- Commit SHA: [${GITHUB_SHA}](${commit_url})"
+            echo "- Artifact version: ${ARTIFACT_VERSION:-not available}"
+            echo "- Target environment: ${EDGE_ENVIRONMENT_NAME}"
+            echo "- Frontend URL: [${EDGE_WEBAPP_URL}](${EDGE_WEBAPP_URL})"
+            echo "- REST backend URL: ${EDGE_RUNTIME_BACKEND_REST}"
+            echo "- WebSocket backend URL: ${EDGE_RUNTIME_BACKEND_WS}"
+            echo "- Workflow run URL: [${workflow_run_url}](${workflow_run_url})"
+
+            if [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' && -n "${WORKFLOW_DISPATCH_REASON}" ]]; then
+              echo "- Manual reason: ${WORKFLOW_DISPATCH_REASON}"
+            fi
+
+            echo
+            echo '### Hosted Dev deployment'
+            echo
+            echo "- Result: ${dev_result}"
+            echo "- Ref: ${GITHUB_REF}"
+            echo "- Commit SHA: [${GITHUB_SHA}](${commit_url})"
+            echo "- Artifact version: ${ARTIFACT_VERSION:-not available}"
+            echo "- Target environment: ${DEV_ELASTIC_BEANSTALK_ENVIRONMENT_NAME}"
+            echo "- Frontend URL: [${DEV_WEBAPP_URL}](${DEV_WEBAPP_URL})"
+            echo "- REST backend URL: ${DEV_RUNTIME_BACKEND_REST}"
+            echo "- WebSocket backend URL: ${DEV_RUNTIME_BACKEND_WS}"
+            echo "- Workflow run URL: [${workflow_run_url}](${workflow_run_url})"
+
+            if [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' && -n "${WORKFLOW_DISPATCH_REASON}" ]]; then
+              echo "- Manual reason: ${WORKFLOW_DISPATCH_REASON}"
+            fi
+
+            echo
+            echo '### Development channel'
+            echo
+            echo "- Result: ${channel_result}"
+            echo "- Ref: ${GITHUB_REF}"
+            echo "- Commit SHA: [${GITHUB_SHA}](${commit_url})"
+            echo "- Artifact version: ${ARTIFACT_VERSION:-not available}"
+            echo '- Target channel: dev'
+            echo "- Docker image: ${docker_image_reference}"
+            echo "- Helm chart repository: ${CHART_REPOSITORY_URL}"
+            echo "- Helm chart version: ${HELM_CHART_VERSION:-not published}"
+            echo "- wire-builds/dev commit: ${wire_builds_commit}"
+            echo "- Workflow run URL: [${workflow_run_url}](${workflow_run_url})"
+
+            if [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' && -n "${WORKFLOW_DISPATCH_REASON}" ]]; then
+              echo "- Manual reason: ${WORKFLOW_DISPATCH_REASON}"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Standardize deployment summaries in the Deliver main workflow

## Context

The job summaries produced by `publish-main.yml` are currently inconsistent.

Hosted Dev shows its frontend, REST backend, and WebSocket backend URLs, while Edge omits them. The development channel follows a different structure, and the aggregate Main delivery summary does not consistently mirror the information shown by the individual jobs.

The superseded checks also write partial summaries before the final `if: always()` summary steps run. This can produce duplicate sections with different fields.

## Changes

This pull request standardizes the summaries produced by the Deliver main workflow.

Edge and Hosted Dev now use the same labels, ordering, and deployment metadata, including the artifact version, target environment, frontend URL, REST backend URL, WebSocket backend URL, commit, and workflow run.

The development channel uses the same general structure while retaining distribution-specific information such as the complete Docker image reference, Helm chart repository and version, and the `wire-builds/dev` commit.

The aggregate Main delivery summary now contains dedicated sections for Edge, Hosted Dev, and the development channel. These sections mirror the corresponding individual job summaries instead of reducing the results to a few status lines.

Summary output was removed from the superseded checks so that every job has exactly one authoritative summary writer.

Relevant HTTP URLs and commit references are rendered as clickable Markdown links.
