### PR TITLE
Remove ineffective code owners [WPB-22420]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @arjita-mitra @e-maad @ikotarac @otto-the-bot @screendriver @thisisamir98 @zskhan


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Context

The current `CODEOWNERS` file assigns every file to almost the entire Web team, causing broad and low-signal review requests.

## Changes

Remove `.github/CODEOWNERS` and update the branch ruleset so pull requests still require peer approval without requiring code-owner approval.