### PR TITLE
Select desktop update event by wrapper capability  [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/main/app.ts
+++ b/apps/webapp/src/script/main/app.ts
@@ -927,6 +927,9 @@ export class App {
   readonly refresh = (): void => {
     refreshApplication({
       isDesktopApplication: Runtime.isDesktopApp,
+      supportsWebViewRefresh: () => {
+        return Config.getDesktopConfig()?.supportsWebViewRefresh === true;
+      },
       publishLifecycleEvent: lifecycleEventName => {
         amplify.publish(lifecycleEventName);
       },

--- a/apps/webapp/src/script/main/applicationRefresh.test.ts
+++ b/apps/webapp/src/script/main/applicationRefresh.test.ts
@@ -22,38 +22,6 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 import {refreshApplication} from './applicationRefresh';
 
 describe('refreshApplication', () => {
-  it('publishes refresh rather than restart in the desktop application', () => {
-    const publishedLifecycleEvents: string[] = [];
-    let reloadWindowLocationCallCount = 0;
-    let focusWindowCallCount = 0;
-
-    function publishLifecycleEvent(lifecycleEventName: string): void {
-      publishedLifecycleEvents.push(lifecycleEventName);
-    }
-
-    function reloadWindowLocation(): void {
-      reloadWindowLocationCallCount += 1;
-    }
-
-    function focusWindow(): void {
-      focusWindowCallCount += 1;
-    }
-
-    refreshApplication({
-      isDesktopApplication: () => {
-        return true;
-      },
-      publishLifecycleEvent,
-      reloadWindowLocation,
-      focusWindow,
-    });
-
-    expect(publishedLifecycleEvents).toEqual([WebAppEvents.LIFECYCLE.REFRESH]);
-    expect(publishedLifecycleEvents).not.toContain(WebAppEvents.LIFECYCLE.RESTART);
-    expect(reloadWindowLocationCallCount).toBe(0);
-    expect(focusWindowCallCount).toBe(0);
-  });
-
   it('reloads and focuses the browser window outside the desktop application', () => {
     const publishedLifecycleEvents: string[] = [];
     let reloadWindowLocationCallCount = 0;
@@ -75,6 +43,9 @@ describe('refreshApplication', () => {
       isDesktopApplication: () => {
         return false;
       },
+      supportsWebViewRefresh: () => {
+        return false;
+      },
       publishLifecycleEvent,
       reloadWindowLocation,
       focusWindow,
@@ -83,5 +54,73 @@ describe('refreshApplication', () => {
     expect(publishedLifecycleEvents).toEqual([]);
     expect(reloadWindowLocationCallCount).toBe(1);
     expect(focusWindowCallCount).toBe(1);
+  });
+
+  it('publishes refresh for a desktop application that supports webview refresh', () => {
+    const publishedLifecycleEvents: string[] = [];
+    let reloadWindowLocationCallCount = 0;
+    let focusWindowCallCount = 0;
+
+    function publishLifecycleEvent(lifecycleEventName: string): void {
+      publishedLifecycleEvents.push(lifecycleEventName);
+    }
+
+    function reloadWindowLocation(): void {
+      reloadWindowLocationCallCount += 1;
+    }
+
+    function focusWindow(): void {
+      focusWindowCallCount += 1;
+    }
+
+    refreshApplication({
+      isDesktopApplication: () => {
+        return true;
+      },
+      supportsWebViewRefresh: () => {
+        return true;
+      },
+      publishLifecycleEvent,
+      reloadWindowLocation,
+      focusWindow,
+    });
+
+    expect(publishedLifecycleEvents).toEqual([WebAppEvents.LIFECYCLE.REFRESH]);
+    expect(reloadWindowLocationCallCount).toBe(0);
+    expect(focusWindowCallCount).toBe(0);
+  });
+
+  it('publishes restart for a desktop application without webview refresh support', () => {
+    const publishedLifecycleEvents: string[] = [];
+    let reloadWindowLocationCallCount = 0;
+    let focusWindowCallCount = 0;
+
+    function publishLifecycleEvent(lifecycleEventName: string): void {
+      publishedLifecycleEvents.push(lifecycleEventName);
+    }
+
+    function reloadWindowLocation(): void {
+      reloadWindowLocationCallCount += 1;
+    }
+
+    function focusWindow(): void {
+      focusWindowCallCount += 1;
+    }
+
+    refreshApplication({
+      isDesktopApplication: () => {
+        return true;
+      },
+      supportsWebViewRefresh: () => {
+        return false;
+      },
+      publishLifecycleEvent,
+      reloadWindowLocation,
+      focusWindow,
+    });
+
+    expect(publishedLifecycleEvents).toEqual([WebAppEvents.LIFECYCLE.RESTART]);
+    expect(reloadWindowLocationCallCount).toBe(0);
+    expect(focusWindowCallCount).toBe(0);
   });
 });

--- a/apps/webapp/src/script/main/applicationRefresh.ts
+++ b/apps/webapp/src/script/main/applicationRefresh.ts
@@ -21,19 +21,26 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 
 type ApplicationRefreshDependencies = {
   readonly isDesktopApplication: () => boolean;
+  readonly supportsWebViewRefresh: () => boolean;
   readonly publishLifecycleEvent: (lifecycleEventName: string) => void;
   readonly reloadWindowLocation: () => void;
   readonly focusWindow: () => void;
 };
 
 export function refreshApplication(dependencies: ApplicationRefreshDependencies): void {
-  const {focusWindow, isDesktopApplication, publishLifecycleEvent, reloadWindowLocation} = dependencies;
+  const {focusWindow, isDesktopApplication, publishLifecycleEvent, reloadWindowLocation, supportsWebViewRefresh} =
+    dependencies;
 
-  if (isDesktopApplication()) {
+  if (!isDesktopApplication()) {
+    reloadWindowLocation();
+    focusWindow();
+    return;
+  }
+
+  if (supportsWebViewRefresh()) {
     publishLifecycleEvent(WebAppEvents.LIFECYCLE.REFRESH);
     return;
   }
 
-  reloadWindowLocation();
-  focusWindow();
+  publishLifecycleEvent(WebAppEvents.LIFECYCLE.RESTART);
 }

--- a/apps/webapp/src/script/repositories/conversation/linkPreviews/index.ts
+++ b/apps/webapp/src/script/repositories/conversation/linkPreviews/index.ts
@@ -54,6 +54,7 @@ declare global {
     desktopAppConfig?: {
       version: string;
       supportsCallingPopoutWindow?: boolean;
+      supportsWebViewRefresh?: boolean;
       managedConfig?: {applockOverride: boolean};
     };
   }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Use the `desktopAppConfig` refresh capability to publish `REFRESH` only for wrappers that support in-place WebView reloads. Preserve browser reload behavior and fall back to `RESTART` for older desktop wrappers.

See also https://github.com/wireapp/wire-desktop/pull/9708

