### PR TITLE
Prevent stale meeting sync races [WPB-26735]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.tsx
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.tsx
@@ -24,10 +24,13 @@ import {MeetingStoreProvider} from 'Components/Meeting/meetingStore/MeetingStore
 import {deleteMeetingForAll, deleteMeetingForMe} from 'Components/Meeting/shared/service/deleteMeeting';
 import {meetNowMeeting, scheduleMeeting, updateMeeting} from 'Components/Meeting/shared/service/meetingService';
 import {useApplicationContext} from 'src/script/page/rootProvider';
+import {getLogger} from 'Util/logger';
 import {useMeetingsFeatureFlag} from 'Util/useMeetingsFeatureFlag';
 
 import {createMeetingLifecycleDispatcher} from './createMeetingLifecycleDispatcher';
 import {subscribeToMeetingLifecycleEvents} from './subscribeToMeetingLifecycleEvents';
+
+const logger = getLogger('MeetingStoreRoot');
 
 type MeetingStoreRootProps = {
   children: ReactNode;
@@ -70,6 +73,9 @@ export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
       loadMeetings: () => store.getState().loadMeetings(),
       syncMeeting: meetingId => store.getState().syncMeetingByQualifiedId(meetingId),
       removeMeeting: meetingId => store.getState().removeMeetingByQualifiedId(meetingId),
+      reportOperationFailure: operationName => {
+        logger.warn('Meeting lifecycle operation failed', {operationName});
+      },
     });
 
     const unsubscribeFromMeetingLifecycleEvents = subscribeToMeetingLifecycleEvents({dispatcher});

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.test.ts
@@ -67,6 +67,7 @@ const createDependencies = (
   loadMeetings: async () => undefined,
   syncMeeting: () => task.resolve(meetingSeries),
   removeMeeting: () => undefined,
+  reportOperationFailure: jest.fn(),
   ...overrides,
 });
 
