### PR TITLE
Keep completed meetings in the list until local midnight [WPB-27504]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingList.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingList.tsx
@@ -39,6 +39,7 @@ import {getMeetingInstances} from 'Components/Meeting/selectors/getMeetingInstan
 import {getVisibleTimeWindow} from 'Components/Meeting/selectors/getVisibleTimeWindow';
 import {groupMeetingInstancesByDay} from 'Components/Meeting/selectors/groupMeetingInstancesByDay';
 import type {MeetingInstancesByDay} from 'Components/Meeting/selectors/groupMeetingInstancesByDay';
+import {isMeetingInstanceVisibleInMeetingList} from 'Components/Meeting/selectors/isMeetingInstanceVisibleInMeetingList';
 import type {MeetingSeries} from 'Components/Meeting/types/meetingSeries';
 import {getDaySectionHeader} from 'Components/Meeting/utils/getDaySectionHeader';
 import type {User} from 'Repositories/entity/User';
@@ -57,15 +58,15 @@ export interface MeetingListProps {
 const getCalendarDayKey = (timestampInMilliseconds: number): string =>
   formatISO9075(startOfDay(new Date(timestampInMilliseconds)), {representation: 'date'});
 
-const filterNotEndedMeetingInstances = (
+const filterVisibleMeetingInstances = (
   meetingInstancesByDay: MeetingInstancesByDay[],
   nowMilliseconds: number,
 ): MeetingInstancesByDay[] =>
   meetingInstancesByDay
     .map(dayGroup => ({
       ...dayGroup,
-      meetingInstances: dayGroup.meetingInstances.filter(
-        meetingInstance => meetingInstance.end.getTime() >= nowMilliseconds,
+      meetingInstances: dayGroup.meetingInstances.filter(meetingInstance =>
+        isMeetingInstanceVisibleInMeetingList(meetingInstance, nowMilliseconds),
       ),
     }))
     .filter(dayGroup => is.nonEmptyArray(dayGroup.meetingInstances));
@@ -105,7 +106,7 @@ export const MeetingList = ({
   }, [meetingSeries, visibleDayCount, visibleDayStart]);
 
   const meetingInstancesByDay = useMemo(
-    () => filterNotEndedMeetingInstances(expandedMeetingInstancesByDay, nowMilliseconds),
+    () => filterVisibleMeetingInstances(expandedMeetingInstancesByDay, nowMilliseconds),
     [expandedMeetingInstancesByDay, nowMilliseconds],
   );
 

--- a/apps/webapp/src/script/components/Meeting/MeetingList/meetingList.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/meetingList.test.tsx
@@ -171,6 +171,34 @@ describe('MeetingList', () => {
     expect(document.querySelectorAll('section')).toHaveLength(1);
   });
 
+  it('renders completed meetings in the today section until local midnight', () => {
+    const wallClock = createDeterministicWallClock({
+      initialCurrentTimestampInMilliseconds: new Date('2026-06-15T16:00:00.000Z').getTime(),
+    });
+
+    const createRelativeSeries = (startHour: number, endHour: number, title: string): MeetingSeries => {
+      const start = new Date(wallClock.currentDate);
+      start.setHours(startHour, 0, 0, 0);
+
+      const end = new Date(start);
+      end.setHours(endHour, 0, 0, 0);
+
+      return createMeetingSeries(start.toISOString(), end.toISOString(), title);
+    };
+
+    const meetingSeries = [
+      createRelativeSeries(14, 15, 'Completed meeting'),
+      createRelativeSeries(17, 18, 'Upcoming meeting'),
+    ];
+
+    renderMeetingList({meetingSeries, isLoading: false, hasLoadError: false}, wallClock);
+
+    const todaySection = screen.getByText(/meetings\.list\.today/).closest('section');
+    expect(todaySection).not.toBeNull();
+    expect(within(todaySection!).getByText('Completed meeting')).toBeInTheDocument();
+    expect(within(todaySection!).getByText('Upcoming meeting')).toBeInTheDocument();
+  });
+
   it('does not render meetings outside the initial visible day window', () => {
     const wallClock = createDeterministicWallClock({
       initialCurrentTimestampInMilliseconds: new Date('2026-06-15T12:00:00.000Z').getTime(),

--- a/apps/webapp/src/script/components/Meeting/selectors/isMeetingInstanceVisibleInMeetingList.test.ts
+++ b/apps/webapp/src/script/components/Meeting/selectors/isMeetingInstanceVisibleInMeetingList.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {MeetingInstance} from 'Components/Meeting/types/meetingInstance';
+import type {MeetingSeries} from 'Components/Meeting/types/meetingSeries';
+
+import {isMeetingInstanceVisibleInMeetingList} from './isMeetingInstanceVisibleInMeetingList';
+
+const createMeetingSeries = (overrides: Partial<MeetingSeries> = {}): MeetingSeries => ({
+  series_start_date: '2026-06-15T14:00:00.000Z',
+  series_end_date: '2026-06-15T15:00:00.000Z',
+  duration_ms: 3_600_000,
+  recurrence: 'doesNotRepeat',
+  conversation_id: 'conv-id',
+  title: 'Weekly sync',
+  qualified_id: {id: 'meeting-id', domain: 'example.com'},
+  qualified_creator: {id: 'host-id', domain: 'example.com'},
+  qualified_conversation: {id: 'conv-id', domain: 'example.com'},
+  ...overrides,
+});
+
+const createMeetingInstance = (start: Date, end: Date): MeetingInstance => {
+  const meetingSeries = createMeetingSeries({
+    series_start_date: start.toISOString(),
+    series_end_date: end.toISOString(),
+    duration_ms: end.getTime() - start.getTime(),
+  });
+
+  return {meetingSeries, start, end};
+};
+
+describe('isMeetingInstanceVisibleInMeetingList', () => {
+  it('keeps upcoming and ongoing meetings visible', () => {
+    const start = new Date('2026-06-15T14:00:00.000Z');
+    const end = new Date('2026-06-15T15:00:00.000Z');
+    const meetingInstance = createMeetingInstance(start, end);
+
+    expect(isMeetingInstanceVisibleInMeetingList(meetingInstance, Date.parse('2026-06-15T13:00:00.000Z'))).toBe(true);
+    expect(isMeetingInstanceVisibleInMeetingList(meetingInstance, Date.parse('2026-06-15T14:30:00.000Z'))).toBe(true);
+  });
+
+  it('keeps completed meetings visible until local midnight on the day they start', () => {
+    const start = new Date('2026-06-15T14:00:00.000Z');
+    const end = new Date('2026-06-15T15:00:00.000Z');
+    const meetingInstance = createMeetingInstance(start, end);
+
+    expect(isMeetingInstanceVisibleInMeetingList(meetingInstance, Date.parse('2026-06-15T16:00:00.000Z'))).toBe(true);
+    expect(isMeetingInstanceVisibleInMeetingList(meetingInstance, Date.parse('2026-06-15T23:59:59.999Z'))).toBe(true);
+  });
+
+  it('removes completed meetings after local midnight on the day they start', () => {
+    const start = new Date('2026-06-15T14:00:00.000Z');
+    const end = new Date('2026-06-15T15:00:00.000Z');
+    const meetingInstance = createMeetingInstance(start, end);
+
+    expect(isMeetingInstanceVisibleInMeetingList(meetingInstance, Date.parse('2026-06-16T00:00:00.000Z'))).toBe(false);
+  });
+
+  it('removes meetings that started on a previous day', () => {
+    const start = new Date('2026-06-14T14:00:00.000Z');
+    const end = new Date('2026-06-14T15:00:00.000Z');
+    const meetingInstance = createMeetingInstance(start, end);
+
+    expect(isMeetingInstanceVisibleInMeetingList(meetingInstance, Date.parse('2026-06-15T12:00:00.000Z'))).toBe(false);
+  });
+});

--- a/apps/webapp/src/script/components/Meeting/selectors/isMeetingInstanceVisibleInMeetingList.ts
+++ b/apps/webapp/src/script/components/Meeting/selectors/isMeetingInstanceVisibleInMeetingList.ts
@@ -1,0 +1,39 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {startOfDay} from 'date-fns';
+
+import type {MeetingInstance} from 'Components/Meeting/types/meetingInstance';
+
+/**
+ * Completed meetings stay in the list until local midnight on the day they start.
+ */
+export const isMeetingInstanceVisibleInMeetingList = (
+  meetingInstance: MeetingInstance,
+  nowMilliseconds: number,
+): boolean => {
+  if (meetingInstance.end.getTime() >= nowMilliseconds) {
+    return true;
+  }
+
+  const meetingDayStart = startOfDay(meetingInstance.start);
+  const todayStart = startOfDay(new Date(nowMilliseconds));
+
+  return meetingDayStart.getTime() === todayStart.getTime();
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27504" title="WPB-27504" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27504</a>  Completed Meeting should stay in the Meeting list only till midnight. 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Keep completed meetings visible in the meeting list until local midnight on the day they start
- Remove completed meetings from the list after midnight
- Apply the same visibility rules for hosts and participants

## Test plan

- [x] Schedule a meeting, let it finish, and confirm it still appears in the list for the rest of the day
- [x] Start a Meet Now call, end it, and confirm it still appears in the list for the rest of the day
- [x] Check the list again after midnight and confirm completed meetings from the previous day are gone
- [x] Confirm upcoming and ongoing meetings still appear as before