### PR TITLE
WPB-27892: fix: resolve original caller for call-end "called" message

### DIFF
--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -636,9 +636,16 @@ export class CallingRepository {
 
   private readonly handleMissedCall = (conversationId: string, timestamp: number, userId: string) => {
     const callDuration = 0;
+    const parsedConversationId = this.parseQualifiedId(conversationId);
+    // Prefer the original caller captured when the call started ringing
+    // (call.initiator = AVS SETUP sender) over the `missedh` userId, which
+    // is the sender of the missed-trigger message and usually not the
+    // caller. Falls back when no Call exists locally (e.g. the app
+    // cold-launched straight into a missed call).
+    const callerId = this.findCall(parsedConversationId)?.initiator ?? this.parseQualifiedId(userId);
     this.injectDeactivateEvent(
-      this.parseQualifiedId(conversationId),
-      this.parseQualifiedId(userId),
+      parsedConversationId,
+      callerId,
       callDuration,
       REASON.CANCELED,
       new Date(timestamp * 1000).toISOString(),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27892" title="WPB-27892" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27892</a>  Missed-call conversation message names the wrong user ("$USER called")
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-27892

handleMissedCall injected the deactivate event with the missedh userId (the sender of the missed-trigger message), so the "$USER called" conversation message named the wrong participant.

Use the original caller captured at ring time (call.initiator = AVS SETUP sender) when a Call object exists for the conversation, falling back to the missedh userId only when none is present (e.g. the app cold-launched straight into a missed call). callClosed already used call.initiator.


It's LLM-generated, please, review it carefully.

Depends on https://github.com/wireapp/wire-avs/pull/199