@@ -196,6 +197,22 @@ describe('createMeetingLifecycleDispatcher', () => {
     await dispatcher.waitUntilAllSettled();
 
     expect(removeMeeting).toHaveBeenCalledWith(meetingId);
+  });
+
+  it('reports when a sync Task rejects', async () => {
+    const reportOperationFailure = jest.fn();
+    const dispatcher = createMeetingLifecycleDispatcher(
+      createDependencies({
+        syncMeeting: () => task.reject(syncMeetingErrors.fetchFailed),
+        reportOperationFailure,
+      }),
+    );
+
+    dispatcher.enqueueMeetingSync(meetingId);
+
+    await dispatcher.waitUntilAllSettled();
+
+    expect(reportOperationFailure).toHaveBeenCalledWith('meetingSync');
   });
 
   it('keeps running queued work after the initial load throws', async () => {

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.ts
@@ -21,11 +21,8 @@ import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import {task, type Task} from 'true-myth';
 
 import type {MeetingSeries} from 'Components/Meeting/types/meetingSeries';
-import {getLogger} from 'Util/logger';
 
 import type {SyncMeetingError} from './createMeetingStore';
-
-const logger = getLogger('meetingLifecycleDispatcher');
 
 const dispatcherOperationFailed = 'dispatcherOperationFailed';
 
@@ -33,6 +30,7 @@ export type MeetingLifecycleDispatcherDependencies = {
   loadMeetings: () => Promise<void>;
   syncMeeting: (meetingId: QualifiedId) => Task<MeetingSeries, SyncMeetingError>;
   removeMeeting: (meetingId: QualifiedId) => void;
+  reportOperationFailure: (operationName: string) => void;
 };
 
 export type MeetingLifecycleDispatcher = {
@@ -61,7 +59,7 @@ export const createMeetingLifecycleDispatcher = (
       const operationResult = await task.tryOrElse(() => dispatcherOperationFailed, operation);
 
       if (operationResult.isErr) {
-        logger.warn('Meeting lifecycle operation failed', {operationName});
+        dependencies.reportOperationFailure(operationName);
       }
     });
   };
@@ -71,7 +69,13 @@ export const createMeetingLifecycleDispatcher = (
       enqueue('initialLoad', dependencies.loadMeetings);
     },
     enqueueMeetingSync: meetingId => {
-      enqueue('meetingSync', async () => dependencies.syncMeeting(meetingId));
+      enqueue('meetingSync', async () => {
+        const syncResult = await dependencies.syncMeeting(meetingId);
+
+        if (syncResult.isErr) {
+          dependencies.reportOperationFailure('meetingSync');
+        }
+      });
     },
     enqueueMeetingRemoval: meetingId => {
       enqueue('meetingRemoval', async () => {

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
@@ -135,7 +135,7 @@ describe('createMeetingStore', () => {
   });
 
   it('does not restore a removed meeting when an older list reload finishes', async () => {
-    let finishFetch = () => undefined;
+    let finishFetch: () => void = () => {};
     const fetchGate = new Promise<void>(resolve => {
       finishFetch = resolve;
     });
@@ -160,6 +160,32 @@ describe('createMeetingStore', () => {
       isLoading: false,
       meetingSeries: [],
     });
+  });
+
+  it('does not remove a newly synchronized meeting when an older list reload finishes', async () => {
+    let finishFetch: () => void = () => {};
+    const fetchGate = new Promise<void>(resolve => {
+      finishFetch = resolve;
+    });
+    const getMeetingsList = jest.fn().mockReturnValue(
+      task.tryOrElse(
+        () => new Error('fetch failed'),
+        async () => {
+          await fetchGate;
+          return [];
+        },
+      ),
+    );
+    const store = createMeetingStore(createDeps({getMeetingsList}));
+
+    const pendingReload = store.getState().loadMeetings();
+    const syncResult = await store.getState().syncMeetingByQualifiedId(apiMeeting.qualified_id);
+    finishFetch();
+
+    await pendingReload;
+
+    expect(syncResult.isOk).toBe(true);
+    expect(store.getState().meetingSeries).toEqual([expect.objectContaining(meetingSeriesEntry)]);
   });
 
   it('schedules a meeting without refreshing the meetings list', async () => {
@@ -332,7 +358,7 @@ describe('createMeetingStore', () => {
     });
 
     it('does not restore a locally removed meeting when an older sync finishes', async () => {
-      let finishFetch = () => undefined;
+      let finishFetch: () => void = () => {};
       const fetchGate = new Promise<void>(resolve => {
         finishFetch = resolve;
       });

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
@@ -134,6 +134,34 @@ describe('createMeetingStore', () => {
     });
   });
 
+  it('does not restore a removed meeting when an older list reload finishes', async () => {
+    let finishFetch = () => undefined;
+    const fetchGate = new Promise<void>(resolve => {
+      finishFetch = resolve;
+    });
+    const getMeetingsList = jest.fn().mockReturnValue(
+      task.tryOrElse(
+        () => new Error('fetch failed'),
+        async () => {
+          await fetchGate;
+          return [apiMeeting];
+        },
+      ),
+    );
+    const store = createMeetingStore(createDeps({getMeetingsList}), {meetingSeries: [meetingSeriesEntry]});
+
+    const pendingReload = store.getState().loadMeetings();
+    store.getState().removeMeetingByQualifiedId(apiMeeting.qualified_id);
+    finishFetch();
+
+    await pendingReload;
+
+    expect(store.getState()).toMatchObject({
+      isLoading: false,
+      meetingSeries: [],
+    });
+  });
+
   it('schedules a meeting without refreshing the meetings list', async () => {
     const scheduleMeeting = jest.fn().mockReturnValue(task.resolve({failedToAdd: []}));
     const getMeetingsList = jest.fn().mockReturnValue(task.resolve([apiMeeting]));

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
@@ -303,6 +303,30 @@ describe('createMeetingStore', () => {
       expect(store.getState().meetingSeries[0]?.title).toBe('Weekly sync (updated)');
     });
 
+    it('does not restore a locally removed meeting when an older sync finishes', async () => {
+      let finishFetch = () => undefined;
+      const fetchGate = new Promise<void>(resolve => {
+        finishFetch = resolve;
+      });
+      const getMeeting = jest.fn().mockReturnValue(
+        task.tryOrElse(
+          () => new Error('fetch failed'),
+          async () => {
+            await fetchGate;
+            return apiMeeting;
+          },
+        ),
+      );
+      const store = createMeetingStore(createDeps({getMeeting}), {meetingSeries: [meetingSeriesEntry]});
+
+      const pendingSync = store.getState().syncMeetingByQualifiedId(apiMeeting.qualified_id);
+      store.getState().removeMeetingByQualifiedId(apiMeeting.qualified_id);
+      finishFetch();
+
+      expect((await pendingSync).isOk).toBe(true);
+      expect(store.getState().meetingSeries).toEqual([]);
+    });
+
     it('leaves an entry with the same bare id in another domain untouched', async () => {
       const getMeeting = jest.fn().mockReturnValue(task.resolve(apiMeeting));
       const store = createMeetingStore(createDeps({getMeeting}), {meetingSeries: [otherDomainEntry]});

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.ts
@@ -99,11 +99,13 @@ const toQualifiedIdKey = (qualifiedId: QualifiedId): string => `${qualifiedId.do
 
 export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: MeetingStoreInitialState): MeetingStore => {
   const meetingMutationVersions = new Map<string, number>();
+  let meetingStoreMutationVersion = 0;
   const getMeetingMutationVersion = (meetingId: QualifiedId): number =>
     meetingMutationVersions.get(toQualifiedIdKey(meetingId)) ?? 0;
   const incrementMeetingMutationVersion = (meetingId: QualifiedId): void => {
     const meetingIdKey = toQualifiedIdKey(meetingId);
     meetingMutationVersions.set(meetingIdKey, getMeetingMutationVersion(meetingId) + 1);
+    meetingStoreMutationVersion += 1;
   };
 
   return createStore<MeetingStoreState>(set => ({
@@ -111,9 +113,15 @@ export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: Meetin
     isLoading: initialState?.isLoading ?? false,
     hasLoadError: initialState?.hasLoadError ?? false,
     loadMeetings: async () => {
+      const mutationVersionBeforeFetch = meetingStoreMutationVersion;
       set({isLoading: true, hasLoadError: false});
 
       const listResult = await loadMeetingsList(deps.meetingsRepository);
+
+      if (meetingStoreMutationVersion !== mutationVersionBeforeFetch) {
+        set({isLoading: false});
+        return;
+      }
 
       set({meetingSeries: listResult.meetingSeries, hasLoadError: listResult.hasLoadError, isLoading: false});
     },
@@ -155,6 +163,7 @@ export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: Meetin
         .map(updatedSeries => {
           if (getMeetingMutationVersion(meetingId) === mutationVersionBeforeFetch) {
             set(state => ({meetingSeries: upsertMeetingSeries(state.meetingSeries, updatedSeries)}));
+            meetingStoreMutationVersion += 1;
           }
 
           return updatedSeries;

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.ts
@@ -95,8 +95,18 @@ export type MeetingStore = StoreApi<MeetingStoreState>;
 
 type MeetingStoreInitialState = Partial<Pick<MeetingStoreState, 'meetingSeries' | 'isLoading' | 'hasLoadError'>>;
 
-export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: MeetingStoreInitialState): MeetingStore =>
-  createStore<MeetingStoreState>(set => ({
+const toQualifiedIdKey = (qualifiedId: QualifiedId): string => `${qualifiedId.domain}:${qualifiedId.id}`;
+
+export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: MeetingStoreInitialState): MeetingStore => {
+  const meetingMutationVersions = new Map<string, number>();
+  const getMeetingMutationVersion = (meetingId: QualifiedId): number =>
+    meetingMutationVersions.get(toQualifiedIdKey(meetingId)) ?? 0;
+  const incrementMeetingMutationVersion = (meetingId: QualifiedId): void => {
+    const meetingIdKey = toQualifiedIdKey(meetingId);
+    meetingMutationVersions.set(meetingIdKey, getMeetingMutationVersion(meetingId) + 1);
+  };
+
+  return createStore<MeetingStoreState>(set => ({
     meetingSeries: initialState?.meetingSeries ?? [],
     isLoading: initialState?.isLoading ?? false,
     hasLoadError: initialState?.hasLoadError ?? false,
@@ -114,12 +124,16 @@ export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: Meetin
       deps.serviceTasks.deleteMeetingForMe(toDeleteMeetingCommand(meetingInstance)),
     deleteMeetingForAll: meetingInstance =>
       deps.serviceTasks.deleteMeetingForAll(toDeleteMeetingCommand(meetingInstance)),
-    removeMeetingByQualifiedId: meetingId =>
+    removeMeetingByQualifiedId: meetingId => {
+      incrementMeetingMutationVersion(meetingId);
       set(state => ({
         meetingSeries: filterOutMeetingSeries(state.meetingSeries, meetingId),
-      })),
-    syncMeetingByQualifiedId: meetingId =>
-      deps.meetingsRepository
+      }));
+    },
+    syncMeetingByQualifiedId: meetingId => {
+      const mutationVersionBeforeFetch = getMeetingMutationVersion(meetingId);
+
+      return deps.meetingsRepository
         .getMeeting(meetingId)
         .mapRejected((error): SyncMeetingError => {
           logger.warn('Failed to fetch meeting for sync', {error, qualifiedId: meetingId});
@@ -139,9 +153,13 @@ export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: Meetin
           return task.resolve<MeetingSeries, SyncMeetingError>(mapResult.value);
         })
         .map(updatedSeries => {
-          set(state => ({meetingSeries: upsertMeetingSeries(state.meetingSeries, updatedSeries)}));
+          if (getMeetingMutationVersion(meetingId) === mutationVersionBeforeFetch) {
+            set(state => ({meetingSeries: upsertMeetingSeries(state.meetingSeries, updatedSeries)}));
+          }
+
           return updatedSeries;
-        }),
+        });
+    },
     loadMeetingForEdit: meetingInstance => {
       const {meetingSeries} = meetingInstance;
 
@@ -160,3 +178,4 @@ export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: Meetin
         });
     },
   }));
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26735" title="WPB-26735" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26735</a>  [Web] Support new event types for Meetings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
Guard against stale sync and list reloads overwriting newer local state, and report rejected sync Tasks.

## Stack
Previous: #22081, #22082, #22083 (merge in order)
Follow-up: #22085