### PR TITLE
chore(e2e): Increase timeout for TC-2927 [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Calling/calling.spec.ts
@@ -698,6 +698,7 @@ test.describe('Calling', () => {
     },
   ].forEach(({description, tag, verify}) => {
     test(description, {tag: [tag, '@regression']}, async ({createPage, createUser}) => {
+      test.setTimeout(120_000);
       const {pages: userAPages, modals: userAModals} = PageManager.from(await createPage(withLogin(userA))).webapp;
 
       const {groupMembers, memberPages} =

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -357,8 +357,9 @@ test.describe('Federation', () => {
           .conversation()
           .getMessage({sender: federatedUser})
           .filter({has: normalUserPage.getByTestId('image-asset')});
-        await expect(messageWithImage).toBeVisible();
 
+        // It takes a bit longer for the image to be uploaded and received, so the timeout is increased to 30 seconds to avoid flakiness in the test
+        await expect(messageWithImage).toBeVisible({timeout: 30_000}); 
         // Wait for messages to be read before exporting backup
         await expect(groupConversation.unreadIndicator).not.toBeVisible();
       });

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -359,7 +359,7 @@ test.describe('Federation', () => {
           .filter({has: normalUserPage.getByTestId('image-asset')});
 
         // It takes a bit longer for the image to be uploaded and received, so the timeout is increased to 30 seconds to avoid flakiness in the test
-        await expect(messageWithImage).toBeVisible({timeout: 30_000}); 
+        await expect(messageWithImage).toBeVisible({timeout: 30_000});
         // Wait for messages to be read before exporting backup
         await expect(groupConversation.unreadIndicator).not.toBeVisible();
       });

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -358,8 +358,7 @@ test.describe('Federation', () => {
           .getMessage({sender: federatedUser})
           .filter({has: normalUserPage.getByTestId('image-asset')});
 
-        // It takes a bit longer for the image to be uploaded and received, so the timeout is increased to 30 seconds to avoid flakiness in the test
-        await expect(messageWithImage).toBeVisible({timeout: 30_000});
+        await expect(messageWithImage).toBeVisible();
         // Wait for messages to be read before exporting backup
         await expect(groupConversation.unreadIndicator).not.toBeVisible();
       });

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -357,8 +357,8 @@ test.describe('Federation', () => {
           .conversation()
           .getMessage({sender: federatedUser})
           .filter({has: normalUserPage.getByTestId('image-asset')});
-
         await expect(messageWithImage).toBeVisible();
+        
         // Wait for messages to be read before exporting backup
         await expect(groupConversation.unreadIndicator).not.toBeVisible();
       });

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -358,7 +358,7 @@ test.describe('Federation', () => {
           .getMessage({sender: federatedUser})
           .filter({has: normalUserPage.getByTestId('image-asset')});
         await expect(messageWithImage).toBeVisible();
-        
+
         // Wait for messages to be read before exporting backup
         await expect(groupConversation.unreadIndicator).not.toBeVisible();
       });


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->



- Increase timeout for TC-2927 to accommodate for slow staging environment.