### PR TITLE
Avoid redundant continuous integration runs after merge [WPB-22420]

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,10 +9,6 @@ on:
   merge_group:
     branches: [main, release/*]
 
-  push:
-    # Push CI on the trunk branch updates coverage monitoring.
-    branches: [main]
-
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The continuous integration workflow currently runs for pull requests, merge groups and pushes to `main`.

The pull-request run provides early feedback while a change is being developed. The merge-group run is the authoritative integration check: it validates the candidate against the latest target branch before GitHub allows it to be merged.

Running the complete workflow again after the resulting commit reaches `main` does not introduce another meaningful quality gate. It repeats unit tests, linting, type checking, library builds, generated-artifact checks, filename linting and workflow security analysis after the code has already passed the merge queue.

This creates avoidable GitHub Actions usage, additional noise and duplicate feedback without making the merge safer.