### PR TITLE
Make release-appearance comments retryable and cumulative [WPB-26469]

### DIFF
--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -541,7 +541,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
-          ref: ${{ needs.build_artifact.outputs.release_commit_sha }}
+          ref: ${{ github.sha }}
 
       - name: Add repository Yarn wrapper to PATH
         run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
@@ -562,6 +562,7 @@ jobs:
           BETA_TAG: ${{ needs.create_beta_tag.outputs.beta_tag_name }}
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_COMMIT_SHA: ${{ needs.build_artifact.outputs.release_commit_sha }}
+          WORKFLOW_TOOLING_COMMIT_SHA: ${{ github.sha }}
         run: |
           node \
             tools/release-appearance/releaseAppearanceCommand.ts \
@@ -923,7 +924,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
-          ref: ${{ needs.build_artifact.outputs.release_commit_sha }}
+          ref: ${{ github.sha }}
 
       - name: Add repository Yarn wrapper to PATH
         run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
@@ -945,6 +946,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PRODUCTION_TAG: ${{ needs.create_production_tag.outputs.production_tag_name }}
           RELEASE_COMMIT_SHA: ${{ needs.build_artifact.outputs.release_commit_sha }}
+          WORKFLOW_TOOLING_COMMIT_SHA: ${{ github.sha }}
         run: |
           node \
             tools/release-appearance/releaseAppearanceCommand.ts \

--- a/tools/release-appearance/releaseAppearanceCommand.test.ts
+++ b/tools/release-appearance/releaseAppearanceCommand.test.ts
@@ -50,6 +50,8 @@ const previousProductionCommit = 'b'.repeat(40);
 const betaCommit = 'c'.repeat(40);
 const previousProductionTag = '2026-01-01.1-production';
 const betaTag = '2026-01-02.1-beta.1';
