### PR TITLE
Add release appearance comment dry run [WPB-26469]

### DIFF
--- a/.github/workflows/dry-run-release-appearance-comments.yml
+++ b/.github/workflows/dry-run-release-appearance-comments.yml
@@ -1,0 +1,130 @@
+---
+name: Dry run release appearance comments
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: 'Release stage to inspect'
+        required: true
+        type: choice
+        options:
+          - beta
+          - production
+      release_tag:
+        description: 'Existing immutable release tag appropriate for the selected stage'
+        required: true
+        type: string
+      promoted_beta_tag:
+        description: 'Existing promoted Beta tag; required only for Production'
+        required: false
+        default: ''
+        type: string
+permissions: {}
+concurrency:
+  group: dry-run-release-appearance-comments
+  cancel-in-progress: false
+jobs:
+  dry_run_release_appearance_comments:
+    name: Plan release appearance comments
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # required to check out and inspect release history
+      pull-requests: read # required to discover merged pull requests
+      issues: read # required to list existing pull request comments
+    steps:
+      - name: Checkout release history
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Validate workflow ref
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" != 'refs/heads/main' ]]; then
+            echo 'The dry run must be started with "Use workflow from: main".' >&2
+            exit 1
+          fi
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Fetch tags
+        run: git fetch --tags origin
+
+      - name: Validate stage inputs
+        env:
+          PROMOTED_BETA_TAG: ${{ inputs.promoted_beta_tag }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          STAGE: ${{ inputs.stage }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${RELEASE_TAG//[[:space:]]/}" ]]; then
+            echo 'release_tag must not be empty.' >&2
+            exit 1
+          fi
+
+          case "${STAGE}" in
+            beta)
+              if [[ -n "${PROMOTED_BETA_TAG}" ]]; then
+                echo 'promoted_beta_tag must be empty for Beta.' >&2
+                exit 1
+              fi
+              ;;
+            production)
+              if [[ -z "${PROMOTED_BETA_TAG//[[:space:]]/}" ]]; then
+                echo 'promoted_beta_tag must be provided for Production.' >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Unsupported stage: ${STAGE}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Resolve release commit
+        id: resolve_release_commit
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          release_commit="$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")"
+          echo "release_commit=${release_commit}" >> "$GITHUB_OUTPUT"
+
+      - name: Plan release appearance comments
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PROMOTED_BETA_TAG: ${{ inputs.promoted_beta_tag }}
+          RELEASE_COMMIT: ${{ steps.resolve_release_commit.outputs.release_commit }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          STAGE: ${{ inputs.stage }}
+        run: |
+          set -euo pipefail
+          if [[ "${STAGE}" == 'beta' ]]; then
+            release_appearance_command_arguments=(beta "${RELEASE_TAG}" "${RELEASE_COMMIT}" --dry-run)
+          else
+            release_appearance_command_arguments=(production "${RELEASE_TAG}" "${RELEASE_COMMIT}" "${PROMOTED_BETA_TAG}" --dry-run)
+          fi
+          node tools/release-appearance/releaseAppearanceCommand.ts "${release_appearance_command_arguments[@]}"
+
+      - name: Confirm read-only issue permissions
+        if: ${{ always() }}
+        run: |
+          {
+            echo ''
+            echo 'The workflow token had read-only issue permissions; GitHub comment mutations were not authorized.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/tools/release-appearance/releaseAppearanceCommand.test.ts
+++ b/tools/release-appearance/releaseAppearanceCommand.test.ts
@@ -34,6 +34,7 @@ import type {
   ExecuteReleaseAppearanceCommandOptions,
   ReleaseAppearanceCommandDependencies,
 } from './releaseAppearanceCommand.ts';
+import {createGitHubClient} from './githubClient.ts';
 import type {
   CreateIssueCommentOptions,
   GitHubClient,
@@ -41,6 +42,7 @@ import type {
   PullRequestRecord,
   UpdateIssueCommentOptions,
 } from './githubClient.ts';
+import type {HttpRequest} from './httpClient.ts';
 import type {ExecuteGitCommand} from './releaseHistory.ts';
 
 const releaseCommit = 'a'.repeat(40);
@@ -262,14 +264,69 @@ async function runCommand(runCommandOptions: RunCommandOptions): Promise<{
 }
 
 describe('parseCommandLineArguments', () => {
-  it('parses supported commands and requires full release commit SHAs', () => {
-    const betaResult = parseCommandLineArguments(['beta', betaTag, releaseCommit]);
-    const productionResult = parseCommandLineArguments(['production', productionTag, releaseCommit, betaTag]);
+  it('normal Beta parsing defaults to write mode', () => {
+    const actualResult = parseCommandLineArguments(['beta', betaTag, releaseCommit]);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toEqual({
+      stage: 'beta',
+      releaseTag: betaTag,
+      releaseCommit,
+      executionMode: 'write',
+    });
+  });
+
+  it('normal Production parsing defaults to write mode', () => {
+    const actualResult = parseCommandLineArguments(['production', productionTag, releaseCommit, betaTag]);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toEqual({
+      stage: 'production',
+      releaseTag: productionTag,
+      releaseCommit,
+      promotedBetaTag: betaTag,
+      executionMode: 'write',
+    });
+  });
+
+  it('accepts final --dry-run for Beta', () => {
+    const actualResult = parseCommandLineArguments(['beta', betaTag, releaseCommit, '--dry-run']);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value.executionMode).toBe('dry-run');
+  });
+
+  it('accepts final --dry-run for Production', () => {
+    const actualResult = parseCommandLineArguments(['production', productionTag, releaseCommit, betaTag, '--dry-run']);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value.executionMode).toBe('dry-run');
+  });
+
+  it('rejects repeated --dry-run', () => {
+    const actualResult = parseCommandLineArguments(['beta', betaTag, releaseCommit, '--dry-run', '--dry-run']);
+
+    expect(actualResult.isErr).toBe(true);
+  });
+
+  it('rejects unknown options and additional arguments', () => {
+    const unknownOptionResult = parseCommandLineArguments(['beta', betaTag, releaseCommit, '--write']);
+    const additionalArgumentResult = parseCommandLineArguments(['beta', betaTag, releaseCommit, '--dry-run', 'extra']);
+
+    expect(unknownOptionResult.isErr).toBe(true);
+    expect(additionalArgumentResult.isErr).toBe(true);
+  });
+
+  it('rejects misplaced --dry-run', () => {
+    const actualResult = parseCommandLineArguments(['production', productionTag, '--dry-run', releaseCommit, betaTag]);
+
+    expect(actualResult.isErr).toBe(true);
+  });
+
+  it('requires full release commit SHAs', () => {
     const abbreviatedCommitResult = parseCommandLineArguments(['beta', betaTag, 'abcdef0']);
     const longCommitResult = parseCommandLineArguments(['beta', betaTag, 'a'.repeat(64)]);
 
-    expect(betaResult.isOk).toBe(true);
-    expect(productionResult.isOk).toBe(true);
     expect(abbreviatedCommitResult.isErr).toBe(true);
     expect(longCommitResult.isErr).toBe(true);
   });
@@ -328,16 +385,179 @@ describe('executeReleaseAppearanceCommand', () => {
     assert(summary.isJust);
     expect(createdComment.value.commentBody).toMatch(/2026-01-02\.1-beta\.1/);
     expect(summary.value).toMatch(/Pull requests discovered: 1 \(#8\)/);
-    expect(commandRun.result.summary).toContain('- Comments created: 1');
-    expect(commandRun.result.summary).toContain('- Failed pull requests: none');
-    expect(commandRun.result.summary).toContain('### Failures\n\nNone');
+    expect(commandRun.result.summary).toBe(
+      [
+        '### Release appearance',
+        '',
+        '- Stage: beta',
+        `- Release tag: \`${betaTag}\``,
+        '- Bootstrap: no',
+        `- Preceding Production tag: ${previousProductionTag}`,
+        `- Beta candidate ranges for Production: ${betaTag}: ${previousProductionTag} -> ${betaTag}`,
+        `- Commits inspected: 1 (${betaCommit})`,
+        '- Pull requests discovered: 1 (#8)',
+        '- Comments created: 1',
+        '- Comments updated: 0',
+        '- Comments unchanged: 0',
+        '- Failed pull requests: none',
+        '- Commits without associated pull requests: none',
+        '',
+        '### Failures',
+        '',
+        'None',
+      ].join('\n'),
+    );
+  });
+
+  it('updates release appearance comments in write mode', async () => {
+    const existingBetaComment = renderPersistentComment({
+      beta: Maybe.just(betaTag),
+      production: Maybe.nothing<string>(),
+    });
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByCommit: new Map([[betaCommit, [createPullRequest(9)]]]),
+      commentsByPullRequest: new Map([[9, [issueCommentRecordFactory.build({id: 19, body: existingBetaComment})]]]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: ['production', productionTag, releaseCommit, betaTag],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: fakeGitHubClient.githubClient,
+    });
+
+    expect(commandRun.result.exitCode).toBe(0);
+    expect(fakeGitHubClient.state.createdComments).toEqual([]);
+    expect(fakeGitHubClient.state.updatedComments).toHaveLength(1);
+  });
+
+  it('plans create, update, and unchanged comments without mutations in dry-run mode', async () => {
+    const existingBetaComment = renderPersistentComment({
+      beta: Maybe.just(betaTag),
+      production: Maybe.nothing<string>(),
+    });
+    const existingProductionComment = renderPersistentComment({
+      beta: Maybe.just(betaTag),
+      production: Maybe.just(productionTag),
+    });
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByCommit: new Map([[betaCommit, [createPullRequest(1), createPullRequest(2), createPullRequest(3)]]]),
+      commentsByPullRequest: new Map([
+        [2, [issueCommentRecordFactory.build({id: 12, body: existingBetaComment})]],
+        [3, [issueCommentRecordFactory.build({id: 13, body: existingProductionComment})]],
+      ]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: ['production', productionTag, releaseCommit, betaTag, '--dry-run'],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: fakeGitHubClient.githubClient,
+    });
+
+    expect(commandRun.result.exitCode).toBe(0);
+    expect(fakeGitHubClient.state.commentPullRequests).toEqual([1, 2, 3]);
+    expect(fakeGitHubClient.state.createdComments).toEqual([]);
+    expect(fakeGitHubClient.state.updatedComments).toEqual([]);
+    expect(commandRun.result.summary).toContain('- Mode: dry run');
+    expect(commandRun.result.summary).toContain('- Comments that would be created: 1');
+    expect(commandRun.result.summary).toContain('- Comments that would be updated: 1');
+    expect(commandRun.result.summary).toContain('- Unchanged comments: 1');
+    expect(commandRun.result.summary).toContain('- #1: would create');
+    expect(commandRun.result.summary).toContain('- #2: would update');
+    expect(commandRun.result.summary).toContain('- #3: unchanged');
+    expect(commandRun.result.summary).toContain('No GitHub comments were created or updated.');
+  });
+
+  it('uses paginated GitHub comment reads without mutations in dry-run mode', async () => {
+    const githubRequests: HttpRequest[] = [];
+    const firstCommentPage = Array.from({length: 100}, (_, commentIndex) => {
+      return {id: commentIndex + 1, body: `Unrelated comment ${commentIndex + 1}`};
+    });
+    const githubClient = createGitHubClient({
+      githubApiUrl: new URL('https://api.github.example/'),
+      githubRepository: 'wireapp/wire-webapp',
+      githubToken: 'github-token',
+      httpClient: {
+        requestJson: async function requestJson(request): Promise<unknown> {
+          githubRequests.push(request);
+          if (request.url.pathname.endsWith('/pulls')) {
+            return [{number: 7, merged_at: '2026-01-02T00:00:00Z', base: {ref: 'main'}}];
+          }
+          if (request.method !== 'get') {
+            throw new Error('Dry run attempted a mutation request');
+          }
+          return request.url.searchParams.get('page') === '1' ? firstCommentPage : [];
+        },
+      },
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: ['beta', betaTag, releaseCommit, '--dry-run'],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient,
+    });
+
+    expect(commandRun.result.exitCode).toBe(0);
+    expect(
+      githubRequests
+        .filter(request => {
+          return request.url.pathname.endsWith('/issues/7/comments');
+        })
+        .map(request => {
+          return request.url.searchParams.get('page');
+        }),
+    ).toEqual(['1', '2']);
+    expect(
+      githubRequests.every(request => {
+        return request.method === 'get';
+      }),
+    ).toBe(true);
+  });
+
+  it('continues dry-run planning after malformed markers, duplicate markers, and read failures', async () => {
+    const malformedMarker = '<!-- wire-webapp-release-appearance:v1\n{"beta":}\n-->';
+    const markerComment = renderPersistentComment({
+      beta: Maybe.just(betaTag),
+      production: Maybe.nothing<string>(),
+    });
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByCommit: new Map([
+        [betaCommit, [createPullRequest(1), createPullRequest(2), createPullRequest(3), createPullRequest(4)]],
+      ]),
+      commentsByPullRequest: new Map([
+        [1, [issueCommentRecordFactory.build({body: malformedMarker})]],
+        [
+          2,
+          [
+            issueCommentRecordFactory.build({id: 21, body: markerComment}),
+            issueCommentRecordFactory.build({id: 22, body: markerComment}),
+          ],
+        ],
+      ]),
+      commentListFailuresByPullRequest: new Map([[3, `Unable to read ${commandEnvironment.GITHUB_TOKEN}`]]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: ['beta', betaTag, releaseCommit, '--dry-run'],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: fakeGitHubClient.githubClient,
+    });
+
+    expect(commandRun.result.exitCode).toBe(1);
+    expect(fakeGitHubClient.state.commentPullRequests).toEqual([1, 2, 3, 4]);
+    expect(fakeGitHubClient.state.createdComments).toEqual([]);
+    expect(fakeGitHubClient.state.updatedComments).toEqual([]);
+    expect(commandRun.result.summary).toContain('Malformed release-appearance marker state');
+    expect(commandRun.result.summary).toContain('More than one release-appearance marker comment exists');
+    expect(commandRun.result.summary).toContain('[REDACTED]');
+    expect(commandRun.result.summary).not.toContain(commandEnvironment.GITHUB_TOKEN);
+    expect(commandRun.result.summary).toContain('- #4: would create');
   });
 
   it('includes release-history planning failures in the summary', async () => {
     const fakeGitHubClient = createFakeGitHubClient();
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', 'invalid-beta-tag', releaseCommit],
+      commandLineArguments: ['beta', 'invalid-beta-tag', releaseCommit, '--dry-run'],
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
     });
@@ -357,18 +577,15 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit],
+      commandLineArguments: ['beta', betaTag, releaseCommit, '--dry-run'],
       executeGitCommand: createFakeGitCommand({commits: [failedDiscoveryCommit, betaCommit]}),
       githubClient: fakeGitHubClient.githubClient,
     });
 
     expect(commandRun.result.exitCode).toBe(1);
     expect(fakeGitHubClient.state.pullRequestCommits).toEqual([failedDiscoveryCommit, betaCommit]);
-    expect(
-      fakeGitHubClient.state.createdComments.map(comment => {
-        return comment.pullRequestNumber;
-      }),
-    ).toEqual([2]);
+    expect(fakeGitHubClient.state.createdComments).toEqual([]);
+    expect(commandRun.result.summary).toContain('- #2: would create');
     expect(commandRun.result.summary).toContain(`- Discovery: ${discoveryFailureMessage}`);
   });
 
