### PR TITLE
Serialize WebApp deployments and cancel superseded main builds [WPB-26469]

### DIFF
--- a/.github/workflows/publish-and-deploy-webapp.yml
+++ b/.github/workflows/publish-and-deploy-webapp.yml
@@ -363,6 +363,10 @@ jobs:
     environment: ${{ matrix.target }}
     needs: [build, set_deployment_targets, release_critical_flow]
     if: ${{ always() && needs.build.result == 'success' && needs.set_deployment_targets.result == 'success' && needs.set_deployment_targets.outputs.deployment_targets && (needs.release_critical_flow.result == 'success' || needs.release_critical_flow.result == 'skipped') }}
+    concurrency:
+      group: ${{ matrix.target == 'wire-webapp-staging' && 'deploy-webapp-beta' || matrix.target == 'wire-webapp-prod' && 'deploy-webapp-production' || format('deploy-webapp-target-{0}', matrix.target) }}
+      cancel-in-progress: false
+      queue: max
 
     strategy:
       matrix:

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -73,6 +73,9 @@ jobs:
     name: Build main delivery artifacts
     runs-on: ubuntu-24.04
     needs: validate_request
+    concurrency:
+      group: build-main-delivery
+      cancel-in-progress: true
     permissions:
       contents: read
     outputs:
@@ -186,8 +189,8 @@ jobs:
     permissions:
       contents: read
     concurrency:
-      group: deploy-edge
-      cancel-in-progress: true
+      group: deploy-webapp-edge
+      cancel-in-progress: false
     outputs:
       superseded: ${{ steps.check_latest_main.outputs.superseded }}
     # ADR 0002 requires Edge to deploy without an approval gate, so the
@@ -317,8 +320,8 @@ jobs:
     permissions:
       contents: read
     concurrency:
-      group: deploy-dev
-      cancel-in-progress: true
+      group: deploy-webapp-dev
+      cancel-in-progress: false
     outputs:
       superseded: ${{ steps.check_latest_main.outputs.superseded }}
     environment:

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -180,6 +180,10 @@ jobs:
       AWS_REGION: eu-central-1
     needs: [validate_request, build_artifact]
     environment: wire-webapp-prod
+    concurrency:
+      group: deploy-webapp-production
+      cancel-in-progress: false
+      queue: max
 
     steps:
       - name: Download build artifact

--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -31,7 +31,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ inputs.promote_to_production && 'release-webapp-production' || format('release-webapp-beta-{0}', inputs.release_identifier) }}
+  group: release-webapp-${{ inputs.release_identifier }}
   cancel-in-progress: false
   queue: max
 
@@ -385,6 +385,10 @@ jobs:
     needs: build_artifact
     permissions:
       contents: read
+    concurrency:
+      group: deploy-webapp-beta
+      cancel-in-progress: false
+      queue: max
     environment:
       name: wire-webapp-beta
       url: https://wire-webapp-beta.wire.com/
@@ -742,6 +746,10 @@ jobs:
     permissions: {}
     # Production approval is enforced by the wire-webapp-prod GitHub Environment settings.
     environment: wire-webapp-prod
+    concurrency:
+      group: deploy-webapp-production
+      cancel-in-progress: false
+      queue: max
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -221,7 +221,7 @@ jobs:
     # Production rollback approval is enforced by the wire-webapp-prod GitHub Environment settings.
     environment: wire-webapp-prod
     concurrency:
-      group: release-webapp-production
+      group: deploy-webapp-production
       cancel-in-progress: false
       queue: max
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This change fixes the concurrency model of the WebApp delivery and release workflows.

`Deliver main` now follows a latest-commit-wins model. When a newer `main` delivery starts, the complete older workflow is cancelled before it can finish building and enter the deployment jobs.

Deployments themselves are no longer cancelled while they are running. Instead, workflows targeting the same physical environment wait for one another through shared environment-specific concurrency groups.

## Changes

The `Deliver main` workflow now has workflow-level concurrency for `main`, with `cancel-in-progress` enabled. This prevents stale builds from consuming runners and avoids an older build entering a deployment job after a newer build.

Edge and Hosted Dev deployments now use non-cancelling, queued concurrency groups:

* `deploy-webapp-edge`
* `deploy-webapp-dev`

Beta and Production deployments now use shared environment locks:

* `deploy-webapp-beta`
* `deploy-webapp-production`

These locks are shared across the regular release workflow and the relevant legacy, redeployment, and recovery workflows, so two workflows cannot deploy different artifacts to the same environment at the same time.

Release workflow runs remain non-cancelling. Duplicate runs for the same release identifier wait for one another, while different releases may still prepare and build concurrently where safe.

The existing `publish-webapp-distribution` lock remains unchanged. Docker, Helm, and `wire-builds` publication continues to be serialized separately from environment deployment.

## Resulting behaviour

Two overlapping `main` deliveries cancel the older workflow.

Two Beta releases may build concurrently, but their Beta deployments wait for one another.

Production releases, Production redeployments, and Production recovery operations share the same deployment lock and cannot overlap.

A running external deployment is never automatically cancelled by a newer workflow.