### PR TITLE
Show Beta release summary before E2E [WPB-26469]

### DIFF
--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -500,6 +500,64 @@ jobs:
 
           echo "beta_tag_name=${beta_tag_name}" >> "$GITHUB_OUTPUT"
 
+  summarize_beta_release:
+    name: Summarize Beta release
+    runs-on: ubuntu-24.04
+    needs:
+      - build_artifact
+      - deploy_to_beta
+      - create_beta_tag
+    if: ${{ always() }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout WebApp release summary renderer
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install renderer dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable
+
+      - name: Add Beta release summary
+        env:
+          ARTIFACT_CHECKSUM: ${{ needs.build_artifact.outputs.artifact_checksum }}
+          ARTIFACT_BUILT_AT: ${{ needs.build_artifact.outputs.artifact_built_at }}
+          ARTIFACT_ASSET_VERSION: ${{ needs.build_artifact.outputs.artifact_asset_version }}
+          ARTIFACT_NAME: ${{ needs.build_artifact.outputs.artifact_name }}
+          ARTIFACT_VERSION: ${{ needs.build_artifact.outputs.artifact_version }}
+          BETA_RESULT: ${{ needs.deploy_to_beta.result }}
+          BETA_ELASTIC_BEANSTALK_ENVIRONMENT_NAME: ${{ env.BETA_ELASTIC_BEANSTALK_ENVIRONMENT_NAME }}
+          BETA_RUNTIME_BACKEND_REST: ${{ env.BETA_RUNTIME_BACKEND_REST }}
+          BETA_RUNTIME_BACKEND_WS: ${{ env.BETA_RUNTIME_BACKEND_WS }}
+          BETA_RUNTIME_VERIFICATION_RESULT: ${{ needs.deploy_to_beta.outputs.runtime_verification_result }}
+          BETA_TAG_CREATION_RESULT: ${{ needs.create_beta_tag.result }}
+          BETA_TAG_NAME: ${{ needs.create_beta_tag.outputs.beta_tag_name }}
+          BETA_WEBAPP_URL: ${{ env.BETA_WEBAPP_URL }}
+          RELEASE_BRANCH: ${{ needs.build_artifact.outputs.release_branch }}
+          RELEASE_ACTOR: ${{ github.actor }}
+          RELEASE_BRANCH_ACTION: ${{ needs.build_artifact.outputs.release_branch_action }}
+          RELEASE_COMMIT_SHA: ${{ needs.build_artifact.outputs.release_commit_sha }}
+          RELEASE_IDENTIFIER: ${{ needs.build_artifact.outputs.release_identifier }}
+          RELEASE_REASON: ${{ inputs.reason }}
+          SOURCE_COMMIT_SHA: ${{ needs.build_artifact.outputs.source_commit_sha }}
+          SOURCE_REF: ${{ needs.build_artifact.outputs.source_ref }}
+        run: node bin/renderWebappReleaseSummary.ts --beta-release >> "$GITHUB_STEP_SUMMARY"
+
   # WebApp release owns release-specific success and failure notifications.
   # The reusable workflow's optional failure-only notification is intentionally
   # not enabled here to prevent duplicate failure messages.
@@ -676,75 +734,6 @@ jobs:
             echo 'production_skipped_reason='
             echo "production_tag_name=${production_tag_name}"
           } >> "$GITHUB_OUTPUT"
