### PR TITLE
Make Production promotion part of every WebApp release [WPB-26469]

### DIFF
--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -16,12 +16,7 @@ on:
         default: main
         type: string
       confirm_release:
-        description: 'Confirm that this will create or reuse the release branch, deploy Beta, and run the WebApp release validation flow'
-        required: true
-        default: false
-        type: boolean
-      promote_to_production:
-        description: 'Continue to hosted Production approval after the release E2E gate succeeds'
+        description: 'Confirm the complete WebApp release: create or reuse the release branch, validate Beta and E2E, then continue to Production approval and distribution'
         required: true
         default: false
         type: boolean
@@ -283,18 +278,10 @@ jobs:
         run: ./bin/yarn nx run webapp:configure
 
       - name: Build and package public production
-        if: ${{ inputs.promote_to_production }}
         env:
           WIRE_WEBAPP_BUILD_COMMIT: ${{ steps.release_metadata.outputs.release_commit_sha }}
           WIRE_WEBAPP_BUILD_VERSION: ${{ steps.release_metadata.outputs.release_identifier }}
         run: ./bin/yarn build:prod:public
-
-      - name: Build and package internal production
-        if: ${{ !inputs.promote_to_production }}
-        env:
-          WIRE_WEBAPP_BUILD_COMMIT: ${{ steps.release_metadata.outputs.release_commit_sha }}
-          WIRE_WEBAPP_BUILD_VERSION: ${{ steps.release_metadata.outputs.release_identifier }}
-        run: ./bin/yarn build:prod
 
       - name: Validate release artifact metadata
         id: validate_artifact_metadata
@@ -320,7 +307,6 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Prepare exact public Docker distribution context
-        if: ${{ inputs.promote_to_production }}
         id: distribution_artifact
         env:
           ARTIFACT_CHECKSUM: ${{ steps.artifact_metadata.outputs.artifact_checksum }}
@@ -365,7 +351,6 @@ jobs:
           echo "distribution_artifact_name=${distribution_artifact_name}" >> "$GITHUB_OUTPUT"
 
       - name: Upload exact public Docker distribution context
-        if: ${{ inputs.promote_to_production }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ steps.distribution_artifact.outputs.distribution_artifact_name }}
@@ -624,7 +609,6 @@ jobs:
             Commit: ${{ needs.build_artifact.outputs.release_commit_sha }}
             Beta tag: ${{ needs.create_beta_tag.outputs.beta_tag_name }}
             E2E system gate: ${{ needs.run_e2e.result }}
-            Production promotion requested: ${{ inputs.promote_to_production }}
             Production preflight: ${{ needs.production_preflight.outputs.production_preflight_result }}
             Production deployment required: ${{ needs.production_preflight.outputs.should_deploy }}
             Playwright report: ${{ needs.run_e2e.outputs.reportUrl || 'unavailable' }}
@@ -633,12 +617,10 @@ jobs:
             ${{
               needs.production_preflight.outputs.should_deploy == 'true' &&
               'Production is ready for approval through the wire-webapp-prod GitHub Environment.' ||
-              inputs.promote_to_production &&
               format(
                 'Production deployment is not required: {0}',
                 needs.production_preflight.outputs.production_skipped_reason
-              ) ||
-              'This was a Beta-only release run; Production promotion was not requested.'
+              )
             }}
 
   production_preflight:
@@ -655,7 +637,6 @@ jobs:
 
     steps:
       - name: Checkout release commit
