### PR TITLE
fix: establish MLS for meeting conversations after login [WPB-26735]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/joinMeetingCall.test.ts
+++ b/apps/webapp/src/script/components/Meeting/joinMeetingCall.test.ts
@@ -60,6 +60,7 @@ const createDeps = (overrides: Partial<JoinMeetingCallDeps> = {}): JoinMeetingCa
 
   const conversationRepository = {
     safeGetConversationById: () => task.reject('not found'),
+    safeEnsureConversationExists: () => task.resolve(undefined),
   } as unknown as ConversationRepository;
 
   const callingRepository = {
@@ -99,6 +100,58 @@ describe('joinMeetingCall', () => {
     expect(answer).not.toHaveBeenCalled();
   });
 
+  it('ensures the MLS group exists locally before starting the call', async () => {
+    const conversation = createMeetingConversation();
+    const startAudio = jest.fn(async () => {});
+    const safeEnsureConversationExists = jest.fn(() => task.resolve(undefined));
+
+    const deps = createDeps({
+      conversationState: {
+        findConversation: () => conversation,
+      } as unknown as ConversationState,
+      conversationRepository: {
+        safeGetConversationById: () => task.reject('not found'),
+        safeEnsureConversationExists,
+      } as unknown as ConversationRepository,
+      callingViewModel: {
+        callActions: {answer: jest.fn(), startAudio},
+      } as unknown as CallingViewModel,
+    });
+
+    const result = await joinMeetingCall(deps, qualifiedConversationId);
+
+    expect(result.isOk).toBe(true);
+    expect(safeEnsureConversationExists).toHaveBeenCalledWith({
+      conversationId: conversation.qualifiedId,
+      groupId: conversation.groupId,
+    });
+    expect(startAudio).toHaveBeenCalledWith(conversation);
+  });
+
+  it('returns joinFailed when ensuring the MLS group fails', async () => {
+    const conversation = createMeetingConversation();
+    const startAudio = jest.fn(async () => {});
+
+    const deps = createDeps({
+      conversationState: {
+        findConversation: () => conversation,
+      } as unknown as ConversationState,
+      conversationRepository: {
+        safeGetConversationById: () => task.reject('not found'),
+        safeEnsureConversationExists: () => task.reject(new Error('mls missing')),
+      } as unknown as ConversationRepository,
+      callingViewModel: {
+        callActions: {answer: jest.fn(), startAudio},
+      } as unknown as CallingViewModel,
+    });
+
+    const result = await joinMeetingCall(deps, qualifiedConversationId);
+
+    expect(result.isErr).toBe(true);
+    expect(unwrapErr(result)).toBe(joinMeetingCallErrors.joinFailed);
+    expect(startAudio).not.toHaveBeenCalled();
+  });
+
   it('answers an incoming call when one exists in the meeting conversation', async () => {
     const conversation = createMeetingConversation();
     const incomingCall = createIncomingCall(conversation);
@@ -129,6 +182,7 @@ describe('joinMeetingCall', () => {
     const startAudio = jest.fn(async () => {});
     const findConversation = jest.fn(() => undefined);
     const safeGetConversationById = jest.fn(() => task.resolve(conversation));
+    const safeEnsureConversationExists = jest.fn(() => task.resolve(undefined));
 
     const deps = createDeps({
       conversationState: {
@@ -136,6 +190,7 @@ describe('joinMeetingCall', () => {
       } as unknown as ConversationState,
       conversationRepository: {
         safeGetConversationById,
+        safeEnsureConversationExists,
       } as unknown as ConversationRepository,
       callingViewModel: {
         callActions: {answer: jest.fn(), startAudio},
@@ -147,6 +202,10 @@ describe('joinMeetingCall', () => {
     expect(result.isOk).toBe(true);
     expect(findConversation).toHaveBeenCalledWith(qualifiedConversationId);
     expect(safeGetConversationById).toHaveBeenCalledWith(qualifiedConversationId);
+    expect(safeEnsureConversationExists).toHaveBeenCalledWith({
+      conversationId: conversation.qualifiedId,
+      groupId: conversation.groupId,
+    });
     expect(startAudio).toHaveBeenCalledWith(conversation);
   });
 

--- a/apps/webapp/src/script/components/Meeting/joinMeetingCall.ts
+++ b/apps/webapp/src/script/components/Meeting/joinMeetingCall.ts
@@ -24,6 +24,7 @@ import {STATE as CALL_STATE} from '@wireapp/avs';
 
 import type {CallingRepository} from 'Repositories/calling/CallingRepository';
 import type {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
+import {isMLSCapableConversation} from 'Repositories/conversation/ConversationSelectors';
 import type {ConversationState} from 'Repositories/conversation/ConversationState';
 import type {Conversation} from 'Repositories/entity/Conversation';
 import type {CallingViewModel} from 'src/script/view_model/CallingViewModel';
@@ -57,6 +58,28 @@ const resolveConversation = (
     .mapRejected(() => joinMeetingCallErrors.conversationNotFound);
 };
 
+/**
+ * Meeting conversations are MLS group conversations that are not covered by
+ * `isGroupOrChannel()`, so they can be missing from core-crypto after a fresh login.
+ * Ensure the parent MLS group exists before creating the conference subconversation.
+ */
+const ensureMlsConversationReady = (
+  deps: JoinMeetingCallDeps,
+  conversation: Conversation,
+): Task<Conversation, JoinMeetingCallError> => {
+  if (!isMLSCapableConversation(conversation)) {
+    return task.resolve(conversation);
+  }
+
+  return deps.conversationRepository
+    .safeEnsureConversationExists({
+      conversationId: conversation.qualifiedId,
+      groupId: conversation.groupId,
+    })
+    .map(() => conversation)
+    .mapRejected(() => joinMeetingCallErrors.joinFailed);
+};
+
 const performJoin = (deps: JoinMeetingCallDeps, conversation: Conversation): Task<void, JoinMeetingCallError> => {
   const call = deps.callingRepository.findCall(conversation.qualifiedId);
 
@@ -81,4 +104,6 @@ export const joinMeetingCall = (
   deps: JoinMeetingCallDeps,
   qualifiedConversationId: QualifiedId,
 ): Task<void, JoinMeetingCallError> =>
-  resolveConversation(deps, qualifiedConversationId).andThen(conversation => performJoin(deps, conversation));
+  resolveConversation(deps, qualifiedConversationId)
+    .andThen(conversation => ensureMlsConversationReady(deps, conversation))
+    .andThen(conversation => performJoin(deps, conversation));

--- a/apps/webapp/src/script/mls/MLSConversations.test.ts
+++ b/apps/webapp/src/script/mls/MLSConversations.test.ts
@@ -82,7 +82,7 @@ describe('MLSConversations', () => {
       mlsConversations.forEach(c => (c.epoch = 1));
 
       const conversationRepository = await testFactory.exposeConversationActors();
-      const repositoryCore = (conversationRepository as any).core as Core;
+      const repositoryCore = conversationRepository['core'];
       jest.spyOn(repositoryCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
       jest
         .spyOn(
@@ -106,7 +106,7 @@ describe('MLSConversations', () => {
       mlsConversation.status(ConversationStatus.PAST_MEMBER);
 
       const conversationRepository = await testFactory.exposeConversationActors();
-      const repositoryCore = (conversationRepository as any).core as Core;
+      const repositoryCore = conversationRepository['core'];
 
       jest.spyOn(repositoryCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
       mockSafeEpoch(repositoryCore);
@@ -122,7 +122,7 @@ describe('MLSConversations', () => {
       meetingConversation.groupConversationType(GROUP_CONVERSATION_TYPE.MEETING);
 
       const conversationRepository = await testFactory.exposeConversationActors();
-      const repositoryCore = (conversationRepository as any).core as Core;
+      const repositoryCore = conversationRepository['core'];
       jest.spyOn(repositoryCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
       jest
         .spyOn(
@@ -202,7 +202,7 @@ describe('MLSConversations', () => {
       const conversations = [teamConversation, ...mlsConversations, selfConversation];
 
       const conversationRepository = await testFactory.exposeConversationActors();
-      const repositoryCore = (conversationRepository as any).core as Core;
+      const repositoryCore = conversationRepository['core'];
       jest.spyOn(repositoryCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(true);
       mockSafeEpoch(core);
 
@@ -232,7 +232,7 @@ describe('MLSConversations', () => {
       const conversations = [teamConversation, ...mlsConversations, selfConversation];
 
       const conversationRepository = await testFactory.exposeConversationActors();
-      const repositoryCore = (conversationRepository as any).core as Core;
+      const repositoryCore = conversationRepository['core'];
       mockSafeEpoch(repositoryCore);
       // MLS group is not yet established locally
       jest.spyOn(repositoryCore.service!.mls!, 'isConversationEstablished').mockResolvedValue(false);

--- a/apps/webapp/src/script/mls/MLSConversations.test.ts
+++ b/apps/webapp/src/script/mls/MLSConversations.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
+import {CONVERSATION_TYPE, GROUP_CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {result, task} from 'true-myth';
@@ -115,6 +115,28 @@ describe('MLSConversations', () => {
       await initMLSGroupConversations([mlsConversation], conversationRepository, {core: repositoryCore});
 
       expect(joinSpy).not.toHaveBeenCalled();
+    });
+
+    it('joins unestablished MLS meeting conversations after login', async () => {
+      const meetingConversation = createMLSConversation(CONVERSATION_TYPE.REGULAR, 1);
+      meetingConversation.groupConversationType(GROUP_CONVERSATION_TYPE.MEETING);
+
+      const conversationRepository = await testFactory.exposeConversationActors();
+      const repositoryCore = (conversationRepository as any).core as Core;
+      jest.spyOn(repositoryCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
+      jest
+        .spyOn(
+          (conversationRepository as unknown as {conversationService: {getSafeConversationById: jest.Mock}})
+            .conversationService,
+          'getSafeConversationById',
+        )
+        .mockReturnValue(task.fromResult(result.ok({epoch: 1})));
+      mockSafeEpoch(repositoryCore);
+      const joinSpy = jest.spyOn(repositoryCore.service!.conversation, 'joinByExternalCommit');
+
+      await initMLSGroupConversations([meetingConversation], conversationRepository, {core: repositoryCore});
+
+      expect(joinSpy).toHaveBeenCalledWith(meetingConversation.qualifiedId);
     });
   });
 

--- a/apps/webapp/src/script/mls/MLSConversations.ts
+++ b/apps/webapp/src/script/mls/MLSConversations.ts
@@ -43,6 +43,7 @@ const logger = getLogger('Webapp/MLSConversations');
 
 /**
  * Will initialize all the MLS conversations that the user is member of but that are not yet locally established.
+ * Includes group, channel, and meeting conversations.
  *
  * @param conversations - all the conversations that the user is part of
  * @param core - the instance of the core
@@ -67,7 +68,9 @@ export async function initMLSGroupConversations(
 
   const mlsGroupConversations = conversations.filter(
     (conversation): conversation is MLSCapableConversation =>
-      conversation.isGroupOrChannel() && isMLSCapableConversation(conversation) && !conversation.isSelfUserRemoved(),
+      (conversation.isGroupOrChannel() || conversation.isMeeting()) &&
+      isMLSCapableConversation(conversation) &&
+      !conversation.isSelfUserRemoved(),
   );
 
   for (const mlsConversation of mlsGroupConversations) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26735" title="WPB-26735" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26735</a>  [Web] Support new event types for Meetings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- After a fresh login, joining a meeting could fail with `Couldn't find conversation` because meeting MLS groups were never set up locally.
- Meeting conversations are now included in MLS init on login (they were skipped before because they are not group or channel conversations).
- Joining from the meetings list also ensures the parent MLS group exists before starting or answering the call.

## Test plan
- [x] Fresh login with meetings enabled
- [x] Open Meetings and click Join on an ongoing meeting
- [x] Confirm the call starts without the MLS `Couldn't find conversation` error
- [x] Confirm regular group and channel calls still work after login
- [x] `yarn nx run webapp:test --testFile=src/script/mls/MLSConversations.test.ts`
- [x] `yarn nx run webapp:test --testFile=src/script/components/Meeting/joinMeetingCall.test.ts`