-
-  summarize_release_candidate:
-    name: Summarize release candidate
-    runs-on: ubuntu-24.04
-    needs: [build_artifact, deploy_to_beta, create_beta_tag, run_e2e, production_preflight]
-    if: ${{ always() }}
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout WebApp release summary renderer
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-          fetch-depth: 1
-          ref: ${{ github.sha }}
-
-      - name: Add repository Yarn wrapper to PATH
-        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-
-      - name: Install renderer dependencies
-        env:
-          YARN_ENABLE_SCRIPTS: 'false'
-        run: ./bin/yarn install --immutable
-
-      - name: Add release candidate summary
-        env:
-          ARTIFACT_CHECKSUM: ${{ needs.build_artifact.outputs.artifact_checksum }}
-          ARTIFACT_BUILT_AT: ${{ needs.build_artifact.outputs.artifact_built_at }}
-          ARTIFACT_ASSET_VERSION: ${{ needs.build_artifact.outputs.artifact_asset_version }}
-          ARTIFACT_NAME: ${{ needs.build_artifact.outputs.artifact_name }}
-          ARTIFACT_VERSION: ${{ needs.build_artifact.outputs.artifact_version }}
-          BETA_RESULT: ${{ needs.deploy_to_beta.result }}
-          BETA_ELASTIC_BEANSTALK_ENVIRONMENT_NAME: ${{ env.BETA_ELASTIC_BEANSTALK_ENVIRONMENT_NAME }}
-          BETA_RUNTIME_BACKEND_REST: ${{ env.BETA_RUNTIME_BACKEND_REST }}
-          BETA_RUNTIME_BACKEND_WS: ${{ env.BETA_RUNTIME_BACKEND_WS }}
-          BETA_RUNTIME_VERIFICATION_RESULT: ${{ needs.deploy_to_beta.outputs.runtime_verification_result }}
-          BETA_TAG_CREATION_RESULT: ${{ needs.create_beta_tag.result }}
-          BETA_TAG_NAME: ${{ needs.create_beta_tag.outputs.beta_tag_name }}
-          BETA_WEBAPP_URL: ${{ env.BETA_WEBAPP_URL }}
-          E2E_RUNTIME_BACKEND_REST: ${{ env.E2E_RUNTIME_BACKEND_REST }}
-          E2E_RUNTIME_BACKEND_WS: ${{ env.E2E_RUNTIME_BACKEND_WS }}
-          E2E_ELASTIC_BEANSTALK_ENVIRONMENT_NAME: ${{ env.E2E_ELASTIC_BEANSTALK_ENVIRONMENT_NAME }}
-          E2E_REPORT_URL: ${{ needs.run_e2e.outputs.reportUrl }}
-          E2E_RESULT: ${{ needs.run_e2e.result }}
-          E2E_WEBAPP_URL: ${{ env.E2E_WEBAPP_URL }}
-          PRODUCTION_DEPLOYMENT_REQUIRED: ${{ needs.production_preflight.outputs.should_deploy }}
-          PRODUCTION_ENVIRONMENT_NAME: ${{ env.PRODUCTION_ENVIRONMENT_NAME }}
-          PRODUCTION_PREFLIGHT_JOB_RESULT: ${{ needs.production_preflight.result }}
-          PRODUCTION_PREFLIGHT_RESULT: ${{ needs.production_preflight.outputs.production_preflight_result }}
-          PRODUCTION_PROMOTION_REQUESTED: ${{ inputs.promote_to_production }}
-          PRODUCTION_SKIPPED_REASON: ${{ needs.production_preflight.outputs.production_skipped_reason }}
-          PLANNED_PRODUCTION_TAG_NAME: ${{ needs.production_preflight.outputs.production_tag_name }}
-          RELEASE_BRANCH: ${{ needs.build_artifact.outputs.release_branch }}
-          RELEASE_ACTOR: ${{ github.actor }}
-          RELEASE_BRANCH_ACTION: ${{ needs.build_artifact.outputs.release_branch_action }}
-          RELEASE_COMMIT_SHA: ${{ needs.build_artifact.outputs.release_commit_sha }}
-          RELEASE_IDENTIFIER: ${{ needs.build_artifact.outputs.release_identifier }}
-          RELEASE_REASON: ${{ inputs.reason }}
-          SOURCE_COMMIT_SHA: ${{ needs.build_artifact.outputs.source_commit_sha }}
-          SOURCE_REF: ${{ needs.build_artifact.outputs.source_ref }}
-          TESTINY_RUN_NAME: Release ${{ needs.build_artifact.outputs.release_identifier }} ${{ needs.create_beta_tag.outputs.beta_tag_name }}
-        run: node bin/renderWebappReleaseSummary.ts --release-candidate >> "$GITHUB_STEP_SUMMARY"
 
   deploy_to_production:
     name: Deploy to Production

--- a/bin/renderWebappReleaseSummary.test.ts
+++ b/bin/renderWebappReleaseSummary.test.ts
@@ -21,7 +21,7 @@ import {Maybe} from 'true-myth';
 
 import {
   readWebappReleaseSummaryInput,
-  renderWebappReleaseCandidateSummary,
+  renderWebappBetaReleaseSummary,
   renderWebappReleaseSummary,
 } from './renderWebappReleaseSummary.ts';
 import type {WebappReleaseSummaryInput} from './renderWebappReleaseSummary.ts';
@@ -157,6 +157,25 @@ function assertVisibleIdentity(summary: string): void {
   );
 }
 
