### PR TITLE
Reduce Git fetches in the release workflow [WPB-26469]

### DIFF
--- a/.github/workflows/publish-production-distribution.yml
+++ b/.github/workflows/publish-production-distribution.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ inputs.production_tag }}
 
       - name: Download exact distribution context

--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -862,7 +862,7 @@ jobs:
       - name: Checkout release commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ needs.build_artifact.outputs.release_commit_sha }}
 
       - name: Create and push Production tag
@@ -873,9 +873,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch --tags origin
+          existing_production_tag_ref="$(
+            git ls-remote \
+              --tags \
+              origin \
+              "refs/tags/${PRODUCTION_TAG_NAME}"
+          )"
 
-          if git rev-parse --quiet --verify "refs/tags/${PRODUCTION_TAG_NAME}" >/dev/null; then
+          if [[ -n "${existing_production_tag_ref}" ]]; then
+            git fetch \
+              --no-tags \
+              --depth=1 \
+              origin \
+              "refs/tags/${PRODUCTION_TAG_NAME}:refs/tags/${PRODUCTION_TAG_NAME}"
+
             existing_production_tag_commit_sha="$(git rev-parse "${PRODUCTION_TAG_NAME}^{commit}")"
             echo "Production tag ${PRODUCTION_TAG_NAME} already exists at ${existing_production_tag_commit_sha}." >&2
             exit 1


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

### What changed

This reduces unnecessary Git network operations in the release workflow without changing its behavior.

The `Create Production tag` job now checks out only the required release commit instead of downloading the complete history of every branch and tag. It checks the exact Production tag on the remote rather than fetching all tags before creating it.

The Production-distribution workflow now performs a shallow checkout of the exact immutable Production tag. The tag remains available locally for configuration selection and continues to be validated as an annotated tag pointing to the expected release commit.

### Why

The first complete release using the new process showed that several Git operations dominated the workflow duration.

The `Create Production tag` checkout spent more than four minutes downloading the full `wire-webapp` history, followed by another broad tag fetch. The Production-distribution job repeated the same full-history download for an exact Production tag.

None of these broad or repeated fetches are required on the normal successful path.