-        if: ${{ inputs.promote_to_production }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
@@ -663,43 +644,25 @@ jobs:
           ref: ${{ needs.build_artifact.outputs.release_commit_sha }}
 
       - name: Add repository Yarn wrapper to PATH
-        if: ${{ inputs.promote_to_production }}
         run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
 
       - name: Setup Node.js
-        if: ${{ inputs.promote_to_production }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
       - name: Install dependencies
-        if: ${{ inputs.promote_to_production }}
         run: ./bin/yarn --immutable
 
       - name: Check Production promotion eligibility
         id: production_preflight
         env:
           BETA_TAG_NAME: ${{ needs.create_beta_tag.outputs.beta_tag_name }}
-          PROMOTE_TO_PRODUCTION: ${{ inputs.promote_to_production }}
           RELEASE_COMMIT_SHA: ${{ needs.build_artifact.outputs.release_commit_sha }}
           RELEASE_IDENTIFIER: ${{ needs.build_artifact.outputs.release_identifier }}
         run: |
           set -euo pipefail
-
-          if [[ "${PROMOTE_TO_PRODUCTION}" != 'true' ]]; then
-            production_tag_name="${RELEASE_IDENTIFIER}-production"
-            production_skipped_reason='Production promotion was not requested'
-
-            {
-              echo 'should_deploy=false'
-              echo 'production_preflight_result=skipped'
-              echo "production_skipped_reason=${production_skipped_reason}"
-              echo "production_tag_name=${production_tag_name}"
-            } >> "$GITHUB_OUTPUT"
-
-            exit 0
-          fi
 
           git fetch --tags origin
 
@@ -853,7 +816,7 @@ jobs:
   publish_production_distribution:
     name: Publish Production distribution
     needs: [build_artifact, create_production_tag]
-    if: ${{ needs.create_production_tag.result == 'success' && inputs.promote_to_production }}
+    if: ${{ needs.create_production_tag.result == 'success' }}
     permissions:
       actions: read
       contents: read
@@ -941,7 +904,6 @@ jobs:
           PRODUCTION_ENVIRONMENT_NAME: ${{ env.PRODUCTION_ENVIRONMENT_NAME }}
           PRODUCTION_PREFLIGHT_JOB_RESULT: ${{ needs.production_preflight.result }}
           PRODUCTION_PREFLIGHT_RESULT: ${{ needs.production_preflight.outputs.production_preflight_result }}
-          PRODUCTION_PROMOTION_REQUESTED: ${{ inputs.promote_to_production }}
           PRODUCTION_RUNTIME_VERIFICATION_RESULT: ${{ needs.verify_production_runtime.result }}
           PRODUCTION_RUNTIME_BACKEND_REST: ${{ env.PRODUCTION_RUNTIME_BACKEND_REST }}
           PRODUCTION_RUNTIME_BACKEND_WS: ${{ env.PRODUCTION_RUNTIME_BACKEND_WS }}

--- a/bin/renderWebappReleaseSummary.test.ts
+++ b/bin/renderWebappReleaseSummary.test.ts
@@ -80,7 +80,6 @@ const baselineWebappReleaseSummaryInput: WebappReleaseSummaryInput = {
     plannedTagName: Maybe.just(productionTagName),
     preflightJobResult: Maybe.just('skipped'),
     preflightResult: Maybe.just('skipped'),
-    promotionRequested: false,
     runtimeBackendRest: Maybe.just('https://production-backend.example.com'),
     runtimeBackendWebSocket: Maybe.just('wss://production-backend.example.com'),
     runtimeVerificationResult: Maybe.just('skipped'),
@@ -141,6 +140,8 @@ function assertMarkdownContract(summary: string, includesDistribution: boolean):
   } else {
     expect(summary).not.toContain('### Release distribution');
   }
+
+  assertOptionalProductionPromotionTermsAreAbsent(summary);
 }
 
 function assertVisibleIdentity(summary: string): void {
@@ -176,8 +177,22 @@ function assertBetaSummaryContainsOnlyBetaEvidence(summary: string): void {
   }
 }
 
+function assertOptionalProductionPromotionTermsAreAbsent(summary: string): void {
+  const forbiddenTerms = [
+    'Production promotion requested',
+    'Production promotion was not requested',
+    'Beta-only',
+    'Hosted Production: not requested',
+    'Release distribution: not requested',
+  ];
+
+  for (const forbiddenTerm of forbiddenTerms) {
+    expect(summary).not.toContain(forbiddenTerm);
+  }
+}
+
 describe('WebApp release summary renderer', () => {
-  it('renders a successful Beta-only release with a concise visible overview', () => {
+  it('reports an unexpected skipped Production preflight as an incomplete release', () => {
     const summary = renderWebappReleaseSummary(baselineWebappReleaseSummaryInput);
     const visibleContent = visibleSummary(summary);
     const detailsContent = technicalEvidence(summary);
@@ -185,11 +200,13 @@ describe('WebApp release summary renderer', () => {
     assertMarkdownContract(summary, true);
     assertVisibleIdentity(summary);
     expect(visibleContent).toContain('## WebApp release');
-    expect(visibleContent).toContain('Beta release completed; Production promotion was not requested');
+    expect(visibleContent).toContain('Release incomplete because Production preflight did not run');
     expect(visibleContent).toContain(`- Hosted Beta: deployed and verified successfully - tag [${betaTagName}]`);
     expect(visibleContent).toContain('- E2E system gate: passed successfully - [Playwright report]');
-    expect(visibleContent).toContain('- Hosted Production: not requested');
-    expect(visibleContent).toContain('- Release distribution: not requested');
+    expect(visibleContent).toContain('- Hosted Production: not run because Production preflight did not run');
+    expect(visibleContent).toContain('- Release distribution: not run');
+    expect(detailsContent).toContain('- Production preflight result: skipped');
+    expect(detailsContent).toContain('- Skip reason: Production preflight did not run');
     expect(detailsContent).toContain('- Asset version: 2026-07-17.1-1234567');
     expect(detailsContent).toContain('- Built at (UTC): 2026-07-20T06:18:03.123Z');
     expect(detailsContent).toContain(
@@ -234,7 +251,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.just(true),
         preflightJobResult: Maybe.just('success'),
         preflightResult: Maybe.just('ready'),
-        promotionRequested: true,
         runtimeVerificationResult: Maybe.just('success'),
         tagCreationResult: Maybe.just('success'),
       },
@@ -266,7 +282,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.just(false),
         preflightJobResult: Maybe.just('success'),
         preflightResult: Maybe.just('already_tagged'),
-        promotionRequested: true,
       },
     };
     const summary = renderWebappReleaseSummary(input);
@@ -301,7 +316,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.nothing<boolean>(),
         preflightJobResult: Maybe.just('skipped'),
         preflightResult: Maybe.nothing(),
-        promotionRequested: true,
       },
     };
     const finalSummary = renderWebappReleaseSummary(input);
@@ -348,7 +362,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.nothing<boolean>(),
         preflightJobResult: Maybe.just('skipped'),
         preflightResult: Maybe.nothing(),
-        promotionRequested: true,
       },
     };
     const finalSummary = renderWebappReleaseSummary(input);
@@ -382,7 +395,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.nothing<boolean>(),
         preflightJobResult: Maybe.just('skipped'),
         preflightResult: Maybe.nothing(),
-        promotionRequested: true,
       },
     };
     const finalSummary = renderWebappReleaseSummary(input);
@@ -435,7 +447,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.nothing<boolean>(),
         preflightJobResult: Maybe.just('skipped'),
         preflightResult: Maybe.nothing(),
-        promotionRequested: true,
       },
     };
     const summary = renderWebappReleaseSummary(input);
