### PR TITLE
Expand meetings list initial window to one year [WPB-27637]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/MeetingList/meetingList.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/meetingList.test.tsx
@@ -218,7 +218,7 @@ describe('MeetingList', () => {
 
     const meetingSeries = [
       createMeetingSeries('2026-06-15T14:00:00.000Z', '2026-06-15T15:00:00.000Z', 'Today meeting'),
-      createMeetingSeries('2026-07-10T10:00:00.000Z', '2026-07-10T11:00:00.000Z', 'Far future meeting'),
+      createMeetingSeries('2027-07-10T10:00:00.000Z', '2027-07-10T11:00:00.000Z', 'Far future meeting'),
     ];
 
     renderMeetingList({meetingSeries, isLoading: false, hasLoadError: false}, wallClock);

--- a/apps/webapp/src/script/components/Meeting/MeetingList/meetingListConstants.ts
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/meetingListConstants.ts
@@ -17,7 +17,7 @@
  *
  */
 
-export const INITIAL_VISIBLE_DAY_COUNT = 14;
+export const INITIAL_VISIBLE_DAY_COUNT = 365;
 export const LOAD_MORE_DAY_COUNT = 14;
 export const MEETING_LIST_ITEM_HEIGHT = 75;
 export const MEETING_DAY_GROUP_SECTION_TOP_PADDING = 16;

--- a/apps/webapp/src/script/components/Meeting/selectors/getVisibleTimeWindow.ts
+++ b/apps/webapp/src/script/components/Meeting/selectors/getVisibleTimeWindow.ts
@@ -32,7 +32,7 @@ export type VisibleTimeWindow = {
  * Builds the half-open time range `[from, to)` used when expanding meeting series into list instances.
  *
  * `from` is the start of the calendar day containing `now`. `to` is `from + dayCount` days.
- * The UI chooses `dayCount` (e.g. 14 now; larger when infinite scroll widens the window).
+ * The UI chooses `dayCount` (e.g. 365 initially; larger when infinite scroll widens the window).
  *
  * @param now - Reference time, typically `wallClock.currentDate`.
  * @param options.dayCount - Number of calendar days to include from the start of today.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27637" title="WPB-27637" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27637</a>  Scheduled meeting does not appear in the meeting list when creating a meeting after 15 days
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Increase the meetings list initial visible day window from 14 to 365 days so upcoming meetings (including next month) appear after scheduling.
- Keep scroll-based load-more for meetings beyond one year.

## Test plan
- [x] Schedule a meeting ~1 month ahead and confirm it appears in the Meetings list without scrolling.
- [x] Confirm nearer meetings still render correctly.
- [x] Confirm a meeting more than a year ahead still requires scrolling/load-more to appear.