### PR TITLE
Build config before running production distribution CLI [WPB-26469]

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -86,6 +86,23 @@ jobs:
       - name: Install dependencies
         run: ./bin/yarn --immutable
 
+      - name: Verify deployment CLI from clean install
+        run: |
+          rm -rf libraries/config/lib
+          published_charts_path="$(mktemp)"
+          printf '%s\n' '[]' > "${published_charts_path}"
+
+          helm_action="$(
+            ./bin/run-production-distribution-cli.sh \
+              select-helm-chart \
+              --charts-path "${published_charts_path}" \
+              --image-tag "dev-test-image"
+          )"
+
+          test "${helm_action}" = 'publish'
+          test -f libraries/config/lib/index.js
+          test -f libraries/config/lib/index.d.ts
+
       - name: Restore Nx and ESLint caches
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/bin/publish-development-helm.sh
+++ b/bin/publish-development-helm.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 : "${CHART_REPOSITORY_URL:?CHART_REPOSITORY_URL is required}"
 : "${DOCKER_IMAGE_TAG:?DOCKER_IMAGE_TAG is required}"
 
+script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.15.1
 helm repo add "${CHART_REPOSITORY_NAME}" "${CHART_REPOSITORY_URL}"
 helm repo update
@@ -15,7 +17,7 @@ helm search repo "${CHART_REPOSITORY_NAME}/webapp" --devel --versions --output j
   jq '[.[] | select(.version | contains("-pre."))]' > "${published_charts_path}"
 
 helm_action="$(
-  ./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/productionDistributionCli.ts \
+  "${script_directory}/run-production-distribution-cli.sh" \
     select-helm-chart --charts-path "${published_charts_path}" --image-tag "${DOCKER_IMAGE_TAG}"
 )"
 

--- a/bin/publish-production-helm.sh
+++ b/bin/publish-production-helm.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 : "${CHART_REPOSITORY_URL:?CHART_REPOSITORY_URL is required}"
 : "${DOCKER_IMAGE_TAG:?DOCKER_IMAGE_TAG is required}"
 
+script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.15.1
 helm repo add "${CHART_REPOSITORY_NAME}" "${CHART_REPOSITORY_URL}"
 helm repo update
@@ -14,7 +16,7 @@ published_charts_path="${RUNNER_TEMP}/published-webapp-charts.json"
 helm search repo "${CHART_REPOSITORY_NAME}/webapp" --devel --versions --output json > "${published_charts_path}"
 
 helm_action="$(
-  ./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/productionDistributionCli.ts \
+  "${script_directory}/run-production-distribution-cli.sh" \
     select-helm-chart --charts-path "${published_charts_path}" --image-tag "${DOCKER_IMAGE_TAG}"
 )"
 

--- a/bin/run-production-distribution-cli.sh
+++ b/bin/run-production-distribution-cli.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "${repository_root}"
+
+./bin/yarn nx run config-lib:build >&2
+
+exec ./bin/yarn ts-node \
+  --project ./tsconfig.bin.json \
+  ./bin/productionDistributionCli.ts \
+  "$@"

--- a/bin/update-wire-builds.sh
+++ b/bin/update-wire-builds.sh
@@ -29,9 +29,7 @@ wire_builds_field_options=(
 run_distribution_cli() {
   (
     cd "${webapp_repository_root}"
-    ./bin/yarn ts-node \
-      --project ./tsconfig.bin.json \
-      ./bin/productionDistributionCli.ts \
+    ./bin/run-production-distribution-cli.sh \
       "$@"
   )
 }

--- a/bin/validate-production-distribution.sh
+++ b/bin/validate-production-distribution.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 : "${PRODUCTION_TAG:?PRODUCTION_TAG is required}"
 : "${SOURCE_RUN_ID:?SOURCE_RUN_ID is required}"
 
+script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [[ ! "${PRODUCTION_TAG}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\.[1-9][0-9]*-production$ ]]; then
   echo "Production tag does not match YYYY-MM-DD.N-production: ${PRODUCTION_TAG}" >&2
   exit 1
@@ -35,7 +37,7 @@ if [[ -n "${EXPECTED_COMMIT_SHA}" ]]; then
   validation_options+=(--expected-commit-sha "${EXPECTED_COMMIT_SHA}")
 fi
 
-./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/productionDistributionCli.ts \
+"${script_directory}/run-production-distribution-cli.sh" \
   validate-manifest "${validation_options[@]}"
 
 for required_context_path in \


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Why

The first main delivery after merging the explicit build metadata changes failed while publishing the development Helm chart.

The application artifact itself was built and validated successfully. Edge and Hosted Dev were deployed successfully, and the Hosted Dev runtime verification passed. The development Docker image was also published.

The failure occurred when `publish-development-helm.sh` invoked `productionDistributionCli.ts` directly through `ts-node`:

```text
TS2307: Cannot find module '@wireapp/config' or its corresponding type declarations.
```

`productionDistribution.ts` now imports the authoritative build metadata contract from `@wireapp/config`. That package exposes its compiled `lib` directory, but a clean `yarn --immutable` installation does not build it.

Pull request CI did not expose the problem because the relevant checks had already built workspace libraries before exercising this code path. The main delivery job installs dependencies and invokes the deployment CLI without first building `config-lib`.

The additional `artifactMetadata is of type unknown` diagnostics were cascading errors. TypeScript could not resolve the imported `isBuildMetadata` type guard and therefore could not narrow the value.

## What changed

This pull request adds one supported entry point for the production distribution CLI.

The entry point:

1. resolves the repository root independently of the caller’s current working directory
2. runs `config-lib:build` through Nx
3. executes `productionDistributionCli.ts` with the supplied arguments
4. preserves the CLI exit code

All deployment and distribution shell scripts now use that entry point instead of invoking the TypeScript file directly.

The metadata contract remains owned by `@wireapp/config`. No metadata types or validation logic are duplicated in `bin`.