### PR TITLE
fix: drive file type filter order(WPB-27130)

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/driveFilters/driveFilters.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/driveFilters/driveFilters.test.ts
@@ -28,6 +28,7 @@ import {
   toConversationDriveSearchParams,
   toGlobalDriveSearchParams,
 } from './driveFilters';
+import {FILE_TYPE_CATALOG} from './fileTypeCatalog';
 
 const emptyFilters: ConversationDriveFiltersState = {
   selectedTagIds: [],
@@ -41,6 +42,22 @@ const emptyGlobalFilters: GlobalDriveFiltersState = {
   selectedConversationIds: [],
   path: undefined,
 };
+
+describe('FILE_TYPE_CATALOG', () => {
+  it('lists file types in this fixed display order', () => {
+    expect(FILE_TYPE_CATALOG.map(({id}) => id)).toEqual([
+      'pdfs',
+      'documents',
+      'pictures',
+      'spreadsheets',
+      'presentations',
+      'videos',
+      'audio',
+      'archives',
+      'text',
+    ]);
+  });
+});
 
 describe('hasActiveConversationDriveFilters', () => {
   it('returns false when no filters are active', () => {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/driveFilters/fileTypeCatalog.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/driveFilters/fileTypeCatalog.tsx
@@ -43,6 +43,8 @@ export interface FileTypeCatalogEntry {
 }
 
 export const FILE_TYPE_CATALOG: readonly FileTypeCatalogEntry[] = [
+  {id: 'pdfs', labelKey: 'cells.fileType.pdfs', Icon: PdfFileIcon, mimeTerms: ['application/pdf']},
+  {id: 'documents', labelKey: 'cells.fileType.documents', Icon: DocumentFileIcon, mimeTerms: ['*word*']},
   {id: 'pictures', labelKey: 'cells.fileType.pictures', Icon: ImageFileIcon, mimeTerms: ['image/*']},
   {
     id: 'spreadsheets',
@@ -56,10 +58,8 @@ export const FILE_TYPE_CATALOG: readonly FileTypeCatalogEntry[] = [
     Icon: PresentationFileIcon,
     mimeTerms: ['*presentation*', '*powerpoint*'],
   },
-  {id: 'documents', labelKey: 'cells.fileType.documents', Icon: DocumentFileIcon, mimeTerms: ['*word*']},
-  {id: 'pdfs', labelKey: 'cells.fileType.pdfs', Icon: PdfFileIcon, mimeTerms: ['application/pdf']},
-  {id: 'audio', labelKey: 'cells.fileType.audio', Icon: AudioFileIcon, mimeTerms: ['audio/*']},
   {id: 'videos', labelKey: 'cells.fileType.videos', Icon: VideoFileIcon, mimeTerms: ['video/*']},
+  {id: 'audio', labelKey: 'cells.fileType.audio', Icon: AudioFileIcon, mimeTerms: ['audio/*']},
   {
     id: 'archives',
     labelKey: 'cells.fileType.archives',

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useConversationDriveFilters/useConversationDriveFilters.test.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useConversationDriveFilters/useConversationDriveFilters.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {renderHook} from '@testing-library/react';
+
+import type {CellsRepository} from 'Repositories/cells/cellsRepository';
+import type {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import type {FilterConfig, PopoverFilterConfig} from '../CellsFiltersBar/filterConfig';
+
+import {useConversationDriveFilters} from './useConversationDriveFilters';
+
+const expectedFileTypeFilterItemIds = [
+  'pdfs',
+  'documents',
+  'pictures',
+  'spreadsheets',
+  'presentations',
+  'videos',
+  'audio',
+  'archives',
+  'text',
+];
+
+const isFileTypePopoverFilter = (filter: FilterConfig): filter is PopoverFilterConfig =>
+  filter.id === 'fileType' && filter.type === 'popover';
+
+const cellsRepository = {} as CellsRepository;
+
+const conversationRepository = {
+  getAllCellEnabledGroupConversations: () => [],
+} as unknown as ConversationRepository;
+
+describe('useConversationDriveFilters', () => {
+  it('exposes file type filter items in the required display order', () => {
+    const {result} = renderHook(
+      () => useConversationDriveFilters({cellsRepository, conversationRepository, translate: translateForTest}),
+      {
+        wrapper: createRootProviderWrapperForTest(createRootContextValueForTest({translate: translateForTest})),
+      },
+    );
+
+    const fileTypeFilter = result.current.filters.find(isFileTypePopoverFilter);
+
+    expect(fileTypeFilter?.items.map(({id}) => id)).toEqual(expectedFileTypeFilterItemIds);
+  });
+});

--- a/apps/webapp/src/script/components/cellsGlobalView/common/useGlobalDriveFilters/useGlobalDriveFilters.test.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/common/useGlobalDriveFilters/useGlobalDriveFilters.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {renderHook} from '@testing-library/react';
+import ko from 'knockout';
+import {container} from 'tsyringe';
+
+import type {
+  FilterConfig,
+  PopoverFilterConfig,
+} from 'Components/Conversation/ConversationCells/common/CellsFiltersBar/filterConfig';
+import type {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {ConversationState} from 'Repositories/conversation/ConversationState';
+import type {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
+import {TeamState} from 'Repositories/team/TeamState';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {Core} from 'src/script/service/coreSingleton';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {useGlobalDriveFilters} from './useGlobalDriveFilters';
+
+const expectedFileTypeFilterItemIds = [
+  'pdfs',
+  'documents',
+  'pictures',
+  'spreadsheets',
+  'presentations',
+  'videos',
+  'audio',
+  'archives',
+  'text',
+];
+
+const isFileTypePopoverFilter = (filter: FilterConfig): filter is PopoverFilterConfig =>
+  filter.id === 'fileType' && filter.type === 'popover';
+
+const cellsRepository = {} as CellsRepository;
+
+const conversationRepository = {
+  getAllCellEnabledGroupConversations: () => [],
+} as unknown as ConversationRepository;
+
+describe('useGlobalDriveFilters', () => {
+  beforeEach(() => {
+    container.clearInstances();
+    container.registerInstance(TeamState, {
+      selfRole: ko.pureComputed(() => undefined),
+      teamFeatures: ko.observable(undefined),
+    } as unknown as TeamState);
+    container.registerInstance(ConversationState, {
+      channelConversations: ko.pureComputed(() => []),
+    } as unknown as ConversationState);
+    container.registerInstance(Core, {
+      backendFeatures: {version: 0},
+    } as unknown as Core);
+  });
+
+  it('exposes file type filter items in the required display order', () => {
+    const {result} = renderHook(
+      () => useGlobalDriveFilters({cellsRepository, conversationRepository, translate: translateForTest}),
+      {
+        wrapper: createRootProviderWrapperForTest(createRootContextValueForTest({translate: translateForTest})),
+      },
+    );
+
+    const fileTypeFilter = result.current.filters.find(isFileTypePopoverFilter);
+
+    expect(fileTypeFilter?.items.map(({id}) => id)).toEqual(expectedFileTypeFilterItemIds);
+  });
+});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27130" title="WPB-27130" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27130</a>  [Web] File types are not displayed in the defined fixed order
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Reorder the drive file type catalog to match the PRD-defined display sequence for both Global and Shared Drive filters.

Add a regression test that asserts the catalog order so future changes do not accidentally alter the filter display order.


