### PR TITLE
Extract Release Cloud runtime verification [WPB-26469]

### DIFF
--- a/.github/actions/verify-webapp-runtime/action.yml
+++ b/.github/actions/verify-webapp-runtime/action.yml
@@ -1,0 +1,37 @@
+---
+name: Verify webapp runtime
+description: Verify the deployed webapp runtime version, commit, and backend configuration
+
+inputs:
+  environment-label:
+    description: Label of the deployment environment used in verification diagnostics
+    required: true
+  webapp-url:
+    description: Base URL of the deployed webapp
+    required: true
+  expected-version:
+    description: Expected webapp version returned by the version endpoint
+    required: true
+  expected-commit:
+    description: Expected commit returned by the commit endpoint
+    required: true
+  expected-backend-rest:
+    description: Expected REST backend URL in the runtime configuration
+    required: true
+  expected-backend-ws:
+    description: Expected WebSocket backend URL in the runtime configuration
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Verify runtime
+      shell: bash
+      env:
+        ENVIRONMENT_LABEL: ${{ inputs.environment-label }}
+        WEBAPP_URL: ${{ inputs.webapp-url }}
+        EXPECTED_VERSION: ${{ inputs.expected-version }}
+        EXPECTED_COMMIT: ${{ inputs.expected-commit }}
+        EXPECTED_BACKEND_REST: ${{ inputs.expected-backend-rest }}
+        EXPECTED_BACKEND_WS: ${{ inputs.expected-backend-ws }}
+      run: bash "${GITHUB_ACTION_PATH}/verify-webapp-runtime.sh"

--- a/.github/actions/verify-webapp-runtime/verify-webapp-runtime.sh
+++ b/.github/actions/verify-webapp-runtime/verify-webapp-runtime.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+environment_label="${ENVIRONMENT_LABEL:-unknown}"
+required_environment_variable_names=(
+  ENVIRONMENT_LABEL
+  WEBAPP_URL
+  EXPECTED_VERSION
+  EXPECTED_COMMIT
+  EXPECTED_BACKEND_REST
+  EXPECTED_BACKEND_WS
+)
+
+for required_environment_variable_name in "${required_environment_variable_names[@]}"; do
+  if [[ -z "${!required_environment_variable_name:-}" ]]; then
+    echo "Missing required runtime verification input ${required_environment_variable_name} for environment ${environment_label}." >&2
+    exit 1
+  fi
+done
+
+function normalize_url() {
+  local url="$1"
+
+  while [[ "${url}" == */ ]]; do
+    url="${url%/}"
+  done
+
+  printf '%s' "${url}"
+}
+
+normalized_webapp_url="$(normalize_url "${WEBAPP_URL}")"
+version_endpoint="${normalized_webapp_url}/version"
+commit_endpoint="${normalized_webapp_url}/commit"
+runtime_config_endpoint="${normalized_webapp_url}/config.js"
+expected_backend_rest="$(normalize_url "${EXPECTED_BACKEND_REST}")"
+expected_backend_ws="$(normalize_url "${EXPECTED_BACKEND_WS}")"
+
+for attempt_number in {1..10}; do
+  version_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${version_endpoint}" || true)"
+  commit_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${commit_endpoint}" || true)"
+  runtime_config="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${runtime_config_endpoint}" || true)"
+
+  actual_version="$(
+    printf '%s' "${version_response}" |
+      jq --exit-status --raw-output '.version | strings | select(length > 0)'
+  )" || actual_version=''
+  actual_commit="$(
+    printf '%s' "${commit_response}" |
+      tr -d '\r\n'
+  )"
+  actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
+  actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
+  normalized_actual_backend_rest="$(normalize_url "${actual_backend_rest}")"
+  normalized_actual_backend_ws="$(normalize_url "${actual_backend_ws}")"
+
+  if [[
+    "${actual_version}" == "${EXPECTED_VERSION}" &&
+    "${actual_commit}" == "${EXPECTED_COMMIT}" &&
+    "${normalized_actual_backend_rest}" == "${expected_backend_rest}" &&
+    "${normalized_actual_backend_ws}" == "${expected_backend_ws}"
+  ]]; then
+    echo "${environment_label} runtime verification succeeded on attempt ${attempt_number}: VERSION=${actual_version}, COMMIT=${actual_commit}, REST=${normalized_actual_backend_rest}, WS=${normalized_actual_backend_ws}."
+    exit 0
+  fi
+
+  echo "${environment_label} runtime verification mismatch on attempt ${attempt_number}." >&2
+  echo "Expected: VERSION=${EXPECTED_VERSION}, COMMIT=${EXPECTED_COMMIT}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
+  echo "Observed: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=${normalized_actual_backend_rest:-missing}, WS=${normalized_actual_backend_ws:-missing}." >&2
+
+  if [[ "${attempt_number}" -lt 10 ]]; then
+    sleep 6
+  fi
+done
+
+echo "${environment_label} runtime verification failed after 10 attempts." >&2
+exit 1

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -225,12 +225,20 @@ jobs:
     name: Deploy to Beta
     runs-on: ubuntu-24.04
     needs: build_artifact