+function assertBetaSummaryContainsOnlyBetaEvidence(summary: string): void {
+  const forbiddenTerms = [
+    'E2E system gate',
+    'Playwright',
+    'Testiny',
+    'Hosted Production',
+    'Production preflight',
+    'Production tag',
+    'Release distribution',
+    'Docker image',
+    'Helm chart',
+    'wire-builds',
+  ];
+
+  for (const forbiddenTerm of forbiddenTerms) {
+    expect(summary).not.toContain(forbiddenTerm);
+  }
+}
+
 describe('WebApp release summary renderer', () => {
   it('renders a successful Beta-only release with a concise visible overview', () => {
     const summary = renderWebappReleaseSummary(baselineWebappReleaseSummaryInput);
@@ -181,13 +200,19 @@ describe('WebApp release summary renderer', () => {
     );
   });
 
-  it('shows the verified Beta tag once in the visible candidate summary', () => {
-    const summary = renderWebappReleaseCandidateSummary(baselineWebappReleaseSummaryInput);
+  it('renders a successful Beta release with only Beta evidence', () => {
+    const summary = renderWebappBetaReleaseSummary(baselineWebappReleaseSummaryInput);
     const visibleContent = visibleSummary(summary);
 
+    assertMarkdownContract(summary, false);
+    assertVisibleIdentity(summary);
+    expect(visibleContent).toContain('## WebApp Beta release');
+    expect(visibleContent).toContain('- Outcome: Beta release completed successfully');
     expect(visibleContent).toContain(`- Hosted Beta: deployed and verified successfully — tag [${betaTagName}]`);
     expect(countOccurrences(visibleContent, `[${betaTagName}]`)).toBe(1);
-    expect(visibleContent).not.toContain('- Beta tag:');
+    expect(summary).toContain('### Release preparation');
+    expect(summary).toContain('### Hosted Beta validation');
+    assertBetaSummaryContainsOnlyBetaEvidence(summary);
   });
 
   it('renders a successful Production release and distribution evidence', () => {
@@ -231,36 +256,6 @@ describe('WebApp release summary renderer', () => {
     expect(detailsContent).toContain('- Production tag creation result: created successfully');
     expect(detailsContent).toContain('- Docker image: quay.io/wire/webapp:2026-07-17.1-production-v0.34.9-0-1234567');
     expect(detailsContent).toContain('- Helm chart repository: https://charts.example.com/webapp');
-  });
-
-  it('renders a release candidate that is ready for Production approval', () => {
-    const input: WebappReleaseSummaryInput = {
-      ...baselineWebappReleaseSummaryInput,
-      production: {
-        ...baselineWebappReleaseSummaryInput.production,
-        deploymentRequired: Maybe.just(true),
-        preflightJobResult: Maybe.just('success'),
-        preflightResult: Maybe.just('ready'),
-        promotionRequested: true,
-      },
-    };
-    const summary = renderWebappReleaseCandidateSummary(input);
-    const visibleContent = visibleSummary(summary);
-    const detailsContent = technicalEvidence(summary);
-
-    assertMarkdownContract(summary, false);
-    assertVisibleIdentity(summary);
-    expect(visibleContent).toContain('## WebApp release candidate');
-    expect(visibleContent).toContain('Release candidate passed and is ready for Production approval');
-    expect(visibleContent).toContain(
-      '- Hosted Production: ready for approval through the wire-webapp-prod GitHub Environment',
-    );
-    expect(detailsContent).toContain('- Production promotion requested: true');
-    expect(detailsContent).toContain('- Production preflight job result: success');
-    expect(detailsContent).toContain('- Planned Production tag: `2026-07-17.1-production`');
-    expect(detailsContent).toContain(
-      '- Approval status: Production is ready for deployment. Approval is enforced through the wire-webapp-prod GitHub Environment.',
-    );
   });
 
   it('renders an already-tagged Production release without linking a nonexistent tag', () => {
@@ -310,16 +305,31 @@ describe('WebApp release summary renderer', () => {
       },
     };
     const finalSummary = renderWebappReleaseSummary(input);
-    const candidateSummary = renderWebappReleaseCandidateSummary(input);
+    const betaSummary = renderWebappBetaReleaseSummary(input);
 
     expect(visibleSummary(finalSummary)).toContain('Release stopped because Hosted Beta deployment failed');
-    expect(visibleSummary(candidateSummary)).toContain(
-      'Release candidate blocked because Hosted Beta deployment failed',
-    );
+    expect(visibleSummary(betaSummary)).toContain('Beta release stopped because Hosted Beta deployment failed');
+    expect(visibleSummary(betaSummary)).not.toContain(`[${betaTagName}]`);
     expect(visibleSummary(finalSummary)).toContain(
       '- Hosted Production: blocked because Hosted Beta deployment failed',
     );
     expect(technicalEvidence(finalSummary)).toContain('- Result: failed');
+  });
+
+  it('stops the Beta release when Hosted Beta deployment is cancelled', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      beta: {
+        ...baselineWebappReleaseSummaryInput.beta,
+        deploymentResult: Maybe.just('cancelled'),
+        tagCreationResult: Maybe.just('skipped'),
+        tagName: Maybe.nothing<string>(),
+      },
+    };
+    const summary = renderWebappBetaReleaseSummary(input);
+
+    expect(visibleSummary(summary)).toContain('Beta release stopped because Hosted Beta deployment was cancelled');
+    expect(visibleSummary(summary)).not.toContain('failed');
   });
 
   it('reports an incomplete release when Hosted Beta deployment is skipped', () => {
@@ -341,11 +351,18 @@ describe('WebApp release summary renderer', () => {
         promotionRequested: true,
       },
     };
-    const summary = renderWebappReleaseSummary(input);
-    const visibleContent = visibleSummary(summary);
+    const finalSummary = renderWebappReleaseSummary(input);
+    const betaSummary = renderWebappBetaReleaseSummary(input);
+    const finalVisibleContent = visibleSummary(finalSummary);
+    const betaVisibleContent = visibleSummary(betaSummary);
 
-    expect(visibleContent).toContain('- Outcome: Release incomplete because Hosted Beta deployment did not run');
-    expect(visibleContent).toContain('- Hosted Production: unavailable because Hosted Beta deployment did not run');
+    expect(finalVisibleContent).toContain('- Outcome: Release incomplete because Hosted Beta deployment did not run');
+    expect(finalVisibleContent).toContain(
+      '- Hosted Production: unavailable because Hosted Beta deployment did not run',
+    );
+    expect(betaVisibleContent).toContain(
+      '- Outcome: Beta release incomplete because Hosted Beta deployment did not run',
+    );
   });
 
   it('reports an incomplete release when Beta tag creation is skipped', () => {
@@ -368,11 +385,42 @@ describe('WebApp release summary renderer', () => {
         promotionRequested: true,
       },
     };
-    const summary = renderWebappReleaseSummary(input);
-    const visibleContent = visibleSummary(summary);
+    const finalSummary = renderWebappReleaseSummary(input);
+    const betaSummary = renderWebappBetaReleaseSummary(input);
+    const finalVisibleContent = visibleSummary(finalSummary);
+    const betaVisibleContent = visibleSummary(betaSummary);
 
-    expect(visibleContent).toContain('- Outcome: Release incomplete because Beta tag creation did not run');
-    expect(visibleContent).toContain('- Hosted Production: unavailable because Beta tag creation did not run');
+    expect(finalVisibleContent).toContain('- Outcome: Release incomplete because Beta tag creation did not run');
+    expect(finalVisibleContent).toContain('- Hosted Production: unavailable because Beta tag creation did not run');
+    expect(betaVisibleContent).toContain('- Outcome: Beta release incomplete because Beta tag creation did not run');
+  });
+
+  it('stops the Beta release when Beta tag creation fails', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      beta: {
+        ...baselineWebappReleaseSummaryInput.beta,
+        tagCreationResult: Maybe.just('failure'),
+        tagName: Maybe.nothing<string>(),
+      },
+    };
+    const summary = renderWebappBetaReleaseSummary(input);
+
+    expect(visibleSummary(summary)).toContain('Beta release stopped because Beta tag creation failed');
+  });
+
+  it('stops the Beta release when Beta tag creation is cancelled', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      beta: {
+        ...baselineWebappReleaseSummaryInput.beta,
+        tagCreationResult: Maybe.just('cancelled'),
+        tagName: Maybe.nothing<string>(),
+      },
+    };
+    const summary = renderWebappBetaReleaseSummary(input);
+
+    expect(visibleSummary(summary)).toContain('Beta release stopped because Beta tag creation was cancelled');
   });
 
   it('reports an incomplete release when the E2E system gate is skipped', () => {
@@ -413,10 +461,8 @@ describe('WebApp release summary renderer', () => {
       },
     };
     const finalSummary = renderWebappReleaseSummary(input);
-    const candidateSummary = renderWebappReleaseCandidateSummary(input);
 
     expect(visibleSummary(finalSummary)).toContain('Release stopped because the E2E system gate failed');
-    expect(visibleSummary(candidateSummary)).toContain('Release candidate blocked because the E2E system gate failed');
     expect(visibleSummary(finalSummary)).toContain('- Hosted Production: blocked because the E2E system gate failed');
     expect(technicalEvidence(finalSummary)).toContain('- Result: failed');
   });
@@ -440,12 +486,9 @@ describe('WebApp release summary renderer', () => {
         promotionRequested: true,
       },
     };
-    const candidateSummary = renderWebappReleaseCandidateSummary(input);
     const finalSummary = renderWebappReleaseSummary(input);
-    const candidateVisibleContent = visibleSummary(candidateSummary);
     const finalVisibleContent = visibleSummary(finalSummary);
 
-    expect(candidateVisibleContent).toContain('Release candidate stopped because the E2E system gate was cancelled');
     expect(finalVisibleContent).toContain('Release stopped because the E2E system gate was cancelled');
     expect(finalVisibleContent).toContain('- Hosted Beta: deployed and verified successfully');
     expect(finalVisibleContent).toContain('- E2E system gate: cancelled');
@@ -595,10 +638,8 @@ describe('WebApp release summary renderer', () => {
         identifier: Maybe.nothing<string>(),
       },
     };
-    const candidateSummary = renderWebappReleaseCandidateSummary(input);
     const finalSummary = renderWebappReleaseSummary(input);
 
-    assertMarkdownContract(candidateSummary, false);
     assertMarkdownContract(finalSummary, true);
     expect(visibleSummary(finalSummary)).toContain('- Release: `not available`');
     expect(visibleSummary(finalSummary)).toContain('- Commit: not available');
@@ -615,12 +656,9 @@ describe('WebApp release summary renderer', () => {
         manualReason: Maybe.just('manual release for validation'),
       },
     };
-    const candidateSummary = renderWebappReleaseCandidateSummary(input);
     const finalSummary = renderWebappReleaseSummary(input);
 
-    expect(technicalEvidence(candidateSummary)).toContain('- Manual reason: manual release for validation');
     expect(technicalEvidence(finalSummary)).toContain('- Manual reason: manual release for validation');
-    expect(visibleSummary(candidateSummary)).not.toContain('Manual reason');
     expect(visibleSummary(finalSummary)).not.toContain('Manual reason');
   });
 

