### PR TITLE
fix(drive): disable search in recycle bin [WPB-27709]

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.test.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.test.tsx
@@ -17,63 +17,78 @@
  *
  */
 
-import {ReactNode} from 'react';
-
 import {render, screen} from '@testing-library/react';
 
 import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
 
-import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import type {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
+import {translateForTest} from 'Util/test/translateForTest';
 
 import {CellsHeader} from './CellsHeader';
 
 const cellsNewItemButtonLabel = 'cells.newItemMenu.button';
+const rootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate: translateForTest}),
+);
 
-const rootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate: key => key}));
+const filter = {
+  type: 'toggle' as const,
+  id: 'hasPublicLink' as const,
+  label: 'Public links',
+  isActive: false,
+  onToggle: jest.fn(),
+};
 
-const withTheme = (component: ReactNode) => <StyledApp themeId={THEME_ID.DEFAULT}>{component}</StyledApp>;
+const defaultProperties = {
+  onRefresh: jest.fn(),
+  conversationName: 'Project Alpha',
+  conversationQualifiedId: {id: 'conversation-id', domain: 'wire.com'},
+  cellsRepository: {} as CellsRepository,
+  isSearchViewOpen: true,
+  isInRecycleBin: false,
+  onOpenSearchView: jest.fn(),
+  searchValue: '',
+  onSearchChange: jest.fn(),
+  onSearchClear: jest.fn(),
+  filters: [filter],
+};
 
