### PR TITLE
Simplify Release WebApp dispatch [WPB-26469]

### DIFF
--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -146,8 +146,8 @@ jobs:
 
           release_branch_remote_ref="refs/remotes/origin/${RELEASE_BRANCH}"
           release_branch_action=''
+          source_ref=''
           source_commit_sha=''
-          source_ref='main'
 
           if git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" > /dev/null; then
             release_branch_action='reused'
@@ -159,6 +159,7 @@ jobs:
               exit "${ls_remote_exit_code}"
             fi
 
+            source_ref='main'
             source_commit_sha="${GITHUB_SHA}"
 
             if ! git rev-parse --verify "${source_commit_sha}^{commit}" > /dev/null; then
@@ -177,6 +178,7 @@ jobs:
               fi
 
               release_branch_action='reused'
+              source_ref=''
               source_commit_sha=''
             fi
           fi

--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -10,13 +10,8 @@ on:
         description: 'Release identifier in YYYY-MM-DD.N format, for example 2026-07-18.1'
         required: true
         type: string
-      source_ref:
-        description: 'Source branch used only when the release branch does not already exist'
-        required: true
-        default: main
-        type: string
       confirm_release:
-        description: 'Confirm the complete WebApp release: create or reuse the release branch, validate Beta and E2E, then continue to Production approval and distribution'
+        description: 'I understand that this creates or reuses the release branch, automatically deploys and verifies Beta, runs the blocking E2E gate, and then waits for separate Production approval before deploying Production and publishing the release'
         required: true
         default: false
         type: boolean
@@ -65,7 +60,6 @@ jobs:
     outputs:
       release_identifier: ${{ steps.validate_request.outputs.release_identifier }}
       release_branch: ${{ steps.validate_request.outputs.release_branch }}
-      source_ref: ${{ steps.validate_request.outputs.source_ref }}
 
     steps:
       - name: Checkout workflow tools
@@ -73,6 +67,16 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 1
+
+      - name: Validate workflow ref
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" != 'refs/heads/main' ]]; then
+            echo 'Release WebApp must be started with "Use workflow from: main".' >&2
+            echo "Received workflow ref: ${GITHUB_REF}" >&2
+            exit 1
+          fi
 
       - name: Add repository Yarn wrapper to PATH
         run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
@@ -91,7 +95,6 @@ jobs:
         env:
           CONFIRM_RELEASE: ${{ inputs.confirm_release }}
           RELEASE_IDENTIFIER: ${{ inputs.release_identifier }}
-          SOURCE_REF: ${{ inputs.source_ref }}
         run: |
           set -euo pipefail
 
@@ -100,32 +103,11 @@ jobs:
             exit 1
           fi
 
