### PR TITLE
Hide meetingAction for past meetings [WPB-27800]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/meetingAction.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/meetingAction.test.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {render, screen} from '@testing-library/react';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {createDeterministicWallClock} from '@enormora/wall-clock/deterministic-wall-clock';
 import {ThemeProvider} from '@wireapp/react-ui-kit';
 
@@ -68,7 +68,11 @@ const createMeetingStoreForTest = () =>
     } as MeetingStoreServiceTasks,
   });
 
-const renderAction = (now: string, user = selfUser) =>
+const renderAction = (
+  now: string,
+  user = selfUser,
+  wallClock = createDeterministicWallClock({initialCurrentTimestampInMilliseconds: Date.parse(now)}),
+) =>
   render(
     <MeetingStoreProvider store={createMeetingStoreForTest()}>
       <ThemeProvider>
@@ -79,7 +83,7 @@ const renderAction = (now: string, user = selfUser) =>
       wrapper: createRootProviderWrapperForTest(
         createRootContextValueForTest({
           translate: translateForTest,
-          wallClock: createDeterministicWallClock({initialCurrentTimestampInMilliseconds: Date.parse(now)}),
+          wallClock,
         }),
       ),
     },
@@ -118,5 +122,27 @@ describe('MeetingAction', () => {
     renderAction('2026-06-15T16:00:00.000Z', new User('invitee-id', 'example.com', translateForTest));
 
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('closes the context menu when the meeting becomes past', async () => {
+    const initialTime = new Date('2026-06-15T13:30:00.000Z');
+    const wallClock = createDeterministicWallClock({initialCurrentTimestampInMilliseconds: initialTime.getTime()});
+    const view = renderAction(initialTime.toISOString(), selfUser, wallClock);
+
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
+
+    await act(async () => {
+      wallClock.advanceByMilliseconds(end.getTime() - initialTime.getTime() + 1);
+      view.rerender(
+        <MeetingStoreProvider store={createMeetingStoreForTest()}>
+          <ThemeProvider>
+            <MeetingAction meetingInstance={meetingInstance} selfUser={selfUser} />
+          </ThemeProvider>
+        </MeetingStoreProvider>,
+      );
+    });
+
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
   });
 });

