### PR TITLE
fix(webapp): use trash icon for delete meeting actions [WPB-25513]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/getMeetingActionEntries.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/getMeetingActionEntries.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {CloseIcon, EditIcon, TrashIcon} from '@wireapp/react-ui-kit';
+import {EditIcon, TrashIcon} from '@wireapp/react-ui-kit';
 
 import {
   contextMenuDangerItemIconStyles,
@@ -58,7 +58,7 @@ export const getMeetingActionEntries = ({
 
   const deleteForMeEntry: ContextMenuEntry = {
     css: contextMenuDangerItemStyles,
-    icon: () => <CloseIcon css={contextMenuDangerItemIconStyles} />,
+    icon: () => <TrashIcon css={contextMenuDangerItemIconStyles} />,
     label: translate(MEETING_ACTION_TRANSLATION_KEYS.deleteMeetingForMe),
     click: onDeleteForMe,
   };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25513" title="WPB-25513" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25513</a>  [Web] Delete a meeting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Use the trash icon for "Delete meeting for me" (already used for "Delete for everyone") to match the design.

## Test plan
- [x] Open a meeting overflow menu as a participant and confirm "Delete meeting for me" shows a red trash icon
- [x] Open a meeting overflow menu as host and confirm "Delete meeting for everyone" still shows a red trash icon