### PR TITLE
Disable Dependabot updates in favor of Renovate [WPB-22420]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Renovate is the only dependency-update automation used by this repository.
+#
+# `open-pull-requests-limit: 0` disables Dependabot version-update pull
+# requests. The wildcard ignore rule is also required because security-update
+# pull requests are not subject to that limit.
+
+version: 2
+
+updates:
+  - package-ecosystem: 'npm'
+    directories:
+      - '**/*'
+    schedule:
+      interval: 'monthly'
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: '*'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: '*'
+
+  - package-ecosystem: 'docker'
+    directories:
+      - '**/*'
+    schedule:
+      interval: 'monthly'
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: '*'


### PR DESCRIPTION
## Summary

Add a `.github/dependabot.yml` configuration that prevents Dependabot from creating dependency update pull requests.

Renovate is already the repository's dependency update automation, so running both tools creates duplicate and potentially conflicting pull requests.

## Changes

The new configuration disables Dependabot updates for:

* npm dependencies
* GitHub Actions
* Docker images

`open-pull-requests-limit: 0` prevents regular version update pull requests.

The wildcard `ignore` rule is also necessary because Dependabot security update pull requests are not subject to the regular pull request limit. Ignoring all dependencies suppresses both version and security update pull requests.