--- a/bin/renderWebappReleaseSummary.ts
+++ b/bin/renderWebappReleaseSummary.ts
@@ -110,12 +110,6 @@ export type WebappReleaseSummaryInput = {
   readonly release: ReleaseMetadata;
 };
 
-type FormatProductionApprovalStatusParameters = {
-  readonly input: ProductionSummaryInput;
-  readonly beta: BetaSummaryInput;
-  readonly e2e: E2ESummaryInput;
-};
-
 type RenderReleaseIdentityParameters = {
   readonly title: string;
   readonly outcome: string;
@@ -633,125 +627,6 @@ function formatProductionSkipReason(input: ProductionSummaryInput): Maybe<string
   return Maybe.nothing<string>();
 }
 
-function formatProductionDeploymentRequired(input: ProductionSummaryInput): string {
-  const inferredDeploymentRequirement = input.preflightResult.mapOrElse(
-    () => {
-      return match(input.promotionRequested)
-        .with(false, () => {
-          return 'false';
-        })
-        .otherwise(() => {
-          return 'not available';
-        });
-    },
-    preflightResult => {
-      return match([preflightResult, input.promotionRequested])
-        .with(['ready', P._], () => {
-          return 'true';
-        })
-        .with(['already_tagged', P._], () => {
-          return 'false';
-        })
-        .with([P._, false], () => {
-          return 'false';
-        })
-        .otherwise(() => {
-          return 'not available';
-        });
-    },
-  );
-
-  return input.deploymentRequired.mapOr(inferredDeploymentRequirement, deploymentRequired => {
-    return match(deploymentRequired)
-      .with(true, () => {
-        return 'true';
-      })
-      .with(false, () => {
-        return 'false';
-      })
-      .exhaustive();
-  });
-}
-
-function formatPlannedProductionTag(input: ProductionSummaryInput, release: ReleaseMetadata): string {
-  const plannedTagName = input.plannedTagName.orElse(() => {
-    return release.identifier.map(identifier => {
-      return `${identifier}-production`;
-    });
-  });
-
-  if (input.promotionRequested === false) {
-    return 'not requested';
-  }
-
-  return plannedTagName.mapOr('not available', plannedTag => {
-    return `\`${plannedTag}\``;
-  });
-}
-
-function formatEarlierFailedGate(beta: BetaSummaryInput, e2e: E2ESummaryInput): Maybe<string> {
-  if (hasWorkflowJobResult(beta.deploymentResult, 'failure')) {
-    return Maybe.just('Beta deployment failed');
-  }
-
-  if (hasWorkflowJobResult(beta.tagCreationResult, 'failure')) {
-    return Maybe.just('Beta tag creation failed');
-  }
-
-  if (hasWorkflowJobResult(e2e.result, 'failure')) {
-    return Maybe.just('E2E system gate failed');
-  }
-
-  return Maybe.nothing<string>();
-}
-
-function formatProductionApprovalStatus(parameters: FormatProductionApprovalStatusParameters): string {
-  const {input, beta, e2e} = parameters;
-
-  if (input.promotionRequested === false) {
-    return 'Production promotion was not requested';
-  }
-
-  if (hasProductionPreflightResult(input.preflightResult, 'already_tagged')) {
-    return 'Production deployment is not required because the release is already tagged';
-  }
-
-  if (
-    hasProductionPreflightResult(input.preflightResult, 'ready') &&
-    hasWorkflowJobResult(input.preflightJobResult, 'success')
-  ) {
-    return 'Production is ready for deployment. Approval is enforced through the wire-webapp-prod GitHub Environment.';
-  }
-
-  if (hasWorkflowJobResult(input.preflightJobResult, 'failure')) {
-    return 'Production is blocked because Production preflight failed';
-  }
-
-  if (hasWorkflowJobResult(input.preflightJobResult, 'cancelled')) {
-    return 'Production preflight was cancelled; Production approval is unavailable';
-  }
-
-  if (hasWorkflowJobResult(input.preflightJobResult, 'skipped')) {
-    const earlierFailedGate = formatEarlierFailedGate(beta, e2e);
-
-    if (earlierFailedGate.isJust) {
-      return `Production is blocked because an earlier gate failed: ${earlierFailedGate.value}; Production preflight was skipped`;
-    }
-
-    if (hasWorkflowJobResult(e2e.result, 'cancelled')) {
-      return 'Production preflight was skipped because the E2E system gate was cancelled';
-    }
-
-    if (hasWorkflowJobResult(e2e.result, 'skipped')) {
-      return 'Production preflight was skipped because the E2E system gate did not run';
-    }
-
-    return 'Production preflight was skipped; Production approval is unavailable';
-  }
-
-  return 'Production approval status is unavailable or unexpected';
-}
-
 function formatApprovalGate(input: ProductionSummaryInput): string {
   if (input.promotionRequested === false) {
     return 'not requested';
@@ -974,63 +849,39 @@ function hasHostedProductionCompleted(input: ProductionSummaryInput): boolean {
   );
 }
 
-function formatReleaseCandidateOutcome(input: WebappReleaseSummaryInput): string {
+function formatBetaReleaseOutcome(input: WebappReleaseSummaryInput): string {
   if (hasWorkflowJobResult(input.beta.deploymentResult, 'failure')) {
-    return 'Release candidate blocked because Hosted Beta deployment failed';
+    return 'Beta release stopped because Hosted Beta deployment failed';
   }
 
   if (hasWorkflowJobResult(input.beta.deploymentResult, 'cancelled')) {
-    return 'Release candidate stopped because Hosted Beta deployment was cancelled';
+    return 'Beta release stopped because Hosted Beta deployment was cancelled';
   }
 
   if (hasWorkflowJobResult(input.beta.deploymentResult, 'skipped')) {
-    return 'Release candidate incomplete because Hosted Beta deployment did not run';
+    return 'Beta release incomplete because Hosted Beta deployment did not run';
   }
 
   if (hasWorkflowJobResult(input.beta.tagCreationResult, 'failure')) {
-    return 'Release candidate blocked because Beta tag creation failed';
+    return 'Beta release stopped because Beta tag creation failed';
   }
 
   if (hasWorkflowJobResult(input.beta.tagCreationResult, 'cancelled')) {
-    return 'Release candidate stopped because Beta tag creation was cancelled';
+    return 'Beta release stopped because Beta tag creation was cancelled';
   }
 
-  if (hasWorkflowJobResult(input.e2e.result, 'failure')) {
-    return 'Release candidate blocked because the E2E system gate failed';
-  }
-
-  if (hasWorkflowJobResult(input.e2e.result, 'cancelled')) {
-    return 'Release candidate stopped because the E2E system gate was cancelled';
-  }
-
-  if (hasWorkflowJobResult(input.e2e.result, 'skipped')) {
-    return 'Release candidate incomplete because the E2E system gate did not run';
-  }
-
-  if (hasWorkflowJobResult(input.e2e.result, 'success') && input.production.promotionRequested === false) {
-    return 'Beta release candidate passed; Production promotion was not requested';
-  }
-
-  if (hasProductionPreflightResult(input.production.preflightResult, 'already_tagged')) {
-    return 'Release candidate already has the matching Production tag; deployment is not required';
+  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'skipped')) {
+    return 'Beta release incomplete because Beta tag creation did not run';
   }
 
   if (
-    hasProductionPreflightResult(input.production.preflightResult, 'ready') &&
-    hasWorkflowJobResult(input.production.preflightJobResult, 'success')
+    hasWorkflowJobResult(input.beta.deploymentResult, 'success') &&
+    hasWorkflowJobResult(input.beta.tagCreationResult, 'success')
   ) {
-    return 'Release candidate passed and is ready for Production approval';
+    return 'Beta release completed successfully';
   }
 
-  if (hasProductionPreflightFailure(input.production)) {
-    return 'Release candidate blocked because Production preflight failed';
-  }
-
-  if (hasProductionPreflightCancellation(input.production)) {
-    return 'Release candidate stopped because Production preflight was cancelled';
-  }
-
-  return 'Release candidate status is unavailable or unexpected';
+  return 'Beta release status is unavailable or unexpected';
 }
 
 function formatFinalReleaseOutcome(input: WebappReleaseSummaryInput): string {
@@ -1135,65 +986,6 @@ function formatFinalReleaseOutcome(input: WebappReleaseSummaryInput): string {
   }
 
   return 'Release status is unavailable or unexpected';
-}
-
-function formatCandidateProductionOverview(input: WebappReleaseSummaryInput): string {
-  if (input.production.promotionRequested === false) {
-    return 'promotion was not requested';
-  }
-
-  if (hasWorkflowJobResult(input.beta.deploymentResult, 'failure')) {
-    return 'blocked because Hosted Beta deployment failed';
-  }
-
-  if (hasWorkflowJobResult(input.beta.deploymentResult, 'cancelled')) {
-    return 'unavailable because Hosted Beta deployment was cancelled';
-  }
-
-  if (hasWorkflowJobResult(input.beta.deploymentResult, 'skipped')) {
-    return 'unavailable because Hosted Beta deployment did not run';
-  }
-
-  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'failure')) {
-    return 'blocked because Beta tag creation failed';
-  }
-
-  if (hasWorkflowJobResult(input.beta.tagCreationResult, 'cancelled')) {
-    return 'unavailable because Beta tag creation was cancelled';
-  }
-
-  if (hasWorkflowJobResult(input.e2e.result, 'failure')) {
-    return 'blocked because the E2E system gate failed';
-  }
-
-  if (hasWorkflowJobResult(input.e2e.result, 'cancelled')) {
-    return 'unavailable because the E2E system gate was cancelled';
-  }
-
-  if (hasWorkflowJobResult(input.e2e.result, 'skipped')) {
-    return 'unavailable because the E2E system gate did not run';
-  }
-
-  if (hasProductionPreflightResult(input.production.preflightResult, 'already_tagged')) {
-    return 'already has the matching Production tag; deployment is not required';
-  }
-
-  if (
-    hasProductionPreflightResult(input.production.preflightResult, 'ready') &&
-    hasWorkflowJobResult(input.production.preflightJobResult, 'success')
-  ) {
-    return 'ready for approval through the wire-webapp-prod GitHub Environment';
-  }
-
-  if (hasProductionPreflightFailure(input.production)) {
-    return 'blocked because Production preflight failed';
-  }
-
-  if (hasProductionPreflightCancellation(input.production)) {
-    return 'unavailable because Production preflight was cancelled';
-  }
-
-  return 'unavailable because Production readiness is unknown';
 }
 
 function formatFinalProductionOverview(input: WebappReleaseSummaryInput): string {
@@ -1323,32 +1115,6 @@ function renderE2ESection(input: WebappReleaseSummaryInput): string {
   ].join('\n');
 }
 
