### PR TITLE
Fix loading overlay for call thumbnails - [WPB-27244]

### DIFF
--- a/apps/webapp/src/script/components/calling/GroupVideoGrid.test.tsx
+++ b/apps/webapp/src/script/components/calling/GroupVideoGrid.test.tsx
@@ -25,6 +25,7 @@ import {Call} from 'Repositories/calling/Call';
 import {Participant} from 'Repositories/calling/Participant';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
+import {backgroundEffectsStore} from 'Repositories/media/useBackgroundEffectsStore';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
@@ -71,7 +72,23 @@ const createMockCall = () => {
   );
 };
 
+const createMediaStream = () =>
+  ({
+    getVideoTracks: jest.fn(() => []),
+  }) as unknown as MediaStream;
+
+const createProcessedVideoStream = (stream: MediaStream) => ({
+  stream,
+  release: jest.fn(),
+});
+
 describe('GroupVideoGrid', () => {
+  beforeEach(() => {
+    backgroundEffectsStore.setState({
+      isInitializing: false,
+    });
+  });
+
   it('renders video grids', async () => {
     const selfParticipant = createMockParticipant('selfUser', 'selfClient', {isMuted: true});
     selfParticipant.user.name('Anton Bertha');
@@ -173,6 +190,35 @@ describe('GroupVideoGrid', () => {
 
     expect(thumbnailElements).not.toHaveLength(0);
     expect(thumbnailMutedIcons).not.toHaveLength(0);
+  });
+
+  it('shows and hides the loading overlay while the thumbnail video is loading', () => {
+    const participant = createMockParticipant('userId', 'clientId', {});
+    const videoStream = createMediaStream();
+    participant.videoState(VIDEO_STATE.STARTED);
+    participant.videoStream(videoStream);
+    participant.processedVideoStream(createProcessedVideoStream(videoStream));
+
+    const props: GroupVideoGripProps = {
+      grid: {
+        grid: [],
+        thumbnail: participant,
+      },
+      maximizedParticipant: null,
+      minimized: false,
+      selfParticipant: participant,
+      setMaximizedParticipant: jest.fn(),
+      call: createMockCall(),
+    };
+
+    const {container} = render(<GroupVideoGrid {...props} />, {wrapper: rootProviderWrapper});
+    const video = container.querySelector('[data-uie-name="self-video-thumbnail"]')!;
+
+    expect(container.querySelector('[data-uie-name="background-effect-initializing"]')).toBeInTheDocument();
+
+    fireEvent.canPlay(video);
+
+    expect(container.querySelector('[data-uie-name="background-effect-initializing"]')).not.toBeInTheDocument();
   });
 
   it('does not render muted thumbnail when un-muted', async () => {

--- a/apps/webapp/src/script/components/calling/GroupVideoGrid.tsx
+++ b/apps/webapp/src/script/components/calling/GroupVideoGrid.tsx
@@ -17,14 +17,15 @@
  *
  */
 
-import {ReactNode, CSSProperties, useEffect, useState} from 'react';
+import {CSSProperties, ReactNode, useEffect, useState} from 'react';
 
 import {css} from '@emotion/react';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
-import {QUERY} from '@wireapp/react-ui-kit';
+import {Loading, QUERY} from '@wireapp/react-ui-kit';
 
 import {Avatar, AVATAR_SIZE} from 'Components/avatar';
+import {groupVideoBackgroundInitializingOverlay} from 'Components/calling/GroupVideoGridTile.styles';
 import * as Icon from 'Components/icon';
 import {useActiveWindowMatchMedia} from 'Hooks/useActiveWindowMatchMedia';
 import {Call} from 'Repositories/calling/Call';
@@ -34,6 +35,7 @@ import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 
 import {GroupVideoGridTile} from './GroupVideoGridTile';
+import {useShowLoadingOverlay} from './useShowLoadingOverlay';
 import {Video} from './Video';
 
 const PARTICIPANTS_LIMITS = {
@@ -148,6 +150,11 @@ const GroupVideoGrid = ({
     'videoStream',
     'processedVideoStream',
   ]);
+  const {showLoadingOverlay, onVideoCanPlay} = useShowLoadingOverlay(
+    true,
+    thumbnail.hasActiveVideo,
+    thumbnail.processedVideoStream,
+  );
 
   const [rowsAndColumns, setRowsAndColumns] = useState<RowsAndColumns>(
     calculateRowsAndColumns({
@@ -286,11 +293,21 @@ const GroupVideoGrid = ({
             */
             muted
             data-uie-name="self-video-thumbnail"
+            onCanPlay={onVideoCanPlay}
             css={{
               transform: thumbnail.hasActiveVideo && !thumbnail.sharesScreen ? 'rotateY(180deg)' : 'initial',
             }}
             srcObject={thumbnail.processedVideoStream?.stream ?? thumbnail.videoStream}
           />
+          {showLoadingOverlay && (
+            <div
+              aria-busy={showLoadingOverlay}
+              css={groupVideoBackgroundInitializingOverlay}
+              data-uie-name="background-effect-initializing"
+            >
+              <Loading size={32} />
+            </div>
+          )}
           {selfIsMuted && !minimized && (
             <span className="group-video-grid__element__label__icon" data-uie-name="status-call-audio-muted">
               <Icon.MicOffIcon data-uie-name="mic-icon-off" />


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27244" title="WPB-27244" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27244</a>  Loader not appearing for the user when enabling camera with BGE in 1:1 Call 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Reuse the video loading state for self-participant thumbnails so 1:1 calls and CallingCell display the loader while processed video becomes ready. Add a regression test covering the thumbnail loading lifecycle.


