### PR TITLE
Add next Beta change preview [WPB-26469]

### DIFF
--- a/.github/workflows/preview-next-beta-changes.yml
+++ b/.github/workflows/preview-next-beta-changes.yml
@@ -1,0 +1,68 @@
+---
+name: Preview next Beta changes
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  preview_next_beta_changes:
+    name: Preview next Beta changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check out selected main commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Validate workflow ref
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${WORKFLOW_REF}" != 'refs/heads/main' ]]; then
+            echo 'The preview must be started with "Use workflow from: main".' >&2
+            exit 1
+          fi
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Fetch tags
+        run: git fetch --tags origin
+
+      - name: Preview next Beta changes
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TARGET_MAIN_COMMIT: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          node \
+            tools/release-appearance/previewNextBetaCommand.ts \
+            "${TARGET_MAIN_COMMIT}"
+
+      - name: Confirm read-only permissions
+        if: ${{ always() }}
+        run: |
+          {
+            echo ''
+            echo 'The workflow token had read-only repository and pull request permissions. No GitHub state was modified.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/tools/release-appearance/previewNextBetaCommand.test.ts
+++ b/tools/release-appearance/previewNextBetaCommand.test.ts
@@ -1,0 +1,478 @@
+import assert from 'node:assert';
+
+import is from '@sindresorhus/is';
+import {Maybe, Result, task} from 'true-myth';
+import type {Task} from 'true-myth';
+
+import {executePreviewNextBetaCommand, parseCommandLineArguments} from './previewNextBetaCommand.ts';
+import type {
+  ExecutePreviewNextBetaCommandOptions,
+  PreviewNextBetaCommandDependencies,
+} from './previewNextBetaCommand.ts';
+import type {GitHubClient, IssueCommentRecord, PullRequestRecord} from './githubClient.ts';
+import type {
+  ExecuteGitCommand,
+  NextBetaPreviewHistoryPlan,
+  PlanNextBetaPreviewHistoryOptions,
+} from './releaseHistory.ts';
+
+const targetMainCommit = 'a'.repeat(40);
+const latestBetaCommit = 'b'.repeat(40);
+const mergeBaseCommit = 'c'.repeat(40);
+const firstMainCommit = 'd'.repeat(40);
+const secondMainCommit = 'e'.repeat(40);
+const thirdMainCommit = 'f'.repeat(40);
+const latestBetaTag = '2026-07-27.1-beta.1';
+const githubToken = 'github-token';
+
+const commandEnvironment: NodeJS.ProcessEnv = {
+  GITHUB_API_URL: 'https://api.github.com',
+  GITHUB_REPOSITORY: 'wireapp/wire-webapp',
+  GITHUB_STEP_SUMMARY: '/tmp/preview-next-beta-summary.md',
+  GITHUB_TOKEN: githubToken,
+};
+
+type FakeGitHubClientOptions = {
+  readonly pullRequestsByCommit?: ReadonlyMap<string, readonly PullRequestRecord[]>;
+  readonly failureMessageByCommit?: ReadonlyMap<string, string>;
+  readonly rejectedMessageByCommit?: ReadonlyMap<string, string>;
+};
+
+type FakeGitHubClientState = {
+  readonly listedCommits: string[];
+};
+
+type FakeGitHubClientFixture = {
+  readonly githubClient: GitHubClient;
+  readonly state: FakeGitHubClientState;
+};
+
+type FakeHistoryPlannerState = {
+  calls: number;
+  readonly targetMainCommits: string[];
+};
+
+type FakeHistoryPlannerFixture = {
+  readonly planNextBetaPreviewHistory: (
+    options: PlanNextBetaPreviewHistoryOptions,
+  ) => Task<NextBetaPreviewHistoryPlan, Error>;
+  readonly state: FakeHistoryPlannerState;
+};
+
+type CommandWriterState = {
+  readonly failureMessages: string[];
+  readonly informationMessages: string[];
+  readonly summaryMessages: string[];
+};
+
+type CommandRun = {
+  readonly result: Awaited<ReturnType<typeof executePreviewNextBetaCommand>>;
+  readonly historyPlannerState: FakeHistoryPlannerState;
+  readonly writerState: CommandWriterState;
+};
+
+type CreatePullRequestOptions = {
+  readonly number: number;
+  readonly baseBranch?: string;
+  readonly merged?: boolean;
+};
+
+type RunCommandOptions = {
+  readonly commandLineArguments: readonly string[];
+  readonly executeGitCommand: ExecuteGitCommand;
+  readonly githubClient: GitHubClient;
+  readonly historyPlanResult?: Result<NextBetaPreviewHistoryPlan, Error>;
+  readonly informationFailureMessage?: string;
+  readonly summaryFailureMessage?: string;
+};
+
+const previewHistoryPlan: NextBetaPreviewHistoryPlan = {
+  kind: 'preview',
+  latestBetaReleaseTag: {
+    tagName: latestBetaTag,
+    commit: latestBetaCommit,
+    taggerTimestamp: 1785171600n,
+  },
+  targetMainCommit,
+  mergeBase: mergeBaseCommit,
+  commits: [firstMainCommit, secondMainCommit, thirdMainCommit],
+};
+
+function createPullRequest(createPullRequestOptions: CreatePullRequestOptions): PullRequestRecord {
+  const {number, baseBranch = 'main', merged = true} = createPullRequestOptions;
+
+  return {
+    number,
+    baseBranch,
+    mergedAt: merged ? Maybe.just('2026-07-28T00:00:00Z') : Maybe.nothing<string>(),
+  };
+}
+
+function createFakeGitCommand(): ExecuteGitCommand {
+  return async function executeFakeGitCommand(): Promise<string> {
+    return '';
+  };
+}
+
+function createFakeGitHubClient(fakeGitHubClientOptions: FakeGitHubClientOptions = {}): FakeGitHubClientFixture {
+  const state: FakeGitHubClientState = {
+    listedCommits: [],
+  };
+
+  return {
+    state,
+    githubClient: {
+      async listPullRequestsForCommit(options): Promise<Result<readonly PullRequestRecord[], Error>> {
+        state.listedCommits.push(options.commitSha);
+        const rejectedMessage = Maybe.of(fakeGitHubClientOptions.rejectedMessageByCommit?.get(options.commitSha));
+        if (rejectedMessage.isJust) {
+          throw new Error(rejectedMessage.value);
+        }
+
+        const failureMessage = Maybe.of(fakeGitHubClientOptions.failureMessageByCommit?.get(options.commitSha));
+        if (failureMessage.isJust) {
+          return Result.err(new Error(failureMessage.value));
+        }
+
+        return Result.ok(fakeGitHubClientOptions.pullRequestsByCommit?.get(options.commitSha) ?? []);
+      },
+      async listIssueComments(): Promise<Result<readonly IssueCommentRecord[], Error>> {
+        throw new Error('Preview attempted to list issue comments');
+      },
+      async createIssueComment(): Promise<Result<IssueCommentRecord, Error>> {
+        throw new Error('Preview attempted to create an issue comment');
+      },
+      async updateIssueComment(): Promise<Result<IssueCommentRecord, Error>> {
+        throw new Error('Preview attempted to update an issue comment');
+      },
+    },
+  };
+}
+
+function createFakeHistoryPlanner(
+  historyPlanResult: Result<NextBetaPreviewHistoryPlan, Error>,
+): FakeHistoryPlannerFixture {
+  const state: FakeHistoryPlannerState = {
+    calls: 0,
+    targetMainCommits: [],
+  };
+
+  function planNextBetaPreviewHistory(
+    options: PlanNextBetaPreviewHistoryOptions,
+  ): Task<NextBetaPreviewHistoryPlan, Error> {
+    state.calls += 1;
+    state.targetMainCommits.push(options.targetMainCommit);
+
+    return task.tryOrElse(
+      (error: unknown): Error => {
+        return is.error(error) ? error : new Error('Fake history planner failed');
+      },
+      async (): Promise<NextBetaPreviewHistoryPlan> => {
+        if (historyPlanResult.isErr) {
+          throw historyPlanResult.error;
+        }
+
+        return historyPlanResult.value;
+      },
+    );
+  }
+
+  return {planNextBetaPreviewHistory, state};
+}
+
+async function runCommand(runCommandOptions: RunCommandOptions): Promise<CommandRun> {
+  const {
+    commandLineArguments,
+    executeGitCommand,
+    githubClient,
+    historyPlanResult = Result.ok(previewHistoryPlan),
+    informationFailureMessage,
+    summaryFailureMessage,
+  } = runCommandOptions;
+  const historyPlannerFixture = createFakeHistoryPlanner(historyPlanResult);
+  const writerState: CommandWriterState = {
+    failureMessages: [],
+    informationMessages: [],
+    summaryMessages: [],
+  };
+  const dependencies: PreviewNextBetaCommandDependencies = {
+    executeGitCommand,
+    githubClient,
+    planNextBetaPreviewHistory: historyPlannerFixture.planNextBetaPreviewHistory,
+    async writeFailure(message): Promise<void> {
+      writerState.failureMessages.push(message);
+    },
+    async writeInformation(message): Promise<void> {
+      writerState.informationMessages.push(message);
+      if (Maybe.of(informationFailureMessage).isJust) {
+        throw new Error(informationFailureMessage);
+      }
+    },
+    async writeSummary(summary): Promise<void> {
+      writerState.summaryMessages.push(summary);
+      if (Maybe.of(summaryFailureMessage).isJust) {
+        throw new Error(summaryFailureMessage);
+      }
+    },
+  };
+  const options: ExecutePreviewNextBetaCommandOptions = {
+    commandLineArguments,
+    environment: commandEnvironment,
+    dependencies,
+  };
+  const result = await executePreviewNextBetaCommand(options);
+
+  return {result, historyPlannerState: historyPlannerFixture.state, writerState};
+}
+
+describe('parseCommandLineArguments', () => {
+  test('accepts exactly one full target commit argument', () => {
+    const actualResult = parseCommandLineArguments([targetMainCommit]);
+    const abbreviatedResult = parseCommandLineArguments(['abcdef0']);
+    const missingResult = parseCommandLineArguments([]);
+    const additionalResult = parseCommandLineArguments([targetMainCommit, targetMainCommit]);
+    const flagResult = parseCommandLineArguments(['--target-main-commit']);
+    const malformedResult = parseCommandLineArguments(['g'.repeat(40)]);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toBe(targetMainCommit);
+    expect(abbreviatedResult.isErr).toBe(true);
+    expect(missingResult.isErr).toBe(true);
+    expect(additionalResult.isErr).toBe(true);
+    expect(flagResult.isErr).toBe(true);
+    expect(malformedResult.isErr).toBe(true);
+  });
+});
+
+describe('executePreviewNextBetaCommand', () => {
+  test('delegates history planning with the exact target commit', async () => {
+    const githubClientFixture = createFakeGitHubClient();
+
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+    });
+
+    expect(commandRun.historyPlannerState.calls).toBe(1);
+    expect(commandRun.historyPlannerState.targetMainCommits).toEqual([targetMainCommit]);
+    expect(githubClientFixture.state.listedCommits).toEqual([firstMainCommit, secondMainCommit, thirdMainCommit]);
+  });
+
+  test('does not discover pull requests when history is unavailable', async () => {
+    const githubClientFixture = createFakeGitHubClient();
+    const unavailableHistory: NextBetaPreviewHistoryPlan = {
+      kind: 'unavailable',
+      targetMainCommit,
+    };
+
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+      historyPlanResult: Result.ok(unavailableHistory),
+    });
+
+    expect(commandRun.result.exitCode).toBe(0);
+    expect(githubClientFixture.state.listedCommits).toEqual([]);
+    expect(commandRun.result.summary).toContain(
+      'The preview is unavailable because no new-format Beta tag exists yet.',
+    );
+  });
+
+  test('does not discover pull requests when history planning fails', async () => {
+    const githubClientFixture = createFakeGitHubClient();
+
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+      historyPlanResult: Result.err(new Error(`GitHub token ${githubToken} history failure`)),
+    });
+
+    expect(commandRun.result.exitCode).toBe(1);
+    expect(githubClientFixture.state.listedCommits).toEqual([]);
+    expect(commandRun.result.summary).not.toContain(githubToken);
+    expect(commandRun.result.summary).toContain('[REDACTED]');
+  });
+
+  test('discovers merged main pull requests, ignores release branches, deduplicates, and records gaps', async () => {
+    const githubClientFixture = createFakeGitHubClient({
+      pullRequestsByCommit: new Map([
+        [
+          firstMainCommit,
+          [
+            createPullRequest({number: 22052}),
+            createPullRequest({number: 22040, baseBranch: 'release/2026-07-27'}),
+            createPullRequest({number: 22041, merged: false}),
+          ],
+        ],
+        [secondMainCommit, [createPullRequest({number: 22052})]],
+        [thirdMainCommit, [createPullRequest({number: 22051, baseBranch: 'release/2026-07-27'})]],
+      ]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+    });
+
+    expect(commandRun.result.exitCode).toBe(0);
+    expect(githubClientFixture.state.listedCommits).toEqual([firstMainCommit, secondMainCommit, thirdMainCommit]);
+    expect(commandRun.result.summary).toContain(`Latest Beta tag: \`${latestBetaTag}\``);
+    expect(commandRun.result.summary).toContain(`Latest Beta commit: \`${latestBetaCommit}\``);
+    expect(commandRun.result.summary).toContain(`Current main commit: \`${targetMainCommit}\``);
+    expect(commandRun.result.summary).toContain(`Merge base: \`${mergeBaseCommit}\``);
+    expect(commandRun.result.summary).toContain('Merged pull requests waiting for Beta: 1');
+    expect(commandRun.result.summary).toContain('[#22052](https://github.com/wireapp/wire-webapp/pull/22052)');
+    expect(commandRun.result.summary).toContain(`- \`${thirdMainCommit}\``);
+    expect(commandRun.result.summary).toContain('This is an advisory preview. These changes are on main');
+    expect(commandRun.writerState.informationMessages[0]).toContain('Merged pull requests waiting for Beta: 1');
+  });
+
+  test('continues after a discovery failure, returns non-zero, and sanitizes the failure', async () => {
+    const failedCommit = firstMainCommit;
+    const githubClientFixture = createFakeGitHubClient({
+      failureMessageByCommit: new Map([[failedCommit, `GitHub token ${githubToken} leaked`]]),
+      pullRequestsByCommit: new Map([[secondMainCommit, [createPullRequest({number: 22050})]]]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+      historyPlanResult: Result.ok({
+        ...previewHistoryPlan,
+        commits: [failedCommit, secondMainCommit],
+      }),
+    });
+
+    expect(commandRun.result.exitCode).toBe(1);
+    expect(githubClientFixture.state.listedCommits).toEqual([failedCommit, secondMainCommit]);
+    expect(commandRun.result.summary).not.toContain(githubToken);
+    expect(commandRun.result.summary).toContain('[REDACTED]');
+    expect(commandRun.result.summary).not.toContain('stack trace');
+    expect(commandRun.result.summary).toContain('#22050');
+  });
+
+  test('continues after a rejected GitHub discovery request', async () => {
+    const failedCommit = firstMainCommit;
+    const githubClientFixture = createFakeGitHubClient({
+      rejectedMessageByCommit: new Map([[failedCommit, `token ${githubToken} rejected`]]),
+      pullRequestsByCommit: new Map([[secondMainCommit, [createPullRequest({number: 22050})]]]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+      historyPlanResult: Result.ok({
+        ...previewHistoryPlan,
+        commits: [failedCommit, secondMainCommit],
+      }),
+    });
+
+    expect(commandRun.result.exitCode).toBe(1);
+    expect(githubClientFixture.state.listedCommits).toEqual([failedCommit, secondMainCommit]);
+    expect(commandRun.result.summary).not.toContain(githubToken);
+    expect(commandRun.result.summary).toContain('[REDACTED]');
+    expect(commandRun.result.summary).toContain('#22050');
+  });
+
+  test('returns success with a clear no-change result without GitHub requests', async () => {
+    const githubClientFixture = createFakeGitHubClient();
+
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+      historyPlanResult: Result.ok({...previewHistoryPlan, commits: []}),
+    });
+
+    expect(commandRun.result.exitCode).toBe(0);
+    expect(githubClientFixture.state.listedCommits).toEqual([]);
+    expect(commandRun.result.summary).toContain('Commits not present in Beta: 0');
+    expect(commandRun.result.summary).toContain('No merged pull requests are currently waiting for the next Beta.');
+    expect(commandRun.writerState.informationMessages[0]).toContain('Commits not present in Beta: 0');
+  });
+
+  test('reports sanitized informational-output failure without repeating processing', async () => {
+    const githubClientFixture = createFakeGitHubClient({
+      pullRequestsByCommit: new Map([[firstMainCommit, [createPullRequest({number: 22050})]]]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+      informationFailureMessage: `token ${githubToken} in information writer`,
+    });
+
+    expect(commandRun.result.exitCode).toBe(1);
+    expect(commandRun.historyPlannerState.calls).toBe(1);
+    expect(githubClientFixture.state.listedCommits).toEqual([firstMainCommit, secondMainCommit, thirdMainCommit]);
+    expect(commandRun.writerState.summaryMessages).toHaveLength(1);
+    expect(commandRun.writerState.informationMessages).toHaveLength(1);
+    expect(commandRun.writerState.failureMessages).toHaveLength(1);
+    expect(commandRun.writerState.failureMessages[0]).not.toContain(githubToken);
+    expect(commandRun.writerState.failureMessages[0]).toContain('[REDACTED]');
+    expect(commandRun.result.summary).toContain('#22050');
+  });
+
+  test('reports sanitized summary-output failure without repeating processing', async () => {
+    const githubClientFixture = createFakeGitHubClient();
+
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+      summaryFailureMessage: `token ${githubToken} in summary writer`,
+    });
+
+    expect(commandRun.result.exitCode).toBe(1);
+    expect(commandRun.historyPlannerState.calls).toBe(1);
+    expect(githubClientFixture.state.listedCommits).toEqual([firstMainCommit, secondMainCommit, thirdMainCommit]);
+    expect(commandRun.writerState.summaryMessages).toHaveLength(1);
+    expect(commandRun.writerState.informationMessages).toHaveLength(1);
+    expect(commandRun.writerState.failureMessages).toHaveLength(1);
+    expect(commandRun.writerState.failureMessages[0]).not.toContain(githubToken);
+    expect(commandRun.writerState.failureMessages[0]).toContain('[REDACTED]');
+    expect(commandRun.result.summary).toContain('Unable to write GitHub Actions summary');
+  });
+
+  test('reports both writer failures once and keeps secrets redacted', async () => {
+    const githubClientFixture = createFakeGitHubClient();
+
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+      informationFailureMessage: `token ${githubToken} in information writer`,
+      summaryFailureMessage: `token ${githubToken} in summary writer`,
+    });
+
+    expect(commandRun.result.exitCode).toBe(1);
+    expect(commandRun.historyPlannerState.calls).toBe(1);
+    expect(githubClientFixture.state.listedCommits).toEqual([firstMainCommit, secondMainCommit, thirdMainCommit]);
+    expect(commandRun.writerState.summaryMessages).toHaveLength(1);
+    expect(commandRun.writerState.informationMessages).toHaveLength(1);
+    expect(commandRun.writerState.failureMessages).toHaveLength(2);
+    expect(commandRun.writerState.failureMessages.join('\n')).not.toContain(githubToken);
+    expect(commandRun.result.summary).not.toContain(githubToken);
+  });
+
+  test('returns non-zero when the history planner fails', async () => {
+    const githubClientFixture = createFakeGitHubClient();
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+      historyPlanResult: Result.err(new Error('target commit does not exist')),
+    });
+
+    expect(commandRun.result.exitCode).toBe(1);
+    expect(commandRun.result.summary).toContain('Git history: target commit does not exist');
+    expect(githubClientFixture.state.listedCommits).toEqual([]);
+  });
+});

