### PR TITLE
Reuse runtime verification for Hosted Dev [WPB-26469]

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -324,6 +324,14 @@ jobs:
           echo 'superseded=false' >> "${GITHUB_OUTPUT}"
           echo 'deploy_allowed=true' >> "${GITHUB_OUTPUT}"
 
+      - name: Checkout runtime verification action
+        if: ${{ steps.check_latest_main.outputs.deploy_allowed == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/verify-webapp-runtime
+          sparse-checkout-cone-mode: true
+
       - name: Download shared main artifact
         if: ${{ steps.check_latest_main.outputs.deploy_allowed == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -357,73 +365,14 @@ jobs:
       - name: Verify Hosted Dev runtime
         id: verify_runtime
         if: ${{ steps.check_latest_main.outputs.deploy_allowed == 'true' }}
-        env:
-          EXPECTED_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_version }}
-          EXPECTED_COMMIT: ${{ github.sha }}
-          EXPECTED_BACKEND_REST: ${{ env.DEV_RUNTIME_BACKEND_REST }}
-          EXPECTED_BACKEND_WS: ${{ env.DEV_RUNTIME_BACKEND_WS }}
-          DEV_WEBAPP_URL: ${{ env.DEV_WEBAPP_URL }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ -z "${EXPECTED_VERSION}" || -z "${EXPECTED_COMMIT}" || -z "${EXPECTED_BACKEND_REST}" || -z "${EXPECTED_BACKEND_WS}" ]]; then
-            echo 'Hosted Dev runtime verification requires all expected values.' >&2
-            exit 1
-          fi
-
-          normalize_url() {
-            local normalized_url="${1}"
-
-            while [[ "${normalized_url}" == */ ]]; do
-              normalized_url="${normalized_url%/}"
-            done
-
-            printf '%s' "${normalized_url}"
-          }
-
-          expected_backend_rest="$(normalize_url "${EXPECTED_BACKEND_REST}")"
-          expected_backend_ws="$(normalize_url "${EXPECTED_BACKEND_WS}")"
-
-          for attempt_number in {1..10}; do
-            version_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${DEV_WEBAPP_URL}version" || true)"
-            commit_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${DEV_WEBAPP_URL}commit" || true)"
-            runtime_config="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${DEV_WEBAPP_URL}config.js" || true)"
-
-            actual_version="$(
-              printf '%s' "${version_response}" |
-                jq --exit-status --raw-output '.version | strings | select(length > 0)'
-            )" || actual_version=''
-            actual_commit="$(
-              printf '%s' "${commit_response}" |
-                tr -d '\r\n'
-            )"
-            actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
-            actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
-
-            if [[
-              "${actual_version}" == "${EXPECTED_VERSION}" &&
-              "${actual_commit}" == "${EXPECTED_COMMIT}" &&
-              "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" &&
-              "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}"
-            ]]; then
-              echo "Hosted Dev runtime verification succeeded on attempt ${attempt_number}: VERSION=${actual_version}, COMMIT=${actual_commit}, REST=$(normalize_url "${actual_backend_rest}"), WS=$(normalize_url "${actual_backend_ws}")."
-              exit 0
-            fi
-
-            echo "Hosted Dev runtime configuration mismatch on attempt ${attempt_number}." >&2
-            echo "Expected: VERSION=${EXPECTED_VERSION}, COMMIT=${EXPECTED_COMMIT}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
-            echo "Observed: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
-
-            if [[ "${attempt_number}" -lt 10 ]]; then
-              sleep 6
-            fi
-          done
-
-          echo 'Hosted Dev runtime verification failed after 10 attempts.' >&2
-          echo "Expected: VERSION=${EXPECTED_VERSION}, COMMIT=${EXPECTED_COMMIT}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
-          echo "Observed: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=$(normalize_url "${actual_backend_rest:-missing}"), WS=$(normalize_url "${actual_backend_ws:-missing}")." >&2
-          exit 1
+        uses: ./.github/actions/verify-webapp-runtime
+        with:
+          environment-label: Hosted Dev
+          webapp-url: ${{ env.DEV_WEBAPP_URL }}
+          expected-version: ${{ needs.build_main_artifacts.outputs.artifact_version }}
+          expected-commit: ${{ github.sha }}
+          expected-backend-rest: ${{ env.DEV_RUNTIME_BACKEND_REST }}
+          expected-backend-ws: ${{ env.DEV_RUNTIME_BACKEND_WS }}
 
       - name: Summarize Hosted Dev deployment
         if: always()


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

The Deliver main workflow contains an inline Hosted Dev runtime verification implementation that duplicates the repository-owned verification action already used by Release Cloud.

Both implementations verify the deployed artifact version, source commit, REST backend, and WebSocket backend through `/version`, `/commit`, and `/config.js`.

Keeping the same behavior in multiple workflow files makes the delivery pipelines harder to maintain and allows their verification behavior to drift over time.