### PR TITLE
fix: update concurrency group of pull translation [WPB-22420]

### DIFF
--- a/.github/workflows/pull-translations-from-crowdin.yml
+++ b/.github/workflows/pull-translations-from-crowdin.yml
@@ -1,8 +1,8 @@
 name: Pull translations from Crowdin
 
 on:
-  push:
-    branches: [main]
+  schedule:
+    - cron: '17 12,14,16,18 * * 1-5'
   workflow_dispatch:
 
 permissions:
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: crowdin-pull-main
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   pull_from_crowdin:

--- a/.github/workflows/pull-translations-from-crowdin.yml
+++ b/.github/workflows/pull-translations-from-crowdin.yml
@@ -1,8 +1,6 @@
 name: Pull translations from Crowdin
 
 on:
-  schedule:
-    - cron: '17 12,14,16,18 * * 1-5'
   workflow_dispatch:
 
 permissions:
@@ -11,7 +9,7 @@ permissions:
 
 concurrency:
   group: crowdin-pull-main
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   pull_from_crowdin:

--- a/.github/workflows/push-translations-to-crowdin.yml
+++ b/.github/workflows/push-translations-to-crowdin.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: crowdin-push-${{ github.ref }}
-  cancel-in-progress: true
+  group: crowdin-push-main
+  cancel-in-progress: false
 
 jobs:
   push_to_crowdin:


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Update concurrency group name of pull translation to crowdin-pull-main and cancel-in-progress to true for both workflow
This ensures source uploads and translation downloads cannot run concurrently.