### PR TITLE
Expose complete build metadata through the version endpoint [WPB-26469]

### DIFF
--- a/.github/actions/verify-webapp-runtime/action.yml
+++ b/.github/actions/verify-webapp-runtime/action.yml
@@ -1,6 +1,6 @@
 ---
 name: Verify webapp runtime
-description: Verify the deployed webapp runtime version, commit, and backend configuration
+description: Verify the deployed webapp build metadata and backend configuration
 
 inputs:
   environment-label:
@@ -10,10 +10,16 @@ inputs:
     description: Base URL of the deployed webapp
     required: true
   expected-version:
-    description: Expected webapp version returned by the version endpoint
+    description: Expected logical webapp version returned by the version endpoint
+    required: true
+  expected-asset-version:
+    description: Expected browser asset version returned by the version endpoint
     required: true
   expected-commit:
-    description: Expected commit returned by the commit endpoint
+    description: Expected full commit SHA returned by the version endpoint
+    required: true
+  expected-built-at:
+    description: Expected artifact assembly timestamp returned by the version endpoint
     required: true
   expected-backend-rest:
     description: Expected REST backend URL in the runtime configuration
@@ -31,7 +37,9 @@ runs:
         ENVIRONMENT_LABEL: ${{ inputs.environment-label }}
         WEBAPP_URL: ${{ inputs.webapp-url }}
         EXPECTED_VERSION: ${{ inputs.expected-version }}
+        EXPECTED_ASSET_VERSION: ${{ inputs.expected-asset-version }}
         EXPECTED_COMMIT: ${{ inputs.expected-commit }}
+        EXPECTED_BUILT_AT: ${{ inputs.expected-built-at }}
         EXPECTED_BACKEND_REST: ${{ inputs.expected-backend-rest }}
         EXPECTED_BACKEND_WS: ${{ inputs.expected-backend-ws }}
       run: bash "${GITHUB_ACTION_PATH}/verify-webapp-runtime.sh"

--- a/.github/actions/verify-webapp-runtime/verify-webapp-runtime.sh
+++ b/.github/actions/verify-webapp-runtime/verify-webapp-runtime.sh
@@ -7,7 +7,9 @@ required_environment_variable_names=(
   ENVIRONMENT_LABEL
   WEBAPP_URL
   EXPECTED_VERSION
+  EXPECTED_ASSET_VERSION
   EXPECTED_COMMIT
+  EXPECTED_BUILT_AT
   EXPECTED_BACKEND_REST
   EXPECTED_BACKEND_WS
 )
@@ -31,42 +33,32 @@ function normalize_url() {
 
 normalized_webapp_url="$(normalize_url "${WEBAPP_URL}")"
 version_endpoint="${normalized_webapp_url}/version"
-commit_endpoint="${normalized_webapp_url}/commit"
 runtime_config_endpoint="${normalized_webapp_url}/config.js"
 expected_backend_rest="$(normalize_url "${EXPECTED_BACKEND_REST}")"
 expected_backend_ws="$(normalize_url "${EXPECTED_BACKEND_WS}")"
+validation_script_path="${GITHUB_WORKSPACE}/bin/validateRuntimeResponses.mts"
 
 for attempt_number in {1..10}; do
   version_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${version_endpoint}" || true)"
-  commit_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${commit_endpoint}" || true)"
   runtime_config="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "${runtime_config_endpoint}" || true)"
 
-  actual_version="$(
+  if validation_message="$(
     printf '%s' "${version_response}" |
-      jq --exit-status --raw-output '.version | strings | select(length > 0)'
-  )" || actual_version=''
-  actual_commit="$(
-    printf '%s' "${commit_response}" |
-      tr -d '\r\n'
-  )"
-  actual_backend_rest="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_REST":"\([^"]*\)".*/\1/p')"
-  actual_backend_ws="$(printf '%s' "${runtime_config}" | sed -n 's/.*"BACKEND_WS":"\([^"]*\)".*/\1/p')"
-  normalized_actual_backend_rest="$(normalize_url "${actual_backend_rest}")"
-  normalized_actual_backend_ws="$(normalize_url "${actual_backend_ws}")"
+      RUNTIME_CONFIG_RESPONSE="${runtime_config}" node "${validation_script_path}" 2>&1
+  )"; then
+    runtime_validation_succeeded=true
+  else
+    runtime_validation_succeeded=false
+  fi
 
-  if [[
-    "${actual_version}" == "${EXPECTED_VERSION}" &&
-    "${actual_commit}" == "${EXPECTED_COMMIT}" &&
-    "${normalized_actual_backend_rest}" == "${expected_backend_rest}" &&
-    "${normalized_actual_backend_ws}" == "${expected_backend_ws}"
-  ]]; then
-    echo "${environment_label} runtime verification succeeded on attempt ${attempt_number}: VERSION=${actual_version}, COMMIT=${actual_commit}, REST=${normalized_actual_backend_rest}, WS=${normalized_actual_backend_ws}."
+  if [[ "${runtime_validation_succeeded}" == 'true' ]]; then
+    echo "${environment_label} runtime verification succeeded on attempt ${attempt_number}: VERSION=${EXPECTED_VERSION}, ASSET_VERSION=${EXPECTED_ASSET_VERSION}, COMMIT=${EXPECTED_COMMIT}, BUILT_AT=${EXPECTED_BUILT_AT}, REST=${expected_backend_rest}, WS=${expected_backend_ws}."
     exit 0
   fi
 
   echo "${environment_label} runtime verification mismatch on attempt ${attempt_number}." >&2
-  echo "Expected: VERSION=${EXPECTED_VERSION}, COMMIT=${EXPECTED_COMMIT}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
-  echo "Observed: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=${normalized_actual_backend_rest:-missing}, WS=${normalized_actual_backend_ws:-missing}." >&2
+  echo "Expected: VERSION=${EXPECTED_VERSION}, ASSET_VERSION=${EXPECTED_ASSET_VERSION}, COMMIT=${EXPECTED_COMMIT}, BUILT_AT=${EXPECTED_BUILT_AT}, REST=${expected_backend_rest}, WS=${expected_backend_ws}." >&2
+  echo "Validation details: ${validation_message:-missing}." >&2
 
   if [[ "${attempt_number}" -lt 10 ]]; then
     sleep 6

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -79,6 +79,9 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
+      - name: Verify sparse runtime validation entry point
+        run: bash ./bin/verifySparseRuntimeValidation.sh
+
       - name: Install dependencies
         run: ./bin/yarn --immutable
 

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -78,6 +78,7 @@ jobs:
     outputs:
       main_artifact_name: ${{ steps.prepare_artifact.outputs.main_artifact_name }}
       artifact_version: ${{ steps.validate_artifact_metadata.outputs.artifact_version }}
+      artifact_asset_version: ${{ steps.validate_artifact_metadata.outputs.artifact_asset_version }}
       artifact_commit: ${{ steps.validate_artifact_metadata.outputs.artifact_commit }}
       artifact_built_at: ${{ steps.validate_artifact_metadata.outputs.artifact_built_at }}
       development_context_artifact_name: ${{ steps.prepare_artifact.outputs.development_context_artifact_name }}
@@ -409,7 +410,9 @@ jobs:
           environment-label: Hosted Dev
           webapp-url: ${{ env.DEV_WEBAPP_URL }}
           expected-version: ${{ needs.build_main_artifacts.outputs.artifact_version }}
+          expected-asset-version: ${{ needs.build_main_artifacts.outputs.artifact_asset_version }}
           expected-commit: ${{ needs.build_main_artifacts.outputs.artifact_commit }}
+          expected-built-at: ${{ needs.build_main_artifacts.outputs.artifact_built_at }}
           expected-backend-rest: ${{ env.DEV_RUNTIME_BACKEND_REST }}
           expected-backend-ws: ${{ env.DEV_RUNTIME_BACKEND_WS }}
 

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -358,8 +358,18 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-          sparse-checkout: .github/actions/verify-webapp-runtime
-          sparse-checkout-cone-mode: true
+          sparse-checkout: |
+            .nvmrc
+            .github/actions/verify-webapp-runtime
+            bin/validateRuntimeResponses.mts
+            bin/validateRuntimeResponses.ts
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Node.js for runtime verification
+        if: ${{ steps.check_latest_main.outputs.deploy_allowed == 'true' }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Download shared main artifact
         if: ${{ steps.check_latest_main.outputs.deploy_allowed == 'true' }}

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -263,6 +263,7 @@ jobs:
           ARTIFACT_BUILT_AT: ${{ needs.build_main_artifacts.outputs.artifact_built_at }}
           ARTIFACT_COMMIT: ${{ needs.build_main_artifacts.outputs.artifact_commit }}
           ARTIFACT_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_version }}
+          ARTIFACT_ASSET_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_asset_version }}
           DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
           EDGE_RUNTIME_BACKEND_REST: ${{ env.EDGE_RUNTIME_BACKEND_REST }}
           EDGE_RUNTIME_BACKEND_WS: ${{ env.EDGE_RUNTIME_BACKEND_WS }}
@@ -294,8 +295,9 @@ jobs:
             echo
             echo "- Result: ${edge_result}"
             echo "- Ref: ${GITHUB_REF}"
-            echo "- Commit SHA: ${artifact_commit_display}"
             echo "- Webapp version: ${ARTIFACT_VERSION:-not available}"
+            echo "- Asset version: ${ARTIFACT_ASSET_VERSION:-not available}"
+            echo "- Commit SHA: ${artifact_commit_display}"
             echo "- Built at (UTC): ${ARTIFACT_BUILT_AT:-not available}"
             echo "- Target environment: ${EDGE_ENVIRONMENT_NAME}"
             echo "- Frontend URL: [${EDGE_WEBAPP_URL}](${EDGE_WEBAPP_URL})"
@@ -422,6 +424,7 @@ jobs:
           ARTIFACT_BUILT_AT: ${{ needs.build_main_artifacts.outputs.artifact_built_at }}
           ARTIFACT_COMMIT: ${{ needs.build_main_artifacts.outputs.artifact_commit }}
           ARTIFACT_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_version }}
+          ARTIFACT_ASSET_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_asset_version }}
           DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
           DEV_RUNTIME_BACKEND_REST: ${{ env.DEV_RUNTIME_BACKEND_REST }}
           DEV_RUNTIME_BACKEND_WS: ${{ env.DEV_RUNTIME_BACKEND_WS }}
@@ -454,8 +457,9 @@ jobs:
             echo
             echo "- Result: ${dev_result}"
             echo "- Ref: ${GITHUB_REF}"
-            echo "- Commit SHA: ${artifact_commit_display}"
             echo "- Webapp version: ${ARTIFACT_VERSION:-not available}"
+            echo "- Asset version: ${ARTIFACT_ASSET_VERSION:-not available}"
+            echo "- Commit SHA: ${artifact_commit_display}"
             echo "- Built at (UTC): ${ARTIFACT_BUILT_AT:-not available}"
             echo "- Target environment: ${DEV_ELASTIC_BEANSTALK_ENVIRONMENT_NAME}"
             echo "- Frontend URL: [${DEV_WEBAPP_URL}](${DEV_WEBAPP_URL})"
@@ -587,6 +591,7 @@ jobs:
           ARTIFACT_BUILT_AT: ${{ needs.build_main_artifacts.outputs.artifact_built_at }}
           ARTIFACT_COMMIT: ${{ needs.build_main_artifacts.outputs.artifact_commit }}
           ARTIFACT_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_version }}
+          ARTIFACT_ASSET_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_asset_version }}
           CHART_REPOSITORY_URL: ${{ env.CHART_REPOSITORY_URL }}
           DOCKER_IMAGE_OUTCOME: ${{ steps.publish_docker.outcome }}
           DOCKER_IMAGE_TAG: ${{ steps.publish_docker.outputs.docker_image_tag }}
@@ -640,8 +645,9 @@ jobs:
             echo
             echo "- Result: ${channel_result}"
             echo "- Ref: ${GITHUB_REF}"
-            echo "- Commit SHA: ${artifact_commit_display}"
             echo "- Webapp version: ${ARTIFACT_VERSION:-not available}"
+            echo "- Asset version: ${ARTIFACT_ASSET_VERSION:-not available}"
+            echo "- Commit SHA: ${artifact_commit_display}"
             echo "- Built at (UTC): ${ARTIFACT_BUILT_AT:-not available}"
             echo '- Target channel: dev'
             echo "- Docker image: ${docker_image_reference}"
@@ -721,6 +727,7 @@ jobs:
           ARTIFACT_BUILT_AT: ${{ needs.build_main_artifacts.outputs.artifact_built_at }}
           ARTIFACT_COMMIT: ${{ needs.build_main_artifacts.outputs.artifact_commit }}
           ARTIFACT_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_version }}
+          ARTIFACT_ASSET_VERSION: ${{ needs.build_main_artifacts.outputs.artifact_asset_version }}
           EDGE_RESULT: ${{ needs.deploy_to_edge.result }}
           EDGE_RUNTIME_BACKEND_REST: ${{ env.EDGE_RUNTIME_BACKEND_REST }}
           EDGE_RUNTIME_BACKEND_WS: ${{ env.EDGE_RUNTIME_BACKEND_WS }}
@@ -812,8 +819,9 @@ jobs:
             echo '## Main delivery'
             echo
             echo "- Ref: ${GITHUB_REF}"
-            echo "- Commit SHA: ${artifact_commit_display}"
             echo "- Webapp version: ${ARTIFACT_VERSION:-not available}"
+            echo "- Asset version: ${ARTIFACT_ASSET_VERSION:-not available}"
+            echo "- Commit SHA: ${artifact_commit_display}"
             echo "- Built at (UTC): ${ARTIFACT_BUILT_AT:-not available}"
             echo "- Workflow run URL: [${workflow_run_url}](${workflow_run_url})"
 
@@ -822,8 +830,10 @@ jobs:
             echo
             echo "- Result: ${edge_result}"
             echo "- Ref: ${GITHUB_REF}"
-            echo "- Commit SHA: ${artifact_commit_display}"
             echo "- Webapp version: ${ARTIFACT_VERSION:-not available}"
+            echo "- Asset version: ${ARTIFACT_ASSET_VERSION:-not available}"
+            echo "- Commit SHA: ${artifact_commit_display}"
+            echo "- Built at (UTC): ${ARTIFACT_BUILT_AT:-not available}"
             echo "- Target environment: ${EDGE_ENVIRONMENT_NAME}"
             echo "- Frontend URL: [${EDGE_WEBAPP_URL}](${EDGE_WEBAPP_URL})"
             echo "- REST backend URL: ${EDGE_RUNTIME_BACKEND_REST}"
@@ -839,8 +849,10 @@ jobs:
             echo
             echo "- Result: ${dev_result}"
             echo "- Ref: ${GITHUB_REF}"
-            echo "- Commit SHA: ${artifact_commit_display}"
             echo "- Webapp version: ${ARTIFACT_VERSION:-not available}"
+            echo "- Asset version: ${ARTIFACT_ASSET_VERSION:-not available}"
+            echo "- Commit SHA: ${artifact_commit_display}"
+            echo "- Built at (UTC): ${ARTIFACT_BUILT_AT:-not available}"
             echo "- Target environment: ${DEV_ELASTIC_BEANSTALK_ENVIRONMENT_NAME}"
             echo "- Frontend URL: [${DEV_WEBAPP_URL}](${DEV_WEBAPP_URL})"
             echo "- REST backend URL: ${DEV_RUNTIME_BACKEND_REST}"
