### PR TITLE
Keep meeting lifecycle state synchronized globally [WPB-26735]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.test.tsx
@@ -155,6 +155,25 @@ describe('MeetingStoreRoot', () => {
     });
   });
 
+  it('reloads meetings when missed events are reported', async () => {
+    const getMeetingsList = jest
+      .fn()
+      .mockReturnValueOnce(task.resolve([createApiMeeting('Weekly sync')]))
+      .mockReturnValueOnce(task.resolve([createApiMeeting('Weekly sync (refreshed)')]));
+    renderMeetingStoreRoot({getMeetingsList});
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('Weekly sync');
+    });
+
+    amplify.publish(WebAppEvents.CONVERSATION.MISSED_EVENTS);
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('Weekly sync (refreshed)');
+    });
+    expect(getMeetingsList).toHaveBeenCalledTimes(2);
+  });
+
   it('stops handling meeting lifecycle events after unmounting', async () => {
     const {getMeeting, unmount} = renderMeetingStoreRoot();
 
@@ -164,8 +183,11 @@ describe('MeetingStoreRoot', () => {
 
     unmount();
 
-    amplify.publish(WebAppEvents.MEETING.CREATED, meetingId);
-    amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
+    await act(async () => {
+      amplify.publish(WebAppEvents.MEETING.CREATED, meetingId);
+      amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
+      await Promise.resolve();
+    });
 
     expect(getMeeting).not.toHaveBeenCalled();
   });

--- a/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.test.tsx
@@ -1,0 +1,182 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createDeterministicWallClock} from '@enormora/wall-clock/deterministic-wall-clock';
+import {FEATURE_STATUS, type FeatureList} from '@wireapp/api-client/lib/team/feature/';
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
+import {WebAppEvents} from '@wireapp/webapp-events';
+import {act, render, screen, waitFor} from '@testing-library/react';
+import {amplify} from 'amplify';
+import {task} from 'true-myth';
+import {container} from 'tsyringe';
+
+import {useMeetingStore} from 'Components/Meeting/meetingStore/MeetingStoreProvider';
+import {TeamState} from 'Repositories/team/TeamState';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import type {MainViewModel} from 'src/script/view_model/MainViewModel';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {MeetingStoreRoot} from './MeetingStoreRoot';
+
+const meetingId: QualifiedId = {id: 'meeting-id', domain: 'example.com'};
+
+const createApiMeeting = (title: string, qualifiedId: QualifiedId = meetingId) => ({
+  created_at: '2026-06-15T09:00:00.000Z',
+  updated_at: '2026-06-15T09:00:00.000Z',
+  start_time: '2026-06-16T10:00:00.000Z',
+  end_time: '2026-06-16T11:00:00.000Z',
+  title,
+  qualified_conversation: {id: 'conversation-id', domain: 'example.com'},
+  qualified_creator: {id: 'creator-id', domain: 'example.com'},
+  qualified_id: qualifiedId,
+  trial: false,
+});
+
+const meetingTitlesTestId = 'meeting-titles';
+
+const setMeetingsTeamFeature = (status: FEATURE_STATUS) => {
+  act(() => {
+    container.resolve(TeamState).teamFeatures({meetings: {status}} as FeatureList);
+  });
+};
+
+const MeetingTitlesProbe = () => {
+  const meetingSeries = useMeetingStore(state => state.meetingSeries);
+
+  return <div data-uie-name={meetingTitlesTestId}>{meetingSeries.map(series => series.title).join(',')}</div>;
+};
+
+type RenderParameters = {
+  readonly getMeetingsList?: jest.Mock;
+  readonly getMeeting?: jest.Mock;
+  readonly isMeetingsFeatureEnabled?: boolean;
+};
+
+const renderMeetingStoreRoot = ({
+  getMeetingsList = jest.fn(() => task.resolve([createApiMeeting('Weekly sync')])),
+  getMeeting = jest.fn(() => task.resolve(createApiMeeting('Weekly sync (updated)'))),
+  isMeetingsFeatureEnabled = true,
+}: RenderParameters = {}) => {
+  setMeetingsTeamFeature(isMeetingsFeatureEnabled ? FEATURE_STATUS.ENABLED : FEATURE_STATUS.DISABLED);
+
+  const mainViewModel = {
+    content: {
+      repositories: {
+        meetings: {getMeetingsList, getMeeting},
+        conversation: {},
+        calling: {},
+      },
+    },
+  } as unknown as MainViewModel;
+
+  const rootProviderWrapper = createRootProviderWrapperForTest(
+    createRootContextValueForTest({
+      translate: translateForTest,
+      wallClock: createDeterministicWallClock(),
+      mainViewModel,
+      isFeatureToggleEnabled: () => true,
+    }),
+  );
+
+  const renderResult = render(
+    <MeetingStoreRoot>
+      <MeetingTitlesProbe />
+    </MeetingStoreRoot>,
+    {wrapper: rootProviderWrapper},
+  );
+
+  return {...renderResult, getMeetingsList, getMeeting};
+};
+
+const getRenderedMeetingTitles = () => screen.getByTestId(meetingTitlesTestId).textContent;
+
+describe('MeetingStoreRoot', () => {
+  afterEach(() => {
+    act(() => {
+      container.resolve(TeamState).teamFeatures(undefined);
+    });
+  });
+
+  it('loads the meetings list once for the signed-in session', async () => {
+    const {getMeetingsList} = renderMeetingStoreRoot();
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('Weekly sync');
+    });
+
+    expect(getMeetingsList).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs a meeting into the store when a meeting created event is published', async () => {
+    const {getMeeting} = renderMeetingStoreRoot({
+      getMeetingsList: jest.fn(() => task.resolve([])),
+      getMeeting: jest.fn(() => task.resolve(createApiMeeting('Newly created meeting'))),
+    });
+
+    amplify.publish(WebAppEvents.MEETING.CREATED, meetingId);
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('Newly created meeting');
+    });
+
+    expect(getMeeting).toHaveBeenCalledWith(meetingId);
+  });
+
+  it('removes a meeting from the store when a meeting deleted event is published', async () => {
+    renderMeetingStoreRoot();
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('Weekly sync');
+    });
+
+    amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('');
+    });
+  });
+
+  it('stops handling meeting lifecycle events after unmounting', async () => {
+    const {getMeeting, unmount} = renderMeetingStoreRoot();
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('Weekly sync');
+    });
+
+    unmount();
+
+    amplify.publish(WebAppEvents.MEETING.CREATED, meetingId);
+    amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
+
+    expect(getMeeting).not.toHaveBeenCalled();
+  });
+
+  it('does not load meeting data when the meetings feature is disabled', async () => {
+    const {getMeetingsList} = renderMeetingStoreRoot({isMeetingsFeatureEnabled: false});
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('');
+    });
+
+    expect(getMeetingsList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.tsx
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.tsx
@@ -1,0 +1,83 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {type ReactNode, useEffect, useMemo} from 'react';
+
+import {createMeetingStore} from 'Components/Meeting/meetingStore/createMeetingStore';
+import {MeetingStoreProvider} from 'Components/Meeting/meetingStore/MeetingStoreProvider';
+import {deleteMeetingForAll, deleteMeetingForMe} from 'Components/Meeting/shared/service/deleteMeeting';
+import {meetNowMeeting, scheduleMeeting, updateMeeting} from 'Components/Meeting/shared/service/meetingService';
+import {useApplicationContext} from 'src/script/page/rootProvider';
+import {useMeetingsFeatureFlag} from 'Util/useMeetingsFeatureFlag';
+
+import {createMeetingLifecycleDispatcher} from './createMeetingLifecycleDispatcher';
+import {subscribeToMeetingLifecycleEvents} from './subscribeToMeetingLifecycleEvents';
+
+type MeetingStoreRootProps = {
+  children: ReactNode;
+};
+
+/**
+ * Owns the single meeting store of a signed-in session and keeps it in sync with the
+ * meeting lifecycle events, independently of whether the meetings view is currently rendered.
+ */
+export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
+  const {mainViewModel, wallClock} = useApplicationContext();
+  const {isMeetingsEnabled} = useMeetingsFeatureFlag();
+  const {
+    meetings: meetingsRepository,
+    conversation: conversationRepository,
+    calling: callingRepository,
+  } = mainViewModel.content.repositories;
+
+  const store = useMemo(() => {
+    const meetingServiceDeps = {meetingsRepository, conversationRepository, callingRepository, wallClock};
+
+    return createMeetingStore({
+      ...meetingServiceDeps,
+      serviceTasks: {
+        scheduleMeeting: command => scheduleMeeting(command, meetingServiceDeps),
+        meetNowMeeting: command => meetNowMeeting(command, meetingServiceDeps),
+        updateMeeting: command => updateMeeting(command, meetingServiceDeps),
+        deleteMeetingForMe: command => deleteMeetingForMe(command, meetingServiceDeps),
+        deleteMeetingForAll: command => deleteMeetingForAll(command, meetingServiceDeps),
+      },
+    });
+  }, [meetingsRepository, conversationRepository, callingRepository, wallClock]);
+
+  useEffect(() => {
+    if (!isMeetingsEnabled) {
+      return undefined;
+    }
+
+    const dispatcher = createMeetingLifecycleDispatcher({
+      loadMeetings: () => store.getState().loadMeetings(),
+      syncMeeting: meetingId => store.getState().syncMeetingByQualifiedId(meetingId),
+      removeMeeting: meetingId => store.getState().removeMeetingByQualifiedId(meetingId),
+    });
+
+    const unsubscribeFromMeetingLifecycleEvents = subscribeToMeetingLifecycleEvents({dispatcher});
+
+    dispatcher.enqueueInitialLoad();
+
+    return unsubscribeFromMeetingLifecycleEvents;
+  }, [isMeetingsEnabled, store]);
+
+  return <MeetingStoreProvider store={store}>{children}</MeetingStoreProvider>;
+};

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.test.ts
@@ -1,0 +1,238 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
+import {task} from 'true-myth';
+
+import type {MeetingSeries} from 'Components/Meeting/types/meetingSeries';
+
+import {createMeetingLifecycleDispatcher} from './createMeetingLifecycleDispatcher';
+import type {MeetingLifecycleDispatcherDependencies} from './createMeetingLifecycleDispatcher';
+import {syncMeetingErrors} from './createMeetingStore';
+
+const flushPendingWork = () => Promise.resolve();
+
+const meetingId: QualifiedId = {id: 'meeting-id', domain: 'example.com'};
+const otherMeetingId: QualifiedId = {id: 'other-meeting-id', domain: 'example.com'};
+
+const meetingSeries: MeetingSeries = {
+  title: 'Weekly sync',
+  series_start_date: '2026-06-16T10:00:00.000Z',
+  series_end_date: '2026-06-16T11:00:00.000Z',
+  duration_ms: 3_600_000,
+  conversation_id: 'conversation-id',
+  qualified_id: meetingId,
+  qualified_conversation: {id: 'conversation-id', domain: 'example.com'},
+  qualified_creator: {id: 'creator-id', domain: 'example.com'},
+  recurrence: 'doesNotRepeat',
+};
+
+type Deferred = {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+};
+
+const createDeferred = (): Deferred => {
+  let resolveDeferred: () => void = () => undefined;
+
+  const promise = new Promise<void>(resolve => {
+    resolveDeferred = resolve;
+  });
+
+  return {
+    promise,
+    resolve: () => resolveDeferred(),
+  };
+};
+
+const createDependencies = (
+  overrides: Partial<MeetingLifecycleDispatcherDependencies> = {},
+): MeetingLifecycleDispatcherDependencies => ({
+  loadMeetings: async () => undefined,
+  syncMeeting: () => task.resolve(meetingSeries),
+  removeMeeting: () => undefined,
+  ...overrides,
+});
+
+describe('createMeetingLifecycleDispatcher', () => {
+  it('finishes the initial meetings load before running lifecycle work queued after it', async () => {
+    const completedSteps: string[] = [];
+    const pendingLoad = createDeferred();
+    const dispatcher = createMeetingLifecycleDispatcher(
+      createDependencies({
+        loadMeetings: async () => {
+          completedSteps.push('load:started');
+          await pendingLoad.promise;
+          completedSteps.push('load:finished');
+        },
+        syncMeeting: id => {
+          completedSteps.push(`sync:${id.id}`);
+          return task.resolve(meetingSeries);
+        },
+      }),
+    );
+
+    dispatcher.enqueueInitialLoad();
+    dispatcher.enqueueMeetingSync(meetingId);
+
+    await flushPendingWork();
+
+    expect(completedSteps).toEqual(['load:started']);
+
+    pendingLoad.resolve();
+    await dispatcher.waitUntilAllSettled();
+
+    expect(completedSteps).toEqual(['load:started', 'load:finished', `sync:${meetingId.id}`]);
+  });
+
+  it('removes a meeting only after a slow sync queued before it has finished', async () => {
+    const completedSteps: string[] = [];
+    const pendingSync = createDeferred();
+    const dispatcher = createMeetingLifecycleDispatcher(
+      createDependencies({
+        syncMeeting: id =>
+          task.tryOrElse(
+            () => syncMeetingErrors.fetchFailed,
+            async () => {
+              completedSteps.push(`sync:${id.id}:started`);
+              await pendingSync.promise;
+              completedSteps.push(`sync:${id.id}:finished`);
+
+              return meetingSeries;
+            },
+          ),
+        removeMeeting: id => {
+          completedSteps.push(`remove:${id.id}`);
+        },
+      }),
+    );
+
+    dispatcher.enqueueMeetingSync(meetingId);
+    dispatcher.enqueueMeetingRemoval(meetingId);
+
+    await flushPendingWork();
+
+    expect(completedSteps).toEqual([`sync:${meetingId.id}:started`]);
+
+    pendingSync.resolve();
+    await dispatcher.waitUntilAllSettled();
+
+    expect(completedSteps).toEqual([
+      `sync:${meetingId.id}:started`,
+      `sync:${meetingId.id}:finished`,
+      `remove:${meetingId.id}`,
+    ]);
+  });
+
+  it('runs a sync queued after a slow sync in enqueue order', async () => {
+    const completedSteps: string[] = [];
+    const pendingCreateSync = createDeferred();
+    const dispatcher = createMeetingLifecycleDispatcher(
+      createDependencies({
+        syncMeeting: id =>
+          task.tryOrElse(
+            () => syncMeetingErrors.fetchFailed,
+            async () => {
+              completedSteps.push(`sync:${id.id}:started`);
+
+              if (id.id === meetingId.id) {
+                await pendingCreateSync.promise;
+              }
+
+              completedSteps.push(`sync:${id.id}:finished`);
+
+              return meetingSeries;
+            },
+          ),
+      }),
+    );
+
+    dispatcher.enqueueMeetingSync(meetingId);
+    dispatcher.enqueueMeetingSync(otherMeetingId);
+
+    await flushPendingWork();
+
+    expect(completedSteps).toEqual([`sync:${meetingId.id}:started`]);
+
+    pendingCreateSync.resolve();
+    await dispatcher.waitUntilAllSettled();
+
+    expect(completedSteps).toEqual([
+      `sync:${meetingId.id}:started`,
+      `sync:${meetingId.id}:finished`,
+      `sync:${otherMeetingId.id}:started`,
+      `sync:${otherMeetingId.id}:finished`,
+    ]);
+  });
+
+  it('keeps running queued work after a sync rejects', async () => {
+    const removeMeeting = jest.fn();
+    const dispatcher = createMeetingLifecycleDispatcher(
+      createDependencies({
+        syncMeeting: () => task.reject(syncMeetingErrors.fetchFailed),
+        removeMeeting,
+      }),
+    );
+
+    dispatcher.enqueueMeetingSync(meetingId);
+    dispatcher.enqueueMeetingRemoval(meetingId);
+
+    await dispatcher.waitUntilAllSettled();
+
+    expect(removeMeeting).toHaveBeenCalledWith(meetingId);
+  });
+
+  it('keeps running queued work after the initial load throws', async () => {
+    const removeMeeting = jest.fn();
+    const dispatcher = createMeetingLifecycleDispatcher(
+      createDependencies({
+        loadMeetings: async () => {
+          throw new Error('load failed');
+        },
+        removeMeeting,
+      }),
+    );
+
+    dispatcher.enqueueInitialLoad();
+    dispatcher.enqueueMeetingRemoval(meetingId);
+
+    await dispatcher.waitUntilAllSettled();
+
+    expect(removeMeeting).toHaveBeenCalledWith(meetingId);
+  });
+
+  it('keeps running queued work after a removal throws', async () => {
+    const loadMeetings = jest.fn(async () => undefined);
+    const dispatcher = createMeetingLifecycleDispatcher(
+      createDependencies({
+        loadMeetings,
+        removeMeeting: () => {
+          throw new Error('remove failed');
+        },
+      }),
+    );
+
+    dispatcher.enqueueMeetingRemoval(meetingId);
+    dispatcher.enqueueInitialLoad();
+
+    await dispatcher.waitUntilAllSettled();
+
+    expect(loadMeetings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.ts
@@ -1,0 +1,83 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
+import {task, type Task} from 'true-myth';
+
+import type {MeetingSeries} from 'Components/Meeting/types/meetingSeries';
+import {getLogger} from 'Util/logger';
+
+import type {SyncMeetingError} from './createMeetingStore';
+
+const logger = getLogger('meetingLifecycleDispatcher');
+
+const dispatcherOperationFailed = 'dispatcherOperationFailed';
+
+export type MeetingLifecycleDispatcherDependencies = {
+  loadMeetings: () => Promise<void>;
+  syncMeeting: (meetingId: QualifiedId) => Task<MeetingSeries, SyncMeetingError>;
+  removeMeeting: (meetingId: QualifiedId) => void;
+};
+
+export type MeetingLifecycleDispatcher = {
+  /** Queues the initial meetings list load. */
+  enqueueInitialLoad: () => void;
+  /** Queues a refetch of a single meeting, used for created and updated events. */
+  enqueueMeetingSync: (meetingId: QualifiedId) => void;
+  /** Queues the removal of a single meeting from the store. */
+  enqueueMeetingRemoval: (meetingId: QualifiedId) => void;
+  /** Resolves once all work queued before this call has settled. */
+  waitUntilAllSettled: () => Promise<void>;
+};
+
+/**
+ * Runs meeting lifecycle work strictly in enqueue order, so that a slow fetch can never
+ * overwrite or resurrect a meeting that a later event already changed or deleted.
+ * A failing operation is isolated and never stops the operations queued after it.
+ */
+export const createMeetingLifecycleDispatcher = (
+  dependencies: MeetingLifecycleDispatcherDependencies,
+): MeetingLifecycleDispatcher => {
+  let queuedOperations: Promise<void> = Promise.resolve();
+
+  const enqueue = (operationName: string, operation: () => Promise<unknown>): void => {
+    queuedOperations = queuedOperations.then(async () => {
+      const operationResult = await task.tryOrElse(() => dispatcherOperationFailed, operation);
+
+      if (operationResult.isErr) {
+        logger.warn('Meeting lifecycle operation failed', {operationName});
+      }
+    });
+  };
+
+  return {
+    enqueueInitialLoad: () => {
+      enqueue('initialLoad', dependencies.loadMeetings);
+    },
+    enqueueMeetingSync: meetingId => {
+      enqueue('meetingSync', async () => dependencies.syncMeeting(meetingId));
+    },
+    enqueueMeetingRemoval: meetingId => {
+      enqueue('meetingRemoval', async () => {
+        dependencies.removeMeeting(meetingId);
+      });
+    },
+    waitUntilAllSettled: () => queuedOperations,
+  };
+};

--- a/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
@@ -81,6 +81,15 @@ describe('subscribeToMeetingLifecycleEvents', () => {
     expect(dispatcher.enqueueMeetingSync).not.toHaveBeenCalled();
   });
 
+  it('queues a meetings reload when missed events are reported', () => {
+    const dispatcher = createDispatcherDouble();
+    subscribe(dispatcher);
+
+    amplify.publish(WebAppEvents.CONVERSATION.MISSED_EVENTS);
+
+    expect(dispatcher.enqueueInitialLoad).toHaveBeenCalledTimes(1);
+  });
+
   it('stops handling meeting lifecycle events after unsubscribing', () => {
     const dispatcher = createDispatcherDouble();
     const unsubscribe = subscribe(dispatcher);
@@ -90,7 +99,9 @@ describe('subscribeToMeetingLifecycleEvents', () => {
     amplify.publish(WebAppEvents.MEETING.CREATED, meetingId);
     amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId);
     amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
+    amplify.publish(WebAppEvents.CONVERSATION.MISSED_EVENTS);
 
+    expect(dispatcher.enqueueInitialLoad).not.toHaveBeenCalled();
     expect(dispatcher.enqueueMeetingSync).not.toHaveBeenCalled();
     expect(dispatcher.enqueueMeetingRemoval).not.toHaveBeenCalled();
   });

--- a/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
+import {WebAppEvents} from '@wireapp/webapp-events';
+import {amplify} from 'amplify';
+
+import type {MeetingLifecycleDispatcher} from './createMeetingLifecycleDispatcher';
+import {subscribeToMeetingLifecycleEvents} from './subscribeToMeetingLifecycleEvents';
+
+const meetingId: QualifiedId = {id: 'meeting-id', domain: 'example.com'};
+
+type MeetingLifecycleDispatcherDouble = {
+  [Key in keyof MeetingLifecycleDispatcher]: jest.Mock;
+};
+
+const createDispatcherDouble = (): MeetingLifecycleDispatcherDouble => ({
+  enqueueInitialLoad: jest.fn(),
+  enqueueMeetingSync: jest.fn(),
+  enqueueMeetingRemoval: jest.fn(),
+  waitUntilAllSettled: jest.fn(async () => undefined),
+});
+
+describe('subscribeToMeetingLifecycleEvents', () => {
+  const activeUnsubscribeCallbacks: (() => void)[] = [];
+
+  const subscribe = (dispatcher: MeetingLifecycleDispatcherDouble) => {
+    const unsubscribe = subscribeToMeetingLifecycleEvents({dispatcher});
+    activeUnsubscribeCallbacks.push(unsubscribe);
+
+    return unsubscribe;
+  };
+
+  afterEach(() => {
+    activeUnsubscribeCallbacks.splice(0).forEach(unsubscribe => unsubscribe());
+  });
+
+  it('queues a meeting sync when a meeting created event is published', () => {
+    const dispatcher = createDispatcherDouble();
+    subscribe(dispatcher);
+
+    amplify.publish(WebAppEvents.MEETING.CREATED, meetingId);
+
+    expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId);
+    expect(dispatcher.enqueueMeetingRemoval).not.toHaveBeenCalled();
+  });
+
+  it('queues a meeting sync when a meeting updated event is published', () => {
+    const dispatcher = createDispatcherDouble();
+    subscribe(dispatcher);
+
+    amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId);
+
+    expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId);
+    expect(dispatcher.enqueueMeetingRemoval).not.toHaveBeenCalled();
+  });
+
+  it('queues a meeting removal when a meeting deleted event is published', () => {
+    const dispatcher = createDispatcherDouble();
+    subscribe(dispatcher);
+
+    amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
+
+    expect(dispatcher.enqueueMeetingRemoval).toHaveBeenCalledWith(meetingId);
+    expect(dispatcher.enqueueMeetingSync).not.toHaveBeenCalled();
+  });
+
+  it('stops handling meeting lifecycle events after unsubscribing', () => {
+    const dispatcher = createDispatcherDouble();
+    const unsubscribe = subscribe(dispatcher);
+
+    unsubscribe();
+
+    amplify.publish(WebAppEvents.MEETING.CREATED, meetingId);
+    amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId);
+    amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
+
+    expect(dispatcher.enqueueMeetingSync).not.toHaveBeenCalled();
+    expect(dispatcher.enqueueMeetingRemoval).not.toHaveBeenCalled();
+  });
+
+  it('does not queue the initial load on its own', () => {
+    const dispatcher = createDispatcherDouble();
+    subscribe(dispatcher);
+
+    expect(dispatcher.enqueueInitialLoad).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
@@ -47,13 +47,19 @@ export const subscribeToMeetingLifecycleEvents = ({
     dispatcher.enqueueMeetingRemoval(meetingId);
   };
 
+  const onMissedEvents = () => {
+    dispatcher.enqueueInitialLoad();
+  };
+
   amplify.subscribe(WebAppEvents.MEETING.CREATED, onMeetingCreated);
   amplify.subscribe(WebAppEvents.MEETING.UPDATED, onMeetingUpdated);
   amplify.subscribe(WebAppEvents.MEETING.DELETED, onMeetingDeleted);
+  amplify.subscribe(WebAppEvents.CONVERSATION.MISSED_EVENTS, onMissedEvents);
 
   return () => {
     amplify.unsubscribe(WebAppEvents.MEETING.CREATED, onMeetingCreated);
     amplify.unsubscribe(WebAppEvents.MEETING.UPDATED, onMeetingUpdated);
     amplify.unsubscribe(WebAppEvents.MEETING.DELETED, onMeetingDeleted);
+    amplify.unsubscribe(WebAppEvents.CONVERSATION.MISSED_EVENTS, onMissedEvents);
   };
 };

--- a/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
@@ -1,0 +1,59 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
+import {amplify} from 'amplify';
+
+import {WebAppEvents} from '@wireapp/webapp-events';
+
+import type {MeetingLifecycleDispatcher} from './createMeetingLifecycleDispatcher';
+
+export type SubscribeToMeetingLifecycleEventsDependencies = {
+  dispatcher: MeetingLifecycleDispatcher;
+};
+
+/**
+ * Routes the meeting lifecycle events distributed by the event repository to the dispatcher.
+ * Returns the callback which removes all subscriptions again.
+ */
+export const subscribeToMeetingLifecycleEvents = ({
+  dispatcher,
+}: SubscribeToMeetingLifecycleEventsDependencies): (() => void) => {
+  const onMeetingCreated = (meetingId: QualifiedId) => {
+    dispatcher.enqueueMeetingSync(meetingId);
+  };
+
+  const onMeetingUpdated = (meetingId: QualifiedId) => {
+    dispatcher.enqueueMeetingSync(meetingId);
+  };
+
+  const onMeetingDeleted = (meetingId: QualifiedId) => {
+    dispatcher.enqueueMeetingRemoval(meetingId);
+  };
+
+  amplify.subscribe(WebAppEvents.MEETING.CREATED, onMeetingCreated);
+  amplify.subscribe(WebAppEvents.MEETING.UPDATED, onMeetingUpdated);
+  amplify.subscribe(WebAppEvents.MEETING.DELETED, onMeetingDeleted);
+
+  return () => {
+    amplify.unsubscribe(WebAppEvents.MEETING.CREATED, onMeetingCreated);
+    amplify.unsubscribe(WebAppEvents.MEETING.UPDATED, onMeetingUpdated);
+    amplify.unsubscribe(WebAppEvents.MEETING.DELETED, onMeetingDeleted);
+  };
+};

--- a/apps/webapp/src/script/components/Meeting/meetings.tsx
+++ b/apps/webapp/src/script/components/Meeting/meetings.tsx
@@ -17,53 +17,26 @@
  *
  */
 
-import {useEffect, useMemo, useRef} from 'react';
+import {useRef} from 'react';
 
-import type {QualifiedId} from '@wireapp/api-client/lib/user';
-import {amplify} from 'amplify';
 import {container} from 'tsyringe';
-
-import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {contentStyles} from 'Components/Meeting/meeting.styles';
 import {MeetingCallingView} from 'Components/Meeting/MeetingCallingView/meetingCallingView';
 import {meetingsContentWrapperStyles} from 'Components/Meeting/MeetingCallingView/meetingCallingView.styles';
 import {MeetingHeader} from 'Components/Meeting/MeetingHeader/MeetingHeader';
 import {MeetingList} from 'Components/Meeting/MeetingList/MeetingList';
-import {createMeetingStore} from 'Components/Meeting/meetingStore/createMeetingStore';
-import {MeetingStoreProvider, useMeetingStore} from 'Components/Meeting/meetingStore/MeetingStoreProvider';
+import {useMeetingStore} from 'Components/Meeting/meetingStore/MeetingStoreProvider';
 import {MeetNowModal} from 'Components/Meeting/meetNowModal/meetNowModal';
 import {ScheduleMeetingModal} from 'Components/Meeting/ScheduleMeetingModal';
-import {deleteMeetingForAll, deleteMeetingForMe} from 'Components/Meeting/shared/service/deleteMeeting';
-import {meetNowMeeting, scheduleMeeting, updateMeeting} from 'Components/Meeting/shared/service/meetingService';
 import {UserState} from 'Repositories/user/userState';
-import {useApplicationContext} from 'src/script/page/rootProvider';
 
-const MeetingsContent = () => {
-  const {fireAndForgetInvoker} = useApplicationContext();
+export const Meetings = () => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const meetingSeries = useMeetingStore(state => state.meetingSeries);
   const isLoading = useMeetingStore(state => state.isLoading);
   const hasLoadError = useMeetingStore(state => state.hasLoadError);
-  const loadMeetings = useMeetingStore(state => state.loadMeetings);
-  const removeMeetingByQualifiedId = useMeetingStore(state => state.removeMeetingByQualifiedId);
   const selfUser = container.resolve(UserState).self();
-
-  useEffect(() => {
-    fireAndForgetInvoker.fireAndForget(loadMeetings);
-  }, [loadMeetings, fireAndForgetInvoker]);
-
-  useEffect(() => {
-    const onMeetingDeleted = (meetingId: QualifiedId) => {
-      removeMeetingByQualifiedId(meetingId);
-    };
-
-    amplify.subscribe(WebAppEvents.MEETING.DELETED, onMeetingDeleted);
-
-    return () => {
-      amplify.unsubscribe(WebAppEvents.MEETING.DELETED, onMeetingDeleted);
-    };
-  }, [removeMeetingByQualifiedId]);
 
   return (
     <div css={meetingsContentWrapperStyles}>
@@ -81,35 +54,5 @@ const MeetingsContent = () => {
       <ScheduleMeetingModal />
       <MeetNowModal />
     </div>
-  );
-};
-
-export const Meetings = () => {
-  const {mainViewModel, wallClock} = useApplicationContext();
-  const {
-    meetings: meetingsRepository,
-    conversation: conversationRepository,
-    calling: callingRepository,
-  } = mainViewModel.content.repositories;
-
-  const store = useMemo(() => {
-    const meetingServiceDeps = {meetingsRepository, conversationRepository, callingRepository, wallClock};
-
-    return createMeetingStore({
-      ...meetingServiceDeps,
-      serviceTasks: {
-        scheduleMeeting: command => scheduleMeeting(command, meetingServiceDeps),
-        meetNowMeeting: command => meetNowMeeting(command, meetingServiceDeps),
-        updateMeeting: command => updateMeeting(command, meetingServiceDeps),
-        deleteMeetingForMe: command => deleteMeetingForMe(command, meetingServiceDeps),
-        deleteMeetingForAll: command => deleteMeetingForAll(command, meetingServiceDeps),
-      },
-    });
-  }, [meetingsRepository, conversationRepository, callingRepository, wallClock]);
-
-  return (
-    <MeetingStoreProvider store={store}>
-      <MeetingsContent />
-    </MeetingStoreProvider>
   );
 };

--- a/apps/webapp/src/script/components/appContainer/appContainer.tsx
+++ b/apps/webapp/src/script/components/appContainer/appContainer.tsx
@@ -29,6 +29,7 @@ import {FireAndForgetInvoker} from '@wireapp/core';
 import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
+import {MeetingStoreRoot} from 'Components/Meeting/meetingStore/MeetingStoreRoot';
 import {LeaveGroupAdminModal} from 'Components/Modals/LeaveGroupAdminModal/LeaveGroupAdminModal';
 import {PrimaryModalComponent} from 'Components/Modals/PrimaryModal/PrimaryModal';
 import {QualityFeedbackModal} from 'Components/Modals/QualityFeedbackModal';
@@ -203,15 +204,17 @@ export const AppContainer = (properties: AppProps) => {
       >
         {selfUser => {
           return (
-            <AppMain
-              app={app}
-              isFeatureToggleEnabled={isFeatureToggleEnabled}
-              selfUser={selfUser}
-              mainView={mainView}
-              locked={softLockEnabled}
-              fireAndForgetInvoker={fireAndForgetInvoker}
-              wallClock={wallClock}
-            />
+            <MeetingStoreRoot>
+              <AppMain
+                app={app}
+                isFeatureToggleEnabled={isFeatureToggleEnabled}
+                selfUser={selfUser}
+                mainView={mainView}
+                locked={softLockEnabled}
+                fireAndForgetInvoker={fireAndForgetInvoker}
+                wallClock={wallClock}
+              />
+            </MeetingStoreRoot>
           );
         }}
       </AppLoader>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26735" title="WPB-26735" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26735</a>  [Web] Support new event types for Meetings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
Wire lifecycle events into a session-scoped meeting store with a serialized dispatcher so create, update, and delete stay consistent.

## Stack
Previous: #22081, #22082 (merge in order)
Follow-up: #22084