-function renderProductionReadinessSection(input: WebappReleaseSummaryInput): string {
-  const productionSkipReason = formatProductionSkipReason(input.production);
-  const productionSkipReasonLines = productionSkipReason
-    .map(reason => {
-      return [`- Production skip reason: ${reason}`];
-    })
-    .unwrapOr([]);
-
-  return [
-    '### Hosted Production promotion',
-    '',
-    `- Production promotion requested: ${input.production.promotionRequested === true ? 'true' : 'false'}`,
-    `- Production preflight job result: ${formatValueOrFallback(input.production.preflightJobResult)}`,
-    `- Production preflight result: ${formatProductionPreflightResult(input.production)}`,
-    `- Production deployment required: ${formatProductionDeploymentRequired(input.production)}`,
-    ...productionSkipReasonLines,
-    `- Planned Production tag: ${formatPlannedProductionTag(input.production, input.release)}`,
-    `- GitHub Environment: ${formatValueOrFallback(input.production.environmentName)}`,
-    `- Approval status: ${formatProductionApprovalStatus({
-      input: input.production,
-      beta: input.beta,
-      e2e: input.e2e,
-    })}`,
-  ].join('\n');
-}
-
 function renderProductionSection(input: WebappReleaseSummaryInput): string {
   const productionSkipReason = formatProductionSkipReason(input.production);
   const productionSkipReasonLines = productionSkipReason
@@ -1420,15 +1186,13 @@ function renderReleasePreparationSection(input: WebappReleaseSummaryInput): stri
   ].join('\n');
 }
 