-    permissions: {}
+    permissions:
+      contents: read
     environment:
       name: wire-webapp-beta
       url: https://wire-webapp-beta.wire.com/
 
     steps:
+      - name: Checkout runtime verification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/verify-webapp-runtime
+          sparse-checkout-cone-mode: true
+
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -258,56 +266,14 @@ jobs:
           use-existing-application-version-if-available: true
 
       - name: Verify Beta runtime
-        env:
-          BETA_WEBAPP_URL: ${{ env.BETA_WEBAPP_URL }}
-          EXPECTED_BACKEND_REST: ${{ env.BETA_RUNTIME_BACKEND_REST }}
-          EXPECTED_BACKEND_WS: ${{ env.BETA_RUNTIME_BACKEND_WS }}
-          EXPECTED_COMMIT: ${{ needs.build_artifact.outputs.release_commit_sha }}
-          EXPECTED_VERSION: ${{ needs.build_artifact.outputs.artifact_version }}
-        run: |
-          set -euo pipefail
-
-          normalize_url() {
-            printf '%s' "${1%/}"
-          }
-
-          expected_backend_rest="$(normalize_url "${EXPECTED_BACKEND_REST}")"
-          expected_backend_ws="$(normalize_url "${EXPECTED_BACKEND_WS}")"
-
-          for attempt_number in {1..10}; do
-            version_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${BETA_WEBAPP_URL}version" || true)"
-            commit_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${BETA_WEBAPP_URL}commit" || true)"
-            runtime_config="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${BETA_WEBAPP_URL}config.js" || true)"
-
-            actual_version="$(
-              printf '%s' "${version_response}" |
-                jq --raw-output '.version'
-            )" || actual_version=''
-            actual_commit="$(
-              printf '%s' "${commit_response}" |
-                tr -d '\r\n'
-            )"
-            actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
-            actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
-
-            if [[
-              "${actual_version}" == "${EXPECTED_VERSION}" &&
-              "${actual_commit}" == "${EXPECTED_COMMIT}" &&
-              "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" &&
-              "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}"
-            ]]; then
-              exit 0
-            fi
-
-            echo "Beta runtime verification mismatch on attempt ${attempt_number}: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}." >&2
-
-            if [[ "${attempt_number}" -lt 10 ]]; then
-              sleep 6
-            fi
-          done
-
-          echo "Beta runtime verification failed after 10 attempts." >&2
-          exit 1
+        uses: ./.github/actions/verify-webapp-runtime
+        with:
+          environment-label: Beta
+          webapp-url: ${{ env.BETA_WEBAPP_URL }}
+          expected-version: ${{ needs.build_artifact.outputs.artifact_version }}
+          expected-commit: ${{ needs.build_artifact.outputs.release_commit_sha }}
+          expected-backend-rest: ${{ env.BETA_RUNTIME_BACKEND_REST }}
+          expected-backend-ws: ${{ env.BETA_RUNTIME_BACKEND_WS }}
 
   create_beta_tag:
     name: Create Beta tag