--- a/tools/release-appearance/previewNextBetaCommand.ts
+++ b/tools/release-appearance/previewNextBetaCommand.ts
@@ -1,0 +1,554 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import is from '@sindresorhus/is';
+import {Maybe, Result} from 'true-myth';
+import type {Task} from 'true-myth';
+
+import {execFile} from 'node:child_process';
+import {appendFile} from 'node:fs/promises';
+import {promisify} from 'node:util';
+
+import {createGitHubClient} from './githubClient.ts';
+import type {GitHubClient, PullRequestRecord} from './githubClient.ts';
+import {createRuntimeKyHttpClient} from './httpClient.ts';
+import {readCommandEnvironment} from './releaseAppearanceCommand.ts';
+import type {CommandEnvironment} from './releaseAppearanceCommand.ts';
+import {planNextBetaPreviewHistory} from './releaseHistory.ts';
+import type {
+  BetaReleaseTagReference,
+  ExecuteGitCommand,
+  NextBetaPreviewHistoryPlan,
+  PlanNextBetaPreviewHistoryOptions,
+} from './releaseHistory.ts';
+
+export type PreviewNextBetaCommandDependencies = {
+  readonly executeGitCommand: ExecuteGitCommand;
+  readonly githubClient: GitHubClient;
+  readonly planNextBetaPreviewHistory: (
+    options: PlanNextBetaPreviewHistoryOptions,
+  ) => Task<NextBetaPreviewHistoryPlan, Error>;
+  readonly writeFailure: (message: string) => Promise<void>;
+  readonly writeInformation: (message: string) => Promise<void>;
+  readonly writeSummary: (summary: string) => Promise<void>;
+};
+
+export type ExecutePreviewNextBetaCommandOptions = {
+  readonly commandLineArguments: readonly string[];
+  readonly environment: NodeJS.ProcessEnv;
+  readonly dependencies: PreviewNextBetaCommandDependencies;
+};
+
+export type PreviewNextBetaCommandResult = {
+  readonly exitCode: number;
+  readonly summary: string;
+};
+
+type PreviewNextBetaState = {
+  readonly latestBetaReleaseTag: Maybe<BetaReleaseTagReference>;
+  readonly targetMainCommit: string;
+  readonly mergeBase: Maybe<string>;
+  readonly commitsInspected: readonly string[];
+  readonly pullRequestNumbers: readonly number[];
+  readonly commitsWithoutMergedMainPullRequest: readonly string[];
+  readonly failureMessages: readonly string[];
+};
+
+type DiscoverPullRequestsOptions = {
+  readonly commits: readonly string[];
+  readonly githubClient: GitHubClient;
+  readonly githubToken: string;
+};
+
+type DiscoverPullRequestsResult = {
+  readonly pullRequestNumbers: readonly number[];
+  readonly commitsWithoutMergedMainPullRequest: readonly string[];
+  readonly failureMessages: readonly string[];
+};
+
+type CreatePreviewStateOptions = {
+  readonly targetMainCommit: string;
+  readonly executeGitCommand: ExecuteGitCommand;
+  readonly planNextBetaPreviewHistory: (
+    options: PlanNextBetaPreviewHistoryOptions,
+  ) => Task<NextBetaPreviewHistoryPlan, Error>;
+  readonly githubClient: GitHubClient;
+  readonly githubToken: string;
+};
+
+type CreateReportOptions = {
+  readonly state: PreviewNextBetaState;
+  readonly githubRepository: string;
+  readonly markdown: boolean;
+};
+
+type WriteInformationSafelyOptions = {
+  readonly writeFailure: (message: string) => Promise<void>;
+  readonly writeInformation: (message: string) => Promise<void>;
+  readonly information: string;
+  readonly githubToken: string;
+};
+
+type WriteSummarySafelyOptions = {
+  readonly writeFailure: (message: string) => Promise<void>;
+  readonly writeSummary: (summary: string) => Promise<void>;
+  readonly summary: string;
+  readonly githubToken: string;
+};
+
+const processArgumentStartIndex = 2;
+const fullGitCommitPattern = /^[0-9a-f]{40}$/i;
+const executeFile = promisify(execFile);
+const advisoryMessage =
+  'This is an advisory preview. These changes are on main but have not been deployed or verified in Beta.';
+
+function redactSecret(message: string, secret: string): string {
+  if (is.emptyString(secret)) {
+    return message;
+  }
+
+  return message.replaceAll(secret, '[REDACTED]');
+}
+
+async function writeFailureSafely(writeFailure: (message: string) => Promise<void>, message: string): Promise<void> {
+  try {
+    await writeFailure(message);
+  } catch {
+    // Failure reporting must not turn an operational failure into an unhandled rejection.
+  }
+}
+
+async function writeInformationSafely(
+  writeInformationSafelyOptions: WriteInformationSafelyOptions,
+): Promise<Maybe<string>> {
+  const {writeFailure, writeInformation, information, githubToken} = writeInformationSafelyOptions;
+  try {
+    await writeInformation(information);
+
+    return Maybe.nothing<string>();
+  } catch (error: unknown) {
+    const failureMessage = `Unable to write informational output: ${redactSecret(
+      is.error(error) ? error.message : 'Unknown failure',
+      githubToken,
+    )}`;
+    await writeFailureSafely(writeFailure, failureMessage);
+
+    return Maybe.just(failureMessage);
+  }
+}
+
+async function writeSummarySafely(writeSummarySafelyOptions: WriteSummarySafelyOptions): Promise<Maybe<string>> {
+  const {writeFailure, writeSummary, summary, githubToken} = writeSummarySafelyOptions;
+  try {
+    await writeSummary(summary);
+
+    return Maybe.nothing<string>();
+  } catch (error: unknown) {
+    const failureMessage = `Unable to write GitHub Actions summary: ${redactSecret(
+      is.error(error) ? error.message : 'Unknown failure',
+      githubToken,
+    )}`;
+    await writeFailureSafely(writeFailure, failureMessage);
+
+    return Maybe.just(failureMessage);
+  }
+}
+
+export function parseCommandLineArguments(commandLineArguments: readonly string[]): Result<string, Error> {
+  if (commandLineArguments.length !== 1) {
+    return Result.err(
+      new Error('Usage: node tools/release-appearance/previewNextBetaCommand.ts <target-main-commit-sha>'),
+    );
+  }
+
+  const targetMainCommit = Maybe.of(commandLineArguments[0]);
+  if (targetMainCommit.isNothing || !fullGitCommitPattern.test(targetMainCommit.value)) {
+    return Result.err(new Error('Target main commit SHA must contain exactly 40 hexadecimal characters'));
+  }
+
+  return Result.ok(targetMainCommit.value);
+}
+
+async function discoverPullRequests(
+  discoverPullRequestsOptions: DiscoverPullRequestsOptions,
+): Promise<DiscoverPullRequestsResult> {
+  const {commits, githubClient, githubToken} = discoverPullRequestsOptions;
+  const pullRequestNumbersByNumber = new Set<number>();
+  const commitsWithoutMergedMainPullRequest: string[] = [];
+  const failureMessages: string[] = [];
+
+  for (const commitSha of commits) {
+    let pullRequestsResult: Result<readonly PullRequestRecord[], Error>;
+    try {
+      pullRequestsResult = await githubClient.listPullRequestsForCommit({commitSha});
+    } catch (error: unknown) {
+      failureMessages.push(
+        redactSecret(is.error(error) ? error.message : 'Unknown GitHub pull request discovery failure', githubToken),
+      );
+
+      continue;
+    }
+
+    if (pullRequestsResult.isErr) {
+      failureMessages.push(redactSecret(pullRequestsResult.error.message, githubToken));
+      continue;
+    }
+
+    const mergedMainPullRequests = pullRequestsResult.value.filter(pullRequest => {
+      return pullRequest.baseBranch === 'main' && pullRequest.mergedAt.isJust;
+    });
+    if (is.emptyArray(mergedMainPullRequests)) {
+      commitsWithoutMergedMainPullRequest.push(commitSha);
+      continue;
+    }
+
+    for (const pullRequest of mergedMainPullRequests) {
+      pullRequestNumbersByNumber.add(pullRequest.number);
+    }
+  }
+
+  return {
+    pullRequestNumbers: [...pullRequestNumbersByNumber].toSorted((leftNumber, rightNumber) => {
+      return leftNumber - rightNumber;
+    }),
+    commitsWithoutMergedMainPullRequest,
+    failureMessages,
+  };
+}
+
+function createUnavailableState(
+  targetMainCommit: string,
+  failureMessages: readonly string[] = [],
+): PreviewNextBetaState {
+  return {
+    latestBetaReleaseTag: Maybe.nothing<BetaReleaseTagReference>(),
+    targetMainCommit,
+    mergeBase: Maybe.nothing<string>(),
+    commitsInspected: [],
+    pullRequestNumbers: [],
+    commitsWithoutMergedMainPullRequest: [],
+    failureMessages,
+  };
+}
+
+async function createPreviewState(createPreviewStateOptions: CreatePreviewStateOptions): Promise<PreviewNextBetaState> {
+  const {targetMainCommit, executeGitCommand, planNextBetaPreviewHistory, githubClient, githubToken} =
+    createPreviewStateOptions;
+  const historyPlanResult = await planNextBetaPreviewHistory({executeGitCommand, targetMainCommit});
+  if (historyPlanResult.isErr) {
+    return createUnavailableState(targetMainCommit, [
+      redactSecret(`Git history: ${historyPlanResult.error.message}`, githubToken),
+    ]);
+  }
+
+  if (historyPlanResult.value.kind === 'unavailable') {
+    return createUnavailableState(historyPlanResult.value.targetMainCommit);
+  }
+
+  const {
+    latestBetaReleaseTag,
+    targetMainCommit: resolvedTargetMainCommit,
+    mergeBase,
+    commits,
+  } = historyPlanResult.value;
+
+  const discoveryResult = await discoverPullRequests({
+    commits,
+    githubClient,
+    githubToken,
+  });
+
+  return {
+    latestBetaReleaseTag: Maybe.just(latestBetaReleaseTag),
+    targetMainCommit: resolvedTargetMainCommit,
+    mergeBase: Maybe.just(mergeBase),
+    commitsInspected: commits,
+    pullRequestNumbers: discoveryResult.pullRequestNumbers,
+    commitsWithoutMergedMainPullRequest: discoveryResult.commitsWithoutMergedMainPullRequest,
+    failureMessages: discoveryResult.failureMessages,
+  };
+}
+
+function formatCommitLines(state: PreviewNextBetaState): readonly string[] {
+  if (state.mergeBase.isNothing) {
+    return ['Not inspected.'];
+  }
+
+  return is.emptyArray(state.commitsWithoutMergedMainPullRequest)
+    ? ['None']
+    : state.commitsWithoutMergedMainPullRequest.map(commitSha => {
+        return `- \`${commitSha}\``;
+      });
+}
+
+function formatPullRequestLines(state: PreviewNextBetaState, githubRepository: string): readonly string[] {
+  if (state.mergeBase.isNothing) {
+    return ['Not inspected.'];
+  }
+
+  return is.emptyArray(state.pullRequestNumbers)
+    ? ['No merged pull requests are currently waiting for the next Beta.']
+    : state.pullRequestNumbers.map(pullRequestNumber => {
+        return `- [#${pullRequestNumber}](https://github.com/${githubRepository}/pull/${pullRequestNumber})`;
+      });
+}
+
+function formatDetailValue(value: string, markdown: boolean): string {
+  return markdown ? `\`${value}\`` : value;
+}
+
+function createDetailLines(state: PreviewNextBetaState, markdown: boolean): readonly string[] {
+  const linePrefix = markdown ? '- ' : '';
+  const latestBetaValues = state.latestBetaReleaseTag
+    .map(value => {
+      return [formatDetailValue(value.tagName, markdown), formatDetailValue(value.commit, markdown)];
+    })
+    .unwrapOr(['unavailable', 'unavailable']);
+  const targetMainCommitValue = formatDetailValue(state.targetMainCommit, markdown);
+  const mergeBaseValue = state.mergeBase
+    .map(value => {
+      return formatDetailValue(value, markdown);
+    })
+    .unwrapOr('unavailable');
+  const inspectionValues = state.mergeBase.isJust
+    ? {
+        commitsInspected: state.commitsInspected.length.toString(),
+        pullRequests: state.pullRequestNumbers.length.toString(),
+        commitsWithoutPullRequests: state.commitsWithoutMergedMainPullRequest.length.toString(),
+      }
+    : {
+        commitsInspected: 'not inspected',
+        pullRequests: 'not inspected',
+        commitsWithoutPullRequests: 'not inspected',
+      };
+
+  return [
+    `${linePrefix}Latest Beta tag: ${latestBetaValues[0]}`,
+    `${linePrefix}Latest Beta commit: ${latestBetaValues[1]}`,
+    `${linePrefix}Current main commit: ${targetMainCommitValue}`,
+    `${linePrefix}Merge base: ${mergeBaseValue}`,
+    `${linePrefix}Commits not present in Beta: ${inspectionValues.commitsInspected}`,
+    `${linePrefix}Merged pull requests waiting for Beta: ${inspectionValues.pullRequests}`,
+    `${linePrefix}Commits without a merged main pull request: ${inspectionValues.commitsWithoutPullRequests}`,
+  ];
+}
+
+function createReport(createReportOptions: CreateReportOptions): string {
+  const {state, githubRepository, markdown} = createReportOptions;
+  let unavailableMessage = '';
+  if (state.latestBetaReleaseTag.isNothing) {
+    unavailableMessage = 'The preview is unavailable because the latest Beta history could not be evaluated.';
+    if (is.emptyArray(state.failureMessages)) {
+      unavailableMessage = 'The preview is unavailable because no new-format Beta tag exists yet.';
+    }
+  }
+  const failureLines = state.failureMessages.map(failureMessage => {
+    return `- ${failureMessage}`;
+  });
+  const markdownFailureLines = is.emptyArray(failureLines) ? ['None'] : failureLines;
+  const markdownLines = [
+    '### Preview next Beta changes',
+    '',
+    ...createDetailLines(state, true),
+    ...(is.emptyString(unavailableMessage) ? [] : ['', unavailableMessage]),
+    '',
+    '### Pull requests waiting for Beta',
+    '',
+    ...formatPullRequestLines(state, githubRepository),
+    '',
+    '### Commits without a merged main pull request',
+    '',
+    ...formatCommitLines(state),
+    '',
+    '### Failures',
+    '',
+    ...markdownFailureLines,
+    '',
+    advisoryMessage,
+  ];
+  if (markdown) {
+    return markdownLines.join('\n');
+  }
+
+  return [
+    'Preview next Beta changes',
+    ...createDetailLines(state, false),
+    ...(is.emptyString(unavailableMessage) ? [] : ['', unavailableMessage]),
+    ...(state.mergeBase.isJust && is.emptyArray(state.pullRequestNumbers)
+      ? ['No merged pull requests are currently waiting for the next Beta.']
+      : []),
+    ...(is.emptyArray(failureLines) ? [] : ['Failures:', ...failureLines]),
+    advisoryMessage,
+  ].join('\n');
+}
+
+export async function executePreviewNextBetaCommand(
+  executePreviewNextBetaCommandOptions: ExecutePreviewNextBetaCommandOptions,
+): Promise<PreviewNextBetaCommandResult> {
+  const {commandLineArguments, environment, dependencies} = executePreviewNextBetaCommandOptions;
+  const githubToken = Maybe.of(environment.GITHUB_TOKEN).unwrapOr('');
+  const parsedCommandResult = parseCommandLineArguments(commandLineArguments);
+  if (parsedCommandResult.isErr) {
+    await writeFailureSafely(dependencies.writeFailure, parsedCommandResult.error.message);
+
+    return {exitCode: 1, summary: ''};
+  }
+
+  const commandEnvironmentResult = readCommandEnvironment(environment);
+  if (commandEnvironmentResult.isErr) {
+    await writeFailureSafely(
+      dependencies.writeFailure,
+      redactSecret(commandEnvironmentResult.error.message, githubToken),
+    );
+
+    return {exitCode: 1, summary: ''};
+  }
+
+  const targetMainCommit = parsedCommandResult.value;
+  let previewState: PreviewNextBetaState;
+  try {
+    previewState = await createPreviewState({
+      targetMainCommit,
+      executeGitCommand: dependencies.executeGitCommand,
+      planNextBetaPreviewHistory: dependencies.planNextBetaPreviewHistory,
+      githubClient: dependencies.githubClient,
+      githubToken: commandEnvironmentResult.value.githubToken,
+    });
+  } catch (error: unknown) {
+    previewState = createUnavailableState(targetMainCommit, [
+      redactSecret(
+        `Preview failed: ${is.error(error) ? error.message : 'Unknown failure'}`,
+        commandEnvironmentResult.value.githubToken,
+      ),
+    ]);
+  }
+
+  let summary = createReport({
+    state: previewState,
+    githubRepository: commandEnvironmentResult.value.githubRepository,
+    markdown: true,
+  });
+  let exitCode = is.emptyArray(previewState.failureMessages) ? 0 : 1;
+  const summaryFailureResult = await writeSummarySafely({
+    writeFailure: dependencies.writeFailure,
+    writeSummary: dependencies.writeSummary,
+    summary,
+    githubToken: commandEnvironmentResult.value.githubToken,
+  });
+  if (summaryFailureResult.isJust) {
+    previewState = {
+      ...previewState,
+      failureMessages: [...previewState.failureMessages, summaryFailureResult.value],
+    };
+    summary = createReport({
+      state: previewState,
+      githubRepository: commandEnvironmentResult.value.githubRepository,
+      markdown: true,
+    });
+    exitCode = 1;
+  }
+
+  const informationFailureResult = await writeInformationSafely({
+    writeFailure: dependencies.writeFailure,
+    writeInformation: dependencies.writeInformation,
+    information: createReport({
+      state: previewState,
+      githubRepository: commandEnvironmentResult.value.githubRepository,
+      markdown: false,
+    }),
+    githubToken: commandEnvironmentResult.value.githubToken,
+  });
+  if (informationFailureResult.isJust) {
+    exitCode = 1;
+  }
+
+  return {exitCode, summary};
+}
+
+async function executeRuntimeGitCommand(commandArguments: readonly string[]): Promise<string> {
+  const commandResult = await executeFile('git', commandArguments, {encoding: 'utf8'});
+
+  return commandResult.stdout.toString();
+}
+
+async function writeRuntimeFailure(message: string): Promise<void> {
+  process.stderr.write(`${message}\n`);
+}
+
+async function writeRuntimeInformation(message: string): Promise<void> {
+  process.stdout.write(`${message}\n`);
+}
+
+function createRuntimeDependencies(commandEnvironment: CommandEnvironment): PreviewNextBetaCommandDependencies {
+  const httpClient = createRuntimeKyHttpClient();
+  const githubClient = createGitHubClient({
+    httpClient,
+    githubApiUrl: commandEnvironment.githubApiUrl,
+    githubRepository: commandEnvironment.githubRepository,
+    githubToken: commandEnvironment.githubToken,
+  });
+
+  return {
+    executeGitCommand: executeRuntimeGitCommand,
+    githubClient,
+    planNextBetaPreviewHistory,
+    writeFailure: writeRuntimeFailure,
+    writeInformation: writeRuntimeInformation,
+    async writeSummary(summary): Promise<void> {
+      await appendFile(commandEnvironment.githubStepSummary, `${summary}\n`, 'utf8');
+    },
+  };
+}
+
+async function startPreviewNextBetaCommand(): Promise<void> {
+  const githubToken = Maybe.of(process.env.GITHUB_TOKEN).unwrapOr('');
+  try {
+    const commandEnvironmentResult = readCommandEnvironment(process.env);
+    if (commandEnvironmentResult.isErr) {
+      await writeRuntimeFailure(redactSecret(commandEnvironmentResult.error.message, githubToken));
+      process.exitCode = 1;
+
+      return;
+    }
+
+    const commandResult = await executePreviewNextBetaCommand({
+      commandLineArguments: process.argv.slice(processArgumentStartIndex),
+      environment: process.env,
+      dependencies: createRuntimeDependencies(commandEnvironmentResult.value),
+    });
+    process.exitCode = commandResult.exitCode;
+  } catch (error: unknown) {
+    await writeRuntimeFailure(
+      redactSecret(is.error(error) ? error.message : 'Unexpected preview failure', githubToken),
+    );
+    process.exitCode = 1;
+  }
+}
+
+function isPreviewNextBetaCommandEntrypoint(): boolean {
+  return Maybe.of(process.argv[1])
+    .map(entrypointPath => {
+      return /(?:^|[\\/])previewNextBetaCommand\.ts$/.test(entrypointPath);
+    })
+    .unwrapOr(false);
+}
+
+if (isPreviewNextBetaCommandEntrypoint()) {
+  void startPreviewNextBetaCommand();
+}