-const renderCellsHeader = () => {
+const renderCellsHeader = (properties: Partial<typeof defaultProperties> = {}) => {
   return render(
-    withTheme(
-      <CellsHeader
-        onRefresh={jest.fn()}
-        conversationName="Conversation"
-        conversationQualifiedId={{id: 'conversation-id', domain: 'wire.com'}}
-        cellsRepository={{} as CellsRepository}
-        isSearchViewOpen={false}
-        onOpenSearchView={jest.fn()}
-        searchValue=""
-        onSearchChange={jest.fn()}
-        onSearchClear={jest.fn()}
-        filters={[]}
-      />,
-    ),
+    <StyledApp themeId={THEME_ID.DEFAULT}>
+      <CellsHeader {...defaultProperties} {...properties} />
+    </StyledApp>,
     {wrapper: rootProviderWrapper},
   );
 };
 
 describe('CellsHeader', () => {
-  afterEach(() => {
-    window.location.hash = '';
+  it('hides search and filters while viewing the recycle bin', () => {
+    renderCellsHeader({isInRecycleBin: true});
+
+    expect(screen.queryByRole('textbox', {name: 'cells.search.placeholder'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Public links'})).not.toBeInTheDocument();
+  });
+
+  it('keeps search and filters available outside the recycle bin', () => {
+    renderCellsHeader();
+
+    expect(screen.getByRole('textbox', {name: 'cells.search.placeholder'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Public links'})).toBeInTheDocument();
   });
 
   it('renders the new-item menu outside the recycle bin', () => {
-    window.location.hash = '#/conversation/conversation-id/wire.com/files/';
-
-    renderCellsHeader();
+    renderCellsHeader({isSearchViewOpen: false});
 
     expect(screen.getByRole('button', {name: cellsNewItemButtonLabel})).toBeInTheDocument();
   });
 
   it('does not render the new-item menu in the recycle bin', () => {
-    window.location.hash = '#/conversation/conversation-id/wire.com/files/recycle_bin';
-
-    renderCellsHeader();
+    renderCellsHeader({isInRecycleBin: true, isSearchViewOpen: false});
 
     expect(screen.queryByRole('button', {name: cellsNewItemButtonLabel})).not.toBeInTheDocument();
   });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.tsx
@@ -41,7 +41,6 @@ import type {FilterConfig} from '../common/CellsFiltersBar/filterConfig';
 import {getBreadcrumbsFromPath} from '../common/getBreadcrumbsFromPath/getBreadcrumbsFromPath';
 import {getCellsFilesPath} from '../common/getCellsFilesPath/getCellsFilesPath';
 import {openBreadcrumb} from '../common/openBreadcrumb/openBreadcrumb';
-import {isInRecycleBin} from '../common/recycleBin/recycleBin';
 
 interface CellsHeaderProps {
   onRefresh: () => void;
@@ -49,6 +48,7 @@ interface CellsHeaderProps {
   conversationQualifiedId: QualifiedId;
   cellsRepository: CellsRepository;
   isSearchViewOpen: boolean;
+  isInRecycleBin: boolean;
   onOpenSearchView: () => void;
   searchValue: string;
   onSearchChange: (value: string) => void;
@@ -62,6 +62,7 @@ export const CellsHeader = ({
   conversationQualifiedId,
   cellsRepository,
   isSearchViewOpen,
+  isInRecycleBin,
   onOpenSearchView,
   searchValue,
   onSearchChange,
@@ -75,28 +76,29 @@ export const CellsHeader = ({
     recycleBinLabel: translate('cells.recycleBin.breadcrumb'),
   });
   const isRootLevel = breadcrumbs.length === 1;
-  const isInsideRecycleBin = isInRecycleBin();
 
   return (
     <div css={wrapperStyles}>
       <div css={contentStyles}>
-        <div css={searchWrapperStyles}>
-          <CellsSearchInput
-            value={searchValue}
-            placeholder={translate('cells.search.placeholder')}
-            onChange={onSearchChange}
-            onClear={onSearchClear}
-            onFocus={onOpenSearchView}
-            clearAriaLabel={translate('fullsearchCancelCloseBtn')}
-            uieName="full-search-header-input"
-          />
-        </div>
+        {!isInRecycleBin && (
+          <div css={searchWrapperStyles}>
+            <CellsSearchInput
+              value={searchValue}
+              placeholder={translate('cells.search.placeholder')}
+              onChange={onSearchChange}
+              onClear={onSearchClear}
+              onFocus={onOpenSearchView}
+              clearAriaLabel={translate('fullsearchCancelCloseBtn')}
+              uieName="full-search-header-input"
+            />
+          </div>
+        )}
 
-        {isSearchViewOpen ? (
+        {isSearchViewOpen && !isInRecycleBin ? (
           <CellsFiltersBar filters={filters} />
         ) : (
           <div css={actionsStyles}>
-            {isInsideRecycleBin === false && (
+            {!isInRecycleBin && (
               <CellsNewMenu
                 cellsRepository={cellsRepository}
                 conversationQualifiedId={conversationQualifiedId}

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
@@ -36,7 +36,7 @@ import {CellsPagination} from './CellsPagination/CellsPagination';
 import {CellsStateInfo} from './cellsStateInfo/cellsStateInfo';
 import {CellsTable} from './CellsTable/CellsTable';
 import {getLoadMoreOffset} from './common/loadMorePagination/loadMorePagination';
-import {isInRecycleBin} from './common/recycleBin/recycleBin';
+import {isInRecycleBin as isCurrentPathInRecycleBin} from './common/recycleBin/recycleBin';
 import {useCellsSorting} from './common/useCellsSorting/useCellsSorting';
 import {useCellsStore} from './common/useCellsStore/useCellsStore';
 import {useConversationDriveFilters} from './common/useConversationDriveFilters/useConversationDriveFilters';
@@ -89,8 +89,10 @@ export const ConversationCells = memo(
 
     const isCellsStateReady = cellsState === CONVERSATION_CELLS_STATE.READY;
     const isCellsStatePending = cellsState === CONVERSATION_CELLS_STATE.PENDING;
+    const isInRecycleBin = isCurrentPathInRecycleBin();
+    const isSearchMode = isSearchViewOpen && !isInRecycleBin;
 
-    const sortScopeKey = `${conversationId}:${isSearchViewOpen ? 'search' : 'browse'}`;
+    const sortScopeKey = `${conversationId}:${isSearchMode ? 'search' : 'browse'}`;
     const {sort, setSort, getDirectionFor, toggleSort} = useCellsSorting(sortScopeKey);
 
     const {refresh, setOffset} = useGetAllCellsNodes({
@@ -98,7 +100,7 @@ export const ConversationCells = memo(
       conversationQualifiedId,
       //Without this, the browse hook's hashchange handler would compete with
       // (and flap against) search results.
-      enabled: isCellsStateReady && !isSearchViewOpen,
+      enabled: isCellsStateReady && !isSearchMode,
       fireAndForgetInvoker,
       userRepository,
       sort,
@@ -119,7 +121,7 @@ export const ConversationCells = memo(
     } = useConversationSearchFiles({
       cellsRepository,
       conversationQualifiedId,
-      enabled: isCellsStateReady && isSearchViewOpen,
+      enabled: isCellsStateReady && isSearchMode,
       fireAndForgetInvoker,
       userRepository,
       filters: filterState,
@@ -129,40 +131,49 @@ export const ConversationCells = memo(
 
     // Search view open ⇒ load-more UI + search-hook data; closed ⇒ page-nav UI + browse-hook data.
     // The mode is owned by the view, not by whether the user has typed/filtered yet.
-    const isInSearchMode = isSearchViewOpen;
-    const wasSearchViewOpen = useRef(isSearchViewOpen);
+    const wasSearchViewOpen = useRef(isSearchMode);
 
     const handleClearSearch = useCallback((): void => {
       clearSearch();
     }, [clearSearch]);
 
     useEffect(() => {
-      if (wasSearchViewOpen.current && !isSearchViewOpen) {
+      if (wasSearchViewOpen.current && !isSearchMode) {
         // Search view just closed — reset any active search/filter and restore the
         // browse-mode dataset (handled by clearSearch's onClear callback → refresh).
         clearAll({conversationId});
         clearAllFilters();
         clearSearch({preserveFilters: false});
       }
-      wasSearchViewOpen.current = isSearchViewOpen;
-    }, [clearAll, clearAllFilters, clearSearch, conversationId, isSearchViewOpen]);
+      wasSearchViewOpen.current = isSearchMode;
+    }, [clearAll, clearAllFilters, clearSearch, conversationId, isSearchMode]);
 
     // Navigating into a folder or the recycle bin happens via the URL hash without
     // remounting; reset the sort on those transitions too.
     useEffect(() => {
-      const handleHashChange = (): void => setSort(null);
+      const closeSearchInRecycleBin = (): void => {
+        if (isSearchViewOpen && isCurrentPathInRecycleBin()) {
+          onCloseSearchView();
+        }
+      };
+      const handleHashChange = (): void => {
+        setSort(null);
+        closeSearchInRecycleBin();
+      };
+
+      closeSearchInRecycleBin();
       window.addEventListener('hashchange', handleHashChange);
       return () => window.removeEventListener('hashchange', handleHashChange);
-    }, [setSort]);
+    }, [isSearchViewOpen, onCloseSearchView, setSort]);
 
     const handleRefresh = useCallback((): void => {
-      if (isInSearchMode) {
+      if (isSearchMode) {
         fireAndForgetInvoker.fireAndForget(handleReload);
         return;
       }
 
       fireAndForgetInvoker.fireAndForget(refresh);
-    }, [fireAndForgetInvoker, handleReload, isInSearchMode, refresh]);
+    }, [fireAndForgetInvoker, handleReload, isSearchMode, refresh]);
 
     const nodes = getNodes({conversationId});
     const pagination = getPagination({conversationId});
@@ -182,7 +193,7 @@ export const ConversationCells = memo(
       });
     }, [loadMoreOffset, loadMoreSearchResults]);
 
-    const handleSearchViewClosure = isSearchViewOpen ? onCloseSearchView : undefined;
+    const handleSearchViewClosure = isSearchMode ? onCloseSearchView : undefined;
 
     useOnPresignedUrlExpired({conversationId, refreshCallback: handleRefresh});
 
@@ -196,18 +207,18 @@ export const ConversationCells = memo(
 
     const isLoadingVisible = isLoading && isCellsStateReady;
     const isFetchingMoreVisible = isFetchingMore && isCellsStateReady && hasNodes;
-    const isNoNodesVisible = !isLoading && !isFetchingMore && emptyView && !isInRecycleBin();
-    const isEmptyRecycleBin = isInRecycleBin() && emptyView && !isLoading && !isFetchingMore;
-    const isEmptySearchResultsVisible = isInSearchMode && isNoNodesVisible;
+    const isNoNodesVisible = !isLoading && !isFetchingMore && emptyView && !isInRecycleBin;
+    const isEmptyRecycleBin = isInRecycleBin && emptyView && !isLoading && !isFetchingMore;
+    const isEmptySearchResultsVisible = isSearchMode && isNoNodesVisible;
     const isTableVisible =
       (isSuccess || isLoading || isFetchingMore) && isCellsStateReady && !isEmptySearchResultsVisible;
     const hasMorePages = loadMoreOffset.isJust;
     const hasAppendError = isSuccess && hasNodes && storeError !== null;
 
-    const isPaginationVisible = !isInSearchMode && !emptyView;
+    const isPaginationVisible = !isSearchMode && !emptyView;
     const isLoadMoreVisible =
-      isInSearchMode && !isLoading && !isFetchingMore && !emptyView && isSuccess && hasMorePages && !hasAppendError;
-    const isLoadMoreErrorVisible = isInSearchMode && hasAppendError && hasMorePages;
+      isSearchMode && !isLoading && !isFetchingMore && !emptyView && isSuccess && hasMorePages && !hasAppendError;
+    const isLoadMoreErrorVisible = isSearchMode && hasAppendError && hasMorePages;
 
     return (
       <div css={wrapperStyles}>
@@ -216,7 +227,8 @@ export const ConversationCells = memo(
           conversationName={name}
           conversationQualifiedId={conversationQualifiedId}
           cellsRepository={cellsRepository}
-          isSearchViewOpen={isSearchViewOpen}
+          isSearchViewOpen={isSearchMode}
+          isInRecycleBin={isInRecycleBin}
           onOpenSearchView={onOpenSearchView}
           searchValue={searchValue}
           onSearchChange={handleSearch}
@@ -234,7 +246,7 @@ export const ConversationCells = memo(
             // with that folder (and breadcrumbs)
             onCloseSearchView={handleSearchViewClosure}
             getDirectionFor={getDirectionFor}
-            isSortingEnabled
+            isSortingEnabled={!isInRecycleBin}
             onToggleSort={toggleSort}
           />
         )}

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/getCellsFilesPath/getCellsFilesPath.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/getCellsFilesPath/getCellsFilesPath.ts
@@ -19,10 +19,10 @@
 
 const MIN_PARTS_LENGTH = 2;
 
-export const getCellsFilesPath = () => {
-  const hash = window.location.hash.replace('#', '');
+export const getCellsFilesPath = (hash = window.location.hash) => {
+  const normalizedHash = hash.replace('#', '');
 
-  const parts = hash.split('/files/');
+  const parts = normalizedHash.split('/files/');
   const hasFilesPath = parts.length >= MIN_PARTS_LENGTH;
 
   if (!hasFilesPath) {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/recycleBin/recycleBin.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/recycleBin/recycleBin.test.ts
@@ -17,43 +17,43 @@
  *
  */
 
-import {isInRecycleBin} from './recycleBin';
+import {getCellsFilesPath} from '../getCellsFilesPath/getCellsFilesPath';
 
-describe('isInRecycleBin', () => {
-  afterEach(() => {
-    window.location.hash = '';
-  });
+import {isPathInRecycleBin} from './recycleBin';
 
-  it('returns true for a recycle bin path', () => {
-    window.location.hash = '#/conversation/conversation-id/wire.com/files/recycle_bin/folder';
-
-    expect(isInRecycleBin()).toBe(true);
-  });
-
-  it('returns false for a path outside the recycle bin', () => {
-    window.location.hash = '#/conversation/conversation-id/wire.com/files/folder';
-
-    expect(isInRecycleBin()).toBe(false);
-  });
-
-  it.each(['test_recycle_bin', 'recycle_bin_test', 'foobar/recycle_bin'])(
-    'returns false when a regular path contains the recycle bin name: %s',
+describe('isPathInRecycleBin', () => {
+  it.each(['recycle_bin', 'recycle_bin/folder', 'recycle_bin/recycle_bin', 'recycle_bin/deleted-file/nested-folder'])(
+    'recognizes a recycle bin path: %s',
     path => {
-      window.location.hash = `#/conversation/conversation-id/wire.com/files/${path}`;
-
-      expect(isInRecycleBin()).toBe(false);
+      expect(isPathInRecycleBin(path)).toBe(true);
     },
   );
 
-  it('returns true when a recycle-bin descendant is also named recycle_bin', () => {
-    window.location.hash = '#/conversation/conversation-id/wire.com/files/recycle_bin/recycle_bin';
+  it.each([
+    'folder',
+    'test_recycle_bin',
+    'recycle_bin_test',
+    'foobar/recycle_bin',
+    'recycle_bin_notes',
+    'recycle_bin archive',
+  ])('does not match a folder name: %s', path => {
+    expect(isPathInRecycleBin(path)).toBe(false);
+  });
+});
 
-    expect(isInRecycleBin()).toBe(true);
+describe('recycle bin detection from a URL-encoded files path', () => {
+  // getCellsFilesPath accepts the hash directly, so the decode + validation
+  // pipeline is exercised without mutating window.location.
+  it.each([
+    {encodedPath: 'recycle_bin%2Fdeleted-file', isInBin: true},
+    {encodedPath: 'recycle_bin%20archive', isInBin: false},
+  ])('decodes $encodedPath before validating', ({encodedPath, isInBin}) => {
+    const hash = `#/conversation/conversation-id/wire.com/files/${encodedPath}`;
+
+    expect(isPathInRecycleBin(getCellsFilesPath(hash))).toBe(isInBin);
   });
 
   it('returns false when the hash has no files path', () => {
-    window.location.hash = '#/conversation/conversation-id/wire.com';
-
-    expect(isInRecycleBin()).toBe(false);
+    expect(isPathInRecycleBin(getCellsFilesPath('#/conversation/conversation-id/wire.com'))).toBe(false);
   });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/recycleBin/recycleBin.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/recycleBin/recycleBin.ts
@@ -17,26 +17,16 @@
  *
  */
 
+import {getCellsFilesPath} from '../getCellsFilesPath/getCellsFilesPath';
+
 export const RECYCLE_BIN_PATH = 'recycle_bin';
 
-export const isRootRecycleBinPath = () => {
-  const hash = window.location.hash.replace('#', '');
+export const isPathInRecycleBin = (path: string): boolean =>
+  path === RECYCLE_BIN_PATH || path.startsWith(`${RECYCLE_BIN_PATH}/`);
 
-  const parts = hash.split('/files/');
+export const isRootRecycleBinPath = (): boolean => getCellsFilesPath() === RECYCLE_BIN_PATH;
 
-  const path = decodeURIComponent(parts[1]);
-
-  return path === RECYCLE_BIN_PATH;
-};
-
-export const isInRecycleBin = (): boolean => {
-  const hash = window.location.hash.replace('#', '');
-
-  const parts = hash.split('/files/');
-  const path = parts[1];
-
-  return path === RECYCLE_BIN_PATH || path?.startsWith(`${RECYCLE_BIN_PATH}/`) === true;
-};
+export const isInRecycleBin = (): boolean => isPathInRecycleBin(getCellsFilesPath());
 
 export const getNodeRootParentPath = ({nodePath}: {nodePath: string}) => {
   const segments = nodePath.split('/');


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27709" title="WPB-27709" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27709</a>  [Web] Remove the option to sort, filter and search files and folders in Recycling Bin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Avoid showing the conversation Drive search view when navigating to the recycle bin, and hide search controls and filters while it is active. Match recycle-bin path segments exactly so folders with similar names retain Drive controls.

Jira: https://wearezeta.atlassian.net/browse/WPB-27709