@@ -457,7 +468,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.nothing<boolean>(),
         preflightJobResult: Maybe.just('skipped'),
         preflightResult: Maybe.nothing(),
-        promotionRequested: true,
       },
     };
     const finalSummary = renderWebappReleaseSummary(input);
@@ -483,7 +493,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.nothing<boolean>(),
         preflightJobResult: Maybe.just('skipped'),
         preflightResult: Maybe.nothing(),
-        promotionRequested: true,
       },
     };
     const finalSummary = renderWebappReleaseSummary(input);
@@ -505,7 +514,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.just(true),
         preflightJobResult: Maybe.just('failure'),
         preflightResult: Maybe.just('failure'),
-        promotionRequested: true,
       },
     };
     const summary = renderWebappReleaseSummary(input);
@@ -524,7 +532,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.just(true),
         preflightJobResult: Maybe.just('success'),
         preflightResult: Maybe.just('ready'),
-        promotionRequested: true,
         runtimeVerificationResult: Maybe.just('skipped'),
         tagCreationResult: Maybe.just('skipped'),
       },
@@ -545,7 +552,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.just(true),
         preflightJobResult: Maybe.just('success'),
         preflightResult: Maybe.just('ready'),
-        promotionRequested: true,
         runtimeVerificationResult: Maybe.just('failure'),
         tagCreationResult: Maybe.just('skipped'),
       },
@@ -566,7 +572,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.just(true),
         preflightJobResult: Maybe.just('success'),
         preflightResult: Maybe.just('ready'),
-        promotionRequested: true,
         runtimeVerificationResult: Maybe.just('success'),
         tagCreationResult: Maybe.just('failure'),
       },
