### PR TITLE
feat: consume simplifiedUserConnectionRequestQRCode [WPB-22749]

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -1817,6 +1817,8 @@
   "preferencesOptionsPreviewsSendCheckbox": "Link previews",
   "preferencesOptionsPreviewsSendDetail": "When this is on, you create link previews when you share a URL in a conversation. You also get previews sent by others if they have turned it on.",
   "preferencesOptionsUseDarkMode": "Dark theme",
+  "profileLinkDisabled": "Using profile links or QR codes is not allowed in your team. Contact your admin.",
+  "profileLinkDisabledHeadline": "Not allowed",
   "proteusDeviceDetails": "Proteus Device Details",
   "proteusDeviceVerified": "Device verified (Proteus)",
   "proteusID": "Proteus ID",

--- a/apps/webapp/src/script/components/Conversation/Conversation.tsx
+++ b/apps/webapp/src/script/components/Conversation/Conversation.tsx
@@ -329,6 +329,21 @@ export const Conversation = ({
   };
 
   const openUserProfile = async (id: string, domain?: string) => {
+    if (!teamState.isProfileLinkEnabled()) {
+      PrimaryModal.show(
+        PrimaryModal.type.ACKNOWLEDGE,
+        {
+          text: {
+            message: translate('profileLinkDisabled'),
+            title: translate('profileLinkDisabledHeadline'),
+          },
+        },
+        undefined,
+        translate,
+      );
+      return;
+    }
+
     try {
       const userEntity = await repositories.user.getUserById({
         id,

--- a/apps/webapp/src/script/externalRoute.ts
+++ b/apps/webapp/src/script/externalRoute.ts
@@ -43,6 +43,10 @@ const getAccountPagesUrl = (path: string = ''): string | undefined => {
   return URL.ACCOUNT_BASE ? `${URL.ACCOUNT_BASE}${path}` : undefined;
 };
 
+export const getUserProfileUrl = (userId: string, domain: string): string | undefined => {
+  return getAccountPagesUrl(`/user-profile/?id=${userId}@${domain}`);
+};
+
 const getPrivacyPolicyUrl = () => {
   const language = currentLanguage();
   if (language === 'de-DE') {

--- a/apps/webapp/src/script/page/appMain.tsx
+++ b/apps/webapp/src/script/page/appMain.tsx
@@ -226,6 +226,22 @@ export const AppMain = (properties: AppMainProps) => {
         return;
       }
 
+      if (!teamState.isProfileLinkEnabled()) {
+        PrimaryModal.show(
+          PrimaryModal.type.ACKNOWLEDGE,
+          {
+            text: {
+              message: translate('profileLinkDisabled'),
+              title: translate('profileLinkDisabledHeadline'),
+            },
+          },
+          undefined,
+          translate,
+        );
+        navigate('/');
+        return;
+      }
+
       showMostRecentConversation();
       showUserModal({domain, id: userId}, () => navigate('/'));
     };

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences.tsx
@@ -93,7 +93,11 @@ export const AccountPreferences = ({
 }: AccountPreferencesProps) => {
   const core = container.resolve(Core);
   const {translate} = useApplicationContext();
-  const {isTeam, teamName} = useKoSubscribableChildren(teamState, ['isTeam', 'teamName']);
+  const {isTeam, teamName, isProfileLinkEnabled} = useKoSubscribableChildren(teamState, [
+    'isTeam',
+    'teamName',
+    'isProfileLinkEnabled',
+  ]);
   const {name, email, availability, username, managedBy} = useKoSubscribableChildren(selfUser, [
     'name',
     'email',
@@ -217,11 +221,13 @@ export const AccountPreferences = ({
             ))}
           </div>
 
-          <AccountLink
-            label={translate('preferencesAccountLink')}
-            value={`${Config.getConfig().URL.ACCOUNT_BASE}/user-profile/?id=${selfUser.id}@${selfUser.domain}`}
-            data-uie-name="element-profile-link"
-          />
+          {isProfileLinkEnabled && (
+            <AccountLink
+              label={translate('preferencesAccountLink')}
+              value={`${Config.getConfig().URL.ACCOUNT_BASE}/user-profile/?id=${selfUser.id}@${selfUser.domain}`}
+              data-uie-name="element-profile-link"
+            />
+          )}
         </PreferencesSection>
       ) : (
         <PreferencesSection hasSeparator>

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences.tsx
@@ -24,7 +24,6 @@ import {Runtime} from '@wireapp/commons';
 
 import {UserVerificationBadges} from 'Components/badge';
 import {ErrorFallback} from 'Components/errorFallback';
-import {getUserProfileUrl} from 'src/script/externalRoute';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {useEnrichedFields} from 'Components/panel/enrichedFields';
 import {ClientRepository} from 'Repositories/client';
@@ -35,6 +34,7 @@ import {PropertiesRepository} from 'Repositories/properties/propertiesRepository
 import {TeamState} from 'Repositories/team/TeamState';
 import {AppLockRepository} from 'Repositories/user/appLockRepository';
 import type {UserRepository} from 'Repositories/user/userRepository';
+import {getUserProfileUrl} from 'src/script/externalRoute';
 import {TeamCreationAccountHeader} from 'src/script/page/leftSidebar/panels/conversations/conversationTabs/teamCreation/teamCreationAccountHeader';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {ContentState} from 'src/script/page/useAppState';

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/accountPreferences.tsx
@@ -24,6 +24,7 @@ import {Runtime} from '@wireapp/commons';
 
 import {UserVerificationBadges} from 'Components/badge';
 import {ErrorFallback} from 'Components/errorFallback';
+import {getUserProfileUrl} from 'src/script/externalRoute';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import {useEnrichedFields} from 'Components/panel/enrichedFields';
 import {ClientRepository} from 'Repositories/client';
@@ -224,7 +225,7 @@ export const AccountPreferences = ({
           {isProfileLinkEnabled && (
             <AccountLink
               label={translate('preferencesAccountLink')}
-              value={`${Config.getConfig().URL.ACCOUNT_BASE}/user-profile/?id=${selfUser.id}@${selfUser.domain}`}
+              value={getUserProfileUrl(selfUser.id, selfUser.domain) ?? ''}
               data-uie-name="element-profile-link"
             />
           )}

--- a/apps/webapp/src/script/repositories/team/TeamState.ts
+++ b/apps/webapp/src/script/repositories/team/TeamState.ts
@@ -50,6 +50,7 @@ export class TeamState {
   public readonly isProtocolToggleEnabledForUser: ko.PureComputed<boolean>;
   public readonly isBackgroundEffectsEnabled: ko.PureComputed<boolean>;
   public readonly isGuestLinkEnabled: ko.PureComputed<boolean>;
+  public readonly isProfileLinkEnabled: ko.PureComputed<boolean>;
   public readonly isSelfDeletingMessagesEnabled: ko.PureComputed<boolean>;
   public readonly isSelfDeletingMessagesEnforced: ko.PureComputed<boolean>;
   public readonly getEnforcedSelfDeletingMessagesTimeout: ko.PureComputed<SELF_DELETING_TIMEOUT>;
@@ -141,6 +142,11 @@ export class TeamState {
     this.isGuestLinkEnabled = ko.pureComputed(
       () => this.teamFeatures()?.conversationGuestLinks?.status === FEATURE_STATUS.ENABLED,
     );
+
+    this.isProfileLinkEnabled = ko.pureComputed(() => {
+      const status = this.teamFeatures()?.simplifiedUserConnectionRequestQRCode?.status;
+      return status ? status === FEATURE_STATUS.ENABLED : true;
+    });
 
     this.selfRole = ko.pureComputed(() => {
       const roles = this.memberRoles();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22749" title="WPB-22749" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22749</a>  [Web] Pick up on QR code connectivity backend flag for Web Profile Links
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Introduces a computed TeamState.isProfileLinkEnabled flag based on simplifiedUserConnectionRequestQRCode and updates account preferences, profile navigation, and conversation flows to respect the setting. Includes new localized strings for disabled-state messaging.

**PR summary**

- Added isProfileLinkEnabled to TeamState.
- Hid profile-link UI when disabled.
- Prevented profile-link navigation and access.
- Added a modal explaining why profile links are unavailable.
- Added localization strings for the new messaging.