### PR TITLE
Pin emoji-picker-react to 4.16.1 [WPB-22420]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -142,6 +142,11 @@
     {
       "matchPackageNames": ["geolite2"],
       "allowedVersions": "<2"
+    },
+    {
+      "description": "Keep emoji-picker-react on 4.16.1 because later versions change emoji data and runtime aliases used by Wire",
+      "matchPackageNames": ["emoji-picker-react"],
+      "allowedVersions": "4.16.1"
     }
   ]
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This pull request keeps `emoji-picker-react` pinned to exactly `4.16.1` and prevents Renovate from proposing a newer version.

It replaces Renovate pull request #21965, which updates the dependency to `4.19.1` and will be closed.

## Why the dependency cannot be updated safely

Versions after `4.16.1` change the structure of the internal emoji catalog imported by Wire.

Version `4.16.1` exposes a top-level map of emoji categories. Newer versions expose an object containing separate `categories` and `emojis` properties. This causes the current type-check and unit-test failures in #21965.

Fixing only that structural incompatibility would make the pipeline green, but it would not preserve the existing behavior.

Wire uses the first value in each emoji's `n` array as application behavior. It is used for emoji autocomplete, reaction titles and tooltips, suggestion sorting, and persisted emoji usage-count keys. Newer versions change and reorder those aliases. For example, an emoji whose canonical alias was previously `wink` may have `face` as its first value in the new catalog.

A structural adapter would therefore silently change user-visible and persisted behavior.

## Previous attempt

The dependency was previously updated to `4.18.0` in #20340. That pull request added an extractor for the new data structure and passed CI, but runtime behavior was broken.

The complete update was subsequently reverted in #20639, restoring version `4.16.1` and the previous behavior.

## Future upgrade

A future update must be handled as an explicitly owned compatibility migration rather than an automated dependency bump.

It will require an application-owned emoji-data contract and regression tests that preserve canonical aliases, autocomplete behavior, reaction titles, suggestion ordering, persisted usage counts, skin tones and both emoji-picker integrations.

Until that work is done, `4.16.1` is the last version known to preserve Wire's existing behavior.