@@ -498,7 +715,7 @@ describe('executeReleaseAppearanceCommand', () => {
     const fakeGitHubClient = createFakeGitHubClient();
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit],
+      commandLineArguments: ['beta', betaTag, releaseCommit, '--dry-run'],
       executeGitCommand: createFakeGitCommand({bootstrap: true}),
       githubClient: fakeGitHubClient.githubClient,
     });
@@ -508,6 +725,8 @@ describe('executeReleaseAppearanceCommand', () => {
     const summary = Maybe.of(commandRun.summaries[0]);
     assert(summary.isJust);
     expect(summary.value).toMatch(/Bootstrap: yes/);
+    expect(summary.value).toContain('No pull request comment operations were planned.');
+    expect(summary.value).toContain('No GitHub comments were created or updated.');
     expect(commandRun.result.summary).toContain('### Failures\n\nNone');
   });
 });

--- a/tools/release-appearance/releaseAppearanceCommand.ts
+++ b/tools/release-appearance/releaseAppearanceCommand.ts
@@ -38,18 +38,21 @@ import {planBetaReleaseHistory, planProductionReleaseHistory} from './releaseHis
 import type {CommitRange, ExecuteGitCommand, ReleaseHistoryPlan} from './releaseHistory.ts';
 
 export type ReleaseAppearanceCommandStage = 'beta' | 'production';
