### PR TITLE
Fix meeting delete availability and confirm button icon [WPB-25513]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/getMeetingActionEntries.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/getMeetingActionEntries.test.tsx
@@ -23,21 +23,10 @@ import {getMeetingActionEntries} from 'Components/Meeting/MeetingList/MeetingLis
 import {MEETING_ACTION_TRANSLATION_KEYS} from 'Components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/meetingActionTranslationKeys';
 import {User} from 'Repositories/entity/User';
 import {translateForTest} from 'Util/test/translateForTest';
-import {createDeterministicWallClock} from '@enormora/wall-clock/deterministic-wall-clock';
 
-const fixedFutureNow = new Date('2026-06-15T13:00:00.000Z');
-const fixedOngoingNow = new Date('2026-06-15T14:30:00.000Z');
-const fixedPastNow = new Date('2026-06-15T16:00:00.000Z');
-
-const futureWallClock = createDeterministicWallClock({
-  initialCurrentTimestampInMilliseconds: fixedFutureNow.getTime(),
-});
-const ongoingWallClock = createDeterministicWallClock({
-  initialCurrentTimestampInMilliseconds: fixedOngoingNow.getTime(),
-});
-const pastWallClock = createDeterministicWallClock({
-  initialCurrentTimestampInMilliseconds: fixedPastNow.getTime(),
-});
+const futureNowMilliseconds = Date.parse('2026-06-15T13:00:00.000Z');
+const ongoingNowMilliseconds = Date.parse('2026-06-15T14:30:00.000Z');
+const pastNowMilliseconds = Date.parse('2026-06-15T16:00:00.000Z');
 
 const createSeries = (overrides: Partial<MeetingSeries> = {}): MeetingSeries => ({
   series_start_date: '2026-06-15T14:00:00.000Z',
@@ -88,7 +77,7 @@ describe('getMeetingActionEntries', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser(),
-      nowMilliseconds: futureWallClock.currentTimestampInMilliseconds,
+      nowMilliseconds: futureNowMilliseconds,
       translate,
       onEdit: jest.fn(),
       onDeleteForAll: noop,
@@ -106,7 +95,7 @@ describe('getMeetingActionEntries', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser(),
-      nowMilliseconds: futureWallClock.currentTimestampInMilliseconds,
+      nowMilliseconds: futureNowMilliseconds,
       translate,
       onEdit: jest.fn(),
       onDeleteForAll: noop,
@@ -120,7 +109,7 @@ describe('getMeetingActionEntries', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser('invitee-id'),
-      nowMilliseconds: futureWallClock.currentTimestampInMilliseconds,
+      nowMilliseconds: futureNowMilliseconds,
       translate,
       onEdit: jest.fn(),
       onDeleteForAll: noop,
@@ -134,7 +123,7 @@ describe('getMeetingActionEntries', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser(),
-      nowMilliseconds: ongoingWallClock.currentTimestampInMilliseconds,
+      nowMilliseconds: ongoingNowMilliseconds,
       translate,
       onEdit: jest.fn(),
       onDeleteForAll: noop,
@@ -148,7 +137,7 @@ describe('getMeetingActionEntries', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser(),
-      nowMilliseconds: pastWallClock.currentTimestampInMilliseconds,
+      nowMilliseconds: pastNowMilliseconds,
       translate,
       onEdit: jest.fn(),
       onDeleteForAll: noop,
@@ -170,7 +159,7 @@ describe('getMeetingActionEntries', () => {
         end: new Date('2026-06-22T11:00:00.000Z'),
       },
       selfUser: createSelfUser(),
-      nowMilliseconds: futureWallClock.currentTimestampInMilliseconds,
+      nowMilliseconds: futureNowMilliseconds,
       translate,
       onEdit: jest.fn(),
       onDeleteForAll: noop,
@@ -184,7 +173,7 @@ describe('getMeetingActionEntries', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser(),
-      nowMilliseconds: futureWallClock.currentTimestampInMilliseconds,
+      nowMilliseconds: futureNowMilliseconds,
       translate,
       onEdit: jest.fn(),
       onDeleteForAll: noop,
@@ -199,7 +188,7 @@ describe('getMeetingActionEntries', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser(),
-      nowMilliseconds: ongoingWallClock.currentTimestampInMilliseconds,
+      nowMilliseconds: ongoingNowMilliseconds,
       translate,
       onEdit: jest.fn(),
       onDeleteForAll: noop,
@@ -214,7 +203,7 @@ describe('getMeetingActionEntries', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser('invitee-id'),
-      nowMilliseconds: futureWallClock.currentTimestampInMilliseconds,
+      nowMilliseconds: futureNowMilliseconds,
       translate,
       onEdit: jest.fn(),
       onDeleteForAll: noop,
@@ -229,7 +218,7 @@ describe('getMeetingActionEntries', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser('invitee-id'),
-      nowMilliseconds: ongoingWallClock.currentTimestampInMilliseconds,
+      nowMilliseconds: ongoingNowMilliseconds,
       translate,
       onEdit: jest.fn(),
       onDeleteForAll: noop,
@@ -244,7 +233,7 @@ describe('getMeetingActionEntries', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser(),
-      nowMilliseconds: pastWallClock.currentTimestampInMilliseconds,
+      nowMilliseconds: pastNowMilliseconds,
       translate,
       onEdit: jest.fn(),
       onDeleteForAll: noop,

--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/getMeetingActionEntries.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/getMeetingActionEntries.test.tsx
@@ -195,11 +195,41 @@ describe('getMeetingActionEntries', () => {
     expect(getDeleteForMeEntryLabel(entries)).toBeUndefined();
   });
 
+  it('omits Delete meeting for everyone when the instance has started', () => {
+    const entries = getMeetingActionEntries({
+      meetingInstance: createMeetingInstance(),
+      selfUser: createSelfUser(),
+      nowMilliseconds: ongoingWallClock.currentTimestampInMilliseconds,
+      translate,
+      onEdit: jest.fn(),
+      onDeleteForAll: noop,
+      onDeleteForMe: noop,
+    });
+
+    expect(getDeleteForAllEntryLabel(entries)).toBeUndefined();
+    expect(getDeleteForMeEntryLabel(entries)).toBeUndefined();
+  });
+
   it('includes Delete meeting for me for a participant', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser('invitee-id'),
       nowMilliseconds: futureWallClock.currentTimestampInMilliseconds,
+      translate,
+      onEdit: jest.fn(),
+      onDeleteForAll: noop,
+      onDeleteForMe: noop,
+    });
+
+    expect(getDeleteForMeEntryLabel(entries)).toBeDefined();
+    expect(getDeleteForAllEntryLabel(entries)).toBeUndefined();
+  });
+
+  it('includes Delete meeting for me for a participant while the meeting is ongoing', () => {
+    const entries = getMeetingActionEntries({
+      meetingInstance: createMeetingInstance(),
+      selfUser: createSelfUser('invitee-id'),
+      nowMilliseconds: ongoingWallClock.currentTimestampInMilliseconds,
       translate,
       onEdit: jest.fn(),
       onDeleteForAll: noop,

--- a/apps/webapp/src/script/components/Meeting/shared/delete/showDeleteMeetingModal.styles.ts
+++ b/apps/webapp/src/script/components/Meeting/shared/delete/showDeleteMeetingModal.styles.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+
+export const deleteMeetingConfirmButtonContentStyles: CSSObject = {
+  alignItems: 'center',
+  display: 'inline-flex',
+  gap: '8px',
+};
+
+export const deleteMeetingConfirmButtonIconStyles: CSSObject = {
+  fill: 'currentColor',
+};

--- a/apps/webapp/src/script/components/Meeting/shared/delete/showDeleteMeetingModal.tsx
+++ b/apps/webapp/src/script/components/Meeting/shared/delete/showDeleteMeetingModal.tsx
@@ -19,6 +19,10 @@
 
 import {TrashIcon} from '@wireapp/react-ui-kit';
 
+import {
+  deleteMeetingConfirmButtonContentStyles,
+  deleteMeetingConfirmButtonIconStyles,
+} from 'Components/Meeting/shared/delete/showDeleteMeetingModal.styles';
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
 import type {Translate, TranslationKey} from 'Util/localizerUtil';
 
@@ -65,9 +69,10 @@ export const showDeleteMeetingModal = ({
       primaryAction: {
         action: onConfirm,
         text: (
-          <>
-            <TrashIcon width={16} height={16} /> {translate('meetings.deleteModal.confirmDelete')}
-          </>
+          <span css={deleteMeetingConfirmButtonContentStyles}>
+            <TrashIcon width={16} height={16} css={deleteMeetingConfirmButtonIconStyles} />
+            {translate('meetings.deleteModal.confirmDelete')}
+          </span>
         ),
       },
       secondaryAction: {

--- a/apps/webapp/src/script/components/Meeting/shared/submit/submitDeleteMeeting.test.ts
+++ b/apps/webapp/src/script/components/Meeting/shared/submit/submitDeleteMeeting.test.ts
@@ -64,18 +64,6 @@ const createSelfUser = (id = 'host-id') => {
   return user;
 };
 
-const futureWallClock = createDeterministicWallClock({
-  initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
-});
-
-const ongoingWallClock = createDeterministicWallClock({
-  initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T14:30:00.000Z'),
-});
-
-const pastWallClock = createDeterministicWallClock({
-  initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T16:00:00.000Z'),
-});
-
 describe('submitDeleteMeeting', () => {
   let primaryModalShow: jest.Mock;
 
@@ -96,14 +84,18 @@ describe('submitDeleteMeeting', () => {
       deleteMeetingForMe?: jest.Mock;
       removeMeetingByQualifiedId?: jest.Mock;
       loadMeetings?: jest.Mock;
-      wallClock?: typeof futureWallClock;
+      wallClock?: ReturnType<typeof createDeterministicWallClock>;
       selfUser?: User | undefined;
     } = {},
   ) => ({
     meetingInstance: createMeetingInstance(),
     mode: 'forAll' as const,
     selfUser: 'selfUser' in overrides ? overrides.selfUser : createSelfUser(),
-    wallClock: overrides.wallClock ?? futureWallClock,
+    wallClock:
+      overrides.wallClock ??
+      createDeterministicWallClock({
+        initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
+      }),
     translate: translateForTest,
     deleteMeetingForMe: overrides.deleteMeetingForMe ?? jest.fn().mockReturnValue(task.resolve(undefined)),
     deleteMeetingForAll: overrides.deleteMeetingForAll ?? jest.fn().mockReturnValue(task.resolve(undefined)),
@@ -180,11 +172,14 @@ describe('submitDeleteMeeting', () => {
 
   it('blocks delete for all when the meeting has started before submit', async () => {
     const deleteMeetingForAll = jest.fn().mockReturnValue(task.resolve(undefined));
+    const wallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T14:30:00.000Z'),
+    });
 
     const result = await submitDeleteMeeting(
       createSubmitDeps({
         deleteMeetingForAll,
-        wallClock: ongoingWallClock,
+        wallClock,
       }),
     );
 
@@ -205,11 +200,14 @@ describe('submitDeleteMeeting', () => {
 
   it('blocks delete when the meeting became past before submit', async () => {
     const deleteMeetingForAll = jest.fn().mockReturnValue(task.resolve(undefined));
+    const wallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T16:00:00.000Z'),
+    });
 
     const result = await submitDeleteMeeting(
       createSubmitDeps({
         deleteMeetingForAll,
-        wallClock: pastWallClock,
+        wallClock,
       }),
     );
 

--- a/apps/webapp/src/script/components/Meeting/shared/submit/submitDeleteMeeting.test.ts
+++ b/apps/webapp/src/script/components/Meeting/shared/submit/submitDeleteMeeting.test.ts
@@ -68,6 +68,10 @@ const futureWallClock = createDeterministicWallClock({
   initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
 });
 
+const ongoingWallClock = createDeterministicWallClock({
+  initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T14:30:00.000Z'),
+});
+
 const pastWallClock = createDeterministicWallClock({
   initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T16:00:00.000Z'),
 });
@@ -172,6 +176,31 @@ describe('submitDeleteMeeting', () => {
     expect(removeMeetingByQualifiedId).not.toHaveBeenCalled();
     expect(loadMeetings).not.toHaveBeenCalled();
     expect(primaryModalShow).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks delete for all when the meeting has started before submit', async () => {
+    const deleteMeetingForAll = jest.fn().mockReturnValue(task.resolve(undefined));
+
+    const result = await submitDeleteMeeting(
+      createSubmitDeps({
+        deleteMeetingForAll,
+        wallClock: ongoingWallClock,
+      }),
+    );
+
+    expect(result).toBe(deleteMeetingSubmitResults.blocked);
+    expect(deleteMeetingForAll).not.toHaveBeenCalled();
+    expect(primaryModalShow).toHaveBeenCalledWith(
+      PrimaryModal.type.ACKNOWLEDGE,
+      expect.objectContaining({
+        text: expect.objectContaining({
+          title: translateForTest('meetings.deleteModal.error.notAllowedTitle'),
+          message: translateForTest('meetings.deleteModal.error.notAllowed'),
+        }),
+      }),
+      undefined,
+      translateForTest,
+    );
   });
 
   it('blocks delete when the meeting became past before submit', async () => {

--- a/apps/webapp/src/script/components/Meeting/shared/submit/submitDeleteMeeting.test.ts
+++ b/apps/webapp/src/script/components/Meeting/shared/submit/submitDeleteMeeting.test.ts
@@ -84,18 +84,14 @@ describe('submitDeleteMeeting', () => {
       deleteMeetingForMe?: jest.Mock;
       removeMeetingByQualifiedId?: jest.Mock;
       loadMeetings?: jest.Mock;
-      wallClock?: ReturnType<typeof createDeterministicWallClock>;
+      wallClock: ReturnType<typeof createDeterministicWallClock>;
       selfUser?: User | undefined;
-    } = {},
+    },
   ) => ({
     meetingInstance: createMeetingInstance(),
     mode: 'forAll' as const,
     selfUser: 'selfUser' in overrides ? overrides.selfUser : createSelfUser(),
-    wallClock:
-      overrides.wallClock ??
-      createDeterministicWallClock({
-        initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
-      }),
+    wallClock: overrides.wallClock,
     translate: translateForTest,
     deleteMeetingForMe: overrides.deleteMeetingForMe ?? jest.fn().mockReturnValue(task.resolve(undefined)),
     deleteMeetingForAll: overrides.deleteMeetingForAll ?? jest.fn().mockReturnValue(task.resolve(undefined)),
@@ -106,11 +102,15 @@ describe('submitDeleteMeeting', () => {
   it('removes the meeting from the store after a successful delete for all', async () => {
     const removeMeetingByQualifiedId = jest.fn();
     const deleteMeetingForAll = jest.fn().mockReturnValue(task.resolve(undefined));
+    const wallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
+    });
 
     const result = await submitDeleteMeeting(
       createSubmitDeps({
         deleteMeetingForAll,
         removeMeetingByQualifiedId,
+        wallClock,
       }),
     );
 
@@ -126,12 +126,16 @@ describe('submitDeleteMeeting', () => {
       .fn()
       .mockReturnValue(task.reject(meetingSubmitErrors.deleteSucceededButLocalCleanupFailed));
     const loadMeetings = jest.fn().mockResolvedValue(undefined);
+    const wallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
+    });
 
     const result = await submitDeleteMeeting(
       createSubmitDeps({
         deleteMeetingForAll,
         removeMeetingByQualifiedId,
         loadMeetings,
+        wallClock,
       }),
     );
 
@@ -155,12 +159,16 @@ describe('submitDeleteMeeting', () => {
     const removeMeetingByQualifiedId = jest.fn();
     const deleteMeetingForAll = jest.fn().mockReturnValue(task.reject(meetingSubmitErrors.deleteFailed));
     const loadMeetings = jest.fn().mockResolvedValue(undefined);
+    const wallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
+    });
 
     const result = await submitDeleteMeeting(
       createSubmitDeps({
         deleteMeetingForAll,
         removeMeetingByQualifiedId,
         loadMeetings,
+        wallClock,
       }),
     );
 
@@ -228,11 +236,15 @@ describe('submitDeleteMeeting', () => {
 
   it('shows feedback when selfUser is missing', async () => {
     const deleteMeetingForAll = jest.fn().mockReturnValue(task.resolve(undefined));
+    const wallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
+    });
 
     const result = await submitDeleteMeeting(
       createSubmitDeps({
         deleteMeetingForAll,
         selfUser: undefined,
+        wallClock,
       }),
     );
 
@@ -265,10 +277,14 @@ describe('submitDeleteMeeting', () => {
       ),
     );
     const removeMeetingByQualifiedId = jest.fn();
+    const wallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
+    });
 
     const deps = createSubmitDeps({
       deleteMeetingForAll,
       removeMeetingByQualifiedId,
+      wallClock,
     });
 
     const firstSubmit = submitDeleteMeeting(deps);
@@ -297,12 +313,16 @@ describe('submitDeleteMeeting', () => {
     const removeMeetingByQualifiedId = jest.fn();
     const deleteMeetingForMe = jest.fn().mockReturnValue(task.resolve(undefined));
     const invitee = createSelfUser('invitee-id');
+    const wallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
+    });
 
     const result = await submitDeleteMeeting({
       ...createSubmitDeps({
         deleteMeetingForMe,
         removeMeetingByQualifiedId,
         selfUser: invitee,
+        wallClock,
       }),
       mode: 'forMe',
     });
@@ -316,12 +336,16 @@ describe('submitDeleteMeeting', () => {
     const removeMeetingByQualifiedId = jest.fn();
     const deleteMeetingForMe = jest.fn().mockReturnValue(task.reject(meetingSubmitErrors.leaveConversationFailed));
     const invitee = createSelfUser('invitee-id');
+    const wallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
+    });
 
     const result = await submitDeleteMeeting({
       ...createSubmitDeps({
         deleteMeetingForMe,
         removeMeetingByQualifiedId,
         selfUser: invitee,
+        wallClock,
       }),
       mode: 'forMe',
     });

--- a/apps/webapp/src/script/components/Meeting/shared/submit/submitDeleteMeeting.test.ts
+++ b/apps/webapp/src/script/components/Meeting/shared/submit/submitDeleteMeeting.test.ts
@@ -78,16 +78,14 @@ describe('submitDeleteMeeting', () => {
     resetInFlightDeleteMeetingsForTest();
   });
 
-  const createSubmitDeps = (
-    overrides: {
-      deleteMeetingForAll?: jest.Mock;
-      deleteMeetingForMe?: jest.Mock;
-      removeMeetingByQualifiedId?: jest.Mock;
-      loadMeetings?: jest.Mock;
-      wallClock: ReturnType<typeof createDeterministicWallClock>;
-      selfUser?: User | undefined;
-    },
-  ) => ({
+  const createSubmitDeps = (overrides: {
+    deleteMeetingForAll?: jest.Mock;
+    deleteMeetingForMe?: jest.Mock;
+    removeMeetingByQualifiedId?: jest.Mock;
+    loadMeetings?: jest.Mock;
+    wallClock: ReturnType<typeof createDeterministicWallClock>;
+    selfUser?: User | undefined;
+  }) => ({
     meetingInstance: createMeetingInstance(),
     mode: 'forAll' as const,
     selfUser: 'selfUser' in overrides ? overrides.selfUser : createSelfUser(),

--- a/apps/webapp/src/script/components/Meeting/utils/canDeleteMeeting.test.ts
+++ b/apps/webapp/src/script/components/Meeting/utils/canDeleteMeeting.test.ts
@@ -79,29 +79,19 @@ describe('canDeleteMeetingForAll', () => {
   it('allows host delete when the meeting has not started', () => {
     const meetingInstance = createMeetingInstance();
 
-    expect(
-      canDeleteMeetingForAll(meetingInstance, createSelfUser(), futureNowMilliseconds),
-    ).toBe(true);
+    expect(canDeleteMeetingForAll(meetingInstance, createSelfUser(), futureNowMilliseconds)).toBe(true);
   });
 
   it('disallows host delete when the meeting has started', () => {
     const meetingInstance = createMeetingInstance();
 
-    expect(
-      canDeleteMeetingForAll(meetingInstance, createSelfUser(), ongoingNowMilliseconds),
-    ).toBe(false);
+    expect(canDeleteMeetingForAll(meetingInstance, createSelfUser(), ongoingNowMilliseconds)).toBe(false);
   });
 
   it('disallows delete for non-host users', () => {
     const meetingInstance = createMeetingInstance();
 
-    expect(
-      canDeleteMeetingForAll(
-        meetingInstance,
-        createSelfUser('invitee-id'),
-        futureNowMilliseconds,
-      ),
-    ).toBe(false);
+    expect(canDeleteMeetingForAll(meetingInstance, createSelfUser('invitee-id'), futureNowMilliseconds)).toBe(false);
   });
 });
 
@@ -109,20 +99,12 @@ describe('canDeleteMeetingForMe', () => {
   it('allows participant delete when the meeting is not past', () => {
     const meetingInstance = createMeetingInstance();
 
-    expect(
-      canDeleteMeetingForMe(
-        meetingInstance,
-        createSelfUser('invitee-id'),
-        futureNowMilliseconds,
-      ),
-    ).toBe(true);
+    expect(canDeleteMeetingForMe(meetingInstance, createSelfUser('invitee-id'), futureNowMilliseconds)).toBe(true);
   });
 
   it('disallows delete for the host', () => {
     const meetingInstance = createMeetingInstance();
 
-    expect(
-      canDeleteMeetingForMe(meetingInstance, createSelfUser(), futureNowMilliseconds),
-    ).toBe(false);
+    expect(canDeleteMeetingForMe(meetingInstance, createSelfUser(), futureNowMilliseconds)).toBe(false);
   });
 });

--- a/apps/webapp/src/script/components/Meeting/utils/canDeleteMeeting.test.ts
+++ b/apps/webapp/src/script/components/Meeting/utils/canDeleteMeeting.test.ts
@@ -87,12 +87,20 @@ describe('canDeleteMeeting', () => {
 });
 
 describe('canDeleteMeetingForAll', () => {
-  it('allows host delete when the meeting is not past', () => {
+  it('allows host delete when the meeting has not started', () => {
     const meetingInstance = createMeetingInstance();
 
     expect(
       canDeleteMeetingForAll(meetingInstance, createSelfUser(), futureWallClock.currentTimestampInMilliseconds),
     ).toBe(true);
+  });
+
+  it('disallows host delete when the meeting has started', () => {
+    const meetingInstance = createMeetingInstance();
+
+    expect(
+      canDeleteMeetingForAll(meetingInstance, createSelfUser(), ongoingWallClock.currentTimestampInMilliseconds),
+    ).toBe(false);
   });
 
   it('disallows delete for non-host users', () => {

--- a/apps/webapp/src/script/components/Meeting/utils/canDeleteMeeting.test.ts
+++ b/apps/webapp/src/script/components/Meeting/utils/canDeleteMeeting.test.ts
@@ -26,21 +26,10 @@ import {
 } from 'Components/Meeting/utils/canDeleteMeeting';
 import {User} from 'Repositories/entity/User';
 import {translateForTest} from 'Util/test/translateForTest';
-import {createDeterministicWallClock} from '@enormora/wall-clock/deterministic-wall-clock';
 
-const fixedFutureNow = new Date('2026-06-15T13:00:00.000Z');
-const fixedOngoingNow = new Date('2026-06-15T14:30:00.000Z');
-const fixedPastNow = new Date('2026-06-15T16:00:00.000Z');
-
-const futureWallClock = createDeterministicWallClock({
-  initialCurrentTimestampInMilliseconds: fixedFutureNow.getTime(),
-});
-const ongoingWallClock = createDeterministicWallClock({
-  initialCurrentTimestampInMilliseconds: fixedOngoingNow.getTime(),
-});
-const pastWallClock = createDeterministicWallClock({
-  initialCurrentTimestampInMilliseconds: fixedPastNow.getTime(),
-});
+const futureNowMilliseconds = Date.parse('2026-06-15T13:00:00.000Z');
+const ongoingNowMilliseconds = Date.parse('2026-06-15T14:30:00.000Z');
+const pastNowMilliseconds = Date.parse('2026-06-15T16:00:00.000Z');
 
 const createSeries = (overrides: Partial<MeetingSeries> = {}): MeetingSeries => ({
   series_start_date: '2026-06-15T14:00:00.000Z',
@@ -75,14 +64,14 @@ describe('canDeleteMeeting', () => {
   it('allows delete for upcoming and ongoing meetings', () => {
     const meetingInstance = createMeetingInstance();
 
-    expect(canDeleteMeeting(meetingInstance, futureWallClock.currentTimestampInMilliseconds)).toBe(true);
-    expect(canDeleteMeeting(meetingInstance, ongoingWallClock.currentTimestampInMilliseconds)).toBe(true);
+    expect(canDeleteMeeting(meetingInstance, futureNowMilliseconds)).toBe(true);
+    expect(canDeleteMeeting(meetingInstance, ongoingNowMilliseconds)).toBe(true);
   });
 
   it('disallows delete for past meetings', () => {
     const meetingInstance = createMeetingInstance();
 
-    expect(canDeleteMeeting(meetingInstance, pastWallClock.currentTimestampInMilliseconds)).toBe(false);
+    expect(canDeleteMeeting(meetingInstance, pastNowMilliseconds)).toBe(false);
   });
 });
 
@@ -91,7 +80,7 @@ describe('canDeleteMeetingForAll', () => {
     const meetingInstance = createMeetingInstance();
 
     expect(
-      canDeleteMeetingForAll(meetingInstance, createSelfUser(), futureWallClock.currentTimestampInMilliseconds),
+      canDeleteMeetingForAll(meetingInstance, createSelfUser(), futureNowMilliseconds),
     ).toBe(true);
   });
 
@@ -99,7 +88,7 @@ describe('canDeleteMeetingForAll', () => {
     const meetingInstance = createMeetingInstance();
 
     expect(
-      canDeleteMeetingForAll(meetingInstance, createSelfUser(), ongoingWallClock.currentTimestampInMilliseconds),
+      canDeleteMeetingForAll(meetingInstance, createSelfUser(), ongoingNowMilliseconds),
     ).toBe(false);
   });
 
@@ -110,7 +99,7 @@ describe('canDeleteMeetingForAll', () => {
       canDeleteMeetingForAll(
         meetingInstance,
         createSelfUser('invitee-id'),
-        futureWallClock.currentTimestampInMilliseconds,
+        futureNowMilliseconds,
       ),
     ).toBe(false);
   });
@@ -124,7 +113,7 @@ describe('canDeleteMeetingForMe', () => {
       canDeleteMeetingForMe(
         meetingInstance,
         createSelfUser('invitee-id'),
-        futureWallClock.currentTimestampInMilliseconds,
+        futureNowMilliseconds,
       ),
     ).toBe(true);
   });
@@ -133,7 +122,7 @@ describe('canDeleteMeetingForMe', () => {
     const meetingInstance = createMeetingInstance();
 
     expect(
-      canDeleteMeetingForMe(meetingInstance, createSelfUser(), futureWallClock.currentTimestampInMilliseconds),
+      canDeleteMeetingForMe(meetingInstance, createSelfUser(), futureNowMilliseconds),
     ).toBe(false);
   });
 });

--- a/apps/webapp/src/script/components/Meeting/utils/canDeleteMeeting.ts
+++ b/apps/webapp/src/script/components/Meeting/utils/canDeleteMeeting.ts
@@ -34,8 +34,15 @@ export const canDeleteMeetingForAll = (
   meetingInstance: MeetingInstance,
   selfUser: User,
   nowMilliseconds: number,
-): boolean =>
-  canDeleteMeeting(meetingInstance, nowMilliseconds) && isMeetingHost(meetingInstance.meetingSeries, selfUser);
+): boolean => {
+  const instanceHasNotStarted = nowMilliseconds < meetingInstance.start.getTime();
+
+  return (
+    canDeleteMeeting(meetingInstance, nowMilliseconds) &&
+    isMeetingHost(meetingInstance.meetingSeries, selfUser) &&
+    instanceHasNotStarted
+  );
+};
 
 export const canDeleteMeetingForMe = (
   meetingInstance: MeetingInstance,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25513" title="WPB-25513" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25513</a>  [Web] Delete a meeting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Limit "Delete meeting for everyone" to hosts on scheduled meetings that have not started yet
- Keep "Delete meeting for me" for non-host participants on upcoming and ongoing meetings
- Fix the delete confirm button icon color and spacing in the confirmation modal

## Test plan

- [x] As a host, open the menu on an upcoming meeting and confirm "Delete meeting for everyone" is shown
- [x] As a host, open the menu on an ongoing meeting and confirm no delete actions are shown
- [x] As a participant, open the menu on an upcoming or ongoing meeting and confirm "Delete meeting for me" is shown
- [x] Open the delete confirmation modal and check the trash icon is white with clear spacing from the label