### PR TITLE
feat: Add self user drive role (editor / viewer) in shared drive(WPB-26111)

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
@@ -35,6 +35,10 @@ import {CellsLoader} from './CellsLoader/CellsLoader';
 import {CellsPagination} from './CellsPagination/CellsPagination';
 import {CellsStateInfo} from './cellsStateInfo/cellsStateInfo';
 import {CellsTable} from './CellsTable/CellsTable';
+import {
+  CellsSelfUserDriveRoleProvider,
+  getSelfUserDriveRole,
+} from './common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
 import {getLoadMoreOffset} from './common/loadMorePagination/loadMorePagination';
 import {isInRecycleBin as isCurrentPathInRecycleBin} from './common/recycleBin/recycleBin';
 import {useCellsSorting} from './common/useCellsSorting/useCellsSorting';
@@ -73,7 +77,11 @@ export const ConversationCells = memo(
     onCloseSearchView,
   }: ConversationCellsProps) => {
     const {fireAndForgetInvoker, translate} = useApplicationContext();
-    const {cellsState: initialCellState, name} = useKoSubscribableChildren(activeConversation, ['cellsState', 'name']);
+    const {
+      cellsState: initialCellState,
+      name,
+      selfUser,
+    } = useKoSubscribableChildren(activeConversation, ['cellsState', 'name', 'selfUser']);
 
     const {getNodes, status: nodesStatus, getPagination, error: storeError, clearAll} = useCellsStore();
 
@@ -219,81 +227,87 @@ export const ConversationCells = memo(
     const isLoadMoreVisible =
       isSearchMode && !isLoading && !isFetchingMore && !emptyView && isSuccess && hasMorePages && !hasAppendError;
     const isLoadMoreErrorVisible = isSearchMode && hasAppendError && hasMorePages;
+    const selfUserDriveRole = getSelfUserDriveRole({
+      conversationTeamId: activeConversation.teamId,
+      selfUserTeamId: selfUser?.teamId,
+    });
 
     return (
-      <div css={wrapperStyles}>
-        <CellsHeader
-          onRefresh={handleRefresh}
-          conversationName={name}
-          conversationQualifiedId={conversationQualifiedId}
-          cellsRepository={cellsRepository}
-          isSearchViewOpen={isSearchMode}
-          isInRecycleBin={isInRecycleBin}
-          onOpenSearchView={onOpenSearchView}
-          searchValue={searchValue}
-          onSearchChange={handleSearch}
-          onSearchClear={handleClearSearch}
-          filters={filters}
-        />
-        {isTableVisible && (
-          <CellsTable
-            nodes={isLoading ? [] : nodes}
-            cellsRepository={cellsRepository}
-            conversationQualifiedId={conversationQualifiedId}
-            conversationName={name}
+      <CellsSelfUserDriveRoleProvider selfUserDriveRole={selfUserDriveRole}>
+        <div css={wrapperStyles}>
+          <CellsHeader
             onRefresh={handleRefresh}
-            // opening a folder must close search view and open the browse view
-            // with that folder (and breadcrumbs)
-            onCloseSearchView={handleSearchViewClosure}
-            getDirectionFor={getDirectionFor}
-            isSortingEnabled={!isInRecycleBin}
-            onToggleSort={toggleSort}
+            conversationName={name}
+            conversationQualifiedId={conversationQualifiedId}
+            cellsRepository={cellsRepository}
+            isSearchViewOpen={isSearchMode}
+            isInRecycleBin={isInRecycleBin}
+            onOpenSearchView={onOpenSearchView}
+            searchValue={searchValue}
+            onSearchChange={handleSearch}
+            onSearchClear={handleClearSearch}
+            filters={filters}
           />
-        )}
-        {isCellsStatePending && !isRefreshing && (
-          <CellsStateInfo
-            heading={translate('cells.pending.heading')}
-            description={translate('cells.pending.description')}
-          />
-        )}
-        {isNoNodesVisible && !isEmptySearchResultsVisible && (
-          <CellsStateInfo
-            heading={translate('cells.noNodes.heading')}
-            description={translate('cells.noNodes.description')}
-          />
-        )}
-        {isEmptySearchResultsVisible && (
-          <CellsStateInfo
-            variant="search"
-            heading={translate('cells.emptySearchResults.heading')}
-            description={translate('cells.emptySearchResults.description')}
-          />
-        )}
-        {isEmptyRecycleBin && <CellsStateInfo description={translate('cells.emptyRecycleBin.description')} />}
-        {(isLoadingVisible || isRefreshing || isFetchingMoreVisible) && <CellsLoader />}
-        {isError && (
-          <CellsStateInfo
-            heading={translate('cells.error.heading')}
-            description={translate('cells.error.description')}
-          />
-        )}
-        {isPaginationVisible && <CellsPagination {...getPaginationProps()} goToPage={goToPage} />}
-        {isLoadMoreVisible && (
-          <div css={loadMoreWrapperStyles}>
-            <Button variant={ButtonVariant.TERTIARY} onClick={handleLoadMore}>
-              {translate('cells.pagination.loadMoreResults')}
-            </Button>
-          </div>
-        )}
-        {isLoadMoreErrorVisible && (
-          <div css={loadMoreErrorWrapperStyles} role="alert">
-            <span css={loadMoreErrorMessageStyles}>{translate('cells.pagination.loadMoreError.heading')}</span>
-            <Button variant={ButtonVariant.TERTIARY} onClick={handleLoadMore}>
-              {translate('cells.pagination.loadMoreError.retry')}
-            </Button>
-          </div>
-        )}
-      </div>
+          {isTableVisible && (
+            <CellsTable
+              nodes={isLoading ? [] : nodes}
+              cellsRepository={cellsRepository}
+              conversationQualifiedId={conversationQualifiedId}
+              conversationName={name}
+              onRefresh={handleRefresh}
+              // opening a folder must close search view and open the browse view
+              // with that folder (and breadcrumbs)
+              onCloseSearchView={handleSearchViewClosure}
+              getDirectionFor={getDirectionFor}
+              isSortingEnabled={!isInRecycleBin}
+              onToggleSort={toggleSort}
+            />
+          )}
+          {isCellsStatePending && !isRefreshing && (
+            <CellsStateInfo
+              heading={translate('cells.pending.heading')}
+              description={translate('cells.pending.description')}
+            />
+          )}
+          {isNoNodesVisible && !isEmptySearchResultsVisible && (
+            <CellsStateInfo
+              heading={translate('cells.noNodes.heading')}
+              description={translate('cells.noNodes.description')}
+            />
+          )}
+          {isEmptySearchResultsVisible && (
+            <CellsStateInfo
+              variant="search"
+              heading={translate('cells.emptySearchResults.heading')}
+              description={translate('cells.emptySearchResults.description')}
+            />
+          )}
+          {isEmptyRecycleBin && <CellsStateInfo description={translate('cells.emptyRecycleBin.description')} />}
+          {(isLoadingVisible || isRefreshing || isFetchingMoreVisible) && <CellsLoader />}
+          {isError && (
+            <CellsStateInfo
+              heading={translate('cells.error.heading')}
+              description={translate('cells.error.description')}
+            />
+          )}
+          {isPaginationVisible && <CellsPagination {...getPaginationProps()} goToPage={goToPage} />}
+          {isLoadMoreVisible && (
+            <div css={loadMoreWrapperStyles}>
+              <Button variant={ButtonVariant.TERTIARY} onClick={handleLoadMore}>
+                {translate('cells.pagination.loadMoreResults')}
+              </Button>
+            </div>
+          )}
+          {isLoadMoreErrorVisible && (
+            <div css={loadMoreErrorWrapperStyles} role="alert">
+              <span css={loadMoreErrorMessageStyles}>{translate('cells.pagination.loadMoreError.heading')}</span>
+              <Button variant={ButtonVariant.TERTIARY} onClick={handleLoadMore}>
+                {translate('cells.pagination.loadMoreError.retry')}
+              </Button>
+            </div>
+          )}
+        </div>
+      </CellsSelfUserDriveRoleProvider>
     );
   },
 );

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CELLS_SELF_USER_DRIVE_ROLE, getSelfUserDriveRole} from './CellsSelfUserDriveRoleContext';
+
+describe('getSelfUserDriveRole', () => {
+  it('returns editor when conversation and self user are in the same team', () => {
+    expect(getSelfUserDriveRole({conversationTeamId: 'team-a', selfUserTeamId: 'team-a'})).toBe(
+      CELLS_SELF_USER_DRIVE_ROLE.EDITOR,
+    );
+  });
+
+  it('returns viewer when conversation and self user are in different teams', () => {
+    expect(getSelfUserDriveRole({conversationTeamId: 'team-a', selfUserTeamId: 'team-b'})).toBe(
+      CELLS_SELF_USER_DRIVE_ROLE.VIEWER,
+    );
+  });
+
+  it('defaults to editor when local team data is missing', () => {
+    expect(getSelfUserDriveRole({conversationTeamId: undefined, selfUserTeamId: 'team-a'})).toBe(
+      CELLS_SELF_USER_DRIVE_ROLE.EDITOR,
+    );
+    expect(getSelfUserDriveRole({conversationTeamId: 'team-a', selfUserTeamId: undefined})).toBe(
+      CELLS_SELF_USER_DRIVE_ROLE.EDITOR,
+    );
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext.tsx
@@ -1,0 +1,62 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createContext, type ReactNode, useContext} from 'react';
+
+export const CELLS_SELF_USER_DRIVE_ROLE = {
+  EDITOR: 'editor',
+  VIEWER: 'viewer',
+} as const;
+
+export type CellsSelfUserDriveRole = (typeof CELLS_SELF_USER_DRIVE_ROLE)[keyof typeof CELLS_SELF_USER_DRIVE_ROLE];
+
+interface GetSelfUserDriveRoleParams {
+  conversationTeamId?: string;
+  selfUserTeamId?: string;
+}
+
+export const getSelfUserDriveRole = ({
+  conversationTeamId,
+  selfUserTeamId,
+}: GetSelfUserDriveRoleParams): CellsSelfUserDriveRole => {
+  if (!conversationTeamId || !selfUserTeamId) {
+    return CELLS_SELF_USER_DRIVE_ROLE.EDITOR;
+  }
+
+  return conversationTeamId === selfUserTeamId ? CELLS_SELF_USER_DRIVE_ROLE.EDITOR : CELLS_SELF_USER_DRIVE_ROLE.VIEWER;
+};
+
+const CellsSelfUserDriveRoleContext = createContext<CellsSelfUserDriveRole>(CELLS_SELF_USER_DRIVE_ROLE.EDITOR);
+
+interface CellsSelfUserDriveRoleProviderProps {
+  children: ReactNode;
+  selfUserDriveRole: CellsSelfUserDriveRole;
+}
+
+export const CellsSelfUserDriveRoleProvider = ({children, selfUserDriveRole}: CellsSelfUserDriveRoleProviderProps) => {
+  return (
+    <CellsSelfUserDriveRoleContext.Provider value={selfUserDriveRole}>
+      {children}
+    </CellsSelfUserDriveRoleContext.Provider>
+  );
+};
+
+export const useCellsSelfUserDriveRole = (): CellsSelfUserDriveRole => {
+  return useContext(CellsSelfUserDriveRoleContext);
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26111" title="WPB-26111" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26111</a>  [Web] Add self user drive role (editor / viewer) in shared drive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
As a system, I want to know my role (editor / viewer) in the shared drive screen so I know what are the actions available to me.

Editor = all actions

Viewer = restricted actions

Note:

In milestone1 (this current task), this will default to editor for all users including guests.