### PR TITLE
[WPB-27360] Fetch team collaborators and show them in the add-participants list

### DIFF
--- a/apps/webapp/src/script/page/rightSidebar/addParticipants/addParticipants.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/addParticipants/addParticipants.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {FC, useCallback, useMemo, useState} from 'react';
+import {FC, useCallback, useEffect, useMemo, useState} from 'react';
 
 import is from '@sindresorhus/is';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
@@ -124,13 +124,43 @@ const AddParticipants: FC<AddParticipantsProps> = ({
   const [selectedContacts, setSelectedContacts] = useState<User[]>([]);
 
   const [isInitialServiceSearch, setIsInitialServiceSearch] = useState<boolean>(true);
-  const contacts = useMemo(() => {
+  const [collaborators, setCollaborators] = useState<User[]>([]);
+
+  useEffect(() => {
+    if (!isTeam) {
+      return undefined;
+    }
+
+    let isCurrent = true;
+
+    void teamRepository.getTeamCollaborators().then(fetchedCollaborators => {
+      if (isCurrent) {
+        setCollaborators(fetchedCollaborators);
+      }
+    });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [isTeam, teamRepository]);
+
+  const baseContacts = useMemo(() => {
     if (isTeam) {
       const isTeamOrServices = isTeamOnly || isServicesRoom;
       return isTeamOrServices ? teamMembers.toSorted(sortUsersByPriority) : teamUsers;
     }
     return connectedUsers;
   }, [connectedUsers, isServicesRoom, isTeam, isTeamOnly, teamMembers, teamUsers]);
+
+  const contacts = useMemo(() => {
+    if (!collaborators.length) {
+      return baseContacts;
+    }
+    // Collaborators (team-level, without full team membership) are shown alongside team members/apps
+    const knownIds = new Set(baseContacts.map(contact => contact.id));
+    const newCollaborators = collaborators.filter(collaborator => !knownIds.has(collaborator.id));
+    return [...baseContacts, ...newCollaborators];
+  }, [baseContacts, collaborators]);
 
   const apps = useMemo(() => {
     const normalizedQuery = searchInput.trim().toLowerCase();

--- a/apps/webapp/src/script/repositories/team/TeamRepository.ts
+++ b/apps/webapp/src/script/repositories/team/TeamRepository.ts
@@ -388,6 +388,22 @@ export class TeamRepository extends TypedEventEmitter<Events> {
     return IntegrationMapper.mapServicesFromArray(servicesData, domain);
   }
 
+  async getTeamCollaborators(): Promise<User[]> {
+    const teamId = this.teamState.team()?.id;
+    if (!teamId) {
+      return [];
+    }
+
+    const domain = this.teamState.teamDomain();
+    const selfId = this.userState.self().id;
+    const collaborators = await this.teamService.getCollaborators(teamId);
+    const collaboratorIds: QualifiedId[] = collaborators
+      .map(({user}) => ({domain, id: user}))
+      .filter(({id}) => id !== selfId);
+
+    return this.userRepository.getUsersById(collaboratorIds);
+  }
+
   readonly onTeamEvent = async (eventJson: any, source: EventSource): Promise<void> => {
     if (this.teamState.isTeamDeleted()) {
       // We don't want to handle any events after the team has been deleted

--- a/apps/webapp/src/script/repositories/team/TeamService.ts
+++ b/apps/webapp/src/script/repositories/team/TeamService.ts
@@ -24,7 +24,7 @@ import {TeamMigrationPayload} from '@wireapp/api-client/lib/team/invitation/team
 import type {LegalHoldMemberData} from '@wireapp/api-client/lib/team/legalhold/';
 import type {MemberData, Members} from '@wireapp/api-client/lib/team/member/';
 import type {Services} from '@wireapp/api-client/lib/team/service/';
-import type {TeamData} from '@wireapp/api-client/lib/team/team/';
+import type {TeamCollaborator, TeamData} from '@wireapp/api-client/lib/team/team/';
 import {container} from 'tsyringe';
 
 import {APIClient} from '../../service/apiClientSingleton';
@@ -62,6 +62,10 @@ export class TeamService {
 
   getWhitelistedServices(teamId: string): Promise<Services> {
     return this.apiClient.api.teams.service.getTeamServices(teamId);
+  }
+
+  getCollaborators(teamId: string): Promise<TeamCollaborator[]> {
+    return this.apiClient.api.teams.team.getCollaborators(teamId);
   }
 
   async conversationHasGuestLink(conversationId: string): Promise<boolean> {

--- a/libraries/api-client/src/team/index.ts
+++ b/libraries/api-client/src/team/index.ts
@@ -20,7 +20,16 @@
 export {NewTeamInvitation, TeamInvitation, TeamInvitationAPI, TeamInvitationChunk} from './invitation/';
 export {LegalHoldAPI} from './legalhold/';
 export {MemberAPI, MemberData, Members, Permissions, PermissionsData, Role} from './member/';
-export {NewTeamData, TeamAPI, TeamChunkData, TeamData, TeamInfo, UpdateTeamData} from './team/';
+export {
+  CollaboratorPermission,
+  NewTeamData,
+  TeamAPI,
+  TeamChunkData,
+  TeamCollaborator,
+  TeamData,
+  TeamInfo,
+  UpdateTeamData,
+} from './team/';
 export {PaymentAPI, PaymentData} from './payment/';
 export {ServiceAPI, Service, ServiceWhitelistData} from './service/';
 export {TeamError, InviteEmailInUseError, InvalidInvitationCodeError, ServiceNotFoundError} from './teamError';

--- a/libraries/api-client/src/team/team/collaborator/teamCollaborator.ts
+++ b/libraries/api-client/src/team/team/collaborator/teamCollaborator.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,11 +17,13 @@
  *
  */
 
-export * from './collaborator/teamCollaborator';
-export * from './newTeamData';
-export * from './teamApi';
-export * from './teamChunkData';
-export * from './teamData';
-export * from './teamInfo';
-export * from './updateTeamData';
-export * from './teamSizeData';
+export enum CollaboratorPermission {
+  CREATE_TEAM_CONVERSATION = 'create_team_conversation',
+  IMPLICIT_CONNECTION = 'implicit_connection',
+}
+
+export interface TeamCollaborator {
+  permissions: CollaboratorPermission[];
+  team: string;
+  user: string;
+}

--- a/libraries/api-client/src/team/team/teamApi.ts
+++ b/libraries/api-client/src/team/team/teamApi.ts
@@ -21,6 +21,7 @@ import Axios, {AxiosRequestConfig} from 'axios';
 
 import {NewAppRequest} from './app/newAppRequest';
 import {NewAppResponse} from './app/newAppResponse';
+import {TeamCollaborator} from './collaborator/teamCollaborator';
 import {LeadData} from './leadData';
 import {TeamSizeData} from './teamSizeData';
 import {UpdateTeamData} from './updateTeamData';
@@ -34,6 +35,7 @@ export class TeamAPI {
 
   public static readonly URL = {
     APPS: 'apps',
+    COLLABORATORS: 'collaborators',
     SIZE: 'size',
     TEAMS: '/teams',
     CONSENT: '/consent',
@@ -140,6 +142,16 @@ export class TeamAPI {
     };
 
     const response = await this.client.sendJSON<any>(config);
+    return response.data;
+  }
+
+  public async getCollaborators(teamId: string): Promise<TeamCollaborator[]> {
+    const config: AxiosRequestConfig = {
+      method: 'get',
+      url: `${TeamAPI.URL.TEAMS}/${teamId}/${TeamAPI.URL.COLLABORATORS}`,
+    };
+
+    const response = await this.client.sendJSON<TeamCollaborator[]>(config);
     return response.data;
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27360" title="WPB-27360" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27360</a>  [Integrations] [Web] External apps not visible when adding participants to a conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add a getCollaborators endpoint on TeamAPI (GET /teams/{tid}/collaborators), plumb it through TeamService and a new TeamRepository.getTeamCollaborators() that resolves the returned user IDs into full profiles via UserRepository. Merge the resolved collaborators into addParticipants' contacts list so they appear alongside team members and services when adding participants to a conversation, without needing a separate tab or picker.


