### PR TITLE
fix(cells): hide +New in recycle bin [WPB-27712]

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.test.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.test.tsx
@@ -63,7 +63,7 @@ describe('CellsHeader', () => {
   });
 
   it('renders the new-item menu outside the recycle bin', () => {
-    window.location.hash = '#/conversation/conversation-id/wire.com/files/folder';
+    window.location.hash = '#/conversation/conversation-id/wire.com/files/';
 
     renderCellsHeader();
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.test.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ReactNode} from 'react';
+
+import {render, screen} from '@testing-library/react';
+
+import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
+
+import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+
+import {CellsHeader} from './CellsHeader';
+
+const cellsNewItemButtonLabel = 'cells.newItemMenu.button';
+
+const rootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate: key => key}));
+
+const withTheme = (component: ReactNode) => <StyledApp themeId={THEME_ID.DEFAULT}>{component}</StyledApp>;
+
+const renderCellsHeader = () => {
+  return render(
+    withTheme(
+      <CellsHeader
+        onRefresh={jest.fn()}
+        conversationName="Conversation"
+        conversationQualifiedId={{id: 'conversation-id', domain: 'wire.com'}}
+        cellsRepository={{} as CellsRepository}
+        isSearchViewOpen={false}
+        onOpenSearchView={jest.fn()}
+        searchValue=""
+        onSearchChange={jest.fn()}
+        onSearchClear={jest.fn()}
+        filters={[]}
+      />,
+    ),
+    {wrapper: rootProviderWrapper},
+  );
+};
+
+describe('CellsHeader', () => {
+  afterEach(() => {
+    window.location.hash = '';
+  });
+
+  it('renders the new-item menu outside the recycle bin', () => {
+    window.location.hash = '#/conversation/conversation-id/wire.com/files/folder';
+
+    renderCellsHeader();
+
+    expect(screen.getByRole('button', {name: cellsNewItemButtonLabel})).toBeInTheDocument();
+  });
+
+  it('does not render the new-item menu in the recycle bin', () => {
+    window.location.hash = '#/conversation/conversation-id/wire.com/files/recycle_bin';
+
+    renderCellsHeader();
+
+    expect(screen.queryByRole('button', {name: cellsNewItemButtonLabel})).not.toBeInTheDocument();
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.tsx
@@ -75,7 +75,7 @@ export const CellsHeader = ({
     recycleBinLabel: translate('cells.recycleBin.breadcrumb'),
   });
   const isRootLevel = breadcrumbs.length === 1;
-  const isRecycleBin = isInRecycleBin();
+  const isInsideRecycleBin = isInRecycleBin();
 
   return (
     <div css={wrapperStyles}>
@@ -96,7 +96,7 @@ export const CellsHeader = ({
           <CellsFiltersBar filters={filters} />
         ) : (
           <div css={actionsStyles}>
-            {!isRecycleBin && (
+            {isInsideRecycleBin === false && (
               <CellsNewMenu
                 cellsRepository={cellsRepository}
                 conversationQualifiedId={conversationQualifiedId}

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.tsx
@@ -41,6 +41,7 @@ import type {FilterConfig} from '../common/CellsFiltersBar/filterConfig';
 import {getBreadcrumbsFromPath} from '../common/getBreadcrumbsFromPath/getBreadcrumbsFromPath';
 import {getCellsFilesPath} from '../common/getCellsFilesPath/getCellsFilesPath';
 import {openBreadcrumb} from '../common/openBreadcrumb/openBreadcrumb';
+import {isInRecycleBin} from '../common/recycleBin/recycleBin';
 
 interface CellsHeaderProps {
   onRefresh: () => void;
@@ -74,6 +75,7 @@ export const CellsHeader = ({
     recycleBinLabel: translate('cells.recycleBin.breadcrumb'),
   });
   const isRootLevel = breadcrumbs.length === 1;
+  const isRecycleBin = isInRecycleBin();
 
   return (
     <div css={wrapperStyles}>
@@ -94,11 +96,13 @@ export const CellsHeader = ({
           <CellsFiltersBar filters={filters} />
         ) : (
           <div css={actionsStyles}>
-            <CellsNewMenu
-              cellsRepository={cellsRepository}
-              conversationQualifiedId={conversationQualifiedId}
-              onRefresh={onRefresh}
-            />
+            {!isRecycleBin && (
+              <CellsNewMenu
+                cellsRepository={cellsRepository}
+                conversationQualifiedId={conversationQualifiedId}
+                onRefresh={onRefresh}
+              />
+            )}
             <CellsRefresh onRefresh={onRefresh} />
             <CellsMoreMenu conversationQualifiedId={conversationQualifiedId} />
           </div>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27712" title="WPB-27712" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27712</a>  [Web] The Recycle Bin screen should not include the +New button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Hide the creation menu when a Conversation Drive is in recycle bin, preventing file and folder creation there. Cover normal-folder and recycle-bin header rendering.

ref: https://wearezeta.atlassian.net/browse/WPB-27712


