### PR TITLE
Expose meeting fetch and route lifecycle events [WPB-26735]

### DIFF
--- a/apps/webapp/src/script/repositories/event/EventRepository.test.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {BackendEvent, CONVERSATION_EVENT, USER_EVENT} from '@wireapp/api-client/lib/event/';
+import {BackendEvent, CONVERSATION_EVENT, MEETING_EVENT, USER_EVENT} from '@wireapp/api-client/lib/event/';
 import {ConnectionState} from '@wireapp/core';
 import {WebAppEvents} from '@wireapp/webapp-events';
 import {amplify} from 'amplify';
@@ -261,40 +261,88 @@ describe('EventRepository', () => {
       jest.restoreAllMocks();
     });
 
-    it('publishes MEETING.DELETED with qualified_id for RFC-shaped meeting.delete events', async () => {
-      const meetingId = {id: 'meeting-id', domain: 'example.com'};
+    const meetingId = {id: 'meeting-id', domain: 'example.com'};
+    const meetingLifecycleEventBase = {
+      time: '2026-07-21T12:00:00.000Z',
+      qualified_id: meetingId,
+      conversation: 'conversation-id',
+      qualified_conversation: {id: 'conversation-id', domain: 'example.com'},
+      from: 'user-id',
+      qualified_from: {id: 'user-id', domain: 'example.com'},
+      via: 'user',
+    };
+
+    const meetingLifecycleCases = [
+      [MEETING_EVENT.CREATE, WebAppEvents.MEETING.CREATED],
+      [MEETING_EVENT.UPDATE, WebAppEvents.MEETING.UPDATED],
+      [MEETING_EVENT.DELETE, WebAppEvents.MEETING.DELETED],
+    ] as const;
+
+    it.each(meetingLifecycleCases)(
+      'publishes %s as normalized WebApp event with qualified_id only',
+      async (eventType, webAppEvent) => {
+        const event = {
+          ...meetingLifecycleEventBase,
+          type: eventType,
+        };
+
+        await eventRepository['distributeEvent'](event as any, EventSource.WEBSOCKET);
+
+        expect(amplify.publish).toHaveBeenCalledWith(webAppEvent, meetingId);
+        expect(amplify.publish).not.toHaveBeenCalledWith(eventType, expect.anything());
+        expect(amplify.publish).not.toHaveBeenCalledWith(
+          WebAppEvents.CONVERSATION.EVENT_FROM_BACKEND,
+          expect.anything(),
+          expect.anything(),
+        );
+      },
+    );
+
+    const malformedQualifiedIdCases = [
+      ['missing qualified_id', {qualified_id: undefined}],
+      ['non-string id', {qualified_id: {id: 123, domain: 'example.com'}}],
+      ['non-string domain', {qualified_id: {id: 'meeting-id', domain: 456}}],
+    ] as const;
+
+    it.each(
+      meetingLifecycleCases.flatMap(([eventType, webAppEvent]) =>
+        malformedQualifiedIdCases.map(([description, eventOverrides]) => ({
+          description,
+          eventOverrides,
+          eventType,
+          webAppEvent,
+        })),
+      ),
+    )(
+      'does not publish normalized event when $eventType has $description',
+      async ({eventType, webAppEvent, eventOverrides}) => {
+        const warnSpy = jest.spyOn(eventRepository.logger, 'warn').mockImplementation(() => {});
+        const event = {
+          ...meetingLifecycleEventBase,
+          ...eventOverrides,
+          type: eventType,
+        };
+
+        await eventRepository['distributeEvent'](event as any, EventSource.WEBSOCKET);
+
+        expect(amplify.publish).not.toHaveBeenCalledWith(webAppEvent, expect.anything());
+        expect(warnSpy).toHaveBeenCalled();
+      },
+    );
+
+    it('publishes unknown meeting events with the raw backend event type', async () => {
       const event = {
-        type: 'meeting.delete',
+        type: 'meeting.unknown',
         time: '2026-07-21T12:00:00.000Z',
-        qualified_id: meetingId,
-        conversation: 'conversation-id',
-        qualified_conversation: {id: 'conversation-id', domain: 'example.com'},
-        from: 'user-id',
-        qualified_from: {id: 'user-id', domain: 'example.com'},
-        via: 'user',
+        payload: 'keep-me',
       };
 
       await eventRepository['distributeEvent'](event as any, EventSource.WEBSOCKET);
 
-      expect(amplify.publish).toHaveBeenCalledWith(WebAppEvents.MEETING.DELETED, meetingId);
-      expect(amplify.publish).not.toHaveBeenCalledWith(
-        WebAppEvents.CONVERSATION.EVENT_FROM_BACKEND,
-        expect.anything(),
-        expect.anything(),
-      );
-    });
-
-    it('does not publish MEETING.DELETED when meeting.delete is missing qualified_id', async () => {
-      const warnSpy = jest.spyOn(eventRepository.logger, 'warn').mockImplementation(() => {});
-      const event = {
-        type: 'meeting.delete',
-        time: '2026-07-21T12:00:00.000Z',
-      };
-
-      await eventRepository['distributeEvent'](event as any, EventSource.WEBSOCKET);
-
+      expect(amplify.publish).toHaveBeenCalledWith('meeting.unknown', event);
+      expect(amplify.publish).not.toHaveBeenCalledWith(WebAppEvents.MEETING.CREATED, expect.anything());
+      expect(amplify.publish).not.toHaveBeenCalledWith(WebAppEvents.MEETING.UPDATED, expect.anything());
       expect(amplify.publish).not.toHaveBeenCalledWith(WebAppEvents.MEETING.DELETED, expect.anything());
-      expect(warnSpy).toHaveBeenCalled();
     });
   });
 