@@ -856,8 +868,10 @@ jobs:
             echo
             echo "- Result: ${channel_result}"
             echo "- Ref: ${GITHUB_REF}"
-            echo "- Commit SHA: ${artifact_commit_display}"
             echo "- Webapp version: ${ARTIFACT_VERSION:-not available}"
+            echo "- Asset version: ${ARTIFACT_ASSET_VERSION:-not available}"
+            echo "- Commit SHA: ${artifact_commit_display}"
+            echo "- Built at (UTC): ${ARTIFACT_BUILT_AT:-not available}"
             echo '- Target channel: dev'
             echo "- Docker image: ${docker_image_reference}"
             echo "- Helm chart repository: ${CHART_REPOSITORY_URL}"

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-          ref: main
+          ref: ${{ github.workflow_sha }}
           fetch-depth: 1
           path: workflow-source
 
@@ -116,14 +116,12 @@ jobs:
             echo "commit_subject=${commit_subject}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Setup Node.js
+      - name: Setup Node.js for workflow tools
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version-file: 'workflow-source/.nvmrc'
           cache: 'yarn'
-          cache-dependency-path: |
-            workflow-source/yarn.lock
-            selected-release/yarn.lock
+          cache-dependency-path: 'workflow-source/yarn.lock'
 
       - name: Install workflow tool dependencies
         working-directory: workflow-source
@@ -132,6 +130,13 @@ jobs:
       - name: Build workflow tool dependencies
         working-directory: workflow-source
         run: ./bin/yarn nx run config-lib:build
+
+      - name: Setup Node.js for selected release
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: 'selected-release/.nvmrc'
+          cache: 'yarn'
+          cache-dependency-path: 'selected-release/yarn.lock'
 
       - name: Install selected release dependencies
         working-directory: selected-release
@@ -147,6 +152,11 @@ jobs:
           WIRE_WEBAPP_BUILD_COMMIT: ${{ steps.git_metadata.outputs.commit_sha }}
           WIRE_WEBAPP_BUILD_VERSION: ${{ needs.validate_request.outputs.webapp_build_version }}
         run: ./bin/yarn build:prod:public
+
+      - name: Restore Node.js for workflow tools
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: 'workflow-source/.nvmrc'
 
       - name: Validate redeploy artifact metadata
         id: validate_artifact_metadata

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -85,15 +85,25 @@ jobs:
           set -euo pipefail
           git ls-remote --exit-code --tags "https://github.com/${REPOSITORY}.git" "refs/tags/${TAG}"
 
+      - name: Checkout current workflow tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          ref: main
+          fetch-depth: 1
+          path: workflow-source
+
       - name: Checkout selected tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           ref: refs/tags/${{ needs.validate_request.outputs.tag }}
           fetch-depth: 0
+          path: selected-release
 
       - name: Collect git metadata
         id: git_metadata
+        working-directory: selected-release
         run: |
           set -euo pipefail
           commit_sha="$(git rev-parse HEAD)"
@@ -106,22 +116,33 @@ jobs:
             echo "commit_subject=${commit_subject}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Add repository Yarn wrapper to PATH
-        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: 'workflow-source/.nvmrc'
           cache: 'yarn'
+          cache-dependency-path: |
+            workflow-source/yarn.lock
+            selected-release/yarn.lock
 
-      - name: Install JS dependencies
+      - name: Install workflow tool dependencies
+        working-directory: workflow-source
         run: ./bin/yarn --immutable
 
-      - name: Update configuration
+      - name: Build workflow tool dependencies
+        working-directory: workflow-source
+        run: ./bin/yarn nx run config-lib:build
+
+      - name: Install selected release dependencies
+        working-directory: selected-release
+        run: ./bin/yarn --immutable
+
+      - name: Update selected release configuration
+        working-directory: selected-release
         run: ./bin/yarn nx run webapp:configure
 
       - name: Build and package
+        working-directory: selected-release
         env:
           WIRE_WEBAPP_BUILD_COMMIT: ${{ steps.git_metadata.outputs.commit_sha }}
           WIRE_WEBAPP_BUILD_VERSION: ${{ needs.validate_request.outputs.webapp_build_version }}
@@ -129,17 +150,18 @@ jobs:
 
       - name: Validate redeploy artifact metadata
         id: validate_artifact_metadata
+        working-directory: workflow-source
         env:
-          BUILD_ARTIFACT_PATH: apps/server/dist/s3/ebs.zip
+          BUILD_ARTIFACT_PATH: ${{ github.workspace }}/selected-release/apps/server/dist/s3/ebs.zip
           EXPECTED_COMMIT: ${{ steps.git_metadata.outputs.commit_sha }}
           EXPECTED_VERSION: ${{ needs.validate_request.outputs.webapp_build_version }}
-        run: node ./bin/validateBuildArtifact.mts
+        run: node ./bin/validateRecoveryBuildArtifact.mts
 
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: build-artifact-${{ needs.validate_request.outputs.tag }}
-          path: apps/server/dist/s3/ebs.zip
+          path: selected-release/apps/server/dist/s3/ebs.zip
 
   deploy_to_production:
     name: Deploy to production

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -68,6 +68,10 @@ jobs:
     runs-on: ubuntu-24.04
     needs: validate_request
     outputs:
+      artifact_version: ${{ steps.validate_artifact_metadata.outputs.artifact_version }}
+      artifact_asset_version: ${{ steps.validate_artifact_metadata.outputs.artifact_asset_version }}
+      artifact_commit: ${{ steps.validate_artifact_metadata.outputs.artifact_commit }}
+      artifact_built_at: ${{ steps.validate_artifact_metadata.outputs.artifact_built_at }}
       commit_sha: ${{ steps.git_metadata.outputs.commit_sha }}
       commit_url: ${{ steps.git_metadata.outputs.commit_url }}
       commit_subject: ${{ steps.git_metadata.outputs.commit_subject }}
@@ -122,6 +126,14 @@ jobs:
           WIRE_WEBAPP_BUILD_COMMIT: ${{ steps.git_metadata.outputs.commit_sha }}
           WIRE_WEBAPP_BUILD_VERSION: ${{ needs.validate_request.outputs.webapp_build_version }}
         run: ./bin/yarn build:prod:public
+
+      - name: Validate redeploy artifact metadata
+        id: validate_artifact_metadata
+        env:
+          BUILD_ARTIFACT_PATH: apps/server/dist/s3/ebs.zip
+          EXPECTED_COMMIT: ${{ steps.git_metadata.outputs.commit_sha }}
+          EXPECTED_VERSION: ${{ needs.validate_request.outputs.webapp_build_version }}
+        run: node ./bin/validateBuildArtifact.mts
 
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -187,5 +199,8 @@ jobs:
           text: |
             ❌ Production redeploy failed for tag ${{ needs.validate_request.outputs.tag }} ❌
             **Triggered by:** ${{ github.actor }}
-            **Commit:** [${{ needs.build_artifact.outputs.commit_sha }}](${{ needs.build_artifact.outputs.commit_url }}) — ${{ needs.build_artifact.outputs.commit_subject }}
+            **Webapp version:** ${{ needs.build_artifact.outputs.artifact_version || 'unavailable' }}
+            **Asset version:** ${{ needs.build_artifact.outputs.artifact_asset_version || 'unavailable' }}
+            **Commit SHA:** ${{ needs.build_artifact.outputs.artifact_commit || 'unavailable' }} — ${{ needs.build_artifact.outputs.commit_subject }}
+            **Built at (UTC):** ${{ needs.build_artifact.outputs.artifact_built_at || 'unavailable' }}
             **Build log:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -250,8 +250,17 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-          sparse-checkout: .github/actions/verify-webapp-runtime
-          sparse-checkout-cone-mode: true
+          sparse-checkout: |
+            .nvmrc
+            .github/actions/verify-webapp-runtime
+            bin/validateRuntimeResponses.mts
+            bin/validateRuntimeResponses.ts
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Node.js for runtime verification
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -573,8 +582,17 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-          sparse-checkout: .github/actions/verify-webapp-runtime
-          sparse-checkout-cone-mode: true
+          sparse-checkout: |
+            .nvmrc
+            .github/actions/verify-webapp-runtime
+            bin/validateRuntimeResponses.mts
+            bin/validateRuntimeResponses.ts
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Node.js for runtime verification
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Verify Production runtime
         uses: ./.github/actions/verify-webapp-runtime

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -93,6 +93,7 @@ jobs:
       artifact_checksum: ${{ steps.artifact_metadata.outputs.artifact_checksum }}
       artifact_name: ${{ steps.artifact_metadata.outputs.artifact_name }}
       artifact_version: ${{ steps.validate_artifact_metadata.outputs.artifact_version }}
+      artifact_asset_version: ${{ steps.validate_artifact_metadata.outputs.artifact_asset_version }}
       artifact_commit: ${{ steps.validate_artifact_metadata.outputs.artifact_commit }}
       artifact_built_at: ${{ steps.validate_artifact_metadata.outputs.artifact_built_at }}
       distribution_artifact_name: ${{ steps.distribution_artifact.outputs.distribution_artifact_name }}
@@ -294,7 +295,9 @@ jobs:
           environment-label: Beta
           webapp-url: ${{ env.BETA_WEBAPP_URL }}
           expected-version: ${{ needs.build_artifact.outputs.artifact_version }}
+          expected-asset-version: ${{ needs.build_artifact.outputs.artifact_asset_version }}
           expected-commit: ${{ needs.build_artifact.outputs.artifact_commit }}
+          expected-built-at: ${{ needs.build_artifact.outputs.artifact_built_at }}
           expected-backend-rest: ${{ env.BETA_RUNTIME_BACKEND_REST }}
           expected-backend-ws: ${{ env.BETA_RUNTIME_BACKEND_WS }}
 
@@ -600,7 +603,9 @@ jobs:
           environment-label: Production
           webapp-url: ${{ env.PRODUCTION_WEBAPP_URL }}
           expected-version: ${{ needs.build_artifact.outputs.artifact_version }}
+          expected-asset-version: ${{ needs.build_artifact.outputs.artifact_asset_version }}
           expected-commit: ${{ needs.build_artifact.outputs.artifact_commit }}
+          expected-built-at: ${{ needs.build_artifact.outputs.artifact_built_at }}
           expected-backend-rest: ${{ env.PRODUCTION_RUNTIME_BACKEND_REST }}
           expected-backend-ws: ${{ env.PRODUCTION_RUNTIME_BACKEND_WS }}
 

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -708,6 +708,7 @@ jobs:
         env:
           ARTIFACT_CHECKSUM: ${{ needs.build_artifact.outputs.artifact_checksum }}
           ARTIFACT_BUILT_AT: ${{ needs.build_artifact.outputs.artifact_built_at }}
+          ARTIFACT_ASSET_VERSION: ${{ needs.build_artifact.outputs.artifact_asset_version }}
           ARTIFACT_NAME: ${{ needs.build_artifact.outputs.artifact_name }}
           ARTIFACT_VERSION: ${{ needs.build_artifact.outputs.artifact_version }}
           BETA_RESULT: ${{ needs.deploy_to_beta.result }}

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -103,6 +103,10 @@ jobs:
       contents: read
     outputs:
       artifact_name: ${{ steps.artifact_metadata.outputs.artifact_name }}
+      artifact_version: ${{ steps.validate_artifact_metadata.outputs.artifact_version }}
+      artifact_asset_version: ${{ steps.validate_artifact_metadata.outputs.artifact_asset_version }}
+      artifact_commit: ${{ steps.validate_artifact_metadata.outputs.artifact_commit }}
+      artifact_built_at: ${{ steps.validate_artifact_metadata.outputs.artifact_built_at }}
       rollback_commit_sha: ${{ steps.git_metadata.outputs.rollback_commit_sha }}
       rollback_commit_subject: ${{ steps.git_metadata.outputs.rollback_commit_subject }}
       rollback_commit_url: ${{ steps.git_metadata.outputs.rollback_commit_url }}
@@ -152,6 +156,14 @@ jobs:
           WIRE_WEBAPP_BUILD_COMMIT: ${{ steps.git_metadata.outputs.rollback_commit_sha }}
           WIRE_WEBAPP_BUILD_VERSION: ${{ needs.validate_request.outputs.webapp_build_version }}
         run: ./bin/yarn build:prod:public
+
+      - name: Validate rollback artifact metadata
+        id: validate_artifact_metadata
+        env:
+          BUILD_ARTIFACT_PATH: ${{ env.ARTIFACT_PATH }}
+          EXPECTED_COMMIT: ${{ steps.git_metadata.outputs.rollback_commit_sha }}
+          EXPECTED_VERSION: ${{ needs.validate_request.outputs.webapp_build_version }}
+        run: node ./bin/validateBuildArtifact.mts
 
       - name: Compute artifact metadata
         id: artifact_metadata
@@ -217,11 +229,13 @@ jobs:
     steps:
       - name: Add rollback summary
         env:
+          ARTIFACT_ASSET_VERSION: ${{ needs.build_artifact.outputs.artifact_asset_version || 'unavailable' }}
+          ARTIFACT_BUILT_AT: ${{ needs.build_artifact.outputs.artifact_built_at || 'unavailable' }}
+          ARTIFACT_COMMIT: ${{ needs.build_artifact.outputs.artifact_commit || 'unavailable' }}
+          ARTIFACT_VERSION: ${{ needs.build_artifact.outputs.artifact_version || 'unavailable' }}
           INCIDENT_REFERENCE: ${{ inputs.incident_reference }}
           PRODUCTION_ENVIRONMENT_NAME: ${{ env.PRODUCTION_ENVIRONMENT_NAME }}
-          ROLLBACK_COMMIT_SHA: ${{ needs.build_artifact.outputs.rollback_commit_sha || 'unavailable' }}
           ROLLBACK_COMMIT_SUBJECT: ${{ needs.build_artifact.outputs.rollback_commit_subject || 'unavailable' }}
