### PR TITLE
Cap schedule meeting end time at 23:45 on the same day WPB-27038

### DIFF
--- a/apps/webapp/src/script/components/Meeting/shared/defaults/meetingDateTimeDefaults.test.ts
+++ b/apps/webapp/src/script/components/Meeting/shared/defaults/meetingDateTimeDefaults.test.ts
@@ -48,23 +48,29 @@ describe('meetingDateTimeDefaults', () => {
     expect(getDefaultMeetingEndDateTime(start)).toEqual(new Date(2026, 6, 13, 18, 0, 0, 0));
   });
 
-  it('caps the end time at midnight when the start is at 11:45 PM', () => {
+  it('caps the end time at 11:45 PM when the start is at 11:45 PM', () => {
     const start = new Date(2026, 6, 13, 23, 45, 0, 0);
 
-    expect(getDefaultMeetingEndDateTime(start)).toEqual(new Date(2026, 6, 14, 0, 0, 0, 0));
+    expect(getDefaultMeetingEndDateTime(start)).toEqual(new Date(2026, 6, 13, 23, 45, 0, 0));
   });
 
-  it('caps the end time at midnight when one hour would cross into the next day', () => {
+  it('caps the end time at 11:45 PM when one hour would cross into the next day', () => {
     const start = new Date(2026, 6, 13, 23, 0, 0, 0);
 
-    expect(getDefaultMeetingEndDateTime(start)).toEqual(new Date(2026, 6, 14, 0, 0, 0, 0));
+    expect(getDefaultMeetingEndDateTime(start)).toEqual(new Date(2026, 6, 13, 23, 45, 0, 0));
   });
 
-  it('caps end times at midnight for late starts', () => {
+  it('caps the end time at 11:45 PM when the start is at 11:30 PM', () => {
+    const start = new Date(2026, 6, 13, 23, 30, 0, 0);
+
+    expect(getDefaultMeetingEndDateTime(start)).toEqual(new Date(2026, 6, 13, 23, 45, 0, 0));
+  });
+
+  it('caps end times at 11:45 PM for late starts', () => {
     const start = new Date(2026, 6, 13, 23, 15, 0, 0);
     const end = new Date(2026, 6, 14, 0, 0, 0, 0);
 
-    expect(capEndForStart(start, end)).toEqual(new Date(2026, 6, 14, 0, 0, 0, 0));
+    expect(capEndForStart(start, end)).toEqual(new Date(2026, 6, 13, 23, 45, 0, 0));
   });
 
   it('shifts the end forward when the start is moved past the current end', () => {
@@ -100,14 +106,14 @@ describe('meetingDateTimeDefaults', () => {
     });
   });
 
-  it('sets the end to midnight when the start is moved to 11:45 PM', () => {
+  it('sets the end to 11:45 PM when the start is moved to 11:45 PM', () => {
     const previousStart = new Date(2026, 6, 13, 22, 45, 0, 0);
     const previousEnd = new Date(2026, 6, 13, 23, 45, 0, 0);
     const nextStart = new Date(2026, 6, 13, 23, 45, 0, 0);
 
     expect(resolveStartChange(previousStart, previousEnd, nextStart)).toEqual({
       start: nextStart,
-      end: new Date(2026, 6, 14, 0, 0, 0, 0),
+      end: new Date(2026, 6, 13, 23, 45, 0, 0),
     });
   });
 
@@ -129,13 +135,13 @@ describe('meetingDateTimeDefaults', () => {
     });
   });
 
-  it('caps meet-now end time at midnight for late starts', () => {
+  it('caps meet-now end time at 11:45 PM for late starts', () => {
     const now = new Date(2026, 6, 13, 23, 45, 0, 0);
     const wallClock = createDeterministicWallClock({initialCurrentTimestampInMilliseconds: now.getTime()});
 
     expect(getMeetNowMeetingTimes(wallClock)).toEqual({
       start: now,
-      end: new Date(2026, 6, 14, 0, 0, 0, 0),
+      end: new Date(2026, 6, 13, 23, 45, 0, 0),
     });
   });
 });

--- a/apps/webapp/src/script/components/Meeting/shared/defaults/meetingDateTimeDefaults.ts
+++ b/apps/webapp/src/script/components/Meeting/shared/defaults/meetingDateTimeDefaults.ts
@@ -24,6 +24,7 @@ const HOURS_PER_DAY = 24;
 const MILLISECONDS_PER_SECOND = 1000;
 const MINUTES_PER_DAY = HOURS_PER_DAY * MINUTES_PER_HOUR;
 const LAST_HOUR_OF_DAY = 23;
+const LAST_MINUTE_OF_DAY = 45;
 const HALF_HOUR_MINUTES = 30;
 const MEETING_DURATION_MILLISECONDS = MINUTES_PER_HOUR * MINUTES_PER_HOUR * MILLISECONDS_PER_SECOND;
 
@@ -32,7 +33,11 @@ const isSameCalendarDay = (left: Date, right: Date): boolean =>
   left.getMonth() === right.getMonth() &&
   left.getDate() === right.getDate();
 
-const isAfter11Pm = (date: Date): boolean => date.getHours() === LAST_HOUR_OF_DAY && date.getMinutes() > 0;
+export const getLatestMeetingEndDateTime = (date: Date): Date => {
+  const latestEnd = new Date(date);
+  latestEnd.setHours(LAST_HOUR_OF_DAY, LAST_MINUTE_OF_DAY, 0, 0);
+  return latestEnd;
+};
 
 export const getNextHalfHourDateTime = (now: Date): Date => {
   const totalMinutes = now.getHours() * MINUTES_PER_HOUR + now.getMinutes();
@@ -51,21 +56,12 @@ export const getNextHalfHourDateTime = (now: Date): Date => {
   return result;
 };
 
-export const getMidnightAfter = (date: Date): Date => {
-  const midnight = new Date(date);
-  midnight.setHours(HOURS_PER_DAY, 0, 0, 0);
-  return midnight;
-};
-
 export const getDefaultMeetingEndDateTime = (start: Date): Date => {
-  if (isAfter11Pm(start)) {
-    return getMidnightAfter(start);
-  }
-
   const end = new Date(start.getTime() + MEETING_DURATION_MILLISECONDS);
+  const latestEnd = getLatestMeetingEndDateTime(start);
 
-  if (!isSameCalendarDay(start, end)) {
-    return getMidnightAfter(start);
+  if (!isSameCalendarDay(start, end) || end.getTime() > latestEnd.getTime()) {
+    return latestEnd;
   }
 
   return end;
@@ -83,8 +79,10 @@ export const getMeetingDurationMilliseconds = (start: Date, end: Date): number =
 };
 
 export const capEndForStart = (start: Date, end: Date): Date => {
-  const midnight = getMidnightAfter(start);
-  return end.getTime() > midnight.getTime() ? midnight : end;
+  const latestEnd = getLatestMeetingEndDateTime(start);
+  const cappedEnd = end.getTime() > latestEnd.getTime() ? latestEnd : end;
+
+  return alignEndTimeToStartDate(start, cappedEnd);
 };
 
 export const resolveStartChange = (


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27038" title="WPB-27038" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27038</a>  [Web] Disable end date in Schedule meeting modal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Cap schedule meeting end times at 23:45 on the start date instead of midnight on the next day.
- Keep capped end times aligned to the start date so the disabled end-date field stays in sync.
- Update meeting datetime default tests for the late-night start scenarios from WPB-27038.

## Test plan
- [x] `yarn nx run webapp:test --testFile=src/script/components/Meeting/shared/defaults/meetingDateTimeDefaults.test.ts`
- [x] Open Schedule meeting modal, set start time to 23:30, confirm end time is 23:45 on the same date
- [x] Set start time to 23:45, confirm end time is 23:45 on the same date and validation error is shown
- [x] Confirm end time no longer rolls over to 12:00 AM on the next day