### PR TITLE
fix: align recycle bin detection with deleted queries [WPB-27712]

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/recycleBin/recycleBin.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/recycleBin/recycleBin.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isInRecycleBin} from './recycleBin';
+
+describe('isInRecycleBin', () => {
+  afterEach(() => {
+    window.location.hash = '';
+  });
+
+  it('returns true for a recycle bin path', () => {
+    window.location.hash = '#/conversation/conversation-id/wire.com/files/recycle_bin/folder';
+
+    expect(isInRecycleBin()).toBe(true);
+  });
+
+  it('returns false for a path outside the recycle bin', () => {
+    window.location.hash = '#/conversation/conversation-id/wire.com/files/folder';
+
+    expect(isInRecycleBin()).toBe(false);
+  });
+
+  it.each(['test_recycle_bin', 'recycle_bin_test', 'foobar/recycle_bin'])(
+    'returns false when a regular path contains the recycle bin name: %s',
+    path => {
+      window.location.hash = `#/conversation/conversation-id/wire.com/files/${path}`;
+
+      expect(isInRecycleBin()).toBe(false);
+    },
+  );
+
+  it('returns true when a recycle-bin descendant is also named recycle_bin', () => {
+    window.location.hash = '#/conversation/conversation-id/wire.com/files/recycle_bin/recycle_bin';
+
+    expect(isInRecycleBin()).toBe(true);
+  });
+
+  it('returns false when the hash has no files path', () => {
+    window.location.hash = '#/conversation/conversation-id/wire.com';
+
+    expect(isInRecycleBin()).toBe(false);
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/recycleBin/recycleBin.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/recycleBin/recycleBin.ts
@@ -29,12 +29,13 @@ export const isRootRecycleBinPath = () => {
   return path === RECYCLE_BIN_PATH;
 };
 
-export const isInRecycleBin = () => {
+export const isInRecycleBin = (): boolean => {
   const hash = window.location.hash.replace('#', '');
 
   const parts = hash.split('/files/');
+  const path = parts[1];
 
-  return parts[1]?.includes(RECYCLE_BIN_PATH);
+  return path === RECYCLE_BIN_PATH || path?.startsWith(`${RECYCLE_BIN_PATH}/`) === true;
 };
 
 export const getNodeRootParentPath = ({nodePath}: {nodePath: string}) => {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.test.ts
@@ -204,6 +204,15 @@ describe('useConversationSearchFiles', () => {
     );
   });
 
+  it('requests deleted nodes when searching inside a nested recycle-bin path', async () => {
+    window.location.hash = `#/conversation/${CONV_ID}/${DOMAIN}/files/recycle_bin/folder`;
+    const cellsRepository = createFakeCellsRepository();
+    const {fireAndForgetInvoker} = renderSearchHook({cellsRepository});
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(cellsRepository.searchNodes).toHaveBeenCalledWith(expect.objectContaining({deleted: true}));
+  });
+
   it('clears the previous browse rows as soon as search opens', async () => {
     const search = createDeferred<RestNodeCollection>();
     const cellsRepository = {searchNodes: jest.fn().mockReturnValue(search.promise)} as FakeCellsRepository;

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useConversationSearch/useConversationSearchFiles.ts
@@ -36,9 +36,8 @@ import {
   toConversationDriveSearchParams,
 } from '../common/driveFilters/driveFilters';
 import {getCellsApiPath} from '../common/getCellsApiPath/getCellsApiPath';
-import {getCellsFilesPath} from '../common/getCellsFilesPath/getCellsFilesPath';
 import {LOAD_MORE_INCREMENT, LOAD_MORE_INITIAL_SIZE} from '../common/loadMorePagination/loadMorePagination';
-import {RECYCLE_BIN_PATH} from '../common/recycleBin/recycleBin';
+import {isInRecycleBin} from '../common/recycleBin/recycleBin';
 import {CellsSort} from '../common/useCellsSorting/useCellsSorting';
 import {useCellsStore} from '../common/useCellsStore/useCellsStore';
 import {getUsersFromNodes} from '../useGetAllCellsNodes/getUsersFromNodes';
@@ -130,7 +129,7 @@ export const useConversationSearchFiles = ({
         // matches the browse view: folders first, then files.
         const hasQuery = query.length > 0;
         const hasFilters = hasActiveSearchParams(searchParams);
-        const isRecycleBin = getCellsFilesPath() === RECYCLE_BIN_PATH;
+        const deleted = isInRecycleBin();
         const isSearchingOrFiltering = hasQuery || hasFilters;
 
         // search scopes to the folder the user is browsing
@@ -146,7 +145,7 @@ export const useConversationSearchFiles = ({
           // the empty view (no query, no filters) sends no sort to preserve browse/folders-first order.
           sortBy: sort?.field ?? (isSearchingOrFiltering ? 'mtime' : undefined),
           sortDirection: sort?.direction ?? (isSearchingOrFiltering ? 'desc' : undefined),
-          deleted: isRecycleBin,
+          deleted,
           ...searchParams,
         });
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.test.ts
@@ -192,4 +192,13 @@ describe('useGetAllCellsNodes', () => {
 
     expect(useCellsStore.getState().getNodes({conversationId: CONV_ID})[0]?.name).toBe('new-file.txt');
   });
+
+  it('requests deleted nodes inside a nested recycle-bin path', async () => {
+    window.location.hash = `#/conversation/${CONV_ID}/${DOMAIN}/files/recycle_bin/folder`;
+    const cellsRepository = createFakeCellsRepository();
+    const {fireAndForgetInvoker} = renderGetAllNodesHook({cellsRepository});
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(cellsRepository.getAllNodes).toHaveBeenCalledWith(expect.objectContaining({deleted: true}));
+  });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/useGetAllCellsNodes/useGetAllCellsNodes.ts
@@ -30,8 +30,7 @@ import {getUsersFromNodes} from './getUsersFromNodes';
 import {transformDataToCellsNodes, transformToCellPagination} from './transformDataToCellsNodes';
 
 import {getCellsApiPath} from '../common/getCellsApiPath/getCellsApiPath';
-import {getCellsFilesPath} from '../common/getCellsFilesPath/getCellsFilesPath';
-import {RECYCLE_BIN_PATH} from '../common/recycleBin/recycleBin';
+import {isInRecycleBin} from '../common/recycleBin/recycleBin';
 import {CellsSort} from '../common/useCellsSorting/useCellsSorting';
 import {useCellsStore} from '../common/useCellsStore/useCellsStore';
 import {createRequestVersionGate} from '../useConversationSearch/requestVersionGate';
@@ -103,7 +102,7 @@ export const useGetAllCellsNodes = ({
         path: getCellsApiPath({conversationQualifiedId: {domain, id}}),
         limit: pageSize,
         offset,
-        deleted: getCellsFilesPath() === RECYCLE_BIN_PATH,
+        deleted: isInRecycleBin(),
         sortBy: sort?.field,
         sortDirection: sort?.direction,
       });


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27712" title="WPB-27712" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27712</a>  [Web] The Recycle Bin screen should not include the +New button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Problem

We were using different logic to decide if the user is inside the recycle bin, which was causing discrepancies and UX issues.

Basically, the UI and the API query could disagree about which view we are showing

## What changed

- Make `isInRecycleBin()` always return a boolean
- Only match when `recycle_bin` is the first path segment
- Use the same predicate for browse and search requests
- Keep nested recycle-bin paths querying deleted nodes
- Add coverage for similar folder names and nested paths


Task: [WPB-27712](https://wearezeta.atlassian.net/browse/WPB-27712)


[WPB-27712]: https://wearezeta.atlassian.net/browse/WPB-27712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