### PR TITLE
Mitigate Nx cache poisoning in pull request continuous integration [WPB-22420]

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,11 @@ concurrency:
 
 permissions: {}
 
+# Keep Nx task caching disabled in pull_request and merge_group runs because
+# repository-controlled code is untrusted and could poison task results (CVE-2025-36852, CREEP).
+env:
+  NX_SKIP_NX_CACHE: 'true'
+
 jobs:
   workflow-security:
     runs-on: ubuntu-24.04
@@ -95,16 +100,6 @@ jobs:
           test -f libraries/config/lib/index.js
           test -f libraries/config/lib/index.d.ts
 
-      - name: Restore Nx and ESLint caches
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            .nx/cache
-            node_modules/.cache/eslint
-          key: lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-${{ github.sha }}
-          restore-keys: |
-            lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-
-
       - name: Verify generated i18n artifacts are committed
         run: |
           ./bin/yarn nx run webapp:translate-merge
@@ -140,16 +135,6 @@ jobs:
       - name: Install dependencies
         run: ./bin/yarn --immutable
 
-      - name: Restore Nx and ESLint caches
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            .nx/cache
-            node_modules/.cache/eslint
-          key: lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-${{ github.sha }}
-          restore-keys: |
-            lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-
-
       - name: Build libraries
         run: ./bin/yarn nx run-many -t build --projects=tag:type:lib
 
@@ -178,16 +163,6 @@ jobs:
       - name: Install dependencies
         run: ./bin/yarn --immutable
 
-      - name: Restore Nx and ESLint caches
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            .nx/cache
-            node_modules/.cache/eslint
-          key: lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-${{ github.sha }}
-          restore-keys: |
-            lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-
-
       - name: Type check
         run: ./bin/yarn type-check
 
@@ -215,16 +190,6 @@ jobs:
 
       - name: Install dependencies
         run: ./bin/yarn --immutable
-
-      - name: Restore Nx and ESLint caches
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            .nx/cache
-            node_modules/.cache/eslint
-          key: lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-${{ github.sha }}
-          restore-keys: |
-            lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-
 
       - name: Lint file names
         run: ./bin/yarn lint:fileNames
@@ -263,16 +228,6 @@ jobs:
 
       - name: Install dependencies
         run: ./bin/yarn --immutable
-
-      - name: Restore Nx and ESLint caches
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            .nx/cache
-            node_modules/.cache/eslint
-          key: lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-${{ github.sha }}
-          restore-keys: |
-            lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-
 
       - name: Build libraries for lint import resolution
         run: ./bin/yarn nx run-many -t build --projects=tag:type:lib
@@ -330,16 +285,6 @@ jobs:
       - name: Install dependencies
         run: ./bin/yarn --immutable
 
-      - name: Restore Nx and ESLint caches
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            .nx/cache
-            node_modules/.cache/eslint
-          key: lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-${{ github.sha }}
-          restore-keys: |
-            lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-
-
       - name: Test
         run: ./bin/run-with-network-isolation.sh ./bin/yarn nx run-many -t test --all --configuration=ci --detectOpenHandles=false
 
@@ -388,16 +333,6 @@ jobs:
 
       - name: Install dependencies
         run: ./bin/yarn --immutable
-
-      - name: Restore Nx and ESLint caches
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            .nx/cache
-            node_modules/.cache/eslint
-          key: lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-${{ github.sha }}
-          restore-keys: |
-            lint-${{ runner.os }}-${{ hashFiles('eslint.config.ts', 'yarn.lock') }}-
 
       - name: Build and verify public production package
         env:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

This change mitigates the Nx cache poisoning vulnerability described by [CVE-2025-36852](https://www.cve.org/CVERecord?id=CVE-2025-36852).

Our continuous integration workflow previously restored and saved `.nx/cache` through GitHub Actions in jobs triggered by `pull_request` and `merge_group`.

Repository-controlled code, including Yarn lifecycle scripts and Jest, ESLint, and Nx configuration, is executed before GitHub saves the final cache contents. An untrusted pull request could therefore place forged task results into `.nx/cache`. A later run within the same pull request cache scope could restore those entries and report successful Nx cache hits without executing the corresponding tasks.

This does not provide a known path into the production release workflows, but it compromises the integrity of the CI checks used as merge gates.