### PR TITLE
Synchronize meetings into the local store [WPB-26735]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
@@ -32,6 +32,7 @@ import {Conversation} from 'Repositories/entity/Conversation';
 import {EventRepository} from 'Repositories/event/EventRepository';
 import {EventSource} from 'Repositories/event/EventSource';
 import type {MeetingsRepository} from 'Repositories/meetings/meetingsRepository';
+import {unwrap, unwrapErr} from 'Util/test/resultTestSupport';
 import {translateForTest} from 'Util/test/translateForTest';
 
 import {createMeetingStore} from './createMeetingStore';
@@ -87,14 +88,16 @@ describe('createMeetingStore', () => {
 
   const createDeps = ({
     getMeetingsList = jest.fn().mockReturnValue(task.resolve([apiMeeting])),
+    getMeeting = jest.fn().mockReturnValue(task.resolve(apiMeeting)),
     safeGetConversationById = jest.fn(),
     serviceTasks = createServiceTasks(),
   }: {
     getMeetingsList?: jest.Mock;
+    getMeeting?: jest.Mock;
     safeGetConversationById?: jest.Mock;
     serviceTasks?: MeetingStoreServiceTasks;
   } = {}): MeetingStoreDeps => ({
-    meetingsRepository: {getMeetingsList} as unknown as MeetingsRepository,
+    meetingsRepository: {getMeetingsList, getMeeting} as unknown as MeetingsRepository,
     conversationRepository: {safeGetConversationById} as unknown as ConversationRepository,
     callingRepository: {findCall: jest.fn(), leaveCall: jest.fn()} as unknown as CallingRepository,
     wallClock,
@@ -268,5 +271,71 @@ describe('createMeetingStore', () => {
     } finally {
       amplify.unsubscribe(WebAppEvents.MEETING.DELETED, onMeetingDeleted);
     }
+  });
+
+  describe('syncMeetingByQualifiedId', () => {
+    const otherDomainEntry = {
+      ...meetingSeriesEntry,
+      qualified_id: {id: 'meeting-id', domain: 'other.com'},
+    };
+
+    it('inserts the fetched meeting when no entry exists for its qualified id', async () => {
+      const getMeeting = jest.fn().mockReturnValue(task.resolve(apiMeeting));
+      const store = createMeetingStore(createDeps({getMeeting}));
+
+      const result = await store.getState().syncMeetingByQualifiedId(apiMeeting.qualified_id);
+
+      expect(unwrap(result)).toMatchObject(meetingSeriesEntry);
+      expect(getMeeting).toHaveBeenCalledWith(apiMeeting.qualified_id);
+      expect(store.getState().meetingSeries).toHaveLength(1);
+      expect(store.getState().meetingSeries[0]).toMatchObject(meetingSeriesEntry);
+    });
+
+    it('replaces the existing entry for the same qualified id instead of duplicating it', async () => {
+      const updatedApiMeeting = {...apiMeeting, title: 'Weekly sync (updated)'};
+      const getMeeting = jest.fn().mockReturnValue(task.resolve(updatedApiMeeting));
+      const store = createMeetingStore(createDeps({getMeeting}), {meetingSeries: [meetingSeriesEntry]});
+
+      const result = await store.getState().syncMeetingByQualifiedId(apiMeeting.qualified_id);
+
+      expect(unwrap(result).title).toBe('Weekly sync (updated)');
+      expect(store.getState().meetingSeries).toHaveLength(1);
+      expect(store.getState().meetingSeries[0]?.title).toBe('Weekly sync (updated)');
+    });
+
+    it('leaves an entry with the same bare id in another domain untouched', async () => {
+      const getMeeting = jest.fn().mockReturnValue(task.resolve(apiMeeting));
+      const store = createMeetingStore(createDeps({getMeeting}), {meetingSeries: [otherDomainEntry]});
+
+      const result = await store.getState().syncMeetingByQualifiedId(apiMeeting.qualified_id);
+
+      expect(result.isOk).toBe(true);
+      expect(store.getState().meetingSeries).toHaveLength(2);
+      expect(store.getState().meetingSeries).toContainEqual(otherDomainEntry);
+      expect(store.getState().meetingSeries.find(series => series.qualified_id.domain === 'example.com')).toEqual(
+        expect.objectContaining(meetingSeriesEntry),
+      );
+    });
+
+    it('preserves existing state and rejects with fetchFailed when fetching the meeting fails', async () => {
+      const getMeeting = jest.fn().mockReturnValue(task.reject(new Error('network error')));
+      const store = createMeetingStore(createDeps({getMeeting}), {meetingSeries: [meetingSeriesEntry]});
+
+      const result = await store.getState().syncMeetingByQualifiedId(apiMeeting.qualified_id);
+
+      expect(unwrapErr(result)).toBe('fetchFailed');
+      expect(store.getState().meetingSeries).toEqual([meetingSeriesEntry]);
+    });
+
+    it('preserves existing state and rejects with mapFailed when the fetched meeting fails to map', async () => {
+      const invalidApiMeeting = {...apiMeeting, start_time: 'not-a-date'};
+      const getMeeting = jest.fn().mockReturnValue(task.resolve(invalidApiMeeting));
+      const store = createMeetingStore(createDeps({getMeeting}), {meetingSeries: [meetingSeriesEntry]});
+
+      const result = await store.getState().syncMeetingByQualifiedId(apiMeeting.qualified_id);
+
+      expect(unwrapErr(result)).toBe('mapFailed');
+      expect(store.getState().meetingSeries).toEqual([meetingSeriesEntry]);
+    });
   });
 });

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.ts
@@ -18,10 +18,11 @@
  */
 
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
-import type {Task} from 'true-myth';
+import {task, type Task} from 'true-myth';
 import {createStore, type StoreApi} from 'zustand/vanilla';
 
 import {loadMeetingsList} from 'Components/Meeting/loadMeetingsList';
+import {mapApiMeetingToSeries} from 'Components/Meeting/mapApiMeetingToSeries';
 import {mapMeetingInstanceToScheduleFormState} from 'Components/Meeting/mapMeetingInstanceToScheduleFormState';
 import {meetingSubmitErrors, type MeetingSubmitErrors} from 'Components/Meeting/meetingSubmitErrors';
 import type {ScheduleMeetingFormState} from 'Components/Meeting/ScheduleMeetingModal/scheduleMeetingTypes';
@@ -35,9 +36,12 @@ import type {
 import type {MeetingInstance} from 'Components/Meeting/types/meetingInstance';
 import type {MeetingSeries} from 'Components/Meeting/types/meetingSeries';
 import type {User} from 'Repositories/entity/User';
+import {getLogger} from 'Util/logger';
 import {matchQualifiedIds} from 'Util/qualifiedId';
 
 import type {MeetingStoreDeps} from './meetingStoreDeps';
+
+const logger = getLogger('createMeetingStore');
 
 const toDeleteMeetingCommand = (meetingInstance: MeetingInstance): DeleteMeetingCommand => ({
   meetingId: meetingInstance.meetingSeries.qualified_id,
@@ -46,6 +50,25 @@ const toDeleteMeetingCommand = (meetingInstance: MeetingInstance): DeleteMeeting
 
 const filterOutMeetingSeries = (meetingSeries: MeetingSeries[], meetingId: QualifiedId): MeetingSeries[] =>
   meetingSeries.filter(series => !matchQualifiedIds(series.qualified_id, meetingId));
+
+const upsertMeetingSeries = (meetingSeries: MeetingSeries[], updatedSeries: MeetingSeries): MeetingSeries[] => {
+  const existingIndex = meetingSeries.findIndex(series =>
+    matchQualifiedIds(series.qualified_id, updatedSeries.qualified_id),
+  );
+
+  if (existingIndex === -1) {
+    return [...meetingSeries, updatedSeries];
+  }
+
+  return meetingSeries.map((series, index) => (index === existingIndex ? updatedSeries : series));
+};
+
+export const syncMeetingErrors = {
+  fetchFailed: 'fetchFailed',
+  mapFailed: 'mapFailed',
+} as const;
+
+export type SyncMeetingError = (typeof syncMeetingErrors)[keyof typeof syncMeetingErrors];
 
 export type EditMeetingData = {
   formState: ScheduleMeetingFormState;
@@ -64,6 +87,7 @@ export type MeetingStoreState = {
   deleteMeetingForMe: (meetingInstance: MeetingInstance) => Task<void, MeetingSubmitErrors>;
   deleteMeetingForAll: (meetingInstance: MeetingInstance) => Task<void, MeetingSubmitErrors>;
   removeMeetingByQualifiedId: (meetingId: QualifiedId) => void;
+  syncMeetingByQualifiedId: (meetingId: QualifiedId) => Task<MeetingSeries, SyncMeetingError>;
   loadMeetingForEdit: (meetingInstance: MeetingInstance) => Task<EditMeetingData, MeetingSubmitErrors>;
 };
 
@@ -94,6 +118,30 @@ export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: Meetin
       set(state => ({
         meetingSeries: filterOutMeetingSeries(state.meetingSeries, meetingId),
       })),
+    syncMeetingByQualifiedId: meetingId =>
+      deps.meetingsRepository
+        .getMeeting(meetingId)
+        .mapRejected((error): SyncMeetingError => {
+          logger.warn('Failed to fetch meeting for sync', {error, qualifiedId: meetingId});
+          return syncMeetingErrors.fetchFailed;
+        })
+        .andThen(apiMeeting => {
+          const mapResult = mapApiMeetingToSeries(apiMeeting);
+
+          if (mapResult.isErr) {
+            logger.warn('Failed to map fetched meeting for sync', {
+              error: mapResult.error,
+              qualifiedId: meetingId,
+            });
+            return task.reject<MeetingSeries, SyncMeetingError>(syncMeetingErrors.mapFailed);
+          }
+
+          return task.resolve<MeetingSeries, SyncMeetingError>(mapResult.value);
+        })
+        .map(updatedSeries => {
+          set(state => ({meetingSeries: upsertMeetingSeries(state.meetingSeries, updatedSeries)}));
+          return updatedSeries;
+        }),
     loadMeetingForEdit: meetingInstance => {
       const {meetingSeries} = meetingInstance;
 

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.ts
@@ -51,17 +51,10 @@ const toDeleteMeetingCommand = (meetingInstance: MeetingInstance): DeleteMeeting
 const filterOutMeetingSeries = (meetingSeries: MeetingSeries[], meetingId: QualifiedId): MeetingSeries[] =>
   meetingSeries.filter(series => !matchQualifiedIds(series.qualified_id, meetingId));
 
-const upsertMeetingSeries = (meetingSeries: MeetingSeries[], updatedSeries: MeetingSeries): MeetingSeries[] => {
-  const existingIndex = meetingSeries.findIndex(series =>
-    matchQualifiedIds(series.qualified_id, updatedSeries.qualified_id),
-  );
-
-  if (existingIndex === -1) {
-    return [...meetingSeries, updatedSeries];
-  }
-
-  return meetingSeries.map((series, index) => (index === existingIndex ? updatedSeries : series));
-};
+const upsertMeetingSeries = (meetingSeries: MeetingSeries[], updatedSeries: MeetingSeries): MeetingSeries[] => [
+  ...meetingSeries.filter(series => !matchQualifiedIds(series.qualified_id, updatedSeries.qualified_id)),
+  updatedSeries,
+];
 
 export const syncMeetingErrors = {
   fetchFailed: 'fetchFailed',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26735" title="WPB-26735" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26735</a>  [Web] Support new event types for Meetings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
Fetch complete meeting records on lifecycle events and upsert or remove them in the local meeting store.

## Stack
Previous: #22081 (merge first)
Follow-up: #22083