-          if [[ -z "${SOURCE_REF//[[:space:]]/}" ]]; then
-            echo 'source_ref must not be empty.' >&2
-            exit 1
-          fi
-
-          if [[ "${SOURCE_REF}" == refs/* || "${SOURCE_REF}" == origin/* ]]; then
-            echo "source_ref must be a branch name like main or release/YYYY-MM-DD.N, not a fully qualified or remote-style ref: ${SOURCE_REF}" >&2
-            exit 1
-          fi
-
-          if [[ "${SOURCE_REF}" == -* ]]; then
-            echo "source_ref must not begin with '-': ${SOURCE_REF}" >&2
-            exit 1
-          fi
-
-          if ! git check-ref-format --branch "${SOURCE_REF}" > /dev/null; then
-            echo "source_ref must be a valid branch name: ${SOURCE_REF}" >&2
-            exit 1
-          fi
-
           release_branch="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts release-branch "${RELEASE_IDENTIFIER}")"
 
           {
             echo "release_identifier=${RELEASE_IDENTIFIER}"
             echo "release_branch=${release_branch}"
-            echo "source_ref=${SOURCE_REF}"
           } >> "$GITHUB_OUTPUT"
 
   prepare_release_branch:
@@ -152,19 +134,20 @@ jobs:
         with:
           persist-credentials: true
           fetch-depth: 1
+          ref: ${{ github.sha }}
 
       - name: Prepare release branch
         id: prepare_release_branch
         env:
           RELEASE_BRANCH: ${{ needs.validate_request.outputs.release_branch }}
           RELEASE_IDENTIFIER: ${{ needs.validate_request.outputs.release_identifier }}
-          SOURCE_REF: ${{ needs.validate_request.outputs.source_ref }}
         run: |
           set -euo pipefail
 
           release_branch_remote_ref="refs/remotes/origin/${RELEASE_BRANCH}"
           release_branch_action=''
           source_commit_sha=''
+          source_ref='main'
 
           if git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" > /dev/null; then
             release_branch_action='reused'
@@ -176,8 +159,12 @@ jobs:
               exit "${ls_remote_exit_code}"
             fi
 
-            git fetch --no-tags origin "+refs/heads/${SOURCE_REF}:refs/remotes/origin/${SOURCE_REF}"
-            source_commit_sha="$(git rev-parse "refs/remotes/origin/${SOURCE_REF}^{commit}")"
+            source_commit_sha="${GITHUB_SHA}"
+
+            if ! git rev-parse --verify "${source_commit_sha}^{commit}" > /dev/null; then
+              echo "The workflow dispatch commit is not available in the local repository: ${source_commit_sha}" >&2
+              exit 1
+            fi
 
             if git push origin "${source_commit_sha}:refs/heads/${RELEASE_BRANCH}"; then
               release_branch_action='created'
@@ -207,7 +194,7 @@ jobs:
             echo "release_branch=${RELEASE_BRANCH}"
             echo "release_commit_sha=${release_commit_sha}"
             echo "release_branch_action=${release_branch_action}"
-            echo "source_ref=${SOURCE_REF}"
+            echo "source_ref=${source_ref}"
             echo "source_commit_sha=${source_commit_sha}"
           } >> "$GITHUB_OUTPUT"
 

--- a/bin/renderWebappReleaseSummary.test.ts
+++ b/bin/renderWebappReleaseSummary.test.ts
@@ -212,13 +212,14 @@ describe('WebApp release summary renderer', () => {
         ...baselineWebappReleaseSummaryInput.preparation,
         branchAction: Maybe.just('reused'),
         sourceCommitSha: Maybe.nothing<string>(),
+        sourceRef: Maybe.nothing<string>(),
       },
     };
     const summary = renderWebappReleaseSummary(input);
     const visibleContent = visibleSummary(summary);
     const detailsContent = technicalEvidence(summary);
 
-    expect(detailsContent).toContain('- Branch creation source: main');
+    expect(detailsContent).toContain('- Branch creation source: not applicable; existing release branch was reused');
     expect(detailsContent).toContain(
       '- Commit used to create the release branch: not applicable; existing release branch was reused',
     );

--- a/bin/renderWebappReleaseSummary.test.ts
+++ b/bin/renderWebappReleaseSummary.test.ts
@@ -192,6 +192,45 @@ function assertOptionalProductionPromotionTermsAreAbsent(summary: string): void 
 }
 
 describe('WebApp release summary renderer', () => {
+  it('documents the exact main commit used to create a release branch', () => {
+    const summary = renderWebappReleaseSummary(baselineWebappReleaseSummaryInput);
+    const detailsContent = technicalEvidence(summary);
+
+    expect(detailsContent).toContain('- Branch creation source: main');
+    expect(detailsContent).toContain(
+      `- Commit used to create the release branch: [${sourceCommitSha}](https://github.com/wireapp/wire-webapp/commit/${sourceCommitSha})`,
+    );
+    expect(detailsContent).toContain(
+      'The release branch was created from the exact main commit selected when the workflow was started.',
+    );
+  });
+
+  it('documents that an existing release branch head is reused without applying main', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      preparation: {
+        ...baselineWebappReleaseSummaryInput.preparation,
+        branchAction: Maybe.just('reused'),
+        sourceCommitSha: Maybe.nothing<string>(),
+      },
+    };
+    const summary = renderWebappReleaseSummary(input);
+    const visibleContent = visibleSummary(summary);
+    const detailsContent = technicalEvidence(summary);
+
+    expect(detailsContent).toContain('- Branch creation source: main');
+    expect(detailsContent).toContain(
+      '- Commit used to create the release branch: not applicable; existing release branch was reused',
+    );
+    expect(detailsContent).toContain(
+      'The existing release branch head was reused. The selected main commit was not merged, reset, or applied.',
+    );
+    expect(visibleContent).toContain(`- Hosted Beta: deployed and verified successfully - tag [${betaTagName}]`);
+    expect(visibleContent).toContain('- E2E system gate: passed successfully - [Playwright report]');
+    expect(visibleContent).toContain('- Hosted Production: not run because Production preflight did not run');
+    expect(visibleContent).toContain('- Release distribution: not run');
+  });
+
   it('reports an unexpected skipped Production preflight as an incomplete release', () => {
     const summary = renderWebappReleaseSummary(baselineWebappReleaseSummaryInput);
     const visibleContent = visibleSummary(summary);
@@ -649,7 +688,7 @@ describe('WebApp release summary renderer', () => {
     expect(visibleSummary(finalSummary)).toContain('- Commit: not available');
     expect(technicalEvidence(finalSummary)).toContain('- Artifact name: not available');
     expect(technicalEvidence(finalSummary)).toContain('- Artifact checksum: not available');
-    expect(technicalEvidence(finalSummary)).toContain('- Source commit used for creation: not available');
+    expect(technicalEvidence(finalSummary)).toContain('- Commit used to create the release branch: not available');
   });
 
   it('keeps an optional manual reason in Release preparation evidence only', () => {

--- a/bin/renderWebappReleaseSummary.ts
+++ b/bin/renderWebappReleaseSummary.ts
@@ -331,10 +331,10 @@ function formatReleaseBranchPreparationNote(branchAction: Maybe<ReleaseBranchAct
     actualAction => {
       return match(actualAction)
         .with('created', () => {
-          return 'The release branch was created from the resolved source commit.';
+          return 'The release branch was created from the exact main commit selected when the workflow was started.';
         })
         .with('reused', () => {
-          return 'The existing release branch was reused and was not moved to source_ref.';
+          return 'The existing release branch head was reused. The selected main commit was not merged, reset, or applied.';
         })
         .exhaustive();
     },
@@ -352,7 +352,7 @@ function formatSourceCommit(input: WebappReleaseSummaryInput): string {
           return formatCommitLink(input.preparation.sourceCommitSha, input.github);
         })
         .with('reused', () => {
-          return 'not applicable; existing branch was reused';
+          return 'not applicable; existing release branch was reused';
         })
         .exhaustive();
     },
@@ -1145,8 +1145,8 @@ function renderReleasePreparationSection(input: WebappReleaseSummaryInput): stri
     `- Release identifier: ${formatValueOrFallback(input.release.identifier)}`,
     `- Release branch: ${formatValueOrFallback(input.release.branch)}`,
     `- Branch action: ${formatReleaseBranchAction(input.preparation.branchAction)}`,
-    `- Source ref: ${formatValueOrFallback(input.preparation.sourceRef)}`,
-    `- Source commit used for creation: ${sourceCommitLink}`,
+    `- Branch creation source: ${formatValueOrFallback(input.preparation.sourceRef)}`,
+    `- Commit used to create the release branch: ${sourceCommitLink}`,
     `- Authoritative release commit: ${commitLink}`,
     `- Branch preparation: ${formatReleaseBranchPreparationNote(input.preparation.branchAction)}`,
     `- Actor: ${formatValueOrFallback(input.github.actor)}`,

--- a/bin/renderWebappReleaseSummary.ts
+++ b/bin/renderWebappReleaseSummary.ts
@@ -341,6 +341,24 @@ function formatReleaseBranchPreparationNote(branchAction: Maybe<ReleaseBranchAct
   );
 }
 
+function formatBranchCreationSource(input: WebappReleaseSummaryInput): string {
+  return input.preparation.branchAction.mapOrElse(
+    () => {
+      return formatValueOrFallback(input.preparation.sourceRef);
+    },
+    branchAction => {
+      return match(branchAction)
+        .with('created', () => {
+          return formatValueOrFallback(input.preparation.sourceRef);
+        })
+        .with('reused', () => {
+          return 'not applicable; existing release branch was reused';
+        })
+        .exhaustive();
+    },
+  );
+}
+
 function formatSourceCommit(input: WebappReleaseSummaryInput): string {
   return input.preparation.branchAction.mapOrElse(
     () => {
@@ -1145,7 +1163,7 @@ function renderReleasePreparationSection(input: WebappReleaseSummaryInput): stri
     `- Release identifier: ${formatValueOrFallback(input.release.identifier)}`,
     `- Release branch: ${formatValueOrFallback(input.release.branch)}`,
     `- Branch action: ${formatReleaseBranchAction(input.preparation.branchAction)}`,
-    `- Branch creation source: ${formatValueOrFallback(input.preparation.sourceRef)}`,
+    `- Branch creation source: ${formatBranchCreationSource(input)}`,
     `- Commit used to create the release branch: ${sourceCommitLink}`,
     `- Authoritative release commit: ${commitLink}`,
     `- Branch preparation: ${formatReleaseBranchPreparationNote(input.preparation.branchAction)}`,

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -28,7 +28,7 @@ flowchart LR
   hostedDevEnvironment[Hosted Dev<br/>Staging backend]
   developmentDistribution[Publish dev Docker image and Helm chart<br/>Update wire-builds/dev]
   runReleaseWebApp[Run Release WebApp]
-  prepareReleaseBranch[Prepare release branch<br/>Resolve one exact source commit]
+  prepareReleaseBranch[Prepare release branch<br/>Create from dispatch commit or reuse current head]
   releaseBranch[release/YYYY-MM-DD.N]
   releaseArtifact[Release artifact]
   betaEnvironment[Beta company validation<br/>Production backend]
@@ -103,10 +103,11 @@ The release identifier uses the release branch name: `YYYY-MM-DD.N`. The full id
 
 The WebApp release process is:
 
-- `Release WebApp` is the single user-facing normal-release entrypoint. The release captain supplies a release identifier in `YYYY-MM-DD.N` format; the workflow derives `release/YYYY-MM-DD.N` and performs branch preparation, hosted deployment, validation, approval, and release distribution.
-- When the derived release branch does not exist, `Release WebApp` resolves the requested `source_ref` to one exact remote commit, creates the branch at that commit without force-pushing, refetches it, and verifies the resulting remote head. If another run wins the creation race, the workflow resolves and reuses the actual remote branch.
-- When the derived release branch already exists, its current remote head is authoritative. The workflow reuses that branch without moving it to `source_ref`, current `main`, or any other commit. Reviewed fixes may therefore update an active release branch before a later candidate run.
-- Repeated dispatches with the same identifier reuse the release branch and build its current head, producing subsequent Beta candidates such as `YYYY-MM-DD.N-beta.2`. A new identifier is required to release a newer state of `main`.
+- `Release WebApp` is the single user-facing normal-release entrypoint and must be manually started with GitHub's `Use workflow from: main` selector. Its dispatch form has no configurable source-branch input; the release captain supplies only a release identifier in `YYYY-MM-DD.N` format, release confirmation, and an optional reason. The workflow derives `release/YYYY-MM-DD.N` and performs branch preparation, hosted deployment, validation, approval, and release distribution.
+- When the derived release branch does not exist, `Release WebApp` creates it from the exact `GITHUB_SHA` selected for that manual workflow run on `main`, without force-pushing, refetches it, and verifies the resulting remote head. The workflow does not resolve a later moving `main` head, so the branch remains based on the dispatch commit even if `main` advances while the run waits or is rerun. If another run wins the creation race, the workflow resolves and reuses the actual remote branch.
+- When the derived release branch already exists, its current remote head is authoritative. The workflow reuses that branch without merging, resetting, rebasing, force-pushing, or otherwise applying the selected `main` commit. Reviewed fixes may therefore update an active release branch through reviewed pull requests targeting that release branch before a later candidate run.
+- Repeated dispatches with the same identifier reuse the release branch's current head and build it exactly as it exists, producing subsequent Beta candidates such as `YYYY-MM-DD.N-beta.2`. A new identifier is required to release a newer state of `main`.
+- Every confirmed normal release follows the complete release path: Beta deployment and runtime verification, Beta tagging, the blocking E2E deployment/runtime gate and Testiny reporting, Production preflight and explicit Production Environment approval, Production deployment and runtime verification, Production tagging, and Docker, Helm, and `wire-builds/main` distribution.
 - Hosted Beta and hosted Production are deployment stages operated by Wire. E2E remains a blocking release gate, and Production approval remains explicit through the `wire-webapp-prod` GitHub Environment.
 - Docker, Helm, and `wire-builds/main` form the release distribution consumed by hosted and customer-managed deployments. Release distribution is part of the complete WebApp release lifecycle, not merely a hosted deployment detail.
 - The standalone branch-creation workflow no longer exists. `Release WebApp` is intentionally started explicitly; branch preparation and the complete release lifecycle are one auditable workflow operation.

--- a/docs/nx-monorepo-integration-overview.md
+++ b/docs/nx-monorepo-integration-overview.md
@@ -34,7 +34,6 @@ These commands are exposed as root npm scripts in [`package.json`](package.json)
 {
   "scripts": {
     "clean:jest": "nx reset && nx run workspace-tools:clean-jest",
-    "deploy": "nx run server:package && eb deploy",
     "docker": "nx run workspace-tools:docker",
     "release": "nx release",
     "release:dry-run": "nx release --dry-run",
@@ -919,7 +918,7 @@ The deployment includes:
 
 **Deployment Artifacts:**
 
-The final `ebs.zip` file is uploaded to AWS Elastic Beanstalk via the `eb deploy` command (defined in [`package.json`](package.json) as `deploy` script).
+The final `ebs.zip` file is consumed by the maintained GitHub Actions deployment workflows for their target environments. The repository does not expose a local Elastic Beanstalk deployment script.
 
 ### Edge Cases and Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "bundle:prod:public": "nx run server:assemble-webapp-public",
     "clean:jest": "nx reset && nx run workspace-tools:clean-jest",
     "clean:yarn": "find . -name node_modules -type d -prune -exec rm -rf '{}' + && ./bin/yarn cache clean",
-    "deploy": "nx run server:package && eb deploy",
     "dev": "nx serve server",
     "dev:packages": "nx run-many -t watch --projects=tag:type:lib",
     "docker": "nx run workspace-tools:docker",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Simplify the `Release WebApp` dispatch form and make release branch preparation explicit.

The workflow now asks only for:

```text
release identifier
release confirmation
optional reason
```

The configurable source branch input has been removed.

The obsolete local Elastic Beanstalk deployment command has also been removed:

```text
yarn deploy
```

## Branch preparation

`Release WebApp` must be started with `Use workflow from: main`.

When the derived release branch does not exist:

```text
exact main commit selected at workflow dispatch
=> release/YYYY-MM-DD.N
```

The workflow uses the dispatch commit rather than resolving a potentially newer `main` commit later.

When the release branch already exists:

```text
existing release branch head
=> authoritative release commit
```

The selected `main` commit is not merged, reset, or otherwise applied. This preserves reviewed fixes already added to the release line.

## Release confirmation

The checkbox now describes the complete release operation:

- create or reuse the release branch;
- automatically deploy and verify Beta;
- run the blocking E2E gate;
- wait for separate Production approval;
- deploy and verify Production;
- publish the Production distribution.

The checkbox confirms the operation. It does not enable or disable individual release stages.

Tracking: #21597