### PR TITLE
chore: update AVS library to fix delayed video state handling during glare [WPB-27428]

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -36,7 +36,7 @@
     "@sindresorhus/is": "4.6.0",
     "@tanstack/react-table": "8.21.3",
     "@tanstack/react-virtual": "3.14.7",
-    "@wireapp/avs": "10.4.5",
+    "@wireapp/avs": "10.4.28",
     "@wireapp/avs-debugger": "0.0.7",
     "@wireapp/commons": "workspace:^",
     "@wireapp/config": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11464,10 +11464,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/avs@npm:10.4.5":
-  version: 10.4.5
-  resolution: "@wireapp/avs@npm:10.4.5"
-  checksum: 10/f6098dadcde46df8931f68d0819fd1515c1833b42ffa40bf7027fdf4c02012cd82ef27ddd0ccec4cc1af6ec9f3e14524db2edcaf6c190cc47363d53b6d28eb54
+"@wireapp/avs@npm:10.4.28":
+  version: 10.4.28
+  resolution: "@wireapp/avs@npm:10.4.28"
+  checksum: 10/3e4b9a939b1cb9d1a16694ccf36e472337944408500ef7093a4032d33bcdc9abc6479c2b49155894726b1549b376ffec0b1d9ddcb3527981bf5481a3ef0634f4
   languageName: node
   linkType: hard
 
@@ -11965,7 +11965,7 @@ __metadata:
     "@types/webpack-bundle-analyzer": "npm:4.7.0"
     "@types/webpack-env": "npm:1.18.8"
     "@types/wicg-file-system-access": "npm:2023.10.7"
-    "@wireapp/avs": "npm:10.4.5"
+    "@wireapp/avs": "npm:10.4.28"
     "@wireapp/avs-debugger": "npm:0.0.7"
     "@wireapp/commons": "workspace:^"
     "@wireapp/config": "workspace:^"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27428" title="WPB-27428" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27428</a>  [Calling] Update AVS library to fix delayed video state handling during glare (AVS: 10.4.28)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

A bug has been identified in the calling AVS library where video state changes can be lost while a glare (simultaneous session update) is in progress. The issue has been fixed in the AVS library and requires updating the application to the latest library version.