--- a/tools/release-appearance/releaseHistory.integration.test.ts
+++ b/tools/release-appearance/releaseHistory.integration.test.ts
@@ -23,7 +23,12 @@ import {mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {promisify} from 'node:util';
 
-import {planBetaReleaseHistory, planProductionReleaseHistory} from './releaseHistory.ts';
+import {
+  findLatestBetaReleaseTag,
+  planBetaReleaseHistory,
+  planNextBetaPreviewHistory,
+  planProductionReleaseHistory,
+} from './releaseHistory.ts';
 import type {ExecuteGitCommand} from './releaseHistory.ts';
 
 const executeFile = promisify(execFile);
@@ -94,6 +99,36 @@ async function createAnnotatedTag(createAnnotatedTagOptions: CreateAnnotatedTagO
     commandArguments: ['tag', '--annotate', tagName, '--message', `Release ${tagName}`, commit],
     environmentOverrides: {GIT_COMMITTER_DATE: taggerDate},
   });
+}
+
+type CreateAnnotatedTagsOptions = {
+  readonly repositoryPath: string;
+  readonly commit: string;
+  readonly tagDefinitions: readonly Pick<CreateAnnotatedTagOptions, 'tagName' | 'taggerDate'>[];
+};
+
+type CreateLightweightTagOptions = {
+  readonly repositoryPath: string;
+  readonly tagName: string;
+  readonly commit: string;
+};
+
+async function createLightweightTag(createLightweightTagOptions: CreateLightweightTagOptions): Promise<void> {
+  const {repositoryPath, tagName, commit} = createLightweightTagOptions;
+
+  await runGitCommand({repositoryPath, commandArguments: ['tag', tagName, commit]});
+}
+
+async function createAnnotatedTags(createAnnotatedTagsOptions: CreateAnnotatedTagsOptions): Promise<void> {
+  const {repositoryPath, commit, tagDefinitions} = createAnnotatedTagsOptions;
+
+  for (const tagDefinition of tagDefinitions) {
+    await createAnnotatedTag({...tagDefinition, repositoryPath, commit});
+  }
+}
+
+async function createSelectionCommit(repositoryPath: string, commitDate: string): Promise<string> {
+  return createCommit({repositoryPath, fileName: 'release.txt', fileContents: 'release', commitDate});
 }
 
 async function createTemporaryGitRepository(scenario: TemporaryRepositoryScenario): Promise<void> {
@@ -544,6 +579,289 @@ describe('release history planning', () => {
 
       assert(actualResult.isOk);
       expect(actualResult.value).toEqual({kind: 'bootstrap'});
+    });
+  });
+});
+
+describe('latest Beta release tag selection', () => {
+  it('ignores legacy, malformed, and unrelated tags and selects by annotation timestamp', async () => {
+    await createTemporaryGitRepository(async (repositoryPath, executeGitCommand) => {
+      const commit = await createSelectionCommit(repositoryPath, '2026-07-31T00:00:00+0000');
+      const selectedTagName = '2026-07-30.1-beta.1';
+      await createAnnotatedTags({
+        repositoryPath,
+        commit,
+        tagDefinitions: [
+          {tagName: '2026-07-31.1-beta.1', taggerDate: '2026-07-31T01:00:00+0000'},
+          {tagName: selectedTagName, taggerDate: '2026-08-01T01:00:00+0000'},
+          {tagName: '2026-07-31.1-production', taggerDate: '2026-08-02T01:00:00+0000'},
+          {tagName: '2026-07-31-staging.0', taggerDate: '2026-08-03T01:00:00+0000'},
+          {tagName: 'other-package-2026-08-03.1-beta.1', taggerDate: '2026-08-04T01:00:00+0000'},
+          {tagName: '2026-08-03.1-beta.0', taggerDate: '2026-08-05T01:00:00+0000'},
+        ],
+      });
+
+      const actualResult = await findLatestBetaReleaseTag(executeGitCommand);
+
+      assert(actualResult.isOk);
+      assert(actualResult.value.isJust);
+      expect(actualResult.value.value.tagName).toBe(selectedTagName);
+    });
+  });
+
+  it('uses numeric release and candidate ordering when annotation timestamps tie', async () => {
+    await createTemporaryGitRepository(async (repositoryPath, executeGitCommand) => {
+      const commit = await createSelectionCommit(repositoryPath, '2026-08-01T00:00:00+0000');
+      const numericReleaseTag = '2026-08-01.10-beta.2';
+      await createAnnotatedTags({
+        repositoryPath,
+        commit,
+        tagDefinitions: [
+          {tagName: '2026-08-01.2-beta.10', taggerDate: '2026-08-01T01:00:00+0000'},
+          {tagName: numericReleaseTag, taggerDate: '2026-08-01T01:00:00+0000'},
+        ],
+      });
+
+      const numericReleaseResult = await findLatestBetaReleaseTag(executeGitCommand);
+
+      assert(numericReleaseResult.isOk);
+      assert(numericReleaseResult.value.isJust);
+      expect(numericReleaseResult.value.value.tagName).toBe(numericReleaseTag);
+      const numericCandidateTag = '2026-08-02.1-beta.10';
+      await createAnnotatedTags({
+        repositoryPath,
+        commit,
+        tagDefinitions: [
+          {tagName: '2026-08-02.1-beta.2', taggerDate: '2026-08-02T01:00:00+0000'},
+          {tagName: numericCandidateTag, taggerDate: '2026-08-02T01:00:00+0000'},
+        ],
+      });
+
+      const actualResult = await findLatestBetaReleaseTag(executeGitCommand);
+
+      assert(actualResult.isOk);
+      assert(actualResult.value.isJust);
+      expect(actualResult.value.value.tagName).toBe(numericCandidateTag);
+    });
+  });
+
+  it('rejects a matching lightweight Beta tag', async () => {
+    await createTemporaryGitRepository(async (repositoryPath, executeGitCommand) => {
+      const commit = await createSelectionCommit(repositoryPath, '2026-08-01T00:00:00+0000');
+      const lightweightTagName = '2026-08-01.1-beta.1';
+      await createLightweightTag({repositoryPath, tagName: lightweightTagName, commit});
+
+      const actualResult = await findLatestBetaReleaseTag(executeGitCommand);
+
+      assert(actualResult.isErr);
+      expect(actualResult.error.message).toBe(`Release tag must be annotated: ${lightweightTagName}`);
+    });
+  });
+});
+
+describe('next Beta preview history planning', () => {
+  it('plans changes after an ancestor Beta tag up to the exact target main commit', async () => {
+    await createTemporaryGitRepository(async (repositoryPath, executeGitCommand) => {
+      const commonCommit = await createCommit({
+        repositoryPath,
+        fileName: 'common.txt',
+        fileContents: 'common',
+        commitDate: '2026-07-01T00:00:00+0000',
+      });
+      const betaCommit = await createCommit({
+        repositoryPath,
+        fileName: 'beta.txt',
+        fileContents: 'beta',
+        commitDate: '2026-07-02T00:00:00+0000',
+      });
+      const betaTag = '2026-07-02.1-beta.1';
+      await createAnnotatedTag({
+        repositoryPath,
+        tagName: betaTag,
+        commit: betaCommit,
+        taggerDate: '2026-07-02T01:00:00+0000',
+      });
+      const firstMainCommit = await createCommit({
+        repositoryPath,
+        fileName: 'main-one.txt',
+        fileContents: 'main one',
+        commitDate: '2026-07-03T00:00:00+0000',
+      });
+      const secondMainCommit = await createCommit({
+        repositoryPath,
+        fileName: 'main-two.txt',
+        fileContents: 'main two',
+        commitDate: '2026-07-04T00:00:00+0000',
+      });
+      await createCommit({
+        repositoryPath,
+        fileName: 'main-after-target.txt',
+        fileContents: 'after target',
+        commitDate: '2026-07-05T00:00:00+0000',
+      });
+
+      const actualResult = await planNextBetaPreviewHistory({
+        executeGitCommand,
+        targetMainCommit: secondMainCommit,
+      });
+
+      assert(actualResult.isOk);
+      expect(actualResult.value.kind).toBe('preview');
+      if (actualResult.value.kind !== 'preview') {
+        assert.fail('Expected a next Beta preview history plan');
+      }
+      expect(actualResult.value.latestBetaReleaseTag.tagName).toBe(betaTag);
+      expect(actualResult.value.latestBetaReleaseTag.commit).toBe(betaCommit);
+      expect(actualResult.value.targetMainCommit).toBe(secondMainCommit);
+      expect(actualResult.value.mergeBase).toBe(betaCommit);
+      expect(actualResult.value.commits).toEqual([firstMainCommit, secondMainCommit]);
+      expect(actualResult.value.commits).not.toContain(commonCommit);
+      expect(actualResult.value.commits).not.toContain(betaCommit);
+    });
+  });
+
+  it('uses the merge base when the latest Beta tag is on a sibling release branch', async () => {
+    await createTemporaryGitRepository(async (repositoryPath, executeGitCommand) => {
+      const commonCommit = await createCommit({
+        repositoryPath,
+        fileName: 'common.txt',
+        fileContents: 'common',
+        commitDate: '2026-07-01T00:00:00+0000',
+      });
+      await runGitCommand({
+        repositoryPath,
+        commandArguments: ['switch', '--quiet', '--create', 'beta-release', commonCommit],
+      });
+      const betaOnlyCommit = await createCommit({
+        repositoryPath,
+        fileName: 'beta-only.txt',
+        fileContents: 'beta only',
+        commitDate: '2026-07-02T00:00:00+0000',
+      });
+      const betaTag = '2026-07-02.1-beta.1';
+      await createAnnotatedTag({
+        repositoryPath,
+        tagName: betaTag,
+        commit: betaOnlyCommit,
+        taggerDate: '2026-07-02T01:00:00+0000',
+      });
+      await runGitCommand({repositoryPath, commandArguments: ['switch', '--quiet', 'main']});
+      const firstMainCommit = await createCommit({
+        repositoryPath,
+        fileName: 'main-one.txt',
+        fileContents: 'main one',
+        commitDate: '2026-07-03T00:00:00+0000',
+      });
+      const secondMainCommit = await createCommit({
+        repositoryPath,
+        fileName: 'main-two.txt',
+        fileContents: 'main two',
+        commitDate: '2026-07-04T00:00:00+0000',
+      });
+
+      const actualResult = await planNextBetaPreviewHistory({
+        executeGitCommand,
+        targetMainCommit: secondMainCommit,
+      });
+
+      assert(actualResult.isOk);
+      expect(actualResult.value.kind).toBe('preview');
+      if (actualResult.value.kind !== 'preview') {
+        assert.fail('Expected a next Beta preview history plan');
+      }
+      expect(actualResult.value.latestBetaReleaseTag.commit).toBe(betaOnlyCommit);
+      expect(actualResult.value.targetMainCommit).toBe(secondMainCommit);
+      expect(actualResult.value.mergeBase).toBe(commonCommit);
+      expect(actualResult.value.commits).toEqual([firstMainCommit, secondMainCommit]);
+      expect(actualResult.value.commits).not.toContain(betaOnlyCommit);
+    });
+  });
+
+  it('returns an empty range when Beta is at the target main commit', async () => {
+    await createTemporaryGitRepository(async (repositoryPath, executeGitCommand) => {
+      const betaCommit = await createCommit({
+        repositoryPath,
+        fileName: 'beta.txt',
+        fileContents: 'beta',
+        commitDate: '2026-07-02T00:00:00+0000',
+      });
+      await createAnnotatedTag({
+        repositoryPath,
+        tagName: '2026-07-02.1-beta.1',
+        commit: betaCommit,
+        taggerDate: '2026-07-02T01:00:00+0000',
+      });
+
+      const actualResult = await planNextBetaPreviewHistory({
+        executeGitCommand,
+        targetMainCommit: betaCommit,
+      });
+
+      assert(actualResult.isOk);
+      expect(actualResult.value.kind).toBe('preview');
+      if (actualResult.value.kind !== 'preview') {
+        assert.fail('Expected a next Beta preview history plan');
+      }
+      expect(actualResult.value.mergeBase).toBe(betaCommit);
+      expect(actualResult.value.commits).toEqual([]);
+    });
+  });
+
+  it('returns unavailable when no new-format Beta tag exists', async () => {
+    await createTemporaryGitRepository(async (repositoryPath, executeGitCommand) => {
+      const targetCommit = await createSelectionCommit(repositoryPath, '2026-07-01T00:00:00+0000');
+      await createAnnotatedTag({
+        repositoryPath,
+        tagName: '2026-07-01-staging.0',
+        commit: targetCommit,
+        taggerDate: '2026-07-01T01:00:00+0000',
+      });
+      await createAnnotatedTags({
+        repositoryPath,
+        commit: targetCommit,
+        tagDefinitions: [
+          {tagName: '2026-07-01.1-production', taggerDate: '2026-07-01T02:00:00+0000'},
+          {tagName: 'other-package-2026-07-01.1-beta.1', taggerDate: '2026-07-01T03:00:00+0000'},
+          {tagName: '2026-07-01.1-beta', taggerDate: '2026-07-01T04:00:00+0000'},
+        ],
+      });
+
+      const actualResult = await planNextBetaPreviewHistory({
+        executeGitCommand,
+        targetMainCommit: targetCommit,
+      });
+
+      assert(actualResult.isOk);
+      expect(actualResult.value).toEqual({kind: 'unavailable', targetMainCommit: targetCommit});
+    });
+  });
+
+  it('rejects invalid target commits before planning history', async () => {
+    await createTemporaryGitRepository(async (repositoryPath, executeGitCommand) => {
+      let gitWasExecuted = false;
+      async function executeTrackedGitCommand(commandArguments: readonly string[]): Promise<string> {
+        gitWasExecuted = true;
+
+        return executeGitCommand(commandArguments);
+      }
+
+      const abbreviatedResult = await planNextBetaPreviewHistory({
+        executeGitCommand: executeTrackedGitCommand,
+        targetMainCommit: 'abcdef0',
+      });
+
+      assert(abbreviatedResult.isErr);
+      expect(abbreviatedResult.error.message).toMatch(/exactly 40 hexadecimal characters/);
+      expect(gitWasExecuted).toBe(false);
+
+      const unresolvedResult = await planNextBetaPreviewHistory({
+        executeGitCommand,
+        targetMainCommit: 'f'.repeat(40),
+      });
+
+      assert(unresolvedResult.isErr);
+      expect(unresolvedResult.error.message).not.toContain('github-token');
+      expect(unresolvedResult.error.message).not.toContain('stack trace');
     });
   });
 });

