### PR TITLE
Simplify WebApp release summaries [WPB-26469]

### DIFF
--- a/bin/renderWebappReleaseSummary.test.ts
+++ b/bin/renderWebappReleaseSummary.test.ts
@@ -17,18 +17,19 @@
  *
  */
 
+import {Maybe} from 'true-myth';
+
 import {
   readWebappReleaseSummaryInput,
   renderWebappReleaseCandidateSummary,
   renderWebappReleaseSummary,
 } from './renderWebappReleaseSummary.ts';
-import type {
-  ProductionPreflightResult,
-  ReleaseBranchAction,
-  WebappReleaseSummaryInput,
-  WorkflowJobResult,
-} from './renderWebappReleaseSummary.ts';
-import {Maybe} from 'true-myth';
+import type {WebappReleaseSummaryInput} from './renderWebappReleaseSummary.ts';
+
+const releaseCommitSha = '1234567890abcdef1234567890abcdef12345678';
+const sourceCommitSha = 'abcdef1234567890abcdef1234567890abcdef12';
+const betaTagName = '2026-07-17.1-beta.1';
+const productionTagName = '2026-07-17.1-production';
 
 const baselineWebappReleaseSummaryInput: WebappReleaseSummaryInput = {
   beta: {
@@ -38,7 +39,7 @@ const baselineWebappReleaseSummaryInput: WebappReleaseSummaryInput = {
     runtimeBackendWebSocket: Maybe.just('wss://beta-backend.example.com'),
     runtimeVerificationResult: Maybe.just('success'),
     tagCreationResult: Maybe.just('success'),
-    tagName: Maybe.just('2026-07-17.1-beta.1'),
+    tagName: Maybe.just(betaTagName),
     webappUrl: Maybe.just('https://beta.example.com'),
   },
   distribution: {
@@ -68,7 +69,7 @@ const baselineWebappReleaseSummaryInput: WebappReleaseSummaryInput = {
   },
   preparation: {
     branchAction: Maybe.just('created'),
-    sourceCommitSha: Maybe.just('abcdef1234567890abcdef1234567890abcdef12'),
+    sourceCommitSha: Maybe.just(sourceCommitSha),
     sourceRef: Maybe.just('main'),
   },
   production: {
@@ -76,7 +77,7 @@ const baselineWebappReleaseSummaryInput: WebappReleaseSummaryInput = {
     deploymentResult: Maybe.just('skipped'),
     deploymentRequired: Maybe.just(false),
     environmentName: Maybe.just('wire-webapp-production'),
-    plannedTagName: Maybe.just('2026-07-17.1-production'),
+    plannedTagName: Maybe.just(productionTagName),
     preflightJobResult: Maybe.just('skipped'),
     preflightResult: Maybe.just('skipped'),
     promotionRequested: false,
@@ -94,70 +95,108 @@ const baselineWebappReleaseSummaryInput: WebappReleaseSummaryInput = {
     artifactName: Maybe.just('wire-webapp-release-2026-07-17.1'),
     artifactVersion: Maybe.just('2026-07-17.1'),
     branch: Maybe.just('release/2026-07-17.1'),
-    commitSha: Maybe.just('1234567890abcdef1234567890abcdef12345678'),
+    commitSha: Maybe.just(releaseCommitSha),
     identifier: Maybe.just('2026-07-17.1'),
     manualReason: Maybe.nothing<string>(),
   },
 };
 
-function assertSummaryContract(summary: string): void {
-  expect(summary).toMatch(/\n$/);
-  expect(summary).toMatch(/^## Release preparation$/m);
-  expect(summary).toMatch(/^### Hosted Beta validation$/m);
-  expect(summary).toMatch(/^### E2E system gate$/m);
-  expect(summary).toMatch(/^### Hosted Production promotion$/m);
-  expect(summary).toMatch(/^### Release distribution$/m);
-  expect(summary).not.toMatch(/\]\(\)/);
-  expect(summary).not.toMatch(/\/releases\/tag\//);
-  expect(summary).not.toMatch(/undefined/);
-  expect(summary).not.toMatch(/null/);
-  expect(summary).not.toMatch(/Artifact version:/);
+function visibleSummary(summary: string): string {
+  return summary.split('<details>')[0];
+}
+
+function technicalEvidence(summary: string): string {
+  return summary.slice(summary.indexOf('<details>'));
+}
+
+function countOccurrences(value: string, searchedValue: string): number {
+  return value.split(searchedValue).length - 1;
+}
+
+function assertMarkdownContract(summary: string, includesDistribution: boolean): void {
+  const visibleContent = visibleSummary(summary);
+  const detailsContent = technicalEvidence(summary);
+
+  expect(summary.endsWith('\n')).toBe(true);
+  expect(summary.endsWith('\n\n')).toBe(false);
+  expect(countOccurrences(summary, '<details>')).toBe(1);
+  expect(countOccurrences(summary, '</details>')).toBe(1);
+  expect(summary).toContain('<details>\n<summary>Technical release evidence</summary>\n\n');
+  expect(detailsContent).toContain('\n\n</details>');
+  expect(summary).not.toContain(']();');
+  expect(summary).not.toContain(']()');
+  expect(summary).not.toContain('/releases/tag/');
+  expect(summary).not.toContain('undefined');
+  expect(summary).not.toContain('null');
+  expect(countOccurrences(visibleContent, '- Webapp version:')).toBe(1);
+  expect(countOccurrences(visibleContent, '- Workflow run:')).toBe(1);
+  expect(visibleContent).not.toContain('- Asset version:');
+  expect(visibleContent).not.toContain('- Built at (UTC):');
+  expect(visibleContent).not.toContain('- Artifact name:');
+  expect(visibleContent).not.toContain('- Artifact checksum:');
+  expect(technicalEvidence(summary)).toContain('### Release preparation');
+
+  if (includesDistribution) {
+    expect(summary).toContain('### Release distribution');
+  } else {
+    expect(summary).not.toContain('### Release distribution');
+  }
+}
+
+function assertVisibleIdentity(summary: string): void {
+  const visibleContent = visibleSummary(summary);
+
+  expect(visibleContent).toContain('- Release: `2026-07-17.1`');
+  expect(visibleContent).toContain('- Release branch: `release/2026-07-17.1`');
+  expect(visibleContent).toContain(
+    `- Commit: [${releaseCommitSha}](https://github.com/wireapp/wire-webapp/commit/${releaseCommitSha})`,
+  );
+  expect(visibleContent).toContain('- Webapp version: `2026-07-17.1`');
+  expect(visibleContent).toContain(
+    '- Workflow run: [https://github.com/wireapp/wire-webapp/actions/runs/123456789](https://github.com/wireapp/wire-webapp/actions/runs/123456789)',
+  );
 }
 
 describe('WebApp release summary renderer', () => {
-  it('renders a successful Beta-only release', () => {
+  it('renders a successful Beta-only release with a concise visible overview', () => {
     const summary = renderWebappReleaseSummary(baselineWebappReleaseSummaryInput);
+    const visibleContent = visibleSummary(summary);
+    const detailsContent = technicalEvidence(summary);
 
-    assertSummaryContract(summary);
-    expect(summary).toMatch(/^- Release identifier: 2026-07-17\.1$/m);
-    expect(summary).toMatch(
-      /^- Commit SHA: \[1234567890abcdef1234567890abcdef12345678\]\(https:\/\/github\.com\/wireapp\/wire-webapp\/commit\/1234567890abcdef1234567890abcdef12345678\)$/m,
+    assertMarkdownContract(summary, true);
+    assertVisibleIdentity(summary);
+    expect(visibleContent).toContain('## WebApp release');
+    expect(visibleContent).toContain('Beta release completed; Production promotion was not requested');
+    expect(visibleContent).toContain(`- Hosted Beta: deployed and verified successfully — tag [${betaTagName}]`);
+    expect(visibleContent).toContain('- E2E system gate: passed successfully — [Playwright report]');
+    expect(visibleContent).toContain('- Hosted Production: not requested');
+    expect(visibleContent).toContain('- Release distribution: not requested');
+    expect(detailsContent).toContain('- Asset version: 2026-07-17.1-1234567');
+    expect(detailsContent).toContain('- Built at (UTC): 2026-07-20T06:18:03.123Z');
+    expect(detailsContent).toContain(
+      '- Artifact checksum: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     );
-    expect(summary).toContain(
-      [
-        '- Webapp version: 2026-07-17.1',
-        '- Asset version: 2026-07-17.1-1234567',
-        '- Commit SHA: [1234567890abcdef1234567890abcdef12345678](https://github.com/wireapp/wire-webapp/commit/1234567890abcdef1234567890abcdef12345678)',
-        '- Built at (UTC): 2026-07-20T06:18:03.123Z',
-      ].join('\n'),
+    expect(detailsContent).toContain(
+      '- Workflow run URL: [https://github.com/wireapp/wire-webapp/actions/runs/123456789]',
     );
-    expect(summary).toMatch(/^- Built at \(UTC\): 2026-07-20T06:18:03\.123Z$/m);
-    expect(summary).toMatch(/### Hosted Beta validation[\s\S]*?- Webapp version: 2026-07-17\.1/m);
-    expect(summary).toMatch(/### Hosted Beta validation[\s\S]*?- Asset version: 2026-07-17\.1-1234567/m);
-    expect(summary).toMatch(/### E2E system gate[\s\S]*?- Webapp version: 2026-07-17\.1/m);
-    expect(summary).toMatch(/### E2E system gate[\s\S]*?- Asset version: 2026-07-17\.1-1234567/m);
-    expect(summary).toMatch(/### Hosted Production promotion[\s\S]*?- Webapp version: 2026-07-17\.1/m);
-    expect(summary).toMatch(/### Hosted Production promotion[\s\S]*?- Asset version: 2026-07-17\.1-1234567/m);
-    expect(summary).toMatch(/### Hosted Beta validation[\s\S]*?- Result: deployed and verified successfully/m);
-    expect(summary).toMatch(/### E2E system gate[\s\S]*?- Result: passed successfully/m);
-    expect(summary).toMatch(/### Hosted Production promotion[\s\S]*?- Result: not requested/m);
-    expect(summary).toMatch(/### Release distribution[\s\S]*?- Result: not requested/m);
-    expect(summary).toMatch(
-      /- Beta tag: \[2026-07-17\.1-beta\.1\]\(https:\/\/github\.com\/wireapp\/wire-webapp\/tree\/2026-07-17\.1-beta\.1\)/,
-    );
-    expect(summary).toMatch(/- Production tag: not requested/);
-    expect(summary).not.toMatch(/### Hosted Production promotion[\s\S]*?- Production tag: \[/m);
   });
 
-  it('renders a successful Production release with distribution metadata', () => {
-    const productionTagName = '2026-07-17.1-production';
-    const productionImageTag = `${productionTagName}-v0.34.9-0-1234567`;
+  it('shows the verified Beta tag once in the visible candidate summary', () => {
+    const summary = renderWebappReleaseCandidateSummary(baselineWebappReleaseSummaryInput);
+    const visibleContent = visibleSummary(summary);
+
+    expect(visibleContent).toContain(`- Hosted Beta: deployed and verified successfully — tag [${betaTagName}]`);
+    expect(countOccurrences(visibleContent, `[${betaTagName}]`)).toBe(1);
+    expect(visibleContent).not.toContain('- Beta tag:');
+  });
+
+  it('renders a successful Production release and distribution evidence', () => {
     const wireBuildsCommitSha = 'abcdefabcdefabcdefabcdefabcdefabcdefabcd';
     const input: WebappReleaseSummaryInput = {
       ...baselineWebappReleaseSummaryInput,
       distribution: {
         ...baselineWebappReleaseSummaryInput.distribution,
-        dockerImageTag: Maybe.just(productionImageTag),
+        dockerImageTag: Maybe.just(`${productionTagName}-v0.34.9-0-1234567`),
         distributionJobResult: Maybe.just('success'),
         distributionResult: Maybe.just('success'),
         helmChartVersion: Maybe.just('0.8.0-pre.3175'),
@@ -167,6 +206,7 @@ describe('WebApp release summary renderer', () => {
         ...baselineWebappReleaseSummaryInput.production,
         createdTagName: Maybe.just(productionTagName),
         deploymentResult: Maybe.just('success'),
+        deploymentRequired: Maybe.just(true),
         preflightJobResult: Maybe.just('success'),
         preflightResult: Maybe.just('ready'),
         promotionRequested: true,
@@ -175,66 +215,291 @@ describe('WebApp release summary renderer', () => {
       },
     };
     const summary = renderWebappReleaseSummary(input);
+    const visibleContent = visibleSummary(summary);
+    const detailsContent = technicalEvidence(summary);
 
-    assertSummaryContract(summary);
-    expect(summary).toMatch(
-      /### Hosted Production promotion[\s\S]*?- Result: deployed, verified, and tagged successfully/m,
+    assertMarkdownContract(summary, true);
+    assertVisibleIdentity(summary);
+    expect(visibleContent).toContain('- Outcome: Release completed successfully');
+    expect(visibleContent).toContain(
+      `Hosted Production: deployed, verified, and tagged successfully — tag [${productionTagName}]`,
     );
-    expect(summary).toMatch(
-      /### Hosted Production promotion[\s\S]*?- Runtime verification result: verified successfully/m,
+    expect(visibleContent).toContain(
+      `Release distribution: published successfully — Docker \`quay.io/wire/webapp:${productionTagName}-v0.34.9-0-1234567\`, Helm \`0.8.0-pre.3175\`, wire-builds [${wireBuildsCommitSha}](https://github.com/wireapp/wire-builds/commit/${wireBuildsCommitSha})`,
     );
-    expect(summary).toMatch(
-      /### Hosted Production promotion[\s\S]*?- Runtime verification: \/version and \/config\.js/m,
-    );
-    expect(summary).toMatch(
-      /- Production tag: \[2026-07-17\.1-production\]\(https:\/\/github\.com\/wireapp\/wire-webapp\/tree\/2026-07-17\.1-production\)/,
-    );
-    expect(summary).toMatch(/- Docker image: quay\.io\/wire\/webapp:2026-07-17\.1-production-v0\.34\.9-0-1234567/);
-    expect(summary).toMatch(/- Helm chart repository: https:\/\/charts\.example\.com\/webapp/);
-    expect(summary).toMatch(/- Helm chart version: 0\.8\.0-pre\.3175/);
-    expect(summary).toMatch(
-      /- wire-builds\/main commit: \[abcdefabcdefabcdefabcdefabcdefabcdefabcd\]\(https:\/\/github\.com\/wireapp\/wire-builds\/commit\/abcdefabcdefabcdefabcdefabcdefabcdefabcd\)/,
-    );
-    expect(summary).toMatch(/- Approval gate: wire-webapp-production GitHub Environment settings/);
+    expect(detailsContent).toContain('- Runtime verification result: verified successfully');
+    expect(detailsContent).toContain('- Production tag creation result: created successfully');
+    expect(detailsContent).toContain('- Docker image: quay.io/wire/webapp:2026-07-17.1-production-v0.34.9-0-1234567');
+    expect(detailsContent).toContain('- Helm chart repository: https://charts.example.com/webapp');
   });
 
-  it('renders a Production release that is already tagged', () => {
-    const plannedProductionTagName = '2026-07-17.1-production';
+  it('renders a release candidate that is ready for Production approval', () => {
     const input: WebappReleaseSummaryInput = {
       ...baselineWebappReleaseSummaryInput,
       production: {
         ...baselineWebappReleaseSummaryInput.production,
-        createdTagName: Maybe.just('created-production-tag'),
-        deploymentResult: Maybe.just('skipped'),
+        deploymentRequired: Maybe.just(true),
+        preflightJobResult: Maybe.just('success'),
+        preflightResult: Maybe.just('ready'),
+        promotionRequested: true,
+      },
+    };
+    const summary = renderWebappReleaseCandidateSummary(input);
+    const visibleContent = visibleSummary(summary);
+    const detailsContent = technicalEvidence(summary);
+
+    assertMarkdownContract(summary, false);
+    assertVisibleIdentity(summary);
+    expect(visibleContent).toContain('## WebApp release candidate');
+    expect(visibleContent).toContain('Release candidate passed and is ready for Production approval');
+    expect(visibleContent).toContain(
+      '- Hosted Production: ready for approval through the wire-webapp-prod GitHub Environment',
+    );
+    expect(detailsContent).toContain('- Production promotion requested: true');
+    expect(detailsContent).toContain('- Production preflight job result: success');
+    expect(detailsContent).toContain('- Planned Production tag: `2026-07-17.1-production`');
+    expect(detailsContent).toContain(
+      '- Approval status: Production is ready for deployment. Approval is enforced through the wire-webapp-prod GitHub Environment.',
+    );
+  });
+
+  it('renders an already-tagged Production release without linking a nonexistent tag', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      production: {
+        ...baselineWebappReleaseSummaryInput.production,
+        deploymentRequired: Maybe.just(false),
         preflightJobResult: Maybe.just('success'),
         preflightResult: Maybe.just('already_tagged'),
         promotionRequested: true,
+      },
+    };
+    const summary = renderWebappReleaseSummary(input);
+    const visibleContent = visibleSummary(summary);
+    const detailsContent = technicalEvidence(summary);
+
+    assertMarkdownContract(summary, true);
+    expect(visibleContent).toContain('Release already has the matching Production tag; deployment was not repeated');
+    expect(visibleContent).toContain(
+      `Hosted Production: already tagged; deployment not required — tag [${productionTagName}](https://github.com/wireapp/wire-webapp/tree/${productionTagName})`,
+    );
+    expect(visibleContent).toContain('- Release distribution: not run; Production tag already exists');
+    expect(detailsContent).toContain('- Production tag creation result: not required; tag already exists');
+    expect(summary).not.toContain('created-production-tag');
+  });
+
+  it('stops a release when Hosted Beta deployment fails', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      beta: {
+        ...baselineWebappReleaseSummaryInput.beta,
+        deploymentResult: Maybe.just('failure'),
+        tagCreationResult: Maybe.just('skipped'),
+        tagName: Maybe.nothing<string>(),
+      },
+      e2e: {
+        ...baselineWebappReleaseSummaryInput.e2e,
+        result: Maybe.just('skipped'),
+      },
+      production: {
+        ...baselineWebappReleaseSummaryInput.production,
+        deploymentRequired: Maybe.nothing<boolean>(),
+        preflightJobResult: Maybe.just('skipped'),
+        preflightResult: Maybe.nothing(),
+        promotionRequested: true,
+      },
+    };
+    const finalSummary = renderWebappReleaseSummary(input);
+    const candidateSummary = renderWebappReleaseCandidateSummary(input);
+
+    expect(visibleSummary(finalSummary)).toContain('Release stopped because Hosted Beta deployment failed');
+    expect(visibleSummary(candidateSummary)).toContain(
+      'Release candidate blocked because Hosted Beta deployment failed',
+    );
+    expect(visibleSummary(finalSummary)).toContain(
+      '- Hosted Production: blocked because Hosted Beta deployment failed',
+    );
+    expect(technicalEvidence(finalSummary)).toContain('- Result: failed');
+  });
+
+  it('reports an incomplete release when Hosted Beta deployment is skipped', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      beta: {
+        ...baselineWebappReleaseSummaryInput.beta,
+        deploymentResult: Maybe.just('skipped'),
+      },
+      e2e: {
+        ...baselineWebappReleaseSummaryInput.e2e,
+        result: Maybe.just('skipped'),
+      },
+      production: {
+        ...baselineWebappReleaseSummaryInput.production,
+        deploymentRequired: Maybe.nothing<boolean>(),
+        preflightJobResult: Maybe.just('skipped'),
+        preflightResult: Maybe.nothing(),
+        promotionRequested: true,
+      },
+    };
+    const summary = renderWebappReleaseSummary(input);
+    const visibleContent = visibleSummary(summary);
+
+    expect(visibleContent).toContain('- Outcome: Release incomplete because Hosted Beta deployment did not run');
+    expect(visibleContent).toContain('- Hosted Production: unavailable because Hosted Beta deployment did not run');
+  });
+
+  it('reports an incomplete release when Beta tag creation is skipped', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      beta: {
+        ...baselineWebappReleaseSummaryInput.beta,
+        tagCreationResult: Maybe.just('skipped'),
+        tagName: Maybe.nothing<string>(),
+      },
+      e2e: {
+        ...baselineWebappReleaseSummaryInput.e2e,
+        result: Maybe.just('skipped'),
+      },
+      production: {
+        ...baselineWebappReleaseSummaryInput.production,
+        deploymentRequired: Maybe.nothing<boolean>(),
+        preflightJobResult: Maybe.just('skipped'),
+        preflightResult: Maybe.nothing(),
+        promotionRequested: true,
+      },
+    };
+    const summary = renderWebappReleaseSummary(input);
+    const visibleContent = visibleSummary(summary);
+
+    expect(visibleContent).toContain('- Outcome: Release incomplete because Beta tag creation did not run');
+    expect(visibleContent).toContain('- Hosted Production: unavailable because Beta tag creation did not run');
+  });
+
+  it('reports an incomplete release when the E2E system gate is skipped', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      e2e: {
+        ...baselineWebappReleaseSummaryInput.e2e,
+        result: Maybe.just('skipped'),
+      },
+      production: {
+        ...baselineWebappReleaseSummaryInput.production,
+        deploymentRequired: Maybe.nothing<boolean>(),
+        preflightJobResult: Maybe.just('skipped'),
+        preflightResult: Maybe.nothing(),
+        promotionRequested: true,
+      },
+    };
+    const summary = renderWebappReleaseSummary(input);
+    const visibleContent = visibleSummary(summary);
+
+    expect(visibleContent).toContain('- Outcome: Release incomplete because the E2E system gate did not run');
+    expect(visibleContent).toContain('- Hosted Production: unavailable because the E2E system gate did not run');
+  });
+
+  it('stops a release when the E2E system gate fails', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      e2e: {
+        ...baselineWebappReleaseSummaryInput.e2e,
+        result: Maybe.just('failure'),
+      },
+      production: {
+        ...baselineWebappReleaseSummaryInput.production,
+        deploymentRequired: Maybe.nothing<boolean>(),
+        preflightJobResult: Maybe.just('skipped'),
+        preflightResult: Maybe.nothing(),
+        promotionRequested: true,
+      },
+    };
+    const finalSummary = renderWebappReleaseSummary(input);
+    const candidateSummary = renderWebappReleaseCandidateSummary(input);
+
+    expect(visibleSummary(finalSummary)).toContain('Release stopped because the E2E system gate failed');
+    expect(visibleSummary(candidateSummary)).toContain('Release candidate blocked because the E2E system gate failed');
+    expect(visibleSummary(finalSummary)).toContain('- Hosted Production: blocked because the E2E system gate failed');
+    expect(technicalEvidence(finalSummary)).toContain('- Result: failed');
+  });
+
+  it('communicates an E2E cancellation without calling it a failure', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      e2e: {
+        ...baselineWebappReleaseSummaryInput.e2e,
+        result: Maybe.just('cancelled'),
+      },
+      github: {
+        ...baselineWebappReleaseSummaryInput.github,
+        runId: Maybe.just('29831901474'),
+      },
+      production: {
+        ...baselineWebappReleaseSummaryInput.production,
+        deploymentRequired: Maybe.nothing<boolean>(),
+        preflightJobResult: Maybe.just('skipped'),
+        preflightResult: Maybe.nothing(),
+        promotionRequested: true,
+      },
+    };
+    const candidateSummary = renderWebappReleaseCandidateSummary(input);
+    const finalSummary = renderWebappReleaseSummary(input);
+    const candidateVisibleContent = visibleSummary(candidateSummary);
+    const finalVisibleContent = visibleSummary(finalSummary);
+
+    expect(candidateVisibleContent).toContain('Release candidate stopped because the E2E system gate was cancelled');
+    expect(finalVisibleContent).toContain('Release stopped because the E2E system gate was cancelled');
+    expect(finalVisibleContent).toContain('- Hosted Beta: deployed and verified successfully');
+    expect(finalVisibleContent).toContain('- E2E system gate: cancelled');
+    expect(finalVisibleContent).toContain('- Hosted Production: unavailable because the E2E system gate was cancelled');
+    expect(finalVisibleContent).toContain('- Release distribution: not run');
+    expect(finalVisibleContent).not.toContain('E2E system gate failed');
+  });
+
+  it('stops a release when Production preflight fails', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      production: {
+        ...baselineWebappReleaseSummaryInput.production,
+        deploymentRequired: Maybe.just(true),
+        preflightJobResult: Maybe.just('failure'),
+        preflightResult: Maybe.just('failure'),
+        promotionRequested: true,
+      },
+    };
+    const summary = renderWebappReleaseSummary(input);
+
+    expect(visibleSummary(summary)).toContain('Release stopped because Production preflight failed');
+    expect(visibleSummary(summary)).toContain('- Hosted Production: failed during preflight');
+    expect(technicalEvidence(summary)).toContain('- Production preflight result: failed');
+  });
+
+  it('stops a release when Hosted Production deployment fails', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      production: {
+        ...baselineWebappReleaseSummaryInput.production,
+        deploymentResult: Maybe.just('failure'),
+        deploymentRequired: Maybe.just(true),
+        preflightJobResult: Maybe.just('success'),
+        preflightResult: Maybe.just('ready'),
+        promotionRequested: true,
+        runtimeVerificationResult: Maybe.just('skipped'),
         tagCreationResult: Maybe.just('skipped'),
       },
     };
     const summary = renderWebappReleaseSummary(input);
 
-    assertSummaryContract(summary);
-    expect(summary).toMatch(
-      /### Hosted Production promotion[\s\S]*?- Result: already tagged; deployment not required/m,
-    );
-    expect(summary).toMatch(/### Hosted Production promotion[\s\S]*?- Production preflight result: already tagged/m);
-    expect(summary).toMatch(
-      new RegExp(
-        `- Production tag: \\[${plannedProductionTagName}\\]\\(https://github\\.com/wireapp/wire-webapp/tree/${plannedProductionTagName}\\)`,
-      ),
-    );
-    expect(summary).toMatch(/- Production tag creation result: not required; tag already exists/);
-    expect(summary).toMatch(/### Release distribution[\s\S]*?- Result: not run; Production tag already exists/m);
-    expect(summary).not.toMatch(/created-production-tag/);
+    expect(visibleSummary(summary)).toContain('Release stopped because Hosted Production deployment failed');
+    expect(visibleSummary(summary)).toContain('- Hosted Production: failed during deployment');
+    expect(technicalEvidence(summary)).toContain('- Production tag creation result: not run');
   });
 
-  it('renders a Production runtime verification failure', () => {
+  it('reports a Hosted Production runtime-verification failure', () => {
     const input: WebappReleaseSummaryInput = {
       ...baselineWebappReleaseSummaryInput,
       production: {
         ...baselineWebappReleaseSummaryInput.production,
         deploymentResult: Maybe.just('success'),
+        deploymentRequired: Maybe.just(true),
         preflightJobResult: Maybe.just('success'),
         preflightResult: Maybe.just('ready'),
         promotionRequested: true,
@@ -244,526 +509,68 @@ describe('WebApp release summary renderer', () => {
     };
     const summary = renderWebappReleaseSummary(input);
 
-    assertSummaryContract(summary);
-    expect(summary).toMatch(
-      /### Hosted Production promotion[\s\S]*?- Result: deployed, but runtime verification failed/m,
-    );
-    expect(summary).toMatch(/### Hosted Production promotion[\s\S]*?- Runtime verification result: failed/m);
-    expect(summary).toMatch(/### Hosted Production promotion[\s\S]*?- Production tag: not created/m);
-    expect(summary).toMatch(/### Release distribution[\s\S]*?- Result: not run/m);
-    expect(summary).not.toMatch(/### Hosted Production promotion[\s\S]*?- Production tag: \[/m);
+    expect(visibleSummary(summary)).toContain('Hosted Production was deployed, but runtime verification failed');
+    expect(visibleSummary(summary)).toContain('- Hosted Production: deployed, but runtime verification failed');
+    expect(technicalEvidence(summary)).toContain('- Runtime verification result: failed');
   });
 
-  it('renders a Beta deployment failure with the remaining gates not run', () => {
+  it('reports Production tag-creation failure after deployment verification', () => {
     const input: WebappReleaseSummaryInput = {
       ...baselineWebappReleaseSummaryInput,
-      beta: {
-        ...baselineWebappReleaseSummaryInput.beta,
-        deploymentResult: Maybe.just('failure'),
-        tagCreationResult: Maybe.just('skipped'),
+      production: {
+        ...baselineWebappReleaseSummaryInput.production,
+        deploymentResult: Maybe.just('success'),
+        deploymentRequired: Maybe.just(true),
+        preflightJobResult: Maybe.just('success'),
+        preflightResult: Maybe.just('ready'),
+        promotionRequested: true,
+        runtimeVerificationResult: Maybe.just('success'),
+        tagCreationResult: Maybe.just('failure'),
       },
-      e2e: {
-        ...baselineWebappReleaseSummaryInput.e2e,
-        result: Maybe.just('skipped'),
+    };
+    const summary = renderWebappReleaseSummary(input);
+
+    expect(visibleSummary(summary)).toContain(
+      'Hosted Production was deployed and verified, but Production tag creation failed',
+    );
+    expect(visibleSummary(summary)).toContain('- Hosted Production: deployed and verified, but tag creation failed');
+    expect(technicalEvidence(summary)).toContain('- Production tag creation result: failed');
+  });
+
+  it('reports distribution failure after successful Hosted Production', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      distribution: {
+        ...baselineWebappReleaseSummaryInput.distribution,
+        distributionJobResult: Maybe.just('failure'),
+        distributionResult: Maybe.just('failure'),
       },
       production: {
         ...baselineWebappReleaseSummaryInput.production,
-        preflightJobResult: Maybe.just('skipped'),
-        preflightResult: Maybe.just('skipped'),
+        createdTagName: Maybe.just(productionTagName),
+        deploymentResult: Maybe.just('success'),
+        deploymentRequired: Maybe.just(true),
+        preflightJobResult: Maybe.just('success'),
+        preflightResult: Maybe.just('ready'),
+        promotionRequested: true,
+        runtimeVerificationResult: Maybe.just('success'),
+        tagCreationResult: Maybe.just('success'),
       },
     };
     const summary = renderWebappReleaseSummary(input);
+    const visibleContent = visibleSummary(summary);
 
-    assertSummaryContract(summary);
-    expect(summary).toMatch(/### Hosted Beta validation[\s\S]*?- Result: failed/m);
-    expect(summary).toMatch(/### Hosted Beta validation[\s\S]*?- Beta tag: not created/m);
-    expect(summary).toMatch(/### E2E system gate[\s\S]*?- Result: did not run/m);
+    expect(visibleContent).toContain('Hosted Production completed, but release distribution failed');
+    expect(visibleContent).toContain('- Release distribution: failed');
+    expect(visibleContent).not.toContain('not published');
+    expect(visibleContent).not.toContain('not updated');
+    expect(technicalEvidence(summary)).toContain('- Docker image: not published');
+    expect(technicalEvidence(summary)).toContain('- wire-builds/main commit: not updated');
   });
 
-  it('renders unknown results instead of treating unknown job states as success', () => {
-    const parsedInput = readWebappReleaseSummaryInput({BETA_RESULT: 'unexpected'});
+  it('keeps missing metadata explicit without producing unsafe links', () => {
     const input: WebappReleaseSummaryInput = {
       ...baselineWebappReleaseSummaryInput,
-      beta: {
-        ...baselineWebappReleaseSummaryInput.beta,
-        deploymentResult: parsedInput.beta.deploymentResult,
-      },
-    };
-    const summary = renderWebappReleaseSummary(input);
-
-    assertSummaryContract(summary);
-    expect(summary).toMatch(/### Hosted Beta validation[\s\S]*?- Result: unknown result/m);
-    expect(summary).not.toMatch(/### Hosted Beta validation[\s\S]*?- Result: deployed and verified successfully/m);
-  });
-
-  it('uses not available for missing release metadata', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineWebappReleaseSummaryInput,
-      release: {
-        ...baselineWebappReleaseSummaryInput.release,
-        artifactBuiltAt: Maybe.nothing<string>(),
-        artifactAssetVersion: Maybe.nothing<string>(),
-        artifactChecksum: Maybe.nothing<string>(),
-        artifactName: Maybe.nothing<string>(),
-        artifactVersion: Maybe.nothing<string>(),
-        commitSha: Maybe.nothing<string>(),
-        identifier: Maybe.nothing<string>(),
-      },
-    };
-    const summary = renderWebappReleaseSummary(input);
-
-    assertSummaryContract(summary);
-    expect(summary).toMatch(/- Artifact checksum: not available/);
-    expect(summary).toMatch(/- Artifact name: not available/);
-    expect(summary).toMatch(/### Hosted Beta validation[\s\S]*?- Webapp version: not available/m);
-    expect(summary).toMatch(/### Hosted Beta validation[\s\S]*?- Asset version: not available/m);
-    expect(summary).toMatch(/- Built at \(UTC\): not available/);
-    expect(summary).toMatch(/- Commit SHA: not available/);
-    expect(summary).toMatch(/- Release identifier: not available/);
-  });
-
-  it('reads artifact build time from the workflow environment', () => {
-    const input = readWebappReleaseSummaryInput({
-      ARTIFACT_ASSET_VERSION: '2026-07-17.1-1234567',
-      ARTIFACT_BUILT_AT: '2026-07-20T06:18:03.123Z',
-      RELEASE_ACTOR: 'release-captain',
-      RELEASE_BRANCH_ACTION: 'created',
-      SOURCE_COMMIT_SHA: 'abcdef1234567890abcdef1234567890abcdef12',
-      SOURCE_REF: 'main',
-    });
-
-    expect(input.release.artifactAssetVersion.unwrapOr('not available')).toBe('2026-07-17.1-1234567');
-    expect(input.release.artifactBuiltAt.unwrapOr('not available')).toBe('2026-07-20T06:18:03.123Z');
-    expect(input.github.actor.unwrapOr('not available')).toBe('release-captain');
-    expect(input.preparation.branchAction.unwrapOr('reused')).toBe('created');
-    expect(input.preparation.sourceCommitSha.unwrapOr('not available')).toBe(
-      'abcdef1234567890abcdef1234567890abcdef12',
-    );
-    expect(input.preparation.sourceRef.unwrapOr('not available')).toBe('main');
-  });
-
-  it('renders a main-style artifact with the same webapp and asset versions', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineWebappReleaseSummaryInput,
-      release: {
-        ...baselineWebappReleaseSummaryInput.release,
-        artifactAssetVersion: Maybe.just('main-bdb93c9'),
-        artifactVersion: Maybe.just('main-bdb93c9'),
-      },
-    };
-    const summary = renderWebappReleaseSummary(input);
-
-    expect(summary).toMatch(/^- Webapp version: main-bdb93c9$/m);
-    expect(summary).toMatch(/^- Asset version: main-bdb93c9$/m);
-  });
-
-  it('renders Manual reason only when a reason is provided', () => {
-    const inputWithReason: WebappReleaseSummaryInput = {
-      ...baselineWebappReleaseSummaryInput,
-      release: {
-        ...baselineWebappReleaseSummaryInput.release,
-        manualReason: Maybe.just('manual release for validation'),
-      },
-    };
-    const summaryWithReason = renderWebappReleaseSummary(inputWithReason);
-    const summaryWithoutReason = renderWebappReleaseSummary(baselineWebappReleaseSummaryInput);
-
-    assertSummaryContract(summaryWithReason);
-    assertSummaryContract(summaryWithoutReason);
-    expect(summaryWithReason).toMatch(/- Manual reason: manual release for validation/);
-    expect(summaryWithoutReason).not.toMatch(/- Manual reason:/);
-  });
-
-  const baselineReleaseCandidateInput: WebappReleaseSummaryInput = {
-    beta: {
-      deploymentResult: Maybe.just('success'),
-      environmentName: Maybe.just('wire-webapp-staging'),
-      runtimeBackendRest: Maybe.just('https://prod-nginz-https.wire.com'),
-      runtimeBackendWebSocket: Maybe.just('wss://prod-nginz-ssl.wire.com'),
-      runtimeVerificationResult: Maybe.just('success'),
-      tagCreationResult: Maybe.just('success'),
-      tagName: Maybe.just('2026-07-17.1-beta.1'),
-      webappUrl: Maybe.just('https://wire-webapp-beta.wire.com/'),
-    },
-    distribution: {
-      chartRepositoryUrl: Maybe.just('https://charts.example.com/webapp'),
-      dockerImageTag: Maybe.nothing<string>(),
-      dockerRepository: Maybe.just('quay.io/wire/webapp'),
-      distributionJobResult: Maybe.just('skipped'),
-      distributionResult: Maybe.just('skipped'),
-      helmChartVersion: Maybe.nothing<string>(),
-      wireBuildsCommitSha: Maybe.nothing<string>(),
-    },
-    e2e: {
-      environmentName: Maybe.just('wire-webapp-precommit-3'),
-      reportUrl: Maybe.just('https://e2e.example.com/report/123'),
-      result: Maybe.just('success'),
-      runtimeBackendRest: Maybe.just('https://staging-nginz-https.zinfra.io/'),
-      runtimeBackendWebSocket: Maybe.just('wss://staging-nginz-ssl.zinfra.io/'),
-      testinyRunName: Maybe.just('Release 2026-07-17.1 2026-07-17.1-beta.1'),
-      webappUrl: Maybe.just('https://wire-webapp-precommit-3.zinfra.io/'),
-    },
-    github: {
-      actor: Maybe.just('release-captain'),
-      repository: Maybe.just('wireapp/wire-webapp'),
-      runId: Maybe.just('123456789'),
-      serverUrl: Maybe.just('https://github.com'),
-      wireBuildsRepository: Maybe.just('wireapp/wire-builds'),
-    },
-    preparation: {
-      branchAction: Maybe.just('created'),
-      sourceCommitSha: Maybe.just('abcdef1234567890abcdef1234567890abcdef12'),
-      sourceRef: Maybe.just('main'),
-    },
-    production: {
-      createdTagName: Maybe.nothing<string>(),
-      deploymentResult: Maybe.nothing<WorkflowJobResult>(),
-      deploymentRequired: Maybe.just(true),
-      environmentName: Maybe.just('wire-webapp-prod'),
-      plannedTagName: Maybe.just('2026-07-17.1-production'),
-      preflightJobResult: Maybe.just('success'),
-      preflightResult: Maybe.just('ready'),
-      promotionRequested: true,
-      runtimeBackendRest: Maybe.nothing<string>(),
-      runtimeBackendWebSocket: Maybe.nothing<string>(),
-      runtimeVerificationResult: Maybe.nothing<WorkflowJobResult>(),
-      skippedReason: Maybe.nothing<string>(),
-      tagCreationResult: Maybe.nothing<WorkflowJobResult>(),
-      webappUrl: Maybe.nothing<string>(),
-    },
-    release: {
-      artifactAssetVersion: Maybe.just('2026-07-17.1-1234567'),
-      artifactBuiltAt: Maybe.just('2026-07-20T06:18:03.123Z'),
-      artifactChecksum: Maybe.just('sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
-      artifactName: Maybe.just('release-cloud-ebs-2026-07-17.1-123456789-1'),
-      artifactVersion: Maybe.just('2026-07-17.1'),
-      branch: Maybe.just('release/2026-07-17.1'),
-      commitSha: Maybe.just('1234567890abcdef1234567890abcdef12345678'),
-      identifier: Maybe.just('2026-07-17.1'),
-      manualReason: Maybe.nothing<string>(),
-    },
-  };
-
-  function assertCandidateSummaryContract(summary: string): void {
-    expect(summary).toMatch(/\n$/);
-    expect(summary).toMatch(/^## Release preparation$/m);
-    expect(summary).toMatch(/^### Hosted Beta validation$/m);
-    expect(summary).toMatch(/^### E2E system gate$/m);
-    expect(summary).toMatch(/^### Hosted Production promotion$/m);
-    expect(summary).not.toMatch(/^### Release distribution$/m);
-    expect(summary).not.toMatch(/undefined/);
-    expect(summary).not.toMatch(/null/);
-    expect(summary).not.toMatch(/\]\(\)/);
-  }
-
-  it('renders a successful release candidate ready for Production approval', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      release: {
-        ...baselineReleaseCandidateInput.release,
-        manualReason: Maybe.just('manual release for validation'),
-      },
-    };
-    const summary = renderWebappReleaseCandidateSummary(input);
-
-    assertCandidateSummaryContract(summary);
-    expect(summary).toMatch(/- Release branch: release\/2026-07-17\.1/);
-    expect(summary).toMatch(/- Branch action: created/);
-    expect(summary).toMatch(/- Source ref: main/);
-    expect(summary).toMatch(
-      /- Source commit used for creation: \[abcdef1234567890abcdef1234567890abcdef12\]\(https:\/\/github\.com\/wireapp\/wire-webapp\/commit\/abcdef1234567890abcdef1234567890abcdef12\)/,
-    );
-    expect(summary).toMatch(/- Authoritative release commit: \[1234567890abcdef1234567890abcdef12345678\]/);
-    expect(summary).toMatch(/- Branch preparation: The release branch was created from the resolved source commit\./);
-    expect(summary).toMatch(/- Actor: release-captain/);
-    expect(summary).toMatch(
-      /- Commit SHA: \[1234567890abcdef1234567890abcdef12345678\]\(https:\/\/github\.com\/wireapp\/wire-webapp\/commit\/1234567890abcdef1234567890abcdef12345678\)/,
-    );
-    expect(summary).toMatch(
-      /- Artifact checksum: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/,
-    );
-    expect(summary).toMatch(
-      /- Beta tag: \[2026-07-17\.1-beta\.1\]\(https:\/\/github\.com\/wireapp\/wire-webapp\/tree\/2026-07-17\.1-beta\.1\)/,
-    );
-    expect(summary).toMatch(/### Hosted Beta validation[\s\S]*?- Runtime verification result: verified successfully/m);
-    expect(summary).toMatch(/### E2E system gate[\s\S]*?- Runtime verification: \/version and \/config\.js/m);
-    expect(summary).toMatch(
-      /- Playwright report URL: \[https:\/\/e2e\.example\.com\/report\/123\]\(https:\/\/e2e\.example\.com\/report\/123\)/,
-    );
-    expect(summary).toMatch(/- Production preflight job result: success/);
-    expect(summary).toMatch(/- Production preflight result: ready/);
-    expect(summary).toMatch(/- Production deployment required: true/);
-    expect(summary).toMatch(/- Planned Production tag: `2026-07-17\.1-production`/);
-    expect(summary).not.toMatch(/- Planned Production tag: \[/);
-    expect(summary).toMatch(
-      /- Approval status: Production is ready for deployment\. Approval is enforced through the wire-webapp-prod GitHub Environment\./,
-    );
-    expect(summary).toMatch(/- Manual reason: manual release for validation/);
-    expect(summary).toMatch(
-      /- Workflow run URL: \[https:\/\/github\.com\/wireapp\/wire-webapp\/actions\/runs\/123456789\]\(https:\/\/github\.com\/wireapp\/wire-webapp\/actions\/runs\/123456789\)/,
-    );
-  });
-
-  it('renders reused release branch preparation without a source commit link', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      preparation: {
-        branchAction: Maybe.just('reused'),
-        sourceCommitSha: Maybe.nothing<string>(),
-        sourceRef: Maybe.just('main'),
-      },
-    };
-    const summary = renderWebappReleaseCandidateSummary(input);
-
-    expect(summary).toMatch(/- Branch action: reused/);
-    expect(summary).toMatch(/- Source ref: main/);
-    expect(summary).toMatch(/- Source commit used for creation: not applicable; existing branch was reused/);
-    expect(summary).toMatch(
-      /- Branch preparation: The existing release branch was reused and was not moved to source_ref\./,
-    );
-    expect(summary).not.toMatch(/Source commit used for creation: \[/);
-  });
-
-  it('does not infer Beta runtime verification failure from a failed deployment', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      beta: {
-        ...baselineReleaseCandidateInput.beta,
-        deploymentResult: Maybe.just('failure'),
-        runtimeVerificationResult: Maybe.nothing<WorkflowJobResult>(),
-        tagCreationResult: Maybe.just('skipped'),
-        tagName: Maybe.nothing<string>(),
-      },
-      e2e: {
-        ...baselineReleaseCandidateInput.e2e,
-        result: Maybe.just('skipped'),
-        runtimeVerificationResult: Maybe.nothing<WorkflowJobResult>(),
-      },
-    };
-    const summary = renderWebappReleaseCandidateSummary(input);
-
-    expect(summary).toMatch(/### Hosted Beta validation[\s\S]*?- Result: failed/m);
-    expect(summary).not.toMatch(/### Hosted Beta validation[\s\S]*?- Runtime verification result:/m);
-    expect(summary).not.toMatch(/### Hosted Beta validation[\s\S]*?- Runtime verification result: failed/m);
-  });
-
-  it('renders an explicit Beta runtime verification failure', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      beta: {
-        ...baselineReleaseCandidateInput.beta,
-        deploymentResult: Maybe.just('failure'),
-        runtimeVerificationResult: Maybe.just('failure'),
-        tagCreationResult: Maybe.just('skipped'),
-        tagName: Maybe.nothing<string>(),
-      },
-    };
-    const summary = renderWebappReleaseCandidateSummary(input);
-
-    expect(summary).toMatch(/### Hosted Beta validation[\s\S]*?- Runtime verification result: failed/m);
-  });
-
-  it('does not report an independent runtime result for failed E2E tests', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      e2e: {
-        ...baselineReleaseCandidateInput.e2e,
-        result: Maybe.just('failure'),
-      },
-      production: {
-        ...baselineReleaseCandidateInput.production,
-        deploymentRequired: Maybe.nothing<boolean>(),
-        preflightJobResult: Maybe.just('skipped'),
-        preflightResult: Maybe.nothing<ProductionPreflightResult>(),
-      },
-    };
-    const summary = renderWebappReleaseCandidateSummary(input);
-
-    expect(summary).toMatch(/### E2E system gate[\s\S]*?- Result: failed/m);
-    expect(summary).not.toMatch(/### E2E system gate[\s\S]*?- Runtime verification result:/m);
-    expect(summary).not.toMatch(/### E2E system gate[\s\S]*?- Runtime verification: \/version and \/config\.js/m);
-  });
-
-  it('does not report runtime verification when precommit deployment failed first', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      e2e: {
-        ...baselineReleaseCandidateInput.e2e,
-        result: Maybe.just('failure'),
-      },
-    };
-    const summary = renderWebappReleaseCandidateSummary(input);
-
-    expect(summary).toMatch(/### E2E system gate[\s\S]*?- Result: failed/m);
-    expect(summary).not.toMatch(/### E2E system gate[\s\S]*?- Runtime verification result:/m);
-  });
-
-  it('uses no runtime verification result line when the dedicated information is missing', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      beta: {
-        ...baselineReleaseCandidateInput.beta,
-        runtimeVerificationResult: Maybe.nothing<WorkflowJobResult>(),
-      },
-      e2e: {
-        ...baselineReleaseCandidateInput.e2e,
-      },
-    };
-    const summary = renderWebappReleaseCandidateSummary(input);
-
-    expect(summary).not.toMatch(/Runtime verification result: unknown result/);
-    expect(summary).not.toMatch(/### Hosted Beta validation[\s\S]*?- Runtime verification result:/m);
-    expect(summary).not.toMatch(/### E2E system gate[\s\S]*?- Runtime verification result:/m);
-  });
-
-  it('renders a Beta-only release candidate without Production noise', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      production: {
-        ...baselineReleaseCandidateInput.production,
-        deploymentRequired: Maybe.just(false),
-        preflightJobResult: Maybe.just('skipped'),
-        preflightResult: Maybe.just('skipped'),
-        promotionRequested: false,
-      },
-    };
-    const summary = renderWebappReleaseCandidateSummary(input);
-
-    assertCandidateSummaryContract(summary);
-    expect(summary).toMatch(/- Production promotion requested: false/);
-    expect(summary).toMatch(/- Production deployment required: false/);
-    expect(summary).toMatch(/- Production skip reason: Production promotion was not requested/);
-    expect(summary).toMatch(/- Approval status: Production promotion was not requested/);
-    expect(summary).toMatch(/- Planned Production tag: not requested/);
-  });
-
-  it('renders an already-tagged Production release candidate without an approval gate', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      production: {
-        ...baselineReleaseCandidateInput.production,
-        deploymentRequired: Maybe.just(false),
-        preflightResult: Maybe.just('already_tagged'),
-        skippedReason: Maybe.just('Release is already tagged as Production with 2026-07-17.1-production'),
-      },
-    };
-    const summary = renderWebappReleaseCandidateSummary(input);
-
-    assertCandidateSummaryContract(summary);
-    expect(summary).toMatch(/- Production deployment required: false/);
-    expect(summary).toMatch(
-      /- Production skip reason: Release is already tagged as Production with 2026-07-17\.1-production/,
-    );
-    expect(summary).toMatch(
-      /- Approval status: Production deployment is not required because the release is already tagged/,
-    );
-  });
-
-  it('renders an E2E failure as an earlier gate blocking Production preflight', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      e2e: {
-        ...baselineReleaseCandidateInput.e2e,
-        result: Maybe.just('failure'),
-      },
-      production: {
-        ...baselineReleaseCandidateInput.production,
-        deploymentRequired: Maybe.nothing<boolean>(),
-        preflightJobResult: Maybe.just('skipped'),
-        preflightResult: Maybe.nothing<ProductionPreflightResult>(),
-      },
-    };
-    const summary = renderWebappReleaseCandidateSummary(input);
-
-    assertCandidateSummaryContract(summary);
-    expect(summary).toMatch(/### E2E system gate[\s\S]*?- Result: failed/);
-    expect(summary).toMatch(/- Production preflight job result: skipped/);
-    expect(summary).toMatch(/- Production preflight result: not run/);
-    expect(summary).toMatch(
-      /- Approval status: Production is blocked because an earlier gate failed: E2E system gate failed; Production preflight was skipped/,
-    );
-    expect(summary).toMatch(/- Playwright report URL: \[https:\/\/e2e\.example\.com\/report\/123\]/);
-  });
-
-  it('renders a Beta deployment failure as an earlier gate blocking Production', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      beta: {
-        ...baselineReleaseCandidateInput.beta,
-        deploymentResult: Maybe.just('failure'),
-        tagCreationResult: Maybe.just('skipped'),
-        tagName: Maybe.nothing<string>(),
-      },
-      e2e: {
-        ...baselineReleaseCandidateInput.e2e,
-        result: Maybe.just('skipped'),
-      },
-      production: {
-        ...baselineReleaseCandidateInput.production,
-        deploymentRequired: Maybe.nothing<boolean>(),
-        preflightJobResult: Maybe.just('skipped'),
-        preflightResult: Maybe.nothing<ProductionPreflightResult>(),
-      },
-    };
-    const summary = renderWebappReleaseCandidateSummary(input);
-
-    assertCandidateSummaryContract(summary);
-    expect(summary).toMatch(/### Hosted Beta validation[\s\S]*?- Result: failed/);
-    expect(summary).toMatch(/### E2E system gate[\s\S]*?- Result: did not run/);
-    expect(summary).toMatch(
-      /- Approval status: Production is blocked because an earlier gate failed: Beta deployment failed; Production preflight was skipped/,
-    );
-  });
-
-  it('renders cancelled E2E and preflight states distinctly', () => {
-    const cancelledE2EInput: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      e2e: {
-        ...baselineReleaseCandidateInput.e2e,
-        result: Maybe.just('cancelled'),
-      },
-      production: {
-        ...baselineReleaseCandidateInput.production,
-        deploymentRequired: Maybe.nothing<boolean>(),
-        preflightJobResult: Maybe.just('skipped'),
-        preflightResult: Maybe.nothing<ProductionPreflightResult>(),
-      },
-    };
-    const cancelledE2ESummary = renderWebappReleaseCandidateSummary(cancelledE2EInput);
-    expect(cancelledE2ESummary).toMatch(/### E2E system gate[\s\S]*?- Result: cancelled/);
-    expect(cancelledE2ESummary).toMatch(
-      /- Approval status: Production preflight was skipped because the E2E system gate was cancelled/,
-    );
-
-    const cancelledPreflightInput: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      production: {
-        ...baselineReleaseCandidateInput.production,
-        deploymentRequired: Maybe.nothing<boolean>(),
-        preflightJobResult: Maybe.just('cancelled'),
-        preflightResult: Maybe.nothing<ProductionPreflightResult>(),
-      },
-    };
-    const cancelledPreflightSummary = renderWebappReleaseCandidateSummary(cancelledPreflightInput);
-    expect(cancelledPreflightSummary).toMatch(/- Production preflight job result: cancelled/);
-    expect(cancelledPreflightSummary).toMatch(
-      /- Approval status: Production preflight was cancelled; Production approval is unavailable/,
-    );
-  });
-
-  it('uses deliberate fallbacks when optional candidate values are missing', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineReleaseCandidateInput,
-      beta: {
-        ...baselineReleaseCandidateInput.beta,
-        tagCreationResult: Maybe.just('skipped'),
-        tagName: Maybe.nothing<string>(),
-      },
-      e2e: {
-        ...baselineReleaseCandidateInput.e2e,
-        reportUrl: Maybe.nothing<string>(),
-        testinyRunName: Maybe.nothing<string>(),
-      },
       github: {
         actor: Maybe.nothing<string>(),
         repository: Maybe.nothing<string>(),
@@ -772,39 +579,81 @@ describe('WebApp release summary renderer', () => {
         wireBuildsRepository: Maybe.nothing<string>(),
       },
       preparation: {
-        branchAction: Maybe.nothing<ReleaseBranchAction>(),
+        branchAction: Maybe.nothing(),
         sourceCommitSha: Maybe.nothing<string>(),
         sourceRef: Maybe.nothing<string>(),
       },
-      production: {
-        ...baselineReleaseCandidateInput.production,
-        deploymentRequired: Maybe.nothing<boolean>(),
-        plannedTagName: Maybe.nothing<string>(),
-        preflightJobResult: Maybe.nothing<WorkflowJobResult>(),
-        preflightResult: Maybe.nothing<ProductionPreflightResult>(),
-      },
       release: {
-        ...baselineReleaseCandidateInput.release,
+        ...baselineWebappReleaseSummaryInput.release,
+        artifactAssetVersion: Maybe.nothing<string>(),
+        artifactBuiltAt: Maybe.nothing<string>(),
         artifactChecksum: Maybe.nothing<string>(),
         artifactName: Maybe.nothing<string>(),
+        artifactVersion: Maybe.nothing<string>(),
+        branch: Maybe.nothing<string>(),
         commitSha: Maybe.nothing<string>(),
         identifier: Maybe.nothing<string>(),
       },
     };
-    const summary = renderWebappReleaseCandidateSummary(input);
+    const candidateSummary = renderWebappReleaseCandidateSummary(input);
+    const finalSummary = renderWebappReleaseSummary(input);
 
-    assertCandidateSummaryContract(summary);
-    expect(summary).toMatch(/- Commit SHA: not available/);
-    expect(summary).toMatch(/- Artifact name: not available/);
-    expect(summary).toMatch(/- Artifact checksum: not available/);
-    expect(summary).toMatch(/- Branch action: not available/);
-    expect(summary).toMatch(/- Source ref: not available/);
-    expect(summary).toMatch(/- Source commit used for creation: not available/);
-    expect(summary).toMatch(/- Branch preparation: not available/);
-    expect(summary).toMatch(/- Actor: not available/);
-    expect(summary).toMatch(/- Playwright report URL: not available/);
-    expect(summary).toMatch(/- Planned Production tag: not available/);
-    expect(summary).toMatch(/- Production preflight job result: not available/);
-    expect(summary).toMatch(/- Approval status: Production approval status is unavailable or unexpected/);
+    assertMarkdownContract(candidateSummary, false);
+    assertMarkdownContract(finalSummary, true);
+    expect(visibleSummary(finalSummary)).toContain('- Release: `not available`');
+    expect(visibleSummary(finalSummary)).toContain('- Commit: not available');
+    expect(technicalEvidence(finalSummary)).toContain('- Artifact name: not available');
+    expect(technicalEvidence(finalSummary)).toContain('- Artifact checksum: not available');
+    expect(technicalEvidence(finalSummary)).toContain('- Source commit used for creation: not available');
+  });
+
+  it('keeps an optional manual reason in Release preparation evidence only', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      release: {
+        ...baselineWebappReleaseSummaryInput.release,
+        manualReason: Maybe.just('manual release for validation'),
+      },
+    };
+    const candidateSummary = renderWebappReleaseCandidateSummary(input);
+    const finalSummary = renderWebappReleaseSummary(input);
+
+    expect(technicalEvidence(candidateSummary)).toContain('- Manual reason: manual release for validation');
+    expect(technicalEvidence(finalSummary)).toContain('- Manual reason: manual release for validation');
+    expect(visibleSummary(candidateSummary)).not.toContain('Manual reason');
+    expect(visibleSummary(finalSummary)).not.toContain('Manual reason');
+  });
+
+  it('reads release summary values from the workflow environment', () => {
+    const input = readWebappReleaseSummaryInput({
+      ARTIFACT_ASSET_VERSION: '2026-07-17.1-1234567',
+      ARTIFACT_BUILT_AT: '2026-07-20T06:18:03.123Z',
+      RELEASE_ACTOR: 'release-captain',
+      RELEASE_BRANCH_ACTION: 'created',
+      SOURCE_COMMIT_SHA: sourceCommitSha,
+      SOURCE_REF: 'main',
+    });
+
+    expect(input.release.artifactAssetVersion.unwrapOr('not available')).toBe('2026-07-17.1-1234567');
+    expect(input.release.artifactBuiltAt.unwrapOr('not available')).toBe('2026-07-20T06:18:03.123Z');
+    expect(input.github.actor.unwrapOr('not available')).toBe('release-captain');
+    expect(input.preparation.branchAction.unwrapOr('reused')).toBe('created');
+    expect(input.preparation.sourceCommitSha.unwrapOr('not available')).toBe(sourceCommitSha);
+    expect(input.preparation.sourceRef.unwrapOr('not available')).toBe('main');
+  });
+
+  it('does not create a link for an invalid E2E report URL', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      e2e: {
+        ...baselineWebappReleaseSummaryInput.e2e,
+        reportUrl: Maybe.just('not-a-url'),
+      },
+    };
+    const summary = renderWebappReleaseSummary(input);
+
+    expect(visibleSummary(summary)).not.toContain('Playwright report');
+    expect(technicalEvidence(summary)).toContain('- Playwright report URL: not available');
+    expect(summary).not.toContain(']()');
   });
 });

--- a/bin/renderWebappReleaseSummary.ts
+++ b/bin/renderWebappReleaseSummary.ts
@@ -110,6 +110,18 @@ export type WebappReleaseSummaryInput = {
   readonly release: ReleaseMetadata;
 };
 
+type FormatProductionApprovalStatusParameters = {
+  readonly input: ProductionSummaryInput;
+  readonly beta: BetaSummaryInput;
+  readonly e2e: E2ESummaryInput;
+};
+
+type RenderReleaseIdentityParameters = {
+  readonly title: string;
+  readonly outcome: string;
+  readonly input: WebappReleaseSummaryInput;
+};
+
 function readOptionalEnvironmentValue(environment: NodeJS.ProcessEnv, variableName: string): Maybe<string> {
   return Maybe.of(environment[variableName]).andThen(environmentValue => {
     if (environmentValue === '') {
@@ -298,6 +310,7 @@ function formatWorkflowRunLink(github: GitHubLinkContext): string {
       return github.repository.andThen(repository => {
         return github.runId.map(runId => {
           const workflowRunUrl = `${serverUrl}/${repository}/actions/runs/${runId}`;
+
           return formatMarkdownLink(workflowRunUrl, workflowRunUrl);
         });
       });
@@ -692,11 +705,9 @@ function formatEarlierFailedGate(beta: BetaSummaryInput, e2e: E2ESummaryInput): 
   return Maybe.nothing<string>();
 }
 
-function formatProductionApprovalStatus(
-  input: ProductionSummaryInput,
-  beta: BetaSummaryInput,
-  e2e: E2ESummaryInput,
-): string {
+function formatProductionApprovalStatus(parameters: FormatProductionApprovalStatusParameters): string {
+  const {input, beta, e2e} = parameters;
+
   if (input.promotionRequested === false) {
     return 'Production promotion was not requested';
   }
@@ -889,16 +900,396 @@ function formatWireBuildsCommit(distribution: ProductionDistributionSummaryInput
     .unwrapOr('not updated');
 }
 
-function renderBetaSection(input: WebappReleaseSummaryInput, commitLink: string, workflowRunLink: string): string {
+function formatOptionalExternalLink(label: string, url: Maybe<string>): Maybe<string> {
+  return url.andThen(value => {
+    if (value.startsWith('http://') || value.startsWith('https://')) {
+      return Maybe.just(formatMarkdownLink(label, value));
+    }
+
+    return Maybe.nothing<string>();
+  });
+}
+
+function formatVerifiedBetaTagLink(input: BetaSummaryInput, github: GitHubLinkContext): Maybe<string> {
+  if (hasWorkflowJobResult(input.tagCreationResult, 'success')) {
+    return formatRepositoryTreeLink(input.tagName, github);
+  }
+
+  return Maybe.nothing<string>();
+}
+
+function formatVerifiedProductionTagLink(input: ProductionSummaryInput, github: GitHubLinkContext): Maybe<string> {
+  if (hasWorkflowJobResult(input.tagCreationResult, 'success')) {
+    return formatRepositoryTreeLink(input.createdTagName, github);
+  }
+
+  if (hasProductionPreflightResult(input.preflightResult, 'already_tagged')) {
+    return formatRepositoryTreeLink(input.plannedTagName, github);
+  }
+
+  return Maybe.nothing<string>();
+}
+
+function formatCodeValue(value: Maybe<string>): string {
+  return `\`${formatValueOrFallback(value)}\``;
+}
+
+function formatBetaStageOverview(input: WebappReleaseSummaryInput): string {
+  const betaTagLink = formatVerifiedBetaTagLink(input.beta, input.github);
+  const betaResult = formatBetaResult(input.beta.deploymentResult);
+
+  return betaTagLink.mapOr(betaResult, tagLink => {
+    return `${betaResult} — tag ${tagLink}`;
+  });
+}
+
+function formatE2EStageOverview(input: WebappReleaseSummaryInput): string {
+  const reportLink = formatOptionalExternalLink('Playwright report', input.e2e.reportUrl);
+  const e2EResult = formatE2EResult(input.e2e.result);
+
+  return reportLink.mapOr(e2EResult, link => {
+    return `${e2EResult} — ${link}`;
+  });
+}
+
+function hasProductionPreflightFailure(input: ProductionSummaryInput): boolean {
+  return (
+    hasWorkflowJobResult(input.preflightJobResult, 'failure') ||
+    hasProductionPreflightResult(input.preflightResult, 'failure')
+  );
+}
+
+function hasProductionPreflightCancellation(input: ProductionSummaryInput): boolean {
+  return hasWorkflowJobResult(input.preflightJobResult, 'cancelled');
+}
+
+function hasHostedProductionCompleted(input: ProductionSummaryInput): boolean {
+  return (
+    input.promotionRequested &&
+    hasProductionPreflightResult(input.preflightResult, 'ready') &&
+    hasWorkflowJobResult(input.preflightJobResult, 'success') &&
+    hasWorkflowJobResult(input.deploymentResult, 'success') &&
+    hasWorkflowJobResult(input.runtimeVerificationResult, 'success') &&
+    hasWorkflowJobResult(input.tagCreationResult, 'success')
+  );
+}
+
+function formatReleaseCandidateOutcome(input: WebappReleaseSummaryInput): string {
+  if (hasWorkflowJobResult(input.beta.deploymentResult, 'failure')) {
+    return 'Release candidate blocked because Hosted Beta deployment failed';
+  }
+
+  if (hasWorkflowJobResult(input.beta.deploymentResult, 'cancelled')) {
+    return 'Release candidate stopped because Hosted Beta deployment was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.beta.deploymentResult, 'skipped')) {
+    return 'Release candidate incomplete because Hosted Beta deployment did not run';
+  }
+
+  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'failure')) {
+    return 'Release candidate blocked because Beta tag creation failed';
+  }
+
+  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'cancelled')) {
+    return 'Release candidate stopped because Beta tag creation was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'failure')) {
+    return 'Release candidate blocked because the E2E system gate failed';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'cancelled')) {
+    return 'Release candidate stopped because the E2E system gate was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'skipped')) {
+    return 'Release candidate incomplete because the E2E system gate did not run';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'success') && input.production.promotionRequested === false) {
+    return 'Beta release candidate passed; Production promotion was not requested';
+  }
+
+  if (hasProductionPreflightResult(input.production.preflightResult, 'already_tagged')) {
+    return 'Release candidate already has the matching Production tag; deployment is not required';
+  }
+
+  if (
+    hasProductionPreflightResult(input.production.preflightResult, 'ready') &&
+    hasWorkflowJobResult(input.production.preflightJobResult, 'success')
+  ) {
+    return 'Release candidate passed and is ready for Production approval';
+  }
+
+  if (hasProductionPreflightFailure(input.production)) {
+    return 'Release candidate blocked because Production preflight failed';
+  }
+
+  if (hasProductionPreflightCancellation(input.production)) {
+    return 'Release candidate stopped because Production preflight was cancelled';
+  }
+
+  return 'Release candidate status is unavailable or unexpected';
+}
+
+function formatFinalReleaseOutcome(input: WebappReleaseSummaryInput): string {
+  if (hasWorkflowJobResult(input.beta.deploymentResult, 'failure')) {
+    return 'Release stopped because Hosted Beta deployment failed';
+  }
+
+  if (hasWorkflowJobResult(input.beta.deploymentResult, 'cancelled')) {
+    return 'Release stopped because Hosted Beta deployment was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.beta.deploymentResult, 'skipped')) {
+    return 'Release incomplete because Hosted Beta deployment did not run';
+  }
+
+  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'failure')) {
+    return 'Release stopped because Beta tag creation failed';
+  }
+
+  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'cancelled')) {
+    return 'Release stopped because Beta tag creation was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'skipped')) {
+    return 'Release incomplete because Beta tag creation did not run';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'failure')) {
+    return 'Release stopped because the E2E system gate failed';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'cancelled')) {
+    return 'Release stopped because the E2E system gate was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'skipped')) {
+    return 'Release incomplete because the E2E system gate did not run';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'success') && input.production.promotionRequested === false) {
+    return 'Beta release completed; Production promotion was not requested';
+  }
+
+  if (hasProductionPreflightResult(input.production.preflightResult, 'already_tagged')) {
+    return 'Release already has the matching Production tag; deployment was not repeated';
+  }
+
+  if (hasProductionPreflightFailure(input.production)) {
+    return 'Release stopped because Production preflight failed';
+  }
+
+  if (hasProductionPreflightCancellation(input.production)) {
+    return 'Release stopped because Production preflight was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.production.deploymentResult, 'failure')) {
+    return 'Release stopped because Hosted Production deployment failed';
+  }
+
+  if (hasWorkflowJobResult(input.production.deploymentResult, 'cancelled')) {
+    return 'Release stopped because Hosted Production deployment was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.production.runtimeVerificationResult, 'failure')) {
+    return 'Hosted Production was deployed, but runtime verification failed';
+  }
+
+  if (hasWorkflowJobResult(input.production.runtimeVerificationResult, 'cancelled')) {
+    return 'Hosted Production was deployed, but runtime verification was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.production.tagCreationResult, 'failure')) {
+    return 'Hosted Production was deployed and verified, but Production tag creation failed';
+  }
+
+  if (hasWorkflowJobResult(input.production.tagCreationResult, 'cancelled')) {
+    return 'Hosted Production was deployed and verified, but Production tag creation was cancelled';
+  }
+
+  if (
+    hasHostedProductionCompleted(input.production) &&
+    (hasWorkflowJobResult(input.distribution.distributionJobResult, 'failure') ||
+      hasWorkflowJobResult(input.distribution.distributionResult, 'failure'))
+  ) {
+    return 'Hosted Production completed, but release distribution failed';
+  }
+
+  if (
+    hasHostedProductionCompleted(input.production) &&
+    (hasWorkflowJobResult(input.distribution.distributionJobResult, 'cancelled') ||
+      hasWorkflowJobResult(input.distribution.distributionResult, 'cancelled'))
+  ) {
+    return 'Hosted Production completed, but release distribution was cancelled';
+  }
+
+  if (
+    hasHostedProductionCompleted(input.production) &&
+    hasWorkflowJobResult(input.distribution.distributionJobResult, 'success') &&
+    hasWorkflowJobResult(input.distribution.distributionResult, 'success')
+  ) {
+    return 'Release completed successfully';
+  }
+
+  return 'Release status is unavailable or unexpected';
+}
+
+function formatCandidateProductionOverview(input: WebappReleaseSummaryInput): string {
+  if (input.production.promotionRequested === false) {
+    return 'promotion was not requested';
+  }
+
+  if (hasWorkflowJobResult(input.beta.deploymentResult, 'failure')) {
+    return 'blocked because Hosted Beta deployment failed';
+  }
+
+  if (hasWorkflowJobResult(input.beta.deploymentResult, 'cancelled')) {
+    return 'unavailable because Hosted Beta deployment was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.beta.deploymentResult, 'skipped')) {
+    return 'unavailable because Hosted Beta deployment did not run';
+  }
+
+  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'failure')) {
+    return 'blocked because Beta tag creation failed';
+  }
+
+  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'cancelled')) {
+    return 'unavailable because Beta tag creation was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'failure')) {
+    return 'blocked because the E2E system gate failed';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'cancelled')) {
+    return 'unavailable because the E2E system gate was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'skipped')) {
+    return 'unavailable because the E2E system gate did not run';
+  }
+
+  if (hasProductionPreflightResult(input.production.preflightResult, 'already_tagged')) {
+    return 'already has the matching Production tag; deployment is not required';
+  }
+
+  if (
+    hasProductionPreflightResult(input.production.preflightResult, 'ready') &&
+    hasWorkflowJobResult(input.production.preflightJobResult, 'success')
+  ) {
+    return 'ready for approval through the wire-webapp-prod GitHub Environment';
+  }
+
+  if (hasProductionPreflightFailure(input.production)) {
+    return 'blocked because Production preflight failed';
+  }
+
+  if (hasProductionPreflightCancellation(input.production)) {
+    return 'unavailable because Production preflight was cancelled';
+  }
+
+  return 'unavailable because Production readiness is unknown';
+}
+
+function formatFinalProductionOverview(input: WebappReleaseSummaryInput): string {
+  if (hasWorkflowJobResult(input.beta.deploymentResult, 'failure')) {
+    return 'blocked because Hosted Beta deployment failed';
+  }
+
+  if (hasWorkflowJobResult(input.beta.deploymentResult, 'cancelled')) {
+    return 'unavailable because Hosted Beta deployment was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.beta.deploymentResult, 'skipped')) {
+    return 'unavailable because Hosted Beta deployment did not run';
+  }
+
+  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'failure')) {
+    return 'blocked because Beta tag creation failed';
+  }
+
+  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'cancelled')) {
+    return 'unavailable because Beta tag creation was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'skipped')) {
+    return 'unavailable because Beta tag creation did not run';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'failure')) {
+    return 'blocked because the E2E system gate failed';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'cancelled')) {
+    return 'unavailable because the E2E system gate was cancelled';
+  }
+
+  if (hasWorkflowJobResult(input.e2e.result, 'skipped')) {
+    return 'unavailable because the E2E system gate did not run';
+  }
+
+  return formatProductionResult(input.production);
+}
+
+function formatDistributionPublicationEvidence(
+  distribution: ProductionDistributionSummaryInput,
+  github: GitHubLinkContext,
+): string {
+  const evidence: string[] = [];
+
+  const dockerImage = formatDockerImage(distribution);
+  if (dockerImage !== 'not published') {
+    evidence.push(`Docker \`${dockerImage}\``);
+  }
+
+  distribution.helmChartVersion.map(version => {
+    evidence.push(`Helm \`${version}\``);
+
+    return version;
+  });
+
+  const wireBuildsCommitLink = distribution.wireBuildsCommitSha.andThen(commitSha => {
+    return github.serverUrl.andThen(serverUrl => {
+      return github.wireBuildsRepository.map(repository => {
+        return formatMarkdownLink(commitSha, `${serverUrl}/${repository}/commit/${commitSha}`);
+      });
+    });
+  });
+  wireBuildsCommitLink.map(commitLink => {
+    evidence.push(`wire-builds ${commitLink}`);
+
+    return commitLink;
+  });
+
+  return evidence.join(', ');
+}
+
+function renderReleaseIdentity({title, outcome, input}: RenderReleaseIdentityParameters): string {
+  const identityLines = [
+    title,
+    '',
+    `- Outcome: ${outcome}`,
+    `- Release: ${formatCodeValue(input.release.identifier)}`,
+    `- Release branch: ${formatCodeValue(input.release.branch)}`,
+    `- Commit: ${formatCommitLink(input.release.commitSha, input.github)}`,
+    `- Webapp version: ${formatCodeValue(input.release.artifactVersion)}`,
+  ];
+
+  identityLines.push(`- Workflow run: ${formatWorkflowRunLink(input.github)}`);
+
+  return identityLines.join('\n');
+}
+
+function renderBetaSection(input: WebappReleaseSummaryInput): string {
   return [
     '### Hosted Beta validation',
     '',
     `- Result: ${formatBetaResult(input.beta.deploymentResult)}`,
-    `- Release branch: ${formatValueOrFallback(input.release.branch)}`,
-    `- Webapp version: ${formatValueOrFallback(input.release.artifactVersion)}`,
-    `- Asset version: ${formatValueOrFallback(input.release.artifactAssetVersion)}`,
-    `- Commit SHA: ${commitLink}`,
-    `- Built at (UTC): ${formatValueOrFallback(input.release.artifactBuiltAt)}`,
     '- GitHub Environment: wire-webapp-beta',
     `- Target environment: ${formatValueOrFallback(input.beta.environmentName)}`,
     `- Frontend URL: ${formatOptionalFrontendUrl(input.beta.webappUrl)}`,
@@ -909,13 +1300,10 @@ function renderBetaSection(input: WebappReleaseSummaryInput, commitLink: string,
       ? ['- Runtime verification: /version and /config.js']
       : []),
     `- Beta tag: ${formatBetaTag(input.beta, input.github)}`,
-    `- Artifact name: ${formatValueOrFallback(input.release.artifactName)}`,
-    `- Artifact checksum: ${formatValueOrFallback(input.release.artifactChecksum)}`,
-    `- Workflow run URL: ${workflowRunLink}`,
   ].join('\n');
 }
 
-function renderE2ESection(input: WebappReleaseSummaryInput, commitLink: string, workflowRunLink: string): string {
+function renderE2ESection(input: WebappReleaseSummaryInput): string {
   const testinyRunName =
     input.release.identifier.isJust && input.beta.tagName.isJust
       ? formatValueOrFallback(input.e2e.testinyRunName)
@@ -925,10 +1313,6 @@ function renderE2ESection(input: WebappReleaseSummaryInput, commitLink: string, 
     '### E2E system gate',
     '',
     `- Result: ${formatE2EResult(input.e2e.result)}`,
-    `- Webapp version: ${formatValueOrFallback(input.release.artifactVersion)}`,
-    `- Asset version: ${formatValueOrFallback(input.release.artifactAssetVersion)}`,
-    `- Commit SHA: ${commitLink}`,
-    `- Built at (UTC): ${formatValueOrFallback(input.release.artifactBuiltAt)}`,
     `- Target environment: ${formatValueOrFallback(input.e2e.environmentName)}`,
     `- Frontend URL: ${formatOptionalFrontendUrl(input.e2e.webappUrl)}`,
     `- REST backend URL: ${formatValueOrFallback(input.e2e.runtimeBackendRest)}`,
@@ -936,11 +1320,10 @@ function renderE2ESection(input: WebappReleaseSummaryInput, commitLink: string, 
     ...(hasWorkflowJobResult(input.e2e.result, 'success') ? ['- Runtime verification: /version and /config.js'] : []),
     `- Playwright report URL: ${formatOptionalReportUrl(input.e2e.reportUrl)}`,
     `- Testiny run name: ${testinyRunName}`,
-    `- Workflow run URL: ${workflowRunLink}`,
   ].join('\n');
 }
 
-function renderProductionReadinessSection(input: WebappReleaseSummaryInput, workflowRunLink: string): string {
+function renderProductionReadinessSection(input: WebappReleaseSummaryInput): string {
   const productionSkipReason = formatProductionSkipReason(input.production);
   const productionSkipReasonLines = productionSkipReason
     .map(reason => {
@@ -958,16 +1341,15 @@ function renderProductionReadinessSection(input: WebappReleaseSummaryInput, work
     ...productionSkipReasonLines,
     `- Planned Production tag: ${formatPlannedProductionTag(input.production, input.release)}`,
     `- GitHub Environment: ${formatValueOrFallback(input.production.environmentName)}`,
-    `- Approval status: ${formatProductionApprovalStatus(input.production, input.beta, input.e2e)}`,
-    `- Workflow run URL: ${workflowRunLink}`,
+    `- Approval status: ${formatProductionApprovalStatus({
+      input: input.production,
+      beta: input.beta,
+      e2e: input.e2e,
+    })}`,
   ].join('\n');
 }
 
-function renderProductionSection(
-  input: WebappReleaseSummaryInput,
-  commitLink: string,
-  workflowRunLink: string,
-): string {
+function renderProductionSection(input: WebappReleaseSummaryInput): string {
   const productionSkipReason = formatProductionSkipReason(input.production);
   const productionSkipReasonLines = productionSkipReason
     .map(reason => {
@@ -982,10 +1364,6 @@ function renderProductionSection(
     `- Production promotion requested: ${input.production.promotionRequested === true ? 'true' : 'false'}`,
     `- Production preflight result: ${formatProductionPreflightResult(input.production)}`,
     ...productionSkipReasonLines,
-    `- Webapp version: ${formatValueOrFallback(input.release.artifactVersion)}`,
-    `- Asset version: ${formatValueOrFallback(input.release.artifactAssetVersion)}`,
-    `- Commit SHA: ${commitLink}`,
-    `- Built at (UTC): ${formatValueOrFallback(input.release.artifactBuiltAt)}`,
     `- Target environment: ${formatValueOrFallback(input.production.environmentName)}`,
     `- Frontend URL: ${formatOptionalFrontendUrl(input.production.webappUrl)}`,
     `- REST backend URL: ${formatValueOrFallback(input.production.runtimeBackendRest)}`,
@@ -997,39 +1375,28 @@ function renderProductionSection(
     `- Production tag: ${formatProductionTag(input.production, input.github)}`,
     `- Production tag creation result: ${formatProductionTagCreationResult(input.production)}`,
     `- Approval gate: ${formatApprovalGate(input.production)}`,
-    `- Workflow run URL: ${workflowRunLink}`,
   ].join('\n');
 }
 
-function renderProductionDistributionSection(
-  input: WebappReleaseSummaryInput,
-  commitLink: string,
-  workflowRunLink: string,
-): string {
+function renderProductionDistributionSection(input: WebappReleaseSummaryInput): string {
   return [
     '### Release distribution',
     '',
     `- Result: ${formatDistributionResult(input.production, input.distribution)}`,
-    `- Webapp version: ${formatValueOrFallback(input.release.artifactVersion)}`,
-    `- Asset version: ${formatValueOrFallback(input.release.artifactAssetVersion)}`,
-    `- Commit SHA: ${commitLink}`,
-    `- Built at (UTC): ${formatValueOrFallback(input.release.artifactBuiltAt)}`,
     `- Docker image: ${formatDockerImage(input.distribution)}`,
     `- Helm chart repository: ${formatValueOrFallback(input.distribution.chartRepositoryUrl)}`,
     `- Helm chart version: ${formatValueOrFallback(input.distribution.helmChartVersion, 'not published')}`,
     `- wire-builds/main commit: ${formatWireBuildsCommit(input.distribution, input.github)}`,
-    `- Workflow run URL: ${workflowRunLink}`,
   ].join('\n');
 }
 
-function renderReleasePreparationSection(
-  input: WebappReleaseSummaryInput,
-  commitLink: string,
-  sourceCommitLink: string,
-  workflowRunLink: string,
-): string {
+function renderReleasePreparationSection(input: WebappReleaseSummaryInput): string {
+  const commitLink = formatCommitLink(input.release.commitSha, input.github);
+  const sourceCommitLink = formatSourceCommit(input);
+  const workflowRunLink = formatWorkflowRunLink(input.github);
+
   return [
-    '## Release preparation',
+    '### Release preparation',
     '',
     `- Release identifier: ${formatValueOrFallback(input.release.identifier)}`,
     `- Release branch: ${formatValueOrFallback(input.release.branch)}`,
@@ -1041,7 +1408,6 @@ function renderReleasePreparationSection(
     `- Actor: ${formatValueOrFallback(input.github.actor)}`,
     `- Webapp version: ${formatValueOrFallback(input.release.artifactVersion)}`,
     `- Asset version: ${formatValueOrFallback(input.release.artifactAssetVersion)}`,
-    `- Commit SHA: ${commitLink}`,
     `- Built at (UTC): ${formatValueOrFallback(input.release.artifactBuiltAt)}`,
     `- Artifact name: ${formatValueOrFallback(input.release.artifactName)}`,
     `- Artifact checksum: ${formatValueOrFallback(input.release.artifactChecksum)}`,
@@ -1054,38 +1420,82 @@ function renderReleasePreparationSection(
   ].join('\n');
 }
 
-export function renderWebappReleaseCandidateSummary(input: WebappReleaseSummaryInput): string {
-  const commitLink = formatCommitLink(input.release.commitSha, input.github);
-  const sourceCommitLink = formatSourceCommit(input);
-  const workflowRunLink = formatWorkflowRunLink(input.github);
+function renderTechnicalReleaseEvidence(input: WebappReleaseSummaryInput, isCandidate: boolean): string {
+  const technicalSections = [
+    renderReleasePreparationSection(input),
+    renderBetaSection(input),
+    renderE2ESection(input),
+    isCandidate ? renderProductionReadinessSection(input) : renderProductionSection(input),
+  ];
 
-  return (
+  if (!isCandidate) {
+    technicalSections.push(renderProductionDistributionSection(input));
+  }
+
+  return [
+    '<details>',
+    '<summary>Technical release evidence</summary>',
+    '',
+    technicalSections.join('\n\n'),
+    '',
+    '</details>',
+  ].join('\n');
+}
+
+export function renderWebappReleaseCandidateSummary(input: WebappReleaseSummaryInput): string {
+  const visibleSummary = [
+    renderReleaseIdentity({
+      title: '## WebApp release candidate',
+      outcome: formatReleaseCandidateOutcome(input),
+      input,
+    }),
     [
-      renderReleasePreparationSection(input, commitLink, sourceCommitLink, workflowRunLink),
-      renderBetaSection(input, commitLink, workflowRunLink),
-      renderE2ESection(input, commitLink, workflowRunLink),
-      renderProductionReadinessSection(input, workflowRunLink),
-    ].join('\n\n') + '\n'
-  );
+      '### Release stages',
+      '',
+      `- Hosted Beta: ${formatBetaStageOverview(input)}`,
+      `- E2E system gate: ${formatE2EStageOverview(input)}`,
+      `- Hosted Production: ${formatCandidateProductionOverview(input)}`,
+    ].join('\n'),
+  ].join('\n\n');
+
+  return `${visibleSummary}\n\n${renderTechnicalReleaseEvidence(input, true)}\n`;
 }
 
 export function renderWebappReleaseSummary(input: WebappReleaseSummaryInput): string {
-  const commitLink = formatCommitLink(input.release.commitSha, input.github);
-  const sourceCommitLink = formatSourceCommit(input);
-  const workflowRunLink = formatWorkflowRunLink(input.github);
-
-  return (
+  const distributionResult = formatDistributionResult(input.production, input.distribution);
+  const distributionEvidence =
+    distributionResult === 'published successfully'
+      ? formatDistributionPublicationEvidence(input.distribution, input.github)
+      : '';
+  const distributionOverview =
+    distributionEvidence === '' ? distributionResult : `${distributionResult} — ${distributionEvidence}`;
+  const productionTagLink = formatVerifiedProductionTagLink(input.production, input.github);
+  const formattedProductionOverview = formatFinalProductionOverview(input);
+  const productionOverview = productionTagLink.mapOr(formattedProductionOverview, tagLink => {
+    return `${formattedProductionOverview} — tag ${tagLink}`;
+  });
+  const visibleSummary = [
+    renderReleaseIdentity({
+      title: '## WebApp release',
+      outcome: formatFinalReleaseOutcome(input),
+      input,
+    }),
     [
-      renderReleasePreparationSection(input, commitLink, sourceCommitLink, workflowRunLink),
-      renderBetaSection(input, commitLink, workflowRunLink),
-      renderE2ESection(input, commitLink, workflowRunLink),
-      renderProductionSection(input, commitLink, workflowRunLink),
-      renderProductionDistributionSection(input, commitLink, workflowRunLink),
-    ].join('\n\n') + '\n'
-  );
+      '### Release stages',
+      '',
+      `- Hosted Beta: ${formatBetaStageOverview(input)}`,
+      `- E2E system gate: ${formatE2EStageOverview(input)}`,
+      `- Hosted Production: ${productionOverview}`,
+      `- Release distribution: ${distributionOverview}`,
+    ].join('\n'),
+  ].join('\n\n');
+
+  return `${visibleSummary}\n\n${renderTechnicalReleaseEvidence(input, false)}\n`;
 }
 
 type WebappReleaseSummaryPhase = 'candidate' | 'final';
+
+const commandLineArgumentStartIndex = 2;
 
 function readWebappReleaseSummaryPhase(commandLineArguments: readonly string[]): WebappReleaseSummaryPhase {
   if (commandLineArguments.includes('--release-candidate')) {
@@ -1098,7 +1508,7 @@ function readWebappReleaseSummaryPhase(commandLineArguments: readonly string[]):
 function main(): void {
   try {
     const input = readWebappReleaseSummaryInput(process.env);
-    const summaryPhase = readWebappReleaseSummaryPhase(process.argv.slice(2));
+    const summaryPhase = readWebappReleaseSummaryPhase(process.argv.slice(commandLineArgumentStartIndex));
     const summary =
       summaryPhase === 'candidate' ? renderWebappReleaseCandidateSummary(input) : renderWebappReleaseSummary(input);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The WebApp release workflow produces both a release-candidate summary and a final release summary.

This separation is useful because the candidate summary communicates readiness before Production approval, while the final summary records the complete release outcome.

The summaries currently present every technical field at the same visual level, however. Release identity such as the WebApp version, asset version, commit, build timestamp, and workflow URL is repeated across several stages. The final summary also repeats much of the information already shown in the candidate summary.

The underlying evidence is valuable, but the current presentation makes the most important outcome harder to identify quickly.