### PR TITLE
Include pull request titles in Beta preview [WPB-26469]

### DIFF
--- a/tools/release-appearance/githubClient.test.ts
+++ b/tools/release-appearance/githubClient.test.ts
@@ -130,7 +130,7 @@ function readPage(request: HttpRequest): number {
 }
 
 describe('GitHub client', () => {
-  it('maps GitHub pull requests into stripped domain records', async () => {
+  it('maps GitHub pull requests into stripped domain records with titles', async () => {
     const fakeHttpClient = createFakeHttpClient({
       responseForRequest() {
         return [githubPullRequestResponseFactory.build({number: 7})];
@@ -144,8 +144,9 @@ describe('GitHub client', () => {
     expect(actualResult.value).toHaveLength(1);
     const pullRequest = Maybe.of(actualResult.value[0]);
     assert(pullRequest.isJust);
-    expect(Object.keys(pullRequest.value)).toEqual(['number', 'baseBranch', 'mergedAt']);
+    expect(Object.keys(pullRequest.value)).toEqual(['number', 'title', 'baseBranch', 'mergedAt']);
     expect(pullRequest.value.number).toBe(7);
+    expect(pullRequest.value.title).toBe('Pull request');
     expect(pullRequest.value.baseBranch).toBe('main');
     assert(pullRequest.value.mergedAt.isJust);
     expect(pullRequest.value.mergedAt.value).toBe('2026-07-21T00:00:00Z');
@@ -165,7 +166,7 @@ describe('GitHub client', () => {
     });
     const responsesByPage = new Map<number, unknown>([
       [1, firstPage],
-      [2, [githubPullRequestResponseFactory.build({number: 200})]],
+      [2, [githubPullRequestResponseFactory.build({number: 200, title: 'Second page pull request'})]],
     ]);
     const fakeHttpClient = createFakeHttpClient({
       responseForRequest(request) {
@@ -187,6 +188,16 @@ describe('GitHub client', () => {
         return pullRequest.number === 200;
       }),
     ).toBe(true);
+    expect(
+      actualResult.value.some(pullRequest => {
+        return pullRequest.number === 200 && pullRequest.title === 'Second page pull request';
+      }),
+    ).toBe(true);
+    expect(
+      actualResult.value.some(pullRequest => {
+        return pullRequest.number === 1 || pullRequest.number === 2;
+      }),
+    ).toBe(false);
   });
 
   it('paginates issue comments and strips unused properties', async () => {
@@ -249,10 +260,52 @@ describe('GitHub client', () => {
     expect(updateRequest.value.url.toString()).toMatch(/issues\/comments\/11$/);
   });
 
-  it('rejects malformed GitHub responses', async () => {
+  it('rejects a GitHub response without a title as malformed', async () => {
     const fakeHttpClient = createFakeHttpClient({
       responseForRequest() {
-        return [{number: 1, merged_at: 42, base: {ref: 'main'}}];
+        return [{number: 1, merged_at: '2026-07-21T00:00:00Z', base: {ref: 'main'}}];
+      },
+    });
+    const githubClient = createClient(fakeHttpClient.httpClient);
+
+    const actualResult = await githubClient.listPullRequestsForCommit({commitSha: 'commit-sha'});
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('Malformed GitHub pull request response');
+  });
+
+  it('rejects a GitHub response with a non-string title as malformed', async () => {
+    const fakeHttpClient = createFakeHttpClient({
+      responseForRequest() {
+        return [{number: 1, title: 42, merged_at: '2026-07-21T00:00:00Z', base: {ref: 'main'}}];
+      },
+    });
+    const githubClient = createClient(fakeHttpClient.httpClient);
+
+    const actualResult = await githubClient.listPullRequestsForCommit({commitSha: 'commit-sha'});
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('Malformed GitHub pull request response');
+  });
+
+  it('rejects a GitHub response with an empty title as malformed', async () => {
+    const fakeHttpClient = createFakeHttpClient({
+      responseForRequest() {
+        return [{number: 1, title: '', merged_at: '2026-07-21T00:00:00Z', base: {ref: 'main'}}];
+      },
+    });
+    const githubClient = createClient(fakeHttpClient.httpClient);
+
+    const actualResult = await githubClient.listPullRequestsForCommit({commitSha: 'commit-sha'});
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('Malformed GitHub pull request response');
+  });
+
+  it('rejects other malformed GitHub responses', async () => {
+    const fakeHttpClient = createFakeHttpClient({
+      responseForRequest() {
+        return [{number: 1, title: 'Pull request', merged_at: 42, base: {ref: 'main'}}];
       },
     });
     const githubClient = createClient(fakeHttpClient.httpClient);

--- a/tools/release-appearance/githubClient.ts
+++ b/tools/release-appearance/githubClient.ts
@@ -25,6 +25,7 @@ import type {HttpClient, HttpMethod, HttpRequest} from './httpClient.ts';
 
 export type PullRequestRecord = {
   readonly number: number;
+  readonly title: string;
   readonly baseBranch: string;
   readonly mergedAt: Maybe<string>;
 };
@@ -80,6 +81,7 @@ const githubApiVersion = '2022-11-28';
 
 const githubPullRequestResponseSchema = z.object({
   number: z.number().int().positive(),
+  title: z.string().min(1),
   merged_at: z.string().nullable(),
   base: z.object({
     ref: z.string(),
@@ -172,6 +174,7 @@ function parsePullRequestPage(githubResponse: unknown): Result<ParsedPullRequest
   const pullRequests = validationResult.data.map(pullRequest => {
     return {
       number: pullRequest.number,
+      title: pullRequest.title,
       baseBranch: pullRequest.base.ref,
       mergedAt: Maybe.of(pullRequest.merged_at),
     };

--- a/tools/release-appearance/previewNextBetaCommand.test.ts
+++ b/tools/release-appearance/previewNextBetaCommand.test.ts
@@ -75,6 +75,7 @@ type CreatePullRequestOptions = {
   readonly number: number;
   readonly baseBranch?: string;
   readonly merged?: boolean;
+  readonly title?: string;
 };
 
 type RunCommandOptions = {
@@ -99,10 +100,11 @@ const previewHistoryPlan: NextBetaPreviewHistoryPlan = {
 };
 
 function createPullRequest(createPullRequestOptions: CreatePullRequestOptions): PullRequestRecord {
-  const {number, baseBranch = 'main', merged = true} = createPullRequestOptions;
+  const {number, baseBranch = 'main', merged = true, title = `Pull request #${number}`} = createPullRequestOptions;
 
   return {
     number,
+    title,
     baseBranch,
     mergedAt: merged ? Maybe.just('2026-07-28T00:00:00Z') : Maybe.nothing<string>(),
   };
@@ -302,12 +304,12 @@ describe('executePreviewNextBetaCommand', () => {
         [
           firstMainCommit,
           [
-            createPullRequest({number: 22052}),
+            createPullRequest({number: 22052, title: 'Add next Beta change preview [WPB-26469]'}),
             createPullRequest({number: 22040, baseBranch: 'release/2026-07-27'}),
             createPullRequest({number: 22041, merged: false}),
           ],
         ],
-        [secondMainCommit, [createPullRequest({number: 22052})]],
+        [secondMainCommit, [createPullRequest({number: 22052, title: 'A duplicate title that must be ignored'})]],
         [thirdMainCommit, [createPullRequest({number: 22051, baseBranch: 'release/2026-07-27'})]],
       ]),
     });
@@ -325,10 +327,73 @@ describe('executePreviewNextBetaCommand', () => {
     expect(commandRun.result.summary).toContain(`Current main commit: \`${targetMainCommit}\``);
     expect(commandRun.result.summary).toContain(`Merge base: \`${mergeBaseCommit}\``);
     expect(commandRun.result.summary).toContain('Merged pull requests waiting for Beta: 1');
-    expect(commandRun.result.summary).toContain('[#22052](https://github.com/wireapp/wire-webapp/pull/22052)');
+    expect(commandRun.result.summary).toContain(
+      '- [#22052](https://github.com/wireapp/wire-webapp/pull/22052) Add next Beta change preview \\[WPB-26469\\]',
+    );
+    expect(commandRun.result.summary).not.toContain('A duplicate title that must be ignored');
     expect(commandRun.result.summary).toContain(`- \`${thirdMainCommit}\``);
     expect(commandRun.result.summary).toContain('This is an advisory preview. These changes are on main');
     expect(commandRun.writerState.informationMessages[0]).toContain('Merged pull requests waiting for Beta: 1');
+    expect(commandRun.writerState.informationMessages[0]).not.toContain('Add next Beta change preview');
+  });
+
+  test('sorts multiple merged main pull requests numerically', async () => {
+    const githubClientFixture = createFakeGitHubClient({
+      pullRequestsByCommit: new Map([
+        [
+          firstMainCommit,
+          [
+            createPullRequest({number: 22056, title: 'Add next Beta change preview [WPB-26469]'}),
+            createPullRequest({number: 22050, title: 'Add first-appearance release comments [WPB-26469]'}),
+          ],
+        ],
+        [
+          secondMainCommit,
+          [createPullRequest({number: 22052, title: 'Add release appearance comment dry run [WPB-26469]'})],
+        ],
+      ]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+      historyPlanResult: Result.ok({...previewHistoryPlan, commits: [firstMainCommit, secondMainCommit]}),
+    });
+
+    expect(commandRun.result.exitCode).toBe(0);
+    expect(commandRun.result.summary.indexOf('#22050')).toBeLessThan(commandRun.result.summary.indexOf('#22052'));
+    expect(commandRun.result.summary.indexOf('#22052')).toBeLessThan(commandRun.result.summary.indexOf('#22056'));
+  });
+
+  test('normalizes and escapes hostile pull request titles into one safe list item', async () => {
+    const githubClientFixture = createFakeGitHubClient({
+      pullRequestsByCommit: new Map([
+        [
+          firstMainCommit,
+          [
+            createPullRequest({
+              number: 22060,
+              title:
+                '  Fix [preview] *output*\nfor <Beta>\t_with_ `code`\\path ~draft~\n- forged list\n# forged heading  ',
+            }),
+          ],
+        ],
+      ]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: [targetMainCommit],
+      executeGitCommand: createFakeGitCommand(),
+      githubClient: githubClientFixture.githubClient,
+      historyPlanResult: Result.ok({...previewHistoryPlan, commits: [firstMainCommit]}),
+    });
+
+    const expectedHostilePullRequestLine =
+      '- [#22060](https://github.com/wireapp/wire-webapp/pull/22060) Fix \\[preview\\] \\*output\\* for \\<Beta\\> \\_with\\_ \\`code\\`\\\\path \\~draft\\~ - forged list # forged heading';
+    expect(commandRun.result.summary).toContain(expectedHostilePullRequestLine);
+    expect(commandRun.result.summary).not.toContain('\n- forged list');
+    expect(commandRun.result.summary).not.toContain('\n# forged heading');
   });
 
   test('continues after a discovery failure, returns non-zero, and sanitizes the failure', async () => {

--- a/tools/release-appearance/previewNextBetaCommand.ts
+++ b/tools/release-appearance/previewNextBetaCommand.ts
@@ -65,9 +65,14 @@ type PreviewNextBetaState = {
   readonly targetMainCommit: string;
   readonly mergeBase: Maybe<string>;
   readonly commitsInspected: readonly string[];
-  readonly pullRequestNumbers: readonly number[];
+  readonly pullRequests: readonly PreviewPullRequest[];
   readonly commitsWithoutMergedMainPullRequest: readonly string[];
   readonly failureMessages: readonly string[];
+};
+
+type PreviewPullRequest = {
+  readonly number: number;
+  readonly title: string;
 };
 
 type DiscoverPullRequestsOptions = {
@@ -77,7 +82,7 @@ type DiscoverPullRequestsOptions = {
 };
 
 type DiscoverPullRequestsResult = {
-  readonly pullRequestNumbers: readonly number[];
+  readonly pullRequests: readonly PreviewPullRequest[];
   readonly commitsWithoutMergedMainPullRequest: readonly string[];
   readonly failureMessages: readonly string[];
 };
@@ -114,6 +119,7 @@ type WriteSummarySafelyOptions = {
 
 const processArgumentStartIndex = 2;
 const fullGitCommitPattern = /^[0-9a-f]{40}$/i;
+const markdownSpecialCharacterPattern = /[\\`*_\[\]<>~]/gu;
 const executeFile = promisify(execFile);
 const advisoryMessage =
   'This is an advisory preview. These changes are on main but have not been deployed or verified in Beta.';
@@ -189,7 +195,7 @@ async function discoverPullRequests(
   discoverPullRequestsOptions: DiscoverPullRequestsOptions,
 ): Promise<DiscoverPullRequestsResult> {
   const {commits, githubClient, githubToken} = discoverPullRequestsOptions;
-  const pullRequestNumbersByNumber = new Set<number>();
+  const pullRequestsByNumber = new Map<number, PreviewPullRequest>();
   const commitsWithoutMergedMainPullRequest: string[] = [];
   const failureMessages: string[] = [];
 
@@ -219,13 +225,18 @@ async function discoverPullRequests(
     }
 
     for (const pullRequest of mergedMainPullRequests) {
-      pullRequestNumbersByNumber.add(pullRequest.number);
+      if (!pullRequestsByNumber.has(pullRequest.number)) {
+        pullRequestsByNumber.set(pullRequest.number, {
+          number: pullRequest.number,
+          title: pullRequest.title,
+        });
+      }
     }
   }
 
   return {
-    pullRequestNumbers: [...pullRequestNumbersByNumber].toSorted((leftNumber, rightNumber) => {
-      return leftNumber - rightNumber;
+    pullRequests: [...pullRequestsByNumber.values()].toSorted((leftPullRequest, rightPullRequest) => {
+      return leftPullRequest.number - rightPullRequest.number;
     }),
     commitsWithoutMergedMainPullRequest,
     failureMessages,
@@ -241,7 +252,7 @@ function createUnavailableState(
     targetMainCommit,
     mergeBase: Maybe.nothing<string>(),
     commitsInspected: [],
-    pullRequestNumbers: [],
+    pullRequests: [],
     commitsWithoutMergedMainPullRequest: [],
     failureMessages,
   };
@@ -279,7 +290,7 @@ async function createPreviewState(createPreviewStateOptions: CreatePreviewStateO
     targetMainCommit: resolvedTargetMainCommit,
     mergeBase: Maybe.just(mergeBase),
     commitsInspected: commits,
-    pullRequestNumbers: discoveryResult.pullRequestNumbers,
+    pullRequests: discoveryResult.pullRequests,
     commitsWithoutMergedMainPullRequest: discoveryResult.commitsWithoutMergedMainPullRequest,
     failureMessages: discoveryResult.failureMessages,
   };
@@ -302,11 +313,22 @@ function formatPullRequestLines(state: PreviewNextBetaState, githubRepository: s
     return ['Not inspected.'];
   }
 
-  return is.emptyArray(state.pullRequestNumbers)
+  return is.emptyArray(state.pullRequests)
     ? ['No merged pull requests are currently waiting for the next Beta.']
-    : state.pullRequestNumbers.map(pullRequestNumber => {
-        return `- [#${pullRequestNumber}](https://github.com/${githubRepository}/pull/${pullRequestNumber})`;
+    : state.pullRequests.map(pullRequest => {
+        return `- [#${pullRequest.number}](https://github.com/${githubRepository}/pull/${pullRequest.number}) ${normalizePullRequestTitle(
+          pullRequest.title,
+        )}`;
       });
+}
+
+function normalizePullRequestTitle(title: string): string {
+  return title
+    .trim()
+    .replace(/\s+/gu, ' ')
+    .replace(markdownSpecialCharacterPattern, character => {
+      return `\\${character}`;
+    });
 }
 
 function formatDetailValue(value: string, markdown: boolean): string {
@@ -329,7 +351,7 @@ function createDetailLines(state: PreviewNextBetaState, markdown: boolean): read
   const inspectionValues = state.mergeBase.isJust
     ? {
         commitsInspected: state.commitsInspected.length.toString(),
-        pullRequests: state.pullRequestNumbers.length.toString(),
+        pullRequests: state.pullRequests.length.toString(),
         commitsWithoutPullRequests: state.commitsWithoutMergedMainPullRequest.length.toString(),
       }
     : {
@@ -390,7 +412,7 @@ function createReport(createReportOptions: CreateReportOptions): string {
     'Preview next Beta changes',
     ...createDetailLines(state, false),
     ...(is.emptyString(unavailableMessage) ? [] : ['', unavailableMessage]),
-    ...(state.mergeBase.isJust && is.emptyArray(state.pullRequestNumbers)
+    ...(state.mergeBase.isJust && is.emptyArray(state.pullRequests)
       ? ['No merged pull requests are currently waiting for the next Beta.']
       : []),
     ...(is.emptyArray(failureLines) ? [] : ['Failures:', ...failureLines]),

--- a/tools/release-appearance/releaseAppearanceCommand.test.ts
+++ b/tools/release-appearance/releaseAppearanceCommand.test.ts
@@ -124,6 +124,7 @@ function createFailure<valueType>(message: string): Result<valueType, Error> {
 function createPullRequest(number: number): PullRequestRecord {
   return {
     number,
+    title: 'Add release appearance test coverage',
     baseBranch: 'main',
     mergedAt: Maybe.just('2026-01-02T00:00:00Z'),
   };
@@ -559,7 +560,14 @@ describe('executeReleaseAppearanceCommand', () => {
         requestJson: async function requestJson(request): Promise<unknown> {
           githubRequests.push(request);
           if (request.url.pathname.endsWith('/pulls')) {
-            return [{number: 7, merged_at: '2026-01-02T00:00:00Z', base: {ref: 'main'}}];
+            return [
+              {
+                number: 7,
+                title: 'Add release appearance test coverage',
+                merged_at: '2026-01-02T00:00:00Z',
+                base: {ref: 'main'},
+              },
+            ];
           }
           if (request.method !== 'get') {
             throw new Error('Dry run attempted a mutation request');


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Include pull request titles in the detailed output of the **Preview next Beta changes** workflow.

The workflow already lists the pull requests that are currently on `main` but not part of the latest Beta candidate. Adding their titles makes the result easier to understand and provides a useful starting point for Beta release notes.

The summary now renders pull requests as:

```text
#22050 Add first-appearance release comments to pull requests [WPB-26469]
#22052 Add release appearance comment dry run [WPB-26469]
#22056 Add next Beta change preview [WPB-26469]

[WPB-26469]: https://wearezeta.atlassian.net/browse/WPB-26469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WPB-26469]: https://wearezeta.atlassian.net/browse/WPB-26469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WPB-26469]: https://wearezeta.atlassian.net/browse/WPB-26469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