### PR TITLE
feat: Add alternate developer menu access [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/configToolbar/configToolbar.test.tsx
+++ b/apps/webapp/src/script/components/configToolbar/configToolbar.test.tsx
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {openDebugToolbar, openDebugToolbarEventName} from './debugToolbarEvents';
+
+describe('openDebugToolbar', () => {
+  it('requests the developer menu to open', () => {
+    const openHandler = jest.fn();
+    window.addEventListener(openDebugToolbarEventName, openHandler);
+
+    openDebugToolbar();
+
+    expect(openHandler).toHaveBeenCalledTimes(1);
+    window.removeEventListener(openDebugToolbarEventName, openHandler);
+  });
+});

--- a/apps/webapp/src/script/components/configToolbar/configToolbar.test.tsx
+++ b/apps/webapp/src/script/components/configToolbar/configToolbar.test.tsx
@@ -8,16 +8,30 @@
  * (at your option) any later version.
  */
 
-import {openDebugToolbar, openDebugToolbarEventName} from './debugToolbarEvents';
+import {act, render, screen} from '@testing-library/react';
 
-describe('openDebugToolbar', () => {
-  it('requests the developer menu to open', () => {
-    const openHandler = jest.fn();
-    window.addEventListener(openDebugToolbarEventName, openHandler);
+import {withTheme} from 'src/script/auth/util/test/testUtil';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {translateForTest} from 'Util/test/translateForTest';
 
-    openDebugToolbar();
+import {ConfigToolbar} from './configToolbar';
+import {openDebugToolbar} from './debugToolbarEvents';
 
-    expect(openHandler).toHaveBeenCalledTimes(1);
-    window.removeEventListener(openDebugToolbarEventName, openHandler);
+const rootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate: translateForTest}),
+);
+
+describe('ConfigToolbar', () => {
+  it('opens the developer menu when requested', () => {
+    render(withTheme(<ConfigToolbar />), {wrapper: rootProviderWrapper});
+
+    expect(screen.queryByRole('heading', {name: 'Developer Menu'})).not.toBeInTheDocument();
+
+    act(() => openDebugToolbar());
+
+    expect(screen.getByRole('heading', {name: 'Developer Menu'})).toBeInTheDocument();
   });
 });

--- a/apps/webapp/src/script/components/configToolbar/configToolbar.tsx
+++ b/apps/webapp/src/script/components/configToolbar/configToolbar.tsx
@@ -34,6 +34,7 @@ import {CoreCryptoLogLevel} from 'Util/debugUtil';
 import {getLogger} from 'Util/logger';
 
 import {wrapperStyles} from './configToolbar.styles';
+import {openDebugToolbarEventName} from './debugToolbarEvents';
 
 const logger = getLogger('ConfigToolbar');
 
@@ -83,6 +84,13 @@ export function ConfigToolbar() {
   const [notificationDumpToMode, setNotificationDumpToMode] = useState<NotificationDumpToMode>('now');
   const [notificationDumpToDate, setNotificationDumpToDate] = useState(() => toDateInputValue(new Date()));
   const [isDownloadingNotifications, setIsDownloadingNotifications] = useState(false);
+
+  useEffect(() => {
+    const openToolbar = () => setShowConfig(true);
+    window.addEventListener(openDebugToolbarEventName, openToolbar);
+
+    return () => window.removeEventListener(openDebugToolbarEventName, openToolbar);
+  }, []);
 
   // Toggle config tool on 'cmd/ctrl + shift + 2'
   useEffect(() => {

--- a/apps/webapp/src/script/components/configToolbar/debugToolbarEvents.ts
+++ b/apps/webapp/src/script/components/configToolbar/debugToolbarEvents.ts
@@ -1,0 +1,24 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export const openDebugToolbarEventName = 'wire:open-debug-toolbar';
+
+export function openDebugToolbar(): void {
+  window.dispatchEvent(new Event(openDebugToolbarEventName));
+}

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTab/conversationTab.test.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTab/conversationTab.test.tsx
@@ -16,10 +16,9 @@ import {SidebarTabs} from 'src/script/page/leftSidebar/panels/conversations/useS
 import {ConversationTab} from './conversationTab';
 
 describe('ConversationTab', () => {
-  it('exposes the Alt modifier to alternate tab actions', async () => {
+  it('changes to the selected tab when clicked', async () => {
     const user = userEvent.setup();
     const onChangeTab = jest.fn();
-    const onMouseEnter = jest.fn();
 
     render(
       <ConversationTab
@@ -29,16 +28,31 @@ describe('ConversationTab', () => {
         onChangeTab={onChangeTab}
         Icon={<span />}
         dataUieName="go-preferences"
-        onMouseEnter={onMouseEnter}
       />,
     );
 
-    await user.keyboard('{Alt>}');
-    await user.hover(screen.getByRole('tab', {name: 'Settings'}));
     await user.click(screen.getByRole('tab', {name: 'Settings'}));
-    await user.keyboard('{/Alt}');
 
-    expect(onMouseEnter).toHaveBeenCalledTimes(1);
-    expect(onChangeTab).toHaveBeenCalledWith(SidebarTabs.PREFERENCES, expect.objectContaining({altKey: true}));
+    expect(onChangeTab).toHaveBeenCalledWith(SidebarTabs.PREFERENCES);
+  });
+
+  it('runs a custom click action when clicked', async () => {
+    const user = userEvent.setup();
+    const onClick = jest.fn();
+
+    render(
+      <ConversationTab
+        title="Settings"
+        type={SidebarTabs.PREFERENCES}
+        conversationTabIndex={1}
+        onClick={onClick}
+        Icon={<span />}
+        dataUieName="go-preferences"
+      />,
+    );
+
+    await user.click(screen.getByRole('tab', {name: 'Settings'}));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTab/conversationTab.test.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTab/conversationTab.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {SidebarTabs} from 'src/script/page/leftSidebar/panels/conversations/useSidebarStore';
+
+import {ConversationTab} from './conversationTab';
+
+describe('ConversationTab', () => {
+  it('exposes the Alt modifier to alternate tab actions', async () => {
+    const user = userEvent.setup();
+    const onChangeTab = jest.fn();
+    const onMouseEnter = jest.fn();
+
+    render(
+      <ConversationTab
+        title="Settings"
+        type={SidebarTabs.PREFERENCES}
+        conversationTabIndex={1}
+        onChangeTab={onChangeTab}
+        Icon={<span />}
+        dataUieName="go-preferences"
+        onMouseEnter={onMouseEnter}
+      />,
+    );
+
+    await user.keyboard('{Alt>}');
+    await user.hover(screen.getByRole('tab', {name: 'Settings'}));
+    await user.click(screen.getByRole('tab', {name: 'Settings'}));
+    await user.keyboard('{/Alt}');
+
+    expect(onMouseEnter).toHaveBeenCalledTimes(1);
+    expect(onChangeTab).toHaveBeenCalledWith(SidebarTabs.PREFERENCES, expect.objectContaining({altKey: true}));
+  });
+});

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTab/conversationTab.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTab/conversationTab.tsx
@@ -21,12 +21,21 @@ import cx from 'classnames';
 
 import {SidebarTabs} from 'src/script/page/leftSidebar/panels/conversations/useSidebarStore';
 
-interface ConversationTabProps {
+type ConversationTabActionProps =
+  | {
+      onChangeTab: (tab: SidebarTabs) => void;
+      onClick?: never;
+    }
+  | {
+      onChangeTab?: never;
+      onClick: React.MouseEventHandler<HTMLButtonElement>;
+    };
+
+type ConversationTabProps = {
   title: string;
   label?: string;
   type: SidebarTabs;
   conversationTabIndex: number;
-  onChangeTab: (tab: SidebarTabs, event: React.MouseEvent<HTMLButtonElement>) => void;
   Icon: JSX.Element;
   unreadConversations?: number;
   dataUieName: string;
@@ -36,7 +45,7 @@ interface ConversationTabProps {
   onMouseLeave?: React.MouseEventHandler<HTMLButtonElement>;
   onFocus?: React.FocusEventHandler<HTMLButtonElement>;
   onBlur?: React.FocusEventHandler<HTMLButtonElement>;
-}
+} & ConversationTabActionProps;
 
 export const ConversationTab = ({
   title,
@@ -44,6 +53,7 @@ export const ConversationTab = ({
   type,
   conversationTabIndex,
   onChangeTab,
+  onClick,
   Icon,
   unreadConversations = 0,
   dataUieName,
@@ -60,7 +70,14 @@ export const ConversationTab = ({
       type="button"
       role="tab"
       className={cx(`conversations-sidebar-btn`, {active: isActive})}
-      onClick={event => onChangeTab(type, event)}
+      onClick={event => {
+        if (onClick) {
+          onClick(event);
+          return;
+        }
+
+        onChangeTab(type);
+      }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onFocus={onFocus}

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTab/conversationTab.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTab/conversationTab.tsx
@@ -26,12 +26,16 @@ interface ConversationTabProps {
   label?: string;
   type: SidebarTabs;
   conversationTabIndex: number;
-  onChangeTab: (tab: SidebarTabs) => void;
+  onChangeTab: (tab: SidebarTabs, event: React.MouseEvent<HTMLButtonElement>) => void;
   Icon: JSX.Element;
   unreadConversations?: number;
   dataUieName: string;
   isActive?: boolean;
   showNotificationsBadge?: boolean;
+  onMouseEnter?: React.MouseEventHandler<HTMLButtonElement>;
+  onMouseLeave?: React.MouseEventHandler<HTMLButtonElement>;
+  onFocus?: React.FocusEventHandler<HTMLButtonElement>;
+  onBlur?: React.FocusEventHandler<HTMLButtonElement>;
 }
 
 export const ConversationTab = ({
@@ -45,6 +49,10 @@ export const ConversationTab = ({
   dataUieName,
   isActive = false,
   showNotificationsBadge = false,
+  onMouseEnter,
+  onMouseLeave,
+  onFocus,
+  onBlur,
 }: ConversationTabProps) => {
   return (
     <button
@@ -52,7 +60,11 @@ export const ConversationTab = ({
       type="button"
       role="tab"
       className={cx(`conversations-sidebar-btn`, {active: isActive})}
-      onClick={() => onChangeTab(type)}
+      onClick={event => onChangeTab(type, event)}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onFocus={onFocus}
+      onBlur={onBlur}
       title={title}
       data-uie-name={dataUieName}
       data-uie-status={isActive ? 'active' : 'inactive'}

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/conversationTabs.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/conversationTabs.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import {useEffect, useState} from 'react';
+
 import {container} from 'tsyringe';
 
 import {
@@ -31,6 +33,7 @@ import {
   Tooltip,
 } from '@wireapp/react-ui-kit';
 
+import {openDebugToolbar} from 'Components/configToolbar/debugToolbarEvents';
 import * as Icon from 'Components/icon';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {Conversation} from 'Repositories/entity/Conversation';
@@ -110,6 +113,39 @@ export const ConversationTabs = ({
   const {teamRole} = useKoSubscribableChildren(selfUser, ['teamRole']);
   const {isCellsEnabled: isCellsEnabledForTeam} = useKoSubscribableChildren(teamState, ['isCellsEnabled']);
   const {isMeetingsEnabled} = useMeetingsFeatureFlag();
+  const isDebugEnabled = Config.getConfig().FEATURE.ENABLE_DEBUG;
+  const [isAltKeyPressed, setIsAltKeyPressed] = useState(false);
+  const [isSettingsTargeted, setIsSettingsTargeted] = useState(false);
+
+  useEffect(() => {
+    if (!isDebugEnabled) {
+      return;
+    }
+
+    const showAlternateSettingsAction = (event: KeyboardEvent) => {
+      if (event.key === 'Alt') {
+        setIsAltKeyPressed(true);
+      }
+    };
+    const hideAlternateSettingsAction = (event: KeyboardEvent) => {
+      if (event.key === 'Alt') {
+        setIsAltKeyPressed(false);
+      }
+    };
+    const resetAlternateSettingsAction = () => setIsAltKeyPressed(false);
+
+    window.addEventListener('keydown', showAlternateSettingsAction);
+    window.addEventListener('keyup', hideAlternateSettingsAction);
+    window.addEventListener('blur', resetAlternateSettingsAction);
+
+    return () => {
+      window.removeEventListener('keydown', showAlternateSettingsAction);
+      window.removeEventListener('keyup', hideAlternateSettingsAction);
+      window.removeEventListener('blur', resetAlternateSettingsAction);
+    };
+  }, [isDebugEnabled]);
+
+  const settingsLabel = isAltKeyPressed && isSettingsTargeted ? 'Developer Menu' : translate('preferencesHeadline');
 
   const totalUnreadFavoriteConversations = favoriteConversations.filter(favoriteConversation =>
     favoriteConversation.hasUnread(),
@@ -383,11 +419,17 @@ export const ConversationTabs = ({
         )}
 
         <ConversationTab
-          title={translate('preferencesHeadline')}
-          label={translate('preferencesHeadline')}
+          title={settingsLabel}
+          label={settingsLabel}
           type={SidebarTabs.PREFERENCES}
           Icon={<Icon.SettingsIcon />}
-          onChangeTab={tab => {
+          onChangeTab={(tab, event) => {
+            if (isDebugEnabled && isAltKeyPressed && isSettingsTargeted) {
+              event.stopPropagation();
+              openDebugToolbar();
+              return;
+            }
+
             onChangeTab(tab);
             onClickPreferences(ContentState.PREFERENCES_ACCOUNT);
           }}
@@ -395,6 +437,10 @@ export const ConversationTabs = ({
           dataUieName="go-preferences"
           showNotificationsBadge={showNotificationsBadge}
           isActive={currentTab === SidebarTabs.PREFERENCES}
+          onMouseEnter={() => setIsSettingsTargeted(true)}
+          onMouseLeave={() => setIsSettingsTargeted(false)}
+          onFocus={() => setIsSettingsTargeted(true)}
+          onBlur={() => setIsSettingsTargeted(false)}
         />
 
         {hasAccessToFeature(FEATURES.MANAGE_TEAM, teamRole) && (

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/conversationTabs.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/conversationTabs.tsx
@@ -17,8 +17,6 @@
  *
  */
 
-import {useEffect, useState} from 'react';
-
 import {container} from 'tsyringe';
 
 import {
@@ -65,6 +63,7 @@ import {
 } from './conversationTabs.styles';
 import {FolderIcon} from './folderIcon';
 import {MeetingsConversationTab} from './meetingsConversationTab';
+import {SettingsTab} from './settingsTab';
 import {TeamCreationBanner} from './teamCreation/teamCreationBanner';
 
 import {Config} from '../../../../../Config';
@@ -114,38 +113,6 @@ export const ConversationTabs = ({
   const {isCellsEnabled: isCellsEnabledForTeam} = useKoSubscribableChildren(teamState, ['isCellsEnabled']);
   const {isMeetingsEnabled} = useMeetingsFeatureFlag();
   const isDebugEnabled = Config.getConfig().FEATURE.ENABLE_DEBUG;
-  const [isAltKeyPressed, setIsAltKeyPressed] = useState(false);
-  const [isSettingsTargeted, setIsSettingsTargeted] = useState(false);
-
-  useEffect(() => {
-    if (!isDebugEnabled) {
-      return;
-    }
-
-    const showAlternateSettingsAction = (event: KeyboardEvent) => {
-      if (event.key === 'Alt') {
-        setIsAltKeyPressed(true);
-      }
-    };
-    const hideAlternateSettingsAction = (event: KeyboardEvent) => {
-      if (event.key === 'Alt') {
-        setIsAltKeyPressed(false);
-      }
-    };
-    const resetAlternateSettingsAction = () => setIsAltKeyPressed(false);
-
-    window.addEventListener('keydown', showAlternateSettingsAction);
-    window.addEventListener('keyup', hideAlternateSettingsAction);
-    window.addEventListener('blur', resetAlternateSettingsAction);
-
-    return () => {
-      window.removeEventListener('keydown', showAlternateSettingsAction);
-      window.removeEventListener('keyup', hideAlternateSettingsAction);
-      window.removeEventListener('blur', resetAlternateSettingsAction);
-    };
-  }, [isDebugEnabled]);
-
-  const settingsLabel = isAltKeyPressed && isSettingsTargeted ? 'Developer Menu' : translate('preferencesHeadline');
 
   const totalUnreadFavoriteConversations = favoriteConversations.filter(favoriteConversation =>
     favoriteConversation.hasUnread(),
@@ -418,29 +385,16 @@ export const ConversationTabs = ({
           </div>
         )}
 
-        <ConversationTab
-          title={settingsLabel}
-          label={settingsLabel}
-          type={SidebarTabs.PREFERENCES}
-          Icon={<Icon.SettingsIcon />}
-          onChangeTab={(tab, event) => {
-            if (isDebugEnabled && isAltKeyPressed && isSettingsTargeted) {
-              event.stopPropagation();
-              openDebugToolbar();
-              return;
-            }
-
-            onChangeTab(tab);
+        <SettingsTab
+          settingsLabel={translate('preferencesHeadline')}
+          isDebugEnabled={isDebugEnabled}
+          onOpenDeveloperMenu={openDebugToolbar}
+          onOpenPreferences={() => {
+            onChangeTab(SidebarTabs.PREFERENCES);
             onClickPreferences(ContentState.PREFERENCES_ACCOUNT);
           }}
-          conversationTabIndex={1}
-          dataUieName="go-preferences"
           showNotificationsBadge={showNotificationsBadge}
           isActive={currentTab === SidebarTabs.PREFERENCES}
-          onMouseEnter={() => setIsSettingsTargeted(true)}
-          onMouseLeave={() => setIsSettingsTargeted(false)}
-          onFocus={() => setIsSettingsTargeted(true)}
-          onBlur={() => setIsSettingsTargeted(false)}
         />
 
         {hasAccessToFeature(FEATURES.MANAGE_TEAM, teamRole) && (

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/settingsTab.test.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/settingsTab.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {SettingsTab} from './settingsTab';
+
+function renderSettingsTab({isDebugEnabled = true}: {isDebugEnabled?: boolean} = {}) {
+  const onOpenDeveloperMenu = jest.fn();
+  const onOpenPreferences = jest.fn();
+
+  render(
+    <SettingsTab
+      isActive={false}
+      isDebugEnabled={isDebugEnabled}
+      onOpenDeveloperMenu={onOpenDeveloperMenu}
+      onOpenPreferences={onOpenPreferences}
+      settingsLabel="Settings"
+      showNotificationsBadge={false}
+    />,
+  );
+
+  return {onOpenDeveloperMenu, onOpenPreferences};
+}
+
+describe('SettingsTab', () => {
+  it('opens preferences when clicked without Alt', async () => {
+    const user = userEvent.setup();
+    const {onOpenDeveloperMenu, onOpenPreferences} = renderSettingsTab();
+
+    await user.click(screen.getByRole('tab', {name: 'Settings'}));
+
+    expect(onOpenPreferences).toHaveBeenCalledTimes(1);
+    expect(onOpenDeveloperMenu).not.toHaveBeenCalled();
+  });
+
+  it('opens the developer menu when Alt is held while hovering', async () => {
+    const user = userEvent.setup();
+    const {onOpenDeveloperMenu, onOpenPreferences} = renderSettingsTab();
+    const settingsTab = screen.getByRole('tab', {name: 'Settings'});
+
+    await user.hover(settingsTab);
+    await user.keyboard('{Alt>}');
+    await user.click(screen.getByRole('tab', {name: 'Developer Menu'}));
+    await user.keyboard('{/Alt}');
+
+    expect(onOpenDeveloperMenu).toHaveBeenCalledTimes(1);
+    expect(onOpenPreferences).not.toHaveBeenCalled();
+  });
+
+  it('keeps the developer menu action while focused after the pointer leaves', async () => {
+    const user = userEvent.setup();
+    const {onOpenDeveloperMenu, onOpenPreferences} = renderSettingsTab();
+    const settingsTab = screen.getByRole('tab', {name: 'Settings'});
+
+    await user.tab();
+    await user.hover(settingsTab);
+    await user.keyboard('{Alt>}');
+    await user.unhover(settingsTab);
+
+    expect(settingsTab).toHaveFocus();
+    expect(screen.getByRole('tab', {name: 'Developer Menu'})).toBeInTheDocument();
+
+    fireEvent.click(settingsTab);
+    await user.keyboard('{/Alt}');
+
+    expect(onOpenDeveloperMenu).toHaveBeenCalledTimes(1);
+    expect(onOpenPreferences).not.toHaveBeenCalled();
+  });
+
+  it('keeps normal Settings behavior when debug mode is disabled', async () => {
+    const user = userEvent.setup();
+    const {onOpenDeveloperMenu, onOpenPreferences} = renderSettingsTab({isDebugEnabled: false});
+    const settingsTab = screen.getByRole('tab', {name: 'Settings'});
+
+    await user.hover(settingsTab);
+    await user.keyboard('{Alt>}');
+    await user.click(screen.getByRole('tab', {name: 'Settings'}));
+    await user.keyboard('{/Alt}');
+
+    expect(onOpenPreferences).toHaveBeenCalledTimes(1);
+    expect(onOpenDeveloperMenu).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/settingsTab.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/settingsTab.tsx
@@ -1,0 +1,95 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useEffect, useState} from 'react';
+
+import * as Icon from 'Components/icon';
+
+import {ConversationTab} from '../conversationTab';
+import {SidebarTabs} from '../useSidebarStore';
+
+type SettingsTabProps = {
+  isActive: boolean;
+  isDebugEnabled: boolean;
+  onOpenDeveloperMenu: () => void;
+  onOpenPreferences: () => void;
+  settingsLabel: string;
+  showNotificationsBadge: boolean;
+};
+
+export const SettingsTab = ({
+  isActive,
+  isDebugEnabled,
+  onOpenDeveloperMenu,
+  onOpenPreferences,
+  settingsLabel,
+  showNotificationsBadge,
+}: SettingsTabProps) => {
+  const [isAltKeyPressed, setIsAltKeyPressed] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+
+  useEffect(() => {
+    if (!isDebugEnabled) {
+      return;
+    }
+
+    const updateAltKeyPressed = (event: KeyboardEvent) => setIsAltKeyPressed(event.altKey);
+    const resetAltKeyPressed = () => setIsAltKeyPressed(false);
+
+    window.addEventListener('keydown', updateAltKeyPressed);
+    window.addEventListener('keyup', updateAltKeyPressed);
+    window.addEventListener('blur', resetAltKeyPressed);
+
+    return () => {
+      window.removeEventListener('keydown', updateAltKeyPressed);
+      window.removeEventListener('keyup', updateAltKeyPressed);
+      window.removeEventListener('blur', resetAltKeyPressed);
+    };
+  }, [isDebugEnabled]);
+
+  const isDeveloperMenuTargeted = isDebugEnabled && isAltKeyPressed && (isHovered || isFocused);
+  const label = isDeveloperMenuTargeted ? 'Developer Menu' : settingsLabel;
+
+  return (
+    <ConversationTab
+      title={label}
+      label={label}
+      type={SidebarTabs.PREFERENCES}
+      Icon={<Icon.SettingsIcon />}
+      onClick={event => {
+        if (isDeveloperMenuTargeted) {
+          event.stopPropagation();
+          onOpenDeveloperMenu();
+          return;
+        }
+
+        onOpenPreferences();
+      }}
+      conversationTabIndex={1}
+      dataUieName="go-preferences"
+      showNotificationsBadge={showNotificationsBadge}
+      isActive={isActive}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onFocus={() => setIsFocused(true)}
+      onBlur={() => setIsFocused(false)}
+    />
+  );
+};


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

WPB-22420

## Summary

- expose Developer Menu by holding Alt/Option while hovering or focusing Settings
- keep normal Settings behavior and existing debug keyboard shortcut
- open debug toolbar through an explicit internal event

## Demo

https://github.com/user-attachments/assets/509de1ad-581e-4266-abc5-9c83ab4ccef1