-function renderTechnicalReleaseEvidence(input: WebappReleaseSummaryInput, isCandidate: boolean): string {
-  const technicalSections = [
-    renderReleasePreparationSection(input),
-    renderBetaSection(input),
-    renderE2ESection(input),
-    isCandidate ? renderProductionReadinessSection(input) : renderProductionSection(input),
-  ];
+type WebappReleaseSummaryPhase = 'beta' | 'final';
 
-  if (!isCandidate) {
+function renderTechnicalReleaseEvidence(input: WebappReleaseSummaryInput, phase: WebappReleaseSummaryPhase): string {
+  const technicalSections = [renderReleasePreparationSection(input), renderBetaSection(input)];
+
+  if (phase === 'final') {
+    technicalSections.push(renderE2ESection(input), renderProductionSection(input));
     technicalSections.push(renderProductionDistributionSection(input));
   }
 
@@ -1442,23 +1206,17 @@ function renderTechnicalReleaseEvidence(input: WebappReleaseSummaryInput, isCand
   ].join('\n');
 }
 
-export function renderWebappReleaseCandidateSummary(input: WebappReleaseSummaryInput): string {
+export function renderWebappBetaReleaseSummary(input: WebappReleaseSummaryInput): string {
   const visibleSummary = [
     renderReleaseIdentity({
-      title: '## WebApp release candidate',
-      outcome: formatReleaseCandidateOutcome(input),
+      title: '## WebApp Beta release',
+      outcome: formatBetaReleaseOutcome(input),
       input,
     }),
-    [
-      '### Release stages',
-      '',
-      `- Hosted Beta: ${formatBetaStageOverview(input)}`,
-      `- E2E system gate: ${formatE2EStageOverview(input)}`,
-      `- Hosted Production: ${formatCandidateProductionOverview(input)}`,
-    ].join('\n'),
+    ['### Release stages', '', `- Hosted Beta: ${formatBetaStageOverview(input)}`].join('\n'),
   ].join('\n\n');
 
-  return `${visibleSummary}\n\n${renderTechnicalReleaseEvidence(input, true)}\n`;
+  return `${visibleSummary}\n\n${renderTechnicalReleaseEvidence(input, 'beta')}\n`;
 }
 
 export function renderWebappReleaseSummary(input: WebappReleaseSummaryInput): string {
@@ -1490,16 +1248,14 @@ export function renderWebappReleaseSummary(input: WebappReleaseSummaryInput): st
     ].join('\n'),
   ].join('\n\n');
 
-  return `${visibleSummary}\n\n${renderTechnicalReleaseEvidence(input, false)}\n`;
+  return `${visibleSummary}\n\n${renderTechnicalReleaseEvidence(input, 'final')}\n`;
 }
-
-type WebappReleaseSummaryPhase = 'candidate' | 'final';
 
 const commandLineArgumentStartIndex = 2;
 
 function readWebappReleaseSummaryPhase(commandLineArguments: readonly string[]): WebappReleaseSummaryPhase {
-  if (commandLineArguments.includes('--release-candidate')) {
-    return 'candidate';
+  if (commandLineArguments.includes('--beta-release')) {
+    return 'beta';
   }
 
   return 'final';
@@ -1509,8 +1265,7 @@ function main(): void {
   try {
     const input = readWebappReleaseSummaryInput(process.env);
     const summaryPhase = readWebappReleaseSummaryPhase(process.argv.slice(commandLineArgumentStartIndex));
-    const summary =
-      summaryPhase === 'candidate' ? renderWebappReleaseCandidateSummary(input) : renderWebappReleaseSummary(input);
+    const summary = summaryPhase === 'beta' ? renderWebappBetaReleaseSummary(input) : renderWebappReleaseSummary(input);
 
     process.stdout.write(summary);
   } catch (error) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Context

The WebApp release workflow currently produces its first summary only after the complete E2E workflow and Production preflight have finished.

Because the E2E suite can take a significant amount of time, the workflow run provides no concise top-level release information even though Hosted Beta may already have been deployed, verified, and tagged successfully.

The first durable release milestone is the verified Beta tag. The corresponding summary should therefore become available as soon as that milestone has settled.

## Changes

This pull request replaces the post-E2E release-candidate summary with an earlier Beta release summary.

The renamed `Summarize Beta release` job now runs after:

* the release artifact has been built;
* Hosted Beta deployment and runtime verification have completed;
* Beta tag creation has completed.

The Beta summary and E2E workflow can then start independently. E2E does not wait for the summary job.