### PR TITLE
fix: show folder name in drive search title [WPB-27589]

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -509,6 +509,7 @@
   "cells.restoreRootNodeModal.file.headline": "Restore file?",
   "cells.restoreRootNodeModal.folder.description": "This folder {name} will be restored with all its contents and available again to everyone in this conversation.",
   "cells.restoreRootNodeModal.folder.headline": "Restore folder",
+  "cells.search.allFilesPlaceholder": "Search files",
   "cells.search.closeButton": "Close",
   "cells.search.failed": "Something went wrong, please try again later.",
   "cells.search.placeholder": "Search files and folders",

--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -512,6 +512,8 @@
   "cells.search.closeButton": "Close",
   "cells.search.failed": "Something went wrong, please try again later.",
   "cells.search.placeholder": "Search files and folders",
+  "cells.search.results": "Search results",
+  "cells.search.resultsIn": "Search results in {folderName}",
   "cells.selfDeletingMessage.info": "The feature is not available for conversations with a shared Drive.",
   "cells.shareModal.changePassword": "Change Password",
   "cells.shareModal.copyLink": "Copy Link",

--- a/apps/webapp/src/script/components/Conversation/Conversation.tsx
+++ b/apps/webapp/src/script/components/Conversation/Conversation.tsx
@@ -61,6 +61,8 @@ import {
   tabsHiddenStyles,
   tabsWrapperStyles,
 } from './Conversation.styles';
+import {getCellsFilesPath} from './ConversationCells/common/getCellsFilesPath/getCellsFilesPath';
+import {getCurrentFolderName} from './ConversationCells/common/getCurrentFolderName/getCurrentFolderName';
 import {ConversationCells} from './ConversationCells/ConversationCells';
 import {ConversationFileDropzone} from './ConversationFileDropzone/ConversationFileDropzone';
 import {ConversationMessagesWrapper} from './ConversationMessagesWrapper/ConversationMessagesWrapper';
@@ -597,6 +599,8 @@ export const Conversation = ({
       translate,
     });
 
+  const currentFolderName = getCurrentFolderName(getCellsFilesPath());
+
   return (
     <ConversationFileDropzone
       isDragAccept={isDragAccept}
@@ -638,7 +642,11 @@ export const Conversation = ({
                 </div>
                 {isSharedDriveSearchViewOpen && (
                   <div css={searchResultsOverlayStyles}>
-                    <h3 css={searchResultsHeadingStyles}>Search results</h3>
+                    <h3 css={searchResultsHeadingStyles}>
+                      {currentFolderName
+                        ? translate('cells.search.resultsIn', {folderName: currentFolderName})
+                        : translate('cells.search.results')}
+                    </h3>
                   </div>
                 )}
               </div>

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/getCurrentFolderName/getCurrentFolderName.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/getCurrentFolderName/getCurrentFolderName.test.ts
@@ -1,0 +1,15 @@
+import {getCurrentFolderName} from './getCurrentFolderName';
+
+describe('getCurrentFolderName', () => {
+  it('returns the last folder from a nested path', () => {
+    expect(getCurrentFolderName('Parent/Current folder')).toBe('Current folder');
+  });
+
+  it('returns nothing for the drive root', () => {
+    expect(getCurrentFolderName('')).toBe('');
+  });
+
+  it('returns nothing for the recycle bin path', () => {
+    expect(getCurrentFolderName('recycle_bin')).toBe('');
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/getCurrentFolderName/getCurrentFolderName.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/getCurrentFolderName/getCurrentFolderName.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import is from '@sindresorhus/is';
+
 import {RECYCLE_BIN_PATH} from '../recycleBin/recycleBin';
 
 export const getCurrentFolderName = (currentPath: string): string => {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/getCurrentFolderName/getCurrentFolderName.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/getCurrentFolderName/getCurrentFolderName.ts
@@ -17,12 +17,12 @@
  *
  */
 
-import is from '@sindresorhus/is';
+import {isEmptyString} from '@sindresorhus/is';
 
 import {RECYCLE_BIN_PATH} from '../recycleBin/recycleBin';
 
 export const getCurrentFolderName = (currentPath: string): string => {
-  if (is.emptyString(currentPath) || currentPath === RECYCLE_BIN_PATH) {
+  if (isEmptyString(currentPath) || currentPath === RECYCLE_BIN_PATH) {
     return '';
   }
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/getCurrentFolderName/getCurrentFolderName.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/getCurrentFolderName/getCurrentFolderName.ts
@@ -1,0 +1,29 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {RECYCLE_BIN_PATH} from '../recycleBin/recycleBin';
+
+export const getCurrentFolderName = (currentPath: string): string => {
+  if (!currentPath || currentPath === RECYCLE_BIN_PATH) {
+    return '';
+  }
+
+  const segments = currentPath.split('/').filter(Boolean);
+  return segments.at(-1) ?? '';
+};

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/getCurrentFolderName/getCurrentFolderName.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/getCurrentFolderName/getCurrentFolderName.ts
@@ -20,7 +20,7 @@
 import {RECYCLE_BIN_PATH} from '../recycleBin/recycleBin';
 
 export const getCurrentFolderName = (currentPath: string): string => {
-  if (!currentPath || currentPath === RECYCLE_BIN_PATH) {
+  if (is.emptyString(currentPath) || currentPath === RECYCLE_BIN_PATH) {
     return '';
   }
 

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsHeader/cellsSearch/cellsSeach.test.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsHeader/cellsSearch/cellsSeach.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {ReactNode} from 'react';
+
+import {render, screen} from '@testing-library/react';
+
+import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
+
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import type {Translate} from 'Util/localizerUtil';
+
+import {CellsSearch} from './cellsSeach';
+
+const translate: Translate = translationKey => {
+  if (translationKey === 'cells.search.allFilesPlaceholder') {
+    return 'Search files';
+  }
+
+  return translationKey;
+};
+
+const rootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
+
+const wrapper = ({children}: {children: ReactNode}) => (
+  <StyledApp themeId={THEME_ID.DEFAULT}>{rootProviderWrapper({children})}</StyledApp>
+);
+
+describe('CellsSearch', () => {
+  it('displays the files-only search placeholder in the all-files Drive view', () => {
+    render(<CellsSearch searchValue="" onSearch={jest.fn()} onClearSearch={jest.fn()} />, {wrapper});
+
+    expect(screen.getByRole('textbox', {name: 'Search files'})).toHaveAttribute('placeholder', 'Search files');
+  });
+});

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsHeader/cellsSearch/cellsSeach.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsHeader/cellsSearch/cellsSeach.tsx
@@ -35,7 +35,7 @@ export const CellsSearch = ({searchValue, onSearch, onClearSearch}: CellsSearchP
     <div css={wrapperStyles}>
       <CellsSearchInput
         value={searchValue}
-        placeholder={translate('cells.search.placeholder')}
+        placeholder={translate('cells.search.allFilesPlaceholder')}
         onChange={onSearch}
         onClear={onClearSearch}
         clearAriaLabel={translate('cells.search.closeButton')}


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27589" title="WPB-27589" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27589</a>  [Web] Folder name absent from the page title of Search results
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


https://wearezeta.atlassian.net/browse/WPB-27589

Included also https://wearezeta.atlassian.net/browse/WPB-27638

## Summary

- show the current Shared Drive folder in the search results heading
- keep the generic heading for root and recycle-bin searches
- move the heading copy to translations