--- a/apps/webapp/src/script/repositories/event/EventRepository.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.ts
@@ -581,38 +581,28 @@ export class EventRepository {
   }
 
   private distributeMeetingEvent(event: IncomingEvent): void {
+    const webAppEventByMeetingEvent: Partial<Record<MEETING_EVENT, string>> = {
+      [MEETING_EVENT.CREATE]: WebAppEvents.MEETING.CREATED,
+      [MEETING_EVENT.UPDATE]: WebAppEvents.MEETING.UPDATED,
+      [MEETING_EVENT.DELETE]: WebAppEvents.MEETING.DELETED,
+    };
+
+    const webAppEvent = webAppEventByMeetingEvent[event.type as MEETING_EVENT];
+    if (webAppEvent === undefined) {
+      amplify.publish(event.type, event);
+      return;
+    }
+
     const meetingId = 'qualified_id' in event ? event.qualified_id : undefined;
     const hasValidQualifiedId =
       meetingId !== undefined && typeof meetingId.id === 'string' && typeof meetingId.domain === 'string';
 
-    switch (event.type) {
-      case MEETING_EVENT.CREATE: {
-        if (!hasValidQualifiedId) {
-          this.logger.warn('Ignored meeting.create event without a valid qualified_id', event);
-          return;
-        }
-        amplify.publish(WebAppEvents.MEETING.CREATED, meetingId);
-        return;
-      }
-      case MEETING_EVENT.UPDATE: {
-        if (!hasValidQualifiedId) {
-          this.logger.warn('Ignored meeting.update event without a valid qualified_id', event);
-          return;
-        }
-        amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId);
-        return;
-      }
-      case MEETING_EVENT.DELETE: {
-        if (!hasValidQualifiedId) {
-          this.logger.warn('Ignored meeting.delete event without a valid qualified_id', event);
-          return;
-        }
-        amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
-        return;
-      }
-      default:
-        amplify.publish(event.type, event);
+    if (!hasValidQualifiedId) {
+      this.logger.warn(`Ignored ${event.type} event without a valid qualified_id`, event);
+      return;
     }
+
+    amplify.publish(webAppEvent, meetingId);
   }
 
   /**

--- a/apps/webapp/src/script/repositories/event/EventRepository.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.ts
@@ -581,18 +581,38 @@ export class EventRepository {
   }
 
   private distributeMeetingEvent(event: IncomingEvent): void {
-    if (event.type !== MEETING_EVENT.DELETE) {
-      amplify.publish(event.type, event);
-      return;
-    }
-
     const meetingId = 'qualified_id' in event ? event.qualified_id : undefined;
-    if (meetingId === undefined || typeof meetingId.id !== 'string' || typeof meetingId.domain !== 'string') {
-      this.logger.warn('Ignored meeting.delete event without a valid qualified_id', event);
-      return;
-    }
+    const hasValidQualifiedId =
+      meetingId !== undefined && typeof meetingId.id === 'string' && typeof meetingId.domain === 'string';
 
-    amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
+    switch (event.type) {
+      case MEETING_EVENT.CREATE: {
+        if (!hasValidQualifiedId) {
+          this.logger.warn('Ignored meeting.create event without a valid qualified_id', event);
+          return;
+        }
+        amplify.publish(WebAppEvents.MEETING.CREATED, meetingId);
+        return;
+      }
+      case MEETING_EVENT.UPDATE: {
+        if (!hasValidQualifiedId) {
+          this.logger.warn('Ignored meeting.update event without a valid qualified_id', event);
+          return;
+        }
+        amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId);
+        return;
+      }
+      case MEETING_EVENT.DELETE: {
+        if (!hasValidQualifiedId) {
+          this.logger.warn('Ignored meeting.delete event without a valid qualified_id', event);
+          return;
+        }
+        amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
+        return;
+      }
+      default:
+        amplify.publish(event.type, event);
+    }
   }
 
   /**

--- a/apps/webapp/src/script/repositories/meetings/meetingsApiDataSource.test.ts
+++ b/apps/webapp/src/script/repositories/meetings/meetingsApiDataSource.test.ts
@@ -41,4 +41,31 @@ describe('MeetingsApiDataSource', () => {
     expect(createMeeting).toHaveBeenCalledTimes(1);
     expect(getMeetingsList).toHaveBeenCalledTimes(1);
   });
+
+  it('delegates getMeeting to the injected MeetingsAPI', async () => {
+    const meetingId = {id: 'meeting-id', domain: 'example.com'};
+    const meeting = {
+      created_at: '2026-06-15T09:00:00.000Z',
+      updated_at: '2026-06-15T09:00:00.000Z',
+      start_time: '2026-06-16T10:00:00.000Z',
+      end_time: '2026-06-16T11:00:00.000Z',
+      title: 'Weekly sync',
+      qualified_conversation: {id: 'conversation-id', domain: 'example.com'},
+      qualified_creator: {id: 'creator-id', domain: 'example.com'},
+      qualified_id: meetingId,
+      trial: false,
+    };
+    const getMeeting = jest.fn().mockResolvedValue(meeting);
+    const meetingsApi = {
+      getMeeting,
+    } as unknown as MeetingsAPI;
+
+    const dataSource = new MeetingsApiDataSource(meetingsApi);
+
+    const result = await dataSource.getMeeting(meetingId);
+
+    expect(getMeeting).toHaveBeenCalledTimes(1);
+    expect(getMeeting).toHaveBeenCalledWith(meetingId);
+    expect(result).toBe(meeting);
+  });
 });

--- a/apps/webapp/src/script/repositories/meetings/meetingsApiDataSource.ts
+++ b/apps/webapp/src/script/repositories/meetings/meetingsApiDataSource.ts
@@ -32,6 +32,10 @@ export class MeetingsApiDataSource implements MeetingsDataSource {
     return this.meetingsApi.deleteMeeting(...args);
   }
 
+  getMeeting(...args: Parameters<MeetingsDataSource['getMeeting']>) {
+    return this.meetingsApi.getMeeting(...args);
+  }
+
   getMeetingsList(...args: Parameters<MeetingsDataSource['getMeetingsList']>) {
     return this.meetingsApi.getMeetingsList(...args);
   }

--- a/apps/webapp/src/script/repositories/meetings/meetingsDataSource.ts
+++ b/apps/webapp/src/script/repositories/meetings/meetingsDataSource.ts
@@ -25,6 +25,7 @@ import type {QualifiedId} from '@wireapp/api-client/lib/user';
 export interface MeetingsDataSource {
   createMeeting(payload: CreateMeeting): Promise<MeetingWithConversation>;
   deleteMeeting(meetingId: QualifiedId): Promise<void>;
+  getMeeting(meetingId: QualifiedId): Promise<Meeting>;
   getMeetingsList(): Promise<Meeting[]>;
   updateMeeting(meetingId: QualifiedId, payload: UpdateMeeting): Promise<MeetingWithConversation>;
 }

--- a/apps/webapp/src/script/repositories/meetings/meetingsRepository.ts
+++ b/apps/webapp/src/script/repositories/meetings/meetingsRepository.ts
@@ -42,6 +42,13 @@ export class MeetingsRepository {
     );
   }
 
+  getMeeting(meetingId: QualifiedId): Task<Meeting, unknown> {
+    return task.tryOrElse(
+      error => error,
+      () => this.dataSource.getMeeting(meetingId),
+    );
+  }
+
   getMeetingsList(): Task<Meeting[], unknown> {
     return task.tryOrElse(
       error => error,

--- a/libraries/core/src/conversation/conversationService/conversationService.test.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.test.ts
@@ -30,6 +30,8 @@ import {
   CONVERSATION_EVENT,
   ConversationMLSMessageAddEvent,
   ConversationMLSWelcomeEvent,
+  MEETING_EVENT,
+  MeetingCreateEvent,
 } from '@wireapp/api-client/lib/event';
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
@@ -104,7 +106,7 @@ describe('ConversationService', () => {
     apiClients.forEach(client => client.disconnect());
   });
 
-  async function buildConversationService() {
+  async function buildConversationService(coreDatabase?: CoreDatabase) {
     const client = new APIClient({urls: APIClient.BACKEND.STAGING});
     apiClients.push(client);
     jest.spyOn(client.api.conversation, 'postMlsMessage').mockReturnValue(
@@ -161,7 +163,7 @@ describe('ConversationService', () => {
       handleMLSWelcomeMessageEvent: jest.fn(),
     } as unknown as MLSService;
 
-    const mockedDb = await openDB('core-test-db');
+    const mockedDb = coreDatabase ?? (await openDB('core-test-db'));
 
     const groupIdFromConversationId = jest.fn(async () => 'groupId');
 
@@ -761,6 +763,22 @@ describe('ConversationService', () => {
   });
 
   describe('handleEvent', () => {
+    it('passes through meeting events without a conversation id', async () => {
+      const getFromDatabase = jest.fn();
+      const coreDatabase = {get: getFromDatabase} as unknown as CoreDatabase;
+      const [conversationService] = await buildConversationService(coreDatabase);
+      const meetingEvent: MeetingCreateEvent = {
+        type: MEETING_EVENT.CREATE,
+        time: '2026-07-27T12:00:00.000Z',
+        qualified_id: {id: 'meeting-id', domain: 'example.com'},
+      };
+
+      const result = await conversationService.handleEvent(meetingEvent);
+
+      expect(result).toEqual({status: 'unhandled'});
+      expect(getFromDatabase).not.toHaveBeenCalled();
+    });
+
     it('rejoins a MLS conversation if epoch mismatch detected when decrypting mls message', async () => {
       const [conversationService, {apiClient, mlsService}] = await buildConversationService();
       const conversationId = {id: 'conversationId', domain: 'staging.zinfra.io'};

--- a/libraries/webapp-events/src/index.ts
+++ b/libraries/webapp-events/src/index.ts
@@ -158,7 +158,9 @@ export const WebAppEvents = {
     UPDATE: 'wire.webapp.lifecycle.update',
   },
   MEETING: {
+    CREATED: 'wire.webapp.meeting.created',
     DELETED: 'wire.webapp.meeting.deleted',
+    UPDATED: 'wire.webapp.meeting.updated',
   },
   NOTIFICATION: {
     CLICK: 'wire.webapp.notification.click',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26735" title="WPB-26735" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26735</a>  [Web] Support new event types for Meetings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
Add single-meeting fetch to the meetings repository and route `meeting.create`, `meeting.update`, and `meeting.delete` through validated WebApp events.

## Stack
First of 5 PRs for WPB-26735. Merge this before reviewing later layers.

Follow-up: #22082