### PR TITLE
Fix TC-548 and TC-553 e2e tests [WPB-27246]

### DIFF
--- a/apps/webapp/test/e2e_tests/pageManager/webapp/components/conversationSidebar.component.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/components/conversationSidebar.component.ts
@@ -36,6 +36,7 @@ export class ConversationSidebar {
   readonly supportButton: Locator;
   readonly favoritesButton: Locator;
   readonly preferencesNotificationBadge: Locator;
+  readonly folderList: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -55,6 +56,7 @@ export class ConversationSidebar {
     this.supportButton = page.getByRole('link', {name: 'Support'});
     this.favoritesButton = page.getByRole('tab', {name: 'Favorites'});
     this.preferencesNotificationBadge = this.preferencesButton.getByTestId('notification-badge');
+    this.folderList = page.getByTestId('folder-list');
   }
 
   async clickPreferencesButton() {

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -513,6 +513,7 @@ test.describe('Federation', () => {
 
   testData.forEach(({title, tags, type}) => {
     test(title, {tag: tags}, async ({createPage}) => {
+      test.setTimeout(120_000);
       const [normalUserPage, federatedUserPage] = await Promise.all([
         createPage(withLogin(normalUser)),
         createPage(withLogin(federatedUser, {baseUrl: federationBaseUrl})),

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -102,7 +102,6 @@ test.describe('Folders', () => {
       await test.step('User A moves group conversation with User B into new custom folder', async () => {
         await userAPages.conversationList().getConversation(conversationName).open();
         await createCustomFolder(userAPageManager, conversationName, customFolderName);
-
       });
 
       await test.step('Group conversation with User B is in the custom folder', async () => {

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -150,19 +150,23 @@ test.describe('Folders', () => {
       const customFolderName = 'Custom-Folder';
       const conversationName = 'Group Conversation with User A and User B';
 
-      // Preconditions: Create a custom folder with 1:1 conversation
-      await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
-      await userAComponents.conversationSidebar().allConversationsButton.click();
-      await createGroup(userAPages, conversationName, [userB]);
+      await test.step('User A creates a custom folder with 1:1 conversation with User B', async () => {
+        await userAPages.conversationList().getConversation(userB.fullName).open();
+        await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
+        await expect(userAComponents.conversationSidebar().folderList.getByText(customFolderName)).toBeVisible();
+      });
 
-      await test.step('User A moves group with User B into an existing custom folder', async () => {
+      await test.step('User A creates and moves group with User B into an existing custom folder', async () => {
+        await userAComponents.conversationSidebar().allConversationsButton.click();
+        await createGroup(userAPages, conversationName, [userB]);
         await moveConversationToFolder(userAPageManager, conversationName, customFolderName);
       });
 
-      await test.step('Group conversation with User B is in the custom folder', async () => {
+      await test.step('User A sees 1:1 and group conversations with User B in the custom folder', async () => {
         const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
-        await expect(userAComponents.conversationSidebar().folderList.getByText(customFolderName)).toBeVisible();
         await expect(actualTitle).toHaveText(customFolderName);
+        await expect(userAPages.conversationList().getConversation(conversationName)).toBeVisible();
+        await expect(userAPages.conversationList().getConversation(userB.fullName)).toBeVisible();
       });
     },
   );

--- a/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Folders/folders.spec.ts
@@ -58,7 +58,7 @@ test.describe('Folders', () => {
   let userA: User;
   let userB: User;
 
-  test.beforeEach(async ({createTeam, createPage, createUser}) => {
+  test.beforeEach(async ({createTeam, createUser}) => {
     userB = await createUser();
     const team = await createTeam('Team', {users: [userB]});
     userA = team.owner;
@@ -74,14 +74,15 @@ test.describe('Folders', () => {
 
       const customFolderName = 'Custom-Folder';
 
-      // Step 1: User A opens 1:1 conversation with User B
-      await userAPages.conversationList().getConversation(userB.fullName).open();
-      // Step 2: User A moves 1:1 conversation with User B into new custom folder
-      await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
-      // Step 3: 1:1 conversation with User B is in the custom folder
-      const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
+      await test.step('User A moves 1:1 conversation with User B into new custom folder', async () => {
+        await userAPages.conversationList().getConversation(userB.fullName).open();
+        await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
+      });
 
-      await expect(actualTitle).toHaveText(customFolderName);
+      await test.step('1:1 conversation with User B is in the custom folder', async () => {
+        const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
+        await expect(actualTitle).toHaveText(customFolderName);
+      });
     },
   );
 
@@ -98,14 +99,16 @@ test.describe('Folders', () => {
 
       await createGroup(userAPages, conversationName, [userB]);
 
-      // Step 1: User A opens group conversation with User B
-      await userAPages.conversationList().getConversation(conversationName).open();
-      // Step 2: User A moves group conversation with User B in new custom folder
-      await createCustomFolder(userAPageManager, conversationName, customFolderName);
-      // Step 3: Group conversation with User B is in the custom folder
-      const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
+      await test.step('User A moves group conversation with User B into new custom folder', async () => {
+        await userAPages.conversationList().getConversation(conversationName).open();
+        await createCustomFolder(userAPageManager, conversationName, customFolderName);
 
-      await expect(actualTitle).toHaveText(customFolderName);
+      });
+
+      await test.step('Group conversation with User B is in the custom folder', async () => {
+        const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
+        await expect(actualTitle).toHaveText(customFolderName);
+      });
     },
   );
 
@@ -126,12 +129,14 @@ test.describe('Folders', () => {
       await createCustomFolder(userAPageManager, conversationName, customFolderName);
       await userAComponents.conversationSidebar().allConversationsButton.click();
 
-      // Step 1: User A moves 1:1 conversation with User B into an existing custom folder
-      await moveConversationToFolder(userAPageManager, userB.fullName, customFolderName);
-      // Step 2: 1:1 conversation with User B is in the custom folder
-      const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
+      await test.step('User A moves 1:1 conversation with User B into an existing custom folder', async () => {
+        await moveConversationToFolder(userAPageManager, userB.fullName, customFolderName);
+      });
 
-      await expect(actualTitle).toHaveText(customFolderName);
+      await test.step('1:1 conversation with User B is in the custom folder', async () => {
+        const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
+        await expect(actualTitle).toHaveText(customFolderName);
+      });
     },
   );
 
@@ -146,35 +151,37 @@ test.describe('Folders', () => {
       const customFolderName = 'Custom-Folder';
       const conversationName = 'Group Conversation with User A and User B';
 
-      await createGroup(userAPages, conversationName, [userB]);
-
       // Preconditions: Create a custom folder with 1:1 conversation
       await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
       await userAComponents.conversationSidebar().allConversationsButton.click();
+      await createGroup(userAPages, conversationName, [userB]);
 
-      // Step 1: User A moves group with User B into an existing custom folder
-      await moveConversationToFolder(userAPageManager, conversationName, customFolderName);
-      // Step 2: Group conversation with User B is in the custom folder
-      const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
+      await test.step('User A moves group with User B into an existing custom folder', async () => {
+        await moveConversationToFolder(userAPageManager, conversationName, customFolderName);
+      });
 
-      await expect(actualTitle).toHaveText(customFolderName);
+      await test.step('Group conversation with User B is in the custom folder', async () => {
+        const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
+        await expect(userAComponents.conversationSidebar().folderList.getByText(customFolderName)).toBeVisible();
+        await expect(actualTitle).toHaveText(customFolderName);
+      });
     },
   );
 
-  // TODO: Blocked due to Bug-Ticket [WPB-22266]
-  test.skip(
+  test(
     'I want to see custom folder removed when last conversation is removed',
     {tag: ['@TC-553', '@regression']},
     async ({createPage}) => {
       const userAPageManager = await PageManager.from(createPage(withLogin(userA)));
       await connectWithUser(userAPageManager, userB);
-      const userAPages = userAPageManager.webapp.pages;
+      const {pages: userAPages, components: userAComponents} = userAPageManager.webapp;
 
       const customFolderName = 'Custom-Folder';
 
       // Preconditions: Conversation is in custom folder
       const conversation = await userAPages.conversationList().getConversation(userB.fullName).open();
       await createCustomFolder(userAPageManager, userB.fullName, customFolderName);
+      await expect(userAComponents.conversationSidebar().folderList.getByText(customFolderName)).toBeVisible();
 
       await test.step("User A clicks 'remove from custom folder' button", async () => {
         const contextMenu = await conversation.openContextMenu();
@@ -183,7 +190,7 @@ test.describe('Folders', () => {
 
       await test.step("The conversation list header is changed to 'All Conversations'", async () => {
         const actualTitle = userAPages.conversationList().conversationListHeaderTitle;
-        await expect(actualTitle).toHaveText('All Conversations');
+        await expect(actualTitle).toHaveText('All conversations');
       });
 
       await test.step('Custom Folder Name is no longer visible in the Move-To-Menu', async () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27246" title="WPB-27246" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27246</a>  [Web][QA] Fix folders e2e tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-27246

**TC-548** test is failing due to stale state condition and because test is running to fast. This condition cannot be reproduced manually and can be fixed by changing sequence of calls in precondition section of the code. 

**TC-553** was skipped before due to bug WPB-22266. But in reality it’s a e2e test implementation issue and stale state condition that could not be reproduced in real usage of the app.