+const betaTwoTag = '2026-01-02.1-beta.2';
+const betaTwoCommit = 'f'.repeat(40);
 const productionTag = '2026-01-02.1-production';
 
 const commandEnvironment: NodeJS.ProcessEnv = {
@@ -57,6 +59,7 @@ const commandEnvironment: NodeJS.ProcessEnv = {
   GITHUB_REPOSITORY: 'wireapp/wire-webapp',
   GITHUB_STEP_SUMMARY: '/tmp/release-appearance-summary.md',
   GITHUB_TOKEN: 'github-token',
+  WORKFLOW_TOOLING_COMMIT_SHA: 'e'.repeat(40),
 };
 
 type FakeGitHubClientOptions = {
@@ -91,6 +94,14 @@ type RunCommandOptions = {
 type FakeGitCommandOptions = {
   readonly bootstrap?: boolean;
   readonly commits?: readonly string[];
+  readonly betaTags?: readonly FakeBetaTag[];
+  readonly mergeBasesByRange?: ReadonlyMap<string, string>;
+  readonly commitsByRange?: ReadonlyMap<string, readonly string[]>;
+};
+
+type FakeBetaTag = {
+  readonly tagName: string;
+  readonly commit: string;
 };
 
 type CreateDependenciesOptions = {
@@ -190,6 +201,7 @@ function createFakeGitHubClient(fakeGitHubClientOptions: FakeGitHubClientOptions
 function createFakeGitCommand(fakeGitCommandOptions: FakeGitCommandOptions = {}): ExecuteGitCommand {
   const bootstrap = fakeGitCommandOptions.bootstrap === true;
   const commits = Maybe.of(fakeGitCommandOptions.commits).unwrapOr([betaCommit]);
+  const betaTags = Maybe.of(fakeGitCommandOptions.betaTags).unwrapOr([{tagName: betaTag, commit: releaseCommit}]);
 
   return async function executeFakeGitCommand(commandArguments: readonly string[]): Promise<string> {
     const command = commandArguments.join(' ');
@@ -197,28 +209,38 @@ function createFakeGitCommand(fakeGitCommandOptions: FakeGitCommandOptions = {})
       return bootstrap ? '' : `${previousProductionTag}\n`;
     }
     if (command === 'tag --list -- *-beta.*') {
-      return `${betaTag}\n`;
+      return `${betaTags.map(betaTagDefinition => betaTagDefinition.tagName).join('\n')}\n`;
     }
     if (command.startsWith('cat-file -t refs/tags/')) {
       return 'tag\n';
     }
     if (command.startsWith('for-each-ref --format=%(taggerdate:unix)')) {
-      return command.includes(betaTag) || command.includes(productionTag) ? '200\n' : '100\n';
+      const isBetaTagCommand = betaTags.some(betaTagDefinition => {
+        return command.includes(betaTagDefinition.tagName);
+      });
+      return isBetaTagCommand || command.includes(productionTag) ? '200\n' : '100\n';
     }
     if (command.includes(`refs/tags/${previousProductionTag}^{commit}`)) {
       return `${previousProductionCommit}\n`;
     }
-    if (command.includes(`refs/tags/${betaTag}^{commit}`)) {
-      return `${releaseCommit}\n`;
+    const betaTagDefinition = betaTags.find(betaTagDefinition => {
+      return command.includes(`refs/tags/${betaTagDefinition.tagName}^{commit}`);
+    });
+    if (betaTagDefinition !== undefined) {
+      return `${betaTagDefinition.commit}\n`;
     }
     if (command.includes(`refs/tags/${productionTag}^{commit}`)) {
       return `${releaseCommit}\n`;
     }
     if (command.startsWith('merge-base ')) {
-      return `${previousProductionCommit}\n`;
+      const range = command.slice('merge-base '.length).replaceAll('refs/tags/', '').replaceAll('^{}', '');
+      const mergeBase = fakeGitCommandOptions.mergeBasesByRange?.get(range);
+      return `${mergeBase ?? previousProductionCommit}\n`;
     }
     if (command.startsWith('rev-list --reverse ')) {
-      return `${commits.join('\n')}\n`;
+      const range = command.slice('rev-list --reverse '.length);
+      const rangeCommits = fakeGitCommandOptions.commitsByRange?.get(range) ?? commits;
+      return `${rangeCommits.join('\n')}\n`;
     }
 
     throw new Error(`Unexpected fake Git command: ${command}`);
@@ -420,10 +442,12 @@ describe('executeReleaseAppearanceCommand', () => {
         '### Release appearance',
         '',
         '- Stage: beta',
+        `- Workflow/tooling commit: \`${commandEnvironment.WORKFLOW_TOOLING_COMMIT_SHA}\``,
         `- Release tag: \`${betaTag}\``,
+        `- Release commit: \`${releaseCommit}\``,
         '- Bootstrap: no',
         `- Preceding Production tag: ${previousProductionTag}`,
-        `- Beta candidate ranges for Production: ${betaTag}: ${previousProductionTag} -> ${betaTag}`,
+        `- Candidate ranges: ${betaTag}: ${previousProductionTag} -> ${betaTag}`,
         `- Commits inspected: 1 (${betaCommit})`,
         '- Pull requests discovered: 1 (#8)',
         '- Comments created: 1',
@@ -437,6 +461,109 @@ describe('executeReleaseAppearanceCommand', () => {
         'None',
       ].join('\n'),
     );
+  });
+
+  it('backfills a missing Beta 1 comment during Beta 2 with the earliest Beta tag', async () => {
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByCommit: new Map([[betaCommit, [createPullRequest(10)]]]),
+    });
+    const fakeGitCommand = createFakeGitCommand({
+      betaTags: [
+        {tagName: betaTag, commit: betaCommit},
+        {tagName: betaTwoTag, commit: betaCommit},
+      ],
+      mergeBasesByRange: new Map([
+        [`${previousProductionTag} ${betaTag}`, previousProductionCommit],
+        [`${betaTag} ${betaTwoTag}`, betaCommit],
+      ]),
+      commitsByRange: new Map([[`${previousProductionCommit}..${betaCommit}`, [betaCommit]]]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: ['beta', betaTwoTag, betaCommit],
+      executeGitCommand: fakeGitCommand,
+      githubClient: fakeGitHubClient.githubClient,
+    });
+
+    expect(commandRun.result.exitCode).toBe(0);
+    expect(fakeGitHubClient.state.pullRequestCommits).toEqual([betaCommit]);
+    expect(fakeGitHubClient.state.createdComments).toHaveLength(1);
+    const createdComment = Maybe.of(fakeGitHubClient.state.createdComments[0]);
+    assert(createdComment.isJust);
+    expect(createdComment.value.commentBody).toContain(betaTag);
+    expect(createdComment.value.commentBody).not.toContain(betaTwoTag);
+    expect(commandRun.result.summary).toContain(
+      `- Candidate ranges: ${betaTag}: ${previousProductionTag} -> ${betaTag}; ${betaTwoTag}: ${betaTag} -> ${betaTwoTag}`,
+    );
+  });
+
+  it('records Beta 2 for a pull request introduced only in Beta 2', async () => {
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByCommit: new Map([[betaTwoCommit, [createPullRequest(12)]]]),
+    });
+    const fakeGitCommand = createFakeGitCommand({
+      betaTags: [
+        {tagName: betaTag, commit: betaCommit},
+        {tagName: betaTwoTag, commit: betaTwoCommit},
+      ],
+      mergeBasesByRange: new Map([
+        [`${previousProductionTag} ${betaTag}`, previousProductionCommit],
+        [`${betaTag} ${betaTwoTag}`, betaCommit],
+      ]),
+      commitsByRange: new Map([
+        [`${previousProductionCommit}..${betaCommit}`, [betaCommit]],
+        [`${betaCommit}..${betaTwoCommit}`, [betaTwoCommit]],
+      ]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: ['beta', betaTwoTag, betaTwoCommit],
+      executeGitCommand: fakeGitCommand,
+      githubClient: fakeGitHubClient.githubClient,
+    });
+
+    expect(commandRun.result.exitCode).toBe(0);
+    expect(fakeGitHubClient.state.createdComments).toHaveLength(1);
+    const createdComment = Maybe.of(fakeGitHubClient.state.createdComments[0]);
+    assert(createdComment.isJust);
+    expect(createdComment.value.commentBody).toContain(betaTwoTag);
+  });
+
+  it('deduplicates a pull request discovered in multiple cumulative Beta ranges', async () => {
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByCommit: new Map([
+        [betaCommit, [createPullRequest(13)]],
+        [betaTwoCommit, [createPullRequest(13)]],
+      ]),
+    });
+    const fakeGitCommand = createFakeGitCommand({
+      betaTags: [
+        {tagName: betaTag, commit: betaCommit},
+        {tagName: betaTwoTag, commit: betaTwoCommit},
+      ],
+      mergeBasesByRange: new Map([
+        [`${previousProductionTag} ${betaTag}`, previousProductionCommit],
+        [`${betaTag} ${betaTwoTag}`, betaCommit],
+      ]),
+      commitsByRange: new Map([
+        [`${previousProductionCommit}..${betaCommit}`, [betaCommit]],
+        [`${betaCommit}..${betaTwoCommit}`, [betaTwoCommit]],
+      ]),
+    });
+
+    const commandRun = await runCommand({
+      commandLineArguments: ['beta', betaTwoTag, betaTwoCommit],
+      executeGitCommand: fakeGitCommand,
+      githubClient: fakeGitHubClient.githubClient,
+    });
+
+    expect(commandRun.result.exitCode).toBe(0);
+    expect(fakeGitHubClient.state.pullRequestCommits).toEqual([betaCommit, betaTwoCommit]);
+    expect(fakeGitHubClient.state.commentPullRequests).toEqual([13]);
+    expect(fakeGitHubClient.state.createdComments).toHaveLength(1);
+    const createdComment = Maybe.of(fakeGitHubClient.state.createdComments[0]);
+    assert(createdComment.isJust);
+    expect(createdComment.value.commentBody).toContain(betaTag);
   });
 
   it('updates release appearance comments in write mode', async () => {
@@ -519,11 +646,12 @@ describe('executeReleaseAppearanceCommand', () => {
         '',
         '- Mode: dry run',
         '- Stage: production',
+        `- Workflow/tooling commit: \`${commandEnvironment.WORKFLOW_TOOLING_COMMIT_SHA}\``,
         `- Release tag: \`${productionTag}\``,
         `- Release commit: \`${releaseCommit}\``,
         '- Bootstrap: no',
         `- Preceding Production tag: ${previousProductionTag}`,
-        `- Beta candidate ranges for Production: ${betaTag}: ${previousProductionTag} -> ${betaTag}`,
+        `- Candidate ranges: ${betaTag}: ${previousProductionTag} -> ${betaTag}`,
         `- Commits inspected: 1 (${betaCommit})`,
         '- Pull requests discovered: 3 (#1, #2, #3)',
         '- Comments that would be created: 1',

--- a/tools/release-appearance/releaseAppearanceCommand.ts
+++ b/tools/release-appearance/releaseAppearanceCommand.ts
@@ -60,6 +60,7 @@ export type CommandEnvironment = {
   readonly githubRepository: string;
   readonly githubStepSummary: string;
   readonly githubToken: string;
+  readonly workflowToolingCommitSha: string;
 };
 
 export type ReleaseAppearanceCommandDependencies = {
@@ -126,6 +127,7 @@ type SummaryOptions = {
   readonly stage: ReleaseAppearanceCommandStage;
   readonly releaseTag: string;
   readonly releaseCommit: string;
+  readonly workflowToolingCommitSha: string;
   readonly bootstrap: boolean;
   readonly precedingProductionTag: string;
   readonly candidateRanges: readonly DiscoveryRange[];
@@ -312,6 +314,24 @@ function readRequiredEnvironmentValue(environment: NodeJS.ProcessEnv, variableNa
     : createFailure(`${variableName} must be set`);
 }
 
+function readWorkflowToolingCommitSha(environment: NodeJS.ProcessEnv): Result<string, Error> {
+  const configuredWorkflowToolingCommitSha = environment.WORKFLOW_TOOLING_COMMIT_SHA;
+  const githubSha = environment.GITHUB_SHA;
+  const workflowToolingCommitSha = isNonEmptyStringAndNotWhitespace(configuredWorkflowToolingCommitSha)
+    ? configuredWorkflowToolingCommitSha
+    : githubSha;
+
+  if (!isNonEmptyStringAndNotWhitespace(workflowToolingCommitSha)) {
+    return createSuccess('unavailable');
+  }
+
+  if (!fullGitCommitPattern.test(workflowToolingCommitSha)) {
+    return createFailure('Workflow tooling commit SHA must contain exactly 40 hexadecimal characters');
+  }
+
+  return createSuccess(workflowToolingCommitSha);
+}
+
 export function readCommandEnvironment(environment: NodeJS.ProcessEnv): Result<CommandEnvironment, Error> {
   const githubApiUrlResult = readRequiredEnvironmentValue(environment, 'GITHUB_API_URL');
   if (githubApiUrlResult.isErr) {
@@ -340,11 +360,15 @@ export function readCommandEnvironment(environment: NodeJS.ProcessEnv): Result<C
 
   const githubStepSummaryResult = readRequiredEnvironmentValue(environment, 'GITHUB_STEP_SUMMARY');
   const githubTokenResult = readRequiredEnvironmentValue(environment, 'GITHUB_TOKEN');
+  const workflowToolingCommitShaResult = readWorkflowToolingCommitSha(environment);
   if (githubStepSummaryResult.isErr) {
     return createFailure(githubStepSummaryResult.error.message);
   }
   if (githubTokenResult.isErr) {
     return createFailure(githubTokenResult.error.message);
+  }
+  if (workflowToolingCommitShaResult.isErr) {
+    return createFailure(workflowToolingCommitShaResult.error.message);
   }
 
   return createSuccess({
@@ -352,6 +376,7 @@ export function readCommandEnvironment(environment: NodeJS.ProcessEnv): Result<C
     githubRepository: githubRepositoryResult.value,
     githubStepSummary: githubStepSummaryResult.value,
     githubToken: githubTokenResult.value,
+    workflowToolingCommitSha: workflowToolingCommitShaResult.value,
   });
 }
 
@@ -390,6 +415,10 @@ async function discoverPullRequests(
 
   for (const range of ranges) {
     for (const commitSha of range.commitRange.commits) {
+      if (commitsInspected.has(commitSha)) {
+        continue;
+      }
+
       commitsInspected.add(commitSha);
       const pullRequestsResult = await githubClient.listPullRequestsForCommit({commitSha});
       if (pullRequestsResult.isErr) {
@@ -491,7 +520,7 @@ function createDesiredReleaseState(
 ): ReleaseAppearanceState {
   return match(stage)
     .with('beta', () => {
-      return {beta: Maybe.just(releaseTag), production: Maybe.nothing<string>()};
+      return {beta: Maybe.just(earliestBetaTag), production: Maybe.nothing<string>()};
     })
     .with('production', () => {
       return {beta: Maybe.just(earliestBetaTag), production: Maybe.just(releaseTag)};
@@ -612,12 +641,13 @@ async function processPullRequests(
   };
 }
 
-function createEmptySummaryOptions(parsedCommand: ParsedCommand): SummaryOptions {
+function createEmptySummaryOptions(parsedCommand: ParsedCommand, workflowToolingCommitSha: string): SummaryOptions {
   return {
     executionMode: parsedCommand.executionMode,
     stage: parsedCommand.stage,
     releaseTag: parsedCommand.releaseTag,
     releaseCommit: parsedCommand.releaseCommit,
+    workflowToolingCommitSha,
     bootstrap: false,
     precedingProductionTag: 'unavailable',
     candidateRanges: [],
@@ -642,7 +672,7 @@ function addPlanToSummary(summaryOptions: SummaryOptions, releaseHistoryPlan: Re
       return {
         ...summaryOptions,
         precedingProductionTag: betaPlan.precedingProductionTag,
-        candidateRanges: [{candidateTag: betaPlan.currentTag, commitRange: betaPlan.commitRange}],
+        candidateRanges: betaPlan.candidateRanges,
       };
     })
     .with({kind: 'production'}, productionPlan => {
@@ -707,10 +737,12 @@ function createWriteSummary(summaryOptions: SummaryOptions): string {
     '### Release appearance',
     '',
     `- Stage: ${summaryOptions.stage}`,
+    `- Workflow/tooling commit: \`${summaryOptions.workflowToolingCommitSha}\``,
     `- Release tag: \`${summaryOptions.releaseTag}\``,
+    `- Release commit: \`${summaryOptions.releaseCommit}\``,
     `- Bootstrap: ${summaryOptions.bootstrap ? 'yes' : 'no'}`,
     `- Preceding Production tag: ${summaryOptions.precedingProductionTag}`,
-    `- Beta candidate ranges for Production: ${formatCandidateRanges(summaryOptions.candidateRanges)}`,
+    `- Candidate ranges: ${formatCandidateRanges(summaryOptions.candidateRanges)}`,
     `- Commits inspected: ${summaryOptions.commitsInspected.length} (${formatStringList(summaryOptions.commitsInspected)})`,
     `- Pull requests discovered: ${summaryOptions.pullRequestsDiscovered.length} (${formatPullRequestList(summaryOptions.pullRequestsDiscovered)})`,
     `- Comments created: ${summaryOptions.commentsCreated}`,
@@ -751,11 +783,12 @@ function createDryRunSummary(summaryOptions: SummaryOptions): string {
     '',
     '- Mode: dry run',
     `- Stage: ${summaryOptions.stage}`,
+    `- Workflow/tooling commit: \`${summaryOptions.workflowToolingCommitSha}\``,
     `- Release tag: \`${summaryOptions.releaseTag}\``,
     `- Release commit: \`${summaryOptions.releaseCommit}\``,
     `- Bootstrap: ${summaryOptions.bootstrap ? 'yes' : 'no'}`,
     `- Preceding Production tag: ${summaryOptions.precedingProductionTag}`,
-    `- Beta candidate ranges for Production: ${formatCandidateRanges(summaryOptions.candidateRanges)}`,
+    `- Candidate ranges: ${formatCandidateRanges(summaryOptions.candidateRanges)}`,
     `- Commits inspected: ${summaryOptions.commitsInspected.length} (${formatStringList(summaryOptions.commitsInspected)})`,
     `- Pull requests discovered: ${summaryOptions.pullRequestsDiscovered.length} (${formatPullRequestList(summaryOptions.pullRequestsDiscovered)})`,
     `- Comments that would be created: ${summaryOptions.commentsCreated}`,
@@ -922,7 +955,10 @@ export async function executeReleaseAppearanceCommand(
     );
   }
 
-  let summaryOptions = createEmptySummaryOptions(parsedCommand);
+  let summaryOptions = createEmptySummaryOptions(
+    parsedCommand,
+    commandEnvironmentResult.value.workflowToolingCommitSha,
+  );
   if (historyPlanResult.isErr) {
     const historyFailureMessage = createGeneralFailureMessage(
       'Release history',
@@ -947,7 +983,7 @@ export async function executeReleaseAppearanceCommand(
 
     const discoveryRanges = match(historyPlanResult.value)
       .with({kind: 'beta'}, betaPlan => {
-        return [{candidateTag: betaPlan.currentTag, commitRange: betaPlan.commitRange}];
+        return betaPlan.candidateRanges;
       })
       .with({kind: 'production'}, productionPlan => {
         return productionPlan.candidateRanges;

--- a/tools/release-appearance/releaseHistory.integration.test.ts
+++ b/tools/release-appearance/releaseHistory.integration.test.ts
@@ -213,13 +213,14 @@ describe('release history planning', () => {
       if (actualResult.value.kind !== 'beta') {
         assert.fail('Expected a Beta history plan');
       }
-      expect(actualResult.value.commitRange.baseCommit).toBe(productionCommit);
-      expect(actualResult.value.commitRange.endCommit).toBe(betaCommit);
-      expect(actualResult.value.commitRange.commits).toEqual([betaCommit]);
+      expect(actualResult.value.candidateRanges.map(candidateRange => candidateRange.candidateTag)).toEqual([betaTag]);
+      expect(actualResult.value.candidateRanges[0]?.commitRange.baseCommit).toBe(productionCommit);
+      expect(actualResult.value.candidateRanges[0]?.commitRange.endCommit).toBe(betaCommit);
+      expect(actualResult.value.candidateRanges[0]?.commitRange.commits).toEqual([betaCommit]);
     });
   });
 
-  it('plans only the delta introduced by the current Beta candidate', async () => {
+  it('plans every cumulative Beta candidate range through the current candidate', async () => {
     await createTemporaryGitRepository(async (repositoryPath, executeGitCommand) => {
       await createProductionBaseline(repositoryPath);
       const betaOneCommit = await createCommit({
@@ -260,13 +261,58 @@ describe('release history planning', () => {
       if (actualResult.value.kind !== 'beta') {
         assert.fail('Expected a Beta history plan');
       }
-      expect(actualResult.value.precedingTag).toBe(betaOneTag);
-      expect(actualResult.value.commitRange.startTag).toBe(betaOneTag);
-      expect(actualResult.value.commitRange.endTag).toBe(betaTwoTag);
-      expect(actualResult.value.commitRange.baseCommit).toBe(betaOneCommit);
-      expect(actualResult.value.commitRange.endCommit).toBe(betaTwoCommit);
-      expect(actualResult.value.commitRange.commits).toEqual([betaTwoCommit]);
-      expect(actualResult.value.commitRange.commits).not.toContain(betaOneCommit);
+      expect(actualResult.value.candidateRanges.map(candidateRange => candidateRange.candidateTag)).toEqual([
+        betaOneTag,
+        betaTwoTag,
+      ]);
+      expect(actualResult.value.candidateRanges[0]?.commitRange.startTag).toBe('2026-01-01.1-production');
+      expect(actualResult.value.candidateRanges[0]?.commitRange.endTag).toBe(betaOneTag);
+      expect(actualResult.value.candidateRanges[0]?.commitRange.commits).toEqual([betaOneCommit]);
+      expect(actualResult.value.candidateRanges[1]?.commitRange.startTag).toBe(betaOneTag);
+      expect(actualResult.value.candidateRanges[1]?.commitRange.endTag).toBe(betaTwoTag);
+      expect(actualResult.value.candidateRanges[1]?.commitRange.baseCommit).toBe(betaOneCommit);
+      expect(actualResult.value.candidateRanges[1]?.commitRange.endCommit).toBe(betaTwoCommit);
+      expect(actualResult.value.candidateRanges[1]?.commitRange.commits).toEqual([betaTwoCommit]);
+    });
+  });
+
+  it('retains the first non-empty range when repeated Beta candidates point to one commit', async () => {
+    await createTemporaryGitRepository(async (repositoryPath, executeGitCommand) => {
+      await createProductionBaseline(repositoryPath);
+      const betaCommit = await createCommit({
+        repositoryPath,
+        fileName: 'beta.txt',
+        fileContents: 'beta',
+        commitDate: '2026-01-02T00:00:00+0000',
+      });
+      const betaOneTag = '2026-01-02.1-beta.1';
+      const betaTwoTag = '2026-01-02.1-beta.2';
+      await createAnnotatedTag({
+        repositoryPath,
+        tagName: betaOneTag,
+        commit: betaCommit,
+        taggerDate: '2026-01-02T01:00:00+0000',
+      });
+      await createAnnotatedTag({
+        repositoryPath,
+        tagName: betaTwoTag,
+        commit: betaCommit,
+        taggerDate: '2026-01-02T02:00:00+0000',
+      });
+
+      const actualResult = await planBetaReleaseHistory({
+        executeGitCommand,
+        currentBetaTag: betaTwoTag,
+        releaseCommit: betaCommit,
+      });
+
+      assert(actualResult.isOk);
+      expect(actualResult.value.kind).toBe('beta');
+      if (actualResult.value.kind !== 'beta') {
+        assert.fail('Expected a Beta history plan');
+      }
+      expect(actualResult.value.candidateRanges[0]?.commitRange.commits).toEqual([betaCommit]);
+      expect(actualResult.value.candidateRanges[1]?.commitRange.commits).toEqual([]);
     });
   });
 
@@ -340,13 +386,15 @@ describe('release history planning', () => {
         assert.fail('Expected a Beta history plan');
       }
       expect(actualResult.value.precedingProductionTag).toBe(newerSiblingProductionTag);
-      expect(actualResult.value.precedingTag).toBe(newerSiblingProductionTag);
       expect(actualResult.value.precedingProductionTag).not.toBe(olderAncestorProductionTag);
-      expect(actualResult.value.commitRange.startTag).toBe(newerSiblingProductionTag);
-      expect(actualResult.value.commitRange.endTag).toBe(currentBetaTag);
-      expect(actualResult.value.commitRange.baseCommit).toBe(commonBaseCommit);
-      expect(actualResult.value.commitRange.endCommit).toBe(currentReleaseCommit);
-      expect(actualResult.value.commitRange.commits).toEqual([olderAncestorProductionCommit, currentReleaseCommit]);
+      expect(actualResult.value.candidateRanges[0]?.commitRange.startTag).toBe(newerSiblingProductionTag);
+      expect(actualResult.value.candidateRanges[0]?.commitRange.endTag).toBe(currentBetaTag);
+      expect(actualResult.value.candidateRanges[0]?.commitRange.baseCommit).toBe(commonBaseCommit);
+      expect(actualResult.value.candidateRanges[0]?.commitRange.endCommit).toBe(currentReleaseCommit);
+      expect(actualResult.value.candidateRanges[0]?.commitRange.commits).toEqual([
+        olderAncestorProductionCommit,
+        currentReleaseCommit,
+      ]);
     });
   });
 

--- a/tools/release-appearance/releaseHistory.ts
+++ b/tools/release-appearance/releaseHistory.ts
@@ -608,7 +608,8 @@ function createCommitRange(createCommitRangeOptions: CreateCommitRangeOptions): 
 async function listBetaCandidatesThroughPromotedTag(
   listBetaCandidatesThroughPromotedTagOptions: ListBetaCandidatesThroughTagOptions,
 ): Promise<Result<readonly BetaCandidateRecord[], Error>> {
-  const {executeGitCommand, releaseIdentifier, candidateNumber, currentTagName} = listBetaCandidatesThroughPromotedTagOptions;
+  const {executeGitCommand, releaseIdentifier, candidateNumber, currentTagName} =
+    listBetaCandidatesThroughPromotedTagOptions;
   const betaTagNamesResult = await listTagNames(executeGitCommand, betaTagListPattern);
   if (betaTagNamesResult.isErr) {
     return createFailure(betaTagNamesResult.error.message, betaTagNamesResult.error);

--- a/tools/release-appearance/releaseHistory.ts
+++ b/tools/release-appearance/releaseHistory.ts
@@ -44,7 +44,7 @@ export type CommitRange = {
   readonly commits: readonly string[];
 };
 
-export type ProductionCandidateRange = {
+export type ReleaseCandidateRange = {
   readonly candidateTag: string;
   readonly commitRange: CommitRange;
 };
@@ -55,8 +55,7 @@ export type ReleaseHistoryPlan =
       readonly kind: 'beta';
       readonly currentTag: string;
       readonly precedingProductionTag: string;
-      readonly precedingTag: string;
-      readonly commitRange: CommitRange;
+      readonly candidateRanges: readonly ReleaseCandidateRange[];
     }
   | {
       readonly kind: 'production';
@@ -64,7 +63,7 @@ export type ReleaseHistoryPlan =
       readonly promotedBetaTag: string;
       readonly releaseCommit: string;
       readonly precedingProductionTag: string;
-      readonly candidateRanges: readonly ProductionCandidateRange[];
+      readonly candidateRanges: readonly ReleaseCandidateRange[];
     };
 
 export type PlanBetaReleaseHistoryOptions = {
@@ -114,6 +113,10 @@ type BetaReleaseTagRecord = BetaCandidateRecord & {
   readonly taggerTimestamp: bigint;
 };
 
+type BetaCandidateCommitRecord = BetaCandidateRecord & {
+  readonly commit: string;
+};
+
 type CompareTagOrderOptions = {
   readonly leftTaggerTimestamp: bigint;
   readonly leftReleaseIdentifier: string;
@@ -134,11 +137,11 @@ type CreateCommitRangeOptions = {
   readonly endTag: string;
 };
 
-type ListBetaCandidatesThroughPromotedTagOptions = {
+type ListBetaCandidatesThroughTagOptions = {
   readonly executeGitCommand: ExecuteGitCommand;
   readonly releaseIdentifier: string;
-  readonly promotedBetaCandidate: BetaCandidate;
-  readonly promotedBetaTagName: string;
+  readonly candidateNumber: bigint;
+  readonly currentTagName: string;
 };
 
 const betaTagListPattern = '*-beta.*';
@@ -362,16 +365,17 @@ async function findPrecedingProductionTag(
   return createSuccess(precedingProductionTag);
 }
 
-async function findPrecedingBetaCandidate(
-  executeGitCommand: ExecuteGitCommand,
-  currentBetaCandidate: BetaCandidate,
-): Promise<Result<Maybe<BetaCandidateRecord>, Error>> {
+async function listBetaCandidatesThroughTag(
+  listBetaCandidatesThroughTagOptions: ListBetaCandidatesThroughTagOptions,
+): Promise<Result<readonly BetaCandidateCommitRecord[], Error>> {
+  const {executeGitCommand, releaseIdentifier, candidateNumber, currentTagName} = listBetaCandidatesThroughTagOptions;
   const betaTagNamesResult = await listTagNames(executeGitCommand, betaTagListPattern);
   if (betaTagNamesResult.isErr) {
     return createFailure(betaTagNamesResult.error.message, betaTagNamesResult.error);
   }
 
-  let precedingBetaCandidate: Maybe<BetaCandidateRecord> = Maybe.nothing<BetaCandidateRecord>();
+  const betaCandidateRecords: BetaCandidateCommitRecord[] = [];
+  let currentTagWasFound = false;
   for (const betaTagName of betaTagNamesResult.value) {
     const parsedBetaCandidateResult = parseBetaCandidateTag(betaTagName);
     if (parsedBetaCandidateResult.isErr) {
@@ -380,8 +384,8 @@ async function findPrecedingBetaCandidate(
 
     const parsedBetaCandidate = parsedBetaCandidateResult.value;
     if (
-      parsedBetaCandidate.releaseIdentifier !== currentBetaCandidate.releaseIdentifier ||
-      parsedBetaCandidate.candidateNumber >= currentBetaCandidate.candidateNumber
+      parsedBetaCandidate.releaseIdentifier !== releaseIdentifier ||
+      parsedBetaCandidate.candidateNumber > candidateNumber
     ) {
       continue;
     }
@@ -395,21 +399,42 @@ async function findPrecedingBetaCandidate(
       return createFailure(`Beta candidate tag must be annotated: ${betaTagName}`);
     }
 
-    const betaCandidateRecord: BetaCandidateRecord = {
+    const commitResult = await resolveTagCommit(executeGitCommand, betaTagName);
+    if (commitResult.isErr) {
+      return createFailure(commitResult.error.message, commitResult.error);
+    }
+
+    if (betaTagName === currentTagName) {
+      currentTagWasFound = true;
+    }
+
+    betaCandidateRecords.push({
       ...parsedBetaCandidate,
       tagName: betaTagName,
-    };
-    const shouldReplacePrecedingCandidate = precedingBetaCandidate
-      .map(existingBetaCandidate => {
-        return compareBetaCandidates(betaCandidateRecord, existingBetaCandidate) > 0;
-      })
-      .unwrapOr(true);
-    if (shouldReplacePrecedingCandidate) {
-      precedingBetaCandidate = Maybe.just(betaCandidateRecord);
+      commit: commitResult.value,
+    });
+  }
+
+  if (!currentTagWasFound) {
+    return createFailure(`Current Beta candidate tag was not found in matching tags: ${currentTagName}`);
+  }
+
+  const sortedBetaCandidateRecords = betaCandidateRecords.toSorted((leftCandidate, rightCandidate) => {
+    return compareBetaCandidates(leftCandidate, rightCandidate);
+  });
+  for (let candidateIndex = 0; candidateIndex < sortedBetaCandidateRecords.length; candidateIndex += 1) {
+    const betaCandidate = Maybe.of(sortedBetaCandidateRecords[candidateIndex]);
+    if (betaCandidate.isNothing) {
+      return createFailure('Beta candidate continuity validation failed');
+    }
+
+    const expectedCandidateNumber = BigInt(candidateIndex + 1);
+    if (betaCandidate.value.candidateNumber !== expectedCandidateNumber) {
+      return createFailure(`Missing Beta candidate ${releaseIdentifier}-beta.${expectedCandidateNumber}`);
     }
   }
 
-  return createSuccess(precedingBetaCandidate);
+  return createSuccess(sortedBetaCandidateRecords);
 }
 
 export function findLatestBetaReleaseTag(
@@ -581,10 +606,9 @@ function createCommitRange(createCommitRangeOptions: CreateCommitRangeOptions): 
 }
 
 async function listBetaCandidatesThroughPromotedTag(
-  listBetaCandidatesThroughPromotedTagOptions: ListBetaCandidatesThroughPromotedTagOptions,
+  listBetaCandidatesThroughPromotedTagOptions: ListBetaCandidatesThroughTagOptions,
 ): Promise<Result<readonly BetaCandidateRecord[], Error>> {
-  const {executeGitCommand, releaseIdentifier, promotedBetaCandidate, promotedBetaTagName} =
-    listBetaCandidatesThroughPromotedTagOptions;
+  const {executeGitCommand, releaseIdentifier, candidateNumber, currentTagName} = listBetaCandidatesThroughPromotedTagOptions;
   const betaTagNamesResult = await listTagNames(executeGitCommand, betaTagListPattern);
   if (betaTagNamesResult.isErr) {
     return createFailure(betaTagNamesResult.error.message, betaTagNamesResult.error);
@@ -601,19 +625,19 @@ async function listBetaCandidatesThroughPromotedTag(
     const parsedBetaCandidate = parsedBetaCandidateResult.value;
     if (
       parsedBetaCandidate.releaseIdentifier !== releaseIdentifier ||
-      parsedBetaCandidate.candidateNumber > promotedBetaCandidate.candidateNumber
+      parsedBetaCandidate.candidateNumber > candidateNumber
     ) {
       continue;
     }
 
     betaCandidateRecords.push({...parsedBetaCandidate, tagName: betaTagName});
-    if (betaTagName === promotedBetaTagName) {
+    if (betaTagName === currentTagName) {
       promotedBetaTagWasFound = true;
     }
   }
 
   if (!promotedBetaTagWasFound) {
-    return createFailure(`Promoted Beta tag was not found in matching tags: ${promotedBetaTagName}`);
+    return createFailure(`Promoted Beta tag was not found in matching tags: ${currentTagName}`);
   }
 
   const candidatesThroughPromotedTag = betaCandidateRecords.toSorted((leftCandidate, rightCandidate) => {
@@ -691,34 +715,37 @@ export async function planBetaReleaseHistory(
   }
 
   const precedingProductionTag = precedingProductionTagResult.value.value;
-  const precedingBetaCandidateResult = await findPrecedingBetaCandidate(
+  const betaCandidatesResult = await listBetaCandidatesThroughTag({
     executeGitCommand,
-    parsedBetaCandidateResult.value,
-  );
-  if (precedingBetaCandidateResult.isErr) {
-    return createFailure(precedingBetaCandidateResult.error.message, precedingBetaCandidateResult.error);
+    releaseIdentifier: parsedBetaCandidateResult.value.releaseIdentifier,
+    candidateNumber: parsedBetaCandidateResult.value.candidateNumber,
+    currentTagName: currentBetaTag,
+  });
+  if (betaCandidatesResult.isErr) {
+    return createFailure(betaCandidatesResult.error.message, betaCandidatesResult.error);
   }
 
-  const precedingTag = precedingBetaCandidateResult.value
-    .map(betaCandidate => {
-      return betaCandidate.tagName;
-    })
-    .unwrapOr(precedingProductionTag.tagName);
-  const commitRangeResult = await createCommitRange({
-    executeGitCommand,
-    startTag: precedingTag,
-    endTag: currentBetaTag,
-  });
-  if (commitRangeResult.isErr) {
-    return createFailure(commitRangeResult.error.message, commitRangeResult.error);
+  const candidateRanges: ReleaseCandidateRange[] = [];
+  let precedingTag = precedingProductionTag.tagName;
+  for (const betaCandidate of betaCandidatesResult.value) {
+    const commitRangeResult = await createCommitRange({
+      executeGitCommand,
+      startTag: precedingTag,
+      endTag: betaCandidate.tagName,
+    });
+    if (commitRangeResult.isErr) {
+      return createFailure(commitRangeResult.error.message, commitRangeResult.error);
+    }
+
+    candidateRanges.push({candidateTag: betaCandidate.tagName, commitRange: commitRangeResult.value});
+    precedingTag = betaCandidate.tagName;
   }
 
   return createSuccess({
     kind: 'beta',
     currentTag: currentBetaTag,
     precedingProductionTag: precedingProductionTag.tagName,
-    precedingTag,
-    commitRange: commitRangeResult.value,
+    candidateRanges,
   });
 }
 
@@ -800,14 +827,14 @@ export async function planProductionReleaseHistory(
   const betaCandidatesResult = await listBetaCandidatesThroughPromotedTag({
     executeGitCommand,
     releaseIdentifier: parsedProductionTagResult.value.releaseIdentifier,
-    promotedBetaCandidate: parsedPromotedBetaTagResult.value,
-    promotedBetaTagName: promotedBetaTag,
+    candidateNumber: parsedPromotedBetaTagResult.value.candidateNumber,
+    currentTagName: promotedBetaTag,
   });
   if (betaCandidatesResult.isErr) {
     return createFailure(betaCandidatesResult.error.message, betaCandidatesResult.error);
   }
 
-  const candidateRanges: ProductionCandidateRange[] = [];
+  const candidateRanges: ReleaseCandidateRange[] = [];
   let precedingTag = precedingProductionTag.tagName;
   for (const betaCandidate of betaCandidatesResult.value) {
     const commitRangeResult = await createCommitRange({

--- a/tools/release-appearance/releaseWebappWorkflow.test.ts
+++ b/tools/release-appearance/releaseWebappWorkflow.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {readFile} from 'node:fs/promises';
+
+function readWorkflowJob(workflowContents: string, jobIdentifier: string): string {
+  const jobStart = workflowContents.indexOf(`  ${jobIdentifier}:`);
+  expect(jobStart).not.toBe(-1);
+
+  const followingJobMatch = /\n  [a-z0-9_]+:\n/gu.exec(workflowContents.slice(jobStart + 1));
+  const jobEnd = followingJobMatch === null ? workflowContents.length : jobStart + 1 + followingJobMatch.index;
+  return workflowContents.slice(jobStart, jobEnd);
+}
+
+describe('Release WebApp release-appearance workflow jobs', () => {
+  it.each(['comment_beta_release_appearances', 'comment_production_release_appearances'])(
+    'executes tooling from github.sha while passing the application release SHA as data for %s',
+    async (commentJobIdentifier: string) => {
+      const workflowContents = await readFile('.github/workflows/release-webapp.yml', 'utf8');
+      const jobContents = readWorkflowJob(workflowContents, commentJobIdentifier);
+
+      expect(jobContents).toContain('fetch-depth: 0');
+      expect(jobContents).toContain('fetch-tags: true');
+      expect(jobContents).toContain('ref: ${{ github.sha }}');
+      expect(jobContents).toContain('WORKFLOW_TOOLING_COMMIT_SHA: ${{ github.sha }}');
+      expect(jobContents).toContain('RELEASE_COMMIT_SHA: ${{ needs.build_artifact.outputs.release_commit_sha }}');
+      expect(jobContents).not.toContain('ref: ${{ needs.build_artifact.outputs.release_commit_sha }}');
+    },
+  );
+});


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

- Plan Beta history cumulatively from the preceding Production tag through every candidate up to the current candidate.
- Preserve `earliestBetaTag` when creating or retrying Beta appearance comments, including repeated candidates on the same commit.
- Check out release-appearance tooling from `${{ github.sha }}` with complete history while continuing to pass `RELEASE_COMMIT_SHA` as the application artifact commit.
- Add auditable summaries for workflow/tooling SHA, application release SHA, release tag, candidate ranges, inspected commits, discovered PRs, comment operations, and failures.
