### PR TITLE
Backport complete unit test reports [WPB-26883]

### DIFF
--- a/.github/workflows/generate_test_report.yml
+++ b/.github/workflows/generate_test_report.yml
@@ -2,11 +2,6 @@ name: Generate test reports
 
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Git branch to generate the test report for'
-        required: true
-        type: string
 
 jobs:
   generate_test_report:
@@ -14,12 +9,14 @@ jobs:
 
     env:
       UNIT_TEST_REPORT_FILE: './unit-tests.log'
+      UNIT_TEST_REPORTS_DIRECTORY: './unit-test-reports'
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: refs/heads/${{ inputs.branch }}
+          persist-credentials: false
+          ref: ${{ github.ref }}
 
       - name: Capture checked out commit SHA
         run: echo "TESTED_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
@@ -48,27 +45,31 @@ jobs:
       - name: Install JS dependencies
         run: yarn --immutable
 
-      - name: Test
-        run: |
-          set -euo pipefail
-          : > ${{ env.UNIT_TEST_REPORT_FILE }}
-          (
-            cd ./apps/server
-            node ../../node_modules/jest/bin/jest.js --config jest.config.js --coverage --coverageReporters=lcov
-          ) 2>&1 | tee -a ${{ env.UNIT_TEST_REPORT_FILE }}
-          (
-            cd ./apps/webapp
-            node ../../node_modules/jest/bin/jest.js --config jest.report.config.cjs --coverage --coverageReporters=lcov --verbose
-          ) 2>&1 | tee -a ${{ env.UNIT_TEST_REPORT_FILE }}
-          echo -e "BRANCH = ${{ inputs.branch }}" >> ${{ env.UNIT_TEST_REPORT_FILE }}
-          echo -e "COMMIT SHA = ${TESTED_COMMIT_SHA}" >> ${{ env.UNIT_TEST_REPORT_FILE }}
-          echo -e "TEST RUN DATE = $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${{ env.UNIT_TEST_REPORT_FILE }}
-
-      - name: Upload unit-tests.log to S3
+      - name: Generate unit test reports
+        id: unit_test_reports
+        continue-on-error: true
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: eu-west-1
+          BRANCH: ${{ github.ref_name }}
+        run: yarn ts-node ./bin/generateUnitTestReports.ts
+
+      - name: Upload complete unit test reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: unit-test-reports
+          path: |
+            ${{ env.UNIT_TEST_REPORT_FILE }}
+            ${{ env.UNIT_TEST_REPORTS_DIRECTORY }}/manifest.json
+            ${{ env.UNIT_TEST_REPORTS_DIRECTORY }}/*.log
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Fail when manifest contains failed projects
+        if: always()
         run: |
-          TIMESTAMP=$(date -u +'%Y%m%dT%H%M%SZ')
-          aws s3 cp ${{ env.UNIT_TEST_REPORT_FILE }} s3://wire-webapp/unit-tests-${TIMESTAMP}-${TESTED_COMMIT_SHA}.log
+          node -e '
+            const manifest = require("./unit-test-reports/manifest.json");
+            if (manifest.overallStatus !== "passed") {
+              process.exit(1);
+            }
+          '

--- a/bin/generateUnitTestReports.test.ts
+++ b/bin/generateUnitTestReports.test.ts
@@ -1,0 +1,195 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {ProjectGraph} from '@nx/devkit';
+
+import {
+  createCombinedReport,
+  createManifest,
+  createNxTestCommand,
+  createProjectReport,
+  createReportFileName,
+  findTestableProjects,
+  runProjectTestReports,
+  sanitizeProjectNameForFileName,
+} from './generateUnitTestReports';
+import type {ProjectTestResult, ReportSettings, TestableProject} from './generateUnitTestReports';
+
+const reportSettings: ReportSettings = {
+  branchName: 'dev',
+  combinedReportFile: 'unit-tests.log',
+  commitSha: 'abc123',
+  reportsDirectory: 'unit-test-reports',
+  runDate: '2026-07-10T12:00:00.000Z',
+  workspaceRoot: '/workspace',
+};
+
+function createProjectGraph(): ProjectGraph {
+  return {
+    dependencies: {},
+    externalNodes: {},
+    nodes: {
+      webapp: {
+        data: {root: 'apps/webapp', projectType: 'application', targets: {test: {}}},
+        name: 'webapp',
+        type: 'app',
+      },
+      server: {
+        data: {root: 'apps/server', projectType: 'application', targets: {test: {}}},
+        name: 'server',
+        type: 'app',
+      },
+      nestedLibrary: {
+        data: {root: 'libraries/client/nested', projectType: 'library', targets: {test: {}}},
+        name: 'nested-library',
+        type: 'lib',
+      },
+      untestableLibrary: {
+        data: {root: 'libraries/config', projectType: 'library', targets: {build: {}}},
+        name: 'untestable-library',
+        type: 'lib',
+      },
+    },
+  } as ProjectGraph;
+}
+
+function createProjectTestResult(project: TestableProject, exitCode: number, output: string): ProjectTestResult {
+  return {
+    command: createNxTestCommand(project.name),
+    exitCode,
+    output,
+    project,
+    reportFileName: createReportFileName(project.name, reportSettings.commitSha),
+    status: exitCode === 0 ? 'passed' : 'failed',
+  };
+}
+
+describe('generate-unit-test-reports', (): void => {
+  it('discovers application, library, and nested projects with test targets in deterministic order', (): void => {
+    const actualProjects = findTestableProjects(createProjectGraph());
+
+    expect(actualProjects).toEqual([
+      {name: 'nested-library', root: 'libraries/client/nested', type: 'lib'},
+      {name: 'server', root: 'apps/server', type: 'app'},
+      {name: 'webapp', root: 'apps/webapp', type: 'app'},
+    ]);
+  });
+
+  it('creates the canonical verbose Nx CI test command', (): void => {
+    const actualCommand = createNxTestCommand('webapp');
+
+    expect(actualCommand).toEqual({
+      command: 'yarn',
+      commandArguments: ['nx', 'run', 'webapp:test', '--configuration=ci', '--verbose'],
+    });
+  });
+
+  it('creates stable report file names from sanitized project names and commit SHA values', (): void => {
+    const actualFileName = createReportFileName('@wireapp/api client', 'abc123');
+
+    expect(actualFileName).toBe('unit-tests--wireapp-api-client-abc123.log');
+  });
+
+  it.each([
+    ['api-client-lib', 'api-client-lib'],
+    ['@wireapp/api client', '-wireapp-api-client'],
+    ['@wireapp/react.ui_kit', '-wireapp-react.ui_kit'],
+  ])('sanitizeProjectNameForFileName() maps "%s" to "%s"', (projectName, expectedSanitizedProjectName): void => {
+    const actualSanitizedProjectName = sanitizeProjectNameForFileName(projectName);
+
+    expect(actualSanitizedProjectName).toBe(expectedSanitizedProjectName);
+  });
+
+  it('writes consistent metadata into project reports and the manifest', (): void => {
+    const projectTestResults = [
+      createProjectTestResult({name: 'server', root: 'apps/server', type: 'app'}, 0, 'server output'),
+      createProjectTestResult({name: 'webapp', root: 'apps/webapp', type: 'app'}, 1, 'webapp output'),
+    ];
+    const actualProjectReport = createProjectReport(projectTestResults[0], reportSettings);
+    const actualManifest = createManifest(projectTestResults, reportSettings);
+
+    expect(actualProjectReport).toContain('BRANCH = dev');
+    expect(actualProjectReport).toContain('COMMIT SHA = abc123');
+    expect(actualProjectReport).toContain('TEST RUN DATE = 2026-07-10T12:00:00.000Z');
+    expect(actualProjectReport).toContain('STATUS = passed');
+    expect(actualManifest).toEqual({
+      branch: 'dev',
+      commitSha: 'abc123',
+      overallStatus: 'failed',
+      projects: [
+        {
+          command: 'yarn nx run server:test --configuration=ci --verbose',
+          exitCode: 0,
+          name: 'server',
+          reportFileName: 'unit-tests-server-abc123.log',
+          status: 'passed',
+        },
+        {
+          command: 'yarn nx run webapp:test --configuration=ci --verbose',
+          exitCode: 1,
+          name: 'webapp',
+          reportFileName: 'unit-tests-webapp-abc123.log',
+          status: 'failed',
+        },
+      ],
+      runDate: '2026-07-10T12:00:00.000Z',
+    });
+  });
+
+  it('creates a combined report with every project once in sorted order and explicit delimiters', (): void => {
+    const projectTestResults = [
+      createProjectTestResult({name: 'webapp', root: 'apps/webapp', type: 'app'}, 0, 'webapp output'),
+      createProjectTestResult({name: 'server', root: 'apps/server', type: 'app'}, 0, 'server output'),
+    ];
+    const actualCombinedReport = createCombinedReport(projectTestResults, reportSettings);
+
+    expect(actualCombinedReport).toContain('===== BEGIN PROJECT: server =====');
+    expect(actualCombinedReport).toContain('===== END PROJECT: server =====');
+    expect(actualCombinedReport).toContain('===== BEGIN PROJECT: webapp =====');
+    expect(actualCombinedReport.indexOf('BEGIN PROJECT: server')).toBeLessThan(
+      actualCombinedReport.indexOf('BEGIN PROJECT: webapp'),
+    );
+    expect((actualCombinedReport.match(/===== BEGIN PROJECT:/g) ?? []).length).toBe(2);
+  });
+
+  it('continues after failures and returns a failing result for the failed project', async (): Promise<void> => {
+    const testableProjects = [
+      {name: 'first-project', root: 'libraries/first', type: 'lib'},
+      {name: 'second-project', root: 'libraries/second', type: 'lib'},
+    ] satisfies readonly TestableProject[];
+    const executedProjectNames: string[] = [];
+    const projectTestResults = await runProjectTestReports(
+      testableProjects,
+      reportSettings,
+      async (_command, commandArguments) => {
+        const projectName = commandArguments[2].split(':')[0];
+        executedProjectNames.push(projectName);
+
+        return {exitCode: projectName === 'first-project' ? 1 : 0, output: `${projectName} output`};
+      },
+    );
+
+    expect(executedProjectNames).toEqual(['first-project', 'second-project']);
+    expect(projectTestResults.map((projectTestResult): string => projectTestResult.status)).toEqual([
+      'failed',
+      'passed',
+    ]);
+    expect(createManifest(projectTestResults, reportSettings).overallStatus).toBe('failed');
+  });
+});

--- a/bin/generateUnitTestReports.ts
+++ b/bin/generateUnitTestReports.ts
@@ -1,0 +1,348 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {spawn} from 'node:child_process';
+import {mkdir, writeFile} from 'node:fs/promises';
+import {join} from 'node:path';
+import process = require('node:process');
+import {createProjectGraphAsync} from '@nx/devkit';
+import type {ProjectGraph} from '@nx/devkit';
+
+const defaultReportsDirectory = 'unit-test-reports';
+const defaultCombinedReportFile = 'unit-tests.log';
+
+export type TestableProject = {
+  readonly name: string;
+  readonly root: string;
+  readonly type: string | undefined;
+};
+
+export type NxTestCommand = {
+  readonly command: string;
+  readonly commandArguments: readonly string[];
+};
+
+export type ReportSettings = {
+  readonly branchName: string;
+  readonly commitSha: string;
+  readonly combinedReportFile: string;
+  readonly reportsDirectory: string;
+  readonly runDate: string;
+  readonly workspaceRoot: string;
+};
+
+export type ProjectTestResult = {
+  readonly command: NxTestCommand;
+  readonly exitCode: number;
+  readonly output: string;
+  readonly project: TestableProject;
+  readonly reportFileName: string;
+  readonly status: 'passed' | 'failed';
+};
+
+export type UnitTestReportManifest = {
+  readonly branch: string;
+  readonly commitSha: string;
+  readonly overallStatus: 'passed' | 'failed';
+  readonly projects: readonly {
+    readonly command: string;
+    readonly exitCode: number;
+    readonly name: string;
+    readonly reportFileName: string;
+    readonly status: 'passed' | 'failed';
+  }[];
+  readonly runDate: string;
+};
+
+type CommandExecutionResult = {
+  readonly exitCode: number;
+  readonly output: string;
+};
+
+type RunCommand = (
+  command: string,
+  commandArguments: readonly string[],
+  workspaceRoot: string,
+) => Promise<CommandExecutionResult>;
+
+export function sanitizeProjectNameForFileName(projectName: string): string {
+  return projectName.replace(/[^a-zA-Z0-9._-]/g, '-');
+}
+
+export function createReportFileName(projectName: string, commitSha: string): string {
+  return `unit-tests-${sanitizeProjectNameForFileName(projectName)}-${commitSha}.log`;
+}
+
+export function createNxTestCommand(projectName: string): NxTestCommand {
+  return {
+    command: 'yarn',
+    commandArguments: ['nx', 'run', `${projectName}:test`, '--configuration=ci', '--verbose'],
+  };
+}
+
+export function findTestableProjects(projectGraph: ProjectGraph): readonly TestableProject[] {
+  return [
+    ...Object.values(projectGraph.nodes)
+      .filter((projectNode): boolean => {
+        return projectNode.data.targets?.test !== undefined;
+      })
+      .map((projectNode): TestableProject => {
+        return {
+          name: projectNode.name,
+          root: projectNode.data.root,
+          type: projectNode.type,
+        };
+      })
+      .sort((leftProject, rightProject): number => {
+        return leftProject.name.localeCompare(rightProject.name);
+      }),
+  ];
+}
+
+export async function discoverTestableProjects(): Promise<readonly TestableProject[]> {
+  const projectGraph = await createProjectGraphAsync();
+
+  return findTestableProjects(projectGraph);
+}
+
+function readRequiredEnvironmentValue(name: string): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+function readReportSettings(): ReportSettings {
+  return {
+    branchName: readRequiredEnvironmentValue('BRANCH'),
+    commitSha: readRequiredEnvironmentValue('TESTED_COMMIT_SHA'),
+    combinedReportFile: process.env.UNIT_TEST_REPORT_FILE ?? defaultCombinedReportFile,
+    reportsDirectory: process.env.UNIT_TEST_REPORTS_DIRECTORY ?? defaultReportsDirectory,
+    runDate: new Date().toISOString(),
+    workspaceRoot: process.cwd(),
+  };
+}
+
+export function createCommandText(nxTestCommand: NxTestCommand): string {
+  return [nxTestCommand.command, ...nxTestCommand.commandArguments].join(' ');
+}
+
+export function createProjectReport(projectTestResult: ProjectTestResult, reportSettings: ReportSettings): string {
+  const commandText = createCommandText(projectTestResult.command);
+
+  return [
+    '===== REPORT METADATA =====',
+    `PROJECT = ${projectTestResult.project.name}`,
+    `PROJECT ROOT = ${projectTestResult.project.root}`,
+    `PROJECT TYPE = ${projectTestResult.project.type ?? 'unknown'}`,
+    `BRANCH = ${reportSettings.branchName}`,
+    `COMMIT SHA = ${reportSettings.commitSha}`,
+    `TEST RUN DATE = ${reportSettings.runDate}`,
+    `COMMAND = ${commandText}`,
+    `EXIT CODE = ${projectTestResult.exitCode}`,
+    `STATUS = ${projectTestResult.status}`,
+    '===== END REPORT METADATA =====',
+    '',
+    projectTestResult.output,
+  ].join('\n');
+}
+
+export function createManifest(
+  projectTestResults: readonly ProjectTestResult[],
+  reportSettings: ReportSettings,
+): UnitTestReportManifest {
+  return {
+    branch: reportSettings.branchName,
+    commitSha: reportSettings.commitSha,
+    overallStatus: projectTestResults.every((projectTestResult): boolean => {
+      return projectTestResult.status === 'passed';
+    })
+      ? 'passed'
+      : 'failed',
+    projects: sortProjectTestResults(projectTestResults).map(projectTestResult => {
+      return {
+        command: createCommandText(projectTestResult.command),
+        exitCode: projectTestResult.exitCode,
+        name: projectTestResult.project.name,
+        reportFileName: projectTestResult.reportFileName,
+        status: projectTestResult.status,
+      };
+    }),
+    runDate: reportSettings.runDate,
+  };
+}
+
+export function createCombinedReport(
+  projectTestResults: readonly ProjectTestResult[],
+  reportSettings: ReportSettings,
+): string {
+  return sortProjectTestResults(projectTestResults)
+    .map((projectTestResult): string => {
+      return [
+        `===== BEGIN PROJECT: ${projectTestResult.project.name} =====`,
+        createProjectReport(projectTestResult, reportSettings),
+        `===== END PROJECT: ${projectTestResult.project.name} =====`,
+      ].join('\n');
+    })
+    .join('\n\n');
+}
+
+function sortProjectTestResults(projectTestResults: readonly ProjectTestResult[]): readonly ProjectTestResult[] {
+  return [...projectTestResults].sort((leftProjectTestResult, rightProjectTestResult): number => {
+    return leftProjectTestResult.project.name.localeCompare(rightProjectTestResult.project.name);
+  });
+}
+
+export async function runProjectTestReports(
+  testableProjects: readonly TestableProject[],
+  reportSettings: ReportSettings,
+  runCommand: RunCommand,
+): Promise<readonly ProjectTestResult[]> {
+  const projectTestResults: ProjectTestResult[] = [];
+
+  for (const testableProject of testableProjects) {
+    const nxTestCommand = createNxTestCommand(testableProject.name);
+    console.log(`\n==> ${createCommandText(nxTestCommand)}`);
+    const commandExecutionResult = await runCommand(
+      nxTestCommand.command,
+      nxTestCommand.commandArguments,
+      reportSettings.workspaceRoot,
+    );
+
+    projectTestResults.push({
+      command: nxTestCommand,
+      exitCode: commandExecutionResult.exitCode,
+      output: commandExecutionResult.output,
+      project: testableProject,
+      reportFileName: createReportFileName(testableProject.name, reportSettings.commitSha),
+      status: commandExecutionResult.exitCode === 0 ? 'passed' : 'failed',
+    });
+  }
+
+  return projectTestResults;
+}
+
+async function writeReports(
+  projectTestResults: readonly ProjectTestResult[],
+  reportSettings: ReportSettings,
+): Promise<void> {
+  await mkdir(reportSettings.reportsDirectory, {recursive: true});
+
+  await Promise.all(
+    projectTestResults.map(async (projectTestResult): Promise<void> => {
+      await writeFile(
+        join(reportSettings.reportsDirectory, projectTestResult.reportFileName),
+        createProjectReport(projectTestResult, reportSettings),
+      );
+    }),
+  );
+  await writeFile(
+    join(reportSettings.reportsDirectory, 'manifest.json'),
+    `${JSON.stringify(createManifest(projectTestResults, reportSettings), null, 2)}\n`,
+  );
+  await writeFile(reportSettings.combinedReportFile, createCombinedReport(projectTestResults, reportSettings));
+}
+
+function runCommandAndCaptureOutput(
+  command: string,
+  commandArguments: readonly string[],
+  workspaceRoot: string,
+): Promise<CommandExecutionResult> {
+  return new Promise((resolveCommand): void => {
+    let commandHasFailedToStart = false;
+    let commandOutput = '';
+    const childProcess = spawn(command, commandArguments, {
+      cwd: workspaceRoot,
+      env: process.env,
+      shell: false,
+    });
+
+    childProcess.stdout.on('data', (outputChunk: Buffer): void => {
+      process.stdout.write(outputChunk);
+      commandOutput += outputChunk.toString();
+    });
+
+    childProcess.stderr.on('data', (outputChunk: Buffer): void => {
+      process.stderr.write(outputChunk);
+      commandOutput += outputChunk.toString();
+    });
+
+    childProcess.on('error', (error: Error): void => {
+      commandHasFailedToStart = true;
+      const errorMessage = `Failed to start command: ${error.message}\n`;
+      process.stderr.write(errorMessage);
+      commandOutput += errorMessage;
+      resolveCommand({exitCode: 1, output: commandOutput});
+    });
+
+    childProcess.on('close', (exitCode: number | null): void => {
+      if (!commandHasFailedToStart) {
+        resolveCommand({exitCode: exitCode ?? 1, output: commandOutput});
+      }
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  try {
+    const reportSettings = readReportSettings();
+    const testableProjects = await discoverTestableProjects();
+
+    if (testableProjects.length === 0) {
+      throw new Error('No Nx projects with a test target found');
+    }
+
+    if (process.argv.includes('--list-projects')) {
+      for (const testableProject of testableProjects) {
+        console.log(testableProject.name);
+      }
+
+      return;
+    }
+
+    const projectTestResults = await runProjectTestReports(
+      testableProjects,
+      reportSettings,
+      runCommandAndCaptureOutput,
+    );
+    await writeReports(projectTestResults, reportSettings);
+    const failedProjectNames = projectTestResults
+      .filter((projectTestResult): boolean => {
+        return projectTestResult.status === 'failed';
+      })
+      .map((projectTestResult): string => {
+        return projectTestResult.project.name;
+      });
+
+    if (failedProjectNames.length > 0) {
+      console.error(`Unit test failures: ${failedProjectNames.join(', ')}`);
+      process.exitCode = 1;
+    }
+  } catch (error: unknown) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  void main();
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26883" title="WPB-26883" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26883</a>  [Web] Adjust unit test logs for web-packages for bund deliveries
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- backport the Nx-based unit test report generator and focused tests from main
- use GitHub Actions built-in branch selection and upload one complete report artifact
- preserve the q2-2026 branch's plain Yarn and ts-node setup without dependency or TypeScript configuration changes

The full local report run exposed existing q2 environment failures: missing .env.defaults, the skipped native canvas build, and missing webapp build environment variables.