@@ -584,66 +550,27 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [build_artifact, deploy_to_production]
     if: ${{ needs.deploy_to_production.result == 'success' }}
-    permissions: {}
+    permissions:
+      contents: read
     timeout-minutes: 10
 
     steps:
-      - name: Verify live Production runtime
-        env:
-          EXPECTED_BACKEND_REST: ${{ env.PRODUCTION_RUNTIME_BACKEND_REST }}
-          EXPECTED_BACKEND_WS: ${{ env.PRODUCTION_RUNTIME_BACKEND_WS }}
-          EXPECTED_COMMIT: ${{ needs.build_artifact.outputs.release_commit_sha }}
-          EXPECTED_VERSION: ${{ needs.build_artifact.outputs.artifact_version }}
-          PRODUCTION_WEBAPP_URL: ${{ env.PRODUCTION_WEBAPP_URL }}
-        run: |
-          set -euo pipefail
+      - name: Checkout runtime verification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/verify-webapp-runtime
+          sparse-checkout-cone-mode: true
 
-          normalize_url() {
-            printf '%s' "${1%/}"
-          }
-
-          expected_backend_rest="$(normalize_url "${EXPECTED_BACKEND_REST}")"
-          expected_backend_ws="$(normalize_url "${EXPECTED_BACKEND_WS}")"
-
-          for attempt_number in {1..10}; do
-            version_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${PRODUCTION_WEBAPP_URL}version" || true)"
-            commit_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${PRODUCTION_WEBAPP_URL}commit" || true)"
-            runtime_config="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${PRODUCTION_WEBAPP_URL}config.js" || true)"
-
-            actual_version="$(
-              printf '%s' "${version_response}" |
-                jq --raw-output '.version'
-            )" || actual_version=''
-            actual_commit="$(
-              printf '%s' "${commit_response}" |
-                tr -d '\r\n'
-            )"
-            actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
-            actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
-
-            if [[
-              "${actual_version}" == "${EXPECTED_VERSION}" &&
-              "${actual_commit}" == "${EXPECTED_COMMIT}" &&
-              "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" &&
-              "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}"
-            ]]; then
-              echo "Production runtime verification succeeded on attempt ${attempt_number}: VERSION=${actual_version}, COMMIT=${actual_commit}, REST=$(normalize_url "${actual_backend_rest}"), WS=$(normalize_url "${actual_backend_ws}")."
-              exit 0
-            fi
-
-            echo "Production runtime configuration mismatch on attempt ${attempt_number}." >&2
-            echo "Expected: VERSION=${EXPECTED_VERSION}, COMMIT=${EXPECTED_COMMIT}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
-            echo "Observed: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
-
-            if [[ "${attempt_number}" -lt 10 ]]; then
-              sleep 6
-            fi
-          done
-
-          echo "Production runtime verification failed after 10 attempts." >&2
-          echo "Expected: VERSION=${EXPECTED_VERSION}, COMMIT=${EXPECTED_COMMIT}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
-          echo "Observed: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
-          exit 1
+      - name: Verify Production runtime
+        uses: ./.github/actions/verify-webapp-runtime
+        with:
+          environment-label: Production
+          webapp-url: ${{ env.PRODUCTION_WEBAPP_URL }}
+          expected-version: ${{ needs.build_artifact.outputs.artifact_version }}
+          expected-commit: ${{ needs.build_artifact.outputs.release_commit_sha }}
+          expected-backend-rest: ${{ env.PRODUCTION_RUNTIME_BACKEND_REST }}
+          expected-backend-ws: ${{ env.PRODUCTION_RUNTIME_BACKEND_WS }}
 
   create_production_tag:
     name: Create Production tag


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Context

The Release Cloud workflow currently contains nearly identical inline shell implementations for verifying the Beta and Production runtimes.

Both implementations fetch `/version`, `/commit`, and `/config.js`, compare the deployed version and commit, validate the REST and WebSocket backends, and retry while the deployment becomes available.

Keeping this implementation directly inside the workflow makes the release orchestration harder to understand and duplicates behavior that should remain consistent.