### PR TITLE
fix: return OR results for multiple tags in Drive filter (WPB-27126)

### DIFF
--- a/libraries/api-client/src/cells/cellsApi.test.ts
+++ b/libraries/api-client/src/cells/cellsApi.test.ts
@@ -1914,9 +1914,9 @@ describe('CellsAPI', () => {
       );
     });
 
-    it('filters by tags when provided', async () => {
+    it('filters by a single tag with Should operation', async () => {
       const searchPhrase = 'test';
-      const tags = ['tag1', 'tag2'];
+      const tags = ['tag1'];
       const mockResponse: RestNodeCollection = {
         Nodes: [
           {
@@ -1938,13 +1938,41 @@ describe('CellsAPI', () => {
           Status: {
             Deleted: 'Not',
           },
-          Metadata: [{Namespace: 'usermeta-tags', Term: JSON.stringify(tags.join(','))}],
+          Metadata: [{Namespace: 'usermeta-tags', Term: 'tag1', Operation: 'Should'}],
         },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
       });
       expect(result).toEqual(mockResponse);
+    });
+
+    it('filters by multiple tags with Should operation (OR) so any selected tag matches (WPB-27126)', async () => {
+      const searchPhrase = 'test';
+      const tags = ['tag1', 'tag2'];
+      const mockResponse: RestNodeCollection = {Nodes: []} as RestNodeCollection;
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockResponse));
+
+      await cellsAPI.searchNodes({phrase: searchPhrase, tags});
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Scope: {Root: {Path: '/'}, Recursive: true},
+        Filters: {
+          Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Type: 'UNKNOWN',
+          Status: {
+            Deleted: 'Not',
+          },
+          Metadata: [
+            {Namespace: 'usermeta-tags', Term: 'tag1', Operation: 'Should'},
+            {Namespace: 'usermeta-tags', Term: 'tag2', Operation: 'Should'},
+          ],
+        },
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+      });
     });
 
     it('handles empty tags array', async () => {
@@ -2249,7 +2277,7 @@ describe('CellsAPI', () => {
           Type: 'UNKNOWN',
           Status: {Deleted: 'Not', HasPublicLink: true},
           Metadata: [
-            {Namespace: 'usermeta-tags', Term: JSON.stringify(tags.join(','))},
+            {Namespace: 'usermeta-tags', Term: 'important', Operation: 'Should'},
             {Namespace: 'mime', Term: 'image/*', Operation: 'Must'},
             {Namespace: 'usermeta-owner-uuid', Term: JSON.stringify(creatorId), Operation: 'Must'},
           ],

--- a/libraries/api-client/src/cells/cellsApi.test.ts
+++ b/libraries/api-client/src/cells/cellsApi.test.ts
@@ -1947,7 +1947,7 @@ describe('CellsAPI', () => {
       expect(result).toEqual(mockResponse);
     });
 
-    it('filters by multiple tags with Should operation (OR) so any selected tag matches (WPB-27126)', async () => {
+    it('creates one Should metadata filter per selected tag', async () => {
       const searchPhrase = 'test';
       const tags = ['tag1', 'tag2'];
       const mockResponse: RestNodeCollection = {Nodes: []} as RestNodeCollection;

--- a/libraries/api-client/src/cells/cellsApi.test.ts
+++ b/libraries/api-client/src/cells/cellsApi.test.ts
@@ -1914,7 +1914,7 @@ describe('CellsAPI', () => {
       );
     });
 
-    it('filters by a single tag with Should operation', async () => {
+    it('creates a Should metadata filter for a single tag', async () => {
       const searchPhrase = 'test';
       const tags = ['tag1'];
       const mockResponse: RestNodeCollection = {
@@ -1957,7 +1957,7 @@ describe('CellsAPI', () => {
       await cellsAPI.searchNodes({phrase: searchPhrase, tags});
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
-        Scope: {Root: {Path: '/'}, Recursive: true},
+        Scope: {Root: {Path: ''}, Recursive: true},
         Filters: {
           Text: {SearchIn: 'BaseName', Term: searchPhrase},
           Type: 'UNKNOWN',

--- a/libraries/api-client/src/cells/cellsApi.ts
+++ b/libraries/api-client/src/cells/cellsApi.ts
@@ -468,9 +468,11 @@ export class CellsAPI {
           ...(hasPublicLink !== undefined ? {HasPublicLink: hasPublicLink} : {}),
         },
         Metadata: [
-          ...(tags !== undefined && tags.length > 0
-            ? [{Namespace: USER_META_TAGS_NAMESPACE, Term: this.transformTagsToJson(tags)}]
-            : []),
+          ...(tags?.map(tag => ({
+            Namespace: USER_META_TAGS_NAMESPACE,
+            Term: tag,
+            Operation: 'Should' as const,
+          })) ?? []),
           ...(mimeTypes?.map(term => ({Namespace: MIME_NAMESPACE, Term: term, Operation: mimeOp})) ?? []),
           ...(creatorIds?.map(term => ({
             Namespace: USER_META_OWNER_UUID_NAMESPACE,

--- a/libraries/api-client/src/cells/cellsApi.ts
+++ b/libraries/api-client/src/cells/cellsApi.ts
@@ -20,6 +20,7 @@
 import {AxiosHeaders} from 'axios';
 import {
   NodeServiceApi,
+  LookupFilterMetaFilter,
   RestLookupRequest,
   RestCreateCheckResponse,
   RestDeleteVersionResponse,
@@ -54,6 +55,17 @@ const DEFAULT_OFFSET = 0;
 const USER_META_TAGS_NAMESPACE = 'usermeta-tags';
 const USER_META_OWNER_UUID_NAMESPACE = 'usermeta-owner-uuid';
 const MIME_NAMESPACE = 'mime';
+
+// Each selected tag is sent as its own metadata filter with the `Should` operation so the
+// backend applies OR semantics across tags (a node matching any selected tag is returned).
+// Matches the iOS client shape in WireMessaging RestAPI.swift.
+function createTagMetadataFilters(tags: string[] | undefined): LookupFilterMetaFilter[] {
+  return (tags ?? []).map(tag => ({
+    Namespace: USER_META_TAGS_NAMESPACE,
+    Term: tag,
+    Operation: 'Should',
+  }));
+}
 
 // TODO: remove the apiKey (from pydio and s3) once the Pydio backend has fully support for the auth with the Wire's access token
 // If it's passed we use it to authenticate, instead of the access token
@@ -468,11 +480,7 @@ export class CellsAPI {
           ...(hasPublicLink !== undefined ? {HasPublicLink: hasPublicLink} : {}),
         },
         Metadata: [
-          ...(tags?.map(tag => ({
-            Namespace: USER_META_TAGS_NAMESPACE,
-            Term: tag,
-            Operation: 'Should' as const,
-          })) ?? []),
+          ...createTagMetadataFilters(tags),
           ...(mimeTypes?.map(term => ({Namespace: MIME_NAMESPACE, Term: term, Operation: mimeOp})) ?? []),
           ...(creatorIds?.map(term => ({
             Namespace: USER_META_OWNER_UUID_NAMESPACE,

--- a/libraries/api-client/src/cells/cellsApi.ts
+++ b/libraries/api-client/src/cells/cellsApi.ts
@@ -59,8 +59,8 @@ const MIME_NAMESPACE = 'mime';
 // Each selected tag is sent as its own metadata filter with the `Should` operation so the
 // backend applies OR semantics across tags (a node matching any selected tag is returned).
 // Matches the iOS client shape in WireMessaging RestAPI.swift.
-function createTagMetadataFilters(tags: string[] | undefined): LookupFilterMetaFilter[] {
-  return (tags ?? []).map(tag => ({
+function createTagMetadataFilters(tags: string[]): LookupFilterMetaFilter[] {
+  return tags.map(tag => ({
     Namespace: USER_META_TAGS_NAMESPACE,
     Term: tag,
     Operation: 'Should',
@@ -462,6 +462,7 @@ export class CellsAPI {
       throw new Error(CONFIGURATION_ERROR);
     }
 
+    const tagMetadataFilters = createTagMetadataFilters(tags ?? []);
     const mimeOp: 'Should' | 'Must' = mimeTypes !== undefined && mimeTypes.length > 1 ? 'Should' : 'Must';
     const creatorOp: 'Should' | 'Must' = creatorIds !== undefined && creatorIds.length > 1 ? 'Should' : 'Must';
 
@@ -480,7 +481,7 @@ export class CellsAPI {
           ...(hasPublicLink !== undefined ? {HasPublicLink: hasPublicLink} : {}),
         },
         Metadata: [
-          ...createTagMetadataFilters(tags),
+          ...tagMetadataFilters,
           ...(mimeTypes?.map(term => ({Namespace: MIME_NAMESPACE, Term: term, Operation: mimeOp})) ?? []),
           ...(creatorIds?.map(term => ({
             Namespace: USER_META_OWNER_UUID_NAMESPACE,


### PR DESCRIPTION




<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27126" title="WPB-27126" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27126</a>  [Web] Selecting multiple tags returns no results instead of matching files with any selected tag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->




### What

Multi-tag search in the Cells API previously collapsed all selected tags into a single JSON-encoded term (e.g. `"sam,bug"`), which the backend treated as one literal tag value that no node had  so any filter with 2+ tags returned zero results.

This PR emits one `Metadata` entry per tag with `Operation: 'Should'` and a raw term, mirroring the iOS client (`WireMessaging/Sources/WireMessagingData/WireDrive/NodesAPI/RestAPI.swift:643`) and the existing `mimeTypes` / `creatorIds` pattern in the same file.

Tag filter construction is extracted into a small module-level helper `createTagMetadataFilters` with an explicit `LookupFilterMetaFilter[]` return type so the request literal reads by intent rather than by construction detail.

### Why

Restores the OR semantics defined in the PRD: a file matching any of the selected tags is returned.

### Behaviour change

- **Multiple tags**: previously returned 0; now returns files matching any selected tag.
- **Single tag**: the returned files are unchanged. The on-wire shape does change from a single JSON-joined term to a per-tag `Should` entry with a raw term. Verified against the fulu backend that a single-tag lookup with the new shape returns identical results to the old one.


### Demo
https://github.com/user-attachments/assets/0083f26e-43a0-4d0e-bfed-c8221ffddf94