--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/meetingAction.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/meetingAction.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, screen} from '@testing-library/react';
+import {createDeterministicWallClock} from '@enormora/wall-clock/deterministic-wall-clock';
+import {ThemeProvider} from '@wireapp/react-ui-kit';
+
+import {MeetingAction} from './meetingAction';
+import type {MeetingInstance} from 'Components/Meeting/types/meetingInstance';
+import type {MeetingSeries} from 'Components/Meeting/types/meetingSeries';
+import {User} from 'Repositories/entity/User';
+import {translateForTest} from 'Util/test/translateForTest';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+
+jest.mock('Components/Meeting/useEditMeeting', () => ({
+  useEditMeeting: () => ({editMeeting: jest.fn()}),
+}));
+jest.mock('Components/Meeting/useDeleteMeeting', () => ({
+  useDeleteMeeting: () => ({openDeleteMeetingModal: jest.fn()}),
+}));
+
+const start = new Date('2026-06-15T14:00:00.000Z');
+const end = new Date('2026-06-15T15:00:00.000Z');
+const series: MeetingSeries = {
+  series_start_date: start.toISOString(),
+  series_end_date: end.toISOString(),
+  duration_ms: end.getTime() - start.getTime(),
+  recurrence: 'doesNotRepeat',
+  conversation_id: 'conversation-id',
+  title: 'Meeting',
+  qualified_id: {id: 'meeting-id', domain: 'example.com'},
+  qualified_creator: {id: 'host-id', domain: 'example.com'},
+  qualified_conversation: {id: 'conversation-id', domain: 'example.com'},
+};
+const meetingInstance: MeetingInstance = {meetingSeries: series, start, end};
+const selfUser = new User('host-id', 'example.com', translateForTest);
+
+const renderAction = (now: string, user = selfUser) =>
+  render(
+    <ThemeProvider>
+      <MeetingAction meetingInstance={meetingInstance} selfUser={user} />
+    </ThemeProvider>,
+    {
+      wrapper: createRootProviderWrapperForTest(
+        createRootContextValueForTest({
+          translate: translateForTest,
+          wallClock: createDeterministicWallClock({initialCurrentTimestampInMilliseconds: Date.parse(now)}),
+        }),
+      ),
+    },
+  );
+
+describe('MeetingAction', () => {
+  it.each([
+    ['upcoming', '2026-06-15T13:00:00.000Z'],
+    ['ongoing', '2026-06-15T14:30:00.000Z'],
+    ['ongoing at the scheduled end', '2026-06-15T15:00:00.000Z'],
+  ])('renders the action button for %s meetings for the host', (_status, now) => {
+    renderAction(now);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['upcoming', '2026-06-15T13:00:00.000Z'],
+    ['ongoing', '2026-06-15T14:30:00.000Z'],
+  ])('renders the action button for %s meetings for an invitee', (_status, now) => {
+    renderAction(now, new User('invitee-id', 'example.com', translateForTest));
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it.each(['2026-06-15T15:00:00.001Z', '2026-06-15T16:00:00.000Z'])(
+    'hides the action button after the meeting ends at %s for the host',
+    now => {
+      renderAction(now);
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    },
+  );
+
+  it('hides the action button after the meeting ends for an invitee', () => {
+    renderAction('2026-06-15T16:00:00.000Z', new User('invitee-id', 'example.com', translateForTest));
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/meetingAction.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/meetingAction.test.tsx
@@ -21,22 +21,21 @@ import {render, screen} from '@testing-library/react';
 import {createDeterministicWallClock} from '@enormora/wall-clock/deterministic-wall-clock';
 import {ThemeProvider} from '@wireapp/react-ui-kit';
 
+import {MeetingStoreProvider} from 'Components/Meeting/meetingStore/MeetingStoreProvider';
+import {createMeetingStore} from 'Components/Meeting/meetingStore/createMeetingStore';
+import type {MeetingStoreServiceTasks} from 'Components/Meeting/meetingStore/meetingStoreDeps';
 import {MeetingAction} from './meetingAction';
 import type {MeetingInstance} from 'Components/Meeting/types/meetingInstance';
 import type {MeetingSeries} from 'Components/Meeting/types/meetingSeries';
+import type {CallingRepository} from 'Repositories/calling/CallingRepository';
+import type {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {User} from 'Repositories/entity/User';
+import type {MeetingsRepository} from 'Repositories/meetings/meetingsRepository';
 import {translateForTest} from 'Util/test/translateForTest';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
-
-jest.mock('Components/Meeting/useEditMeeting', () => ({
-  useEditMeeting: () => ({editMeeting: jest.fn()}),
-}));
-jest.mock('Components/Meeting/useDeleteMeeting', () => ({
-  useDeleteMeeting: () => ({openDeleteMeetingModal: jest.fn()}),
-}));
 
 const start = new Date('2026-06-15T14:00:00.000Z');
 const end = new Date('2026-06-15T15:00:00.000Z');
@@ -54,11 +53,28 @@ const series: MeetingSeries = {
 const meetingInstance: MeetingInstance = {meetingSeries: series, start, end};
 const selfUser = new User('host-id', 'example.com', translateForTest);
 
+const createMeetingStoreForTest = () =>
+  createMeetingStore({
+    meetingsRepository: {} as MeetingsRepository,
+    conversationRepository: {} as ConversationRepository,
+    callingRepository: {} as CallingRepository,
+    wallClock: createDeterministicWallClock(),
+    serviceTasks: {
+      scheduleMeeting: jest.fn(),
+      meetNowMeeting: jest.fn(),
+      updateMeeting: jest.fn(),
+      deleteMeetingForMe: jest.fn(),
+      deleteMeetingForAll: jest.fn(),
+    } as MeetingStoreServiceTasks,
+  });
+
 const renderAction = (now: string, user = selfUser) =>
   render(
-    <ThemeProvider>
-      <MeetingAction meetingInstance={meetingInstance} selfUser={user} />
-    </ThemeProvider>,
+    <MeetingStoreProvider store={createMeetingStoreForTest()}>
+      <ThemeProvider>
+        <MeetingAction meetingInstance={meetingInstance} selfUser={user} />
+      </ThemeProvider>
+    </MeetingStoreProvider>,
     {
       wrapper: createRootProviderWrapperForTest(
         createRootContextValueForTest({

--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/meetingAction.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/meetingAction.tsx
@@ -31,6 +31,7 @@ import {useDeleteMeeting} from 'Components/Meeting/useDeleteMeeting';
 import {useEditMeeting} from 'Components/Meeting/useEditMeeting';
 import {canDeleteMeetingForAll, canDeleteMeetingForMe} from 'Components/Meeting/utils/canDeleteMeeting';
 import {canEditMeeting} from 'Components/Meeting/utils/canEditMeeting';
+import {getMeetingTemporalStatusAt, MeetingTemporalStatuses} from 'Components/Meeting/utils/meetingStatusUtil';
 import type {User} from 'Repositories/entity/User';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 
@@ -45,6 +46,16 @@ export const MeetingAction = ({meetingInstance, selfUser}: MeetingActionProps) =
   const {translate, wallClock, fireAndForgetInvoker} = useApplicationContext();
   const {editMeeting} = useEditMeeting();
   const {openDeleteMeetingModal} = useDeleteMeeting();
+
+  const temporalStatus = getMeetingTemporalStatusAt(
+    new Date(wallClock.currentTimestampInMilliseconds),
+    meetingInstance.start,
+    meetingInstance.end,
+  );
+
+  if (temporalStatus === MeetingTemporalStatuses.PAST) {
+    return null;
+  }
 
   const handleActionButton = (event: MouseEvent<HTMLElement>) => {
     if (selfUser === undefined) {

--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/meetingAction.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingAction/meetingAction.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {MouseEvent} from 'react';
+import {MouseEvent, useEffect} from 'react';
 
 import {IconButton, MoreIcon} from '@wireapp/react-ui-kit';
 
@@ -35,7 +35,7 @@ import {getMeetingTemporalStatusAt, MeetingTemporalStatuses} from 'Components/Me
 import type {User} from 'Repositories/entity/User';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 
-import {showContextMenu} from '../../../../../../ui/contextMenu';
+import {closeContextMenu, showContextMenu} from '../../../../../../ui/contextMenu';
 
 interface MeetingActionProps {
   meetingInstance: MeetingInstance;
@@ -52,6 +52,12 @@ export const MeetingAction = ({meetingInstance, selfUser}: MeetingActionProps) =
     meetingInstance.start,
     meetingInstance.end,
   );
+
+  useEffect(() => {
+    if (temporalStatus === MeetingTemporalStatuses.PAST) {
+      closeContextMenu();
+    }
+  }, [temporalStatus]);
 
   if (temporalStatus === MeetingTemporalStatuses.PAST) {
     return null;

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationCard/meetingNotificationCard.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationCard/meetingNotificationCard.test.tsx
@@ -25,8 +25,8 @@ import {
   type MeetingNotification,
   MeetingNotificationKind,
 } from 'Components/Meeting/meetingNotificationStore/meetingNotificationStore';
-import {translateForTest} from 'Util/test/translateForTest';
 import {formatLocale} from 'Util/timeUtil';
+import type {Translate} from 'Util/localizerUtil';
 import type {ReactElement} from 'react';
 import {
   createRootContextValueForTest,
@@ -37,8 +37,10 @@ const qualifiedId: QualifiedId = {id: 'meeting-id', domain: 'example.com'};
 const qualifiedCreator: QualifiedId = {id: 'creator-id', domain: 'example.com'};
 const meetingStartTime = '2026-06-01T09:00:00.000Z';
 const ongoingMeetingStartTime = '2026-06-01T09:50:00.000Z';
+const translateForNotificationTest: Translate = (key, substitutions) =>
+  key === 'meetings.notifications.title' ? `${substitutions?.label} ${substitutions?.meetingTitle}` : key;
 const rootProviderWrapper = createRootProviderWrapperForTest(
-  createRootContextValueForTest({translate: translateForTest}),
+  createRootContextValueForTest({translate: translateForNotificationTest}),
 );
 
 const renderCard = (card: ReactElement) =>
@@ -86,8 +88,34 @@ describe('MeetingNotificationCard', () => {
   it.each(notifications)('renders the $kind variant', notification => {
     renderCard(<MeetingNotificationCard {...notification} onDismiss={jest.fn()} />);
 
-    expect(screen.getByRole('listitem')).toHaveTextContent('meetings.notifications.title');
+    const card = screen.getByRole('listitem');
+    expect(card).toHaveTextContent('Meeting Title');
+    expect(card).toHaveTextContent(
+      {
+        [MeetingNotificationKind.INVITE]: 'meetings.notifications.invitation',
+        [MeetingNotificationKind.UPDATE]: 'meetings.notifications.update',
+        [MeetingNotificationKind.CANCELLED]: 'meetings.notifications.canceled',
+        [MeetingNotificationKind.ONGOING]: 'meetings.notifications.ongoing',
+      }[notification.kind],
+    );
     expect(screen.getByRole('button', {name: 'meetings.notifications.dismiss'})).toBeInTheDocument();
+
+    if (
+      notification.kind === MeetingNotificationKind.INVITE ||
+      notification.kind === MeetingNotificationKind.CANCELLED
+    ) {
+      expect(card).toHaveTextContent(`creator-id • ${formatLocale(meetingStartTime, 'PP, p')}`);
+    }
+
+    if (notification.kind === MeetingNotificationKind.UPDATE) {
+      expect(card).toHaveTextContent('meetings.notifications.newTime');
+    }
+
+    if (notification.kind === MeetingNotificationKind.ONGOING) {
+      expect(card).toHaveTextContent('creator-id');
+      expect(card).toHaveTextContent('meetings.meetingStatus.startedAt');
+      expect(screen.getByText('meetings.meetingStatus.startedAt')).toHaveStyle({color: 'var(--accent-color)'});
+    }
 
     if (notification.kind === MeetingNotificationKind.CANCELLED) {
       expect(screen.queryByRole('button', {name: 'meetings.notifications.view'})).not.toBeInTheDocument();

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationHost/meetingNotificationHost.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationHost/meetingNotificationHost.test.tsx
@@ -79,6 +79,13 @@ describe('MeetingNotificationHost', () => {
       .getState()
       .addNotification({kind: MeetingNotificationKind.UPDATE, qualifiedId, meetingTitle: 'Updated', meetingStartTime});
     useMeetingNotificationStore.getState().addNotification({
+      kind: MeetingNotificationKind.ONGOING,
+      qualifiedId,
+      meetingTitle: 'Ongoing',
+      qualifiedCreator,
+      meetingStartTime,
+    });
+    useMeetingNotificationStore.getState().addNotification({
       kind: MeetingNotificationKind.INVITE,
       qualifiedId,
       meetingTitle: 'Invited',
@@ -88,7 +95,7 @@ describe('MeetingNotificationHost', () => {
 
     renderHost(true, translateForCountTest);
 
-    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
     expect(screen.queryByText('meetings.notifications.title')).not.toBeInTheDocument();
   });
 
@@ -117,6 +124,13 @@ describe('MeetingNotificationHost', () => {
       meetingStartTime,
     });
     addNotification({
+      kind: MeetingNotificationKind.ONGOING,
+      qualifiedId,
+      meetingTitle: 'Ongoing',
+      qualifiedCreator,
+      meetingStartTime,
+    });
+    addNotification({
       kind: MeetingNotificationKind.INVITE,
       qualifiedId,
       meetingTitle: 'Two',
@@ -124,16 +138,9 @@ describe('MeetingNotificationHost', () => {
       meetingStartTime,
     });
     addNotification({
-      kind: MeetingNotificationKind.INVITE,
+      kind: MeetingNotificationKind.CANCELLED,
       qualifiedId,
-      meetingTitle: 'Three',
-      qualifiedCreator,
-      meetingStartTime,
-    });
-    addNotification({
-      kind: MeetingNotificationKind.INVITE,
-      qualifiedId,
-      meetingTitle: 'Four',
+      meetingTitle: 'Canceled',
       qualifiedCreator,
       meetingStartTime,
     });

--- a/apps/webapp/src/script/ui/contextMenu.tsx
+++ b/apps/webapp/src/script/ui/contextMenu.tsx
@@ -76,6 +76,8 @@ const cleanUp = () => {
   }
 };
 
+export const closeContextMenu = () => queueMicrotask(cleanUp);
+
 // Clamping the value between min and max
 const clampValue = (value: number, min: number, max: number) => Math.max(min, Math.min(value, max));
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27800" title="WPB-27800" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27800</a>  Hide the three-dot action menu for completed meetings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