-          ROLLBACK_COMMIT_URL: ${{ needs.build_artifact.outputs.rollback_commit_url || 'unavailable' }}
           ROLLBACK_REASON: ${{ inputs.reason }}
           ROLLBACK_TAG: ${{ needs.validate_request.outputs.production_tag || inputs.production_tag }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -231,8 +245,10 @@ jobs:
           {
             echo '## Production rollback'
             echo "- Rollback tag: ${ROLLBACK_TAG}"
-            echo "- Rollback commit SHA: ${ROLLBACK_COMMIT_SHA}"
-            echo "- Rollback commit URL: ${ROLLBACK_COMMIT_URL}"
+            echo "- Webapp version: ${ARTIFACT_VERSION}"
+            echo "- Asset version: ${ARTIFACT_ASSET_VERSION}"
+            echo "- Commit SHA: ${ARTIFACT_COMMIT}"
+            echo "- Built at (UTC): ${ARTIFACT_BUILT_AT}"
             echo "- Rollback commit subject: ${ROLLBACK_COMMIT_SUBJECT}"
             echo "- Production environment: ${PRODUCTION_ENVIRONMENT_NAME}"
             echo "- Actor: ${GITHUB_ACTOR}"

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-          ref: main
+          ref: ${{ github.workflow_sha }}
           fetch-depth: 1
           path: workflow-source
 
@@ -144,14 +144,12 @@ jobs:
             echo "rollback_commit_url=${rollback_commit_url}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Setup Node.js
+      - name: Setup Node.js for workflow tools
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version-file: 'workflow-source/.nvmrc'
           cache: 'yarn'
-          cache-dependency-path: |
-            workflow-source/yarn.lock
-            selected-release/yarn.lock
+          cache-dependency-path: 'workflow-source/yarn.lock'
 
       - name: Install workflow tool dependencies
         working-directory: workflow-source
@@ -160,6 +158,13 @@ jobs:
       - name: Build workflow tool dependencies
         working-directory: workflow-source
         run: ./bin/yarn nx run config-lib:build
+
+      - name: Setup Node.js for selected release
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: 'selected-release/.nvmrc'
+          cache: 'yarn'
+          cache-dependency-path: 'selected-release/yarn.lock'
 
       - name: Install selected release dependencies
         working-directory: selected-release
@@ -177,6 +182,11 @@ jobs:
           WIRE_WEBAPP_BUILD_COMMIT: ${{ steps.git_metadata.outputs.rollback_commit_sha }}
           WIRE_WEBAPP_BUILD_VERSION: ${{ needs.validate_request.outputs.webapp_build_version }}
         run: ./bin/yarn build:prod:public
+
+      - name: Restore Node.js for workflow tools
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: 'workflow-source/.nvmrc'
 
       - name: Validate rollback artifact metadata
         id: validate_artifact_metadata

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -112,15 +112,25 @@ jobs:
       rollback_commit_url: ${{ steps.git_metadata.outputs.rollback_commit_url }}
 
     steps:
+      - name: Checkout current workflow tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          ref: main
+          fetch-depth: 1
+          path: workflow-source
+
       - name: Checkout selected Production tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           ref: refs/tags/${{ needs.validate_request.outputs.production_tag }}
           fetch-depth: 0
+          path: selected-release
 
       - name: Collect rollback git metadata
         id: git_metadata
+        working-directory: selected-release
         run: |
           set -euo pipefail
 
@@ -134,24 +144,35 @@ jobs:
             echo "rollback_commit_url=${rollback_commit_url}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Add repository Yarn wrapper to PATH
-        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: 'workflow-source/.nvmrc'
           cache: 'yarn'
+          cache-dependency-path: |
+            workflow-source/yarn.lock
+            selected-release/yarn.lock
 
-      - name: Install dependencies
+      - name: Install workflow tool dependencies
+        working-directory: workflow-source
         run: ./bin/yarn --immutable
 
-      - name: Update configuration
+      - name: Build workflow tool dependencies
+        working-directory: workflow-source
+        run: ./bin/yarn nx run config-lib:build
+
+      - name: Install selected release dependencies
+        working-directory: selected-release
+        run: ./bin/yarn --immutable
+
+      - name: Update selected release configuration
+        working-directory: selected-release
         run: ./bin/yarn nx run webapp:configure
 
       # Interim limitation: until durable release artifact storage exists, this
       # workflow rebuilds the deployable artifact from the selected Production tag.
       - name: Build and package
+        working-directory: selected-release
         env:
           WIRE_WEBAPP_BUILD_COMMIT: ${{ steps.git_metadata.outputs.rollback_commit_sha }}
           WIRE_WEBAPP_BUILD_VERSION: ${{ needs.validate_request.outputs.webapp_build_version }}
@@ -159,11 +180,12 @@ jobs:
 
       - name: Validate rollback artifact metadata
         id: validate_artifact_metadata
+        working-directory: workflow-source
         env:
-          BUILD_ARTIFACT_PATH: ${{ env.ARTIFACT_PATH }}
+          BUILD_ARTIFACT_PATH: ${{ github.workspace }}/selected-release/${{ env.ARTIFACT_PATH }}
           EXPECTED_COMMIT: ${{ steps.git_metadata.outputs.rollback_commit_sha }}
           EXPECTED_VERSION: ${{ needs.validate_request.outputs.webapp_build_version }}
-        run: node ./bin/validateBuildArtifact.mts
+        run: node ./bin/validateRecoveryBuildArtifact.mts
 
       - name: Compute artifact metadata
         id: artifact_metadata
@@ -179,7 +201,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ steps.artifact_metadata.outputs.artifact_name }}
-          path: ${{ env.ARTIFACT_PATH }}
+          path: selected-release/${{ env.ARTIFACT_PATH }}
 
   deploy_to_production:
     name: Deploy rollback to Production
@@ -286,7 +308,10 @@ jobs:
           status: failure
           text: |
             Production rollback failed for tag ${{ needs.validate_request.outputs.production_tag || inputs.production_tag }}
+            Webapp version: ${{ needs.build_artifact.outputs.artifact_version || 'unavailable' }}
+            Asset version: ${{ needs.build_artifact.outputs.artifact_asset_version || 'unavailable' }}
             Commit SHA: ${{ needs.build_artifact.outputs.artifact_commit || 'unavailable' }}
+            Built at (UTC): ${{ needs.build_artifact.outputs.artifact_built_at || 'unavailable' }}
             Triggered by: ${{ github.actor }}
             Reason: ${{ inputs.reason }}
             Incident reference: ${{ inputs.incident_reference || 'not provided' }}

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -286,7 +286,7 @@ jobs:
           status: failure
           text: |
             Production rollback failed for tag ${{ needs.validate_request.outputs.production_tag || inputs.production_tag }}
-            Commit: ${{ needs.build_artifact.outputs.rollback_commit_sha || 'unavailable' }}
+            Commit SHA: ${{ needs.build_artifact.outputs.artifact_commit || 'unavailable' }}
             Triggered by: ${{ github.actor }}
             Reason: ${{ inputs.reason }}
             Incident reference: ${{ inputs.incident_reference || 'not provided' }}

--- a/apps/server/Server.ts
+++ b/apps/server/Server.ts
@@ -29,7 +29,7 @@ import http from 'http';
 import https from 'https';
 import path from 'path';
 
-import type {ClientConfig, ServerConfig} from '@wireapp/config';
+import type {BuildMetadata, ClientConfig, ServerConfig} from '@wireapp/config';
 
 import {AppleAssociationRoute} from './routes/appleassociation/appleAssociationRoute';
 import {parseClientVersion} from './routes/clientVersionCheck/clientVersion';
@@ -49,6 +49,7 @@ class Server {
   constructor(
     private readonly config: ServerConfig,
     private readonly clientConfig: ClientConfig,
+    private readonly buildMetadata: BuildMetadata,
   ) {
     if (this.config.DEVELOPMENT) {
       console.info(this.config);
@@ -188,7 +189,7 @@ class Server {
   }
 
   private initStaticRoutes() {
-    this.app.use(RedirectRoutes(this.config));
+    this.app.use(RedirectRoutes(this.config, this.buildMetadata));
 
     const staticRoutes = ['audio', 'ext', 'font', 'image', 'min', 'proto', 'style', 'worker', 'assets'];
 

--- a/apps/server/config.ts
+++ b/apps/server/config.ts
@@ -38,7 +38,7 @@ if (buildMetadataResult.isErr) {
   throw buildMetadataResult.error;
 }
 
-const buildMetadata = buildMetadataResult.value;
+export const buildMetadata = buildMetadataResult.value;
 const dotenvConfigurationIndentationSpaces = 2;
 
 // Determine the correct root path based on the directory structure

--- a/apps/server/index.ts
+++ b/apps/server/index.ts
@@ -17,12 +17,12 @@
  *
  */
 
-import {clientConfig, serverConfig} from './config';
+import {buildMetadata, clientConfig, serverConfig} from './config';
 import {Server} from './Server';
 import {logServerStartup} from './serverStartupLog';
 import {formatDate} from './util/timeUtil';
 
-const server = new Server(serverConfig, clientConfig);
+const server = new Server(serverConfig, clientConfig, buildMetadata);
 
 function getUnhandledRejectionType(unhandledRejection: unknown): string {
   if (unhandledRejection instanceof Error) {

--- a/apps/server/routes/redirectRoutes.ts
+++ b/apps/server/routes/redirectRoutes.ts
@@ -22,12 +22,10 @@ import express, {type Request, type Response} from 'express';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {Maybe, maybe} from 'true-myth';
 
-import type {ServerConfig} from '@wireapp/config';
+import type {BuildMetadata, ServerConfig} from '@wireapp/config';
 
 import {setNonCacheHeaders} from '../http/setNonCacheHeaders';
 import * as BrowserUtil from '../util/browserUtil';
-
-const router = express.Router();
 
 type JoinRedirectQuery = {
   readonly key?: unknown;
@@ -65,49 +63,53 @@ export function redirectToJoinConversation(request: Request, response: Response)
   );
 }
 
-export const RedirectRoutes = (config: ServerConfig) => [
-  router.get('/robots.txt', async (req, res) => {
-    const robotsContent = (config.ROBOTS.ALLOWED_HOSTS as ReadonlyArray<string>).includes(req.hostname)
-      ? config.ROBOTS.ALLOW
-      : config.ROBOTS.DISALLOW;
-    return res.contentType('text/plain; charset=UTF-8').send(robotsContent);
-  }),
-  router.get('/join/?', redirectToJoinConversation),
-  router.get('/browser/?', (req, res, next) => {
-    if (config.DEVELOPMENT) {
-      return next();
-    }
-    const userAgent = req.header('User-Agent');
-    const parseResult = BrowserUtil.parseUserAgent(userAgent);
-    return res.json(parseResult);
-  }),
-  router.get('/test/agent/?', (req, res) => {
-    const userAgent = req.header('User-Agent');
-    const parseResult = BrowserUtil.parseUserAgent(userAgent);
-    return res.json(parseResult);
-  }),
-  router.get('/commit/?', (_req, res) => {
-    const response = setNonCacheHeaders(res);
+export const RedirectRoutes = (config: ServerConfig, buildMetadata: BuildMetadata) => {
+  const router = express.Router();
 
-    return response.send(config.COMMIT);
-  }),
-  router.get('/version/?', (_req, res) => {
-    const response = setNonCacheHeaders(res);
+  return [
+    router.get('/robots.txt', async (req, res) => {
+      const robotsContent = (config.ROBOTS.ALLOWED_HOSTS as ReadonlyArray<string>).includes(req.hostname)
+        ? config.ROBOTS.ALLOW
+        : config.ROBOTS.DISALLOW;
+      return res.contentType('text/plain; charset=UTF-8').send(robotsContent);
+    }),
+    router.get('/join/?', redirectToJoinConversation),
+    router.get('/browser/?', (req, res, next) => {
+      if (config.DEVELOPMENT) {
+        return next();
+      }
+      const userAgent = req.header('User-Agent');
+      const parseResult = BrowserUtil.parseUserAgent(userAgent);
+      return res.json(parseResult);
+    }),
+    router.get('/test/agent/?', (req, res) => {
+      const userAgent = req.header('User-Agent');
+      const parseResult = BrowserUtil.parseUserAgent(userAgent);
+      return res.json(parseResult);
+    }),
+    router.get('/commit/?', (_req, res) => {
+      const response = setNonCacheHeaders(res);
 
-    return response.json({version: config.VERSION});
-  }),
-  /**
-   * This route is used by the OIDC Provider to redirect the user back to the client.
-   * The OIDC Provider will redirect the user to this route with a query string containing the necessary information for the client to complete the authentication.
-   */
-  router.get('/oidc?', (_req, res) => {
-    const {query} = _req;
-    const queryString = Object.keys(query)
-      .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(query[key] as string)}`)
-      .join('&');
-    return res.redirect(
-      HTTP_STATUS.MOVED_TEMPORARILY,
-      `/?${Boolean(queryString) ? queryString : 'no_query=true'}#/e2ei-redirect`,
-    );
-  }),
-];
+      return response.send(config.COMMIT);
+    }),
+    router.get('/version/?', (_req, res) => {
+      const response = setNonCacheHeaders(res);
+
+      return response.json(buildMetadata);
+    }),
+    /**
+     * This route is used by the OIDC Provider to redirect the user back to the client.
+     * The OIDC Provider will redirect the user to this route with a query string containing the necessary information for the client to complete the authentication.
+     */
+    router.get('/oidc?', (_req, res) => {
+      const {query} = _req;
+      const queryString = Object.keys(query)
+        .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(query[key] as string)}`)
+        .join('&');
+      return res.redirect(
+        HTTP_STATUS.MOVED_TEMPORARILY,
+        `/?${Boolean(queryString) ? queryString : 'no_query=true'}#/e2ei-redirect`,
+      );
+    }),
+  ];
+};

--- a/apps/server/routes/redirectRoutes.ts
+++ b/apps/server/routes/redirectRoutes.ts
@@ -96,10 +96,10 @@ export function RedirectRoutes(config: ServerConfig, buildMetadata: BuildMetadat
 
     return response.json(buildMetadata);
   });
-    /**
-     * This route is used by the OIDC Provider to redirect the user back to the client.
-     * The OIDC Provider will redirect the user to this route with a query string containing the necessary information for the client to complete the authentication.
-     */
+  /**
+   * This route is used by the OIDC Provider to redirect the user back to the client.
+   * The OIDC Provider will redirect the user to this route with a query string containing the necessary information for the client to complete the authentication.
+   */
   router.get('/oidc?', (_req, res) => {
     const {query} = _req;
     const queryString = Object.keys(query)

--- a/apps/server/routes/redirectRoutes.ts
+++ b/apps/server/routes/redirectRoutes.ts
@@ -63,53 +63,53 @@ export function redirectToJoinConversation(request: Request, response: Response)
   );
 }
 