--- a/tools/release-appearance/releaseHistory.ts
+++ b/tools/release-appearance/releaseHistory.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import is from '@sindresorhus/is';
 import {Maybe, Result, Task, Unit, result, task} from 'true-myth';
 
 import {
@@ -28,6 +29,12 @@ import {
 import type {BetaCandidate, ProductionTag} from './releaseAppearance.ts';
 
 export type ExecuteGitCommand = (commandArguments: readonly string[]) => Promise<string>;
+
+export type BetaReleaseTagReference = {
+  readonly tagName: string;
+  readonly commit: string;
+  readonly taggerTimestamp: bigint;
+};
 
 export type CommitRange = {
   readonly startTag: string;
@@ -73,6 +80,24 @@ export type PlanProductionReleaseHistoryOptions = {
   readonly releaseCommit: string;
 };
 
+export type NextBetaPreviewHistoryPlan =
+  | {
+      readonly kind: 'unavailable';
+      readonly targetMainCommit: string;
+    }
+  | {
+      readonly kind: 'preview';
+      readonly latestBetaReleaseTag: BetaReleaseTagReference;
+      readonly targetMainCommit: string;
+      readonly mergeBase: string;
+      readonly commits: readonly string[];
+    };
+
+export type PlanNextBetaPreviewHistoryOptions = {
+  readonly executeGitCommand: ExecuteGitCommand;
+  readonly targetMainCommit: string;
+};
+
 type TagAnnotation = 'annotated' | 'lightweight';
 
 type ProductionTagRecord = ProductionTag & {
@@ -82,6 +107,11 @@ type ProductionTagRecord = ProductionTag & {
 
 type BetaCandidateRecord = BetaCandidate & {
   readonly tagName: string;
+};
+
+type BetaReleaseTagRecord = BetaCandidateRecord & {
+  readonly commit: string;
+  readonly taggerTimestamp: bigint;
 };
 
 type CompareTagOrderOptions = {
@@ -157,8 +187,12 @@ function executeSingleLineGitCommand(
 ): Task<string, Error> {
   return executeGitCommandWithTask(executeGitCommand, commandArguments).andThen(commandOutput => {
     const trimmedCommandOutput = commandOutput.trim();
-    if (trimmedCommandOutput.length === 0) {
+    if (is.emptyString(trimmedCommandOutput)) {
       return createFailure(`Git command returned no output: git ${commandArguments.join(' ')}`);
+    }
+
+    if (trimmedCommandOutput.split(/\r?\n/).length !== 1) {
+      return createFailure(`Git command returned multiple lines: git ${commandArguments.join(' ')}`);
     }
 
     return createSuccess(trimmedCommandOutput);
@@ -172,7 +206,7 @@ function splitGitLines(commandOutput: string): readonly string[] {
       return line.trim();
     })
     .filter(line => {
-      return line.length > 0;
+      return is.emptyString(line) === false;
     });
 }
 
@@ -376,6 +410,150 @@ async function findPrecedingBetaCandidate(
   }
 
   return createSuccess(precedingBetaCandidate);
+}
+
+export function findLatestBetaReleaseTag(
+  executeGitCommand: ExecuteGitCommand,
+): Task<Maybe<BetaReleaseTagReference>, Error> {
+  return task.tryOrElse(
+    (error: unknown): Error => {
+      if (is.error(error)) {
+        return error;
+      }
+
+      return new Error('Latest Beta tag selection failed', {cause: error});
+    },
+    async (): Promise<Maybe<BetaReleaseTagReference>> => {
+      const betaTagNamesResult = await listTagNames(executeGitCommand, betaTagListPattern);
+      if (betaTagNamesResult.isErr) {
+        throw betaTagNamesResult.error;
+      }
+
+      let latestBetaReleaseTag: Maybe<BetaReleaseTagRecord> = Maybe.nothing<BetaReleaseTagRecord>();
+      for (const betaTagName of betaTagNamesResult.value) {
+        const parsedBetaCandidateResult = parseBetaCandidateTag(betaTagName);
+        if (parsedBetaCandidateResult.isErr) {
+          continue;
+        }
+
+        const tagAnnotationResult = await requireAnnotatedTag(executeGitCommand, betaTagName);
+        if (tagAnnotationResult.isErr) {
+          throw tagAnnotationResult.error;
+        }
+
+        const taggerTimestampResult = await readTaggerTimestamp(executeGitCommand, betaTagName);
+        if (taggerTimestampResult.isErr) {
+          throw taggerTimestampResult.error;
+        }
+
+        const commitResult = await resolveTagCommit(executeGitCommand, betaTagName);
+        if (commitResult.isErr) {
+          throw commitResult.error;
+        }
+
+        const betaReleaseTagRecord: BetaReleaseTagRecord = {
+          ...parsedBetaCandidateResult.value,
+          tagName: betaTagName,
+          commit: commitResult.value,
+          taggerTimestamp: taggerTimestampResult.value,
+        };
+        const shouldReplaceLatestTag = latestBetaReleaseTag
+          .map(existingLatestTag => {
+            const releaseOrder = compareTagOrder({
+              leftTaggerTimestamp: betaReleaseTagRecord.taggerTimestamp,
+              leftReleaseIdentifier: betaReleaseTagRecord.releaseIdentifier,
+              rightTaggerTimestamp: existingLatestTag.taggerTimestamp,
+              rightReleaseIdentifier: existingLatestTag.releaseIdentifier,
+            });
+
+            return (
+              (releaseOrder === 0 ? compareBetaCandidates(betaReleaseTagRecord, existingLatestTag) : releaseOrder) > 0
+            );
+          })
+          .unwrapOr(true);
+        if (shouldReplaceLatestTag) {
+          latestBetaReleaseTag = Maybe.just(betaReleaseTagRecord);
+        }
+      }
+
+      return latestBetaReleaseTag.map(betaReleaseTag => {
+        return {
+          tagName: betaReleaseTag.tagName,
+          commit: betaReleaseTag.commit,
+          taggerTimestamp: betaReleaseTag.taggerTimestamp,
+        };
+      });
+    },
+  );
+}
+
+export function planNextBetaPreviewHistory(
+  planNextBetaPreviewHistoryOptions: PlanNextBetaPreviewHistoryOptions,
+): Task<NextBetaPreviewHistoryPlan, Error> {
+  const {executeGitCommand, targetMainCommit} = planNextBetaPreviewHistoryOptions;
+
+  return task.tryOrElse(
+    (error: unknown): Error => {
+      if (is.error(error)) {
+        return error;
+      }
+
+      return new Error('Next Beta preview history planning failed', {cause: error});
+    },
+    async (): Promise<NextBetaPreviewHistoryPlan> => {
+      const targetMainCommitResult = validateReleaseCommit(targetMainCommit);
+      if (targetMainCommitResult.isErr) {
+        throw new Error('Target main commit SHA must contain exactly 40 hexadecimal characters');
+      }
+
+      const resolvedTargetMainCommitResult = await executeSingleLineGitCommand(executeGitCommand, [
+        'rev-parse',
+        '--verify',
+        `${targetMainCommitResult.value}^{commit}`,
+      ]);
+      if (resolvedTargetMainCommitResult.isErr) {
+        throw resolvedTargetMainCommitResult.error;
+      }
+
+      const latestBetaReleaseTagResult = await findLatestBetaReleaseTag(executeGitCommand);
+      if (latestBetaReleaseTagResult.isErr) {
+        throw latestBetaReleaseTagResult.error;
+      }
+
+      const resolvedTargetMainCommit = resolvedTargetMainCommitResult.value;
+      if (latestBetaReleaseTagResult.value.isNothing) {
+        return {kind: 'unavailable', targetMainCommit: resolvedTargetMainCommit};
+      }
+
+      const latestBetaReleaseTag = latestBetaReleaseTagResult.value.value;
+      const mergeBaseResult = await executeSingleLineGitCommand(executeGitCommand, [
+        'merge-base',
+        latestBetaReleaseTag.commit,
+        resolvedTargetMainCommit,
+      ]);
+      if (mergeBaseResult.isErr) {
+        throw mergeBaseResult.error;
+      }
+
+      const commitsResult = await executeGitCommandWithTask(executeGitCommand, [
+        'rev-list',
+        '--reverse',
+        '--topo-order',
+        `${mergeBaseResult.value}..${resolvedTargetMainCommit}`,
+      ]).map(splitGitLines);
+      if (commitsResult.isErr) {
+        throw commitsResult.error;
+      }
+
+      return {
+        kind: 'preview',
+        latestBetaReleaseTag,
+        targetMainCommit: resolvedTargetMainCommit,
+        mergeBase: mergeBaseResult.value,
+        commits: commitsResult.value,
+      };
+    },
+  );
 }
 
 function createCommitRange(createCommitRangeOptions: CreateCommitRangeOptions): Task<CommitRange, Error> {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Add a manually dispatched, read-only preview of changes waiting for the next Beta release.

The workflow compares the latest new-format Beta tag with the exact `main` commit selected when the workflow is started. It shows which merged pull requests are currently on `main` but are not part of the latest Beta candidate.

This answers:

> What new work would enter Beta if a release were started from `main` now?

The preview is advisory. The reported changes have not yet been deployed or verified in Beta.

## Preview scope

The preview automatically finds the latest annotated tag matching the ADR 0002 Beta format:

```text
YYYY-MM-DD.N-beta.M