### PR TITLE
fix: harden cells search against stale requests [WPB-20817]

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/requestVersionGate.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/requestVersionGate.test.ts
@@ -38,4 +38,10 @@ describe('createRequestVersionGate', () => {
 
     expect(requestVersionGate.isStale(request)).toBe(true);
   });
+
+  it('returns a frozen gate to protect request state operations', () => {
+    const requestVersionGate = createRequestVersionGate();
+
+    expect(Object.isFrozen(requestVersionGate)).toBe(true);
+  });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/requestVersionGate.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/requestVersionGate.ts
@@ -18,15 +18,15 @@
  */
 
 export interface RequestVersionGate {
-  next: () => number;
-  invalidate: () => void;
-  isStale: (requestId: number) => boolean;
+  readonly next: () => number;
+  readonly invalidate: () => void;
+  readonly isStale: (requestId: number) => boolean;
 }
 
-export const createRequestVersionGate = (): RequestVersionGate => {
+export const createRequestVersionGate = (): Readonly<RequestVersionGate> => {
   let currentRequestId = 0;
 
-  return {
+  return Object.freeze({
     next(): number {
       currentRequestId += 1;
       return currentRequestId;
@@ -37,5 +37,5 @@ export const createRequestVersionGate = (): RequestVersionGate => {
     isStale(requestId: number): boolean {
       return requestId !== currentRequestId;
     },
-  };
+  });
 };

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
@@ -147,7 +147,7 @@ describe('useSearchCellsNodes', () => {
     useCellsStore.getState().clearAll();
   });
 
-  it('uses recency sorting for the global all-files view by default', async () => {
+  it('requests global files with recency sorting by default', async () => {
     const cellsRepository = createFakeCellsRepository();
     const {fireAndForgetInvoker} = renderSearchHook({cellsRepository});
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
@@ -162,7 +162,7 @@ describe('useSearchCellsNodes', () => {
     );
   });
 
-  it('lets the selected sort override the global default', async () => {
+  it('requests global files with the selected sort instead of the default', async () => {
     const cellsRepository = createFakeCellsRepository();
     const {fireAndForgetInvoker} = renderSearchHook({
       cellsRepository,
@@ -179,8 +179,14 @@ describe('useSearchCellsNodes', () => {
     );
   });
 
-  it('cancels a pending debounced search when clearing the search input', async () => {
-    const cellsRepository = createFakeCellsRepository();
+  it('keeps browse results when clearing a scheduled search before it runs', async () => {
+    const cellsRepository: FakeCellsRepository = {
+      searchNodes: jest
+        .fn()
+        .mockResolvedValueOnce({Nodes: [createRestNode('initial-file.pdf')]})
+        .mockResolvedValueOnce({Nodes: [createRestNode('browse-file.pdf')]})
+        .mockResolvedValueOnce({Nodes: [createRestNode('stale-file.pdf')]}),
+    };
     const controlledDebouncedSearch = createControlledDebouncedSearch();
     const {fireAndForgetInvoker, result} = renderSearchHook({
       cellsRepository,
@@ -194,29 +200,38 @@ describe('useSearchCellsNodes', () => {
       await controlledDebouncedSearch.flush();
     });
 
-    expect(cellsRepository.searchNodes).toHaveBeenCalledTimes(2);
-    expect(cellsRepository.searchNodes).not.toHaveBeenCalledWith(expect.objectContaining({query: 'stale-query'}));
+    expect(result.current.searchValue).toBe('');
+    expect(useCellsStore.getState().nodes.map(node => node.name)).toEqual(['browse-file.pdf']);
+    expect(useCellsStore.getState().status).toBe('success');
   });
 
-  it('does not update the shared files store when an in-flight search resolves after unmount', async () => {
-    const search = createDeferred<RestNodeCollection>();
+  it('does not replace files set after unmount when the pending request resolves', async () => {
+    const requestAfterUnmount = createDeferred<RestNodeCollection>();
     const cellsRepository: FakeCellsRepository = {
-      searchNodes: jest.fn().mockReturnValue(search.promise),
+      searchNodes: jest
+        .fn()
+        .mockResolvedValueOnce({Nodes: [createRestNode('current-file.pdf')]})
+        .mockReturnValueOnce(requestAfterUnmount.promise),
     };
+    const {fireAndForgetInvoker, result, unmount} = renderSearchHook({cellsRepository});
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+    const currentFiles = useCellsStore.getState().nodes;
 
-    const {unmount} = renderSearchHook({cellsRepository});
-
+    act(() => {
+      void result.current.handleReload();
+    });
     unmount();
+    useCellsStore.setState({nodes: currentFiles});
 
     await act(async () => {
-      search.resolve({Nodes: [createRestNode('unmounted-file.pdf')]});
+      requestAfterUnmount.resolve({Nodes: [createRestNode('unmounted-file.pdf')]});
       await flushPromises();
     });
 
-    expect(useCellsStore.getState().nodes).toEqual([]);
+    expect(useCellsStore.getState().nodes.map(node => node.name)).toEqual(['current-file.pdf']);
   });
 
-  it('ignores stale search responses when a newer request has already updated the files', async () => {
+  it('keeps results from the newer request when the older request resolves last', async () => {
     const staleSearch = createDeferred<RestNodeCollection>();
     const currentSearch = createDeferred<RestNodeCollection>();
     const cellsRepository: FakeCellsRepository = {

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
@@ -295,7 +295,9 @@ describe('useSearchCellsNodes', () => {
   });
 
   it('shows an error and clears results when the current request fails for a Cells participant', async () => {
-    const cellsRepository: CellsRepositoryMock = {searchNodes: jest.fn().mockRejectedValue(new Error('request failed'))};
+    const cellsRepository: CellsRepositoryMock = {
+      searchNodes: jest.fn().mockRejectedValue(new Error('request failed')),
+    };
     const conversationRepository: ConversationRepositoryMock = {
       ...buildConversationRepositoryMock(),
       getAllCellEnabledGroupConversations: jest.fn().mockReturnValue([{}]),
@@ -310,7 +312,9 @@ describe('useSearchCellsNodes', () => {
   });
 
   it('treats a current request failure as an empty result when the user has no Cells conversations', async () => {
-    const cellsRepository: CellsRepositoryMock = {searchNodes: jest.fn().mockRejectedValue(new Error('request failed'))};
+    const cellsRepository: CellsRepositoryMock = {
+      searchNodes: jest.fn().mockRejectedValue(new Error('request failed')),
+    };
     const {fireAndForgetInvoker} = renderSearchHook({cellsRepository});
 
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
@@ -62,13 +62,11 @@ function createFakeConversationRepository(): FakeConversationRepository {
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+  const promise = new Promise<T>(resolvePromise => {
     resolve = resolvePromise;
-    reject = rejectPromise;
   });
 
-  return {promise, resolve, reject};
+  return {promise, resolve};
 }
 
 function createRestNode(name: string, uuid = name) {
@@ -89,8 +87,24 @@ async function flushPromises() {
   await Promise.resolve();
 }
 
-async function wait(milliseconds: number) {
-  await new Promise(resolve => setTimeout(resolve, milliseconds));
+function createControlledDebouncedSearch() {
+  let pendingSearch: (() => Promise<void>) | undefined;
+
+  return {
+    create: (search: (value: string) => Promise<void>) => {
+      const debouncedSearch = (async (value: string): Promise<void> => {
+        pendingSearch = () => search(value);
+      }) as ((value: string) => Promise<void>) & {cancel: () => void};
+      debouncedSearch.cancel = () => {
+        pendingSearch = undefined;
+      };
+      return debouncedSearch;
+    },
+    flush: async () => {
+      await pendingSearch?.();
+      pendingSearch = undefined;
+    },
+  };
 }
 
 function renderSearchHook({
@@ -100,6 +114,7 @@ function renderSearchHook({
   fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest(),
   filters = emptyFilters,
   sort = null,
+  createDebouncedSearch,
 }: {
   cellsRepository?: FakeCellsRepository;
   userRepository?: FakeUserRepository;
@@ -107,6 +122,9 @@ function renderSearchHook({
   fireAndForgetInvoker?: ReturnType<typeof createExecutingFireAndForgetInvokerForTest>;
   filters?: GlobalDriveFiltersState;
   sort?: CellsSort | null;
+  createDebouncedSearch?: (
+    search: (value: string) => Promise<void>,
+  ) => ((value: string) => Promise<void>) & {cancel: () => void};
 } = {}) {
   return {
     fireAndForgetInvoker,
@@ -118,6 +136,7 @@ function renderSearchHook({
         fireAndForgetInvoker,
         filters,
         sort,
+        createDebouncedSearch,
       }),
     ),
   };
@@ -162,20 +181,39 @@ describe('useSearchCellsNodes', () => {
 
   it('cancels a pending debounced search when clearing the search input', async () => {
     const cellsRepository = createFakeCellsRepository();
-    const {fireAndForgetInvoker, result} = renderSearchHook({cellsRepository});
+    const controlledDebouncedSearch = createControlledDebouncedSearch();
+    const {fireAndForgetInvoker, result} = renderSearchHook({
+      cellsRepository,
+      createDebouncedSearch: controlledDebouncedSearch.create,
+    });
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    act(() => {
-      result.current.handleSearch('stale-query');
-    });
-
     await act(async () => {
+      result.current.handleSearch('stale-query');
       await result.current.handleClearSearch();
-      await wait(350);
+      await controlledDebouncedSearch.flush();
     });
 
     expect(cellsRepository.searchNodes).toHaveBeenCalledTimes(2);
     expect(cellsRepository.searchNodes).not.toHaveBeenCalledWith(expect.objectContaining({query: 'stale-query'}));
+  });
+
+  it('does not update the shared files store when an in-flight search resolves after unmount', async () => {
+    const search = createDeferred<RestNodeCollection>();
+    const cellsRepository: FakeCellsRepository = {
+      searchNodes: jest.fn().mockReturnValue(search.promise),
+    };
+
+    const {unmount} = renderSearchHook({cellsRepository});
+
+    unmount();
+
+    await act(async () => {
+      search.resolve({Nodes: [createRestNode('unmounted-file.pdf')]});
+      await flushPromises();
+    });
+
+    expect(useCellsStore.getState().nodes).toEqual([]);
   });
 
   it('ignores stale search responses when a newer request has already updated the files', async () => {

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
@@ -39,28 +39,28 @@ const emptyFilters: GlobalDriveFiltersState = {
   isSharedViaLink: false,
 };
 
-type FakeCellsRepository = jest.Mocked<Pick<CellsRepository, 'searchNodes'>>;
-type FakeUserRepository = jest.Mocked<Pick<UserRepository, 'getUsersById'>>;
-type FakeConversationRepository = jest.Mocked<
+type CellsRepositoryMock = jest.Mocked<Pick<CellsRepository, 'searchNodes'>>;
+type UserRepositoryMock = jest.Mocked<Pick<UserRepository, 'getUsersById'>>;
+type ConversationRepositoryMock = jest.Mocked<
   Pick<ConversationRepository, 'getAllCellEnabledGroupConversations' | 'getConversationById'>
 >;
 
-function createFakeCellsRepository(searchResult: Partial<RestNodeCollection> = {}): FakeCellsRepository {
+function buildCellsRepositoryMock(searchResult: Partial<RestNodeCollection> = {}): CellsRepositoryMock {
   return {searchNodes: jest.fn().mockResolvedValue({Nodes: [], ...searchResult})};
 }
 
-function createFakeUserRepository(): FakeUserRepository {
+function buildUserRepositoryMock(): UserRepositoryMock {
   return {getUsersById: jest.fn().mockResolvedValue([])};
 }
 
-function createFakeConversationRepository(): FakeConversationRepository {
+function buildConversationRepositoryMock(): ConversationRepositoryMock {
   return {
     getAllCellEnabledGroupConversations: jest.fn().mockReturnValue([]),
     getConversationById: jest.fn().mockResolvedValue({qualifiedId: {id: 'conversation-id', domain: 'example.com'}}),
   };
 }
 
-function createDeferred<T>() {
+function createControllablePromise<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>(resolvePromise => {
     resolve = resolvePromise;
@@ -69,7 +69,7 @@ function createDeferred<T>() {
   return {promise, resolve};
 }
 
-function createRestNode(name: string, uuid = name) {
+function buildRestNodeStub(name: string, uuid = name) {
   return {
     Uuid: uuid,
     Path: `wire-cells-web/${name}`,
@@ -81,13 +81,13 @@ function createRestNode(name: string, uuid = name) {
   };
 }
 
-async function flushPromises() {
+async function flushMicrotasks() {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
 }
 
-function createControlledDebouncedSearch() {
+function createControllableDebouncedSearchStub() {
   let pendingSearch: (() => Promise<void>) | undefined;
 
   return {
@@ -108,17 +108,17 @@ function createControlledDebouncedSearch() {
 }
 
 function renderSearchHook({
-  cellsRepository = createFakeCellsRepository(),
-  userRepository = createFakeUserRepository(),
-  conversationRepository = createFakeConversationRepository(),
+  cellsRepository = buildCellsRepositoryMock(),
+  userRepository = buildUserRepositoryMock(),
+  conversationRepository = buildConversationRepositoryMock(),
   fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest(),
   filters = emptyFilters,
   sort = null,
   createDebouncedSearch,
 }: {
-  cellsRepository?: FakeCellsRepository;
-  userRepository?: FakeUserRepository;
-  conversationRepository?: FakeConversationRepository;
+  cellsRepository?: CellsRepositoryMock;
+  userRepository?: UserRepositoryMock;
+  conversationRepository?: ConversationRepositoryMock;
   fireAndForgetInvoker?: ReturnType<typeof createExecutingFireAndForgetInvokerForTest>;
   filters?: GlobalDriveFiltersState;
   sort?: CellsSort | null;
@@ -148,7 +148,7 @@ describe('useSearchCellsNodes', () => {
   });
 
   it('requests global files with recency sorting by default', async () => {
-    const cellsRepository = createFakeCellsRepository();
+    const cellsRepository = buildCellsRepositoryMock();
     const {fireAndForgetInvoker} = renderSearchHook({cellsRepository});
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
@@ -163,7 +163,7 @@ describe('useSearchCellsNodes', () => {
   });
 
   it('requests global files with the selected sort instead of the default', async () => {
-    const cellsRepository = createFakeCellsRepository();
+    const cellsRepository = buildCellsRepositoryMock();
     const {fireAndForgetInvoker} = renderSearchHook({
       cellsRepository,
       sort: {field: 'name', direction: 'asc'},
@@ -180,24 +180,24 @@ describe('useSearchCellsNodes', () => {
   });
 
   it('keeps browse results when clearing a scheduled search before it runs', async () => {
-    const cellsRepository: FakeCellsRepository = {
+    const cellsRepository: CellsRepositoryMock = {
       searchNodes: jest
         .fn()
-        .mockResolvedValueOnce({Nodes: [createRestNode('initial-file.pdf')]})
-        .mockResolvedValueOnce({Nodes: [createRestNode('browse-file.pdf')]})
-        .mockResolvedValueOnce({Nodes: [createRestNode('stale-file.pdf')]}),
+        .mockResolvedValueOnce({Nodes: [buildRestNodeStub('initial-file.pdf')]})
+        .mockResolvedValueOnce({Nodes: [buildRestNodeStub('browse-file.pdf')]})
+        .mockResolvedValueOnce({Nodes: [buildRestNodeStub('stale-file.pdf')]}),
     };
-    const controlledDebouncedSearch = createControlledDebouncedSearch();
+    const debouncedSearchStub = createControllableDebouncedSearchStub();
     const {fireAndForgetInvoker, result} = renderSearchHook({
       cellsRepository,
-      createDebouncedSearch: controlledDebouncedSearch.create,
+      createDebouncedSearch: debouncedSearchStub.create,
     });
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
     await act(async () => {
       result.current.handleSearch('stale-query');
       await result.current.handleClearSearch();
-      await controlledDebouncedSearch.flush();
+      await debouncedSearchStub.flush();
     });
 
     expect(result.current.searchValue).toBe('');
@@ -206,11 +206,11 @@ describe('useSearchCellsNodes', () => {
   });
 
   it('does not replace files set after unmount when the pending request resolves', async () => {
-    const requestAfterUnmount = createDeferred<RestNodeCollection>();
-    const cellsRepository: FakeCellsRepository = {
+    const requestAfterUnmount = createControllablePromise<RestNodeCollection>();
+    const cellsRepository: CellsRepositoryMock = {
       searchNodes: jest
         .fn()
-        .mockResolvedValueOnce({Nodes: [createRestNode('current-file.pdf')]})
+        .mockResolvedValueOnce({Nodes: [buildRestNodeStub('current-file.pdf')]})
         .mockReturnValueOnce(requestAfterUnmount.promise),
     };
     const {fireAndForgetInvoker, result, unmount} = renderSearchHook({cellsRepository});
@@ -224,17 +224,17 @@ describe('useSearchCellsNodes', () => {
     useCellsStore.setState({nodes: currentFiles});
 
     await act(async () => {
-      requestAfterUnmount.resolve({Nodes: [createRestNode('unmounted-file.pdf')]});
-      await flushPromises();
+      requestAfterUnmount.resolve({Nodes: [buildRestNodeStub('unmounted-file.pdf')]});
+      await flushMicrotasks();
     });
 
     expect(useCellsStore.getState().nodes.map(node => node.name)).toEqual(['current-file.pdf']);
   });
 
   it('keeps results from the newer request when the older request resolves last', async () => {
-    const staleSearch = createDeferred<RestNodeCollection>();
-    const currentSearch = createDeferred<RestNodeCollection>();
-    const cellsRepository: FakeCellsRepository = {
+    const staleSearch = createControllablePromise<RestNodeCollection>();
+    const currentSearch = createControllablePromise<RestNodeCollection>();
+    const cellsRepository: CellsRepositoryMock = {
       searchNodes: jest.fn().mockReturnValueOnce(staleSearch.promise).mockReturnValue(currentSearch.promise),
     };
 
@@ -246,12 +246,12 @@ describe('useSearchCellsNodes', () => {
     });
 
     await act(async () => {
-      currentSearch.resolve({Nodes: [createRestNode('current-file.pdf')]});
+      currentSearch.resolve({Nodes: [buildRestNodeStub('current-file.pdf')]});
       await currentSearchPromise;
-      await flushPromises();
+      await flushMicrotasks();
     });
 
-    staleSearch.resolve({Nodes: [createRestNode('stale-file.pdf')]});
+    staleSearch.resolve({Nodes: [buildRestNodeStub('stale-file.pdf')]});
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
     expect(useCellsStore.getState().nodes.map(node => node.name)).toEqual(['current-file.pdf']);

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
@@ -56,8 +56,41 @@ function createFakeUserRepository(): FakeUserRepository {
 function createFakeConversationRepository(): FakeConversationRepository {
   return {
     getAllCellEnabledGroupConversations: jest.fn().mockReturnValue([]),
-    getConversationById: jest.fn(),
+    getConversationById: jest.fn().mockResolvedValue({qualifiedId: {id: 'conversation-id', domain: 'example.com'}}),
   };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return {promise, resolve, reject};
+}
+
+function createRestNode(name: string, uuid = name) {
+  return {
+    Uuid: uuid,
+    Path: `wire-cells-web/${name}`,
+    Type: 'LEAF',
+    Modified: 1,
+    Size: 1,
+    UserMetadata: [],
+    ContextWorkspace: {Uuid: 'conversation-id@example.com', Label: 'Conversation'},
+  };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function wait(milliseconds: number) {
+  await new Promise(resolve => setTimeout(resolve, milliseconds));
 }
 
 function renderSearchHook({
@@ -125,5 +158,49 @@ describe('useSearchCellsNodes', () => {
         type: 'file',
       }),
     );
+  });
+
+  it('cancels a pending debounced search when clearing the search input', async () => {
+    const cellsRepository = createFakeCellsRepository();
+    const {fireAndForgetInvoker, result} = renderSearchHook({cellsRepository});
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    act(() => {
+      result.current.handleSearch('stale-query');
+    });
+
+    await act(async () => {
+      await result.current.handleClearSearch();
+      await wait(350);
+    });
+
+    expect(cellsRepository.searchNodes).toHaveBeenCalledTimes(2);
+    expect(cellsRepository.searchNodes).not.toHaveBeenCalledWith(expect.objectContaining({query: 'stale-query'}));
+  });
+
+  it('ignores stale search responses when a newer request has already updated the files', async () => {
+    const staleSearch = createDeferred<RestNodeCollection>();
+    const currentSearch = createDeferred<RestNodeCollection>();
+    const cellsRepository: FakeCellsRepository = {
+      searchNodes: jest.fn().mockReturnValueOnce(staleSearch.promise).mockReturnValue(currentSearch.promise),
+    };
+
+    const {fireAndForgetInvoker, result} = renderSearchHook({cellsRepository});
+
+    let currentSearchPromise!: Promise<void>;
+    act(() => {
+      currentSearchPromise = result.current.handleReload();
+    });
+
+    await act(async () => {
+      currentSearch.resolve({Nodes: [createRestNode('current-file.pdf')]});
+      await currentSearchPromise;
+      await flushPromises();
+    });
+
+    staleSearch.resolve({Nodes: [createRestNode('stale-file.pdf')]});
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(useCellsStore.getState().nodes.map(node => node.name)).toEqual(['current-file.pdf']);
   });
 });

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
@@ -145,8 +145,15 @@ function renderSearchHook({
 }
 
 describe('useSearchCellsNodes', () => {
+  let consoleDebugSpy: jest.SpyInstance<void, Parameters<typeof console.debug>>;
+
   beforeEach(() => {
     useCellsStore.getState().clearAll();
+    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleDebugSpy.mockRestore();
   });
 
   it('requests global files with recency sorting by default', async () => {
@@ -256,6 +263,7 @@ describe('useSearchCellsNodes', () => {
     staleSearch.resolve({Nodes: [buildRestNodeStub('stale-file.pdf')]});
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
+    expect(consoleDebugSpy).toHaveBeenCalledWith('Ignoring stale request version:', 1);
     expect(useCellsStore.getState().nodes.map(node => node.name)).toEqual(['current-file.pdf']);
   });
 

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
@@ -62,11 +62,13 @@ function buildConversationRepositoryMock(): ConversationRepositoryMock {
 
 function createControllablePromise<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>(resolvePromise => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
 
-  return {promise, resolve};
+  return {promise, resolve, reject};
 }
 
 function buildRestNodeStub(name: string, uuid = name) {
@@ -255,5 +257,55 @@ describe('useSearchCellsNodes', () => {
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
     expect(useCellsStore.getState().nodes.map(node => node.name)).toEqual(['current-file.pdf']);
+  });
+
+  it('keeps newer results when an older request rejects last', async () => {
+    const staleSearch = createControllablePromise<RestNodeCollection>();
+    const currentSearch = createControllablePromise<RestNodeCollection>();
+    const cellsRepository: CellsRepositoryMock = {
+      searchNodes: jest.fn().mockReturnValueOnce(staleSearch.promise).mockReturnValue(currentSearch.promise),
+    };
+    const {fireAndForgetInvoker, result} = renderSearchHook({cellsRepository});
+
+    let currentSearchPromise!: Promise<void>;
+    act(() => {
+      currentSearchPromise = result.current.handleReload();
+    });
+
+    await act(async () => {
+      currentSearch.resolve({Nodes: [buildRestNodeStub('current-file.pdf')]});
+      await currentSearchPromise;
+      staleSearch.reject(new Error('stale request failed'));
+      await fireAndForgetInvoker.waitUntilAllSettled();
+    });
+
+    expect(useCellsStore.getState().nodes.map(node => node.name)).toEqual(['current-file.pdf']);
+    expect(useCellsStore.getState().status).toBe('success');
+  });
+
+  it('shows an error and clears results when the current request fails for a Cells participant', async () => {
+    const cellsRepository: CellsRepositoryMock = {searchNodes: jest.fn().mockRejectedValue(new Error('request failed'))};
+    const conversationRepository: ConversationRepositoryMock = {
+      ...buildConversationRepositoryMock(),
+      getAllCellEnabledGroupConversations: jest.fn().mockReturnValue([{}]),
+    };
+    const {fireAndForgetInvoker} = renderSearchHook({cellsRepository, conversationRepository});
+
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(useCellsStore.getState().nodes).toEqual([]);
+    expect(useCellsStore.getState().pagination).toBeNull();
+    expect(useCellsStore.getState().status).toBe('error');
+  });
+
+  it('treats a current request failure as an empty result when the user has no Cells conversations', async () => {
+    const cellsRepository: CellsRepositoryMock = {searchNodes: jest.fn().mockRejectedValue(new Error('request failed'))};
+    const {fireAndForgetInvoker} = renderSearchHook({cellsRepository});
+
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(useCellsStore.getState().nodes).toEqual([]);
+    expect(useCellsStore.getState().pagination).toBeNull();
+    expect(useCellsStore.getState().status).toBe('success');
   });
 });

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
@@ -24,6 +24,7 @@ import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {UserRepository} from 'Repositories/user/userRepository';
 import {createExecutingFireAndForgetInvokerForTest} from 'src/script/page/testSupport/rootContextTestSupport';
+import type {Logger} from 'Util/logger';
 
 import {useSearchCellsNodes} from './useSearchCellsNodes';
 
@@ -44,6 +45,7 @@ type UserRepositoryMock = jest.Mocked<Pick<UserRepository, 'getUsersById'>>;
 type ConversationRepositoryMock = jest.Mocked<
   Pick<ConversationRepository, 'getAllCellEnabledGroupConversations' | 'getConversationById'>
 >;
+type LoggerMock = jest.Mocked<Pick<Logger, 'debug'>>;
 
 function buildCellsRepositoryMock(searchResult: Partial<RestNodeCollection> = {}): CellsRepositoryMock {
   return {searchNodes: jest.fn().mockResolvedValue({Nodes: [], ...searchResult})};
@@ -58,6 +60,10 @@ function buildConversationRepositoryMock(): ConversationRepositoryMock {
     getAllCellEnabledGroupConversations: jest.fn().mockReturnValue([]),
     getConversationById: jest.fn().mockResolvedValue({qualifiedId: {id: 'conversation-id', domain: 'example.com'}}),
   };
+}
+
+function buildLoggerMock(): LoggerMock {
+  return {debug: jest.fn()};
 }
 
 function createControllablePromise<T>() {
@@ -117,6 +123,7 @@ function renderSearchHook({
   filters = emptyFilters,
   sort = null,
   createDebouncedSearch,
+  logger = buildLoggerMock(),
 }: {
   cellsRepository?: CellsRepositoryMock;
   userRepository?: UserRepositoryMock;
@@ -127,6 +134,7 @@ function renderSearchHook({
   createDebouncedSearch?: (
     search: (value: string) => Promise<void>,
   ) => ((value: string) => Promise<void>) & {cancel: () => void};
+  logger?: LoggerMock;
 } = {}) {
   return {
     fireAndForgetInvoker,
@@ -139,21 +147,15 @@ function renderSearchHook({
         filters,
         sort,
         createDebouncedSearch,
+        logger: logger as unknown as Logger,
       }),
     ),
   };
 }
 
 describe('useSearchCellsNodes', () => {
-  let consoleDebugSpy: jest.SpyInstance<void, Parameters<typeof console.debug>>;
-
   beforeEach(() => {
     useCellsStore.getState().clearAll();
-    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
-  });
-
-  afterEach(() => {
-    consoleDebugSpy.mockRestore();
   });
 
   it('requests global files with recency sorting by default', async () => {
@@ -246,8 +248,9 @@ describe('useSearchCellsNodes', () => {
     const cellsRepository: CellsRepositoryMock = {
       searchNodes: jest.fn().mockReturnValueOnce(staleSearch.promise).mockReturnValue(currentSearch.promise),
     };
+    const logger = buildLoggerMock();
 
-    const {fireAndForgetInvoker, result} = renderSearchHook({cellsRepository});
+    const {fireAndForgetInvoker, result} = renderSearchHook({cellsRepository, logger});
 
     let currentSearchPromise!: Promise<void>;
     act(() => {
@@ -263,7 +266,7 @@ describe('useSearchCellsNodes', () => {
     staleSearch.resolve({Nodes: [buildRestNodeStub('stale-file.pdf')]});
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    expect(consoleDebugSpy).toHaveBeenCalledWith('Ignoring stale request version:', 1);
+    expect(logger.debug).toHaveBeenCalledWith('Ignoring stale request version:', 1);
     expect(useCellsStore.getState().nodes.map(node => node.name)).toEqual(['current-file.pdf']);
   });
 

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
@@ -112,6 +112,11 @@ function createControllableDebouncedSearchStub() {
       await pendingSearch?.();
       pendingSearch = undefined;
     },
+    startPendingSearch: () => {
+      const searchPromise = pendingSearch?.();
+      pendingSearch = undefined;
+      return searchPromise;
+    },
   };
 }
 
@@ -216,6 +221,64 @@ describe('useSearchCellsNodes', () => {
     expect(useCellsStore.getState().status).toBe('success');
   });
 
+  it('keeps reload results when reloading before a scheduled search runs', async () => {
+    const cellsRepository: CellsRepositoryMock = {
+      searchNodes: jest
+        .fn()
+        .mockResolvedValueOnce({Nodes: [buildRestNodeStub('initial-file.pdf')]})
+        .mockResolvedValueOnce({Nodes: [buildRestNodeStub('reload-file.pdf')]})
+        .mockResolvedValueOnce({Nodes: [buildRestNodeStub('stale-file.pdf')]}),
+    };
+    const debouncedSearchStub = createControllableDebouncedSearchStub();
+    const {fireAndForgetInvoker, result} = renderSearchHook({
+      cellsRepository,
+      createDebouncedSearch: debouncedSearchStub.create,
+    });
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    await act(async () => {
+      result.current.handleSearch('stale-query');
+      await flushMicrotasks();
+      await result.current.handleReload();
+      await debouncedSearchStub.flush();
+    });
+
+    expect(useCellsStore.getState().nodes.map(node => node.name)).toEqual(['reload-file.pdf']);
+    expect(cellsRepository.searchNodes).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps browse results when clearing an in-flight search before it resolves', async () => {
+    const staleSearch = createControllablePromise<RestNodeCollection>();
+    const cellsRepository: CellsRepositoryMock = {
+      searchNodes: jest
+        .fn()
+        .mockResolvedValueOnce({Nodes: [buildRestNodeStub('initial-file.pdf')]})
+        .mockReturnValueOnce(staleSearch.promise)
+        .mockResolvedValueOnce({Nodes: [buildRestNodeStub('browse-file.pdf')]}),
+    };
+    const debouncedSearchStub = createControllableDebouncedSearchStub();
+    const {fireAndForgetInvoker, result} = renderSearchHook({
+      cellsRepository,
+      createDebouncedSearch: debouncedSearchStub.create,
+    });
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    await act(async () => {
+      result.current.handleSearch('stale-query');
+      debouncedSearchStub.startPendingSearch();
+      await flushMicrotasks();
+      await result.current.handleClearSearch();
+    });
+
+    await act(async () => {
+      staleSearch.resolve({Nodes: [buildRestNodeStub('stale-file.pdf')]});
+      await flushMicrotasks();
+    });
+
+    expect(useCellsStore.getState().nodes.map(node => node.name)).toEqual(['browse-file.pdf']);
+    expect(useCellsStore.getState().status).toBe('success');
+  });
+
   it('does not replace files set after unmount when the pending request resolves', async () => {
     const requestAfterUnmount = createControllablePromise<RestNodeCollection>();
     const cellsRepository: CellsRepositoryMock = {
@@ -226,20 +289,19 @@ describe('useSearchCellsNodes', () => {
     };
     const {fireAndForgetInvoker, result, unmount} = renderSearchHook({cellsRepository});
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
-    const currentFiles = useCellsStore.getState().nodes;
 
     act(() => {
       void result.current.handleReload();
     });
     unmount();
-    useCellsStore.setState({nodes: currentFiles});
 
     await act(async () => {
       requestAfterUnmount.resolve({Nodes: [buildRestNodeStub('unmounted-file.pdf')]});
       await flushMicrotasks();
     });
 
-    expect(useCellsStore.getState().nodes.map(node => node.name)).toEqual(['current-file.pdf']);
+    expect(useCellsStore.getState().nodes).toEqual([]);
+    expect(useCellsStore.getState().status).toBe('loading');
   });
 
   it('keeps results from the newer request when the older request resolves last', async () => {

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
@@ -187,19 +187,18 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
     [pageSize, setNodes, setPagination, setStatus, filters, sort, logger],
   );
 
-  const defaultSearchNodesDebounced = useDebouncedCallback(async (value: string): Promise<void> => {
-    shouldPerformFullReload.current = false;
-    setSearchQuery(value);
-    await searchNodes({query: value, status: 'loading'});
-    shouldPerformFullReload.current = true;
-  }, DEBOUNCE_TIME);
-  const searchNodesDebounced =
-    createDebouncedSearch?.(async (value: string): Promise<void> => {
+  const runDebouncedSearch = useCallback(
+    async (value: string): Promise<void> => {
       shouldPerformFullReload.current = false;
       setSearchQuery(value);
       await searchNodes({query: value, status: 'loading'});
       shouldPerformFullReload.current = true;
-    }, DEBOUNCE_TIME) ?? defaultSearchNodesDebounced;
+    },
+    [searchNodes],
+  );
+  const defaultSearchNodesDebounced = useDebouncedCallback(runDebouncedSearch, DEBOUNCE_TIME);
+  const searchNodesDebounced =
+    createDebouncedSearch?.(runDebouncedSearch, DEBOUNCE_TIME) ?? defaultSearchNodesDebounced;
   const searchNodesDebouncedRef = useRef(searchNodesDebounced);
   searchNodesDebouncedRef.current = searchNodesDebounced;
 
@@ -224,6 +223,7 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
   };
 
   const handleReload = async (): Promise<void> => {
+    searchNodesDebouncedRef.current.cancel();
     setStatus('loading');
     clearAll();
     await searchNodes({query: searchQuery.length > 0 ? searchQuery : FETCH_ALL_QUERY, status: 'loading'});

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
@@ -201,12 +201,12 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
     setPageSize(PAGE_INITIAL_SIZE);
     setSearchValue(value);
     fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
-      await searchNodesDebounced(value);
+      await searchNodesDebouncedRef.current(value);
     });
   };
 
   const handleClearSearch = async (): Promise<void> => {
-    searchNodesDebounced.cancel();
+    searchNodesDebouncedRef.current.cancel();
     setPageSize(PAGE_INITIAL_SIZE);
     setSearchValue('');
     setSearchQuery('');
@@ -239,15 +239,17 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
     }
   }, [fireAndForgetInvoker, searchNodes, searchQuery]);
 
+  // This cleanup models hook ownership ending. Do not depend on changing callbacks,
+  // otherwise ordinary rerenders would invalidate valid in-flight requests.
   useEffect(() => {
     const versionGate = requestVersionGate.current;
 
     return () => {
+      // Read from the ref during cleanup so we cancel the latest debounced search,
+      // not the one captured when this mount-only effect was created.
       searchNodesDebouncedRef.current.cancel();
       versionGate.invalidate();
     };
-    // This cleanup models hook ownership ending. Do not depend on changing callbacks,
-    // otherwise ordinary rerenders would invalidate valid in-flight requests.
   }, []);
 
   return {

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
@@ -33,6 +33,7 @@ import {createRequestVersionGate} from 'Components/Conversation/ConversationCell
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {UserRepository} from 'Repositories/user/userRepository';
+import {getLogger, Logger} from 'Util/logger';
 
 import {getConversationsFromNodes} from './getConversationsFromNodes';
 import {getUsersFromNodes} from './getUsersFromNodes';
@@ -53,6 +54,7 @@ interface UseSearchCellsNodesProps {
   filters: GlobalDriveFiltersState;
   sort: CellsSort | null;
   createDebouncedSearch?: CreateDebouncedSearch;
+  logger?: Logger;
 }
 
 type SearchNodesProperties = {
@@ -75,6 +77,7 @@ const PAGE_INITIAL_SIZE = 30;
 const PAGE_SIZE_INCREMENT = 20;
 const DEBOUNCE_TIME = 300;
 const FETCH_ALL_QUERY = '*';
+const defaultLogger = getLogger('useSearchCellsNodes');
 
 export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSearchCellsNodesResult => {
   const {
@@ -85,6 +88,7 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
     filters,
     sort,
     createDebouncedSearch,
+    logger = defaultLogger,
   } = properties;
   const {setNodes, setStatus, setPagination, clearAll} = useCellsStore();
 
@@ -102,8 +106,7 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
       const shouldIgnoreStaleRequest = (): boolean => {
         const isStaleRequest = requestVersionGate.current.isStale(requestVersion);
         if (isStaleRequest) {
-          // eslint-disable-next-line no-console
-          console.debug('Ignoring stale request version:', requestVersion);
+          logger.debug('Ignoring stale request version:', requestVersion);
         }
         return isStaleRequest;
       };
@@ -181,7 +184,7 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
     },
     // cellsRepository is not a dependency because it's a singleton
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [pageSize, setNodes, setPagination, setStatus, filters, sort],
+    [pageSize, setNodes, setPagination, setStatus, filters, sort, logger],
   );
 
   const defaultSearchNodesDebounced = useDebouncedCallback(async (value: string): Promise<void> => {

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
@@ -29,6 +29,7 @@ import {
   toGlobalDriveSearchParams,
 } from 'Components/Conversation/ConversationCells/common/driveFilters/driveFilters';
 import {CellsSort} from 'Components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting';
+import {createRequestVersionGate} from 'Components/Conversation/ConversationCells/useConversationSearch/requestVersionGate';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {UserRepository} from 'Repositories/user/userRepository';
@@ -79,10 +80,14 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
   const [pageSize, setPageSize] = useState(PAGE_INITIAL_SIZE);
   const isInitialLoad = useRef(true);
   const shouldPerformFullReload = useRef(true);
+  const requestVersionGate = useRef(createRequestVersionGate());
 
   const searchNodes = useCallback(
     async (properties: SearchNodesProperties): Promise<void> => {
       const {query, status, limit = pageSize} = properties;
+      const requestVersion = requestVersionGate.current.next();
+      const isCurrentRequest = (): boolean => !requestVersionGate.current.isStale(requestVersion);
+
       try {
         setStatus(status);
 
@@ -97,15 +102,27 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
           type: 'file',
         });
 
+        if (!isCurrentRequest()) {
+          return;
+        }
+
         const users = await getUsersFromNodes({
           nodes: result.Nodes ?? [],
           userRepository,
         });
 
+        if (!isCurrentRequest()) {
+          return;
+        }
+
         const conversations = await getConversationsFromNodes({
           nodes: result.Nodes ?? [],
           conversationRepository,
         });
+
+        if (!isCurrentRequest()) {
+          return;
+        }
 
         // filter out draft nodes from results
         const filteredNodes = result.Nodes?.filter(node => node.IsDraft !== true) ?? [];
@@ -129,6 +146,10 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
 
         setStatus('success');
       } catch {
+        if (!isCurrentRequest()) {
+          return;
+        }
+
         // If the user isn't part of any cells-enabled conversations, the user will not exist in Cells database
         // the search will return a 401 error
         const hasCellsConversations = conversationRepository.getAllCellEnabledGroupConversations().length > 0;
@@ -166,6 +187,7 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
   };
 
   const handleClearSearch = async (): Promise<void> => {
+    searchNodesDebounced.cancel();
     setPageSize(PAGE_INITIAL_SIZE);
     setSearchValue('');
     setSearchQuery('');

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
@@ -99,7 +99,14 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
     async (properties: SearchNodesProperties): Promise<void> => {
       const {query, status, limit = pageSize} = properties;
       const requestVersion = requestVersionGate.current.next();
-      const isCurrentRequest = (): boolean => !requestVersionGate.current.isStale(requestVersion);
+      const shouldIgnoreStaleRequest = (): boolean => {
+        const isStaleRequest = requestVersionGate.current.isStale(requestVersion);
+        if (isStaleRequest) {
+          // eslint-disable-next-line no-console
+          console.debug('Ignoring stale request version:', requestVersion);
+        }
+        return isStaleRequest;
+      };
 
       try {
         setStatus(status);
@@ -115,7 +122,7 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
           type: 'file',
         });
 
-        if (!isCurrentRequest()) {
+        if (shouldIgnoreStaleRequest()) {
           return;
         }
 
@@ -130,7 +137,7 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
           }),
         ]);
 
-        if (!isCurrentRequest()) {
+        if (shouldIgnoreStaleRequest()) {
           return;
         }
 
@@ -156,7 +163,7 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
 
         setStatus('success');
       } catch {
-        if (!isCurrentRequest()) {
+        if (shouldIgnoreStaleRequest()) {
           return;
         }
 

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.ts
@@ -41,6 +41,10 @@ import {useCellsStore, Status} from '../common/useCellsStore/useCellsStore';
 import {transformCellsNodes} from '../transformCellsNodes/transformCellsNodes';
 import {transformCellsPagination} from '../transformCellsPagination/transformCellsPagination';
 
+type DebouncedSearch = ((value: string) => Promise<void>) & {cancel: () => void};
+
+type CreateDebouncedSearch = (search: (value: string) => Promise<void>, debounceTime: number) => DebouncedSearch;
+
 interface UseSearchCellsNodesProps {
   cellsRepository: CellsRepository;
   userRepository: UserRepository;
@@ -48,6 +52,7 @@ interface UseSearchCellsNodesProps {
   fireAndForgetInvoker: FireAndForgetInvoker;
   filters: GlobalDriveFiltersState;
   sort: CellsSort | null;
+  createDebouncedSearch?: CreateDebouncedSearch;
 }
 
 type SearchNodesProperties = {
@@ -72,7 +77,15 @@ const DEBOUNCE_TIME = 300;
 const FETCH_ALL_QUERY = '*';
 
 export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSearchCellsNodesResult => {
-  const {cellsRepository, userRepository, conversationRepository, fireAndForgetInvoker, filters, sort} = properties;
+  const {
+    cellsRepository,
+    userRepository,
+    conversationRepository,
+    fireAndForgetInvoker,
+    filters,
+    sort,
+    createDebouncedSearch,
+  } = properties;
   const {setNodes, setStatus, setPagination, clearAll} = useCellsStore();
 
   const [searchValue, setSearchValue] = useState('');
@@ -106,19 +119,16 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
           return;
         }
 
-        const users = await getUsersFromNodes({
-          nodes: result.Nodes ?? [],
-          userRepository,
-        });
-
-        if (!isCurrentRequest()) {
-          return;
-        }
-
-        const conversations = await getConversationsFromNodes({
-          nodes: result.Nodes ?? [],
-          conversationRepository,
-        });
+        const [users, conversations] = await Promise.all([
+          getUsersFromNodes({
+            nodes: result.Nodes ?? [],
+            userRepository,
+          }),
+          getConversationsFromNodes({
+            nodes: result.Nodes ?? [],
+            conversationRepository,
+          }),
+        ]);
 
         if (!isCurrentRequest()) {
           return;
@@ -167,12 +177,21 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
     [pageSize, setNodes, setPagination, setStatus, filters, sort],
   );
 
-  const searchNodesDebounced = useDebouncedCallback(async (value: string): Promise<void> => {
+  const defaultSearchNodesDebounced = useDebouncedCallback(async (value: string): Promise<void> => {
     shouldPerformFullReload.current = false;
     setSearchQuery(value);
     await searchNodes({query: value, status: 'loading'});
     shouldPerformFullReload.current = true;
   }, DEBOUNCE_TIME);
+  const searchNodesDebounced =
+    createDebouncedSearch?.(async (value: string): Promise<void> => {
+      shouldPerformFullReload.current = false;
+      setSearchQuery(value);
+      await searchNodes({query: value, status: 'loading'});
+      shouldPerformFullReload.current = true;
+    }, DEBOUNCE_TIME) ?? defaultSearchNodesDebounced;
+  const searchNodesDebouncedRef = useRef(searchNodesDebounced);
+  searchNodesDebouncedRef.current = searchNodesDebounced;
 
   const handleSearch = (value: string): void => {
     if (!is.nonEmptyString(value)) {
@@ -219,6 +238,17 @@ export const useSearchCellsNodes = (properties: UseSearchCellsNodesProps): UseSe
       });
     }
   }, [fireAndForgetInvoker, searchNodes, searchQuery]);
+
+  useEffect(() => {
+    const versionGate = requestVersionGate.current;
+
+    return () => {
+      searchNodesDebouncedRef.current.cancel();
+      versionGate.invalidate();
+    };
+    // This cleanup models hook ownership ending. Do not depend on changing callbacks,
+    // otherwise ordinary rerenders would invalidate valid in-flight requests.
+  }, []);
 
   return {
     searchValue,


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20817" title="WPB-20817" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20817</a>  [Web] Search results are not fetching all files when the search box is empty
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## What changed

This hardens the global Cells search against stale requests

The annoying part was that debounce reduced the number of requests, but it did not decide which response was still allowed to update the shared store

So this PR adds lifecycle ownership around global Cells search:

- cancel pending debounced searches when clearing the input
- ignore stale responses with request version gating
- invalidate in-flight requests when the hook unmounts
- keep unmount cleanup lifecycle-only, so normal rerenders do not invalidate valid requests
- parallelize user/conversation enrichment after the Cells response

## Why

When typing quickly and then clearing the search input, an old request could finish after the clear request and overwrite the list with partial search results

This makes latest valid request win, and prevents unmounted hooks from writing into the shared Cells store

## DEMO

https://github.com/user-attachments/assets/1b2d90eb-10f0-4f0a-953a-e36ecc9fc5a1