-export const RedirectRoutes = (config: ServerConfig, buildMetadata: BuildMetadata) => {
+export function RedirectRoutes(config: ServerConfig, buildMetadata: BuildMetadata): express.Router {
   const router = express.Router();
 
-  return [
-    router.get('/robots.txt', async (req, res) => {
-      const robotsContent = (config.ROBOTS.ALLOWED_HOSTS as ReadonlyArray<string>).includes(req.hostname)
-        ? config.ROBOTS.ALLOW
-        : config.ROBOTS.DISALLOW;
-      return res.contentType('text/plain; charset=UTF-8').send(robotsContent);
-    }),
-    router.get('/join/?', redirectToJoinConversation),
-    router.get('/browser/?', (req, res, next) => {
-      if (config.DEVELOPMENT) {
-        return next();
-      }
-      const userAgent = req.header('User-Agent');
-      const parseResult = BrowserUtil.parseUserAgent(userAgent);
-      return res.json(parseResult);
-    }),
-    router.get('/test/agent/?', (req, res) => {
-      const userAgent = req.header('User-Agent');
-      const parseResult = BrowserUtil.parseUserAgent(userAgent);
-      return res.json(parseResult);
-    }),
-    router.get('/commit/?', (_req, res) => {
-      const response = setNonCacheHeaders(res);
+  router.get('/robots.txt', async (req, res) => {
+    const robotsContent = (config.ROBOTS.ALLOWED_HOSTS as ReadonlyArray<string>).includes(req.hostname)
+      ? config.ROBOTS.ALLOW
+      : config.ROBOTS.DISALLOW;
+    return res.contentType('text/plain; charset=UTF-8').send(robotsContent);
+  });
+  router.get('/join/?', redirectToJoinConversation);
+  router.get('/browser/?', (req, res, next) => {
+    if (config.DEVELOPMENT) {
+      return next();
+    }
+    const userAgent = req.header('User-Agent');
+    const parseResult = BrowserUtil.parseUserAgent(userAgent);
+    return res.json(parseResult);
+  });
+  router.get('/test/agent/?', (req, res) => {
+    const userAgent = req.header('User-Agent');
+    const parseResult = BrowserUtil.parseUserAgent(userAgent);
+    return res.json(parseResult);
+  });
+  router.get('/commit/?', (_req, res) => {
+    const response = setNonCacheHeaders(res);
 
-      return response.send(config.COMMIT);
-    }),
-    router.get('/version/?', (_req, res) => {
-      const response = setNonCacheHeaders(res);
+    return response.send(config.COMMIT);
+  });
+  router.get('/version/?', (_req, res) => {
+    const response = setNonCacheHeaders(res);
 
-      return response.json(buildMetadata);
-    }),
+    return response.json(buildMetadata);
+  });
     /**
      * This route is used by the OIDC Provider to redirect the user back to the client.
      * The OIDC Provider will redirect the user to this route with a query string containing the necessary information for the client to complete the authentication.
      */
-    router.get('/oidc?', (_req, res) => {
-      const {query} = _req;
-      const queryString = Object.keys(query)
-        .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(query[key] as string)}`)
-        .join('&');
-      return res.redirect(
-        HTTP_STATUS.MOVED_TEMPORARILY,
-        `/?${Boolean(queryString) ? queryString : 'no_query=true'}#/e2ei-redirect`,
-      );
-    }),
-  ];
-};
+  router.get('/oidc?', (_req, res) => {
+    const {query} = _req;
+    const queryString = Object.keys(query)
+      .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(query[key] as string)}`)
+      .join('&');
+    return res.redirect(
+      HTTP_STATUS.MOVED_TEMPORARILY,
+      `/?${Boolean(queryString) ? queryString : 'no_query=true'}#/e2ei-redirect`,
+    );
+  });
+
+  return router;
+}

--- a/apps/server/server.test.ts
+++ b/apps/server/server.test.ts
@@ -10,6 +10,7 @@ import {Server} from './Server';
 type HttpResponse = {
   readonly body: string;
   readonly headers: http.IncomingHttpHeaders;
+  readonly responseCount: number;
   readonly statusCode: number | undefined;
 };
 
