### PR TITLE
fix: open learn more link in a new tab [WPB-27368]

### DIFF
--- a/apps/webapp/src/script/auth/component/layout.tsx
+++ b/apps/webapp/src/script/auth/component/layout.tsx
@@ -43,7 +43,7 @@ export const Layout = ({children}: {children: ReactNode}) => {
           <div css={{marginTop: '0.5rem'}}>
             <Text css={{...whiteFontCss, lineHeight: '1.5rem'}}>{translate('layoutSidebarContent')}</Text>
             <br />
-            <Link href={Config.getConfig().URL.WEBSITE_BASE}>
+            <Link href={Config.getConfig().URL.WEBSITE_BASE} target="_blank" rel="noopener noreferrer">
               <Bold css={{...whiteFontCss, textDecoration: 'underline'}}> {translate('layoutSidebarLink')}</Bold>
             </Link>
           </div>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27368" title="WPB-27368" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27368</a>  [Web] [Login] External website opens inside Wire Bund when selecting “Find out more” on the login screen by unauthenticated users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Description

Open learn more link in a new tab. 