### PR TITLE
show loader on video tiles in all 1:1 cases and also update styling of loader background [WPB-27244]

### DIFF
--- a/apps/webapp/src/script/components/calling/GroupVideoGrid.test.tsx
+++ b/apps/webapp/src/script/components/calling/GroupVideoGrid.test.tsx
@@ -77,14 +77,10 @@ const createMediaStream = () =>
     getVideoTracks: jest.fn(() => []),
   }) as unknown as MediaStream;
 
-const createProcessedVideoStream = (stream: MediaStream) => ({
-  stream,
-  release: jest.fn(),
-});
-
 describe('GroupVideoGrid', () => {
   beforeEach(() => {
     backgroundEffectsStore.setState({
+      isFeatureEnabled: false,
       isInitializing: false,
     });
   });
@@ -192,12 +188,11 @@ describe('GroupVideoGrid', () => {
     expect(thumbnailMutedIcons).not.toHaveLength(0);
   });
 
-  it('shows and hides the loading overlay while the thumbnail video is loading', () => {
+  it('shows and hides the loading overlay while the raw thumbnail video is loading with background effects disabled', () => {
     const participant = createMockParticipant('userId', 'clientId', {});
     const videoStream = createMediaStream();
     participant.videoState(VIDEO_STATE.STARTED);
     participant.videoStream(videoStream);
-    participant.processedVideoStream(createProcessedVideoStream(videoStream));
 
     const props: GroupVideoGripProps = {
       grid: {

--- a/apps/webapp/src/script/components/calling/GroupVideoGridTile.styles.ts
+++ b/apps/webapp/src/script/components/calling/GroupVideoGridTile.styles.ts
@@ -102,6 +102,6 @@ export const groupVideoBackgroundInitializingOverlay: CSSObject = {
   alignItems: 'center',
   justifyContent: 'center',
   borderRadius: 'inherit',
-  backgroundColor: 'var(--group-video-tile-bg)',
+  backgroundColor: 'var(--background-fade-16)',
   zIndex: 1,
 };

--- a/apps/webapp/src/script/components/calling/GroupVideoGridTile.test.tsx
+++ b/apps/webapp/src/script/components/calling/GroupVideoGridTile.test.tsx
@@ -77,12 +77,14 @@ const renderComponent = ({
 describe('GroupVideoGridTile', () => {
   beforeEach(() => {
     backgroundEffectsStore.setState({
+      isFeatureEnabled: false,
       isInitializing: false,
     });
   });
 
   it('should show loading overlay when background effect is initializing', () => {
     backgroundEffectsStore.setState({
+      isFeatureEnabled: true,
       isInitializing: true,
     });
 

--- a/apps/webapp/src/script/components/calling/useShowLoadingOverlay.test.ts
+++ b/apps/webapp/src/script/components/calling/useShowLoadingOverlay.test.ts
@@ -36,12 +36,14 @@ const createProcessedVideoStream = (stream: MediaStream) => ({
 describe('useShowLoadingOverlay', () => {
   beforeEach(() => {
     backgroundEffectsStore.setState({
+      isFeatureEnabled: false,
       isInitializing: false,
     });
   });
 
   it('should show loading overlay when background effect is initializing', () => {
     backgroundEffectsStore.setState({
+      isFeatureEnabled: true,
       isInitializing: true,
     });
 
@@ -62,6 +64,18 @@ describe('useShowLoadingOverlay', () => {
     const {result} = renderHook(() => useShowLoadingOverlay(true, true, processedVideoStream));
 
     expect(result.current.showLoadingOverlay).toBe(true);
+  });
+
+  it('should show loading overlay while raw video is loading when background effects are disabled', () => {
+    const {result} = renderHook(() => useShowLoadingOverlay(true, true, undefined));
+
+    expect(result.current.showLoadingOverlay).toBe(true);
+
+    act(() => {
+      result.current.onVideoCanPlay();
+    });
+
+    expect(result.current.showLoadingOverlay).toBe(false);
   });
 
   it('should hide loading overlay when video is ready', () => {

--- a/apps/webapp/src/script/components/calling/useShowLoadingOverlay.ts
+++ b/apps/webapp/src/script/components/calling/useShowLoadingOverlay.ts
@@ -31,6 +31,7 @@ const useShowLoadingOverlay = (
   hasActiveVideo: boolean,
   processedVideoStream?: ProcessedVideoStream,
 ) => {
+  const isBackgroundEffectFeatureEnabled = useBackgroundEffectsStore(state => state.isFeatureEnabled);
   const isBackgroundEffectInitializing = useBackgroundEffectsStore(state => state.isInitializing);
   const [isVideoReady, setIsVideoReady] = useState(false);
 
@@ -42,11 +43,9 @@ const useShowLoadingOverlay = (
     setIsVideoReady(true);
   }, []);
 
-  const hasProcessedVideoStream = processedVideoStream !== undefined;
-
   const showLoadingOverlay =
     isSelfParticipant &&
-    (isBackgroundEffectInitializing || (hasActiveVideo && !isVideoReady && hasProcessedVideoStream));
+    ((isBackgroundEffectFeatureEnabled && isBackgroundEffectInitializing) || (hasActiveVideo && !isVideoReady));
 
   return {
     onVideoCanPlay,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27244" title="WPB-27244" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27244</a>  Loader not appearing for the user when enabling camera with BGE in 1:1 Call 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