@@ -147,7 +148,9 @@ async function withHttpServer(
 
 function requestHttpResponse(baseUrl: string, requestPath: string): Promise<HttpResponse> {
   return new Promise((resolve, reject) => {
+    let responseCount = 0;
     const request = http.get(`${baseUrl}${requestPath}`, response => {
+      responseCount += 1;
       const responseBodyChunks: Buffer[] = [];
 
       response.on('data', responseBodyChunk => {
@@ -157,6 +160,7 @@ function requestHttpResponse(baseUrl: string, requestPath: string): Promise<Http
         resolve({
           body: Buffer.concat(responseBodyChunks).toString('utf8'),
           headers: response.headers,
+          responseCount,
           statusCode: response.statusCode,
         });
       });
@@ -238,8 +242,42 @@ describe('server response caching', () => {
       const expectedBody = testCase.requestPath === '/version' ? JSON.stringify(testCase.buildMetadata) : 'abc123';
 
       expect(response.body).toBe(expectedBody);
+      expect(response.responseCount).toBe(1);
       expectNonCacheableResponse(response);
     });
+  });
+
+  it('keeps injected metadata isolated between server instances', async () => {
+    const mainServer = new Server(createServerConfiguration(), createClientConfiguration(), mainBuildMetadata);
+    const releaseServer = new Server(createServerConfiguration(), createClientConfiguration(), releaseBuildMetadata);
+    const mainHttpServer = http.createServer(getServerApplication(mainServer));
+    const releaseHttpServer = http.createServer(getServerApplication(releaseServer));
+    let mainServerIsListening = false;
+    let releaseServerIsListening = false;
+
+    try {
+      const mainBaseUrl = await openHttpServer(mainHttpServer);
+      mainServerIsListening = true;
+      const releaseBaseUrl = await openHttpServer(releaseHttpServer);
+      releaseServerIsListening = true;
+
+      const [mainResponse, releaseResponse] = await Promise.all([
+        requestHttpResponse(mainBaseUrl, '/version'),
+        requestHttpResponse(releaseBaseUrl, '/version'),
+      ]);
+
+      expect(mainResponse.body).toBe(JSON.stringify(mainBuildMetadata));
+      expect(releaseResponse.body).toBe(JSON.stringify(releaseBuildMetadata));
+      expect(mainResponse.responseCount).toBe(1);
+      expect(releaseResponse.responseCount).toBe(1);
+    } finally {
+      if (mainServerIsListening) {
+        await closeHttpServer(mainHttpServer);
+      }
+      if (releaseServerIsListening) {
+        await closeHttpServer(releaseHttpServer);
+      }
+    }
   });
 
   it('keeps the public cache policy for ordinary responses', async () => {

--- a/apps/server/server.test.ts
+++ b/apps/server/server.test.ts
@@ -235,8 +235,7 @@ describe('server response caching', () => {
     await withHttpServer(clientConfiguration, testCase.buildMetadata, async baseUrl => {
       const response = await requestHttpResponse(baseUrl, testCase.requestPath);
 
-      const expectedBody =
-        testCase.requestPath === '/version' ? JSON.stringify(testCase.buildMetadata) : 'abc123';
+      const expectedBody = testCase.requestPath === '/version' ? JSON.stringify(testCase.buildMetadata) : 'abc123';
 
       expect(response.body).toBe(expectedBody);
       expectNonCacheableResponse(response);

--- a/apps/server/server.test.ts
+++ b/apps/server/server.test.ts
@@ -3,7 +3,7 @@ import type {Express} from 'express';
 
 import {createFactory} from '@enormora/objectory';
 import is from '@sindresorhus/is';
-import type {ClientConfig, ServerConfig} from '@wireapp/config';
+import type {BuildMetadata, ClientConfig, ServerConfig} from '@wireapp/config';
 
 import {Server} from './Server';
 
@@ -30,17 +30,24 @@ type ServerResponseTestCase = {
   readonly requestPath: string;
 };
 
+const mainBuildMetadata: BuildMetadata = {
+  version: 'main-bdb93c9',
+  assetVersion: 'main-bdb93c9',
+  commit: 'bdb93c9269866d577c012f3a781cbe904f7bf47c',
+  builtAt: '2026-07-20T14:43:21.123Z',
+};
+
+const releaseBuildMetadata: BuildMetadata = {
+  version: '2026-07-20.1',
+  assetVersion: '2026-07-20.1-025edc6',
+  commit: '025edc663787b3d2da366f21a5958013201e6cd4',
+  builtAt: '2026-07-20T06:18:03.123Z',
+};
+
 const nonCacheableResponseTestCaseFactory = createFactory<ServerResponseTestCase>(() => {
   return {
     expectedContentType: 'application/javascript',
     requestPath: '/config.js',
-  };
-});
-
-const metadataResponseTestCaseFactory = createFactory<ServerResponseTestCase>(() => {
-  return {
-    expectedBody: 'abc123',
-    requestPath: '/commit',
   };
 });
 
@@ -120,9 +127,10 @@ function closeHttpServer(httpServer: http.Server): Promise<void> {
 
 async function withHttpServer(
   clientConfiguration: ClientConfig,
+  buildMetadata: BuildMetadata,
   runTest: (baseUrl: string) => Promise<void>,
 ): Promise<void> {
-  const server = new Server(createServerConfiguration(), clientConfiguration);
+  const server = new Server(createServerConfiguration(), clientConfiguration, buildMetadata);
   const httpServer = http.createServer(getServerApplication(server));
   let serverIsListening = false;
 
@@ -184,7 +192,7 @@ describe('server response caching', () => {
     return async () => {
       const clientConfiguration = createClientConfiguration();
 
-      await withHttpServer(clientConfiguration, async baseUrl => {
+      await withHttpServer(clientConfiguration, mainBuildMetadata, async baseUrl => {
         const response = await requestHttpResponse(baseUrl, testCase.requestPath);
 
         if (testCase.expectedBody !== undefined) {
@@ -210,25 +218,33 @@ describe('server response caching', () => {
   it('returns the serialized runtime configuration from /config.js', async () => {
     const clientConfiguration = createClientConfiguration();
 
-    await withHttpServer(clientConfiguration, async baseUrl => {
+    await withHttpServer(clientConfiguration, mainBuildMetadata, async baseUrl => {
       const response = await requestHttpResponse(baseUrl, '/config.js');
 
       expect(response.body).toContain(`window.wire.env = ${JSON.stringify(clientConfiguration)};`);
     });
   });
 
-  [
-    metadataResponseTestCaseFactory.build({
-      expectedBody: JSON.stringify({version: '2026.03.16.10.30.00'}),
-      requestPath: '/version',
-    }),
-    metadataResponseTestCaseFactory.build(),
-  ].forEach(testCase => {
-    it(`keeps non-cache headers for ${testCase.requestPath}`, createServerResponseTest(testCase));
+  it.each([
+    {buildMetadata: mainBuildMetadata, requestPath: '/version'},
+    {buildMetadata: releaseBuildMetadata, requestPath: '/version'},
+    {buildMetadata: mainBuildMetadata, requestPath: '/commit'},
+  ])('returns exact metadata and keeps non-cache headers for $requestPath', async testCase => {
+    const clientConfiguration = createClientConfiguration();
+
+    await withHttpServer(clientConfiguration, testCase.buildMetadata, async baseUrl => {
+      const response = await requestHttpResponse(baseUrl, testCase.requestPath);
+
+      const expectedBody =
+        testCase.requestPath === '/version' ? JSON.stringify(testCase.buildMetadata) : 'abc123';
+
+      expect(response.body).toBe(expectedBody);
+      expectNonCacheableResponse(response);
+    });
   });
 
   it('keeps the public cache policy for ordinary responses', async () => {
-    await withHttpServer(createClientConfiguration(), async baseUrl => {
+    await withHttpServer(createClientConfiguration(), mainBuildMetadata, async baseUrl => {
       const response = await requestHttpResponse(baseUrl, '/_health');
 
       if (!is.number(response.statusCode)) {

--- a/bin/buildArtifactArchive.ts
+++ b/bin/buildArtifactArchive.ts
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {execFileSync} from 'node:child_process';
+
+import type {BuildArtifactHtmlDocument} from './buildArtifactMetadata.ts';
+
+export function readBuildArtifactArchiveFile(artifactPath: string, archiveFilePath: string): string {
+  return execFileSync('unzip', ['-p', artifactPath, archiveFilePath], {encoding: 'utf8'});
+}
+
+export function readBuildArtifactHtmlDocuments(artifactPath: string): readonly BuildArtifactHtmlDocument[] {
+  const archiveFilePaths = execFileSync('unzip', ['-Z1', artifactPath], {encoding: 'utf8'})
+    .split('\n')
+    .filter(archiveFilePath => {
+      return archiveFilePath.startsWith('static/') && archiveFilePath.endsWith('.html');
+    });
+
+  return archiveFilePaths.map(archiveFilePath => {
+    return {
+      archiveFilePath,
+      contents: readBuildArtifactArchiveFile(artifactPath, archiveFilePath),
+    };
+  });
+}
+
+export function readBuildArtifactMetadata(artifactPath: string): unknown {
+  return JSON.parse(readBuildArtifactArchiveFile(artifactPath, 'version.json'));
+}

--- a/bin/buildArtifactMetadataOutput.ts
+++ b/bin/buildArtifactMetadataOutput.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {BuildMetadata} from '@wireapp/config';
+
+export function formatBuildArtifactMetadataOutputs(metadata: BuildMetadata): string {
+  return [
+    `artifact_version=${metadata.version}`,
+    `artifact_asset_version=${metadata.assetVersion}`,
+    `artifact_commit=${metadata.commit}`,
+    `artifact_built_at=${metadata.builtAt}`,
+    '',
+  ].join('\n');
+}

--- a/bin/legacyBuildMetadata.ts
+++ b/bin/legacyBuildMetadata.ts
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import is from '@sindresorhus/is';
+
+const legacyTimestampBuildVersionPattern = /^\d{4}(?:\.\d{2}){4,5}$/;
+
+export function isLegacyTimestampBuildVersion(value: unknown): value is string {
+  return is.nonEmptyString(value) && legacyTimestampBuildVersionPattern.test(value);
+}

--- a/bin/productionDistribution.ts
+++ b/bin/productionDistribution.ts
@@ -23,6 +23,7 @@ import {Result} from 'true-myth';
 import {isBuildMetadata} from '@wireapp/config';
 import type {BuildMetadata} from '@wireapp/config';
 
+import {isLegacyTimestampBuildVersion} from './legacyBuildMetadata';
 import {validateProductionTagName} from './releaseMetadata';
 
 export type ProductionDistributionManifest = {
@@ -76,8 +77,6 @@ type LegacyProductionDistributionArtifactMetadata = {
   readonly commit: string;
 };
 
-const legacyArtifactVersionPattern = /^\d{4}(?:\.\d{2}){4,5}$/;
-
 function validateProductionDistributionArtifactMetadata(
   artifactMetadata: unknown,
   artifactVersion: string,
@@ -103,7 +102,7 @@ function validateProductionDistributionArtifactMetadata(
   if (
     isRecord(artifactMetadata) &&
     is.nonEmptyString(artifactMetadata.version) &&
-    legacyArtifactVersionPattern.test(artifactMetadata.version) &&
+    isLegacyTimestampBuildVersion(artifactMetadata.version) &&
     is.nonEmptyString(artifactMetadata.commit) &&
     !('assetVersion' in artifactMetadata) &&
     !('builtAt' in artifactMetadata)

--- a/bin/recoveryBuildArtifactMetadata.test.ts
+++ b/bin/recoveryBuildArtifactMetadata.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {validateRecoveryBuildArtifactMetadata} from './recoveryBuildArtifactMetadata';
+import {formatRecoverableBuildArtifactMetadataOutputs} from './recoveryBuildArtifactMetadataOutput';
+import type {BuildArtifactHtmlDocument} from './buildArtifactMetadata';
+import type {BuildMetadata} from '@wireapp/config';
+
+const releaseBuildMetadata: BuildMetadata = {
+  version: '2026-07-20.1',
+  assetVersion: '2026-07-20.1-025edc6',
+  commit: '025edc663787b3d2da366f21a5958013201e6cd4',
+  builtAt: '2026-07-20T06:18:03.123Z',
+};
+
+const matchingHtmlDocuments: readonly BuildArtifactHtmlDocument[] = [
+  {
+    archiveFilePath: 'static/index.html',
+    contents: `<!--! ${releaseBuildMetadata.version} --><script src="/min/app.js?v=${releaseBuildMetadata.assetVersion}"></script>`,
+  },
+];
+
+const expectedCommit = releaseBuildMetadata.commit;
+
+function validateMetadata(metadata: unknown, expectedVersion: string) {
+  return validateRecoveryBuildArtifactMetadata({
+    expectedCommit,
+    expectedVersion,
+    htmlDocuments: matchingHtmlDocuments,
+    metadata,
+  });
+}
+
+describe('recovery build artifact metadata validation', () => {
+  it('accepts current four-field metadata', () => {
+    const validationResult = validateMetadata(releaseBuildMetadata, releaseBuildMetadata.version);
+
+    expect(validationResult.isOk).toBe(true);
+    if (validationResult.isOk) {
+      expect(validationResult.value).toStrictEqual({kind: 'current', metadata: releaseBuildMetadata});
+    }
+  });
+
+  it.each(['2026.07.15.12.00', '2026.07.20.06.18.03'])(
+    'accepts historical timestamp metadata with %s',
+    historicalVersion => {
+      const legacyMetadata = {version: historicalVersion, commit: expectedCommit};
+
+      const validationResult = validateMetadata(legacyMetadata, historicalVersion);
+
+      expect(validationResult.isOk).toBe(true);
+      if (validationResult.isOk) {
+        expect(validationResult.value).toStrictEqual({kind: 'legacy', metadata: legacyMetadata});
+      }
+    },
+  );
+
+  it.each([
+    ['assetVersion', {...releaseBuildMetadata, assetVersion: undefined}],
+    ['builtAt', {...releaseBuildMetadata, builtAt: undefined}],
+  ])('rejects current metadata missing %s', (_fieldName, metadata) => {
+    const validationResult = validateMetadata(metadata, releaseBuildMetadata.version);
+
+    expect(validationResult.isErr).toBe(true);
+    if (validationResult.isErr) {
+      expect(validationResult.error.message).toBe('Build artifact metadata is invalid');
+    }
+  });
+
+  it('rejects arbitrary two-field metadata', () => {
+    const validationResult = validateMetadata(
+      {version: '2026-07-20.1', commit: expectedCommit},
+      releaseBuildMetadata.version,
+    );
+
+    expect(validationResult.isErr).toBe(true);
+    if (validationResult.isErr) {
+      expect(validationResult.error.message).toBe('Legacy build artifact metadata is invalid');
+    }
+  });
+
+  it('rejects a legacy commit mismatch', () => {
+    const validationResult = validateMetadata({
+      version: '2026.07.15.12.00',
+      commit: 'fedcba9876543210fedcba9876543210fedcba98',
+    }, '2026.07.15.12.00');
+
+    expect(validationResult.isErr).toBe(true);
+    if (validationResult.isErr) {
+      expect(validationResult.error.message).toContain('Legacy build artifact commit');
+    }
+  });
+
+  it('rejects a current commit mismatch', () => {
+    const validationResult = validateMetadata({
+      ...releaseBuildMetadata,
+      commit: 'fedcba9876543210fedcba9876543210fedcba98',
+      assetVersion: '2026-07-20.1-fedcba9',
+    }, releaseBuildMetadata.version);
+
+    expect(validationResult.isErr).toBe(true);
+    if (validationResult.isErr) {
+      expect(validationResult.error.message).toContain('Build artifact commit');
+    }
+  });
+
+  it('rejects a current expected version mismatch', () => {
+    const validationResult = validateMetadata(releaseBuildMetadata, '2026-07-20.2');
+
+    expect(validationResult.isErr).toBe(true);
+    if (validationResult.isErr) {
+      expect(validationResult.error.message).toContain('Build artifact version');
+    }
+  });
+
+  it('leaves unavailable legacy outputs empty', () => {
+    const legacyMetadata = {
+      version: '2026.07.15.12.00',
+      commit: expectedCommit,
+    };
+    const validationResult = validateMetadata(legacyMetadata, legacyMetadata.version);
+
+    expect(validationResult.isOk).toBe(true);
+    if (validationResult.isOk) {
+      expect(formatRecoverableBuildArtifactMetadataOutputs(validationResult.value)).toBe(
+        [
+          `artifact_version=${legacyMetadata.version}`,
+          'artifact_asset_version=',
+          `artifact_commit=${legacyMetadata.commit}`,
+          'artifact_built_at=',
+          '',
+        ].join('\n'),
+      );
+    }
+  });
+
+  it('writes all four current outputs exactly', () => {
+    const validationResult = validateMetadata(releaseBuildMetadata, releaseBuildMetadata.version);
+
+    expect(validationResult.isOk).toBe(true);
+    if (validationResult.isOk) {
+      expect(formatRecoverableBuildArtifactMetadataOutputs(validationResult.value)).toBe(
+        [
+          `artifact_version=${releaseBuildMetadata.version}`,
+          `artifact_asset_version=${releaseBuildMetadata.assetVersion}`,
+          `artifact_commit=${releaseBuildMetadata.commit}`,
+          `artifact_built_at=${releaseBuildMetadata.builtAt}`,
+          '',
+        ].join('\n'),
+      );
+    }
+  });
+});

--- a/bin/recoveryBuildArtifactMetadata.test.ts
+++ b/bin/recoveryBuildArtifactMetadata.test.ts
@@ -96,10 +96,13 @@ describe('recovery build artifact metadata validation', () => {
   });
 
   it('rejects a legacy commit mismatch', () => {
-    const validationResult = validateMetadata({
-      version: '2026.07.15.12.00',
-      commit: 'fedcba9876543210fedcba9876543210fedcba98',
-    }, '2026.07.15.12.00');
+    const validationResult = validateMetadata(
+      {
+        version: '2026.07.15.12.00',
+        commit: 'fedcba9876543210fedcba9876543210fedcba98',
+      },
+      '2026.07.15.12.00',
+    );
 
     expect(validationResult.isErr).toBe(true);
     if (validationResult.isErr) {
@@ -108,11 +111,14 @@ describe('recovery build artifact metadata validation', () => {
   });
 
   it('rejects a current commit mismatch', () => {
-    const validationResult = validateMetadata({
-      ...releaseBuildMetadata,
-      commit: 'fedcba9876543210fedcba9876543210fedcba98',
-      assetVersion: '2026-07-20.1-fedcba9',
-    }, releaseBuildMetadata.version);
+    const validationResult = validateMetadata(
+      {
+        ...releaseBuildMetadata,
+        commit: 'fedcba9876543210fedcba9876543210fedcba98',
+        assetVersion: '2026-07-20.1-fedcba9',
+      },
+      releaseBuildMetadata.version,
+    );
 
     expect(validationResult.isErr).toBe(true);
     if (validationResult.isErr) {

--- a/bin/recoveryBuildArtifactMetadata.test.ts
+++ b/bin/recoveryBuildArtifactMetadata.test.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import assert from 'node:assert';
+
 import {validateRecoveryBuildArtifactMetadata} from './recoveryBuildArtifactMetadata';
 import {formatRecoverableBuildArtifactMetadataOutputs} from './recoveryBuildArtifactMetadataOutput';
 import type {BuildArtifactHtmlDocument} from './buildArtifactMetadata';
@@ -51,10 +53,8 @@ describe('recovery build artifact metadata validation', () => {
   it('accepts current four-field metadata', () => {
     const validationResult = validateMetadata(releaseBuildMetadata, releaseBuildMetadata.version);
 
-    expect(validationResult.isOk).toBe(true);
-    if (validationResult.isOk) {
-      expect(validationResult.value).toStrictEqual({kind: 'current', metadata: releaseBuildMetadata});
-    }
+    assert(validationResult.isOk);
+    expect(validationResult.value).toStrictEqual({kind: 'current', metadata: releaseBuildMetadata});
   });
 
   it.each(['2026.07.15.12.00', '2026.07.20.06.18.03'])(
@@ -64,10 +64,8 @@ describe('recovery build artifact metadata validation', () => {
 
       const validationResult = validateMetadata(legacyMetadata, historicalVersion);
 
-      expect(validationResult.isOk).toBe(true);
-      if (validationResult.isOk) {
-        expect(validationResult.value).toStrictEqual({kind: 'legacy', metadata: legacyMetadata});
-      }
+      assert(validationResult.isOk);
+      expect(validationResult.value).toStrictEqual({kind: 'legacy', metadata: legacyMetadata});
     },
   );
 
@@ -77,10 +75,8 @@ describe('recovery build artifact metadata validation', () => {
   ])('rejects current metadata missing %s', (_fieldName, metadata) => {
     const validationResult = validateMetadata(metadata, releaseBuildMetadata.version);
 
-    expect(validationResult.isErr).toBe(true);
-    if (validationResult.isErr) {
-      expect(validationResult.error.message).toBe('Build artifact metadata is invalid');
-    }
+    assert(validationResult.isErr);
+    expect(validationResult.error.message).toBe('Build artifact metadata is invalid');
   });
 
   it('rejects arbitrary two-field metadata', () => {
@@ -89,10 +85,8 @@ describe('recovery build artifact metadata validation', () => {
       releaseBuildMetadata.version,
     );
 
-    expect(validationResult.isErr).toBe(true);
-    if (validationResult.isErr) {
-      expect(validationResult.error.message).toBe('Legacy build artifact metadata is invalid');
-    }
+    assert(validationResult.isErr);
+    expect(validationResult.error.message).toBe('Legacy build artifact metadata is invalid');
   });
 
   it('rejects a legacy commit mismatch', () => {
@@ -104,10 +98,8 @@ describe('recovery build artifact metadata validation', () => {
       '2026.07.15.12.00',
     );
 
-    expect(validationResult.isErr).toBe(true);
-    if (validationResult.isErr) {
-      expect(validationResult.error.message).toContain('Legacy build artifact commit');
-    }
+    assert(validationResult.isErr);
+    expect(validationResult.error.message).toContain('Legacy build artifact commit');
   });
 
   it('rejects a current commit mismatch', () => {
@@ -120,19 +112,15 @@ describe('recovery build artifact metadata validation', () => {
       releaseBuildMetadata.version,
     );
 
-    expect(validationResult.isErr).toBe(true);
-    if (validationResult.isErr) {
-      expect(validationResult.error.message).toContain('Build artifact commit');
-    }
+    assert(validationResult.isErr);
+    expect(validationResult.error.message).toContain('Build artifact commit');
   });
 
   it('rejects a current expected version mismatch', () => {
     const validationResult = validateMetadata(releaseBuildMetadata, '2026-07-20.2');
 
-    expect(validationResult.isErr).toBe(true);
-    if (validationResult.isErr) {
-      expect(validationResult.error.message).toContain('Build artifact version');
-    }
+    assert(validationResult.isErr);
+    expect(validationResult.error.message).toContain('Build artifact version');
   });
 
   it('leaves unavailable legacy outputs empty', () => {
@@ -142,34 +130,30 @@ describe('recovery build artifact metadata validation', () => {
     };
     const validationResult = validateMetadata(legacyMetadata, legacyMetadata.version);
 
-    expect(validationResult.isOk).toBe(true);
-    if (validationResult.isOk) {
-      expect(formatRecoverableBuildArtifactMetadataOutputs(validationResult.value)).toBe(
-        [
-          `artifact_version=${legacyMetadata.version}`,
-          'artifact_asset_version=',
-          `artifact_commit=${legacyMetadata.commit}`,
-          'artifact_built_at=',
-          '',
-        ].join('\n'),
-      );
-    }
+    assert(validationResult.isOk);
+    expect(formatRecoverableBuildArtifactMetadataOutputs(validationResult.value)).toBe(
+      [
+        `artifact_version=${legacyMetadata.version}`,
+        'artifact_asset_version=',
+        `artifact_commit=${legacyMetadata.commit}`,
+        'artifact_built_at=',
+        '',
+      ].join('\n'),
+    );
   });
 
   it('writes all four current outputs exactly', () => {
     const validationResult = validateMetadata(releaseBuildMetadata, releaseBuildMetadata.version);
 
-    expect(validationResult.isOk).toBe(true);
-    if (validationResult.isOk) {
-      expect(formatRecoverableBuildArtifactMetadataOutputs(validationResult.value)).toBe(
-        [
-          `artifact_version=${releaseBuildMetadata.version}`,
-          `artifact_asset_version=${releaseBuildMetadata.assetVersion}`,
-          `artifact_commit=${releaseBuildMetadata.commit}`,
-          `artifact_built_at=${releaseBuildMetadata.builtAt}`,
-          '',
-        ].join('\n'),
-      );
-    }
+    assert(validationResult.isOk);
+    expect(formatRecoverableBuildArtifactMetadataOutputs(validationResult.value)).toBe(
+      [
+        `artifact_version=${releaseBuildMetadata.version}`,
+        `artifact_asset_version=${releaseBuildMetadata.assetVersion}`,
+        `artifact_commit=${releaseBuildMetadata.commit}`,
+        `artifact_built_at=${releaseBuildMetadata.builtAt}`,
+        '',
+      ].join('\n'),
+    );
   });
 });

--- a/bin/recoveryBuildArtifactMetadata.ts
+++ b/bin/recoveryBuildArtifactMetadata.ts
@@ -1,0 +1,130 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import is from '@sindresorhus/is';
+import {Result} from 'true-myth';
+
+import {isBuildMetadata} from '@wireapp/config';
+import type {BuildMetadata} from '@wireapp/config';
+
+import {isLegacyTimestampBuildVersion} from './legacyBuildMetadata.ts';
+import {validateBuildArtifactMetadata} from './buildArtifactMetadata.ts';
+import type {BuildArtifactHtmlDocument} from './buildArtifactMetadata.ts';
+
+export type LegacyBuildMetadata = {
+  readonly version: string;
+  readonly commit: string;
+};
+
+export type RecoverableBuildMetadata =
+  | {
+      readonly kind: 'current';
+      readonly metadata: BuildMetadata;
+    }
+  | {
+      readonly kind: 'legacy';
+      readonly metadata: LegacyBuildMetadata;
+    };
+
+export type RecoveryBuildArtifactMetadataValidationInput = {
+  readonly expectedCommit: string;
+  readonly expectedVersion: string;
+  readonly htmlDocuments: readonly BuildArtifactHtmlDocument[];
+  readonly metadata: unknown;
+};
+
+const fullCommitShaPattern = /^[0-9a-f]{40}$/iu;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return is.plainObject(value);
+}
+
+function hasCurrentMetadataField(metadata: Record<string, unknown>): boolean {
+  return 'assetVersion' in metadata || 'builtAt' in metadata;
+}
+
+function hasExactlyLegacyMetadataFields(metadata: Record<string, unknown>): boolean {
+  const metadataFieldNames = Object.keys(metadata).sort();
+
+  return metadataFieldNames.length === 2 && metadataFieldNames[0] === 'commit' && metadataFieldNames[1] === 'version';
+}
+
+function isFullCommitSha(value: unknown): value is string {
+  return is.nonEmptyString(value) && fullCommitShaPattern.test(value);
+}
+
+function validateCurrentBuildArtifactMetadata(
+  input: RecoveryBuildArtifactMetadataValidationInput,
+): Result<RecoverableBuildMetadata, Error> {
+  const validationResult = validateBuildArtifactMetadata(input);
+
+  if (validationResult.isErr) {
+    return Result.err(validationResult.error);
+  }
+
+  return Result.ok({kind: 'current', metadata: validationResult.value});
+}
+
+function validateLegacyBuildArtifactMetadata(
+  input: RecoveryBuildArtifactMetadataValidationInput,
+  metadata: Record<string, unknown>,
+): Result<RecoverableBuildMetadata, Error> {
+  if (!hasExactlyLegacyMetadataFields(metadata)) {
+    return Result.err(new Error('Build artifact metadata is invalid'));
+  }
+
+  const version = metadata.version;
+  const commit = metadata.commit;
+
+  if (!isLegacyTimestampBuildVersion(version) || !isFullCommitSha(commit)) {
+    return Result.err(new Error('Legacy build artifact metadata is invalid'));
+  }
+
+  if (commit !== input.expectedCommit) {
+    return Result.err(
+      new Error(`Legacy build artifact commit '${commit}' does not match expected commit '${input.expectedCommit}'`),
+    );
+  }
+
+  if (isLegacyTimestampBuildVersion(input.expectedVersion) && version !== input.expectedVersion) {
+    return Result.err(
+      new Error(`Legacy build artifact version '${version}' does not match expected version '${input.expectedVersion}'`),
+    );
+  }
+
+  return Result.ok({kind: 'legacy', metadata: {version, commit}});
+}
+
+export function validateRecoveryBuildArtifactMetadata(
+  input: RecoveryBuildArtifactMetadataValidationInput,
+): Result<RecoverableBuildMetadata, Error> {
+  if (isBuildMetadata(input.metadata)) {
+    return validateCurrentBuildArtifactMetadata(input);
+  }
+
+  if (!isRecord(input.metadata)) {
+    return Result.err(new Error('Build artifact metadata is invalid'));
+  }
+
+  if (hasCurrentMetadataField(input.metadata)) {
+    return validateCurrentBuildArtifactMetadata(input);
+  }
+
+  return validateLegacyBuildArtifactMetadata(input, input.metadata);
+}

--- a/bin/recoveryBuildArtifactMetadata.ts
+++ b/bin/recoveryBuildArtifactMetadata.ts
@@ -104,7 +104,9 @@ function validateLegacyBuildArtifactMetadata(
 
   if (isLegacyTimestampBuildVersion(input.expectedVersion) && version !== input.expectedVersion) {
     return Result.err(
-      new Error(`Legacy build artifact version '${version}' does not match expected version '${input.expectedVersion}'`),
+      new Error(
+        `Legacy build artifact version '${version}' does not match expected version '${input.expectedVersion}'`,
+      ),
     );
   }
 

--- a/bin/recoveryBuildArtifactMetadataOutput.ts
+++ b/bin/recoveryBuildArtifactMetadataOutput.ts
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {RecoverableBuildMetadata} from './recoveryBuildArtifactMetadata.ts';
+
+export function formatRecoverableBuildArtifactMetadataOutputs(metadata: RecoverableBuildMetadata): string {
+  const assetVersion = metadata.kind === 'current' ? metadata.metadata.assetVersion : '';
+  const builtAt = metadata.kind === 'current' ? metadata.metadata.builtAt : '';
+
+  return [
+    `artifact_version=${metadata.metadata.version}`,
+    `artifact_asset_version=${assetVersion}`,
+    `artifact_commit=${metadata.metadata.commit}`,
+    `artifact_built_at=${builtAt}`,
+    '',
+  ].join('\n');
+}

--- a/bin/renderReleaseCloudSummary.test.ts
+++ b/bin/renderReleaseCloudSummary.test.ts
@@ -70,6 +70,7 @@ const baselineReleaseCloudSummaryInput: ReleaseCloudSummaryInput = {
     webappUrl: 'https://production.example.com',
   },
   release: {
+    artifactAssetVersion: '2026-07-17.1-1234567',
     artifactBuiltAt: '2026-07-20T06:18:03.123Z',
     artifactChecksum: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     artifactName: 'wire-webapp-release-2026-07-17.1',
@@ -103,14 +104,21 @@ test('renders a successful Beta-only release', () => {
   expect(summary).toMatch(
     /^- Commit SHA: \[1234567890abcdef1234567890abcdef12345678\]\(https:\/\/github\.com\/wireapp\/wire-webapp\/commit\/1234567890abcdef1234567890abcdef12345678\)$/m,
   );
+  expect(summary).toContain(
+    [
+      '- Webapp version: 2026-07-17.1',
+      '- Asset version: 2026-07-17.1-1234567',
+      '- Commit SHA: [1234567890abcdef1234567890abcdef12345678](https://github.com/wireapp/wire-webapp/commit/1234567890abcdef1234567890abcdef12345678)',
+      '- Built at (UTC): 2026-07-20T06:18:03.123Z',
+    ].join('\n'),
+  );
   expect(summary).toMatch(/^- Built at \(UTC\): 2026-07-20T06:18:03\.123Z$/m);
   expect(summary).toMatch(/### Beta deployment[\s\S]*?- Webapp version: 2026-07-17\.1/m);
+  expect(summary).toMatch(/### Beta deployment[\s\S]*?- Asset version: 2026-07-17\.1-1234567/m);
   expect(summary).toMatch(/### E2E system gate[\s\S]*?- Webapp version: 2026-07-17\.1/m);
+  expect(summary).toMatch(/### E2E system gate[\s\S]*?- Asset version: 2026-07-17\.1-1234567/m);
   expect(summary).toMatch(/### Production deployment[\s\S]*?- Webapp version: 2026-07-17\.1/m);
-  expect(summary.split('\n\n')[0]).not.toMatch(/Webapp version:/);
-  expect(summary).not.toMatch(/### Beta deployment[\s\S]*?- Built at \(UTC\):/m);
-  expect(summary).not.toMatch(/### E2E system gate[\s\S]*?- Built at \(UTC\):/m);
-  expect(summary).not.toMatch(/### Production deployment[\s\S]*?- Built at \(UTC\):/m);
+  expect(summary).toMatch(/### Production deployment[\s\S]*?- Asset version: 2026-07-17\.1-1234567/m);
   expect(summary).toMatch(/### Beta deployment[\s\S]*?- Result: deployed and verified successfully/m);
   expect(summary).toMatch(/### E2E system gate[\s\S]*?- Result: passed successfully/m);
   expect(summary).toMatch(/### Production deployment[\s\S]*?- Result: not requested/m);
@@ -264,6 +272,7 @@ test('uses not available for missing release metadata', () => {
     release: {
       ...baselineReleaseCloudSummaryInput.release,
       artifactBuiltAt: undefined,
+      artifactAssetVersion: undefined,
       artifactChecksum: undefined,
       artifactName: undefined,
       artifactVersion: undefined,
@@ -277,15 +286,35 @@ test('uses not available for missing release metadata', () => {
   expect(summary).toMatch(/- Artifact checksum: not available/);
   expect(summary).toMatch(/- Artifact name: not available/);
   expect(summary).toMatch(/### Beta deployment[\s\S]*?- Webapp version: not available/m);
+  expect(summary).toMatch(/### Beta deployment[\s\S]*?- Asset version: not available/m);
   expect(summary).toMatch(/- Built at \(UTC\): not available/);
   expect(summary).toMatch(/- Commit SHA: not available/);
   expect(summary).toMatch(/- Release identifier: not available/);
 });
 
 test('reads artifact build time from the workflow environment', () => {
-  const input = readReleaseCloudSummaryInput({ARTIFACT_BUILT_AT: '2026-07-20T06:18:03.123Z'});
+  const input = readReleaseCloudSummaryInput({
+    ARTIFACT_ASSET_VERSION: '2026-07-17.1-1234567',
+    ARTIFACT_BUILT_AT: '2026-07-20T06:18:03.123Z',
+  });
 
+  expect(input.release.artifactAssetVersion).toBe('2026-07-17.1-1234567');
   expect(input.release.artifactBuiltAt).toBe('2026-07-20T06:18:03.123Z');
+});
+
+test('renders a main-style artifact with the same webapp and asset versions', () => {
+  const input: ReleaseCloudSummaryInput = {
+    ...baselineReleaseCloudSummaryInput,
+    release: {
+      ...baselineReleaseCloudSummaryInput.release,
+      artifactAssetVersion: 'main-bdb93c9',
+      artifactVersion: 'main-bdb93c9',
+    },
+  };
+  const summary = renderReleaseCloudSummary(input);
+
+  expect(summary).toMatch(/^- Webapp version: main-bdb93c9$/m);
+  expect(summary).toMatch(/^- Asset version: main-bdb93c9$/m);
 });
 
 test('renders Manual reason only when a reason is provided', () => {

--- a/bin/renderReleaseCloudSummary.test.ts
+++ b/bin/renderReleaseCloudSummary.test.ts
@@ -160,6 +160,7 @@ test('renders a successful Production release with distribution metadata', () =>
   assertSummaryContract(summary);
   expect(summary).toMatch(/### Production deployment[\s\S]*?- Result: deployed, verified, and tagged successfully/m);
   expect(summary).toMatch(/### Production deployment[\s\S]*?- Runtime verification result: verified successfully/m);
+  expect(summary).toMatch(/### Production deployment[\s\S]*?- Runtime verification: \/version and \/config\.js/m);
   expect(summary).toMatch(
     /- Production tag: \[2026-07-17\.1-production\]\(https:\/\/github\.com\/wireapp\/wire-webapp\/tree\/2026-07-17\.1-production\)/,
   );

--- a/bin/renderReleaseCloudSummary.ts
+++ b/bin/renderReleaseCloudSummary.ts
@@ -21,6 +21,7 @@ export type WorkflowJobResult = 'cancelled' | 'failure' | 'skipped' | 'success';
 
 export type ReleaseMetadata = {
   readonly artifactChecksum: string | undefined;
+  readonly artifactAssetVersion: string | undefined;
   readonly artifactBuiltAt: string | undefined;
   readonly artifactName: string | undefined;
   readonly artifactVersion: string | undefined;
@@ -183,6 +184,7 @@ export function readReleaseCloudSummaryInput(environment: NodeJS.ProcessEnv): Re
       webappUrl: readOptionalEnvironmentValue(environment, 'PRODUCTION_WEBAPP_URL'),
     },
     release: {
+      artifactAssetVersion: readOptionalEnvironmentValue(environment, 'ARTIFACT_ASSET_VERSION'),
       artifactBuiltAt: readOptionalEnvironmentValue(environment, 'ARTIFACT_BUILT_AT'),
       artifactChecksum: readOptionalEnvironmentValue(environment, 'ARTIFACT_CHECKSUM'),
       artifactName: readOptionalEnvironmentValue(environment, 'ARTIFACT_NAME'),
@@ -572,8 +574,10 @@ function renderBetaSection(input: ReleaseCloudSummaryInput, commitLink: string, 
     '',
     `- Result: ${formatBetaResult(input.beta.deploymentResult)}`,
     `- Release branch: ${formatValueOrFallback(input.release.branch)}`,
-    `- Commit SHA: ${commitLink}`,
     `- Webapp version: ${formatValueOrFallback(input.release.artifactVersion)}`,
+    `- Asset version: ${formatValueOrFallback(input.release.artifactAssetVersion)}`,
+    `- Commit SHA: ${commitLink}`,
+    `- Built at (UTC): ${formatValueOrFallback(input.release.artifactBuiltAt)}`,
     '- GitHub Environment: wire-webapp-beta',
     `- Target environment: ${formatValueOrFallback(input.beta.environmentName)}`,
     `- Frontend URL: ${formatOptionalFrontendUrl(input.beta.webappUrl)}`,
@@ -597,8 +601,10 @@ function renderE2ESection(input: ReleaseCloudSummaryInput, commitLink: string, w
     '### E2E system gate',
     '',
     `- Result: ${formatE2EResult(input.e2e.result)}`,
-    `- Commit SHA: ${commitLink}`,
     `- Webapp version: ${formatValueOrFallback(input.release.artifactVersion)}`,
+    `- Asset version: ${formatValueOrFallback(input.release.artifactAssetVersion)}`,
+    `- Commit SHA: ${commitLink}`,
+    `- Built at (UTC): ${formatValueOrFallback(input.release.artifactBuiltAt)}`,
     `- Target environment: ${formatValueOrFallback(input.e2e.environmentName)}`,
     `- Frontend URL: ${formatOptionalFrontendUrl(input.e2e.webappUrl)}`,
     `- REST backend URL: ${formatValueOrFallback(input.e2e.runtimeBackendRest)}`,
@@ -620,8 +626,10 @@ function renderProductionSection(input: ReleaseCloudSummaryInput, commitLink: st
     `- Production promotion requested: ${input.production.promotionRequested ? 'true' : 'false'}`,
     `- Production preflight result: ${formatProductionPreflightResult(input.production)}`,
     ...(productionSkipReason === undefined ? [] : [`- Skip reason: ${productionSkipReason}`]),
-    `- Commit SHA: ${commitLink}`,
     `- Webapp version: ${formatValueOrFallback(input.release.artifactVersion)}`,
+    `- Asset version: ${formatValueOrFallback(input.release.artifactAssetVersion)}`,
+    `- Commit SHA: ${commitLink}`,
+    `- Built at (UTC): ${formatValueOrFallback(input.release.artifactBuiltAt)}`,
     `- Target environment: ${formatValueOrFallback(input.production.environmentName)}`,
     `- Frontend URL: ${formatOptionalFrontendUrl(input.production.webappUrl)}`,
     `- REST backend URL: ${formatValueOrFallback(input.production.runtimeBackendRest)}`,
@@ -637,11 +645,19 @@ function renderProductionSection(input: ReleaseCloudSummaryInput, commitLink: st
   ].join('\n');
 }
 
-function renderProductionDistributionSection(input: ReleaseCloudSummaryInput, workflowRunLink: string): string {
+function renderProductionDistributionSection(
+  input: ReleaseCloudSummaryInput,
+  commitLink: string,
+  workflowRunLink: string,
+): string {
   return [
     '### Production distribution',
     '',
     `- Result: ${formatDistributionResult(input.production, input.distribution)}`,
+    `- Webapp version: ${formatValueOrFallback(input.release.artifactVersion)}`,
+    `- Asset version: ${formatValueOrFallback(input.release.artifactAssetVersion)}`,
+    `- Commit SHA: ${commitLink}`,
+    `- Built at (UTC): ${formatValueOrFallback(input.release.artifactBuiltAt)}`,
     `- Docker image: ${formatDockerImage(input.distribution)}`,
     `- Helm chart repository: ${formatValueOrFallback(input.distribution.chartRepositoryUrl)}`,
     `- Helm chart version: ${formatValueOrFallback(input.distribution.helmChartVersion, 'not published')}`,
@@ -658,6 +674,8 @@ export function renderReleaseCloudSummary(input: ReleaseCloudSummaryInput): stri
     '',
     `- Release branch: ${formatValueOrFallback(input.release.branch)}`,
     `- Release identifier: ${formatValueOrFallback(input.release.identifier)}`,
+    `- Webapp version: ${formatValueOrFallback(input.release.artifactVersion)}`,
+    `- Asset version: ${formatValueOrFallback(input.release.artifactAssetVersion)}`,
     `- Commit SHA: ${commitLink}`,
     `- Built at (UTC): ${formatValueOrFallback(input.release.artifactBuiltAt)}`,
     `- Artifact name: ${formatValueOrFallback(input.release.artifactName)}`,
@@ -672,7 +690,7 @@ export function renderReleaseCloudSummary(input: ReleaseCloudSummaryInput): stri
       renderBetaSection(input, commitLink, workflowRunLink),
       renderE2ESection(input, commitLink, workflowRunLink),
       renderProductionSection(input, commitLink, workflowRunLink),
-      renderProductionDistributionSection(input, workflowRunLink),
+      renderProductionDistributionSection(input, commitLink, workflowRunLink),
     ].join('\n\n') + '\n'
   );
 }

--- a/bin/renderReleaseCloudSummary.ts
+++ b/bin/renderReleaseCloudSummary.ts
@@ -583,7 +583,7 @@ function renderBetaSection(input: ReleaseCloudSummaryInput, commitLink: string, 
     `- Frontend URL: ${formatOptionalFrontendUrl(input.beta.webappUrl)}`,
     `- REST backend URL: ${formatValueOrFallback(input.beta.runtimeBackendRest)}`,
     `- WebSocket backend URL: ${formatValueOrFallback(input.beta.runtimeBackendWebSocket)}`,
-    ...(input.beta.deploymentResult === 'success' ? ['- Runtime verification: /version, /commit, and /config.js'] : []),
+    ...(input.beta.deploymentResult === 'success' ? ['- Runtime verification: /version and /config.js'] : []),
     `- Beta tag: ${formatBetaTag(input.beta, input.github)}`,
     `- Artifact name: ${formatValueOrFallback(input.release.artifactName)}`,
     `- Artifact checksum: ${formatValueOrFallback(input.release.artifactChecksum)}`,
@@ -609,7 +609,7 @@ function renderE2ESection(input: ReleaseCloudSummaryInput, commitLink: string, w
     `- Frontend URL: ${formatOptionalFrontendUrl(input.e2e.webappUrl)}`,
     `- REST backend URL: ${formatValueOrFallback(input.e2e.runtimeBackendRest)}`,
     `- WebSocket backend URL: ${formatValueOrFallback(input.e2e.runtimeBackendWebSocket)}`,
-    ...(input.e2e.result === 'success' ? ['- Runtime verification: /version, /commit, and /config.js'] : []),
+    ...(input.e2e.result === 'success' ? ['- Runtime verification: /version and /config.js'] : []),
     `- Playwright report URL: ${formatOptionalReportUrl(input.e2e.reportUrl)}`,
     `- Testiny run name: ${testinyRunName}`,
     `- Workflow run URL: ${workflowRunLink}`,
@@ -636,7 +636,7 @@ function renderProductionSection(input: ReleaseCloudSummaryInput, commitLink: st
     `- WebSocket backend URL: ${formatValueOrFallback(input.production.runtimeBackendWebSocket)}`,
     `- Runtime verification result: ${formatProductionRuntimeVerificationResult(input.production.runtimeVerificationResult)}`,
     ...(input.production.runtimeVerificationResult === 'success'
-      ? ['- Runtime verification: /version, /commit, and /config.js']
+      ? ['- Runtime verification: /version and /config.js']
       : []),
     `- Production tag: ${formatProductionTag(input.production, input.github)}`,
     `- Production tag creation result: ${formatProductionTagCreationResult(input.production)}`,

--- a/bin/validateBuildArtifact.mts
+++ b/bin/validateBuildArtifact.mts
@@ -81,10 +81,7 @@ function writeMetadataOutputs(metadata: BuildMetadata): void {
     return;
   }
 
-  appendFileSync(
-    githubOutputPath.value,
-    formatBuildArtifactMetadataOutputs(metadata),
-  );
+  appendFileSync(githubOutputPath.value, formatBuildArtifactMetadataOutputs(metadata));
 }
 
 function validateArtifact(): BuildMetadata {

--- a/bin/validateBuildArtifact.mts
+++ b/bin/validateBuildArtifact.mts
@@ -23,10 +23,7 @@ import {appendFileSync} from 'node:fs';
 
 import {Maybe} from 'true-myth';
 
-import {
-  readBuildArtifactHtmlDocuments,
-  readBuildArtifactMetadata,
-} from './buildArtifactArchive.ts';
+import {readBuildArtifactHtmlDocuments, readBuildArtifactMetadata} from './buildArtifactArchive.ts';
 import {validateBuildArtifactMetadata} from './buildArtifactMetadata.ts';
 import {formatBuildArtifactMetadataOutputs} from './buildArtifactMetadataOutput.ts';
 import type {BuildMetadata} from '@wireapp/config';

--- a/bin/validateBuildArtifact.mts
+++ b/bin/validateBuildArtifact.mts
@@ -25,6 +25,7 @@ import {execFileSync} from 'node:child_process';
 import {Maybe} from 'true-myth';
 
 import {validateBuildArtifactMetadata} from './buildArtifactMetadata.ts';
+import {formatBuildArtifactMetadataOutputs} from './buildArtifactMetadataOutput.ts';
 import type {BuildArtifactHtmlDocument} from './buildArtifactMetadata.ts';
 import type {BuildMetadata} from '@wireapp/config';
 
@@ -82,7 +83,7 @@ function writeMetadataOutputs(metadata: BuildMetadata): void {
 
   appendFileSync(
     githubOutputPath.value,
-    `artifact_version=${metadata.version}\nartifact_commit=${metadata.commit}\nartifact_built_at=${metadata.builtAt}\n`,
+    formatBuildArtifactMetadataOutputs(metadata),
   );
 }
 

--- a/bin/validateBuildArtifact.test.ts
+++ b/bin/validateBuildArtifact.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {formatBuildArtifactMetadataOutputs} from './buildArtifactMetadataOutput';
+import type {BuildMetadata} from '@wireapp/config';
+
+const mainBuildMetadata: BuildMetadata = {
+  version: 'main-bdb93c9',
+  assetVersion: 'main-bdb93c9',
+  commit: 'bdb93c9269866d577c012f3a781cbe904f7bf47c',
+  builtAt: '2026-07-20T14:43:21.123Z',
+};
+
+const releaseBuildMetadata: BuildMetadata = {
+  version: '2026-07-20.1',
+  assetVersion: '2026-07-20.1-025edc6',
+  commit: '025edc663787b3d2da366f21a5958013201e6cd4',
+  builtAt: '2026-07-20T06:18:03.123Z',
+};
+
+describe('artifact metadata GitHub outputs', () => {
+  test.each([
+    ['main metadata', mainBuildMetadata],
+    ['release metadata', releaseBuildMetadata],
+  ])('formats all validated artifact metadata outputs for %s', (_description, metadata) => {
+    const actualOutput = formatBuildArtifactMetadataOutputs(metadata);
+    const expectedOutput = [
+      `artifact_version=${metadata.version}`,
+      `artifact_asset_version=${metadata.assetVersion}`,
+      `artifact_commit=${metadata.commit}`,
+      `artifact_built_at=${metadata.builtAt}`,
+      '',
+    ].join('\n');
+
+    expect(actualOutput).toBe(expectedOutput);
+  });
+});

--- a/bin/validateRecoveryBuildArtifact.mts
+++ b/bin/validateRecoveryBuildArtifact.mts
@@ -27,9 +27,9 @@ import {
   readBuildArtifactHtmlDocuments,
   readBuildArtifactMetadata,
 } from './buildArtifactArchive.ts';
-import {validateBuildArtifactMetadata} from './buildArtifactMetadata.ts';
-import {formatBuildArtifactMetadataOutputs} from './buildArtifactMetadataOutput.ts';
-import type {BuildMetadata} from '@wireapp/config';
+import {formatRecoverableBuildArtifactMetadataOutputs} from './recoveryBuildArtifactMetadataOutput.ts';
+import {validateRecoveryBuildArtifactMetadata} from './recoveryBuildArtifactMetadata.ts';
+import type {RecoverableBuildMetadata} from './recoveryBuildArtifactMetadata.ts';
 
 function readRequiredEnvironmentValue(environmentVariableName: string): string {
   const environmentValue = Maybe.of(process.env[environmentVariableName]).andThen(value => {
@@ -47,7 +47,7 @@ function readRequiredEnvironmentValue(environmentVariableName: string): string {
   return environmentValue.value;
 }
 
-function writeMetadataOutputs(metadata: BuildMetadata): void {
+function writeMetadataOutputs(metadata: RecoverableBuildMetadata): void {
   const githubOutputPath = Maybe.of(process.env.GITHUB_OUTPUT).andThen(value => {
     if (value.trim().length === 0) {
       return Maybe.nothing();
@@ -60,14 +60,14 @@ function writeMetadataOutputs(metadata: BuildMetadata): void {
     return;
   }
 
-  appendFileSync(githubOutputPath.value, formatBuildArtifactMetadataOutputs(metadata));
+  appendFileSync(githubOutputPath.value, formatRecoverableBuildArtifactMetadataOutputs(metadata));
 }
 
-function validateArtifact(): BuildMetadata {
+function validateArtifact(): RecoverableBuildMetadata {
   const artifactPath = readRequiredEnvironmentValue('BUILD_ARTIFACT_PATH');
   const expectedVersion = readRequiredEnvironmentValue('EXPECTED_VERSION');
   const expectedCommit = readRequiredEnvironmentValue('EXPECTED_COMMIT');
-  const validationResult = validateBuildArtifactMetadata({
+  const validationResult = validateRecoveryBuildArtifactMetadata({
     expectedCommit,
     expectedVersion,
     htmlDocuments: readBuildArtifactHtmlDocuments(artifactPath),
@@ -86,7 +86,7 @@ function run(): void {
     const metadata = validateArtifact();
 
     writeMetadataOutputs(metadata);
-    console.log(JSON.stringify(metadata));
+    console.log(JSON.stringify(metadata.metadata));
   } catch (error: unknown) {
     console.error(error);
     process.exitCode = 1;

--- a/bin/validateRecoveryBuildArtifact.mts
+++ b/bin/validateRecoveryBuildArtifact.mts
@@ -23,10 +23,7 @@ import {appendFileSync} from 'node:fs';
 
 import {Maybe} from 'true-myth';
 
-import {
-  readBuildArtifactHtmlDocuments,
-  readBuildArtifactMetadata,
-} from './buildArtifactArchive.ts';
+import {readBuildArtifactHtmlDocuments, readBuildArtifactMetadata} from './buildArtifactArchive.ts';
 import {formatRecoverableBuildArtifactMetadataOutputs} from './recoveryBuildArtifactMetadataOutput.ts';
 import {validateRecoveryBuildArtifactMetadata} from './recoveryBuildArtifactMetadata.ts';
 import type {RecoverableBuildMetadata} from './recoveryBuildArtifactMetadata.ts';

--- a/bin/validateRuntimeResponses.mts
+++ b/bin/validateRuntimeResponses.mts
@@ -20,7 +20,6 @@
  */
 
 import {readFileSync} from 'node:fs';
-import {fileURLToPath} from 'node:url';
 
 import {validateRuntimeResponses} from './validateRuntimeResponses.ts';
 import type {BuildMetadata} from '@wireapp/config';
@@ -61,6 +60,4 @@ function run(): void {
   }
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  run();
-}
+run();

--- a/bin/validateRuntimeResponses.mts
+++ b/bin/validateRuntimeResponses.mts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+
+import {validateRuntimeResponses} from './validateRuntimeResponses.ts';
+import type {BuildMetadata} from '@wireapp/config';
+
+function readRequiredEnvironmentValue(environmentVariableName: string): string {
+  const environmentValue = process.env[environmentVariableName];
+
+  if (typeof environmentValue !== 'string' || environmentValue.length === 0) {
+    throw new Error('Missing required runtime verification input ' + environmentVariableName);
+  }
+
+  return environmentValue;
+}
+
+function readExpectedBuildMetadata(): BuildMetadata {
+  return {
+    version: readRequiredEnvironmentValue('EXPECTED_VERSION'),
+    assetVersion: readRequiredEnvironmentValue('EXPECTED_ASSET_VERSION'),
+    commit: readRequiredEnvironmentValue('EXPECTED_COMMIT'),
+    builtAt: readRequiredEnvironmentValue('EXPECTED_BUILT_AT'),
+  };
+}
+
+function run(): void {
+  const validationErrors = validateRuntimeResponses({
+    versionResponse: readFileSync(0, 'utf8'),
+    runtimeConfigurationResponse: readRequiredEnvironmentValue('RUNTIME_CONFIG_RESPONSE'),
+    expectedBuildMetadata: readExpectedBuildMetadata(),
+    expectedBackendRest: readRequiredEnvironmentValue('EXPECTED_BACKEND_REST'),
+    expectedBackendWebSocket: readRequiredEnvironmentValue('EXPECTED_BACKEND_WS'),
+  });
+
+  if (validationErrors.length > 0) {
+    validationErrors.forEach(validationError => {
+      console.error(validationError);
+    });
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  run();
+}

--- a/bin/validateRuntimeResponses.ts
+++ b/bin/validateRuntimeResponses.ts
@@ -1,0 +1,153 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {BuildMetadata} from '@wireapp/config';
+
+const buildMetadataPropertyNames = ['version', 'assetVersion', 'commit', 'builtAt'] as const;
+const runtimeConfigurationPropertyNames = ['BACKEND_REST', 'BACKEND_WS'] as const;
+
+type ParsedJsonValue = {
+  readonly value: unknown;
+  readonly errors: readonly string[];
+};
+
+export type RuntimeVerificationInput = {
+  readonly versionResponse: string;
+  readonly runtimeConfigurationResponse: string;
+  readonly expectedBuildMetadata: BuildMetadata;
+  readonly expectedBackendRest: string;
+  readonly expectedBackendWebSocket: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && Array.isArray(value) === false;
+}
+
+function normalizeUrl(url: string): string {
+  let normalizedUrl = url;
+
+  while (normalizedUrl.endsWith('/')) {
+    normalizedUrl = normalizedUrl.slice(0, -1);
+  }
+
+  return normalizedUrl;
+}
+
+function parseJson(serializedValue: string, valueDescription: string): ParsedJsonValue {
+  try {
+    return {value: JSON.parse(serializedValue), errors: []};
+  } catch {
+    return {value: undefined, errors: [valueDescription + ' is not valid JSON']};
+  }
+}
+
+export function validateBuildMetadataResponse(
+  versionResponse: string,
+  expectedBuildMetadata: BuildMetadata,
+): readonly string[] {
+  const parsedResponse = parseJson(versionResponse, '/version response');
+
+  if (parsedResponse.errors.length > 0) {
+    return parsedResponse.errors;
+  }
+
+  const responseValue = parsedResponse.value;
+
+  if (!isRecord(responseValue)) {
+    return ['/version response must be a JSON object'];
+  }
+
+  return buildMetadataPropertyNames.flatMap(propertyName => {
+    const actualValue = responseValue[propertyName];
+
+    if (typeof actualValue !== 'string' || actualValue.length === 0) {
+      return [propertyName + ' must be a non-empty string'];
+    }
+
+    if (actualValue !== expectedBuildMetadata[propertyName]) {
+      return [propertyName + ' does not match the expected artifact metadata'];
+    }
+
+    return [];
+  });
+}
+
+function parseRuntimeConfiguration(runtimeConfigurationResponse: string): ParsedJsonValue {
+  const assignmentMarker = 'window.wire.env = ';
+  const assignmentStart = runtimeConfigurationResponse.lastIndexOf(assignmentMarker);
+
+  if (assignmentStart < 0) {
+    return {value: undefined, errors: ['runtime configuration does not contain window.wire.env']};
+  }
+
+  const serializedConfiguration = runtimeConfigurationResponse
+    .slice(assignmentStart + assignmentMarker.length)
+    .trim()
+    .replace(/;$/, '');
+
+  return parseJson(serializedConfiguration, 'runtime configuration');
+}
+
+export function validateRuntimeConfiguration(
+  runtimeConfigurationResponse: string,
+  expectedBackendRest: string,
+  expectedBackendWebSocket: string,
+): readonly string[] {
+  const parsedConfiguration = parseRuntimeConfiguration(runtimeConfigurationResponse);
+
+  if (parsedConfiguration.errors.length > 0) {
+    return parsedConfiguration.errors;
+  }
+
+  const configurationValue = parsedConfiguration.value;
+
+  if (!isRecord(configurationValue)) {
+    return ['runtime configuration must be a JSON object'];
+  }
+
+  const expectedBackendValues: Record<(typeof runtimeConfigurationPropertyNames)[number], string> = {
+    BACKEND_REST: normalizeUrl(expectedBackendRest),
+    BACKEND_WS: normalizeUrl(expectedBackendWebSocket),
+  };
+
+  return runtimeConfigurationPropertyNames.flatMap(propertyName => {
+    const actualValue = configurationValue[propertyName];
+
+    if (typeof actualValue !== 'string' || actualValue.length === 0) {
+      return [propertyName + ' must be a non-empty string'];
+    }
+
+    if (normalizeUrl(actualValue) !== expectedBackendValues[propertyName]) {
+      return [propertyName + ' does not match the expected runtime backend'];
+    }
+
+    return [];
+  });
+}
+
+export function validateRuntimeResponses(input: RuntimeVerificationInput): readonly string[] {
+  return [
+    ...validateBuildMetadataResponse(input.versionResponse, input.expectedBuildMetadata),
+    ...validateRuntimeConfiguration(
+      input.runtimeConfigurationResponse,
+      input.expectedBackendRest,
+      input.expectedBackendWebSocket,
+    ),
+  ];
+}

--- a/bin/verifySparseRuntimeValidation.sh
+++ b/bin/verifySparseRuntimeValidation.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "${script_directory}/.." && pwd)"
+sparse_fixture_directory="$(mktemp -d)"
+runtime_fixture_directory="${sparse_fixture_directory}/runtime"
+
+trap 'rm -rf "${sparse_fixture_directory}"' EXIT
+
+function copy_sparse_runtime_files() {
+  mkdir -p \
+    "${sparse_fixture_directory}/.github/actions/verify-webapp-runtime" \
+    "${sparse_fixture_directory}/bin" \
+    "${runtime_fixture_directory}" \
+    "${sparse_fixture_directory}/test-bin"
+
+  cp \
+    "${repository_root}/.nvmrc" \
+    "${sparse_fixture_directory}/.nvmrc"
+  cp \
+    "${repository_root}/.github/actions/verify-webapp-runtime/action.yml" \
+    "${sparse_fixture_directory}/.github/actions/verify-webapp-runtime/action.yml"
+  cp \
+    "${repository_root}/.github/actions/verify-webapp-runtime/verify-webapp-runtime.sh" \
+    "${sparse_fixture_directory}/.github/actions/verify-webapp-runtime/verify-webapp-runtime.sh"
+  cp \
+    "${repository_root}/bin/validateRuntimeResponses.mts" \
+    "${sparse_fixture_directory}/bin/validateRuntimeResponses.mts"
+  cp \
+    "${repository_root}/bin/validateRuntimeResponses.ts" \
+    "${sparse_fixture_directory}/bin/validateRuntimeResponses.ts"
+
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "${sparse_fixture_directory}/test-bin/sleep"
+  chmod +x "${sparse_fixture_directory}/test-bin/sleep"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    'request_url="${@: -1}"' \
+    'case "${request_url}" in' \
+    '  */version) cat "${RUNTIME_FIXTURE_DIRECTORY}/version" ;;' \
+    '  */config.js) cat "${RUNTIME_FIXTURE_DIRECTORY}/config.js" ;;' \
+    '  *) exit 1 ;;' \
+    'esac' \
+    > "${sparse_fixture_directory}/test-bin/curl"
+  chmod +x "${sparse_fixture_directory}/test-bin/curl"
+}
+
+function run_runtime_verification() {
+  local version_response="$1"
+
+  printf '%s\n' "${version_response}" > "${runtime_fixture_directory}/version"
+  printf '%s\n' \
+    'window.wire.env = {"BACKEND_REST":"https://backend.example.com","BACKEND_WS":"wss://backend.example.com"};' \
+    > "${runtime_fixture_directory}/config.js"
+
+  local verification_output
+  local verification_exit_code
+
+  if verification_output="$(
+    cd "${sparse_fixture_directory}"
+    PATH="${sparse_fixture_directory}/test-bin:${PATH}" \
+      ENVIRONMENT_LABEL='Sparse runtime smoke test' \
+      RUNTIME_FIXTURE_DIRECTORY="${runtime_fixture_directory}" \
+      WEBAPP_URL='https://sparse-runtime.test' \
+      EXPECTED_VERSION='main-bdb93c9' \
+      EXPECTED_ASSET_VERSION='main-bdb93c9' \
+      EXPECTED_COMMIT='bdb93c9269866d577c012f3a781cbe904f7bf47c' \
+      EXPECTED_BUILT_AT='2026-07-20T14:43:21.123Z' \
+      EXPECTED_BACKEND_REST='https://backend.example.com' \
+      EXPECTED_BACKEND_WS='wss://backend.example.com' \
+      GITHUB_WORKSPACE="${sparse_fixture_directory}" \
+      GITHUB_ACTION_PATH="${sparse_fixture_directory}/.github/actions/verify-webapp-runtime" \
+      bash "${sparse_fixture_directory}/.github/actions/verify-webapp-runtime/verify-webapp-runtime.sh" \
+      2>&1
+  )"; then
+    printf '%s\n' "${verification_output}"
+    return 0
+  else
+    verification_exit_code=$?
+    printf '%s\n' "${verification_output}"
+    return "${verification_exit_code}"
+  fi
+}
+
+copy_sparse_runtime_files
+
+matching_version_response='{"version":"main-bdb93c9","assetVersion":"main-bdb93c9","commit":"bdb93c9269866d577c012f3a781cbe904f7bf47c","builtAt":"2026-07-20T14:43:21.123Z"}'
+mismatching_asset_version_response='{"version":"main-bdb93c9","assetVersion":"main-other-assets","commit":"bdb93c9269866d577c012f3a781cbe904f7bf47c","builtAt":"2026-07-20T14:43:21.123Z"}'
+
+matching_output="$(run_runtime_verification "${matching_version_response}")"
+if [[ "${matching_output}" != *'runtime verification succeeded'* ]]; then
+  echo 'Sparse runtime validation did not report success for matching metadata.' >&2
+  printf '%s\n' "${matching_output}" >&2
+  exit 1
+fi
+
+set +e
+mismatching_output="$(run_runtime_verification "${mismatching_asset_version_response}")"
+mismatching_exit_code=$?
+set -e
+
+if [[ "${mismatching_exit_code}" -eq 0 ]]; then
+  echo 'Sparse runtime validation unexpectedly accepted a mismatched assetVersion.' >&2
+  printf '%s\n' "${mismatching_output}" >&2
+  exit 1
+fi
+
+if [[ "${mismatching_output}" != *'assetVersion does not match the expected artifact metadata'* ]]; then
+  echo 'Sparse runtime validation did not report the assetVersion mismatch.' >&2
+  printf '%s\n' "${mismatching_output}" >&2
+  exit 1
+fi
+
+echo 'Sparse runtime validation entry point passed matching and mismatch checks.'

--- a/bin/verifyWebappRuntime.test.ts
+++ b/bin/verifyWebappRuntime.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {validateBuildMetadataResponse, validateRuntimeResponses} from './validateRuntimeResponses';
+import type {BuildMetadata} from '@wireapp/config';
+
+const mainBuildMetadata: BuildMetadata = {
+  version: 'main-bdb93c9',
+  assetVersion: 'main-bdb93c9',
+  commit: 'bdb93c9269866d577c012f3a781cbe904f7bf47c',
+  builtAt: '2026-07-20T14:43:21.123Z',
+};
+
+const matchingRuntimeConfiguration = `window.wire = window.wire || {}; window.wire.env = ${JSON.stringify({
+  BACKEND_REST: 'https://backend.example.com',
+  BACKEND_WS: 'wss://backend.example.com',
+})};`;
+
+function validateMatchingRuntimeResponses(
+  buildMetadata: BuildMetadata,
+  runtimeConfiguration: string,
+): readonly string[] {
+  return validateRuntimeResponses({
+    versionResponse: JSON.stringify(buildMetadata),
+    runtimeConfigurationResponse: runtimeConfiguration,
+    expectedBuildMetadata: mainBuildMetadata,
+    expectedBackendRest: 'https://backend.example.com/',
+    expectedBackendWebSocket: 'wss://backend.example.com/',
+  });
+}
+
+function expectValidationError(validationErrors: readonly string[], expectedFieldName: string): void {
+  expect(validationErrors.some(validationError => validationError.startsWith(expectedFieldName))).toBe(true);
+}
+
+describe('runtime build metadata verification', () => {
+  test('accepts complete matching metadata and backend configuration', () => {
+    expect(validateMatchingRuntimeResponses(mainBuildMetadata, matchingRuntimeConfiguration)).toEqual([]);
+  });
+
+  test.each([
+    ['version', {...mainBuildMetadata, version: 'main-other-version'}],
+    ['assetVersion', {...mainBuildMetadata, assetVersion: 'main-other-assets'}],
+    ['commit', {...mainBuildMetadata, commit: 'other-commit'}],
+    ['builtAt', {...mainBuildMetadata, builtAt: '2026-07-20T15:43:21.123Z'}],
+  ])('rejects a %s mismatch', (propertyName, mismatchedBuildMetadata) => {
+    const validationErrors = validateMatchingRuntimeResponses(mismatchedBuildMetadata, matchingRuntimeConfiguration);
+
+    expectValidationError(validationErrors, propertyName);
+  });
+
+  test('rejects missing assetVersion', () => {
+    const versionResponse = JSON.stringify({
+      version: mainBuildMetadata.version,
+      commit: mainBuildMetadata.commit,
+      builtAt: mainBuildMetadata.builtAt,
+    });
+
+    const validationErrors = validateBuildMetadataResponse(versionResponse, mainBuildMetadata);
+
+    expectValidationError(validationErrors, 'assetVersion');
+  });
+
+  test('rejects missing builtAt', () => {
+    const versionResponse = JSON.stringify({
+      version: mainBuildMetadata.version,
+      assetVersion: mainBuildMetadata.assetVersion,
+      commit: mainBuildMetadata.commit,
+    });
+
+    const validationErrors = validateBuildMetadataResponse(versionResponse, mainBuildMetadata);
+
+    expectValidationError(validationErrors, 'builtAt');
+  });
+
+  test('rejects malformed JSON', () => {
+    const validationErrors = validateBuildMetadataResponse('{not-json', mainBuildMetadata);
+
+    expect(validationErrors).toEqual(['/version response is not valid JSON']);
+  });
+
+  test('continues validating backend configuration', () => {
+    const runtimeConfiguration = matchingRuntimeConfiguration.replaceAll(
+      'backend.example.com',
+      'other-backend.example.com',
+    );
+
+    const validationErrors = validateMatchingRuntimeResponses(mainBuildMetadata, runtimeConfiguration);
+
+    expectValidationError(validationErrors, 'BACKEND_REST');
+    expectValidationError(validationErrors, 'BACKEND_WS');
+  });
+
+  test('does not reconstruct assetVersion or builtAt from other metadata fields', () => {
+    const actualBuildMetadata = {
+      version: mainBuildMetadata.version,
+      assetVersion: 'main-bdb93c9-reconstructed',
+      commit: mainBuildMetadata.commit,
+      builtAt: '2026-07-20T15:43:21.123Z',
+    };
+
+    const validationErrors = validateMatchingRuntimeResponses(actualBuildMetadata, matchingRuntimeConfiguration);
+
+    expect(validationErrors).toHaveLength(2);
+    expectValidationError(validationErrors, 'assetVersion');
+    expectValidationError(validationErrors, 'builtAt');
+  });
+});

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -131,8 +131,9 @@ The cloud release process is:
 - Quality assurance owns the go/no-go quality gate.
 - The engineering release captain owns production rollout, observability, and incident response.
 - The production workflow promotes the beta-tested artifact and does not rebuild from source.
-- Live deployment verification uses `/version` to identify the deployed build, `/commit` to identify its source revision, and `/config.js` to verify the active environment-specific REST and WebSocket backend configuration.
-- Build version and source commit are separate evidence: the same source commit can produce different builds, so `/commit` proves the source revision while `/version` identifies the particular build generated and promoted by the current workflow.
+- Live deployment verification uses `/version` to identify the deployed artifact with its complete authoritative `BuildMetadata` object (`version`, `assetVersion`, `commit`, and `builtAt`), and `/config.js` to verify the active environment-specific REST and WebSocket backend configuration.
+- `version` remains the logical application version, `assetVersion` identifies browser assets for the exact source revision, `commit` is the full Git SHA, and `builtAt` is the artifact assembly time in UTC. `/commit` remains a plain-text compatibility endpoint for existing consumers.
+- Deployment context such as the result, Git reference, target environment, service URLs, Docker image, Helm chart, `wire-builds` commit, workflow run URL, and manual-dispatch reason belongs in GitHub Actions summaries rather than `/version`.
 - Backend configuration is runtime state and is not inferred from build identity. Beta, precommit, and Production must each satisfy their expected combination of build version, source commit, REST backend, and WebSocket backend.
 - A successful deployment operation alone does not create a Production tag. The workflow creates the production tag `YYYY-MM-DD.N-production` only after all Production runtime assertions pass, so the tag represents a successfully deployed and verified runtime.
 - The cloud EBS artifact is built once and promoted unchanged through Beta, E2E, and Production.

--- a/tsconfig.bin.json
+++ b/tsconfig.bin.json
@@ -5,7 +5,8 @@
     "target": "es2024",
     "lib": ["ES2024"],
     "types": ["node"],
-    "rootDir": "."
+    "rootDir": ".",
+    "allowImportingTsExtensions": true
   },
   "include": ["bin/**/*.ts"],
   "exclude": ["node_modules", "dist", "tmp", "bin/**/*.test.ts", "bin/jest.config.js"]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Why

The `/version` endpoint currently exposes only the logical webapp version:

```json
{
  "version": "main-bdb93c9"
}
```

The running artifact already contains a validated and authoritative build metadata object:

```json
{
  "version": "main-bdb93c9",
  "assetVersion": "main-bdb93c9",
  "commit": "bdb93c9269866d577c012f3a781cbe904f7bf47c",
  "builtAt": "2026-07-20T14:43:21.123Z"
}
```

Returning only one field makes it unnecessarily difficult to determine which exact artifact is running. The complete identity is already available during artifact validation and is partially repeated in our GitHub Actions deployment summaries.

The `/version` endpoint should answer one question consistently:

> Which exact webapp artifact is this server currently running?

## Route construction fix

The expanded route tests exposed an existing bug in `RedirectRoutes`.

The route factory previously reused a module-level Express router. Because route handlers close over their dependencies, the first server instance registered handlers containing its metadata. Later server instances reused the same router and therefore continued serving the first instance’s metadata.

This meant that explicitly injected metadata was not actually authoritative per server instance.

Router creation now happens inside the route factory. Every server instance receives a fresh router whose handlers close over that instance’s configuration and build metadata.

Besides fixing the underlying lifecycle bug, this makes the release metadata fixture test meaningful: separate server instances can now be tested with different metadata without leaking state between them.

## Compatibility

The existing top-level `version` property is unchanged, so consumers that read only `response.version` remain compatible.

The response is extended with:

- `assetVersion`
- `commit`
- `builtAt`