### PR TITLE
Fix release-appearance comment authorization and diagnostics [WPB-26469]

### DIFF
--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -532,8 +532,7 @@ jobs:
     continue-on-error: true
     permissions:
       contents: read
-      pull-requests: read
-      issues: write
+      pull-requests: write # required to create and update release-appearance comments
 
     steps:
       - name: Checkout release history
@@ -915,8 +914,7 @@ jobs:
     continue-on-error: true
     permissions:
       contents: read
-      pull-requests: read
-      issues: write
+      pull-requests: write # required to create and update release-appearance comments
 
     steps:
       - name: Checkout release history

--- a/tools/release-appearance/githubClient.test.ts
+++ b/tools/release-appearance/githubClient.test.ts
@@ -27,7 +27,7 @@ import {Maybe} from 'true-myth';
 import {createGitHubClient} from './githubClient.ts';
 import type {GitHubClient} from './githubClient.ts';
 import {createKyHttpClient} from './httpClient.ts';
-import type {HttpClient, HttpRequest} from './httpClient.ts';
+import type {HttpClient, HttpRequest, HttpRequestFailure} from './httpClient.ts';
 
 type GitHubPullRequestResponse = {
   readonly number: number;
@@ -260,6 +260,42 @@ describe('GitHub client', () => {
     expect(updateRequest.value.url.toString()).toMatch(/issues\/comments\/11$/);
   });
 
+  it('exposes GitHub permission diagnostics from a forbidden comment response', async () => {
+    const permissionFailure: HttpRequestFailure = {
+      kind: 'http-response-failure',
+      method: 'post',
+      url: new URL('https://api.github.example/repos/wireapp/wire-webapp/issues/5/comments'),
+      response: {
+        statusCode: 403,
+        githubMessage: Maybe.just('Resource not accessible by integration'),
+        documentationUrl: Maybe.just('https://docs.github.com/rest/issues/comments#create-an-issue-comment'),
+        githubRequestId: Maybe.just('REQUEST-PERMISSION'),
+        acceptedGithubPermissions: Maybe.just('issues=write, pull_requests=read'),
+        retryAfter: Maybe.nothing<string>(),
+        rateLimitRemaining: Maybe.nothing<string>(),
+        rateLimitReset: Maybe.nothing<string>(),
+      },
+    };
+    const fakeHttpClient: HttpClient = {
+      async requestJson(): Promise<unknown> {
+        throw permissionFailure;
+      },
+    };
+    const githubClient = createClient(fakeHttpClient);
+
+    const actualResult = await githubClient.createIssueComment({
+      pullRequestNumber: 5,
+      commentBody: 'release comment',
+    });
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toContain('HTTP status: 403');
+    expect(actualResult.error.message).toContain('Resource not accessible by integration');
+    expect(actualResult.error.message).toContain('GitHub request ID: REQUEST-PERMISSION');
+    expect(actualResult.error.message).toContain('Accepted GitHub permissions: issues=write, pull_requests=read');
+    expect(actualResult.error.message).not.toContain('release comment');
+  });
+
   it('rejects a GitHub response without a title as malformed', async () => {
     const fakeHttpClient = createFakeHttpClient({
       responseForRequest() {
@@ -318,9 +354,24 @@ describe('GitHub client', () => {
 
   it('redacts the GitHub token from transport errors', async () => {
     const githubToken = 'secret-token';
+    const githubResponseFailure: HttpRequestFailure = {
+      kind: 'http-response-failure',
+      method: 'get',
+      url: new URL('https://api.github.example/repos/wireapp/wire-webapp/commits/commit-sha/pulls'),
+      response: {
+        statusCode: 403,
+        githubMessage: Maybe.just(`request failed with ${githubToken}`),
+        documentationUrl: Maybe.nothing<string>(),
+        githubRequestId: Maybe.nothing<string>(),
+        acceptedGithubPermissions: Maybe.nothing<string>(),
+        retryAfter: Maybe.nothing<string>(),
+        rateLimitRemaining: Maybe.nothing<string>(),
+        rateLimitReset: Maybe.nothing<string>(),
+      },
+    };
     const fakeHttpClient: HttpClient = {
       async requestJson(): Promise<unknown> {
-        throw new Error(`request failed with ${githubToken}`);
+        throw githubResponseFailure;
       },
     };
     const githubClient = createClient(fakeHttpClient, githubToken);
@@ -351,7 +402,10 @@ describe('Ky HTTP client', () => {
         headers: {},
         json: Maybe.nothing<NonNullable<unknown>>(),
       }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({
+      kind: 'http-response-failure',
+      response: {statusCode: 503},
+    });
     expect(fetchCallCount).toBe(1);
   });
 });

--- a/tools/release-appearance/githubClient.ts
+++ b/tools/release-appearance/githubClient.ts
@@ -21,6 +21,7 @@ import {isError} from '@sindresorhus/is';
 import {Maybe, Result} from 'true-myth';
 import {z} from 'zod';
 
+import {formatHttpRequestFailure, isHttpRequestFailure} from './httpClient.ts';
 import type {HttpClient, HttpMethod, HttpRequest} from './httpClient.ts';
 
 export type PullRequestRecord = {
@@ -106,6 +107,10 @@ function createFailure<valueType>(message: string): Result<valueType, Error> {
 }
 
 function errorMessage(error: unknown): string {
+  if (isHttpRequestFailure(error)) {
+    return formatHttpRequestFailure(error);
+  }
+
   if (isError(error)) {
     return error.message;
   }

--- a/tools/release-appearance/httpClient.test.ts
+++ b/tools/release-appearance/httpClient.test.ts
@@ -1,0 +1,224 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+
+import ky from 'ky';
+import {Maybe} from 'true-myth';
+
+import {createKyHttpClient, formatHttpRequestFailure, isHttpRequestFailure} from './httpClient.ts';
+import type {HttpRequest, HttpRequestFailure} from './httpClient.ts';
+
+function createCommentRequest(): HttpRequest {
+  return {
+    method: 'post',
+    url: new URL('https://api.github.example/repos/wireapp/wire-webapp/issues/7/comments'),
+    headers: {
+      Authorization: 'Bearer github-token',
+    },
+    json: Maybe.just({body: 'release comment'}),
+  };
+}
+
+async function readHttpRequestFailure(requestPromise: Promise<unknown>): Promise<HttpRequestFailure> {
+  try {
+    await requestPromise;
+    assert.fail('Expected the HTTP request to fail');
+  } catch (error: unknown) {
+    if (isHttpRequestFailure(error) === false) {
+      assert.fail('Expected an application-owned HTTP request failure');
+    }
+
+    return error;
+  }
+}
+
+describe('Ky HTTP client', () => {
+  it('retains safe diagnostics from a normal forbidden response without retrying', async () => {
+    let fetchCallCount = 0;
+    const kyInstance = ky.create({
+      fetch: async (): Promise<Response> => {
+        fetchCallCount += 1;
+        return new Response(
+          JSON.stringify({
+            message: 'Resource not accessible by integration',
+            documentation_url: 'https://docs.github.com/rest/issues/comments#create-an-issue-comment',
+          }),
+          {
+            status: 403,
+            headers: {
+              'content-type': 'application/json',
+              'x-github-request-id': 'REQUEST-403',
+              'x-accepted-github-permissions': 'issues=write, pull_requests=write',
+              'x-ratelimit-remaining': '4999',
+              'x-ratelimit-reset': '1785800000',
+            },
+          },
+        );
+      },
+    });
+    const httpClient = createKyHttpClient({kyInstance});
+
+    const failure = await readHttpRequestFailure(httpClient.requestJson(createCommentRequest()));
+
+    expect(fetchCallCount).toBe(1);
+    assert(failure.kind === 'http-response-failure');
+    expect(failure.response.statusCode).toBe(403);
+    expect(failure.response.githubMessage).toEqual(Maybe.just('Resource not accessible by integration'));
+    expect(failure.response.documentationUrl).toEqual(
+      Maybe.just('https://docs.github.com/rest/issues/comments#create-an-issue-comment'),
+    );
+    expect(failure.response.githubRequestId).toEqual(Maybe.just('REQUEST-403'));
+    expect(failure.response.acceptedGithubPermissions).toEqual(Maybe.just('issues=write, pull_requests=write'));
+    expect(failure.response.rateLimitRemaining).toEqual(Maybe.just('4999'));
+    expect(failure.response.rateLimitReset).toEqual(Maybe.just('1785800000'));
+    expect(failure.response.retryAfter.isNothing).toBe(true);
+  });
+
+  it('retries a secondary-rate-limit response using retry-after and fails boundedly', async () => {
+    let fetchCallCount = 0;
+    const kyInstance = ky.create({
+      fetch: async (): Promise<Response> => {
+        fetchCallCount += 1;
+        return new Response(
+          JSON.stringify({
+            message: 'You have exceeded a secondary rate limit. Please wait a few minutes before you try again.',
+          }),
+          {
+            status: 403,
+            headers: {
+              'content-type': 'application/json',
+              'retry-after': '0',
+              'x-ratelimit-remaining': '0',
+              'x-ratelimit-reset': '1785800000',
+            },
+          },
+        );
+      },
+    });
+    const httpClient = createKyHttpClient({kyInstance});
+
+    const failure = await readHttpRequestFailure(httpClient.requestJson(createCommentRequest()));
+
+    expect(fetchCallCount).toBe(3);
+    assert(failure.kind === 'http-response-failure');
+    expect(failure.response.statusCode).toBe(403);
+    assert(failure.response.githubMessage.isJust);
+    expect(failure.response.githubMessage.value).toMatch(/secondary rate limit/);
+    expect(failure.response.retryAfter).toEqual(Maybe.just('0'));
+  });
+
+  it('retries an HTTP 429 response even when the response body has no GitHub message', async () => {
+    let fetchCallCount = 0;
+    const kyInstance = ky.create({
+      fetch: async (): Promise<Response> => {
+        fetchCallCount += 1;
+        return new Response(JSON.stringify({details: 'release comment'}), {
+          status: 429,
+          headers: {
+            'content-type': 'application/json',
+            'retry-after': '0',
+          },
+        });
+      },
+    });
+    const httpClient = createKyHttpClient({kyInstance});
+
+    const failure = await readHttpRequestFailure(httpClient.requestJson(createCommentRequest()));
+
+    expect(fetchCallCount).toBe(3);
+    assert(failure.kind === 'http-response-failure');
+    expect(failure.response.statusCode).toBe(429);
+    expect(failure.response.githubMessage.isNothing).toBe(true);
+    expect(formatHttpRequestFailure(failure)).not.toContain('release comment');
+  });
+
+  it('retains valid fields while discarding malformed GitHub fields and unrelated response data', async () => {
+    const kyInstance = ky.create({
+      fetch: async (): Promise<Response> => {
+        return new Response(
+          JSON.stringify({
+            message: 403,
+            documentation_url: 'not a URL',
+            body: 'release comment',
+            unrelated: 'do not expose this',
+          }),
+          {
+            status: 403,
+            headers: {
+              'content-type': 'application/json',
+              'x-github-request-id': 'REQUEST-MALFORMED',
+              'x-unrelated-header': 'do not expose this either',
+            },
+          },
+        );
+      },
+    });
+    const httpClient = createKyHttpClient({kyInstance});
+
+    const failure = await readHttpRequestFailure(httpClient.requestJson(createCommentRequest()));
+
+    assert(failure.kind === 'http-response-failure');
+    expect(failure.response.statusCode).toBe(403);
+    expect(failure.response.githubMessage.isNothing).toBe(true);
+    expect(failure.response.documentationUrl.isNothing).toBe(true);
+    expect(failure.response.githubRequestId).toEqual(Maybe.just('REQUEST-MALFORMED'));
+    const actualDiagnostic = formatHttpRequestFailure(failure);
+    expect(actualDiagnostic).not.toContain('release comment');
+    expect(actualDiagnostic).not.toContain('do not expose this');
+    expect(actualDiagnostic).toContain('GitHub request ID: REQUEST-MALFORMED');
+  });
+
+  it('formats only safe actionable diagnostics and never includes the request body or headers', () => {
+    const failure: HttpRequestFailure = {
+      kind: 'http-response-failure',
+      method: 'post',
+      url: new URL('https://api.github.example/repos/wireapp/wire-webapp/issues/7/comments'),
+      response: {
+        statusCode: 403,
+        githubMessage: Maybe.just('Resource not accessible by integration'),
+        documentationUrl: Maybe.just('https://docs.github.com/rest/issues/comments#create-an-issue-comment'),
+        githubRequestId: Maybe.just('REQUEST-403'),
+        acceptedGithubPermissions: Maybe.just('issues=write, pull_requests=write'),
+        retryAfter: Maybe.just('3'),
+        rateLimitRemaining: Maybe.just('0'),
+        rateLimitReset: Maybe.just('1785800000'),
+      },
+    };
+
+    const actualDiagnostic = formatHttpRequestFailure(failure);
+    const expectedDiagnostic = [
+      'GitHub API request failed',
+      'HTTP status: 403',
+      'Request: POST https://api.github.example/repos/wireapp/wire-webapp/issues/7/comments',
+      'GitHub message: Resource not accessible by integration',
+      'Documentation URL: https://docs.github.com/rest/issues/comments#create-an-issue-comment',
+      'GitHub request ID: REQUEST-403',
+      'Accepted GitHub permissions: issues=write, pull_requests=write',
+      'Retry-After: 3',
+      'Rate-limit remaining: 0',
+      'Rate-limit reset: 1785800000',
+    ].join('; ');
+
+    expect(actualDiagnostic).toBe(expectedDiagnostic);
+    expect(actualDiagnostic).not.toContain('release comment');
+    expect(actualDiagnostic).not.toContain('Authorization');
+    expect(actualDiagnostic).not.toContain('Bearer');
+  });
+});

--- a/tools/release-appearance/httpClient.ts
+++ b/tools/release-appearance/httpClient.ts
@@ -17,9 +17,12 @@
  *
  */
 
-import ky from 'ky';
-import type {KyInstance, Options} from 'ky';
+import {isNull, isObject, isString, isUndefined} from '@sindresorhus/is';
+import ky, {isHTTPError} from 'ky';
+import type {KyInstance, Options, RetryOptions} from 'ky';
 import {Maybe} from 'true-myth';
+import {match} from 'ts-pattern';
+import {z} from 'zod';
 
 export type HttpMethod = 'get' | 'post' | 'patch';
 
@@ -34,9 +37,228 @@ export type HttpClient = {
   readonly requestJson: (request: HttpRequest) => Promise<unknown>;
 };
 
+export type GitHubResponseFailureDetails = {
+  readonly statusCode: number;
+  readonly githubMessage: Maybe<string>;
+  readonly documentationUrl: Maybe<string>;
+  readonly githubRequestId: Maybe<string>;
+  readonly acceptedGithubPermissions: Maybe<string>;
+  readonly retryAfter: Maybe<string>;
+  readonly rateLimitRemaining: Maybe<string>;
+  readonly rateLimitReset: Maybe<string>;
+};
+
+export type HttpRequestFailure =
+  | {
+      readonly kind: 'http-response-failure';
+      readonly method: HttpMethod;
+      readonly url: URL;
+      readonly response: GitHubResponseFailureDetails;
+    }
+  | {
+      readonly kind: 'http-transport-failure';
+      readonly method: HttpMethod;
+      readonly url: URL;
+      readonly transportMessage: string;
+    };
+
 export type CreateKyHttpClientOptions = {
   readonly kyInstance: KyInstance;
 };
+
+type ParsedGitHubFailureResponse = {
+  readonly githubMessage: Maybe<string>;
+  readonly documentationUrl: Maybe<string>;
+};
+
+type CreateHttpRequestFailureOptions = {
+  readonly error: unknown;
+  readonly request: HttpRequest;
+};
+
+const maximumRateLimitRetries = 2;
+const forbiddenHttpStatusCode = 403;
+const tooManyRequestsHttpStatusCode = 429;
+const internalServerErrorHttpStatusCode = 500;
+const badGatewayHttpStatusCode = 502;
+const serviceUnavailableHttpStatusCode = 503;
+const gatewayTimeoutHttpStatusCode = 504;
+const rateLimitRetryStatusCodes = [
+  forbiddenHttpStatusCode,
+  tooManyRequestsHttpStatusCode,
+  internalServerErrorHttpStatusCode,
+  badGatewayHttpStatusCode,
+  serviceUnavailableHttpStatusCode,
+  gatewayTimeoutHttpStatusCode,
+];
+const githubRateLimitMessagePattern = /\b(?:api|primary|secondary) rate limit\b|\brate limit exceeded\b/i;
+
+function createMaybeString(value: string | undefined): Maybe<string> {
+  return isUndefined(value) ? Maybe.nothing<string>() : Maybe.just(value);
+}
+
+const githubFailureResponseSchema = z
+  .object({
+    message: z.string().optional().catch(undefined),
+    documentation_url: z.string().url().optional().catch(undefined),
+  })
+  .transform(githubFailureResponse => {
+    return {
+      githubMessage: createMaybeString(githubFailureResponse.message),
+      documentationUrl: createMaybeString(githubFailureResponse.documentation_url),
+    };
+  });
+
+function readResponseHeader(response: Response, headerName: string): Maybe<string> {
+  const headerValue = response.headers.get(headerName);
+  return isNull(headerValue) ? Maybe.nothing<string>() : Maybe.just(headerValue);
+}
+
+function readBearerToken(headers: Readonly<Record<string, string>>): Maybe<string> {
+  const authorizationHeader = headers.Authorization;
+  if (isUndefined(authorizationHeader) || authorizationHeader.startsWith('Bearer ') === false) {
+    return Maybe.nothing<string>();
+  }
+
+  return Maybe.just(authorizationHeader.slice('Bearer '.length));
+}
+
+function redactSecret(value: Maybe<string>, secret: Maybe<string>): Maybe<string> {
+  if (value.isNothing || secret.isNothing || secret.value.length === 0) {
+    return value;
+  }
+
+  return Maybe.just(value.value.replaceAll(secret.value, '[REDACTED]'));
+}
+
+function parseGitHubFailureResponse(responseBody: unknown, githubToken: Maybe<string>): ParsedGitHubFailureResponse {
+  const validationResult = githubFailureResponseSchema.safeParse(responseBody);
+  if (validationResult.success === false) {
+    return {
+      githubMessage: Maybe.nothing<string>(),
+      documentationUrl: Maybe.nothing<string>(),
+    };
+  }
+
+  return {
+    githubMessage: redactSecret(validationResult.data.githubMessage, githubToken),
+    documentationUrl: redactSecret(validationResult.data.documentationUrl, githubToken),
+  };
+}
+
+function createHttpRequestFailure(
+  createHttpRequestFailureOptions: CreateHttpRequestFailureOptions,
+): HttpRequestFailure {
+  const {error, request} = createHttpRequestFailureOptions;
+  const githubToken = readBearerToken(request.headers);
+
+  if (isHTTPError(error)) {
+    const parsedResponse = parseGitHubFailureResponse(error.data, githubToken);
+    return {
+      kind: 'http-response-failure',
+      method: request.method,
+      url: request.url,
+      response: {
+        statusCode: error.response.status,
+        githubMessage: parsedResponse.githubMessage,
+        documentationUrl: parsedResponse.documentationUrl,
+        githubRequestId: readResponseHeader(error.response, 'x-github-request-id'),
+        acceptedGithubPermissions: readResponseHeader(error.response, 'x-accepted-github-permissions'),
+        retryAfter: readResponseHeader(error.response, 'retry-after'),
+        rateLimitRemaining: readResponseHeader(error.response, 'x-ratelimit-remaining'),
+        rateLimitReset: readResponseHeader(error.response, 'x-ratelimit-reset'),
+      },
+    };
+  }
+
+  return {
+    kind: 'http-transport-failure',
+    method: request.method,
+    url: request.url,
+    transportMessage: 'No HTTP response was received',
+  };
+}
+
+export function isHttpRequestFailure(error: unknown): error is HttpRequestFailure {
+  if (isObject(error) === false || 'kind' in error === false || isString(error.kind) === false) {
+    return false;
+  }
+
+  return error.kind === 'http-response-failure' || error.kind === 'http-transport-failure';
+}
+
+export function formatHttpRequestFailure(failure: HttpRequestFailure): string {
+  return match(failure)
+    .with({kind: 'http-transport-failure'}, transportFailure => {
+      return [
+        'GitHub API request failed',
+        `Request: ${transportFailure.method.toUpperCase()} ${transportFailure.url.toString()}`,
+        transportFailure.transportMessage,
+      ].join('; ');
+    })
+    .with({kind: 'http-response-failure'}, responseFailure => {
+      const diagnosticParts = [
+        'GitHub API request failed',
+        `HTTP status: ${responseFailure.response.statusCode}`,
+        `Request: ${responseFailure.method.toUpperCase()} ${responseFailure.url.toString()}`,
+      ];
+      if (responseFailure.response.githubMessage.isJust) {
+        diagnosticParts.push(`GitHub message: ${responseFailure.response.githubMessage.value}`);
+      }
+      if (responseFailure.response.documentationUrl.isJust) {
+        diagnosticParts.push(`Documentation URL: ${responseFailure.response.documentationUrl.value}`);
+      }
+      if (responseFailure.response.githubRequestId.isJust) {
+        diagnosticParts.push(`GitHub request ID: ${responseFailure.response.githubRequestId.value}`);
+      }
+      if (responseFailure.response.acceptedGithubPermissions.isJust) {
+        diagnosticParts.push(
+          `Accepted GitHub permissions: ${responseFailure.response.acceptedGithubPermissions.value}`,
+        );
+      }
+      if (responseFailure.response.retryAfter.isJust) {
+        diagnosticParts.push(`Retry-After: ${responseFailure.response.retryAfter.value}`);
+      }
+      if (responseFailure.response.rateLimitRemaining.isJust) {
+        diagnosticParts.push(`Rate-limit remaining: ${responseFailure.response.rateLimitRemaining.value}`);
+      }
+      if (responseFailure.response.rateLimitReset.isJust) {
+        diagnosticParts.push(`Rate-limit reset: ${responseFailure.response.rateLimitReset.value}`);
+      }
+
+      return diagnosticParts.join('; ');
+    })
+    .exhaustive();
+}
+
+function isRateLimitFailure(failure: HttpRequestFailure): boolean {
+  if (failure.kind === 'http-transport-failure') {
+    return false;
+  }
+
+  if (failure.response.statusCode === tooManyRequestsHttpStatusCode || failure.response.retryAfter.isJust) {
+    return true;
+  }
+
+  return (
+    failure.response.githubMessage.isJust && githubRateLimitMessagePattern.test(failure.response.githubMessage.value)
+  );
+}
+
+function createRateLimitRetryOptions(request: HttpRequest): RetryOptions {
+  return {
+    limit: maximumRateLimitRetries,
+    methods: [request.method],
+    statusCodes: rateLimitRetryStatusCodes,
+    afterStatusCodes: rateLimitRetryStatusCodes,
+    shouldRetry(retryState) {
+      const {error} = retryState;
+      const failure = createHttpRequestFailure({error, request});
+
+      return isRateLimitFailure(failure) ? undefined : false;
+    },
+  };
+}
 
 export function createKyHttpClient(createKyHttpClientOptions: CreateKyHttpClientOptions): HttpClient {
   const {kyInstance} = createKyHttpClientOptions;
@@ -49,16 +271,20 @@ export function createKyHttpClient(createKyHttpClientOptions: CreateKyHttpClient
             method: request.method,
             headers: request.headers,
             json,
-            retry: {limit: 0},
+            retry: createRateLimitRetryOptions(request),
           };
         })
         .unwrapOr({
           method: request.method,
           headers: request.headers,
-          retry: {limit: 0},
+          retry: createRateLimitRetryOptions(request),
         });
 
-      return kyInstance(request.url, requestOptions).json<unknown>();
+      try {
+        return await kyInstance(request.url, requestOptions).json<unknown>();
+      } catch (error: unknown) {
+        throw createHttpRequestFailure({error, request});
+      }
     },
   };
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Release run `30879929469` received HTTP 403 for every pull-request comment request. The job already had `issues: write` but only `pull-requests: read`; `pull-requests: write` is now explicitly requested for both release-appearance comment jobs.

The HTTP boundary now preserves safe GitHub response diagnostics, including the response message, documentation URL, request ID, accepted permissions, and rate-limit headers. This distinguishes permission failures from secondary rate limiting. Retries use Ky’s bounded retry mechanism and occur only for explicit rate-limit responses, including HTTP 429, `retry-after`, or a GitHub rate-limit message.

Release-appearance comments remain informational and continue to use `continue-on-error: true`.

No release artifact, application, Playwright, configuration, Docker, tag, deployment, or release-branch behavior changed.