### PR TITLE
Add meeting notification store [WPB-25510]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.test.ts
@@ -20,6 +20,8 @@
 import {MeetingNotificationKind, useMeetingNotificationStore} from './meetingNotificationStore';
 
 const qualifiedId = {id: 'meeting-id', domain: 'example.com'};
+const qualifiedCreator = {id: 'creator-id', domain: 'example.com'};
+const meetingStartTime = '2026-06-01T09:00:00.000Z';
 
 describe('useMeetingNotificationStore', () => {
   beforeEach(() => {
@@ -33,41 +35,41 @@ describe('useMeetingNotificationStore', () => {
       kind: MeetingNotificationKind.CANCELLED,
       qualifiedId,
       meetingTitle: 'Canceled meeting',
-      organizer: 'Organizer',
-      meetingTime: 'Jun 01, 09:00 AM',
+      qualifiedCreator,
+      meetingStartTime,
     });
     addNotification({
       kind: MeetingNotificationKind.UPDATE,
       qualifiedId,
       meetingTitle: 'Updated meeting',
-      meetingTime: 'Jun 01, 09:00 AM',
+      meetingStartTime,
     });
     addNotification({
       kind: MeetingNotificationKind.INVITE,
       qualifiedId,
       meetingTitle: 'New meeting',
-      organizer: 'Organizer',
-      meetingTime: 'Jun 01, 09:00 AM',
+      qualifiedCreator,
+      meetingStartTime,
     });
     addNotification({
       kind: MeetingNotificationKind.INVITE,
       qualifiedId: {id: 'another-meeting-id', domain: 'example.com'},
       meetingTitle: 'Another meeting',
-      organizer: 'Organizer',
-      meetingTime: 'Jun 01, 09:00 AM',
+      qualifiedCreator,
+      meetingStartTime,
     });
     addNotification({
       kind: MeetingNotificationKind.UPDATE,
       qualifiedId,
       meetingTitle: 'Updated meeting',
-      meetingTime: 'Jun 01, 09:00 AM',
+      meetingStartTime,
     });
     addNotification({
       kind: MeetingNotificationKind.CANCELLED,
       qualifiedId,
       meetingTitle: 'Canceled meeting',
-      organizer: 'Organizer',
-      meetingTime: 'Jun 01, 09:00 AM',
+      qualifiedCreator,
+      meetingStartTime,
     });
 
     expect(useMeetingNotificationStore.getState().notifications).toHaveLength(6);
@@ -89,21 +91,41 @@ describe('useMeetingNotificationStore', () => {
     ).toBe(6);
   });
 
+  it('stores raw meeting data for formatting at render time', () => {
+    useMeetingNotificationStore.getState().addNotification({
+      kind: MeetingNotificationKind.INVITE,
+      qualifiedId,
+      meetingTitle: 'Meeting',
+      qualifiedCreator,
+      meetingStartTime,
+    });
+
+    expect(useMeetingNotificationStore.getState().notifications[0]).toMatchObject({
+      kind: MeetingNotificationKind.INVITE,
+      qualifiedId,
+      meetingTitle: 'Meeting',
+      qualifiedCreator,
+      meetingStartTime,
+    });
+    expect(useMeetingNotificationStore.getState().notifications[0]).not.toHaveProperty('organizer');
+    expect(useMeetingNotificationStore.getState().notifications[0]).not.toHaveProperty('meetingTime');
+  });
+
   it('dismisses only the selected notification by ID', () => {
     const store = useMeetingNotificationStore.getState();
     store.addNotification({
       kind: MeetingNotificationKind.INVITE,
       qualifiedId,
       meetingTitle: 'Meeting',
-      organizer: 'Organizer',
-      meetingTime: 'Jun 01, 09:00 AM',
+      qualifiedCreator,
+      meetingStartTime,
     });
     store.addNotification({
       kind: MeetingNotificationKind.INVITE,
       qualifiedId,
       meetingTitle: 'Meeting',
-      organizer: 'Organizer',
-      meetingTime: 'Jun 01, 09:00 AM',
+      qualifiedCreator,
+      meetingStartTime,
     });
     const [first, second] = useMeetingNotificationStore.getState().notifications;
 
@@ -117,8 +139,8 @@ describe('useMeetingNotificationStore', () => {
       kind: MeetingNotificationKind.INVITE,
       qualifiedId,
       meetingTitle: 'Meeting',
-      organizer: 'Organizer',
-      meetingTime: 'Jun 01, 09:00 AM',
+      qualifiedCreator,
+      meetingStartTime,
     });
 
     useMeetingNotificationStore.getState().clearNotifications();

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {MeetingNotificationKind, useMeetingNotificationStore} from './meetingNotificationStore';
+
+describe('useMeetingNotificationStore', () => {
+  beforeEach(() => {
+    useMeetingNotificationStore.getState().clearNotifications();
+  });
+
+  it('stores every event independently in arrival order', () => {
+    const {addNotification} = useMeetingNotificationStore.getState();
+
+    addNotification({
+      kind: MeetingNotificationKind.CANCELLED,
+      meetingTitle: 'Canceled meeting',
+      organizer: 'Organizer',
+      meetingTime: 'Jun 01, 09:00 AM',
+    });
+    addNotification({
+      kind: MeetingNotificationKind.UPDATE,
+      meetingTitle: 'Updated meeting',
+      meetingTime: 'Jun 01, 09:00 AM',
+    });
+    addNotification({
+      kind: MeetingNotificationKind.INVITE,
+      meetingTitle: 'New meeting',
+      organizer: 'Organizer',
+      meetingTime: 'Jun 01, 09:00 AM',
+    });
+    addNotification({
+      kind: MeetingNotificationKind.INVITE,
+      meetingTitle: 'Another meeting',
+      organizer: 'Organizer',
+      meetingTime: 'Jun 01, 09:00 AM',
+    });
+    addNotification({
+      kind: MeetingNotificationKind.UPDATE,
+      meetingTitle: 'Updated meeting',
+      meetingTime: 'Jun 01, 09:00 AM',
+    });
+    addNotification({
+      kind: MeetingNotificationKind.CANCELLED,
+      meetingTitle: 'Canceled meeting',
+      organizer: 'Organizer',
+      meetingTime: 'Jun 01, 09:00 AM',
+    });
+
+    expect(useMeetingNotificationStore.getState().notifications).toHaveLength(6);
+    expect(
+      useMeetingNotificationStore.getState().notifications.map(({kind, meetingTitle}) => ({kind, meetingTitle})),
+    ).toEqual([
+      {kind: MeetingNotificationKind.CANCELLED, meetingTitle: 'Canceled meeting'},
+      {kind: MeetingNotificationKind.UPDATE, meetingTitle: 'Updated meeting'},
+      {kind: MeetingNotificationKind.INVITE, meetingTitle: 'New meeting'},
+      {kind: MeetingNotificationKind.INVITE, meetingTitle: 'Another meeting'},
+      {kind: MeetingNotificationKind.UPDATE, meetingTitle: 'Updated meeting'},
+      {kind: MeetingNotificationKind.CANCELLED, meetingTitle: 'Canceled meeting'},
+    ]);
+    expect(
+      new Set(useMeetingNotificationStore.getState().notifications.map(notification => notification.id)).size,
+    ).toBe(6);
+  });
+
+  it('dismisses only the selected notification by ID', () => {
+    const store = useMeetingNotificationStore.getState();
+    store.addNotification({
+      kind: MeetingNotificationKind.INVITE,
+      meetingTitle: 'Meeting',
+      organizer: 'Organizer',
+      meetingTime: 'Jun 01, 09:00 AM',
+    });
+    store.addNotification({
+      kind: MeetingNotificationKind.INVITE,
+      meetingTitle: 'Meeting',
+      organizer: 'Organizer',
+      meetingTime: 'Jun 01, 09:00 AM',
+    });
+    const [first, second] = useMeetingNotificationStore.getState().notifications;
+
+    store.dismissNotification(first.id);
+
+    expect(useMeetingNotificationStore.getState().notifications).toEqual([second]);
+  });
+
+  it('clears all notifications explicitly', () => {
+    useMeetingNotificationStore.getState().addNotification({
+      kind: MeetingNotificationKind.INVITE,
+      meetingTitle: 'Meeting',
+      organizer: 'Organizer',
+      meetingTime: 'Jun 01, 09:00 AM',
+    });
+
+    useMeetingNotificationStore.getState().clearNotifications();
+
+    expect(useMeetingNotificationStore.getState().notifications).toEqual([]);
+  });
+});

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.test.ts
@@ -19,6 +19,8 @@
 
 import {MeetingNotificationKind, useMeetingNotificationStore} from './meetingNotificationStore';
 
+const qualifiedId = {id: 'meeting-id', domain: 'example.com'};
+
 describe('useMeetingNotificationStore', () => {
   beforeEach(() => {
     useMeetingNotificationStore.getState().clearNotifications();
@@ -29,34 +31,40 @@ describe('useMeetingNotificationStore', () => {
 
     addNotification({
       kind: MeetingNotificationKind.CANCELLED,
+      qualifiedId,
       meetingTitle: 'Canceled meeting',
       organizer: 'Organizer',
       meetingTime: 'Jun 01, 09:00 AM',
     });
     addNotification({
       kind: MeetingNotificationKind.UPDATE,
+      qualifiedId,
       meetingTitle: 'Updated meeting',
       meetingTime: 'Jun 01, 09:00 AM',
     });
     addNotification({
       kind: MeetingNotificationKind.INVITE,
+      qualifiedId,
       meetingTitle: 'New meeting',
       organizer: 'Organizer',
       meetingTime: 'Jun 01, 09:00 AM',
     });
     addNotification({
       kind: MeetingNotificationKind.INVITE,
+      qualifiedId: {id: 'another-meeting-id', domain: 'example.com'},
       meetingTitle: 'Another meeting',
       organizer: 'Organizer',
       meetingTime: 'Jun 01, 09:00 AM',
     });
     addNotification({
       kind: MeetingNotificationKind.UPDATE,
+      qualifiedId,
       meetingTitle: 'Updated meeting',
       meetingTime: 'Jun 01, 09:00 AM',
     });
     addNotification({
       kind: MeetingNotificationKind.CANCELLED,
+      qualifiedId,
       meetingTitle: 'Canceled meeting',
       organizer: 'Organizer',
       meetingTime: 'Jun 01, 09:00 AM',
@@ -64,14 +72,17 @@ describe('useMeetingNotificationStore', () => {
 
     expect(useMeetingNotificationStore.getState().notifications).toHaveLength(6);
     expect(
-      useMeetingNotificationStore.getState().notifications.map(({kind, meetingTitle}) => ({kind, meetingTitle})),
+      useMeetingNotificationStore.getState().notifications.map(({kind, qualifiedId: notificationQualifiedId}) => ({
+        kind,
+        qualifiedId: notificationQualifiedId,
+      })),
     ).toEqual([
-      {kind: MeetingNotificationKind.CANCELLED, meetingTitle: 'Canceled meeting'},
-      {kind: MeetingNotificationKind.UPDATE, meetingTitle: 'Updated meeting'},
-      {kind: MeetingNotificationKind.INVITE, meetingTitle: 'New meeting'},
-      {kind: MeetingNotificationKind.INVITE, meetingTitle: 'Another meeting'},
-      {kind: MeetingNotificationKind.UPDATE, meetingTitle: 'Updated meeting'},
-      {kind: MeetingNotificationKind.CANCELLED, meetingTitle: 'Canceled meeting'},
+      {kind: MeetingNotificationKind.CANCELLED, qualifiedId},
+      {kind: MeetingNotificationKind.UPDATE, qualifiedId},
+      {kind: MeetingNotificationKind.INVITE, qualifiedId},
+      {kind: MeetingNotificationKind.INVITE, qualifiedId: {id: 'another-meeting-id', domain: 'example.com'}},
+      {kind: MeetingNotificationKind.UPDATE, qualifiedId},
+      {kind: MeetingNotificationKind.CANCELLED, qualifiedId},
     ]);
     expect(
       new Set(useMeetingNotificationStore.getState().notifications.map(notification => notification.id)).size,
@@ -82,12 +93,14 @@ describe('useMeetingNotificationStore', () => {
     const store = useMeetingNotificationStore.getState();
     store.addNotification({
       kind: MeetingNotificationKind.INVITE,
+      qualifiedId,
       meetingTitle: 'Meeting',
       organizer: 'Organizer',
       meetingTime: 'Jun 01, 09:00 AM',
     });
     store.addNotification({
       kind: MeetingNotificationKind.INVITE,
+      qualifiedId,
       meetingTitle: 'Meeting',
       organizer: 'Organizer',
       meetingTime: 'Jun 01, 09:00 AM',
@@ -102,6 +115,7 @@ describe('useMeetingNotificationStore', () => {
   it('clears all notifications explicitly', () => {
     useMeetingNotificationStore.getState().addNotification({
       kind: MeetingNotificationKind.INVITE,
+      qualifiedId,
       meetingTitle: 'Meeting',
       organizer: 'Organizer',
       meetingTime: 'Jun 01, 09:00 AM',

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.test.ts
@@ -147,4 +147,26 @@ describe('useMeetingNotificationStore', () => {
 
     expect(useMeetingNotificationStore.getState().notifications).toEqual([]);
   });
+
+  it('resets notification IDs when clearing notifications', () => {
+    const store = useMeetingNotificationStore.getState();
+    store.addNotification({
+      kind: MeetingNotificationKind.INVITE,
+      qualifiedId,
+      meetingTitle: 'Meeting',
+      qualifiedCreator,
+      meetingStartTime,
+    });
+
+    store.clearNotifications();
+    store.addNotification({
+      kind: MeetingNotificationKind.INVITE,
+      qualifiedId,
+      meetingTitle: 'Meeting',
+      qualifiedCreator,
+      meetingStartTime,
+    });
+
+    expect(useMeetingNotificationStore.getState().notifications[0]?.id).toBe('meeting-notification-0');
+  });
 });

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.test.ts
@@ -111,6 +111,72 @@ describe('useMeetingNotificationStore', () => {
     expect(useMeetingNotificationStore.getState().notifications[0]).not.toHaveProperty('meetingTime');
   });
 
+  it('stores the discriminated fields for every notification kind', () => {
+    const store = useMeetingNotificationStore.getState();
+
+    store.addNotification({
+      kind: MeetingNotificationKind.INVITE,
+      qualifiedId,
+      meetingTitle: 'Invite meeting',
+      qualifiedCreator,
+      meetingStartTime,
+    });
+    store.addNotification({
+      kind: MeetingNotificationKind.UPDATE,
+      qualifiedId,
+      meetingTitle: 'Updated meeting',
+      meetingStartTime,
+    });
+    store.addNotification({
+      kind: MeetingNotificationKind.CANCELLED,
+      qualifiedId,
+      meetingTitle: 'Cancelled meeting',
+      qualifiedCreator,
+      meetingStartTime,
+    });
+    store.addNotification({
+      kind: MeetingNotificationKind.ONGOING,
+      qualifiedId,
+      meetingTitle: 'Ongoing meeting',
+      qualifiedCreator,
+      meetingStartTime,
+    });
+
+    expect(useMeetingNotificationStore.getState().notifications).toEqual([
+      {
+        id: 'meeting-notification-0',
+        kind: MeetingNotificationKind.INVITE,
+        qualifiedId,
+        meetingTitle: 'Invite meeting',
+        qualifiedCreator,
+        meetingStartTime,
+      },
+      {
+        id: 'meeting-notification-1',
+        kind: MeetingNotificationKind.UPDATE,
+        qualifiedId,
+        meetingTitle: 'Updated meeting',
+        meetingStartTime,
+      },
+      {
+        id: 'meeting-notification-2',
+        kind: MeetingNotificationKind.CANCELLED,
+        qualifiedId,
+        meetingTitle: 'Cancelled meeting',
+        qualifiedCreator,
+        meetingStartTime,
+      },
+      {
+        id: 'meeting-notification-3',
+        kind: MeetingNotificationKind.ONGOING,
+        qualifiedId,
+        meetingTitle: 'Ongoing meeting',
+        qualifiedCreator,
+        meetingStartTime,
+      },
+    ]);
+  });
+
   it('dismisses only the selected notification by ID', () => {
     const store = useMeetingNotificationStore.getState();
     store.addNotification({

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.ts
@@ -29,60 +29,31 @@ export enum MeetingNotificationKind {
 }
 
 type MeetingNotificationBase = {
-  id: string;
   qualifiedId: QualifiedId;
   meetingTitle: string;
+  meetingStartTime: string;
 };
 
-export type MeetingNotification =
-  | (MeetingNotificationBase & {
-      kind: MeetingNotificationKind.INVITE;
-      qualifiedCreator: QualifiedId;
-      meetingStartTime: string;
-    })
-  | (MeetingNotificationBase & {
-      kind: MeetingNotificationKind.UPDATE;
-      meetingStartTime: string;
-    })
-  | (MeetingNotificationBase & {
-      kind: MeetingNotificationKind.CANCELLED;
-      qualifiedCreator: QualifiedId;
-      meetingStartTime: string;
-    })
-  | (MeetingNotificationBase & {
-      kind: MeetingNotificationKind.ONGOING;
-      qualifiedCreator: QualifiedId;
-      meetingStartTime: string;
-    });
+export type AddNotificationInput = MeetingNotificationBase &
+  (
+    | {
+        kind: MeetingNotificationKind.INVITE;
+        qualifiedCreator: QualifiedId;
+      }
+    | {
+        kind: MeetingNotificationKind.UPDATE;
+      }
+    | {
+        kind: MeetingNotificationKind.CANCELLED;
+        qualifiedCreator: QualifiedId;
+      }
+    | {
+        kind: MeetingNotificationKind.ONGOING;
+        qualifiedCreator: QualifiedId;
+      }
+  );
 
-export type AddNotificationInput =
-  | {
-      kind: MeetingNotificationKind.INVITE;
-      qualifiedId: QualifiedId;
-      meetingTitle: string;
-      qualifiedCreator: QualifiedId;
-      meetingStartTime: string;
-    }
-  | {
-      kind: MeetingNotificationKind.UPDATE;
-      qualifiedId: QualifiedId;
-      meetingTitle: string;
-      meetingStartTime: string;
-    }
-  | {
-      kind: MeetingNotificationKind.CANCELLED;
-      qualifiedId: QualifiedId;
-      meetingTitle: string;
-      qualifiedCreator: QualifiedId;
-      meetingStartTime: string;
-    }
-  | {
-      kind: MeetingNotificationKind.ONGOING;
-      qualifiedId: QualifiedId;
-      meetingTitle: string;
-      qualifiedCreator: QualifiedId;
-      meetingStartTime: string;
-    };
+export type MeetingNotification = AddNotificationInput & {id: string};
 
 type MeetingNotificationStore = {
   notifications: MeetingNotification[];

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import {match} from 'ts-pattern';
 import {create} from 'zustand';
 
@@ -29,6 +30,7 @@ export enum MeetingNotificationKind {
 
 type MeetingNotificationBase = {
   id: string;
+  qualifiedId: QualifiedId;
   meetingTitle: string;
 };
 
@@ -56,23 +58,27 @@ export type MeetingNotification =
 export type AddNotificationInput =
   | {
       kind: MeetingNotificationKind.INVITE;
+      qualifiedId: QualifiedId;
       meetingTitle: string;
       organizer: string;
       meetingTime: string;
     }
   | {
       kind: MeetingNotificationKind.UPDATE;
+      qualifiedId: QualifiedId;
       meetingTitle: string;
       meetingTime: string;
     }
   | {
       kind: MeetingNotificationKind.CANCELLED;
+      qualifiedId: QualifiedId;
       meetingTitle: string;
       organizer: string;
       meetingTime: string;
     }
   | {
       kind: MeetingNotificationKind.ONGOING;
+      qualifiedId: QualifiedId;
       meetingTitle: string;
       organizer: string;
       meetingTime: string;
@@ -94,33 +100,46 @@ export const useMeetingNotificationStore = create<MeetingNotificationStore>(set 
       notifications: [
         ...state.notifications,
         match(input)
-          .with({kind: MeetingNotificationKind.INVITE}, ({kind, meetingTitle, organizer, meetingTime}) => ({
+          .with(
+            {kind: MeetingNotificationKind.INVITE},
+            ({kind, qualifiedId, meetingTitle, organizer, meetingTime}) => ({
+              kind,
+              qualifiedId,
+              meetingTitle,
+              id: `meeting-notification-${nextNotificationId++}`,
+              organizer,
+              meetingTime,
+            }),
+          )
+          .with({kind: MeetingNotificationKind.UPDATE}, ({kind, qualifiedId, meetingTitle, meetingTime}) => ({
             kind,
+            qualifiedId,
             meetingTitle,
             id: `meeting-notification-${nextNotificationId++}`,
-            organizer,
             meetingTime,
           }))
-          .with({kind: MeetingNotificationKind.UPDATE}, ({kind, meetingTitle, meetingTime}) => ({
-            kind,
-            meetingTitle,
-            id: `meeting-notification-${nextNotificationId++}`,
-            meetingTime,
-          }))
-          .with({kind: MeetingNotificationKind.CANCELLED}, ({kind, meetingTitle, organizer, meetingTime}) => ({
-            kind,
-            meetingTitle,
-            id: `meeting-notification-${nextNotificationId++}`,
-            organizer,
-            meetingTime,
-          }))
-          .with({kind: MeetingNotificationKind.ONGOING}, ({kind, meetingTitle, organizer, meetingTime}) => ({
-            kind,
-            meetingTitle,
-            id: `meeting-notification-${nextNotificationId++}`,
-            organizer,
-            meetingTime,
-          }))
+          .with(
+            {kind: MeetingNotificationKind.CANCELLED},
+            ({kind, qualifiedId, meetingTitle, organizer, meetingTime}) => ({
+              kind,
+              qualifiedId,
+              meetingTitle,
+              id: `meeting-notification-${nextNotificationId++}`,
+              organizer,
+              meetingTime,
+            }),
+          )
+          .with(
+            {kind: MeetingNotificationKind.ONGOING},
+            ({kind, qualifiedId, meetingTitle, organizer, meetingTime}) => ({
+              kind,
+              qualifiedId,
+              meetingTitle,
+              id: `meeting-notification-${nextNotificationId++}`,
+              organizer,
+              meetingTime,
+            }),
+          )
           .exhaustive(),
       ],
     })),

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.ts
@@ -145,5 +145,8 @@ export const useMeetingNotificationStore = create<MeetingNotificationStore>(set 
     })),
   dismissNotification: id =>
     set(state => ({notifications: state.notifications.filter(notification => notification.id !== id)})),
-  clearNotifications: () => set({notifications: []}),
+  clearNotifications: () => {
+    nextNotificationId = 0;
+    set({notifications: []});
+  },
 }));

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.ts
@@ -1,0 +1,130 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {match} from 'ts-pattern';
+import {create} from 'zustand';
+
+export enum MeetingNotificationKind {
+  INVITE = 'invite',
+  UPDATE = 'update',
+  CANCELLED = 'cancelled',
+  ONGOING = 'ongoing',
+}
+
+type MeetingNotificationBase = {
+  id: string;
+  meetingTitle: string;
+};
+
+export type MeetingNotification =
+  | (MeetingNotificationBase & {
+      kind: MeetingNotificationKind.INVITE;
+      organizer: string;
+      meetingTime: string;
+    })
+  | (MeetingNotificationBase & {
+      kind: MeetingNotificationKind.UPDATE;
+      meetingTime: string;
+    })
+  | (MeetingNotificationBase & {
+      kind: MeetingNotificationKind.CANCELLED;
+      organizer: string;
+      meetingTime: string;
+    })
+  | (MeetingNotificationBase & {
+      kind: MeetingNotificationKind.ONGOING;
+      organizer: string;
+      meetingTime: string;
+    });
+
+export type AddNotificationInput =
+  | {
+      kind: MeetingNotificationKind.INVITE;
+      meetingTitle: string;
+      organizer: string;
+      meetingTime: string;
+    }
+  | {
+      kind: MeetingNotificationKind.UPDATE;
+      meetingTitle: string;
+      meetingTime: string;
+    }
+  | {
+      kind: MeetingNotificationKind.CANCELLED;
+      meetingTitle: string;
+      organizer: string;
+      meetingTime: string;
+    }
+  | {
+      kind: MeetingNotificationKind.ONGOING;
+      meetingTitle: string;
+      organizer: string;
+      meetingTime: string;
+    };
+
+type MeetingNotificationStore = {
+  notifications: MeetingNotification[];
+  addNotification: (input: AddNotificationInput) => void;
+  dismissNotification: (id: string) => void;
+  clearNotifications: () => void;
+};
+
+let nextNotificationId = 0;
+
+export const useMeetingNotificationStore = create<MeetingNotificationStore>(set => ({
+  notifications: [],
+  addNotification: input =>
+    set(state => ({
+      notifications: [
+        ...state.notifications,
+        match(input)
+          .with({kind: MeetingNotificationKind.INVITE}, ({kind, meetingTitle, organizer, meetingTime}) => ({
+            kind,
+            meetingTitle,
+            id: `meeting-notification-${nextNotificationId++}`,
+            organizer,
+            meetingTime,
+          }))
+          .with({kind: MeetingNotificationKind.UPDATE}, ({kind, meetingTitle, meetingTime}) => ({
+            kind,
+            meetingTitle,
+            id: `meeting-notification-${nextNotificationId++}`,
+            meetingTime,
+          }))
+          .with({kind: MeetingNotificationKind.CANCELLED}, ({kind, meetingTitle, organizer, meetingTime}) => ({
+            kind,
+            meetingTitle,
+            id: `meeting-notification-${nextNotificationId++}`,
+            organizer,
+            meetingTime,
+          }))
+          .with({kind: MeetingNotificationKind.ONGOING}, ({kind, meetingTitle, organizer, meetingTime}) => ({
+            kind,
+            meetingTitle,
+            id: `meeting-notification-${nextNotificationId++}`,
+            organizer,
+            meetingTime,
+          }))
+          .exhaustive(),
+      ],
+    })),
+  dismissNotification: id =>
+    set(state => ({notifications: state.notifications.filter(notification => notification.id !== id)})),
+  clearNotifications: () => set({notifications: []}),
+}));

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationStore/meetingNotificationStore.ts
@@ -37,22 +37,22 @@ type MeetingNotificationBase = {
 export type MeetingNotification =
   | (MeetingNotificationBase & {
       kind: MeetingNotificationKind.INVITE;
-      organizer: string;
-      meetingTime: string;
+      qualifiedCreator: QualifiedId;
+      meetingStartTime: string;
     })
   | (MeetingNotificationBase & {
       kind: MeetingNotificationKind.UPDATE;
-      meetingTime: string;
+      meetingStartTime: string;
     })
   | (MeetingNotificationBase & {
       kind: MeetingNotificationKind.CANCELLED;
-      organizer: string;
-      meetingTime: string;
+      qualifiedCreator: QualifiedId;
+      meetingStartTime: string;
     })
   | (MeetingNotificationBase & {
       kind: MeetingNotificationKind.ONGOING;
-      organizer: string;
-      meetingTime: string;
+      qualifiedCreator: QualifiedId;
+      meetingStartTime: string;
     });
 
 export type AddNotificationInput =
@@ -60,28 +60,28 @@ export type AddNotificationInput =
       kind: MeetingNotificationKind.INVITE;
       qualifiedId: QualifiedId;
       meetingTitle: string;
-      organizer: string;
-      meetingTime: string;
+      qualifiedCreator: QualifiedId;
+      meetingStartTime: string;
     }
   | {
       kind: MeetingNotificationKind.UPDATE;
       qualifiedId: QualifiedId;
       meetingTitle: string;
-      meetingTime: string;
+      meetingStartTime: string;
     }
   | {
       kind: MeetingNotificationKind.CANCELLED;
       qualifiedId: QualifiedId;
       meetingTitle: string;
-      organizer: string;
-      meetingTime: string;
+      qualifiedCreator: QualifiedId;
+      meetingStartTime: string;
     }
   | {
       kind: MeetingNotificationKind.ONGOING;
       qualifiedId: QualifiedId;
       meetingTitle: string;
-      organizer: string;
-      meetingTime: string;
+      qualifiedCreator: QualifiedId;
+      meetingStartTime: string;
     };
 
 type MeetingNotificationStore = {
@@ -102,42 +102,42 @@ export const useMeetingNotificationStore = create<MeetingNotificationStore>(set 
         match(input)
           .with(
             {kind: MeetingNotificationKind.INVITE},
-            ({kind, qualifiedId, meetingTitle, organizer, meetingTime}) => ({
+            ({kind, qualifiedId, meetingTitle, qualifiedCreator, meetingStartTime}) => ({
               kind,
               qualifiedId,
               meetingTitle,
               id: `meeting-notification-${nextNotificationId++}`,
-              organizer,
-              meetingTime,
+              qualifiedCreator,
+              meetingStartTime,
             }),
           )
-          .with({kind: MeetingNotificationKind.UPDATE}, ({kind, qualifiedId, meetingTitle, meetingTime}) => ({
+          .with({kind: MeetingNotificationKind.UPDATE}, ({kind, qualifiedId, meetingTitle, meetingStartTime}) => ({
             kind,
             qualifiedId,
             meetingTitle,
             id: `meeting-notification-${nextNotificationId++}`,
-            meetingTime,
+            meetingStartTime,
           }))
           .with(
             {kind: MeetingNotificationKind.CANCELLED},
-            ({kind, qualifiedId, meetingTitle, organizer, meetingTime}) => ({
+            ({kind, qualifiedId, meetingTitle, qualifiedCreator, meetingStartTime}) => ({
               kind,
               qualifiedId,
               meetingTitle,
               id: `meeting-notification-${nextNotificationId++}`,
-              organizer,
-              meetingTime,
+              qualifiedCreator,
+              meetingStartTime,
             }),
           )
           .with(
             {kind: MeetingNotificationKind.ONGOING},
-            ({kind, qualifiedId, meetingTitle, organizer, meetingTime}) => ({
+            ({kind, qualifiedId, meetingTitle, qualifiedCreator, meetingStartTime}) => ({
               kind,
               qualifiedId,
               meetingTitle,
               id: `meeting-notification-${nextNotificationId++}`,
-              organizer,
-              meetingTime,
+              qualifiedCreator,
+              meetingStartTime,
             }),
           )
           .exhaustive(),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25510" title="WPB-25510" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25510</a>  [Web] Inform participant of a meeting update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Introduce typed meeting notification state and lifecycle actions so later UI layers can consume notifications independently.