+export type ExecutionMode = 'write' | 'dry-run';
 
 export type ParsedCommand =
   | {
       readonly stage: 'beta';
       readonly releaseTag: string;
       readonly releaseCommit: string;
+      readonly executionMode: ExecutionMode;
     }
   | {
       readonly stage: 'production';
       readonly releaseTag: string;
       readonly releaseCommit: string;
       readonly promotedBetaTag: string;
+      readonly executionMode: ExecutionMode;
     };
 
 export type CommandEnvironment = {
@@ -104,16 +107,24 @@ type PullRequestFailure = {
   readonly message: string;
 };
 
+type PlannedCommentOperation = {
+  readonly pullRequestNumber: number;
+  readonly kind: CommentOperation['kind'];
+};
+
 type ProcessingResult = {
   readonly commentsCreated: number;
   readonly commentsUpdated: number;
   readonly commentsUnchanged: number;
+  readonly plannedCommentOperations: readonly PlannedCommentOperation[];
   readonly failures: readonly PullRequestFailure[];
 };
 
 type SummaryOptions = {
+  readonly executionMode: ExecutionMode;
   readonly stage: ReleaseAppearanceCommandStage;
   readonly releaseTag: string;
+  readonly releaseCommit: string;
   readonly bootstrap: boolean;
   readonly precedingProductionTag: string;
   readonly candidateRanges: readonly DiscoveryRange[];
@@ -123,6 +134,7 @@ type SummaryOptions = {
   readonly commentsCreated: number;
   readonly commentsUpdated: number;
   readonly commentsUnchanged: number;
+  readonly plannedCommentOperations: readonly PlannedCommentOperation[];
   readonly generalFailureMessages: readonly string[];
   readonly pullRequestFailures: readonly PullRequestFailure[];
 };
@@ -141,6 +153,7 @@ const stageArgumentIndex = 0;
 const releaseTagArgumentIndex = 1;
 const releaseCommitArgumentIndex = 2;
 const promotedBetaTagArgumentIndex = 3;
+const dryRunFlag = '--dry-run';
 const fullGitCommitPattern = /^[0-9a-f]{40}$/i;
 
 function createSuccess<valueType>(value: valueType): Result<valueType, Error> {
@@ -176,8 +189,28 @@ function formatPullRequestFailure(pullRequestFailure: PullRequestFailure): strin
 
 function usageFailure(): Result<ParsedCommand, Error> {
   return createFailure(
-    'Usage: beta <beta-tag> <release-commit-sha> or production <production-tag> <release-commit-sha> <promoted-beta-tag>',
+    'Usage: beta <beta-tag> <release-commit-sha> [--dry-run] or production <production-tag> <release-commit-sha> <promoted-beta-tag> [--dry-run]',
   );
+}
+
+function parseExecutionMode(
+  commandLineArguments: readonly string[],
+  writeArgumentCount: number,
+): Result<ExecutionMode, Error> {
+  if (commandLineArguments.length === writeArgumentCount) {
+    return createSuccess('write');
+  }
+
+  const dryRunFlagArgument = Maybe.of(commandLineArguments[writeArgumentCount]);
+  if (
+    commandLineArguments.length === writeArgumentCount + 1 &&
+    dryRunFlagArgument.isJust &&
+    dryRunFlagArgument.value === dryRunFlag
+  ) {
+    return createSuccess('dry-run');
+  }
+
+  return createFailure('Dry-run mode requires exactly one final --dry-run argument');
 }
 
 function readRequiredArgument(
@@ -203,18 +236,24 @@ function readReleaseCommit(commandLineArguments: readonly string[]): Result<stri
   );
 }
 
-function parseBetaCommand(commandLineArguments: readonly string[]): Result<ParsedCommand, Error> {
+function parseBetaCommand(
+  commandLineArguments: readonly string[],
+  executionMode: ExecutionMode,
+): Result<ParsedCommand, Error> {
   const betaTagResult = readRequiredArgument(commandLineArguments, releaseTagArgumentIndex, 'Beta tag');
   if (betaTagResult.isErr) {
     return createFailure(betaTagResult.error.message);
   }
 
   return readReleaseCommit(commandLineArguments).map(releaseCommit => {
-    return {stage: 'beta', releaseTag: betaTagResult.value, releaseCommit};
+    return {stage: 'beta', releaseTag: betaTagResult.value, releaseCommit, executionMode};
   });
 }
 
-function parseProductionCommand(commandLineArguments: readonly string[]): Result<ParsedCommand, Error> {
+function parseProductionCommand(
+  commandLineArguments: readonly string[],
+  executionMode: ExecutionMode,
+): Result<ParsedCommand, Error> {
   const productionTagResult = readRequiredArgument(commandLineArguments, releaseTagArgumentIndex, 'Production tag');
   if (productionTagResult.isErr) {
     return createFailure(productionTagResult.error.message);
@@ -232,6 +271,7 @@ function parseProductionCommand(commandLineArguments: readonly string[]): Result
         releaseTag: productionTagResult.value,
         releaseCommit: releaseCommitResult.value,
         promotedBetaTag,
+        executionMode,
       };
     },
   );
@@ -245,13 +285,15 @@ export function parseCommandLineArguments(commandLineArguments: readonly string[
 
   return match(stage.value)
     .with('beta', () => {
-      return commandLineArguments.length === betaCommandArgumentCount
-        ? parseBetaCommand(commandLineArguments)
+      const executionModeResult = parseExecutionMode(commandLineArguments, betaCommandArgumentCount);
+      return executionModeResult.isOk
+        ? parseBetaCommand(commandLineArguments, executionModeResult.value)
         : usageFailure();
     })
     .with('production', () => {
-      return commandLineArguments.length === productionCommandArgumentCount
-        ? parseProductionCommand(commandLineArguments)
+      const executionModeResult = parseExecutionMode(commandLineArguments, productionCommandArgumentCount);
+      return executionModeResult.isOk
+        ? parseProductionCommand(commandLineArguments, executionModeResult.value)
         : usageFailure();
     })
     .otherwise(() => {
@@ -481,12 +523,14 @@ async function processPullRequests(
   pullRequests: readonly PullRequestAppearance[],
   stage: ReleaseAppearanceCommandStage,
   releaseTag: string,
+  executionMode: ExecutionMode,
   dependencies: Pick<ReleaseAppearanceCommandDependencies, 'githubClient' | 'writeOutput'>,
   githubToken: string,
 ): Promise<ProcessingResult> {
   let commentsCreated = 0;
   let commentsUpdated = 0;
   let commentsUnchanged = 0;
+  const plannedCommentOperations: PlannedCommentOperation[] = [];
   const failures: PullRequestFailure[] = [];
 
   for (const pullRequest of pullRequests) {
@@ -518,8 +562,20 @@ async function processPullRequests(
       await writeFailure(dependencies.writeOutput, formatPullRequestFailure(pullRequestFailure));
       continue;
     }
+    plannedCommentOperations.push({
+      pullRequestNumber: pullRequest.number,
+      kind: operationResult.value.kind,
+    });
     if (operationResult.value.kind === 'unchanged') {
       commentsUnchanged += 1;
+      continue;
+    }
+    if (executionMode === 'dry-run') {
+      if (operationResult.value.kind === 'create') {
+        commentsCreated += 1;
+      } else {
+        commentsUpdated += 1;
+      }
       continue;
     }
 
@@ -545,6 +601,7 @@ async function processPullRequests(
     commentsCreated,
     commentsUpdated,
     commentsUnchanged,
+    plannedCommentOperations,
     failures: failures.toSorted((leftFailure, rightFailure) => {
       return leftFailure.pullRequestNumber - rightFailure.pullRequestNumber;
     }),
@@ -553,8 +610,10 @@ async function processPullRequests(
 
 function createEmptySummaryOptions(parsedCommand: ParsedCommand): SummaryOptions {
   return {
+    executionMode: parsedCommand.executionMode,
     stage: parsedCommand.stage,
     releaseTag: parsedCommand.releaseTag,
+    releaseCommit: parsedCommand.releaseCommit,
     bootstrap: false,
     precedingProductionTag: 'unavailable',
     candidateRanges: [],
@@ -564,6 +623,7 @@ function createEmptySummaryOptions(parsedCommand: ParsedCommand): SummaryOptions
     commentsCreated: 0,
     commentsUpdated: 0,
     commentsUnchanged: 0,
+    plannedCommentOperations: [],
     generalFailureMessages: [],
     pullRequestFailures: [],
   };
@@ -638,7 +698,7 @@ function formatFailureSection(summaryOptions: SummaryOptions): readonly string[]
   return ['', '### Failures', '', ...(failureLines.length === 0 ? ['None'] : failureLines)];
 }
 
-function createSummary(summaryOptions: SummaryOptions): string {
+function createWriteSummary(summaryOptions: SummaryOptions): string {
   return [
     '### Release appearance',
     '',
@@ -656,6 +716,63 @@ function createSummary(summaryOptions: SummaryOptions): string {
     `- Commits without associated pull requests: ${formatStringList(summaryOptions.commitsWithoutPullRequests)}`,
     ...formatFailureSection(summaryOptions),
   ].join('\n');
+}
+
+function formatPlannedCommentOperations(
+  plannedCommentOperations: readonly PlannedCommentOperation[],
+): readonly string[] {
+  if (plannedCommentOperations.length === 0) {
+    return ['No pull request comment operations were planned.'];
+  }
+
+  return plannedCommentOperations.map(plannedCommentOperation => {
+    const operationDescription = match(plannedCommentOperation.kind)
+      .with('create', () => {
+        return 'would create';
+      })
+      .with('update', () => {
+        return 'would update';
+      })
+      .with('unchanged', () => {
+        return 'unchanged';
+      })
+      .exhaustive();
+    return `- #${plannedCommentOperation.pullRequestNumber}: ${operationDescription}`;
+  });
+}
+
+function createDryRunSummary(summaryOptions: SummaryOptions): string {
+  return [
+    '### Release appearance',
+    '',
+    '- Mode: dry run',
+    `- Stage: ${summaryOptions.stage}`,
+    `- Release tag: \`${summaryOptions.releaseTag}\``,
+    `- Release commit: \`${summaryOptions.releaseCommit}\``,
+    `- Bootstrap: ${summaryOptions.bootstrap ? 'yes' : 'no'}`,
+    `- Preceding Production tag: ${summaryOptions.precedingProductionTag}`,
+    `- Beta candidate ranges for Production: ${formatCandidateRanges(summaryOptions.candidateRanges)}`,
+    `- Commits inspected: ${summaryOptions.commitsInspected.length} (${formatStringList(summaryOptions.commitsInspected)})`,
+    `- Pull requests discovered: ${summaryOptions.pullRequestsDiscovered.length} (${formatPullRequestList(summaryOptions.pullRequestsDiscovered)})`,
+    `- Comments that would be created: ${summaryOptions.commentsCreated}`,
+    `- Comments that would be updated: ${summaryOptions.commentsUpdated}`,
+    `- Unchanged comments: ${summaryOptions.commentsUnchanged}`,
+    `- Failed pull requests: ${formatFailedPullRequests(summaryOptions.pullRequestFailures)}`,
+    `- Commits without associated pull requests: ${formatStringList(summaryOptions.commitsWithoutPullRequests)}`,
+    '',
+    '### Planned comment operations',
+    '',
+    ...formatPlannedCommentOperations(summaryOptions.plannedCommentOperations),
+    '',
+    'No GitHub comments were created or updated.',
+    ...formatFailureSection(summaryOptions),
+  ].join('\n');
+}
+
+function createSummary(summaryOptions: SummaryOptions): string {
+  return summaryOptions.executionMode === 'dry-run'
+    ? createDryRunSummary(summaryOptions)
+    : createWriteSummary(summaryOptions);
 }
 
 async function finalizeSummary(
@@ -774,6 +891,7 @@ export async function executeReleaseAppearanceCommand(
       discoveryResult.pullRequests,
       parsedCommand.stage,
       parsedCommand.releaseTag,
+      parsedCommand.executionMode,
       dependencies,
       githubToken,
     );
@@ -785,6 +903,7 @@ export async function executeReleaseAppearanceCommand(
       commentsCreated: processingResult.commentsCreated,
       commentsUpdated: processingResult.commentsUpdated,
       commentsUnchanged: processingResult.commentsUnchanged,
+      plannedCommentOperations: processingResult.plannedCommentOperations,
       generalFailureMessages: discoveryFailureMessages,
       pullRequestFailures: processingResult.failures,
     };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Add a manually dispatched dry run for the release-appearance comment automation.

The workflow evaluates an existing Beta or Production release tag using the same logic as the production release workflow:

- release-tag and release-commit validation
- release-history planning
- Beta delta selection
- Production candidate reconstruction
- pull request discovery
- existing comment retrieval
- persistent marker parsing
- immutable state merging
- comment operation selection

Instead of creating or updating comments, the dry run reports what would happen.

## Usage

Run the **Dry run release appearance comments** workflow from `main`.

For Beta, provide:

- stage: `beta`
- release tag: an existing Beta tag

For Production, provide:

- stage: `production`
- release tag: an existing Production tag
- promoted Beta tag: the Beta candidate that was promoted

The release commit is resolved from the immutable release tag rather than supplied manually.