### PR TITLE
Print release appearance dry-run results [WPB-26469]

### DIFF
--- a/tools/release-appearance/releaseAppearanceCommand.test.ts
+++ b/tools/release-appearance/releaseAppearanceCommand.test.ts
@@ -84,6 +84,7 @@ type RunCommandOptions = {
   readonly commandLineArguments: readonly string[];
   readonly executeGitCommand: ExecuteGitCommand;
   readonly githubClient: GitHubClient;
+  readonly informationWriteFailure?: string;
   readonly summaryWriteFailure?: string;
 };
 
@@ -94,8 +95,11 @@ type FakeGitCommandOptions = {
 
 type CreateDependenciesOptions = {
   readonly executeGitCommand: ExecuteGitCommand;
+  readonly failureMessages: string[];
   readonly githubClient: GitHubClient;
-  readonly outputMessages: string[];
+  readonly informationMessages: string[];
+  readonly informationWriteAttempts: string[];
+  readonly informationWriteFailure?: string;
   readonly summaries: string[];
   readonly summaryWriteFailure?: string;
 };
@@ -223,11 +227,31 @@ function createFakeGitCommand(fakeGitCommandOptions: FakeGitCommandOptions = {})
 function createDependencies(
   createDependenciesOptions: CreateDependenciesOptions,
 ): ReleaseAppearanceCommandDependencies {
-  const {executeGitCommand, githubClient, outputMessages, summaries, summaryWriteFailure} = createDependenciesOptions;
+  const {
+    executeGitCommand,
+    failureMessages,
+    githubClient,
+    informationMessages,
+    informationWriteAttempts,
+    informationWriteFailure,
+    summaries,
+    summaryWriteFailure,
+  } = createDependenciesOptions;
 
   return {
     executeGitCommand,
     githubClient,
+    async writeFailure(message): Promise<void> {
+      failureMessages.push(message);
+    },
+    async writeInformation(message): Promise<void> {
+      informationWriteAttempts.push(message);
+      const failureMessage = Maybe.of(informationWriteFailure);
+      if (failureMessage.isJust) {
+        throw new Error(failureMessage.value);
+      }
+      informationMessages.push(message);
+    },
     async writeSummary(summary): Promise<void> {
       const failureMessage = Maybe.of(summaryWriteFailure);
       if (failureMessage.isJust) {
@@ -235,32 +259,36 @@ function createDependencies(
       }
       summaries.push(summary);
     },
-    async writeOutput(message): Promise<void> {
-      outputMessages.push(message);
-    },
   };
 }
 
 async function runCommand(runCommandOptions: RunCommandOptions): Promise<{
   readonly result: Awaited<ReturnType<typeof executeReleaseAppearanceCommand>>;
-  readonly outputMessages: readonly string[];
+  readonly failureMessages: readonly string[];
+  readonly informationMessages: readonly string[];
+  readonly informationWriteAttempts: readonly string[];
   readonly summaries: readonly string[];
 }> {
-  const outputMessages: string[] = [];
+  const failureMessages: string[] = [];
+  const informationMessages: string[] = [];
+  const informationWriteAttempts: string[] = [];
   const summaries: string[] = [];
   const options: ExecuteReleaseAppearanceCommandOptions = {
     commandLineArguments: runCommandOptions.commandLineArguments,
     environment: commandEnvironment,
     dependencies: createDependencies({
       executeGitCommand: runCommandOptions.executeGitCommand,
+      failureMessages,
       githubClient: runCommandOptions.githubClient,
-      outputMessages,
+      informationMessages,
+      informationWriteAttempts,
+      informationWriteFailure: runCommandOptions.informationWriteFailure,
       summaries,
       summaryWriteFailure: runCommandOptions.summaryWriteFailure,
     }),
   };
   const result = await executeReleaseAppearanceCommand(options);
-  return {result, outputMessages, summaries};
+  return {result, failureMessages, informationMessages, informationWriteAttempts, summaries};
 }
 
 describe('parseCommandLineArguments', () => {
@@ -385,6 +413,7 @@ describe('executeReleaseAppearanceCommand', () => {
     assert(summary.isJust);
     expect(createdComment.value.commentBody).toMatch(/2026-01-02\.1-beta\.1/);
     expect(summary.value).toMatch(/Pull requests discovered: 1 \(#8\)/);
+    expect(commandRun.informationMessages).toEqual([]);
     expect(commandRun.result.summary).toBe(
       [
         '### Release appearance',
@@ -465,6 +494,56 @@ describe('executeReleaseAppearanceCommand', () => {
     expect(commandRun.result.summary).toContain('- #2: would update');
     expect(commandRun.result.summary).toContain('- #3: unchanged');
     expect(commandRun.result.summary).toContain('No GitHub comments were created or updated.');
+    expect(commandRun.informationMessages).toEqual([
+      [
+        'Release appearance dry run',
+        'Stage: production',
+        `Release tag: ${productionTag}`,
+        `Release commit: ${releaseCommit}`,
+        `Preceding Production tag: ${previousProductionTag}`,
+        'Commits inspected: 1',
+        'Pull requests discovered: 3',
+        'Would create: 1',
+        'Would update: 1',
+        'Unchanged: 1',
+        'Failed pull requests: 0',
+        'No GitHub comments were created or updated.',
+      ].join('\n'),
+    ]);
+    expect(commandRun.informationMessages.join('\n')).not.toContain(existingBetaComment);
+    expect(commandRun.informationMessages.join('\n')).not.toContain(existingProductionComment);
+    expect(commandRun.result.summary).toBe(
+      [
+        '### Release appearance',
+        '',
+        '- Mode: dry run',
+        '- Stage: production',
+        `- Release tag: \`${productionTag}\``,
+        `- Release commit: \`${releaseCommit}\``,
+        '- Bootstrap: no',
+        `- Preceding Production tag: ${previousProductionTag}`,
+        `- Beta candidate ranges for Production: ${betaTag}: ${previousProductionTag} -> ${betaTag}`,
+        `- Commits inspected: 1 (${betaCommit})`,
+        '- Pull requests discovered: 3 (#1, #2, #3)',
+        '- Comments that would be created: 1',
+        '- Comments that would be updated: 1',
+        '- Unchanged comments: 1',
+        '- Failed pull requests: none',
+        '- Commits without associated pull requests: none',
+        '',
+        '### Planned comment operations',
+        '',
+        '- #1: would create',
+        '- #2: would update',
+        '- #3: unchanged',
+        '',
+        'No GitHub comments were created or updated.',
+        '',
+        '### Failures',
+        '',
+        'None',
+      ].join('\n'),
+    );
   });
 
   it('uses paginated GitHub comment reads without mutations in dry-run mode', async () => {
@@ -551,6 +630,15 @@ describe('executeReleaseAppearanceCommand', () => {
     expect(commandRun.result.summary).toContain('[REDACTED]');
     expect(commandRun.result.summary).not.toContain(commandEnvironment.GITHUB_TOKEN);
     expect(commandRun.result.summary).toContain('- #4: would create');
+    const informationOutput = commandRun.informationMessages.join('\n');
+    expect(informationOutput).toContain('Failed pull requests: 3');
+    expect(informationOutput).toContain('Failures:');
+    expect(informationOutput).toContain('- Pull request #1: Malformed release-appearance marker state');
+    expect(informationOutput).toContain('- Pull request #2: More than one release-appearance marker comment exists');
+    expect(informationOutput).toContain('- Pull request #3: Unable to read [REDACTED]');
+    expect(informationOutput).not.toContain(commandEnvironment.GITHUB_TOKEN);
+    expect(informationOutput).not.toContain('Pull request #4');
+    expect(informationOutput).not.toContain(markerComment);
   });
 
   it('includes release-history planning failures in the summary', async () => {
@@ -566,6 +654,9 @@ describe('executeReleaseAppearanceCommand', () => {
     expect(commandRun.result.summary).toContain('- Release history: Invalid Beta candidate tag: invalid-beta-tag');
     expect(commandRun.result.summary).not.toContain('### Failures\n\nNone');
     expect(commandRun.result.summary).toContain('- Pull requests discovered: 0 (none)');
+    expect(commandRun.informationMessages.join('\n')).toContain(
+      '- Release history: Invalid Beta candidate tag: invalid-beta-tag',
+    );
   });
 
   it('continues discovery after one commit failure and includes the reason in the summary', async () => {
@@ -682,12 +773,12 @@ describe('executeReleaseAppearanceCommand', () => {
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
     });
-    const output = commandRun.outputMessages.join('\n');
+    const failureOutput = commandRun.failureMessages.join('\n');
 
     expect(commandRun.result.exitCode).toBe(1);
-    expect(output).not.toContain(githubToken.value);
+    expect(failureOutput).not.toContain(githubToken.value);
     expect(commandRun.result.summary).not.toContain(githubToken.value);
-    expect(output).toContain('[REDACTED]');
+    expect(failureOutput).toContain('[REDACTED]');
     expect(commandRun.result.summary).toContain('[REDACTED]');
   });
 
@@ -708,7 +799,7 @@ describe('executeReleaseAppearanceCommand', () => {
       '- Summary: Unable to write GitHub Actions summary: Permission denied for [REDACTED]',
     );
     expect(commandRun.result.summary).not.toContain(githubToken.value);
-    expect(commandRun.outputMessages.join('\n')).not.toContain(githubToken.value);
+    expect(commandRun.failureMessages.join('\n')).not.toContain(githubToken.value);
   });
 
   it('performs no GitHub requests during bootstrap', async () => {
@@ -728,6 +819,40 @@ describe('executeReleaseAppearanceCommand', () => {
     expect(summary.value).toContain('No pull request comment operations were planned.');
     expect(summary.value).toContain('No GitHub comments were created or updated.');
     expect(commandRun.result.summary).toContain('### Failures\n\nNone');
+    expect(commandRun.informationMessages).toEqual([
+      [
+        'Release appearance dry run',
+        'Stage: beta',
+        `Release tag: ${betaTag}`,
+        `Release commit: ${releaseCommit}`,
+        'Bootstrap: yes',
+        'No preceding new-format Production release exists.',
+        'No commit range was inspected.',
+        'No pull request comment operations were planned.',
+        'No GitHub comments were created or updated.',
+      ].join('\n'),
+    ]);
+  });
+
+  it('does not repeat processing or summary generation when informational output fails', async () => {
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByCommit: new Map([[betaCommit, [createPullRequest(8)]]]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: ['beta', betaTag, releaseCommit, '--dry-run'],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: fakeGitHubClient.githubClient,
+      informationWriteFailure: `Unable to write ${commandEnvironment.GITHUB_TOKEN}`,
+    });
+
+    expect(commandRun.result.exitCode).toBe(1);
+    expect(fakeGitHubClient.state.pullRequestCommits).toEqual([betaCommit]);
+    expect(fakeGitHubClient.state.commentPullRequests).toEqual([8]);
+    expect(commandRun.summaries).toHaveLength(1);
+    expect(commandRun.informationWriteAttempts).toHaveLength(1);
+    expect(commandRun.informationMessages).toEqual([]);
+    expect(commandRun.failureMessages).toEqual(['Unable to write dry-run log output: Unable to write [REDACTED]']);
   });
 });
 

--- a/tools/release-appearance/releaseAppearanceCommand.ts
+++ b/tools/release-appearance/releaseAppearanceCommand.ts
@@ -65,8 +65,9 @@ export type CommandEnvironment = {
 export type ReleaseAppearanceCommandDependencies = {
   readonly executeGitCommand: ExecuteGitCommand;
   readonly githubClient: GitHubClient;
+  readonly writeFailure: (message: string) => Promise<void>;
+  readonly writeInformation: (message: string) => Promise<void>;
   readonly writeSummary: (summary: string) => Promise<void>;
-  readonly writeOutput: (message: string) => Promise<void>;
 };
 
 export type ExecuteReleaseAppearanceCommandOptions = {
@@ -140,7 +141,10 @@ type SummaryOptions = {
 };
 
 type FinalizeSummaryOptions = {
-  readonly dependencies: Pick<ReleaseAppearanceCommandDependencies, 'writeSummary' | 'writeOutput'>;
+  readonly dependencies: Pick<
+    ReleaseAppearanceCommandDependencies,
+    'writeFailure' | 'writeInformation' | 'writeSummary'
+  >;
   readonly summaryOptions: SummaryOptions;
   readonly githubToken: string;
   readonly exitCode: number;
@@ -351,16 +355,16 @@ export function readCommandEnvironment(environment: NodeJS.ProcessEnv): Result<C
   });
 }
 
-async function writeFailure(writeOutput: (message: string) => Promise<void>, message: string): Promise<void> {
+async function writeFailureSafely(writeFailure: (message: string) => Promise<void>, message: string): Promise<void> {
   try {
-    await writeOutput(message);
+    await writeFailure(message);
   } catch {
     // Reporting must not stop processing the remaining pull requests.
   }
 }
 
 async function writeSummarySafely(
-  dependencies: Pick<ReleaseAppearanceCommandDependencies, 'writeSummary' | 'writeOutput'>,
+  dependencies: Pick<ReleaseAppearanceCommandDependencies, 'writeFailure' | 'writeSummary'>,
   summary: string,
   githubToken: string,
 ): Promise<Maybe<string>> {
@@ -369,7 +373,7 @@ async function writeSummarySafely(
     return Maybe.nothing<string>();
   } catch (error: unknown) {
     const failureMessage = `Unable to write GitHub Actions summary: ${redactSecret(errorMessage(error), githubToken)}`;
-    await writeFailure(dependencies.writeOutput, failureMessage);
+    await writeFailureSafely(dependencies.writeFailure, failureMessage);
     return Maybe.just(failureMessage);
   }
 }
@@ -524,7 +528,7 @@ async function processPullRequests(
   stage: ReleaseAppearanceCommandStage,
   releaseTag: string,
   executionMode: ExecutionMode,
-  dependencies: Pick<ReleaseAppearanceCommandDependencies, 'githubClient' | 'writeOutput'>,
+  dependencies: Pick<ReleaseAppearanceCommandDependencies, 'githubClient' | 'writeFailure'>,
   githubToken: string,
 ): Promise<ProcessingResult> {
   let commentsCreated = 0;
@@ -544,7 +548,7 @@ async function processPullRequests(
         githubToken,
       );
       failures.push(pullRequestFailure);
-      await writeFailure(dependencies.writeOutput, formatPullRequestFailure(pullRequestFailure));
+      await writeFailureSafely(dependencies.writeFailure, formatPullRequestFailure(pullRequestFailure));
       continue;
     }
 
@@ -559,7 +563,7 @@ async function processPullRequests(
         githubToken,
       );
       failures.push(pullRequestFailure);
-      await writeFailure(dependencies.writeOutput, formatPullRequestFailure(pullRequestFailure));
+      await writeFailureSafely(dependencies.writeFailure, formatPullRequestFailure(pullRequestFailure));
       continue;
     }
     plannedCommentOperations.push({
@@ -587,7 +591,7 @@ async function processPullRequests(
     if (writeResult.isErr) {
       const pullRequestFailure = createPullRequestFailure(pullRequest.number, writeResult.error.message, githubToken);
       failures.push(pullRequestFailure);
-      await writeFailure(dependencies.writeOutput, formatPullRequestFailure(pullRequestFailure));
+      await writeFailureSafely(dependencies.writeFailure, formatPullRequestFailure(pullRequestFailure));
       continue;
     }
     if (operationResult.value.kind === 'create') {
@@ -769,10 +773,76 @@ function createDryRunSummary(summaryOptions: SummaryOptions): string {
   ].join('\n');
 }
 
+function createDryRunLogOutput(summaryOptions: SummaryOptions): string {
+  const releaseDetails = [
+    'Release appearance dry run',
+    `Stage: ${summaryOptions.stage}`,
+    `Release tag: ${summaryOptions.releaseTag}`,
+    `Release commit: ${summaryOptions.releaseCommit}`,
+  ];
+
+  if (summaryOptions.bootstrap) {
+    return [
+      ...releaseDetails,
+      'Bootstrap: yes',
+      'No preceding new-format Production release exists.',
+      'No commit range was inspected.',
+      'No pull request comment operations were planned.',
+      'No GitHub comments were created or updated.',
+    ].join('\n');
+  }
+
+  const failureReasons = [
+    ...summaryOptions.generalFailureMessages,
+    ...summaryOptions.pullRequestFailures.map(pullRequestFailure => {
+      return formatPullRequestFailure(pullRequestFailure);
+    }),
+  ];
+
+  return [
+    ...releaseDetails,
+    `Preceding Production tag: ${summaryOptions.precedingProductionTag}`,
+    `Commits inspected: ${summaryOptions.commitsInspected.length}`,
+    `Pull requests discovered: ${summaryOptions.pullRequestsDiscovered.length}`,
+    `Would create: ${summaryOptions.commentsCreated}`,
+    `Would update: ${summaryOptions.commentsUpdated}`,
+    `Unchanged: ${summaryOptions.commentsUnchanged}`,
+    `Failed pull requests: ${summaryOptions.pullRequestFailures.length}`,
+    ...(failureReasons.length === 0
+      ? []
+      : [
+          'Failures:',
+          ...failureReasons.map(failureReason => {
+            return `- ${failureReason}`;
+          }),
+        ]),
+    'No GitHub comments were created or updated.',
+  ].join('\n');
+}
+
 function createSummary(summaryOptions: SummaryOptions): string {
   return summaryOptions.executionMode === 'dry-run'
     ? createDryRunSummary(summaryOptions)
     : createWriteSummary(summaryOptions);
+}
+
+async function writeDryRunLogOutputSafely(
+  dependencies: Pick<ReleaseAppearanceCommandDependencies, 'writeFailure' | 'writeInformation'>,
+  summaryOptions: SummaryOptions,
+  githubToken: string,
+): Promise<Maybe<string>> {
+  if (summaryOptions.executionMode !== 'dry-run') {
+    return Maybe.nothing<string>();
+  }
+
+  try {
+    await dependencies.writeInformation(createDryRunLogOutput(summaryOptions));
+    return Maybe.nothing<string>();
+  } catch (error: unknown) {
+    const failureMessage = `Unable to write dry-run log output: ${redactSecret(errorMessage(error), githubToken)}`;
+    await writeFailureSafely(dependencies.writeFailure, failureMessage);
+    return Maybe.just(failureMessage);
+  }
 }
 
 async function finalizeSummary(
@@ -781,20 +851,21 @@ async function finalizeSummary(
   const {dependencies, summaryOptions, githubToken, exitCode} = finalizeSummaryOptions;
   const summary = createSummary(summaryOptions);
   const summaryWriteFailure = await writeSummarySafely(dependencies, summary, githubToken);
-  if (summaryWriteFailure.isNothing) {
-    return {exitCode, summary};
+  const dryRunLogOutputWriteFailure = await writeDryRunLogOutputSafely(dependencies, summaryOptions, githubToken);
+  if (summaryWriteFailure.isJust) {
+    return {
+      exitCode: 1,
+      summary: createSummary({
+        ...summaryOptions,
+        generalFailureMessages: [
+          ...summaryOptions.generalFailureMessages,
+          createGeneralFailureMessage('Summary', summaryWriteFailure.value, githubToken),
+        ],
+      }),
+    };
   }
 
-  return {
-    exitCode: 1,
-    summary: createSummary({
-      ...summaryOptions,
-      generalFailureMessages: [
-        ...summaryOptions.generalFailureMessages,
-        createGeneralFailureMessage('Summary', summaryWriteFailure.value, githubToken),
-      ],
-    }),
-  };
+  return {exitCode: dryRunLogOutputWriteFailure.isJust ? 1 : exitCode, summary};
 }
 
 async function planReleaseHistory(
@@ -827,13 +898,16 @@ export async function executeReleaseAppearanceCommand(
   const githubToken = Maybe.of(environment.GITHUB_TOKEN).unwrapOr('');
   const parsedCommandResult = parseCommandLineArguments(commandLineArguments);
   if (parsedCommandResult.isErr) {
-    await writeFailure(dependencies.writeOutput, parsedCommandResult.error.message);
+    await writeFailureSafely(dependencies.writeFailure, parsedCommandResult.error.message);
     return {exitCode: 1, summary: ''};
   }
 
   const commandEnvironmentResult = readCommandEnvironment(environment);
   if (commandEnvironmentResult.isErr) {
-    await writeFailure(dependencies.writeOutput, redactSecret(commandEnvironmentResult.error.message, githubToken));
+    await writeFailureSafely(
+      dependencies.writeFailure,
+      redactSecret(commandEnvironmentResult.error.message, githubToken),
+    );
     return {exitCode: 1, summary: ''};
   }
 
@@ -859,7 +933,7 @@ export async function executeReleaseAppearanceCommand(
       ...summaryOptions,
       generalFailureMessages: [historyFailureMessage],
     };
-    await writeFailure(dependencies.writeOutput, historyFailureMessage);
+    await writeFailureSafely(dependencies.writeFailure, historyFailureMessage);
   } else {
     summaryOptions = addPlanToSummary(summaryOptions, historyPlanResult.value);
     if (historyPlanResult.value.kind === 'bootstrap') {
@@ -884,7 +958,7 @@ export async function executeReleaseAppearanceCommand(
       return createGeneralFailureMessage('Discovery', failureMessage, githubToken);
     });
     for (const discoveryFailureMessage of discoveryFailureMessages) {
-      await writeFailure(dependencies.writeOutput, discoveryFailureMessage);
+      await writeFailureSafely(dependencies.writeFailure, discoveryFailureMessage);
     }
 
     const processingResult = await processPullRequests(
@@ -932,8 +1006,8 @@ export async function main(
     const commandResult = await executeReleaseAppearanceCommand(executeReleaseAppearanceCommandOptions);
     process.exitCode = commandResult.exitCode;
   } catch (error: unknown) {
-    await writeFailure(
-      executeReleaseAppearanceCommandOptions.dependencies.writeOutput,
+    await writeFailureSafely(
+      executeReleaseAppearanceCommandOptions.dependencies.writeFailure,
       redactSecret(errorMessage(error), githubToken),
     );
     process.exitCode = 1;
@@ -946,8 +1020,12 @@ async function executeGitCommand(commandArguments: readonly string[]): Promise<s
   return commandResult.stdout.toString();
 }
 
-async function writeRuntimeOutput(message: string): Promise<void> {
+async function writeRuntimeFailure(message: string): Promise<void> {
   process.stderr.write(`${message}\n`);
+}
+
+async function writeRuntimeInformation(message: string): Promise<void> {
+  process.stdout.write(`${message}\n`);
 }
 
 function createRuntimeDependencies(commandEnvironment: CommandEnvironment): ReleaseAppearanceCommandDependencies {
@@ -962,10 +1040,11 @@ function createRuntimeDependencies(commandEnvironment: CommandEnvironment): Rele
   return {
     executeGitCommand,
     githubClient,
+    writeFailure: writeRuntimeFailure,
+    writeInformation: writeRuntimeInformation,
     async writeSummary(summary): Promise<void> {
       await appendFile(commandEnvironment.githubStepSummary, `${summary}\n`, 'utf8');
     },
-    writeOutput: writeRuntimeOutput,
   };
 }
 
@@ -973,14 +1052,14 @@ async function startReleaseAppearanceCommand(): Promise<void> {
   const commandLineArguments = process.argv.slice(processArgumentStartIndex);
   const parsedCommandResult = parseCommandLineArguments(commandLineArguments);
   if (parsedCommandResult.isErr) {
-    await writeRuntimeOutput(parsedCommandResult.error.message);
+    await writeRuntimeFailure(parsedCommandResult.error.message);
     process.exitCode = 1;
     return;
   }
 
   const commandEnvironmentResult = readCommandEnvironment(process.env);
   if (commandEnvironmentResult.isErr) {
-    await writeRuntimeOutput(commandEnvironmentResult.error.message);
+    await writeRuntimeFailure(commandEnvironmentResult.error.message);
     process.exitCode = 1;
     return;
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Print the result of the release-appearance dry run to the normal GitHub Actions job log.

The dry-run command already writes a detailed Markdown report to the workflow run summary through `GITHUB_STEP_SUMMARY`. That report is not visible when opening the individual job log, which makes a successful bootstrap or empty result look as though the command produced no output.

The command now prints a concise plain-text result in addition to the existing Markdown summary.