### PR TITLE
Show self user in meeting list participants [WPB-27673]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingParticipants/getMeetingParticipantsForDisplay.test.ts
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingParticipants/getMeetingParticipantsForDisplay.test.ts
@@ -29,10 +29,23 @@ const createUser = (id: string, name: string) => {
 };
 
 describe('getMeetingParticipantsForDisplay', () => {
-  it('excludes the self user from the displayed participants', () => {
+  it('places the self user first when they are in the participants list', () => {
     const selfUser = createUser('self', 'Kim Organizer');
     const otherUser = createUser('other', 'Jaqueline Olaho');
 
-    expect(getMeetingParticipantsForDisplay([selfUser, otherUser], selfUser)).toEqual([otherUser]);
+    expect(getMeetingParticipantsForDisplay([otherUser, selfUser], selfUser)).toEqual([selfUser, otherUser]);
+  });
+
+  it('prepends the self user when they are not in the participants list', () => {
+    const selfUser = createUser('self', 'Kim Organizer');
+    const otherUser = createUser('other', 'Jaqueline Olaho');
+
+    expect(getMeetingParticipantsForDisplay([otherUser], selfUser)).toEqual([selfUser, otherUser]);
+  });
+
+  it('returns only the self user when there are no other participants', () => {
+    const selfUser = createUser('self', 'Kim Organizer');
+
+    expect(getMeetingParticipantsForDisplay([], selfUser)).toEqual([selfUser]);
   });
 });

--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingParticipants/getMeetingParticipantsForDisplay.ts
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingParticipants/getMeetingParticipantsForDisplay.ts
@@ -20,5 +20,10 @@
 import type {User} from 'Repositories/entity/User';
 import {matchQualifiedIds} from 'Util/qualifiedId';
 
-export const getMeetingParticipantsForDisplay = (participants: User[], selfUser: User): User[] =>
-  participants.filter(participant => !matchQualifiedIds(participant.qualifiedId, selfUser.qualifiedId));
+export const getMeetingParticipantsForDisplay = (participants: User[], selfUser: User): User[] => {
+  const otherParticipants = participants.filter(
+    participant => !matchQualifiedIds(participant.qualifiedId, selfUser.qualifiedId),
+  );
+
+  return [selfUser, ...otherParticipants];
+};


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27673" title="WPB-27673" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27673</a>  [Web] Show self user in meeting list participants
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

- Show the current user as the first participant in meeting list avatars on web
- Align web behaviour with iOS, where the self user is included in the participant list
- Update `getMeetingParticipantsForDisplay` and its unit tests

## Test plan

- [x] `yarn nx run webapp:test --testFile=src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingParticipants/getMeetingParticipantsForDisplay.test.ts`
- [x] Open the Meetings list and confirm the self user avatar appears first
- [x] Confirm other participants still appear after the self user
- [x] Compare with iOS for a meeting with one other participant