### PR TITLE
fix: show all app participants in group details [WPB-27417]

### DIFF
--- a/apps/webapp/src/script/page/rightSidebar/conversationDetails/conversationDetails.test.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/conversationDetails/conversationDetails.test.tsx
@@ -25,6 +25,7 @@ import {UserType} from '@wireapp/api-client/lib/user';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {ConnectionRepository} from 'Repositories/connection/connectionRepository';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
+import {ConversationMapper} from 'Repositories/conversation/ConversationMapper';
 import {ConversationRoleRepository} from 'Repositories/conversation/ConversationRoleRepository';
 import {MessageRepository} from 'Repositories/conversation/MessageRepository';
 import {Conversation} from 'Repositories/entity/Conversation';
@@ -163,6 +164,35 @@ describe('ConversationDetails', () => {
       expect(getByTestId(`service-list-service-${app.id}`)).not.toBeNull();
     },
   );
+
+  it('keeps legacy bots visible while a Proteus group migrates through Mixed to MLS', () => {
+    const conversation = new Conversation(createUuid(), '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
+    const legacyBot = new User('legacy-bot', '', translateForTest);
+
+    legacyBot.name('Legacy bot');
+    legacyBot.isService = true;
+    legacyBot.type = UserType.BOT;
+    conversation.participating_user_ets([legacyBot]);
+
+    const defaultProps = getDefaultParams();
+    const {getByTestId, rerender} = render(
+      <ConversationDetails {...defaultProps} activeConversation={conversation} />,
+      {wrapper: rootProviderWrapper},
+    );
+    const legacyBotTestId = `service-list-service-${legacyBot.id}`;
+
+    expect(getByTestId(legacyBotTestId)).not.toBeNull();
+
+    ConversationMapper.updateProperties(conversation, {protocol: CONVERSATION_PROTOCOL.MIXED});
+    rerender(<ConversationDetails {...defaultProps} activeConversation={conversation} />);
+
+    expect(getByTestId(legacyBotTestId)).not.toBeNull();
+
+    ConversationMapper.updateProperties(conversation, {protocol: CONVERSATION_PROTOCOL.MLS});
+    rerender(<ConversationDetails {...defaultProps} activeConversation={conversation} />);
+
+    expect(getByTestId(legacyBotTestId)).not.toBeNull();
+  });
 
   it("returns the right actions depending on the conversation's type for non group creators", () => {
     const conversation = new Conversation('', '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);

--- a/apps/webapp/src/script/page/rightSidebar/conversationDetails/conversationDetails.test.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/conversationDetails/conversationDetails.test.tsx
@@ -20,6 +20,7 @@
 import {act, render} from '@testing-library/react';
 import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
+import {UserType} from '@wireapp/api-client/lib/user';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {ConnectionRepository} from 'Repositories/connection/connectionRepository';
@@ -29,6 +30,7 @@ import {MessageRepository} from 'Repositories/conversation/MessageRepository';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {IntegrationRepository} from 'Repositories/integration/IntegrationRepository';
+import {ServiceEntity} from 'Repositories/integration/ServiceEntity';
 import {SearchRepository} from 'Repositories/search/searchRepository';
 import {SelfRepository} from 'Repositories/self/SelfRepository';
 import {TeamEntity} from 'Repositories/team/TeamEntity';
@@ -39,8 +41,9 @@ import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
-import {translate} from 'Util/localizerUtil';
 import 'src/script/util/test/mock/localStorageMock';
+import {translate} from 'Util/localizerUtil';
+import {translateForTest} from 'Util/test/translateForTest';
 import {createUuid} from 'Util/uuid';
 
 import {ConversationDetails} from './conversationDetails';
@@ -48,7 +51,6 @@ import {ConversationDetails} from './conversationDetails';
 import {TestFactory} from '../../../../../test/helper/TestFactory';
 import {ActionsViewModel} from '../../../view_model/ActionsViewModel';
 import {MainViewModel} from '../../../view_model/MainViewModel';
-import {translateForTest} from 'Util/test/translateForTest';
 
 jest.mock('Components/panel/enrichedFields', () => ({
   useEnrichedFields: (): never[] => [],
@@ -120,6 +122,48 @@ const getDefaultParams = () => {
 };
 
 describe('ConversationDetails', () => {
+  it.each([CONVERSATION_PROTOCOL.PROTEUS, CONVERSATION_PROTOCOL.MIXED, CONVERSATION_PROTOCOL.MLS])(
+    'shows legacy bots and apps in %s groups',
+    protocol => {
+      const conversation = new Conversation(createUuid(), '', protocol, translateForTest);
+      const regularUser = new User('regular-user', '', translateForTest);
+      const legacyBot = new User('legacy-bot', '', translateForTest);
+      const app = new User('app', '', translateForTest);
+
+      regularUser.name('Regular user');
+      legacyBot.name('Legacy bot');
+      legacyBot.isService = true;
+      legacyBot.type = UserType.BOT;
+      app.name('App');
+      app.type = UserType.APP;
+      conversation.participating_user_ets([regularUser, legacyBot, app]);
+
+      const defaultProps = getDefaultParams();
+      const integrationRepository = {
+        ...defaultProps.integrationRepository,
+        mapServiceFromUser: (user: User) =>
+          new ServiceEntity({
+            id: user.id,
+            name: user.name(),
+            qualifiedId: user.qualifiedId,
+            type: 'App',
+          }),
+      } as IntegrationRepository;
+
+      const {getByTestId} = render(
+        <ConversationDetails
+          {...defaultProps}
+          activeConversation={conversation}
+          integrationRepository={integrationRepository}
+        />,
+        {wrapper: rootProviderWrapper},
+      );
+
+      expect(getByTestId(`service-list-service-${legacyBot.id}`)).not.toBeNull();
+      expect(getByTestId(`service-list-service-${app.id}`)).not.toBeNull();
+    },
+  );
+
   it("returns the right actions depending on the conversation's type for non group creators", () => {
     const conversation = new Conversation('', '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
     const otherUser = new User('other-user', '', translateForTest);

--- a/apps/webapp/src/script/page/rightSidebar/conversationDetails/conversationDetails.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/conversationDetails/conversationDetails.tsx
@@ -21,7 +21,6 @@ import {forwardRef, useEffect, useMemo, useState} from 'react';
 
 import {CONVERSATION_ACCESS, CONVERSATION_CELLS_STATE} from '@wireapp/api-client/lib/conversation';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data/';
-import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 import {UserType} from '@wireapp/api-client/lib/user';
 
 import {TabIndex} from '@wireapp/react-ui-kit';
@@ -200,20 +199,18 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
     const allUsersCount = exceedsMaxUserCount ? usersCount : 0;
 
     const serviceParticipants: ServiceEntity[] = useMemo(() => {
-      const services = new Array<ServiceEntity>();
+      return participatingUserEts.flatMap(participant => {
+        if (isServiceEntity(participant)) {
+          return [participant];
+        }
 
-      if (activeConversation.protocol === CONVERSATION_PROTOCOL.PROTEUS) {
-        services.push(...participatingUserEts.filter(service => isServiceEntity(service)));
-      } else {
-        services.push(
-          ...participatingUserEts
-            .filter(user => user.type === UserType.APP)
-            .map(user => integrationRepository.mapServiceFromUser(user)),
-        );
-      }
+        if (participant.type === UserType.APP) {
+          return [integrationRepository.mapServiceFromUser(participant)];
+        }
 
-      return services;
-    }, [activeConversation.protocol, integrationRepository, participatingUserEts]);
+        return [];
+      });
+    }, [integrationRepository, participatingUserEts]);
 
     const toggleMute = () => actionsViewModel.toggleMuteConversation(activeConversation);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27417" title="WPB-27417" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27417</a>  [Web] show group members regardless of protocol
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Goal

Keep group participant details complete and consistent when a conversation changes protocol.

## Changes

- combine legacy bot/service participants and newer app participants for every conversation protocol
- remove the protocol-specific participant-list branch
- add regression coverage for Proteus, mixed, and MLS groups

## Root cause

The group details view selected legacy service participants only for Proteus conversations and selected newer app participants for every other protocol. As a result, legacy bots were omitted from the displayed list after a conversation entered mixed or MLS state.

## Impact

Group details now show all bot and app participants consistently throughout protocol migration.

## Validation

- Conversation details regression coverage passes for Proteus, mixed, and MLS groups
- scoped lint and formatting checks pass