@@ -595,7 +600,6 @@ describe('WebApp release summary renderer', () => {
         deploymentRequired: Maybe.just(true),
         preflightJobResult: Maybe.just('success'),
         preflightResult: Maybe.just('ready'),
-        promotionRequested: true,
         runtimeVerificationResult: Maybe.just('success'),
         tagCreationResult: Maybe.just('success'),
       },
@@ -662,10 +666,11 @@ describe('WebApp release summary renderer', () => {
     expect(visibleSummary(finalSummary)).not.toContain('Manual reason');
   });
 
-  it('reads release summary values from the workflow environment', () => {
+  it('reads the Production deployment requirement from the workflow environment', () => {
     const input = readWebappReleaseSummaryInput({
       ARTIFACT_ASSET_VERSION: '2026-07-17.1-1234567',
       ARTIFACT_BUILT_AT: '2026-07-20T06:18:03.123Z',
+      PRODUCTION_DEPLOYMENT_REQUIRED: 'true',
       RELEASE_ACTOR: 'release-captain',
       RELEASE_BRANCH_ACTION: 'created',
       SOURCE_COMMIT_SHA: sourceCommitSha,
@@ -678,6 +683,7 @@ describe('WebApp release summary renderer', () => {
     expect(input.preparation.branchAction.unwrapOr('reused')).toBe('created');
     expect(input.preparation.sourceCommitSha.unwrapOr('not available')).toBe(sourceCommitSha);
     expect(input.preparation.sourceRef.unwrapOr('not available')).toBe('main');
+    expect(input.production.deploymentRequired.unwrapOr(false)).toBe(true);
   });
 
   it('does not create a link for an invalid E2E report URL', () => {

--- a/bin/renderWebappReleaseSummary.ts
+++ b/bin/renderWebappReleaseSummary.ts
@@ -65,7 +65,6 @@ export type ProductionSummaryInput = {
   readonly environmentName: Maybe<string>;
   readonly preflightJobResult: Maybe<WorkflowJobResult>;
   readonly preflightResult: Maybe<ProductionPreflightResult>;
-  readonly promotionRequested: boolean;
   readonly runtimeBackendRest: Maybe<string>;
   readonly runtimeBackendWebSocket: Maybe<string>;
   readonly runtimeVerificationResult: Maybe<WorkflowJobResult>;
@@ -230,12 +229,6 @@ export function readWebappReleaseSummaryInput(environment: NodeJS.ProcessEnv): W
       plannedTagName: readOptionalEnvironmentValue(environment, 'PLANNED_PRODUCTION_TAG_NAME'),
       preflightJobResult: readWorkflowJobResult(environment, 'PRODUCTION_PREFLIGHT_JOB_RESULT'),
       preflightResult: readProductionPreflightResult(environment),
-      promotionRequested: readOptionalBoolean(environment, 'PRODUCTION_PROMOTION_REQUESTED').mapOr(
-        false,
-        promotionRequested => {
-          return promotionRequested === true;
-        },
-      ),
       runtimeBackendRest: readOptionalEnvironmentValue(environment, 'PRODUCTION_RUNTIME_BACKEND_REST'),
       runtimeBackendWebSocket: readOptionalEnvironmentValue(environment, 'PRODUCTION_RUNTIME_BACKEND_WS'),
       runtimeVerificationResult: readWorkflowJobResult(environment, 'PRODUCTION_RUNTIME_VERIFICATION_RESULT'),
@@ -528,10 +521,6 @@ function formatProductionPreflightResult(input: ProductionSummaryInput): string 
 }
 
 function formatProductionResult(input: ProductionSummaryInput): string {
-  if (input.promotionRequested === false) {
-    return 'not requested';
-  }
-
   if (hasProductionPreflightResult(input.preflightResult, 'already_tagged')) {
     return 'already tagged; deployment not required';
   }
@@ -545,6 +534,10 @@ function formatProductionResult(input: ProductionSummaryInput): string {
   }
 
   if (hasWorkflowJobResult(input.preflightJobResult, 'skipped')) {
+    return 'not run because Production preflight did not run';
+  }
+
+  if (hasProductionPreflightResult(input.preflightResult, 'skipped')) {
     return 'not run because Production preflight did not run';
   }
 
@@ -604,11 +597,11 @@ function formatProductionSkipReason(input: ProductionSummaryInput): Maybe<string
     return input.skippedReason;
   }
 
-  if (input.promotionRequested === false) {
-    return Maybe.just('Production promotion was not requested');
+  if (hasWorkflowJobResult(input.preflightJobResult, 'skipped')) {
+    return Maybe.just('Production preflight did not run');
   }
 
-  if (hasWorkflowJobResult(input.preflightJobResult, 'skipped')) {
+  if (hasProductionPreflightResult(input.preflightResult, 'skipped')) {
     return Maybe.just('Production preflight did not run');
   }
 
@@ -628,10 +621,6 @@ function formatProductionSkipReason(input: ProductionSummaryInput): Maybe<string
 }
 
 function formatApprovalGate(input: ProductionSummaryInput): string {
-  if (input.promotionRequested === false) {
-    return 'not requested';
-  }
-
   if (hasProductionPreflightResult(input.preflightResult, 'already_tagged')) {
     return 'not required; the release is already tagged as Production';
   }
@@ -650,14 +639,6 @@ function formatProductionTag(input: ProductionSummaryInput, github: GitHubLinkCo
 
   if (hasProductionPreflightResult(input.preflightResult, 'already_tagged')) {
     return formatRepositoryTreeLink(input.plannedTagName, github).unwrapOr('not available');
-  }
-
-  if (input.promotionRequested === false) {
-    return 'not requested';
-  }
-
-  if (hasProductionPreflightResult(input.preflightResult, 'already_tagged')) {
-    return 'not available';
   }
 
   if (
@@ -687,8 +668,8 @@ function formatProductionTagCreationResult(input: ProductionSummaryInput): strin
         return 'not required; tag already exists';
       }
 
-      if (input.promotionRequested === false) {
-        return 'not requested';
+      if (hasProductionPreflightResult(input.preflightResult, 'skipped')) {
+        return 'not run';
       }
 
       return 'unknown result';
@@ -733,10 +714,6 @@ function formatDistributionResult(
 
   if (hasWorkflowJobResult(distribution.distributionJobResult, 'cancelled')) {
     return 'cancelled';
-  }
-
-  if (hasWorkflowJobResult(distribution.distributionJobResult, 'skipped') && input.promotionRequested === false) {
-    return 'not requested';
   }
 
   if (
@@ -840,7 +817,6 @@ function hasProductionPreflightCancellation(input: ProductionSummaryInput): bool
 
 function hasHostedProductionCompleted(input: ProductionSummaryInput): boolean {
   return (
-    input.promotionRequested &&
     hasProductionPreflightResult(input.preflightResult, 'ready') &&
     hasWorkflowJobResult(input.preflightJobResult, 'success') &&
     hasWorkflowJobResult(input.deploymentResult, 'success') &&
@@ -921,10 +897,6 @@ function formatFinalReleaseOutcome(input: WebappReleaseSummaryInput): string {
     return 'Release incomplete because the E2E system gate did not run';
   }
 
-  if (hasWorkflowJobResult(input.e2e.result, 'success') && input.production.promotionRequested === false) {
-    return 'Beta release completed; Production promotion was not requested';
-  }
-
   if (hasProductionPreflightResult(input.production.preflightResult, 'already_tagged')) {
     return 'Release already has the matching Production tag; deployment was not repeated';
   }
@@ -935,6 +907,13 @@ function formatFinalReleaseOutcome(input: WebappReleaseSummaryInput): string {
 
   if (hasProductionPreflightCancellation(input.production)) {
     return 'Release stopped because Production preflight was cancelled';
+  }
+
+  if (
+    hasWorkflowJobResult(input.production.preflightJobResult, 'skipped') ||
+    hasProductionPreflightResult(input.production.preflightResult, 'skipped')
+  ) {
+    return 'Release incomplete because Production preflight did not run';
   }
 
   if (hasWorkflowJobResult(input.production.deploymentResult, 'failure')) {
@@ -1127,7 +1106,6 @@ function renderProductionSection(input: WebappReleaseSummaryInput): string {
     '### Hosted Production promotion',
     '',
     `- Result: ${formatProductionResult(input.production)}`,
-    `- Production promotion requested: ${input.production.promotionRequested === true ? 'true' : 'false'}`,
     `- Production preflight result: ${formatProductionPreflightResult(input.production)}`,
     ...productionSkipReasonLines,
     `- Target environment: ${formatValueOrFallback(input.production.environmentName)}`,

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -89,7 +89,7 @@ Beta preserves the previous company-facing Staging release-candidate behavior: i
 
 Automated E2E must never run against Production backend services or create test users in Production. The release workflow deploys the exact Beta artifact to the dedicated `wire-webapp-precommit-3` validation environment, verifies that its runtime configuration uses Staging backend services, then runs E2E there with disposable Staging users and test data. Beta, precommit validation, and Production use the same built artifact; their differences are runtime environment configuration, not rebuilt application artifacts.
 
-A Beta candidate may be promoted when validation is complete and no known release-blocking issues remain. Production receives only the exact artifact validated on Beta. Production promotion remains an explicit decision through GitHub Environment approval; the absence of reported issues does not automatically deploy Beta to Production.
+After successful Hosted Beta and E2E validation, every normal WebApp release advances to the `wire-webapp-prod` GitHub Environment approval gate. This does not deploy automatically: Hosted Production still requires explicit human approval, and any failed release gate prevents the approval step from being reached. Production receives only the exact artifact validated on Beta.
 
 The branch model is:
 
@@ -133,7 +133,7 @@ The WebApp release process is:
 - Successful E2E and Testiny reporting are required before Production promotion.
 - Production preflight is not allowed after any E2E failure, and QA approval cannot override a technically failed E2E gate in this workflow.
 - Failed release gates use the WebApp release failure notification with stage evidence and Playwright report links when available.
-- After a successful E2E gate and Production preflight, `Release WebApp` notifies Deployoholics that the candidate passed and reports whether hosted Production is ready for approval, unnecessary because the release is already tagged, or not requested. Notification delivery is informational and does not gate the release. The reusable precommit workflow's optional failure notification remains disabled to prevent duplicate failure messages.
+- After a successful E2E gate and Production preflight, `Release WebApp` notifies Deployoholics that the candidate passed and reports whether hosted Production is ready for approval or unnecessary because the release is already tagged. Notification delivery is informational and does not gate the release. The reusable precommit workflow's optional failure notification remains disabled to prevent duplicate failure messages.
 - The production deployment job waits for GitHub Environment approval on the production environment.
 - GitHub Environment approval means the workflow pauses before using the production environment until configured reviewers approve or reject the deployment in GitHub.
 - Quality assurance owns the go/no-go quality gate.
@@ -145,7 +145,7 @@ The WebApp release process is:
 - Backend configuration is runtime state and is not inferred from build identity. Beta, precommit, and Production must each satisfy their expected combination of build version, source commit, REST backend, and WebSocket backend.
 - A successful deployment operation alone does not create a Production tag. The workflow creates the production tag `YYYY-MM-DD.N-production` only after all Production runtime assertions pass, so the tag represents a successfully deployed and verified runtime.
 - The hosted-deployment EBS artifact is built once and promoted unchanged through hosted Beta, E2E, and hosted Production.
-- A Production-capable run also preserves the exact public build outputs needed by the Dockerfile. The public Docker image is built from those outputs, from the same release commit, without rebuilding the application.
+- Every normal WebApp release preserves the exact public build outputs needed by the Dockerfile. The public Docker image is built from those outputs, from the same release commit, without rebuilding the application.
 - Docker and Helm publication starts only after Production deployment and runtime verification succeed and the immutable Production tag has been created.
 - `wire-builds/main` is updated only after the immutable image and Helm chart have been published or reused and verified.
 - A Production tag represents verified hosted Production deployment. The release is fully distributed only after the `wire-builds/main` update succeeds.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Remove the Beta-only mode from `Release WebApp`.

Every normal WebApp release now follows one complete path:

```text
release branch
→ Hosted Beta
→ Beta tag
→ blocking E2E gate
→ Production preflight
→ Production approval
→ Hosted Production
→ Production tag
→ Docker
→ Helm
→ wire-builds/main
```

The workflow dispatch form now contains one confirmation checkbox for the complete release instead of separate confirmation and Production-promotion decisions.

## Why

A Beta-only run is not a real release mode for the WebApp. Every successful Beta candidate is intended to continue toward Production after passing the blocking E2E gate.

The previous `promote_to_production` input introduced an unnecessary second decision and maintained separate build, preflight, notification, and summary paths.

Production remains protected by the `wire-webapp-prod` GitHub Environment. The workflow reaches the approval gate after successful validation, but Hosted Production is still not deployed without explicit human approval.

Tracking: https://github.com/wireapp/wire-webapp/issues/21597