### PR TITLE
Add maintenance release automation [WPB-26469]

### DIFF
--- a/.github/workflows/precommit-slot-run.yml
+++ b/.github/workflows/precommit-slot-run.yml
@@ -23,7 +23,13 @@ on:
       expectedVersion:
         type: string
         required: false
+      expectedAssetVersion:
+        type: string
+        required: false
       expectedCommit:
+        type: string
+        required: false
+      expectedBuiltAt:
         type: string
         required: false
       grep:
@@ -57,6 +63,9 @@ on:
       reportUrl:
         description: URL of the playwright report artifact
         value: ${{ jobs.e2e_tests.outputs.reportUrl }}
+      runtime_verification_result:
+        description: Result of the optional runtime identity and backend verification
+        value: ${{ jobs.deploy_to_aws.outputs.runtime_verification_result }}
 
 concurrency:
   group: precommit-slot-${{ inputs.env_name }}
@@ -72,6 +81,7 @@ jobs:
 
     outputs:
       precommit_url: ${{ steps.fetch_url.outputs.url }}
+      runtime_verification_result: ${{ steps.verify_precommit_runtime.outcome }}
 
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -121,10 +131,13 @@ jobs:
           echo "url=https://$ENV_NAME.zinfra.io/" >> "$GITHUB_OUTPUT"
 
       - name: Verify precommit runtime
-        if: ${{ inputs.expectedVersion || inputs.expectedCommit || inputs.expectedBackendRest || inputs.expectedBackendWs }}
+        id: verify_precommit_runtime
+        if: ${{ inputs.expectedVersion || inputs.expectedAssetVersion || inputs.expectedCommit || inputs.expectedBuiltAt || inputs.expectedBackendRest || inputs.expectedBackendWs }}
         env:
           EXPECTED_BACKEND_REST: ${{ inputs.expectedBackendRest }}
           EXPECTED_BACKEND_WS: ${{ inputs.expectedBackendWs }}
+          EXPECTED_ASSET_VERSION: ${{ inputs.expectedAssetVersion }}
+          EXPECTED_BUILT_AT: ${{ inputs.expectedBuiltAt }}
           EXPECTED_COMMIT: ${{ inputs.expectedCommit }}
           EXPECTED_VERSION: ${{ inputs.expectedVersion }}
           PRECOMMIT_URL: ${{ steps.fetch_url.outputs.url }}
@@ -147,6 +160,14 @@ jobs:
               printf '%s' "${version_response}" |
                 jq --raw-output '.version'
             )" || actual_version=''
+            actual_asset_version="$(
+              printf '%s' "${version_response}" |
+                jq --raw-output '.assetVersion'
+            )" || actual_asset_version=''
+            actual_built_at="$(
+              printf '%s' "${version_response}" |
+                jq --raw-output '.builtAt'
+            )" || actual_built_at=''
             actual_commit="$(
               printf '%s' "${commit_response}" |
                 tr -d '\r\n'
@@ -156,14 +177,16 @@ jobs:
 
             if [[
               ( -z "${EXPECTED_VERSION}" || "${actual_version}" == "${EXPECTED_VERSION}" ) &&
+              ( -z "${EXPECTED_ASSET_VERSION}" || "${actual_asset_version}" == "${EXPECTED_ASSET_VERSION}" ) &&
               ( -z "${EXPECTED_COMMIT}" || "${actual_commit}" == "${EXPECTED_COMMIT}" ) &&
+              ( -z "${EXPECTED_BUILT_AT}" || "${actual_built_at}" == "${EXPECTED_BUILT_AT}" ) &&
               ( -z "${EXPECTED_BACKEND_REST}" || "$(normalize_url "${actual_backend_rest}")" == "${expected_backend_rest}" ) &&
               ( -z "${EXPECTED_BACKEND_WS}" || "$(normalize_url "${actual_backend_ws}")" == "${expected_backend_ws}" )
             ]]; then
               exit 0
             fi
 
-            echo "Precommit runtime verification mismatch on attempt ${attempt_number}: VERSION=${actual_version:-missing}, COMMIT=${actual_commit:-missing}, REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}." >&2
+            echo "Precommit runtime verification mismatch on attempt ${attempt_number}: VERSION=${actual_version:-missing}, ASSET_VERSION=${actual_asset_version:-missing}, COMMIT=${actual_commit:-missing}, BUILT_AT=${actual_built_at:-missing}, REST=${actual_backend_rest:-missing}, WS=${actual_backend_ws:-missing}." >&2
 
             if [[ "${attempt_number}" -lt 10 ]]; then
               sleep 6

--- a/.github/workflows/publish-maintenance-distribution.yml
+++ b/.github/workflows/publish-maintenance-distribution.yml
@@ -1,0 +1,192 @@
+---
+name: Publish maintenance distribution
+
+on:
+  workflow_call:
+    inputs:
+      maintenance_line_key:
+        description: 'Validated maintenance line key'
+        required: true
+        type: string
+      maintenance_branch:
+        description: 'Validated maintenance branch name'
+        required: true
+        type: string
+      source_production_tag:
+        description: 'Validated source Production tag'
+        required: true
+        type: string
+      source_production_commit_sha:
+        description: 'Commit resolved from the source Production tag'
+        required: true
+        type: string
+      maintenance_commit_sha:
+        description: 'Exact maintenance branch commit to distribute'
+        required: true
+        type: string
+      maintenance_tag:
+        description: 'Existing immutable maintenance tag'
+        required: true
+        type: string
+      source_run_id:
+        description: 'Workflow run containing the exact distribution context'
+        required: true
+        type: string
+      source_run_attempt:
+        description: 'Workflow run attempt containing the exact distribution context'
+        required: true
+        type: string
+      distribution_artifact_name:
+        description: 'Exact maintenance distribution context artifact'
+        required: true
+        type: string
+    outputs:
+      docker_image_tag:
+        description: 'Immutable Quay image identity'
+        value: ${{ jobs.publish_distribution.outputs.docker_image_tag }}
+      helm_chart_version:
+        description: 'Immutable Helm chart identity'
+        value: ${{ jobs.publish_distribution.outputs.helm_chart_version }}
+      distribution_result:
+        description: 'Maintenance distribution result'
+        value: ${{ jobs.publish_distribution.outputs.distribution_result }}
+    secrets:
+      WEBTEAM_QUAY_USERNAME:
+        required: true
+      WEBTEAM_QUAY_PASSWORD:
+        required: true
+      CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID:
+        required: true
+      CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY:
+        required: true
+
+permissions: {}
+
+env:
+  CHART_REPOSITORY_NAME: charts-webapp
+  CHART_REPOSITORY_URL: s3://public.wire.com/charts-webapp
+  DOCKER_REPOSITORY: quay.io/wire/webapp
+  DISTRIBUTION_CONTEXT_PATH: distribution-context
+
+jobs:
+  publish_distribution:
+    name: Publish immutable Docker and Helm artifacts
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+    concurrency:
+      group: publish-webapp-distribution
+      cancel-in-progress: false
+      queue: max
+    outputs:
+      docker_image_tag: ${{ steps.publish_docker.outputs.docker_image_tag }}
+      helm_chart_version: ${{ steps.publish_helm.outputs.helm_chart_version }}
+      distribution_result: ${{ steps.distribution_result.outputs.distribution_result }}
+
+    steps:
+      - name: Checkout exact maintenance tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: ${{ inputs.maintenance_tag }}
+
+      - name: Verify maintenance tag commit
+        env:
+          EXPECTED_MAINTENANCE_COMMIT_SHA: ${{ inputs.maintenance_commit_sha }}
+        run: |
+          set -euo pipefail
+
+          maintenance_commit_sha="$(git rev-parse HEAD)"
+          if [[ "${maintenance_commit_sha}" != "${EXPECTED_MAINTENANCE_COMMIT_SHA}" ]]; then
+            echo "Checked out ${maintenance_commit_sha} from maintenance tag, expected ${EXPECTED_MAINTENANCE_COMMIT_SHA}." >&2
+            exit 1
+          fi
+
+      - name: Download exact maintenance distribution context
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ inputs.distribution_artifact_name }}
+          path: ${{ env.DISTRIBUTION_CONTEXT_PATH }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install exact distribution dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Validate exact maintenance distribution context
+        id: validate_identity
+        env:
+          DISTRIBUTION_CONTEXT_PATH: ${{ env.DISTRIBUTION_CONTEXT_PATH }}
+          MAINTENANCE_BRANCH: ${{ inputs.maintenance_branch }}
+          MAINTENANCE_COMMIT_SHA: ${{ inputs.maintenance_commit_sha }}
+          MAINTENANCE_LINE_KEY: ${{ inputs.maintenance_line_key }}
+          MAINTENANCE_TAG: ${{ inputs.maintenance_tag }}
+          SOURCE_PRODUCTION_COMMIT_SHA: ${{ inputs.source_production_commit_sha }}
+          SOURCE_PRODUCTION_TAG: ${{ inputs.source_production_tag }}
+          WORKFLOW_RUN_ATTEMPT: ${{ inputs.source_run_attempt }}
+          WORKFLOW_RUN_ID: ${{ inputs.source_run_id }}
+        run: ./bin/validate-maintenance-distribution.sh
+
+      - name: Setup Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
+        with:
+          version: '3.21.3'
+
+      - name: Publish or reuse immutable Docker image
+        id: publish_docker
+        env:
+          DOCKER_PASSWORD: ${{ secrets.WEBTEAM_QUAY_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.WEBTEAM_QUAY_USERNAME }}
+          DOCKER_REPOSITORY: ${{ env.DOCKER_REPOSITORY }}
+          DOCKER_IMAGE_TAG_OUTPUT_PATH: ${{ runner.temp }}/maintenance-image-tag.txt
+          IMMUTABLE_ARTIFACT_TAG: ${{ inputs.maintenance_tag }}
+          RELEASE_COMMIT_SHA: ${{ inputs.maintenance_commit_sha }}
+          STABLE_IMAGE_REFERENCE: ${{ env.DOCKER_REPOSITORY }}:${{ inputs.maintenance_tag }}
+          WIRE_WEBAPP_CONFIGURATION: production
+          WIRE_WEBAPP_DOCKER_CONTEXT_PATH: ${{ env.DISTRIBUTION_CONTEXT_PATH }}
+          WIRE_WEBAPP_RELEASE_COMMIT_SHA: ${{ inputs.maintenance_commit_sha }}
+        run: ./bin/publish-immutable-docker.sh
+
+      - name: Publish or reuse immutable Helm chart
+        id: publish_helm
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY }}
+          CHART_REPOSITORY_NAME: ${{ env.CHART_REPOSITORY_NAME }}
+          CHART_REPOSITORY_URL: ${{ env.CHART_REPOSITORY_URL }}
+          DOCKER_IMAGE_TAG: ${{ steps.publish_docker.outputs.docker_image_tag }}
+        run: ./bin/publish-immutable-helm.sh
+
+      - name: Mark maintenance distribution complete
+        id: distribution_result
+        env:
+          DOCKER_IMAGE_TAG: ${{ steps.publish_docker.outputs.docker_image_tag }}
+          HELM_CHART_VERSION: ${{ steps.publish_helm.outputs.helm_chart_version }}
+        run: |
+          set -euo pipefail
+
+          echo 'distribution_result=success' >> "$GITHUB_OUTPUT"
+          {
+            echo '## Maintenance distribution'
+            echo
+            echo "- Maintenance tag: ${{ inputs.maintenance_tag }}"
+            echo "- Maintenance commit: ${{ inputs.maintenance_commit_sha }}"
+            echo "- Docker image: ${DOCKER_IMAGE_TAG}"
+            echo "- Helm chart: ${HELM_CHART_VERSION}"
+            echo '- Hosted Beta/Production deployment: not performed'
+            echo '- wire-builds/main and wire-builds/dev: not updated'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-maintenance-webapp.yml
+++ b/.github/workflows/release-maintenance-webapp.yml
@@ -1,0 +1,813 @@
+---
+name: Release Maintenance WebApp
+
+on:
+  workflow_dispatch:
+    inputs:
+      maintenance_line_key:
+        description: 'Public Git metadata: YYYY-MM-DD.N-qualifier[-qualifier...]. Do not include customer names or sensitive information.'
+        required: true
+        type: string
+      source_production_tag:
+        description: 'Existing annotated ADR Production tag from which the maintenance line starts'
+        required: true
+        type: string
+      confirm_maintenance_release:
+        description: 'Confirm that this creates or reuses the maintenance branch, validates the artifact separately, creates an immutable tag, and publishes customer-managed artifacts without hosted deployment'
+        required: true
+        default: false
+        type: boolean
+      reason:
+        description: 'Required non-sensitive reason for this maintenance release'
+        required: true
+        type: string
+
+concurrency:
+  group: release-maintenance-${{ inputs.maintenance_line_key }}
+  cancel-in-progress: false
+  queue: max
+
+permissions: {}
+
+env:
+  AWS_REGION: eu-central-1
+  ARTIFACT_PATH: apps/server/dist/s3/ebs.zip
+  CHART_REPOSITORY_URL: s3://public.wire.com/charts-webapp
+  DOCKER_REPOSITORY: quay.io/wire/webapp
+  E2E_RUNTIME_BACKEND_REST: https://staging-nginz-https.zinfra.io/
+  E2E_RUNTIME_BACKEND_WS: wss://staging-nginz-ssl.zinfra.io/
+  MAINTENANCE_VALIDATION_ENVIRONMENT_NAME: wire-webapp-precommit
+  MAINTENANCE_VALIDATION_URL: https://wire-webapp-precommit.zinfra.io/
+
+jobs:
+  validate_request:
+    name: Validate maintenance release request
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      maintenance_line_key: ${{ steps.validate_request.outputs.maintenance_line_key }}
+      maintenance_branch: ${{ steps.validate_request.outputs.maintenance_branch }}
+      source_production_tag: ${{ steps.validate_request.outputs.source_production_tag }}
+
+    steps:
+      - name: Checkout workflow tools from main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: main
+
+      - name: Validate workflow ref
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" != 'refs/heads/main' ]]; then
+            echo 'Release Maintenance WebApp must be started with "Use workflow from: main".' >&2
+            echo "Received workflow ref: ${GITHUB_REF}" >&2
+            exit 1
+          fi
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Validate maintenance request
+        id: validate_request
+        env:
+          CONFIRM_MAINTENANCE_RELEASE: ${{ inputs.confirm_maintenance_release }}
+          MAINTENANCE_LINE_KEY: ${{ inputs.maintenance_line_key }}
+          REASON: ${{ inputs.reason }}
+          SOURCE_PRODUCTION_TAG: ${{ inputs.source_production_tag }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${CONFIRM_MAINTENANCE_RELEASE}" != 'true' ]]; then
+            echo 'confirm_maintenance_release must be true to start a maintenance release.' >&2
+            exit 1
+          fi
+
+          if [[ -z "${REASON//[[:space:]]/}" ]]; then
+            echo 'reason must contain meaningful non-whitespace text.' >&2
+            exit 1
+          fi
+
+          maintenance_branch="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts maintenance-branch "${MAINTENANCE_LINE_KEY}")"
+          ./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts validate-maintenance-source "${MAINTENANCE_LINE_KEY}" "${SOURCE_PRODUCTION_TAG}" >/dev/null
+
+          {
+            echo "maintenance_line_key=${MAINTENANCE_LINE_KEY}"
+            echo "maintenance_branch=${maintenance_branch}"
+            echo "source_production_tag=${SOURCE_PRODUCTION_TAG}"
+          } >> "$GITHUB_OUTPUT"
+
+  prepare_maintenance_branch:
+    name: Prepare maintenance branch
+    runs-on: ubuntu-24.04
+    needs: validate_request
+    permissions:
+      contents: write
+    concurrency:
+      group: prepare-maintenance-branch-${{ needs.validate_request.outputs.maintenance_line_key }}
+      cancel-in-progress: false
+      queue: max
+    outputs:
+      maintenance_branch: ${{ steps.prepare_branch.outputs.maintenance_branch }}
+      branch_action: ${{ steps.prepare_branch.outputs.branch_action }}
+      maintenance_commit_sha: ${{ steps.prepare_branch.outputs.maintenance_commit_sha }}
+      maintenance_line_key: ${{ steps.prepare_branch.outputs.maintenance_line_key }}
+      source_production_commit_sha: ${{ steps.prepare_branch.outputs.source_production_commit_sha }}
+      source_production_tag: ${{ steps.prepare_branch.outputs.source_production_tag }}
+
+    steps:
+      - name: Checkout main as workflow tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: true
+          fetch-depth: 0
+          ref: main
+
+      - name: Create or reuse maintenance branch from the exact Production commit
+        id: prepare_branch
+        env:
+          MAINTENANCE_BRANCH: ${{ needs.validate_request.outputs.maintenance_branch }}
+          MAINTENANCE_LINE_KEY: ${{ needs.validate_request.outputs.maintenance_line_key }}
+          SOURCE_PRODUCTION_TAG: ${{ needs.validate_request.outputs.source_production_tag }}
+        run: |
+          set -euo pipefail
+
+          git ls-remote --exit-code --tags origin "refs/tags/${SOURCE_PRODUCTION_TAG}" >/dev/null
+          git fetch --no-tags origin "refs/tags/${SOURCE_PRODUCTION_TAG}:refs/tags/${SOURCE_PRODUCTION_TAG}"
+
+          if [[ "$(git cat-file -t "refs/tags/${SOURCE_PRODUCTION_TAG}")" != 'tag' ]]; then
+            echo "Source Production tag ${SOURCE_PRODUCTION_TAG} is not an annotated tag." >&2
+            exit 1
+          fi
+
+          source_production_commit_sha="$(git rev-parse "refs/tags/${SOURCE_PRODUCTION_TAG}^{commit}")"
+          branch_remote_ref="refs/remotes/origin/${MAINTENANCE_BRANCH}"
+          branch_action='reused'
+
+          if git ls-remote --exit-code --heads origin "refs/heads/${MAINTENANCE_BRANCH}" >/dev/null; then
+            git fetch --no-tags origin "+refs/heads/${MAINTENANCE_BRANCH}:${branch_remote_ref}"
+          else
+            if git push origin "${source_production_commit_sha}:refs/heads/${MAINTENANCE_BRANCH}"; then
+              branch_action='created'
+            elif git ls-remote --exit-code --heads origin "refs/heads/${MAINTENANCE_BRANCH}" >/dev/null; then
+              echo "Maintenance branch ${MAINTENANCE_BRANCH} was created concurrently; resolving the remote branch." >&2
+              branch_action='reused'
+            else
+              echo "Unable to create or resolve maintenance branch ${MAINTENANCE_BRANCH}." >&2
+              exit 1
+            fi
+
+            git fetch --no-tags origin "+refs/heads/${MAINTENANCE_BRANCH}:${branch_remote_ref}"
+          fi
+
+          maintenance_commit_sha="$(git rev-parse "${branch_remote_ref}")"
+
+          if [[ "${branch_action}" == 'created' && "${maintenance_commit_sha}" != "${source_production_commit_sha}" ]]; then
+            echo "Created maintenance branch ${MAINTENANCE_BRANCH} resolved to ${maintenance_commit_sha}, expected ${source_production_commit_sha}." >&2
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "${source_production_commit_sha}" "${maintenance_commit_sha}"; then
+            echo "Maintenance branch ${MAINTENANCE_BRANCH} at ${maintenance_commit_sha} is unrelated to source Production commit ${source_production_commit_sha}." >&2
+            exit 1
+          fi
+
+          {
+            echo "maintenance_branch=${MAINTENANCE_BRANCH}"
+            echo "branch_action=${branch_action}"
+            echo "maintenance_commit_sha=${maintenance_commit_sha}"
+            echo "maintenance_line_key=${MAINTENANCE_LINE_KEY}"
+            echo "source_production_commit_sha=${source_production_commit_sha}"
+            echo "source_production_tag=${SOURCE_PRODUCTION_TAG}"
+          } >> "$GITHUB_OUTPUT"
+
+  preflight_maintenance_tag:
+    name: Preflight maintenance tag
+    runs-on: ubuntu-24.04
+    needs: prepare_maintenance_branch
+    permissions:
+      contents: read
+    outputs:
+      maintenance_tag: ${{ steps.preflight_tag.outputs.maintenance_tag }}
+      tag_action: ${{ steps.preflight_tag.outputs.tag_action }}
+
+    steps:
+      - name: Checkout exact maintenance branch head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Resolve immutable maintenance tag target
+        id: preflight_tag
+        env:
+          MAINTENANCE_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+          MAINTENANCE_LINE_KEY: ${{ needs.prepare_maintenance_branch.outputs.maintenance_line_key }}
+        run: |
+          set -euo pipefail
+
+          git fetch --tags origin
+
+          mapfile -t existing_tag_names < <(
+            git ls-remote --tags --refs origin "${MAINTENANCE_LINE_KEY}-maintenance.*" |
+              awk '{ sub("^refs/tags/", "", $2); print $2; }'
+          )
+          matching_tag_names=()
+
+          for tag_name in "${existing_tag_names[@]}"; do
+            ./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts validate-maintenance-tag "${tag_name}" >/dev/null
+
+            if [[ "$(git cat-file -t "refs/tags/${tag_name}")" != 'tag' ]]; then
+              echo "Maintenance tag ${tag_name} is not annotated." >&2
+              exit 1
+            fi
+
+            tag_commit_sha="$(git rev-parse "refs/tags/${tag_name}^{commit}")"
+            if [[ "${tag_commit_sha}" == "${MAINTENANCE_COMMIT_SHA}" ]]; then
+              matching_tag_names+=("${tag_name}")
+            fi
+          done
+
+          if (( ${#matching_tag_names[@]} > 1 )); then
+            echo "Multiple maintenance tags from ${MAINTENANCE_LINE_KEY} point to ${MAINTENANCE_COMMIT_SHA}: ${matching_tag_names[*]}" >&2
+            exit 1
+          fi
+
+          if (( ${#matching_tag_names[@]} == 1 )); then
+            existing_tag_name="${matching_tag_names[0]}"
+            echo "Maintenance tag ${existing_tag_name} already points to the current branch head. Run Repair Maintenance distribution to verify or repair its immutable distribution." >&2
+            {
+              echo "maintenance_tag=${existing_tag_name}"
+              echo 'tag_action=existing'
+            } >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          if (( ${#existing_tag_names[@]} == 0 )); then
+            maintenance_tag="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts next-maintenance-tag "${MAINTENANCE_LINE_KEY}")"
+          else
+            maintenance_tag="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts next-maintenance-tag "${MAINTENANCE_LINE_KEY}" "${existing_tag_names[@]}")"
+          fi
+
+          {
+            echo "maintenance_tag=${maintenance_tag}"
+            echo 'tag_action=create'
+          } >> "$GITHUB_OUTPUT"
+
+  build_maintenance_artifact:
+    name: Build exact maintenance artifact
+    runs-on: ubuntu-24.04
+    needs: [prepare_maintenance_branch, preflight_maintenance_tag]
+    if: ${{ needs.preflight_maintenance_tag.outputs.tag_action == 'create' }}
+    env:
+      WIRE_WEBAPP_CONFIGURATION: production
+    permissions:
+      contents: read
+    outputs:
+      artifact_asset_version: ${{ steps.validate_artifact_metadata.outputs.artifact_asset_version }}
+      artifact_built_at: ${{ steps.validate_artifact_metadata.outputs.artifact_built_at }}
+      artifact_checksum: ${{ steps.artifact_metadata.outputs.artifact_checksum }}
+      artifact_commit: ${{ steps.validate_artifact_metadata.outputs.artifact_commit }}
+      artifact_name: ${{ steps.artifact_metadata.outputs.artifact_name }}
+      artifact_version: ${{ steps.validate_artifact_metadata.outputs.artifact_version }}
+      distribution_artifact_name: ${{ steps.distribution_artifact.outputs.distribution_artifact_name }}
+
+    steps:
+      - name: Checkout exact maintenance branch head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: ./bin/yarn --immutable
+
+      - name: Verify exact maintenance commit
+        id: maintenance_metadata
+        env:
+          EXPECTED_MAINTENANCE_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+        run: |
+          set -euo pipefail
+
+          maintenance_commit_sha="$(git rev-parse HEAD)"
+          if [[ "${maintenance_commit_sha}" != "${EXPECTED_MAINTENANCE_COMMIT_SHA}" ]]; then
+            echo "Checked out ${maintenance_commit_sha}, expected maintenance commit ${EXPECTED_MAINTENANCE_COMMIT_SHA}." >&2
+            exit 1
+          fi
+
+          echo "maintenance_commit_sha=${maintenance_commit_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Update configuration
+        run: ./bin/yarn nx run webapp:configure
+
+      - name: Build and package public production
+        env:
+          WIRE_WEBAPP_BUILD_COMMIT: ${{ steps.maintenance_metadata.outputs.maintenance_commit_sha }}
+          WIRE_WEBAPP_BUILD_VERSION: ${{ needs.preflight_maintenance_tag.outputs.maintenance_tag }}
+        run: ./bin/yarn build:prod:public
+
+      - name: Validate maintenance artifact metadata
+        id: validate_artifact_metadata
+        env:
+          BUILD_ARTIFACT_PATH: ${{ env.ARTIFACT_PATH }}
+          EXPECTED_COMMIT: ${{ steps.maintenance_metadata.outputs.maintenance_commit_sha }}
+          EXPECTED_VERSION: ${{ needs.preflight_maintenance_tag.outputs.maintenance_tag }}
+        run: node ./bin/validateBuildArtifact.mts
+
+      - name: Compute artifact metadata
+        id: artifact_metadata
+        env:
+          MAINTENANCE_LINE_KEY: ${{ needs.prepare_maintenance_branch.outputs.maintenance_line_key }}
+        run: |
+          set -euo pipefail
+
+          artifact_name="release-maintenance-ebs-${MAINTENANCE_LINE_KEY}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_checksum="$(sha256sum "${ARTIFACT_PATH}" | awk '{print $1}')"
+
+          {
+            echo "artifact_name=${artifact_name}"
+            echo "artifact_checksum=${artifact_checksum}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Prepare exact maintenance Docker distribution context
+        id: distribution_artifact
+        env:
+          ARTIFACT_CHECKSUM: ${{ steps.artifact_metadata.outputs.artifact_checksum }}
+          ARTIFACT_VERSION: ${{ steps.validate_artifact_metadata.outputs.artifact_version }}
+          MAINTENANCE_BRANCH: ${{ needs.prepare_maintenance_branch.outputs.maintenance_branch }}
+          MAINTENANCE_COMMIT_SHA: ${{ steps.maintenance_metadata.outputs.maintenance_commit_sha }}
+          MAINTENANCE_LINE_KEY: ${{ needs.prepare_maintenance_branch.outputs.maintenance_line_key }}
+          MAINTENANCE_TAG: ${{ needs.preflight_maintenance_tag.outputs.maintenance_tag }}
+          SOURCE_PRODUCTION_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.source_production_commit_sha }}
+          SOURCE_PRODUCTION_TAG: ${{ needs.prepare_maintenance_branch.outputs.source_production_tag }}
+        run: |
+          set -euo pipefail
+
+          distribution_artifact_name="release-maintenance-distribution-context-${MAINTENANCE_LINE_KEY}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          distribution_context_directory="${RUNNER_TEMP}/${distribution_artifact_name}"
+          mkdir -p \
+            "${distribution_context_directory}/apps/server" \
+            "${distribution_context_directory}/libraries/config" \
+            "${distribution_context_directory}/bin"
+
+          cp -a package.json yarn.lock .yarnrc.yml .npmrc run.sh .env.defaults "${distribution_context_directory}/"
+          cp -a .yarn "${distribution_context_directory}/.yarn"
+          cp -a bin/yarn "${distribution_context_directory}/bin/yarn"
+          cp -a apps/server/Dockerfile apps/server/package.json "${distribution_context_directory}/apps/server/"
+          cp -a apps/server/dist "${distribution_context_directory}/apps/server/dist"
+          cp -a libraries/config/package.json libraries/config/lib "${distribution_context_directory}/libraries/config/"
+
+          jq -n \
+            --arg maintenance_line_key "${MAINTENANCE_LINE_KEY}" \
+            --arg maintenance_branch "${MAINTENANCE_BRANCH}" \
+            --arg source_production_tag "${SOURCE_PRODUCTION_TAG}" \
+            --arg source_production_commit_sha "${SOURCE_PRODUCTION_COMMIT_SHA}" \
+            --arg maintenance_commit_sha "${MAINTENANCE_COMMIT_SHA}" \
+            --arg maintenance_tag "${MAINTENANCE_TAG}" \
+            --arg artifact_version "${ARTIFACT_VERSION}" \
+            --arg artifact_checksum "${ARTIFACT_CHECKSUM}" \
+            --arg workflow_run_id "${GITHUB_RUN_ID}" \
+            --arg workflow_run_attempt "${GITHUB_RUN_ATTEMPT}" \
+            '{
+              maintenanceLineKey: $maintenance_line_key,
+              maintenanceBranch: $maintenance_branch,
+              sourceProductionTag: $source_production_tag,
+              sourceProductionCommitSha: $source_production_commit_sha,
+              maintenanceCommitSha: $maintenance_commit_sha,
+              maintenanceTag: $maintenance_tag,
+              artifactVersion: $artifact_version,
+              artifactChecksum: $artifact_checksum,
+              workflowRunId: $workflow_run_id,
+              workflowRunAttempt: $workflow_run_attempt
+            }' > "${distribution_context_directory}/distribution-manifest.json"
+
+          echo "distribution_artifact_name=${distribution_artifact_name}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload exact maintenance distribution context
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ steps.distribution_artifact.outputs.distribution_artifact_name }}
+          path: ${{ runner.temp }}/${{ steps.distribution_artifact.outputs.distribution_artifact_name }}
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - name: Upload maintenance validation artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ steps.artifact_metadata.outputs.artifact_name }}
+          path: ${{ env.ARTIFACT_PATH }}
+          if-no-files-found: error
+
+  validate_maintenance_artifact:
+    name: Validate maintenance artifact in dedicated slot
+    needs: [build_maintenance_artifact, preflight_maintenance_tag]
+    if: ${{ needs.build_maintenance_artifact.result == 'success' }}
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/precommit-slot-run.yml
+    with:
+      env_name: wire-webapp-precommit
+      expectedManageTeamUrl: https://teams.wire.com/login/
+      artifact_name: ${{ needs.build_maintenance_artifact.outputs.artifact_name }}
+      expectedBackendRest: https://staging-nginz-https.zinfra.io/
+      expectedBackendWs: wss://staging-nginz-ssl.zinfra.io/
+      expectedVersion: ${{ needs.build_maintenance_artifact.outputs.artifact_version }}
+      expectedAssetVersion: ${{ needs.build_maintenance_artifact.outputs.artifact_asset_version }}
+      expectedCommit: ${{ needs.build_maintenance_artifact.outputs.artifact_commit }}
+      expectedBuiltAt: ${{ needs.build_maintenance_artifact.outputs.artifact_built_at }}
+      grep: '@regression|@crit-flow-web'
+      testinyRunName: WebApp maintenance ${{ needs.preflight_maintenance_tag.outputs.maintenance_tag }}
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      WEBTEAM_AWS_ACCESS_KEY_ID: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+      WEBTEAM_AWS_SECRET_ACCESS_KEY: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+      TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
+
+  create_maintenance_tag:
+    name: Create immutable maintenance tag
+    runs-on: ubuntu-24.04
+    needs:
+      [build_maintenance_artifact, prepare_maintenance_branch, preflight_maintenance_tag, validate_maintenance_artifact]
+    if: ${{ needs.validate_maintenance_artifact.result == 'success' }}
+    permissions:
+      contents: write
+    outputs:
+      maintenance_tag: ${{ steps.create_tag.outputs.maintenance_tag }}
+      tag_action: ${{ steps.create_tag.outputs.tag_action }}
+
+    steps:
+      - name: Checkout exact maintenance commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: true
+          fetch-depth: 0
+          ref: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Create or reuse the immutable maintenance tag
+        id: create_tag
+        env:
+          MAINTENANCE_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+          MAINTENANCE_LINE_KEY: ${{ needs.prepare_maintenance_branch.outputs.maintenance_line_key }}
+          MAINTENANCE_TAG: ${{ needs.preflight_maintenance_tag.outputs.maintenance_tag }}
+          SOURCE_PRODUCTION_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.source_production_commit_sha }}
+          SOURCE_PRODUCTION_TAG: ${{ needs.prepare_maintenance_branch.outputs.source_production_tag }}
+        run: |
+          set -euo pipefail
+
+          git fetch --tags origin
+
+          mapfile -t existing_tag_names < <(
+            git ls-remote --tags --refs origin "${MAINTENANCE_LINE_KEY}-maintenance.*" |
+              awk '{ sub("^refs/tags/", "", $2); print $2; }'
+          )
+          matching_tag_names=()
+
+          for tag_name in "${existing_tag_names[@]}"; do
+            ./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts validate-maintenance-tag "${tag_name}" >/dev/null
+            if [[ "$(git cat-file -t "refs/tags/${tag_name}")" != 'tag' ]]; then
+              echo "Maintenance tag ${tag_name} is not annotated." >&2
+              exit 1
+            fi
+
+            tag_commit_sha="$(git rev-parse "refs/tags/${tag_name}^{commit}")"
+            if [[ "${tag_commit_sha}" == "${MAINTENANCE_COMMIT_SHA}" ]]; then
+              matching_tag_names+=("${tag_name}")
+            fi
+          done
+
+          if (( ${#matching_tag_names[@]} > 1 )); then
+            echo "Multiple maintenance tags from ${MAINTENANCE_LINE_KEY} point to ${MAINTENANCE_COMMIT_SHA}: ${matching_tag_names[*]}" >&2
+            exit 1
+          fi
+
+          if (( ${#matching_tag_names[@]} == 1 )); then
+            existing_tag_name="${matching_tag_names[0]}"
+            echo "Maintenance tag ${existing_tag_name} was created concurrently at the expected commit; reusing it." >&2
+            {
+              echo "maintenance_tag=${existing_tag_name}"
+              echo 'tag_action=reused'
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${MAINTENANCE_TAG}" >/dev/null; then
+            git fetch --no-tags origin "refs/tags/${MAINTENANCE_TAG}:refs/tags/${MAINTENANCE_TAG}"
+
+            if [[ "$(git cat-file -t "refs/tags/${MAINTENANCE_TAG}")" != 'tag' ]]; then
+              echo "Maintenance tag ${MAINTENANCE_TAG} is not annotated." >&2
+              exit 1
+            fi
+
+            existing_tag_commit_sha="$(git rev-parse "refs/tags/${MAINTENANCE_TAG}^{commit}")"
+            if [[ "${existing_tag_commit_sha}" != "${MAINTENANCE_COMMIT_SHA}" ]]; then
+              echo "Maintenance tag ${MAINTENANCE_TAG} already points to ${existing_tag_commit_sha}, expected ${MAINTENANCE_COMMIT_SHA}." >&2
+              exit 1
+            fi
+
+            echo "Maintenance tag ${MAINTENANCE_TAG} already exists but was not associated with the current branch head." >&2
+            exit 1
+          fi
+
+          git config user.email "zebot@users.noreply.github.com"
+          git config user.name "Zebot"
+          git tag --annotate "${MAINTENANCE_TAG}" \
+            --message "Maintenance release ${MAINTENANCE_TAG}" \
+            --message "Line: ${MAINTENANCE_LINE_KEY}" \
+            --message "Maintenance branch: maintenance/${MAINTENANCE_LINE_KEY}" \
+            --message "Source Production tag: ${SOURCE_PRODUCTION_TAG}" \
+            --message "Source Production commit: ${SOURCE_PRODUCTION_COMMIT_SHA}" \
+            --message "Maintenance commit: ${MAINTENANCE_COMMIT_SHA}" \
+            --message "Workflow: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            "${MAINTENANCE_COMMIT_SHA}"
+
+          if git push origin "refs/tags/${MAINTENANCE_TAG}"; then
+            {
+              echo "maintenance_tag=${MAINTENANCE_TAG}"
+              echo 'tag_action=created'
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git tag --delete "${MAINTENANCE_TAG}" >/dev/null 2>&1 || true
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${MAINTENANCE_TAG}" >/dev/null; then
+            echo "Unable to create or resolve maintenance tag ${MAINTENANCE_TAG}." >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin "refs/tags/${MAINTENANCE_TAG}:refs/tags/${MAINTENANCE_TAG}"
+          if [[ "$(git cat-file -t "refs/tags/${MAINTENANCE_TAG}")" != 'tag' || "$(git rev-parse "refs/tags/${MAINTENANCE_TAG}^{commit}")" != "${MAINTENANCE_COMMIT_SHA}" ]]; then
+            echo "Concurrent maintenance tag ${MAINTENANCE_TAG} does not point to the expected commit." >&2
+            exit 1
+          fi
+
+          {
+            echo "maintenance_tag=${MAINTENANCE_TAG}"
+            echo 'tag_action=reused'
+          } >> "$GITHUB_OUTPUT"
+
+  publish_maintenance_distribution:
+    name: Publish customer-managed maintenance distribution
+    needs: [build_maintenance_artifact, create_maintenance_tag, prepare_maintenance_branch]
+    if: ${{ needs.create_maintenance_tag.result == 'success' }}
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/publish-maintenance-distribution.yml
+    with:
+      maintenance_line_key: ${{ needs.prepare_maintenance_branch.outputs.maintenance_line_key }}
+      maintenance_branch: ${{ needs.prepare_maintenance_branch.outputs.maintenance_branch }}
+      source_production_tag: ${{ needs.prepare_maintenance_branch.outputs.source_production_tag }}
+      source_production_commit_sha: ${{ needs.prepare_maintenance_branch.outputs.source_production_commit_sha }}
+      maintenance_commit_sha: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+      maintenance_tag: ${{ needs.create_maintenance_tag.outputs.maintenance_tag }}
+      source_run_id: ${{ github.run_id }}
+      source_run_attempt: ${{ github.run_attempt }}
+      distribution_artifact_name: ${{ needs.build_maintenance_artifact.outputs.distribution_artifact_name }}
+    secrets:
+      WEBTEAM_QUAY_USERNAME: ${{ secrets.WEBTEAM_QUAY_USERNAME }}
+      WEBTEAM_QUAY_PASSWORD: ${{ secrets.WEBTEAM_QUAY_PASSWORD }}
+      CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID }}
+      CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY }}
+
+  notify_maintenance_validated:
+    name: Notify maintenance artifact validated and tagged
+    runs-on: ubuntu-24.04
+    needs:
+      [build_maintenance_artifact, create_maintenance_tag, prepare_maintenance_branch, validate_maintenance_artifact]
+    if: ${{ always() && needs.validate_maintenance_artifact.result == 'success' && needs.create_maintenance_tag.result == 'success' }}
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout notification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: main
+          sparse-checkout: .github/actions/notify-deployoholics
+
+      - name: Announce validated maintenance artifact
+        uses: ./.github/actions/notify-deployoholics
+        with:
+          webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+          status: success
+          text: |
+            ✅ WebApp maintenance artifact successfully validated and immutably tagged ✅
+
+            Maintenance line: ${{ needs.prepare_maintenance_branch.outputs.maintenance_line_key }}
+            Maintenance branch: ${{ needs.prepare_maintenance_branch.outputs.maintenance_branch }}
+            Source Production tag: ${{ needs.prepare_maintenance_branch.outputs.source_production_tag }}
+            Maintenance tag: ${{ needs.create_maintenance_tag.outputs.maintenance_tag }}
+            Validation environment: ${{ env.MAINTENANCE_VALIDATION_ENVIRONMENT_NAME }}
+            Playwright report: ${{ needs.validate_maintenance_artifact.outputs.reportUrl || 'unavailable' }}
+            Workflow URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  notify_maintenance_distribution_success:
+    name: Notify maintenance distribution completed
+    runs-on: ubuntu-24.04
+    needs: [create_maintenance_tag, prepare_maintenance_branch, publish_maintenance_distribution]
+    if: ${{ always() && needs.publish_maintenance_distribution.result == 'success' }}
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout notification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: main
+          sparse-checkout: .github/actions/notify-deployoholics
+
+      - name: Announce completed maintenance distribution
+        uses: ./.github/actions/notify-deployoholics
+        with:
+          webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+          status: success
+          text: |
+            ✅ Customer-managed WebApp maintenance distribution completed ✅
+
+            Maintenance line: ${{ needs.prepare_maintenance_branch.outputs.maintenance_line_key }}
+            Maintenance tag: ${{ needs.create_maintenance_tag.outputs.maintenance_tag }}
+            Docker image: ${{ needs.publish_maintenance_distribution.outputs.docker_image_tag }}
+            Helm chart: ${{ needs.publish_maintenance_distribution.outputs.helm_chart_version }}
+            Customer deployment is outside this workflow; hosted Beta and Production were not touched.
+            Workflow URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  summarize_maintenance_release:
+    name: Summarize maintenance release
+    runs-on: ubuntu-24.04
+    needs:
+      - validate_request
+      - build_maintenance_artifact
+      - create_maintenance_tag
+      - prepare_maintenance_branch
+      - preflight_maintenance_tag
+      - publish_maintenance_distribution
+      - validate_maintenance_artifact
+    if: ${{ always() }}
+    permissions:
+      contents: read
+    steps:
+      - name: Write maintenance release summary
+        env:
+          ARTIFACT_ASSET_VERSION: ${{ needs.build_maintenance_artifact.outputs.artifact_asset_version }}
+          ARTIFACT_BUILT_AT: ${{ needs.build_maintenance_artifact.outputs.artifact_built_at }}
+          ARTIFACT_CHECKSUM: ${{ needs.build_maintenance_artifact.outputs.artifact_checksum }}
+          ARTIFACT_COMMIT: ${{ needs.build_maintenance_artifact.outputs.artifact_commit }}
+          ARTIFACT_VERSION: ${{ needs.build_maintenance_artifact.outputs.artifact_version }}
+          BRANCH_ACTION: ${{ needs.prepare_maintenance_branch.outputs.branch_action }}
+          DOCKER_IMAGE_TAG: ${{ needs.publish_maintenance_distribution.outputs.docker_image_tag }}
+          HELM_CHART_VERSION: ${{ needs.publish_maintenance_distribution.outputs.helm_chart_version }}
+          MAINTENANCE_BRANCH: ${{ needs.prepare_maintenance_branch.outputs.maintenance_branch }}
+          MAINTENANCE_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+          MAINTENANCE_LINE_KEY: ${{ needs.prepare_maintenance_branch.outputs.maintenance_line_key || inputs.maintenance_line_key }}
+          MAINTENANCE_TAG: ${{ needs.create_maintenance_tag.outputs.maintenance_tag || needs.preflight_maintenance_tag.outputs.maintenance_tag }}
+          PUBLISH_RESULT: ${{ needs.publish_maintenance_distribution.result }}
+          REASON: ${{ inputs.reason }}
+          SOURCE_PRODUCTION_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.source_production_commit_sha }}
+          SOURCE_PRODUCTION_TAG: ${{ needs.prepare_maintenance_branch.outputs.source_production_tag || inputs.source_production_tag }}
+          TAG_RESULT: ${{ needs.create_maintenance_tag.result }}
+          TESTINY_RUN_NAME: WebApp maintenance ${{ needs.preflight_maintenance_tag.outputs.maintenance_tag }}
+          VALIDATION_RESULT: ${{ needs.validate_maintenance_artifact.result }}
+          VALIDATION_RUNTIME_RESULT: ${{ needs.validate_maintenance_artifact.outputs.runtime_verification_result }}
+          VALIDATION_REPORT_URL: ${{ needs.validate_maintenance_artifact.outputs.reportUrl }}
+        run: |
+          {
+            echo '## Maintenance release'
+            echo
+            echo "- Maintenance line key: ${MAINTENANCE_LINE_KEY:-unavailable}"
+            echo "- Maintenance branch: ${MAINTENANCE_BRANCH:-unavailable}"
+            echo "- Branch action: ${BRANCH_ACTION:-unavailable}"
+            echo "- Source Production tag: ${SOURCE_PRODUCTION_TAG:-unavailable}"
+            echo "- Source Production commit: ${SOURCE_PRODUCTION_COMMIT_SHA:-unavailable}"
+            echo "- Maintenance commit: ${MAINTENANCE_COMMIT_SHA:-unavailable}"
+            echo "- Target or existing maintenance tag: ${MAINTENANCE_TAG:-unavailable}"
+            echo "- Build version: ${ARTIFACT_VERSION:-unavailable}"
+            echo "- Build asset version: ${ARTIFACT_ASSET_VERSION:-unavailable}"
+            echo "- Build commit: ${ARTIFACT_COMMIT:-unavailable}"
+            echo "- Built at: ${ARTIFACT_BUILT_AT:-unavailable}"
+            echo "- Artifact checksum: ${ARTIFACT_CHECKSUM:-unavailable}"
+            echo "- Validation environment: ${MAINTENANCE_VALIDATION_ENVIRONMENT_NAME}"
+            echo "- Validation URL: ${MAINTENANCE_VALIDATION_URL}"
+            echo "- Runtime verification result: ${VALIDATION_RUNTIME_RESULT:-unavailable}"
+            echo "- E2E result: ${VALIDATION_RESULT:-unavailable}"
+            echo "- Testiny run name: ${TESTINY_RUN_NAME:-unavailable}"
+            echo "- Playwright report link: ${VALIDATION_REPORT_URL:-unavailable}"
+            echo "- Docker image identity: ${DOCKER_IMAGE_TAG:-unavailable}"
+            echo "- Helm chart identity: ${HELM_CHART_VERSION:-unavailable}"
+            echo "- Maintenance tag result: ${TAG_RESULT:-unavailable}"
+            echo "- Distribution result: ${PUBLISH_RESULT:-unavailable}"
+            echo "- Dispatch reason: ${REASON}"
+            echo "- Hosted Beta/Production deployment: not performed"
+            echo "- wire-builds/main and wire-builds/dev: not updated"
+            echo "- Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  notify_maintenance_release_failure:
+    name: Notify maintenance release failure
+    runs-on: ubuntu-24.04
+    needs:
+      - validate_request
+      - build_maintenance_artifact
+      - create_maintenance_tag
+      - prepare_maintenance_branch
+      - preflight_maintenance_tag
+      - publish_maintenance_distribution
+      - validate_maintenance_artifact
+    if: >-
+      ${{
+        always() &&
+        (
+          needs.validate_request.result == 'failure' ||
+          needs.prepare_maintenance_branch.result == 'failure' ||
+          needs.preflight_maintenance_tag.result == 'failure' ||
+          needs.build_maintenance_artifact.result == 'failure' ||
+          needs.validate_maintenance_artifact.result == 'failure' ||
+          needs.create_maintenance_tag.result == 'failure' ||
+          needs.publish_maintenance_distribution.result == 'failure'
+        )
+      }}
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout notification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: main
+          sparse-checkout: .github/actions/notify-deployoholics
+
+      - name: Announce failed maintenance release
+        uses: ./.github/actions/notify-deployoholics
+        with:
+          webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+          status: failure
+          text: |
+            ❌ WebApp maintenance release failed ❌
+
+            Maintenance line: ${{ inputs.maintenance_line_key }}
+            Source Production tag: ${{ inputs.source_production_tag }}
+            Target maintenance tag: ${{ needs.create_maintenance_tag.outputs.maintenance_tag || needs.preflight_maintenance_tag.outputs.maintenance_tag || 'unresolved' }}
+            Validation result: ${{ needs.validate_maintenance_artifact.result }}
+            Distribution result: ${{ needs.publish_maintenance_distribution.result }}
+            No hosted Beta or Production deployment was performed by this workflow.
+            Dispatch reason: ${{ inputs.reason }}
+            Workflow URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/repair-maintenance-distribution.yml
+++ b/.github/workflows/repair-maintenance-distribution.yml
@@ -1,0 +1,277 @@
+---
+name: Repair Maintenance WebApp distribution
+
+on:
+  workflow_dispatch:
+    inputs:
+      maintenance_tag:
+        description: 'Existing annotated immutable maintenance tag to verify or repair'
+        required: true
+        type: string
+      source_run_id:
+        description: 'Workflow run containing the exact maintenance distribution context'
+        required: true
+        type: string
+      distribution_artifact_name:
+        description: 'Exact maintenance distribution context artifact from the source run'
+        required: true
+        type: string
+      confirm_repair:
+        description: 'Confirm repair publication for the existing maintenance tag; no new or moved tag will be created'
+        required: true
+        default: false
+        type: boolean
+      reason:
+        description: 'Required non-sensitive reason for repairing the maintenance distribution'
+        required: true
+        type: string
+
+concurrency:
+  group: repair-maintenance-${{ inputs.maintenance_tag }}
+  cancel-in-progress: false
+  queue: max
+
+permissions: {}
+
+jobs:
+  validate_repair:
+    name: Validate maintenance distribution repair
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      maintenance_branch: ${{ steps.resolve_identity.outputs.maintenance_branch }}
+      maintenance_commit_sha: ${{ steps.resolve_identity.outputs.maintenance_commit_sha }}
+      maintenance_line_key: ${{ steps.resolve_identity.outputs.maintenance_line_key }}
+      maintenance_tag: ${{ steps.resolve_identity.outputs.maintenance_tag }}
+      source_production_commit_sha: ${{ steps.resolve_identity.outputs.source_production_commit_sha }}
+      source_production_tag: ${{ steps.resolve_identity.outputs.source_production_tag }}
+      source_run_attempt: ${{ steps.resolve_identity.outputs.source_run_attempt }}
+
+    steps:
+      - name: Checkout workflow tools from main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: main
+
+      - name: Validate workflow ref
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" != 'refs/heads/main' ]]; then
+            echo 'Repair Maintenance WebApp distribution must be started with "Use workflow from: main".' >&2
+            echo "Received workflow ref: ${GITHUB_REF}" >&2
+            exit 1
+          fi
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Download exact maintenance distribution context
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ inputs.distribution_artifact_name }}
+          path: repair-context
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+
+      - name: Validate existing tag and distribution identity
+        id: resolve_identity
+        env:
+          CONFIRM_REPAIR: ${{ inputs.confirm_repair }}
+          DISTRIBUTION_CONTEXT_PATH: repair-context
+          MAINTENANCE_TAG: ${{ inputs.maintenance_tag }}
+          REASON: ${{ inputs.reason }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${CONFIRM_REPAIR}" != 'true' ]]; then
+            echo 'confirm_repair must be true for a maintenance distribution repair.' >&2
+            exit 1
+          fi
+
+          if [[ -z "${REASON//[[:space:]]/}" ]]; then
+            echo 'reason must contain meaningful non-whitespace text.' >&2
+            exit 1
+          fi
+
+          ./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts validate-maintenance-tag "${MAINTENANCE_TAG}" >/dev/null
+          git ls-remote --exit-code --tags origin "refs/tags/${MAINTENANCE_TAG}" >/dev/null
+          git fetch --no-tags origin "refs/tags/${MAINTENANCE_TAG}:refs/tags/${MAINTENANCE_TAG}"
+
+          if [[ "$(git cat-file -t "refs/tags/${MAINTENANCE_TAG}")" != 'tag' ]]; then
+            echo "Maintenance tag ${MAINTENANCE_TAG} is not annotated." >&2
+            exit 1
+          fi
+
+          maintenance_tag_commit_sha="$(git rev-parse "refs/tags/${MAINTENANCE_TAG}^{commit}")"
+          manifest_path="${DISTRIBUTION_CONTEXT_PATH}/distribution-manifest.json"
+          artifact_metadata_path="${DISTRIBUTION_CONTEXT_PATH}/apps/server/dist/version.json"
+
+          if [[ ! -f "${manifest_path}" || ! -f "${artifact_metadata_path}" ]]; then
+            echo 'The repair artifact is missing distribution-manifest.json or version.json.' >&2
+            exit 1
+          fi
+
+          manifest_maintenance_line_key="$(jq -er '.maintenanceLineKey | strings | select(length > 0)' "${manifest_path}")"
+          manifest_maintenance_branch="$(jq -er '.maintenanceBranch | strings | select(length > 0)' "${manifest_path}")"
+          manifest_source_production_tag="$(jq -er '.sourceProductionTag | strings | select(length > 0)' "${manifest_path}")"
+          manifest_source_production_commit_sha="$(jq -er '.sourceProductionCommitSha | strings | select(length > 0)' "${manifest_path}")"
+          manifest_maintenance_commit_sha="$(jq -er '.maintenanceCommitSha | strings | select(length > 0)' "${manifest_path}")"
+          manifest_maintenance_tag="$(jq -er '.maintenanceTag | strings | select(length > 0)' "${manifest_path}")"
+          manifest_workflow_run_id="$(jq -er '.workflowRunId | strings | select(length > 0)' "${manifest_path}")"
+          manifest_workflow_run_attempt="$(jq -er '.workflowRunAttempt | strings | select(length > 0)' "${manifest_path}")"
+
+          if [[ "${manifest_maintenance_tag}" != "${MAINTENANCE_TAG}" ]]; then
+            echo "Distribution manifest tag ${manifest_maintenance_tag} does not match requested tag ${MAINTENANCE_TAG}." >&2
+            exit 1
+          fi
+
+          if [[ "${manifest_workflow_run_id}" != "${SOURCE_RUN_ID}" ]]; then
+            echo "Distribution manifest source run ${manifest_workflow_run_id} does not match requested source run ${SOURCE_RUN_ID}." >&2
+            exit 1
+          fi
+
+          if [[ "${maintenance_tag_commit_sha}" != "${manifest_maintenance_commit_sha}" ]]; then
+            echo "Maintenance tag ${MAINTENANCE_TAG} points to ${maintenance_tag_commit_sha}, manifest expects ${manifest_maintenance_commit_sha}." >&2
+            exit 1
+          fi
+
+          ./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts validate-maintenance-source "${manifest_maintenance_line_key}" "${manifest_source_production_tag}" >/dev/null
+          git ls-remote --exit-code --tags origin "refs/tags/${manifest_source_production_tag}" >/dev/null
+          git fetch --no-tags origin "refs/tags/${manifest_source_production_tag}:refs/tags/${manifest_source_production_tag}"
+
+          if [[ "$(git cat-file -t "refs/tags/${manifest_source_production_tag}")" != 'tag' ]]; then
+            echo "Source Production tag ${manifest_source_production_tag} is not annotated." >&2
+            exit 1
+          fi
+
+          source_production_commit_sha="$(git rev-parse "refs/tags/${manifest_source_production_tag}^{commit}")"
+          if [[ "${source_production_commit_sha}" != "${manifest_source_production_commit_sha}" ]]; then
+            echo "Source Production tag ${manifest_source_production_tag} resolves to ${source_production_commit_sha}, manifest expects ${manifest_source_production_commit_sha}." >&2
+            exit 1
+          fi
+
+          ./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/maintenanceDistributionCli.ts \
+            validate-manifest \
+            --artifact-metadata-path "${artifact_metadata_path}" \
+            --manifest-path "${manifest_path}" \
+            --maintenance-line-key "${manifest_maintenance_line_key}" \
+            --maintenance-branch "${manifest_maintenance_branch}" \
+            --source-production-tag "${manifest_source_production_tag}" \
+            --source-production-commit-sha "${manifest_source_production_commit_sha}" \
+            --maintenance-commit-sha "${manifest_maintenance_commit_sha}" \
+            --maintenance-tag "${manifest_maintenance_tag}" \
+            --workflow-run-id "${manifest_workflow_run_id}" \
+            --workflow-run-attempt "${manifest_workflow_run_attempt}"
+
+          {
+            echo "maintenance_branch=${manifest_maintenance_branch}"
+            echo "maintenance_commit_sha=${manifest_maintenance_commit_sha}"
+            echo "maintenance_line_key=${manifest_maintenance_line_key}"
+            echo "maintenance_tag=${manifest_maintenance_tag}"
+            echo "source_production_commit_sha=${manifest_source_production_commit_sha}"
+            echo "source_production_tag=${manifest_source_production_tag}"
+            echo "source_run_attempt=${manifest_workflow_run_attempt}"
+          } >> "$GITHUB_OUTPUT"
+
+  publish_maintenance_distribution:
+    name: Repair customer-managed maintenance distribution
+    needs: validate_repair
+    if: ${{ needs.validate_repair.result == 'success' }}
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/publish-maintenance-distribution.yml
+    with:
+      maintenance_line_key: ${{ needs.validate_repair.outputs.maintenance_line_key }}
+      maintenance_branch: ${{ needs.validate_repair.outputs.maintenance_branch }}
+      source_production_tag: ${{ needs.validate_repair.outputs.source_production_tag }}
+      source_production_commit_sha: ${{ needs.validate_repair.outputs.source_production_commit_sha }}
+      maintenance_commit_sha: ${{ needs.validate_repair.outputs.maintenance_commit_sha }}
+      maintenance_tag: ${{ needs.validate_repair.outputs.maintenance_tag }}
+      source_run_id: ${{ inputs.source_run_id }}
+      source_run_attempt: ${{ needs.validate_repair.outputs.source_run_attempt }}
+      distribution_artifact_name: ${{ inputs.distribution_artifact_name }}
+    secrets:
+      WEBTEAM_QUAY_USERNAME: ${{ secrets.WEBTEAM_QUAY_USERNAME }}
+      WEBTEAM_QUAY_PASSWORD: ${{ secrets.WEBTEAM_QUAY_PASSWORD }}
+      CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID }}
+      CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY }}
+
+  summarize_repair:
+    name: Summarize maintenance distribution repair
+    runs-on: ubuntu-24.04
+    needs: [publish_maintenance_distribution, validate_repair]
+    if: ${{ always() }}
+    permissions:
+      contents: read
+    steps:
+      - name: Write repair summary
+        env:
+          DOCKER_IMAGE_TAG: ${{ needs.publish_maintenance_distribution.outputs.docker_image_tag }}
+          HELM_CHART_VERSION: ${{ needs.publish_maintenance_distribution.outputs.helm_chart_version }}
+        run: |
+          {
+            echo '## Maintenance distribution repair'
+            echo
+            echo "- Maintenance line key: ${{ needs.validate_repair.outputs.maintenance_line_key || 'unavailable' }}"
+            echo "- Maintenance tag: ${{ needs.validate_repair.outputs.maintenance_tag || inputs.maintenance_tag }}"
+            echo "- Source workflow: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${{ inputs.source_run_id }}"
+            echo "- Distribution artifact: ${{ inputs.distribution_artifact_name }}"
+            echo "- Docker image: ${DOCKER_IMAGE_TAG:-unavailable}"
+            echo "- Helm chart: ${HELM_CHART_VERSION:-unavailable}"
+            echo "- Distribution result: ${{ needs.publish_maintenance_distribution.result }}"
+            echo '- New or moved maintenance tag: not performed'
+            echo '- Hosted Beta/Production deployment: not performed'
+            echo '- wire-builds/main and wire-builds/dev: not updated'
+            echo "- Repair reason: ${{ inputs.reason }}"
+            echo "- Workflow URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  notify_repair_failure:
+    name: Notify maintenance distribution repair failure
+    runs-on: ubuntu-24.04
+    needs: [publish_maintenance_distribution, validate_repair]
+    if: ${{ always() && (needs.validate_repair.result == 'failure' || needs.publish_maintenance_distribution.result == 'failure') }}
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout notification action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: main
+          sparse-checkout: .github/actions/notify-deployoholics
+
+      - name: Announce failed maintenance distribution repair
+        uses: ./.github/actions/notify-deployoholics
+        with:
+          webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
+          status: failure
+          text: |
+            ❌ WebApp maintenance distribution repair failed ❌
+
+            Maintenance tag: ${{ inputs.maintenance_tag }}
+            Source workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ inputs.source_run_id }}
+            No new or moved tag was created, and no hosted deployment was performed.
+            Repair reason: ${{ inputs.reason }}
+            Workflow URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/bin/maintenanceDistribution.test.ts
+++ b/bin/maintenanceDistribution.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+
+import {validateMaintenanceDistributionManifest} from './maintenanceDistribution';
+
+const maintenanceLineKey = '2026-07-27.1-airgap-a';
+const maintenanceBranch = `maintenance/${maintenanceLineKey}`;
+const sourceProductionTag = '2026-07-27.1-production';
+const sourceProductionCommitSha = '1111111111111111111111111111111111111111';
+const maintenanceCommitSha = '2222222222222222222222222222222222222222';
+const maintenanceTag = `${maintenanceLineKey}-maintenance.1`;
+const artifactChecksum = 'a'.repeat(64);
+
+function createValidManifest(): Record<string, string> {
+  return {
+    maintenanceLineKey,
+    maintenanceBranch,
+    sourceProductionTag,
+    sourceProductionCommitSha,
+    maintenanceCommitSha,
+    maintenanceTag,
+    artifactVersion: maintenanceTag,
+    artifactChecksum,
+    workflowRunId: '30271304258',
+    workflowRunAttempt: '1',
+  };
+}
+
+function createValidArtifactMetadata(): Record<string, string> {
+  return {
+    version: maintenanceTag,
+    assetVersion: `${maintenanceTag}-${maintenanceCommitSha.slice(0, 7)}`,
+    commit: maintenanceCommitSha,
+    builtAt: '2026-07-30T06:18:03.123Z',
+  };
+}
+
+function createValidationParameters(
+  manifest: unknown = createValidManifest(),
+  artifactMetadata: unknown = createValidArtifactMetadata(),
+): {
+  readonly artifactMetadata: unknown;
+  readonly manifest: unknown;
+  readonly maintenanceLineKey: string;
+  readonly maintenanceBranch: string;
+  readonly sourceProductionTag: string;
+  readonly sourceProductionCommitSha: string;
+  readonly maintenanceCommitSha: string;
+  readonly maintenanceTag: string;
+  readonly workflowRunId: string;
+  readonly workflowRunAttempt: string;
+} {
+  return {
+    artifactMetadata,
+    manifest,
+    maintenanceLineKey,
+    maintenanceBranch,
+    sourceProductionTag,
+    sourceProductionCommitSha,
+    maintenanceCommitSha,
+    maintenanceTag,
+    workflowRunId: '30271304258',
+    workflowRunAttempt: '1',
+  };
+}
+
+describe('maintenance distribution', () => {
+  it('validates the manifest and artifact identity together', () => {
+    const actualValidation = validateMaintenanceDistributionManifest(createValidationParameters());
+
+    assert(actualValidation.isOk === true);
+
+    expect(actualValidation.value).toEqual({
+      ...createValidManifest(),
+    });
+  });
+
+  it.each([
+    ['maintenanceLineKey', '2026-07-27.1-airgap-b'],
+    ['maintenanceBranch', 'maintenance/2026-07-27.1-airgap-b'],
+    ['sourceProductionTag', '2026-07-28.1-production'],
+    ['sourceProductionCommitSha', ''],
+    ['maintenanceCommitSha', ''],
+    ['maintenanceTag', '2026-07-27.1-airgap-b-maintenance.1'],
+    ['artifactVersion', '2026-07-27.1-airgap-b-maintenance.1'],
+    ['artifactChecksum', 'not-a-checksum'],
+    ['workflowRunId', ''],
+    ['workflowRunAttempt', ''],
+  ])('rejects manifest field mismatch or invalid value for %s', (fieldName, fieldValue) => {
+    const manifest = {...createValidManifest(), [fieldName]: fieldValue};
+    const actualValidation = validateMaintenanceDistributionManifest(createValidationParameters(manifest));
+
+    expect(actualValidation.isErr).toBe(true);
+  });
+
+  it('rejects artifact metadata with a different maintenance commit', () => {
+    const artifactMetadata = {
+      ...createValidArtifactMetadata(),
+      assetVersion: `${maintenanceTag}-${sourceProductionCommitSha.slice(0, 7)}`,
+      commit: sourceProductionCommitSha,
+    };
+
+    const actualValidation = validateMaintenanceDistributionManifest(
+      createValidationParameters(createValidManifest(), artifactMetadata),
+    );
+
+    assert(actualValidation.isErr === true);
+
+    expect(actualValidation.error.message).toBe(
+      'Maintenance distribution artifact metadata commit does not match the maintenance commit',
+    );
+  });
+
+  it('rejects a legacy source Production tag', () => {
+    const actualValidation = validateMaintenanceDistributionManifest(
+      createValidationParameters({...createValidManifest(), sourceProductionTag: '2026-07-27-production.1'}),
+    );
+
+    expect(actualValidation.isErr).toBe(true);
+  });
+});

--- a/bin/maintenanceDistribution.ts
+++ b/bin/maintenanceDistribution.ts
@@ -1,0 +1,233 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isNonEmptyString, isPlainObject} from '@sindresorhus/is';
+import {Result} from 'true-myth';
+
+import {isBuildMetadata} from '@wireapp/config';
+import type {BuildMetadata} from '@wireapp/config';
+
+import {
+  extractMaintenanceLineKeyFromBranchName,
+  extractMaintenanceTagNameMetadata,
+  validateMaintenanceBranchName,
+  validateMaintenanceLineKey,
+  validateMaintenanceSourceProductionTag,
+  validateMaintenanceTagName,
+  validateProductionTagName,
+} from './releaseMetadata';
+import type {MaintenanceBranchName, MaintenanceLineKey, MaintenanceTagName, ProductionTagName} from './releaseMetadata';
+
+export type MaintenanceDistributionManifest = {
+  readonly maintenanceLineKey: MaintenanceLineKey;
+  readonly maintenanceBranch: MaintenanceBranchName;
+  readonly sourceProductionTag: ProductionTagName;
+  readonly sourceProductionCommitSha: string;
+  readonly maintenanceCommitSha: string;
+  readonly maintenanceTag: MaintenanceTagName;
+  readonly artifactVersion: string;
+  readonly artifactChecksum: string;
+  readonly workflowRunId: string;
+  readonly workflowRunAttempt: string;
+};
+
+export type MaintenanceDistributionManifestValidationParameters = {
+  readonly artifactMetadata: unknown;
+  readonly manifest: unknown;
+  readonly maintenanceLineKey: string;
+  readonly maintenanceBranch: string;
+  readonly sourceProductionTag: string;
+  readonly sourceProductionCommitSha: string;
+  readonly maintenanceCommitSha: string;
+  readonly maintenanceTag: string;
+  readonly workflowRunId: string;
+  readonly workflowRunAttempt: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return isPlainObject(value);
+}
+
+function getNonEmptyString(value: unknown): string | undefined {
+  if (!isNonEmptyString(value)) {
+    return undefined;
+  }
+
+  return value;
+}
+
+function isSha256Checksum(value: string): boolean {
+  return /^[a-f0-9]{64}$/u.test(value);
+}
+
+export function validateMaintenanceDistributionManifest(
+  parameters: MaintenanceDistributionManifestValidationParameters,
+): Result<MaintenanceDistributionManifest, Error> {
+  const maintenanceLineKeyResult = validateMaintenanceLineKey(parameters.maintenanceLineKey);
+
+  if (maintenanceLineKeyResult.isErr) {
+    return Result.err(maintenanceLineKeyResult.error);
+  }
+
+  const maintenanceBranchResult = validateMaintenanceBranchName(parameters.maintenanceBranch);
+
+  if (maintenanceBranchResult.isErr) {
+    return Result.err(maintenanceBranchResult.error);
+  }
+
+  const branchLineKeyResult = extractMaintenanceLineKeyFromBranchName(maintenanceBranchResult.value);
+
+  if (branchLineKeyResult.isErr || branchLineKeyResult.value !== maintenanceLineKeyResult.value) {
+    return Result.err(new Error('Maintenance distribution branch does not match the maintenance line key'));
+  }
+
+  const sourceProductionTagResult = validateMaintenanceSourceProductionTag(
+    maintenanceLineKeyResult.value,
+    parameters.sourceProductionTag,
+  );
+
+  if (sourceProductionTagResult.isErr) {
+    return Result.err(sourceProductionTagResult.error);
+  }
+
+  const sourceProductionTagNameResult = validateProductionTagName(parameters.sourceProductionTag);
+
+  if (sourceProductionTagNameResult.isErr) {
+    return Result.err(sourceProductionTagNameResult.error);
+  }
+
+  const maintenanceTagResult = validateMaintenanceTagName(parameters.maintenanceTag);
+
+  if (maintenanceTagResult.isErr) {
+    return Result.err(maintenanceTagResult.error);
+  }
+
+  const maintenanceTagMetadataResult = extractMaintenanceTagNameMetadata(maintenanceTagResult.value);
+
+  if (
+    maintenanceTagMetadataResult.isErr ||
+    maintenanceTagMetadataResult.value.lineKey !== maintenanceLineKeyResult.value
+  ) {
+    return Result.err(new Error('Maintenance distribution tag does not match the maintenance line key'));
+  }
+
+  if (parameters.sourceProductionCommitSha.length === 0) {
+    return Result.err(new Error('Source Production commit SHA must not be empty'));
+  }
+
+  if (parameters.maintenanceCommitSha.length === 0) {
+    return Result.err(new Error('Maintenance commit SHA must not be empty'));
+  }
+
+  if (parameters.workflowRunId.length === 0) {
+    return Result.err(new Error('Workflow run ID must not be empty'));
+  }
+
+  if (parameters.workflowRunAttempt.length === 0) {
+    return Result.err(new Error('Workflow run attempt must not be empty'));
+  }
+
+  if (!isRecord(parameters.manifest)) {
+    return Result.err(new Error('Maintenance distribution manifest must be a JSON object'));
+  }
+
+  const manifestMaintenanceLineKey = getNonEmptyString(parameters.manifest.maintenanceLineKey);
+  const manifestMaintenanceBranch = getNonEmptyString(parameters.manifest.maintenanceBranch);
+  const manifestSourceProductionTag = getNonEmptyString(parameters.manifest.sourceProductionTag);
+  const manifestSourceProductionCommitSha = getNonEmptyString(parameters.manifest.sourceProductionCommitSha);
+  const manifestMaintenanceCommitSha = getNonEmptyString(parameters.manifest.maintenanceCommitSha);
+  const manifestMaintenanceTag = getNonEmptyString(parameters.manifest.maintenanceTag);
+  const manifestArtifactVersion = getNonEmptyString(parameters.manifest.artifactVersion);
+  const manifestArtifactChecksum = getNonEmptyString(parameters.manifest.artifactChecksum);
+  const manifestWorkflowRunId = getNonEmptyString(parameters.manifest.workflowRunId);
+  const manifestWorkflowRunAttempt = getNonEmptyString(parameters.manifest.workflowRunAttempt);
+
+  if (manifestMaintenanceLineKey !== maintenanceLineKeyResult.value) {
+    return Result.err(new Error('Maintenance distribution manifest line key does not match the request'));
+  }
+
+  if (manifestMaintenanceBranch !== maintenanceBranchResult.value) {
+    return Result.err(new Error('Maintenance distribution manifest branch does not match the request'));
+  }
+
+  if (manifestSourceProductionTag !== sourceProductionTagNameResult.value) {
+    return Result.err(new Error('Maintenance distribution manifest source Production tag does not match the request'));
+  }
+
+  if (manifestSourceProductionCommitSha !== parameters.sourceProductionCommitSha) {
+    return Result.err(
+      new Error('Maintenance distribution manifest source Production commit does not match the request'),
+    );
+  }
+
+  if (manifestMaintenanceCommitSha !== parameters.maintenanceCommitSha) {
+    return Result.err(new Error('Maintenance distribution manifest commit does not match the request'));
+  }
+
+  if (manifestMaintenanceTag !== maintenanceTagResult.value) {
+    return Result.err(new Error('Maintenance distribution manifest tag does not match the request'));
+  }
+
+  if (manifestArtifactVersion !== maintenanceTagResult.value) {
+    return Result.err(new Error('Maintenance distribution artifact version does not match the maintenance tag'));
+  }
+
+  if (manifestArtifactChecksum === undefined || !isSha256Checksum(manifestArtifactChecksum)) {
+    return Result.err(new Error('Maintenance distribution artifact checksum is invalid'));
+  }
+
+  if (manifestWorkflowRunId !== parameters.workflowRunId) {
+    return Result.err(new Error('Maintenance distribution manifest workflow run ID does not match the request'));
+  }
+
+  if (manifestWorkflowRunAttempt !== parameters.workflowRunAttempt) {
+    return Result.err(new Error('Maintenance distribution manifest workflow run attempt does not match the request'));
+  }
+
+  if (!isBuildMetadata(parameters.artifactMetadata)) {
+    return Result.err(new Error('Maintenance distribution artifact metadata is invalid'));
+  }
+
+  const artifactMetadata: BuildMetadata = parameters.artifactMetadata;
+
+  if (artifactMetadata.version !== maintenanceTagResult.value) {
+    return Result.err(
+      new Error('Maintenance distribution artifact metadata version does not match the maintenance tag'),
+    );
+  }
+
+  if (artifactMetadata.commit !== parameters.maintenanceCommitSha) {
+    return Result.err(
+      new Error('Maintenance distribution artifact metadata commit does not match the maintenance commit'),
+    );
+  }
+
+  return Result.ok({
+    maintenanceLineKey: maintenanceLineKeyResult.value,
+    maintenanceBranch: maintenanceBranchResult.value,
+    sourceProductionTag: sourceProductionTagNameResult.value,
+    sourceProductionCommitSha: parameters.sourceProductionCommitSha,
+    maintenanceCommitSha: parameters.maintenanceCommitSha,
+    maintenanceTag: maintenanceTagResult.value,
+    artifactVersion: maintenanceTagResult.value,
+    artifactChecksum: manifestArtifactChecksum,
+    workflowRunId: parameters.workflowRunId,
+    workflowRunAttempt: parameters.workflowRunAttempt,
+  });
+}

--- a/bin/maintenanceDistributionCli.test.ts
+++ b/bin/maintenanceDistributionCli.test.ts
@@ -1,0 +1,154 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {runMaintenanceDistributionCli} from './maintenanceDistributionCli';
+
+const maintenanceLineKey = '2026-07-27.1-airgap-a';
+const maintenanceBranch = `maintenance/${maintenanceLineKey}`;
+const sourceProductionTag = '2026-07-27.1-production';
+const sourceProductionCommitSha = '1111111111111111111111111111111111111111';
+const maintenanceCommitSha = '2222222222222222222222222222222222222222';
+const maintenanceTag = `${maintenanceLineKey}-maintenance.1`;
+
+function createManifest(): Record<string, string> {
+  return {
+    maintenanceLineKey,
+    maintenanceBranch,
+    sourceProductionTag,
+    sourceProductionCommitSha,
+    maintenanceCommitSha,
+    maintenanceTag,
+    artifactVersion: maintenanceTag,
+    artifactChecksum: 'a'.repeat(64),
+    workflowRunId: '30271304258',
+    workflowRunAttempt: '1',
+  };
+}
+
+function createArtifactMetadata(): Record<string, string> {
+  return {
+    version: maintenanceTag,
+    assetVersion: `${maintenanceTag}-${maintenanceCommitSha.slice(0, 7)}`,
+    commit: maintenanceCommitSha,
+    builtAt: '2026-07-30T06:18:03.123Z',
+  };
+}
+
+function runCommand(
+  commandLineArguments: readonly string[],
+  files: ReadonlyMap<string, string> = new Map([
+    ['artifact-metadata.json', JSON.stringify(createArtifactMetadata())],
+    ['manifest.json', JSON.stringify(createManifest())],
+  ]),
+): {readonly errors: readonly string[]; readonly exitCode: number} {
+  const errors: string[] = [];
+  const exitCode = runMaintenanceDistributionCli(commandLineArguments, {
+    readFile(filePath) {
+      const fileContents = files.get(filePath);
+
+      if (fileContents === undefined) {
+        throw new Error(`Missing test file: ${filePath}`);
+      }
+
+      return fileContents;
+    },
+    writeError(message) {
+      errors.push(message);
+    },
+  });
+
+  return {errors, exitCode};
+}
+
+function createValidationArguments(): readonly string[] {
+  return [
+    'validate-manifest',
+    '--artifact-metadata-path',
+    'artifact-metadata.json',
+    '--manifest-path',
+    'manifest.json',
+    '--maintenance-line-key',
+    maintenanceLineKey,
+    '--maintenance-branch',
+    maintenanceBranch,
+    '--source-production-tag',
+    sourceProductionTag,
+    '--source-production-commit-sha',
+    sourceProductionCommitSha,
+    '--maintenance-commit-sha',
+    maintenanceCommitSha,
+    '--maintenance-tag',
+    maintenanceTag,
+    '--workflow-run-id',
+    '30271304258',
+    '--workflow-run-attempt',
+    '1',
+  ];
+}
+
+describe('maintenanceDistributionCli', () => {
+  it('accepts a valid maintenance distribution manifest', () => {
+    const actualResult = runCommand(createValidationArguments());
+
+    expect(actualResult).toEqual({errors: [], exitCode: 0});
+  });
+
+  it('reports manifest validation errors', () => {
+    const invalidManifest = {...createManifest(), maintenanceCommitSha: sourceProductionCommitSha};
+    const actualResult = runCommand(
+      createValidationArguments(),
+      new Map([
+        ['artifact-metadata.json', JSON.stringify(createArtifactMetadata())],
+        ['manifest.json', JSON.stringify(invalidManifest)],
+      ]),
+    );
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.errors).toEqual(['Maintenance distribution manifest commit does not match the request']);
+  });
+
+  it('reports malformed JSON at the file boundary', () => {
+    const actualResult = runCommand(
+      createValidationArguments(),
+      new Map([
+        ['artifact-metadata.json', '{'],
+        ['manifest.json', JSON.stringify(createManifest())],
+      ]),
+    );
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.errors[0]).toContain('Invalid JSON:');
+  });
+
+  it('reports unknown commands as a failed result', () => {
+    const actualResult = runCommand(['unsupported-command']);
+
+    expect(actualResult).toEqual({
+      errors: ['Unknown maintenance distribution command: unsupported-command'],
+      exitCode: 1,
+    });
+  });
+
+  it('reports missing command arguments', () => {
+    const actualResult = runCommand(['validate-manifest']);
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.errors[0]).toContain('Missing required option: --artifact-metadata-path');
+  });
+});

--- a/bin/maintenanceDistributionCli.ts
+++ b/bin/maintenanceDistributionCli.ts
@@ -26,6 +26,11 @@ import {validateMaintenanceDistributionManifest} from './maintenanceDistribution
 
 type CommandLineOptions = ReadonlyMap<string, string>;
 
+export type MaintenanceDistributionCliDependencies = {
+  readonly readFile: (filePath: string) => string;
+  readonly writeError: (message: string) => void;
+};
+
 function parseCommandLineOptions(commandLineArguments: readonly string[]): CommandLineOptions {
   const optionValues = new Map<string, string>();
 
@@ -62,14 +67,17 @@ function parseJson(jsonText: string): unknown {
   }
 }
 
-function readJsonFile(filePath: string): unknown {
-  return parseJson(readFileSync(filePath, 'utf8'));
+function readJsonFile(filePath: string, dependencies: MaintenanceDistributionCliDependencies): unknown {
+  return parseJson(dependencies.readFile(filePath));
 }
 
-function runValidateManifest(optionValues: CommandLineOptions): Result<void, Error> {
+function runValidateManifest(
+  optionValues: CommandLineOptions,
+  dependencies: MaintenanceDistributionCliDependencies,
+): Result<void, Error> {
   const validationResult = validateMaintenanceDistributionManifest({
-    artifactMetadata: readJsonFile(getRequiredOption(optionValues, 'artifact-metadata-path')),
-    manifest: readJsonFile(getRequiredOption(optionValues, 'manifest-path')),
+    artifactMetadata: readJsonFile(getRequiredOption(optionValues, 'artifact-metadata-path'), dependencies),
+    manifest: readJsonFile(getRequiredOption(optionValues, 'manifest-path'), dependencies),
     maintenanceLineKey: getRequiredOption(optionValues, 'maintenance-line-key'),
     maintenanceBranch: getRequiredOption(optionValues, 'maintenance-branch'),
     sourceProductionTag: getRequiredOption(optionValues, 'source-production-tag'),
@@ -87,33 +95,55 @@ function runValidateManifest(optionValues: CommandLineOptions): Result<void, Err
   return Result.ok(undefined);
 }
 
-function runCommand(commandName: string, optionValues: CommandLineOptions): Result<void, Error> {
+function runCommand(
+  commandName: string,
+  optionValues: CommandLineOptions,
+  dependencies: MaintenanceDistributionCliDependencies,
+): Result<void, Error> {
   if (commandName === 'validate-manifest') {
-    return runValidateManifest(optionValues);
+    return runValidateManifest(optionValues, dependencies);
   }
 
   return Result.err(new Error(`Unknown maintenance distribution command: ${commandName}`));
 }
 
-function main(): void {
+export function runMaintenanceDistributionCli(
+  commandLineArguments: readonly string[],
+  dependencies: MaintenanceDistributionCliDependencies,
+): number {
   try {
-    const commandName = process.argv[2];
+    const [commandName, ...optionArguments] = commandLineArguments;
 
     if (!isNonEmptyString(commandName)) {
       throw new Error('A maintenance distribution command is required.');
     }
 
-    const commandResult = runCommand(commandName, parseCommandLineOptions(process.argv.slice(3)));
+    const commandResult = runCommand(commandName, parseCommandLineOptions(optionArguments), dependencies);
 
     if (commandResult.isErr) {
-      console.error(commandResult.error.message);
-      process.exitCode = 1;
+      dependencies.writeError(commandResult.error.message);
+
+      return 1;
     }
+
+    return 0;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error(errorMessage);
-    process.exitCode = 1;
+    dependencies.writeError(errorMessage);
+
+    return 1;
   }
+}
+
+function main(): void {
+  process.exitCode = runMaintenanceDistributionCli(process.argv.slice(2), {
+    readFile(filePath) {
+      return readFileSync(filePath, 'utf8');
+    },
+    writeError(message) {
+      console.error(message);
+    },
+  });
 }
 
 if (process.argv[1]?.endsWith('maintenanceDistributionCli.ts')) {

--- a/bin/maintenanceDistributionCli.ts
+++ b/bin/maintenanceDistributionCli.ts
@@ -1,0 +1,121 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {readFileSync} from 'node:fs';
+
+import {isNonEmptyString} from '@sindresorhus/is';
+import {Result} from 'true-myth';
+
+import {validateMaintenanceDistributionManifest} from './maintenanceDistribution';
+
+type CommandLineOptions = ReadonlyMap<string, string>;
+
+function parseCommandLineOptions(commandLineArguments: readonly string[]): CommandLineOptions {
+  const optionValues = new Map<string, string>();
+
+  for (let argumentIndex = 0; argumentIndex < commandLineArguments.length; argumentIndex += 2) {
+    const optionName = commandLineArguments[argumentIndex];
+    const optionValue = commandLineArguments[argumentIndex + 1];
+
+    if (!isNonEmptyString(optionName) || !optionName.startsWith('--') || !isNonEmptyString(optionValue)) {
+      throw new Error('Options must be supplied as non-empty --name value pairs.');
+    }
+
+    optionValues.set(optionName.slice(2), optionValue);
+  }
+
+  return optionValues;
+}
+
+function getRequiredOption(optionValues: CommandLineOptions, optionName: string): string {
+  const optionValue = optionValues.get(optionName);
+
+  if (!isNonEmptyString(optionValue)) {
+    throw new Error(`Missing required option: --${optionName}`);
+  }
+
+  return optionValue;
+}
+
+function parseJson(jsonText: string): unknown {
+  try {
+    return JSON.parse(jsonText);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid JSON: ${errorMessage}`);
+  }
+}
+
+function readJsonFile(filePath: string): unknown {
+  return parseJson(readFileSync(filePath, 'utf8'));
+}
+
+function runValidateManifest(optionValues: CommandLineOptions): Result<void, Error> {
+  const validationResult = validateMaintenanceDistributionManifest({
+    artifactMetadata: readJsonFile(getRequiredOption(optionValues, 'artifact-metadata-path')),
+    manifest: readJsonFile(getRequiredOption(optionValues, 'manifest-path')),
+    maintenanceLineKey: getRequiredOption(optionValues, 'maintenance-line-key'),
+    maintenanceBranch: getRequiredOption(optionValues, 'maintenance-branch'),
+    sourceProductionTag: getRequiredOption(optionValues, 'source-production-tag'),
+    sourceProductionCommitSha: getRequiredOption(optionValues, 'source-production-commit-sha'),
+    maintenanceCommitSha: getRequiredOption(optionValues, 'maintenance-commit-sha'),
+    maintenanceTag: getRequiredOption(optionValues, 'maintenance-tag'),
+    workflowRunId: getRequiredOption(optionValues, 'workflow-run-id'),
+    workflowRunAttempt: getRequiredOption(optionValues, 'workflow-run-attempt'),
+  });
+
+  if (validationResult.isErr) {
+    return Result.err(validationResult.error);
+  }
+
+  return Result.ok(undefined);
+}
+
+function runCommand(commandName: string, optionValues: CommandLineOptions): Result<void, Error> {
+  if (commandName === 'validate-manifest') {
+    return runValidateManifest(optionValues);
+  }
+
+  return Result.err(new Error(`Unknown maintenance distribution command: ${commandName}`));
+}
+
+function main(): void {
+  try {
+    const commandName = process.argv[2];
+
+    if (!isNonEmptyString(commandName)) {
+      throw new Error('A maintenance distribution command is required.');
+    }
+
+    const commandResult = runCommand(commandName, parseCommandLineOptions(process.argv.slice(3)));
+
+    if (commandResult.isErr) {
+      console.error(commandResult.error.message);
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(errorMessage);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1]?.endsWith('maintenanceDistributionCli.ts')) {
+  main();
+}

--- a/bin/publish-immutable-docker.sh
+++ b/bin/publish-immutable-docker.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${DOCKER_PASSWORD:?DOCKER_PASSWORD is required}"
+: "${DOCKER_USERNAME:?DOCKER_USERNAME is required}"
+: "${DOCKER_REPOSITORY:?DOCKER_REPOSITORY is required}"
+: "${DOCKER_IMAGE_TAG_OUTPUT_PATH:?DOCKER_IMAGE_TAG_OUTPUT_PATH is required}"
+: "${IMMUTABLE_ARTIFACT_TAG:?IMMUTABLE_ARTIFACT_TAG is required}"
+: "${RELEASE_COMMIT_SHA:?RELEASE_COMMIT_SHA is required}"
+: "${STABLE_IMAGE_REFERENCE:?STABLE_IMAGE_REFERENCE is required}"
+: "${WIRE_WEBAPP_DOCKER_CONTEXT_PATH:?WIRE_WEBAPP_DOCKER_CONTEXT_PATH is required}"
+
+expected_image_tag="$(node ./bin/push_docker.js "${IMMUTABLE_ARTIFACT_TAG}" --print-image-tag)"
+expected_release_commit_short_sha="${RELEASE_COMMIT_SHA:0:7}"
+if [[ "${expected_image_tag}" != *"${expected_release_commit_short_sha}"* ]]; then
+  echo "Expected immutable image tag does not contain ${expected_release_commit_short_sha}: ${expected_image_tag}" >&2
+  exit 1
+fi
+
+immutable_image_reference="${DOCKER_REPOSITORY}:${expected_image_tag}"
+
+docker logout quay.io >/dev/null 2>&1 || true
+trap 'docker logout quay.io >/dev/null 2>&1 || true' EXIT
+printf '%s\n' "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin quay.io
+
+manifest_identity() {
+  local image_reference="$1"
+
+  docker manifest inspect "${image_reference}" |
+    jq -cS 'if .manifests then [.manifests[] | {digest, platform}] | sort_by(.digest) else {config: .config.digest, layers: [.layers[]?.digest]} end'
+}
+
+if docker manifest inspect "${immutable_image_reference}" >/dev/null 2>&1; then
+  echo "Reusing existing immutable image ${immutable_image_reference}."
+  docker manifest inspect "${immutable_image_reference}" >/dev/null
+else
+  echo "Building immutable image ${immutable_image_reference} from the exact downloaded context."
+  rm -f "${DOCKER_IMAGE_TAG_OUTPUT_PATH}"
+  node ./bin/push_docker.js "${IMMUTABLE_ARTIFACT_TAG}" "${DOCKER_IMAGE_TAG_OUTPUT_PATH}"
+  captured_image_tag="$(<"${DOCKER_IMAGE_TAG_OUTPUT_PATH}")"
+
+  if [[ "${captured_image_tag}" != "${expected_image_tag}" ]]; then
+    echo "Docker script produced ${captured_image_tag}, expected ${expected_image_tag}." >&2
+    exit 1
+  fi
+fi
+
+docker manifest inspect "${immutable_image_reference}" >/dev/null
+
+if docker manifest inspect "${STABLE_IMAGE_REFERENCE}" >/dev/null 2>&1; then
+  existing_stable_manifest_identity="$(manifest_identity "${STABLE_IMAGE_REFERENCE}")"
+  immutable_manifest_identity="$(manifest_identity "${immutable_image_reference}")"
+
+  if [[ "${existing_stable_manifest_identity}" != "${immutable_manifest_identity}" ]]; then
+    echo "Stable Docker reference ${STABLE_IMAGE_REFERENCE} points to a conflicting immutable image." >&2
+    exit 1
+  fi
+
+  echo "Reusing existing stable Docker reference ${STABLE_IMAGE_REFERENCE}."
+else
+  docker pull "${immutable_image_reference}"
+  docker tag "${immutable_image_reference}" "${STABLE_IMAGE_REFERENCE}"
+  docker push "${STABLE_IMAGE_REFERENCE}"
+fi
+
+if [[ "$(manifest_identity "${STABLE_IMAGE_REFERENCE}")" != "$(manifest_identity "${immutable_image_reference}")" ]]; then
+  echo "Stable Docker reference ${STABLE_IMAGE_REFERENCE} does not match the immutable image." >&2
+  exit 1
+fi
+
+echo "docker_image_tag=${expected_image_tag}" >> "${GITHUB_OUTPUT}"

--- a/bin/publish-immutable-helm.sh
+++ b/bin/publish-immutable-helm.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${CHART_REPOSITORY_NAME:?CHART_REPOSITORY_NAME is required}"
+: "${CHART_REPOSITORY_URL:?CHART_REPOSITORY_URL is required}"
+: "${DOCKER_IMAGE_TAG:?DOCKER_IMAGE_TAG is required}"
+
+script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.15.1
+helm repo add "${CHART_REPOSITORY_NAME}" "${CHART_REPOSITORY_URL}"
+helm repo update
+
+published_charts_path="${RUNNER_TEMP}/published-webapp-charts.json"
+helm search repo "${CHART_REPOSITORY_NAME}/webapp" --devel --versions --output json > "${published_charts_path}"
+
+helm_action="$(
+  "${script_directory}/run-production-distribution-cli.sh" \
+    select-helm-chart --charts-path "${published_charts_path}" --image-tag "${DOCKER_IMAGE_TAG}"
+)"
+
+case "${helm_action}" in
+  reuse:*)
+    chart_version="${helm_action#reuse:}"
+    echo "Reusing existing Helm chart version ${chart_version}."
+    ;;
+  publish)
+    # Keep the current WebApp distribution policy: shared consumers use prerelease chart versions.
+    chart_version="$(./bin/chart-next-version.sh prerelease)"
+    CHART_VERSION="${chart_version}" IMAGE_TAG="${DOCKER_IMAGE_TAG}" \
+      yq -i '.version = strenv(CHART_VERSION) | .appVersion = strenv(IMAGE_TAG)' charts/webapp/Chart.yaml
+    chart_package_directory="${RUNNER_TEMP}/webapp-chart"
+    mkdir -p "${chart_package_directory}"
+    helm package ./charts/webapp --destination "${chart_package_directory}"
+    helm s3 push --relative "${chart_package_directory}/webapp-${chart_version}.tgz" "${CHART_REPOSITORY_NAME}"
+    ;;
+  *)
+    echo "Unknown Helm publication action: ${helm_action}" >&2
+    exit 1
+    ;;
+esac
+
+helm repo update
+helm search repo "${CHART_REPOSITORY_NAME}/webapp" --devel --versions --output json |
+  jq -e --arg chart_version "${chart_version}" --arg image_tag "${DOCKER_IMAGE_TAG}" \
+    'any(.[]; .version == $chart_version and .app_version == $image_tag)' >/dev/null
+
+echo "helm_chart_version=${chart_version}" >> "${GITHUB_OUTPUT}"

--- a/bin/publish-production-docker.sh
+++ b/bin/publish-production-docker.sh
@@ -9,37 +9,10 @@ set -euo pipefail
 : "${PRODUCTION_TAG:?PRODUCTION_TAG is required}"
 : "${RELEASE_COMMIT_SHA:?RELEASE_COMMIT_SHA is required}"
 
-expected_image_tag="$(node ./bin/push_docker.js "${PRODUCTION_TAG}" --print-image-tag)"
-expected_release_commit_short_sha="${RELEASE_COMMIT_SHA:0:7}"
-if [[ "${expected_image_tag}" != *"${expected_release_commit_short_sha}"* ]]; then
-  echo "Expected immutable image tag does not contain ${expected_release_commit_short_sha}: ${expected_image_tag}" >&2
-  exit 1
-fi
+script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-immutable_image_reference="${DOCKER_REPOSITORY}:${expected_image_tag}"
-stable_image_reference="${DOCKER_REPOSITORY}:${PRODUCTION_TAG}"
-
-echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin quay.io
-
-if docker manifest inspect "${immutable_image_reference}" >/dev/null 2>&1; then
-  echo "Reusing existing immutable image ${immutable_image_reference}."
-  docker manifest inspect "${immutable_image_reference}" >/dev/null
-  docker pull "${immutable_image_reference}"
-  docker tag "${immutable_image_reference}" "${stable_image_reference}"
-  docker push "${stable_image_reference}"
-else
-  echo "Building immutable image ${immutable_image_reference} from the downloaded context."
-  rm -f "${PRODUCTION_IMAGE_TAG_OUTPUT_PATH}"
-  node ./bin/push_docker.js "${PRODUCTION_TAG}" "${PRODUCTION_IMAGE_TAG_OUTPUT_PATH}"
-  captured_image_tag="$(<"${PRODUCTION_IMAGE_TAG_OUTPUT_PATH}")"
-
-  if [[ "${captured_image_tag}" != "${expected_image_tag}" ]]; then
-    echo "Docker script produced ${captured_image_tag}, expected ${expected_image_tag}." >&2
-    exit 1
-  fi
-fi
-
-docker manifest inspect "${immutable_image_reference}" >/dev/null
-docker logout quay.io
-
-echo "docker_image_tag=${expected_image_tag}" >> "${GITHUB_OUTPUT}"
+DOCKER_IMAGE_TAG_OUTPUT_PATH="${PRODUCTION_IMAGE_TAG_OUTPUT_PATH}" \
+IMMUTABLE_ARTIFACT_TAG="${PRODUCTION_TAG}" \
+RELEASE_COMMIT_SHA="${RELEASE_COMMIT_SHA}" \
+STABLE_IMAGE_REFERENCE="${DOCKER_REPOSITORY}:${PRODUCTION_TAG}" \
+"${script_directory}/publish-immutable-docker.sh"

--- a/bin/publish-production-helm.sh
+++ b/bin/publish-production-helm.sh
@@ -7,43 +7,4 @@ set -euo pipefail
 : "${DOCKER_IMAGE_TAG:?DOCKER_IMAGE_TAG is required}"
 
 script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.15.1
-helm repo add "${CHART_REPOSITORY_NAME}" "${CHART_REPOSITORY_URL}"
-helm repo update
-
-published_charts_path="${RUNNER_TEMP}/published-webapp-charts.json"
-helm search repo "${CHART_REPOSITORY_NAME}/webapp" --devel --versions --output json > "${published_charts_path}"
-
-helm_action="$(
-  "${script_directory}/run-production-distribution-cli.sh" \
-    select-helm-chart --charts-path "${published_charts_path}" --image-tag "${DOCKER_IMAGE_TAG}"
-)"
-
-case "${helm_action}" in
-  reuse:*)
-    chart_version="${helm_action#reuse:}"
-  echo "Reusing existing Helm chart version ${chart_version}."
-  ;;
-  publish)
-    # Keep the current WebApp distribution policy: wire-builds/main consumes prerelease chart versions.
-    chart_version="$(./bin/chart-next-version.sh prerelease)"
-    CHART_VERSION="${chart_version}" IMAGE_TAG="${DOCKER_IMAGE_TAG}" \
-      yq -i '.version = strenv(CHART_VERSION) | .appVersion = strenv(IMAGE_TAG)' charts/webapp/Chart.yaml
-    chart_package_directory="${RUNNER_TEMP}/webapp-chart"
-    mkdir -p "${chart_package_directory}"
-    helm package ./charts/webapp --destination "${chart_package_directory}"
-    helm s3 push --relative "${chart_package_directory}/webapp-${chart_version}.tgz" "${CHART_REPOSITORY_NAME}"
-    ;;
-  *)
-    echo "Unknown Helm publication action: ${helm_action}" >&2
-    exit 1
-    ;;
-esac
-
-helm repo update
-helm search repo "${CHART_REPOSITORY_NAME}/webapp" --devel --versions --output json |
-  jq -e --arg chart_version "${chart_version}" --arg image_tag "${DOCKER_IMAGE_TAG}" \
-    'any(.[]; .version == $chart_version and .app_version == $image_tag)' >/dev/null
-
-echo "helm_chart_version=${chart_version}" >> "${GITHUB_OUTPUT}"
+"${script_directory}/publish-immutable-helm.sh"

--- a/bin/push_docker.js
+++ b/bin/push_docker.js
@@ -155,9 +155,10 @@ function runDockerPublication(
   ].join(' && ');
 
   /** Defines which config version (listed in "app-config/package.json") is going to be used */
-  const configurationEntry = versionTag.includes('production')
-    ? 'wire-web-config-default-master'
-    : 'wire-web-config-default-staging';
+  const configurationEntry =
+    environment.WIRE_WEBAPP_CONFIGURATION === 'production' || versionTag.includes('production')
+      ? 'wire-web-config-default-master'
+      : 'wire-web-config-default-staging';
   const configurationVersion = appConfigPkg.dependencies[configurationEntry].split('#')[1];
   const uniqueImageTag = createUniqueImageTag({versionTag, configurationVersion, releaseCommitSha});
 

--- a/bin/push_docker.test.ts
+++ b/bin/push_docker.test.ts
@@ -80,6 +80,15 @@ describe('push_docker metadata', () => {
     assert.equal(actualImageTag, expectedImageTag);
   });
 
+  it('uses the production configuration identity for a maintenance tag when requested explicitly', () => {
+    const actualImageTag = runDockerPublication(['2026-07-27.1-airgap-a-maintenance.1', '--print-image-tag'], {
+      WIRE_WEBAPP_CONFIGURATION: 'production',
+      WIRE_WEBAPP_RELEASE_COMMIT_SHA: '1234567890abcdef',
+    });
+
+    expect(actualImageTag).toBe('2026-07-27.1-airgap-a-maintenance.1-v0.34.9-0-1234567');
+  });
+
   it('makes the Yarn wrapper executable after artifact download before invoking it', () => {
     const dockerfilePath = path.join(process.cwd(), 'apps/server/Dockerfile');
     const dockerfileContents = readFileSync(dockerfilePath, 'utf8');

--- a/bin/releaseMetadata.test.ts
+++ b/bin/releaseMetadata.test.ts
@@ -20,17 +20,27 @@
 import assert from 'node:assert';
 
 import {
+  createMaintenanceBranchName,
   createNextBetaTagName,
+  createNextMaintenanceTagName,
   createProductionTagName,
   createReleaseBranchName,
+  extractMaintenanceLineKeyFromBranchName,
+  extractMaintenanceTagNameMetadata,
   extractReleaseIdentifierFromBranchName,
+  isMaintenanceBranchName,
   isReleaseBranchName,
+  maintenanceTagPointsToCommit,
   productionTagExists,
   productionTagPointsToCommit,
   resolveWebappBuildVersion,
+  validateMaintenanceBranchName,
+  validateMaintenanceLineKey,
+  validateMaintenanceSourceProductionTag,
+  validateMaintenanceTagName,
   validateProductionTagName,
 } from './releaseMetadata';
-import type {CommitHash, ReleaseTagMetadata} from './releaseMetadata';
+import type {CommitHash, MaintenanceTagMetadata, ReleaseTagMetadata} from './releaseMetadata';
 
 function createCommitHash(commitHash: string): CommitHash {
   return commitHash as CommitHash;
@@ -349,5 +359,201 @@ describe('releaseMetadata', () => {
     assert(actualProductionTagPointsToCommit.isOk === true);
 
     expect(actualProductionTagPointsToCommit.value).toBe(false);
+  });
+
+  it.each(['2026-07-27.1-airgap-a', '2026-07-27.10-customer-managed'])(
+    'validateMaintenanceLineKey() accepts a valid public maintenance line key "%s"',
+    maintenanceLineKey => {
+      const actualMaintenanceLineKey = validateMaintenanceLineKey(maintenanceLineKey);
+
+      assert(actualMaintenanceLineKey.isOk === true);
+
+      expect(actualMaintenanceLineKey.value).toBe(maintenanceLineKey);
+    },
+  );
+
+  it.each([
+    '2026-07-27.0-airgap-a',
+    '2026-07-27-airgap-a',
+    '2026-07-27.1',
+    '2026-07-27.1-Airgap-a',
+    '2026-07-27.1-airgap/a',
+    '2026-07-27.1-airgap.a',
+    '2026-07-27.1-airgap--a',
+    '2026-07-27.1--airgap',
+    '2026-07-27.1-airgap-',
+    '2026-07-27.1-air gap',
+    '2026-07-27.1-customer_name',
+  ])('validateMaintenanceLineKey() rejects unsafe or malformed line key "%s"', invalidMaintenanceLineKey => {
+    const actualMaintenanceLineKey = validateMaintenanceLineKey(invalidMaintenanceLineKey);
+
+    assert(actualMaintenanceLineKey.isErr === true);
+
+    expect(actualMaintenanceLineKey.error.message).toBe(`Invalid maintenance line key: ${invalidMaintenanceLineKey}`);
+  });
+
+  it('createMaintenanceBranchName() creates a maintenance branch from a valid line key', () => {
+    const actualMaintenanceBranchName = createMaintenanceBranchName('2026-07-27.1-airgap-a');
+
+    assert(actualMaintenanceBranchName.isOk === true);
+
+    expect(actualMaintenanceBranchName.value).toBe('maintenance/2026-07-27.1-airgap-a');
+  });
+
+  it.each([
+    'maintenance/2026-07-27.0-airgap-a',
+    'maintenance/2026-07-27.1',
+    'maintenance/2026-07-27.1-airgap/a',
+    'release/2026-07-27.1-airgap-a',
+  ])('maintenance branch helpers reject invalid branch name "%s"', invalidMaintenanceBranchName => {
+    const actualIsMaintenanceBranchName = isMaintenanceBranchName(invalidMaintenanceBranchName);
+    const actualMaintenanceBranchName = validateMaintenanceBranchName(invalidMaintenanceBranchName);
+    const actualLineKey = extractMaintenanceLineKeyFromBranchName(invalidMaintenanceBranchName);
+
+    expect(actualIsMaintenanceBranchName).toBe(false);
+    expect(actualMaintenanceBranchName.isErr).toBe(true);
+    expect(actualLineKey.isErr).toBe(true);
+  });
+
+  it('maintenance branch helpers validate and extract a maintenance line key', () => {
+    const maintenanceBranchName = 'maintenance/2026-07-27.1-airgap-a';
+    const actualMaintenanceBranchName = validateMaintenanceBranchName(maintenanceBranchName);
+    const actualLineKey = extractMaintenanceLineKeyFromBranchName(maintenanceBranchName);
+
+    assert(actualMaintenanceBranchName.isOk === true);
+    assert(actualLineKey.isOk === true);
+
+    expect(actualMaintenanceBranchName.value).toBe(maintenanceBranchName);
+    expect(actualLineKey.value).toBe('2026-07-27.1-airgap-a');
+  });
+
+  it('validateMaintenanceTagName() accepts a valid maintenance tag', () => {
+    const maintenanceTagName = '2026-07-27.1-airgap-a-maintenance.1';
+
+    const actualMaintenanceTagName = validateMaintenanceTagName(maintenanceTagName);
+
+    assert(actualMaintenanceTagName.isOk === true);
+
+    expect(actualMaintenanceTagName.value).toBe(maintenanceTagName);
+  });
+
+  it.each([
+    '2026-07-27.0-airgap-a-maintenance.1',
+    '2026-07-27.1-airgap-a-maintenance.0',
+    '2026-07-27.1-airgap-a-maintenance.1-extra',
+    '2026-07-27.1-airgap/a-maintenance.1',
+    '2026-07-27.1-airgap-a-maintenance.01',
+  ])('validateMaintenanceTagName() rejects malformed maintenance tag "%s"', invalidMaintenanceTagName => {
+    const actualMaintenanceTagName = validateMaintenanceTagName(invalidMaintenanceTagName);
+
+    assert(actualMaintenanceTagName.isErr === true);
+
+    expect(actualMaintenanceTagName.error.message).toBe(`Invalid maintenance tag name: ${invalidMaintenanceTagName}`);
+  });
+
+  it('extractMaintenanceTagNameMetadata() extracts the line key and sequence', () => {
+    const actualMaintenanceTagMetadata = extractMaintenanceTagNameMetadata('2026-07-27.1-airgap-a-maintenance.12');
+
+    assert(actualMaintenanceTagMetadata.isOk === true);
+
+    expect(actualMaintenanceTagMetadata.value).toEqual({lineKey: '2026-07-27.1-airgap-a', sequence: 12});
+  });
+
+  it('createNextMaintenanceTagName() starts at maintenance.1 for an empty tag history', () => {
+    const actualNextMaintenanceTagName = createNextMaintenanceTagName('2026-07-27.1-airgap-a', []);
+
+    assert(actualNextMaintenanceTagName.isOk === true);
+
+    expect(actualNextMaintenanceTagName.value).toBe('2026-07-27.1-airgap-a-maintenance.1');
+  });
+
+  it('createNextMaintenanceTagName() ignores unrelated tags and orders numeric sequences beyond maintenance.9', () => {
+    const actualNextMaintenanceTagName = createNextMaintenanceTagName('2026-07-27.1-airgap-a', [
+      '2026-07-27.1-airgap-b-maintenance.99',
+      '2026-07-27.1-airgap-a-maintenance.9',
+      '2026-07-27.1-airgap-a-maintenance.10',
+      '2026-07-27.1-airgap-a-production',
+      'unrelated-tag',
+    ]);
+
+    assert(actualNextMaintenanceTagName.isOk === true);
+
+    expect(actualNextMaintenanceTagName.value).toBe('2026-07-27.1-airgap-a-maintenance.11');
+  });
+
+  it('maintenanceTagPointsToCommit() detects a matching maintenance tag and ignores other lines', () => {
+    const currentCommitHash = createCommitHash('1234567890abcdef');
+    const maintenanceTagMetadata: MaintenanceTagMetadata[] = [
+      {
+        tagName: '2026-07-27.1-airgap-b-maintenance.1',
+        commitHash: currentCommitHash,
+      },
+      {
+        tagName: '2026-07-27.1-airgap-a-maintenance.1',
+        commitHash: currentCommitHash,
+      },
+    ];
+
+    const actualTagPointsToCommit = maintenanceTagPointsToCommit({
+      currentCommitHash,
+      maintenanceLineKey: '2026-07-27.1-airgap-a',
+      maintenanceTagMetadata,
+    });
+
+    assert(actualTagPointsToCommit.isOk === true);
+
+    expect(actualTagPointsToCommit.value).toBe(true);
+  });
+
+  it('maintenanceTagPointsToCommit() distinguishes a tag pointing to another commit', () => {
+    const actualTagPointsToCommit = maintenanceTagPointsToCommit({
+      currentCommitHash: createCommitHash('1234567890abcdef'),
+      maintenanceLineKey: '2026-07-27.1-airgap-a',
+      maintenanceTagMetadata: [
+        {
+          tagName: '2026-07-27.1-airgap-a-maintenance.1',
+          commitHash: createCommitHash('fedcba0987654321'),
+        },
+      ],
+    });
+
+    assert(actualTagPointsToCommit.isOk === true);
+
+    expect(actualTagPointsToCommit.value).toBe(false);
+  });
+
+  it('validateMaintenanceSourceProductionTag() accepts a matching ADR Production tag', () => {
+    const actualReleaseIdentifier = validateMaintenanceSourceProductionTag(
+      '2026-07-27.1-airgap-a',
+      '2026-07-27.1-production',
+    );
+
+    assert(actualReleaseIdentifier.isOk === true);
+
+    expect(actualReleaseIdentifier.value).toBe('2026-07-27.1');
+  });
+
+  it('validateMaintenanceSourceProductionTag() rejects a mismatched source Production release', () => {
+    const actualReleaseIdentifier = validateMaintenanceSourceProductionTag(
+      '2026-07-27.1-airgap-a',
+      '2026-07-28.1-production',
+    );
+
+    assert(actualReleaseIdentifier.isErr === true);
+
+    expect(actualReleaseIdentifier.error.message).toBe(
+      'Maintenance line key 2026-07-27.1-airgap-a does not belong to source Production tag 2026-07-28.1-production',
+    );
+  });
+
+  it('validateMaintenanceSourceProductionTag() rejects a legacy Production tag', () => {
+    const actualReleaseIdentifier = validateMaintenanceSourceProductionTag(
+      '2026-07-27.1-airgap-a',
+      '2026-07-27-production.1',
+    );
+
+    assert(actualReleaseIdentifier.isErr === true);
+
+    expect(actualReleaseIdentifier.error.message).toBe('Invalid production tag name: 2026-07-27-production.1');
   });
 });

--- a/bin/releaseMetadata.ts
+++ b/bin/releaseMetadata.ts
@@ -30,6 +30,9 @@ export type ReleaseBranchName = NonEmptyString<`release/${ReleaseIdentifier}`>;
 export type BetaTagName = NonEmptyString<`${ReleaseIdentifier}-beta.${number}`>;
 export type ProductionTagName = NonEmptyString<`${ReleaseIdentifier}-production`>;
 export type ReleaseTagName = BetaTagName | ProductionTagName;
+export type MaintenanceLineKey = NonEmptyString<`${ReleaseIdentifier}-${string}`>;
+export type MaintenanceBranchName = NonEmptyString<`maintenance/${MaintenanceLineKey}`>;
+export type MaintenanceTagName = NonEmptyString<`${MaintenanceLineKey}-maintenance.${number}`>;
 export type CommitHash = string & {readonly [commitHashBrand]: 'CommitHash'};
 export type WebappBuildChannel = 'main' | 'development' | 'production';
 
@@ -44,11 +47,28 @@ export type ProductionTagPointsToCommitParameters = {
   readonly releaseTagMetadata: readonly ReleaseTagMetadata[];
 };
 
+export type MaintenanceTagMetadata = {
+  readonly commitHash: CommitHash;
+  readonly tagName: MaintenanceTagName;
+};
+
+export type MaintenanceTagNameMetadata = {
+  readonly lineKey: MaintenanceLineKey;
+  readonly sequence: number;
+};
+
 const releaseDatePattern = String.raw`\d{4}-\d{2}-\d{2}`;
 const releaseIdentifierPattern = String.raw`${releaseDatePattern}\.[1-9]\d*`;
 const releaseBranchNamePattern = new RegExp(`^release/(${releaseIdentifierPattern})$`);
 const productionTagNamePattern = new RegExp(`^(${releaseIdentifierPattern})-production$`);
 const legacyProductionTagNamePattern = new RegExp(String.raw`^${releaseDatePattern}-production\.\d+$`);
+const maintenanceLineKeyPattern = new RegExp(String.raw`^(${releaseIdentifierPattern}-[a-z0-9]+(?:-[a-z0-9]+)*)$`);
+const maintenanceBranchNamePattern = new RegExp(
+  String.raw`^maintenance/(${releaseIdentifierPattern}-[a-z0-9]+(?:-[a-z0-9]+)*)$`,
+);
+const maintenanceTagNamePattern = new RegExp(
+  String.raw`^(${releaseIdentifierPattern}-[a-z0-9]+(?:-[a-z0-9]+)*)-maintenance\.([1-9]\d*)$`,
+);
 
 function isWebappBuildChannel(value: string): value is WebappBuildChannel {
   return value === 'main' || value === 'development' || value === 'production';
@@ -110,6 +130,162 @@ export function validateProductionTagName(productionTagName: string): Result<Pro
   }
 
   return Result.ok(productionTagName as ProductionTagName);
+}
+
+export function validateMaintenanceLineKey(maintenanceLineKey: string): Result<MaintenanceLineKey, Error> {
+  if (!maintenanceLineKeyPattern.test(maintenanceLineKey)) {
+    return Result.err(new Error(`Invalid maintenance line key: ${maintenanceLineKey}`));
+  }
+
+  return Result.ok(maintenanceLineKey as MaintenanceLineKey);
+}
+
+export function createMaintenanceBranchName(maintenanceLineKey: string): Result<MaintenanceBranchName, Error> {
+  const maintenanceLineKeyResult = validateMaintenanceLineKey(maintenanceLineKey);
+
+  if (maintenanceLineKeyResult.isErr) {
+    return Result.err(maintenanceLineKeyResult.error);
+  }
+
+  return Result.ok(`maintenance/${maintenanceLineKeyResult.value}` as MaintenanceBranchName);
+}
+
+export function isMaintenanceBranchName(branchName: string): boolean {
+  return maintenanceBranchNamePattern.test(branchName);
+}
+
+export function validateMaintenanceBranchName(branchName: string): Result<MaintenanceBranchName, Error> {
+  if (!isMaintenanceBranchName(branchName)) {
+    return Result.err(new Error(`Invalid maintenance branch name: ${branchName}`));
+  }
+
+  return Result.ok(branchName as MaintenanceBranchName);
+}
+
+export function extractMaintenanceLineKeyFromBranchName(branchName: string): Result<MaintenanceLineKey, Error> {
+  const branchNameMatch = maintenanceBranchNamePattern.exec(branchName);
+
+  if (branchNameMatch === null) {
+    return Result.err(new Error(`Invalid maintenance branch name: ${branchName}`));
+  }
+
+  return Result.ok(branchNameMatch[1] as MaintenanceLineKey);
+}
+
+export function validateMaintenanceTagName(maintenanceTagName: string): Result<MaintenanceTagName, Error> {
+  if (!maintenanceTagNamePattern.test(maintenanceTagName)) {
+    return Result.err(new Error(`Invalid maintenance tag name: ${maintenanceTagName}`));
+  }
+
+  return Result.ok(maintenanceTagName as MaintenanceTagName);
+}
+
+export function extractMaintenanceTagNameMetadata(
+  maintenanceTagName: string,
+): Result<MaintenanceTagNameMetadata, Error> {
+  const maintenanceTagNameMatch = maintenanceTagNamePattern.exec(maintenanceTagName);
+
+  if (maintenanceTagNameMatch === null) {
+    return Result.err(new Error(`Invalid maintenance tag name: ${maintenanceTagName}`));
+  }
+
+  const sequence = Number(maintenanceTagNameMatch[2]);
+
+  if (!Number.isSafeInteger(sequence)) {
+    return Result.err(new Error(`Maintenance tag sequence is too large: ${maintenanceTagName}`));
+  }
+
+  return Result.ok({lineKey: maintenanceTagNameMatch[1] as MaintenanceLineKey, sequence});
+}
+
+export function createNextMaintenanceTagName(
+  maintenanceLineKey: string,
+  existingTagNames: readonly string[],
+): Result<MaintenanceTagName, Error> {
+  const maintenanceLineKeyResult = validateMaintenanceLineKey(maintenanceLineKey);
+
+  if (maintenanceLineKeyResult.isErr) {
+    return Result.err(maintenanceLineKeyResult.error);
+  }
+
+  const escapedMaintenanceLineKey = escapeRegularExpression(maintenanceLineKeyResult.value);
+  const existingMaintenanceTagPattern = new RegExp(`^${escapedMaintenanceLineKey}-maintenance\\.([1-9]\\d*)$`);
+  const existingMaintenanceTagSequences = existingTagNames.flatMap(existingTagName => {
+    const existingTagNameMatch = existingMaintenanceTagPattern.exec(existingTagName);
+
+    if (existingTagNameMatch === null) {
+      return [];
+    }
+
+    const sequence = Number(existingTagNameMatch[1]);
+
+    return Number.isSafeInteger(sequence) ? [sequence] : [];
+  });
+  const latestMaintenanceTagSequence =
+    existingMaintenanceTagSequences.length > 0 ? Math.max(...existingMaintenanceTagSequences) : 0;
+  const nextMaintenanceTagSequence = latestMaintenanceTagSequence + 1;
+
+  return Result.ok(`${maintenanceLineKeyResult.value}-maintenance.${nextMaintenanceTagSequence}` as MaintenanceTagName);
+}
+
+export type MaintenanceTagPointsToCommitParameters = {
+  readonly currentCommitHash: CommitHash;
+  readonly maintenanceLineKey: string;
+  readonly maintenanceTagMetadata: readonly MaintenanceTagMetadata[];
+};
+
+export function maintenanceTagPointsToCommit(
+  parameters: MaintenanceTagPointsToCommitParameters,
+): Result<boolean, Error> {
+  const maintenanceLineKeyResult = validateMaintenanceLineKey(parameters.maintenanceLineKey);
+
+  if (maintenanceLineKeyResult.isErr) {
+    return Result.err(maintenanceLineKeyResult.error);
+  }
+
+  return Result.ok(
+    parameters.maintenanceTagMetadata.some(tagMetadata => {
+      const tagMetadataResult = extractMaintenanceTagNameMetadata(tagMetadata.tagName);
+
+      return (
+        tagMetadataResult.isOk &&
+        tagMetadataResult.value.lineKey === maintenanceLineKeyResult.value &&
+        tagMetadata.commitHash === parameters.currentCommitHash
+      );
+    }),
+  );
+}
+
+export function validateMaintenanceSourceProductionTag(
+  maintenanceLineKey: string,
+  sourceProductionTag: string,
+): Result<ReleaseIdentifier, Error> {
+  const maintenanceLineKeyResult = validateMaintenanceLineKey(maintenanceLineKey);
+
+  if (maintenanceLineKeyResult.isErr) {
+    return Result.err(maintenanceLineKeyResult.error);
+  }
+
+  const sourceProductionTagResult = validateProductionTagName(sourceProductionTag);
+
+  if (sourceProductionTagResult.isErr) {
+    return Result.err(sourceProductionTagResult.error);
+  }
+
+  const maintenanceReleaseIdentifier = maintenanceLineKeyResult.value.match(
+    new RegExp(`^(${releaseIdentifierPattern})-`),
+  )?.[1] as ReleaseIdentifier | undefined;
+  const sourceReleaseIdentifier = sourceProductionTagResult.value.replace(/-production$/u, '') as ReleaseIdentifier;
+
+  if (maintenanceReleaseIdentifier !== sourceReleaseIdentifier) {
+    return Result.err(
+      new Error(
+        `Maintenance line key ${maintenanceLineKeyResult.value} does not belong to source Production tag ${sourceProductionTagResult.value}`,
+      ),
+    );
+  }
+
+  return Result.ok(sourceReleaseIdentifier);
 }
 
 export function resolveWebappBuildVersion(

--- a/bin/releaseMetadata.ts
+++ b/bin/releaseMetadata.ts
@@ -303,6 +303,7 @@ export function resolveWebappBuildVersion(
     }
 
     const versionPrefix = buildChannel === 'main' ? 'main' : 'dev';
+
     return Result.ok(`${versionPrefix}-${commitSha.slice(0, 7) || 'unknown'}`);
   }
 

--- a/bin/releaseMetadataCli.test.ts
+++ b/bin/releaseMetadataCli.test.ts
@@ -186,6 +186,94 @@ describe('releaseMetadataCli', () => {
     });
   });
 
+  it('validates a maintenance line key', () => {
+    const actualResult = runCommand(['validate-maintenance-line-key', '2026-07-27.1-airgap-a']);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['2026-07-27.1-airgap-a'],
+    });
+  });
+
+  it('prints a maintenance branch name', () => {
+    const actualResult = runCommand(['maintenance-branch', '2026-07-27.1-airgap-a']);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['maintenance/2026-07-27.1-airgap-a'],
+    });
+  });
+
+  it('prints the maintenance line key from a branch name', () => {
+    const actualResult = runCommand(['maintenance-line-key-from-branch', 'maintenance/2026-07-27.1-airgap-a']);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['2026-07-27.1-airgap-a'],
+    });
+  });
+
+  it('prints maintenance tag metadata as JSON', () => {
+    const actualResult = runCommand(['maintenance-tag-metadata', '2026-07-27.1-airgap-a-maintenance.12']);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['{"lineKey":"2026-07-27.1-airgap-a","sequence":12}'],
+    });
+  });
+
+  it('prints the next maintenance tag and ignores unrelated tags', () => {
+    const actualResult = runCommand([
+      'next-maintenance-tag',
+      '2026-07-27.1-airgap-a',
+      '2026-07-27.1-airgap-b-maintenance.99',
+      '2026-07-27.1-airgap-a-maintenance.9',
+      '2026-07-27.1-airgap-a-maintenance.10',
+    ]);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['2026-07-27.1-airgap-a-maintenance.11'],
+    });
+  });
+
+  it('determines whether a maintenance tag points to the selected commit', () => {
+    const actualResult = runCommand([
+      'maintenance-tag-points-to-commit',
+      '2026-07-27.1-airgap-a',
+      '1234567890abcdef',
+      '2026-07-27.1-airgap-b-maintenance.1',
+      '1234567890abcdef',
+      '2026-07-27.1-airgap-a-maintenance.1',
+      '1234567890abcdef',
+    ]);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['true'],
+    });
+  });
+
+  it('validates that a maintenance source belongs to the same release', () => {
+    const actualResult = runCommand([
+      'validate-maintenance-source',
+      '2026-07-27.1-airgap-a',
+      '2026-07-27.1-production',
+    ]);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['2026-07-27.1'],
+    });
+  });
+
   it('prints usage text for missing command arguments', () => {
     const actualResult = runCommand(['next-beta-tag']);
 

--- a/bin/releaseMetadataCli.test.ts
+++ b/bin/releaseMetadataCli.test.ts
@@ -260,6 +260,20 @@ describe('releaseMetadataCli', () => {
     });
   });
 
+  it('rejects a blank selected commit', () => {
+    const actualResult = runCommand([
+      'maintenance-tag-points-to-commit',
+      '2026-07-27.1-airgap-a',
+      '   ',
+      '2026-07-27.1-airgap-a-maintenance.1',
+      '1234567890abcdef',
+    ]);
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.outputs).toEqual([]);
+    expect(actualResult.errors[0]).toContain('Usage:');
+  });
+
   it('validates that a maintenance source belongs to the same release', () => {
     const actualResult = runCommand([
       'validate-maintenance-source',

--- a/bin/releaseMetadataCli.ts
+++ b/bin/releaseMetadataCli.ts
@@ -19,14 +19,27 @@
 
 import process from 'node:process';
 
+import {isNonEmptyStringAndNotWhitespace} from '@sindresorhus/is';
+import {Result} from 'true-myth';
+
 import {
+  createMaintenanceBranchName,
   createNextBetaTagName,
+  createNextMaintenanceTagName,
   createProductionTagName,
   createReleaseBranchName,
+  extractMaintenanceLineKeyFromBranchName,
+  extractMaintenanceTagNameMetadata,
   extractReleaseIdentifierFromBranchName,
+  maintenanceTagPointsToCommit,
   resolveWebappBuildVersion,
+  validateMaintenanceBranchName,
+  validateMaintenanceLineKey,
+  validateMaintenanceSourceProductionTag,
+  validateMaintenanceTagName,
   validateProductionTagName,
 } from './releaseMetadata';
+import type {CommitHash, MaintenanceTagMetadata, MaintenanceTagNameMetadata} from './releaseMetadata';
 
 type ReleaseMetadataCliDependencies = {
   readonly writeError: (message: string) => void;
@@ -42,26 +55,91 @@ const usageText = [
   '  releaseMetadataCli.ts next-beta-tag <YYYY-MM-DD.N> [existing-tag ...]',
   '  releaseMetadataCli.ts production-tag <YYYY-MM-DD.N>',
   '  releaseMetadataCli.ts validate-production-tag <YYYY-MM-DD.N-production>',
+  '  releaseMetadataCli.ts validate-maintenance-line-key <YYYY-MM-DD.N-qualifier[-qualifier ...]>',
+  '  releaseMetadataCli.ts maintenance-branch <YYYY-MM-DD.N-qualifier[-qualifier ...]>',
+  '  releaseMetadataCli.ts validate-maintenance-branch <maintenance/YYYY-MM-DD.N-qualifier[-qualifier ...]>',
+  '  releaseMetadataCli.ts maintenance-line-key-from-branch <maintenance/YYYY-MM-DD.N-qualifier[-qualifier ...]>',
+  '  releaseMetadataCli.ts validate-maintenance-tag <YYYY-MM-DD.N-qualifier-maintenance.X>',
+  '  releaseMetadataCli.ts maintenance-tag-metadata <YYYY-MM-DD.N-qualifier-maintenance.X>',
+  '  releaseMetadataCli.ts next-maintenance-tag <YYYY-MM-DD.N-qualifier[-qualifier ...]> [existing-tag ...]',
+  '  releaseMetadataCli.ts maintenance-tag-points-to-commit <line-key> <commit> [tag commit ...]',
+  '  releaseMetadataCli.ts validate-maintenance-source <line-key> <YYYY-MM-DD.N-production>',
   '  releaseMetadataCli.ts webapp-build-version <build-reference-or-empty> <full-commit-sha> <main|development|production>',
 ].join('\n');
 
-function writeResult(
-  result:
-    | ReturnType<typeof extractReleaseIdentifierFromBranchName>
-    | ReturnType<typeof createReleaseBranchName>
-    | ReturnType<typeof createNextBetaTagName>
-    | ReturnType<typeof createProductionTagName>
-    | ReturnType<typeof resolveWebappBuildVersion>
-    | ReturnType<typeof validateProductionTagName>,
-  dependencies: ReleaseMetadataCliDependencies,
-): number {
+type ReleaseMetadataCliResult =
+  | ReturnType<typeof extractReleaseIdentifierFromBranchName>
+  | ReturnType<typeof createReleaseBranchName>
+  | ReturnType<typeof createNextBetaTagName>
+  | ReturnType<typeof createProductionTagName>
+  | ReturnType<typeof resolveWebappBuildVersion>
+  | ReturnType<typeof validateProductionTagName>
+  | ReturnType<typeof createMaintenanceBranchName>
+  | ReturnType<typeof createNextMaintenanceTagName>
+  | ReturnType<typeof extractMaintenanceLineKeyFromBranchName>
+  | ReturnType<typeof extractMaintenanceTagNameMetadata>
+  | ReturnType<typeof validateMaintenanceBranchName>
+  | ReturnType<typeof validateMaintenanceLineKey>
+  | ReturnType<typeof validateMaintenanceSourceProductionTag>
+  | ReturnType<typeof validateMaintenanceTagName>
+  | ReturnType<typeof maintenanceTagPointsToCommit>;
+
+function formatResultValue(value: string | boolean | MaintenanceTagNameMetadata): string {
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}
+
+function writeResult(result: ReleaseMetadataCliResult, dependencies: ReleaseMetadataCliDependencies): number {
   if (result.isErr) {
     dependencies.writeError(result.error.message);
     return 1;
   }
 
-  dependencies.writeOutput(result.value);
+  dependencies.writeOutput(formatResultValue(result.value));
   return 0;
+}
+
+function readMaintenanceTagMetadata(
+  commandLineValues: readonly string[],
+): ReturnType<typeof maintenanceTagPointsToCommit> {
+  const [maintenanceLineKey, currentCommitHash, ...tagAndCommitValues] = commandLineValues;
+
+  if (
+    maintenanceLineKey === undefined ||
+    currentCommitHash === undefined ||
+    tagAndCommitValues.length === 0 ||
+    tagAndCommitValues.length % 2 !== 0
+  ) {
+    return Result.err(new Error(usageText));
+  }
+
+  const maintenanceTagMetadata: MaintenanceTagMetadata[] = [];
+
+  for (let valueIndex = 0; valueIndex < tagAndCommitValues.length; valueIndex += 2) {
+    const tagName = tagAndCommitValues[valueIndex];
+    const commitHash = tagAndCommitValues[valueIndex + 1];
+
+    if (!isNonEmptyStringAndNotWhitespace(tagName) || !isNonEmptyStringAndNotWhitespace(commitHash)) {
+      return Result.err(new Error(usageText));
+    }
+
+    const tagNameResult = validateMaintenanceTagName(tagName);
+
+    if (tagNameResult.isErr) {
+      return Result.err(tagNameResult.error);
+    }
+
+    maintenanceTagMetadata.push({tagName: tagNameResult.value, commitHash: commitHash as CommitHash});
+  }
+
+  return maintenanceTagPointsToCommit({
+    currentCommitHash: currentCommitHash as CommitHash,
+    maintenanceLineKey,
+    maintenanceTagMetadata,
+  });
 }
 
 export function runReleaseMetadataCli(
@@ -88,6 +166,48 @@ export function runReleaseMetadataCli(
 
   if (commandName === 'validate-production-tag' && primaryValue !== undefined) {
     return writeResult(validateProductionTagName(primaryValue), dependencies);
+  }
+
+  if (commandName === 'validate-maintenance-line-key' && primaryValue !== undefined && remainingValues.length === 0) {
+    return writeResult(validateMaintenanceLineKey(primaryValue), dependencies);
+  }
+
+  if (commandName === 'maintenance-branch' && primaryValue !== undefined && remainingValues.length === 0) {
+    return writeResult(createMaintenanceBranchName(primaryValue), dependencies);
+  }
+
+  if (commandName === 'validate-maintenance-branch' && primaryValue !== undefined && remainingValues.length === 0) {
+    return writeResult(validateMaintenanceBranchName(primaryValue), dependencies);
+  }
+
+  if (
+    commandName === 'maintenance-line-key-from-branch' &&
+    primaryValue !== undefined &&
+    remainingValues.length === 0
+  ) {
+    return writeResult(extractMaintenanceLineKeyFromBranchName(primaryValue), dependencies);
+  }
+
+  if (commandName === 'validate-maintenance-tag' && primaryValue !== undefined && remainingValues.length === 0) {
+    return writeResult(validateMaintenanceTagName(primaryValue), dependencies);
+  }
+
+  if (commandName === 'maintenance-tag-metadata' && primaryValue !== undefined && remainingValues.length === 0) {
+    return writeResult(extractMaintenanceTagNameMetadata(primaryValue), dependencies);
+  }
+
+  if (commandName === 'next-maintenance-tag' && primaryValue !== undefined) {
+    return writeResult(createNextMaintenanceTagName(primaryValue, remainingValues), dependencies);
+  }
+
+  if (commandName === 'maintenance-tag-points-to-commit') {
+    const maintenanceTagPointsToCommitArguments =
+      primaryValue === undefined ? remainingValues : [primaryValue, ...remainingValues];
+    return writeResult(readMaintenanceTagMetadata(maintenanceTagPointsToCommitArguments), dependencies);
+  }
+
+  if (commandName === 'validate-maintenance-source' && primaryValue !== undefined && remainingValues.length === 1) {
+    return writeResult(validateMaintenanceSourceProductionTag(primaryValue, remainingValues[0]), dependencies);
   }
 
   if (commandName === 'webapp-build-version' && primaryValue !== undefined && remainingValues.length === 2) {

--- a/bin/releaseMetadataCli.ts
+++ b/bin/releaseMetadataCli.ts
@@ -95,10 +95,12 @@ function formatResultValue(value: string | boolean | MaintenanceTagNameMetadata)
 function writeResult(result: ReleaseMetadataCliResult, dependencies: ReleaseMetadataCliDependencies): number {
   if (result.isErr) {
     dependencies.writeError(result.error.message);
+
     return 1;
   }
 
   dependencies.writeOutput(formatResultValue(result.value));
+
   return 0;
 }
 
@@ -203,6 +205,7 @@ export function runReleaseMetadataCli(
   if (commandName === 'maintenance-tag-points-to-commit') {
     const maintenanceTagPointsToCommitArguments =
       primaryValue === undefined ? remainingValues : [primaryValue, ...remainingValues];
+
     return writeResult(readMaintenanceTagMetadata(maintenanceTagPointsToCommitArguments), dependencies);
   }
 
@@ -215,6 +218,7 @@ export function runReleaseMetadataCli(
   }
 
   dependencies.writeError(usageText);
+
   return 1;
 }
 

--- a/bin/releaseMetadataCli.ts
+++ b/bin/releaseMetadataCli.ts
@@ -109,7 +109,7 @@ function readMaintenanceTagMetadata(
 
   if (
     maintenanceLineKey === undefined ||
-    currentCommitHash === undefined ||
+    !isNonEmptyStringAndNotWhitespace(currentCommitHash) ||
     tagAndCommitValues.length === 0 ||
     tagAndCommitValues.length % 2 !== 0
   ) {
@@ -132,11 +132,11 @@ function readMaintenanceTagMetadata(
       return Result.err(tagNameResult.error);
     }
 
-    maintenanceTagMetadata.push({tagName: tagNameResult.value, commitHash: commitHash as CommitHash});
+    maintenanceTagMetadata.push({tagName: tagNameResult.value, commitHash: commitHash as unknown as CommitHash});
   }
 
   return maintenanceTagPointsToCommit({
-    currentCommitHash: currentCommitHash as CommitHash,
+    currentCommitHash: currentCommitHash as unknown as CommitHash,
     maintenanceLineKey,
     maintenanceTagMetadata,
   });

--- a/bin/validate-maintenance-distribution.sh
+++ b/bin/validate-maintenance-distribution.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${DISTRIBUTION_CONTEXT_PATH:?DISTRIBUTION_CONTEXT_PATH is required}"
+: "${MAINTENANCE_BRANCH:?MAINTENANCE_BRANCH is required}"
+: "${MAINTENANCE_COMMIT_SHA:?MAINTENANCE_COMMIT_SHA is required}"
+: "${MAINTENANCE_LINE_KEY:?MAINTENANCE_LINE_KEY is required}"
+: "${MAINTENANCE_TAG:?MAINTENANCE_TAG is required}"
+: "${SOURCE_PRODUCTION_COMMIT_SHA:?SOURCE_PRODUCTION_COMMIT_SHA is required}"
+: "${SOURCE_PRODUCTION_TAG:?SOURCE_PRODUCTION_TAG is required}"
+: "${WORKFLOW_RUN_ID:?WORKFLOW_RUN_ID is required}"
+: "${WORKFLOW_RUN_ATTEMPT:?WORKFLOW_RUN_ATTEMPT is required}"
+
+manifest_path="${DISTRIBUTION_CONTEXT_PATH}/distribution-manifest.json"
+artifact_path="${DISTRIBUTION_CONTEXT_PATH}/apps/server/dist/s3/ebs.zip"
+
+if [[ ! -f "${manifest_path}" ]]; then
+  echo "Maintenance distribution manifest is missing: ${manifest_path}" >&2
+  exit 1
+fi
+
+validation_options=(
+  --artifact-metadata-path "${DISTRIBUTION_CONTEXT_PATH}/apps/server/dist/version.json"
+  --manifest-path "${manifest_path}"
+  --maintenance-line-key "${MAINTENANCE_LINE_KEY}"
+  --maintenance-branch "${MAINTENANCE_BRANCH}"
+  --source-production-tag "${SOURCE_PRODUCTION_TAG}"
+  --source-production-commit-sha "${SOURCE_PRODUCTION_COMMIT_SHA}"
+  --maintenance-commit-sha "${MAINTENANCE_COMMIT_SHA}"
+  --maintenance-tag "${MAINTENANCE_TAG}"
+  --workflow-run-id "${WORKFLOW_RUN_ID}"
+  --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}"
+)
+
+./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/maintenanceDistributionCli.ts \
+  validate-manifest "${validation_options[@]}"
+
+BUILD_ARTIFACT_PATH="${artifact_path}" \
+EXPECTED_COMMIT="${MAINTENANCE_COMMIT_SHA}" \
+EXPECTED_VERSION="${MAINTENANCE_TAG}" \
+node ./bin/validateBuildArtifact.mts
+
+for required_context_path in \
+  "${DISTRIBUTION_CONTEXT_PATH}/apps/server/Dockerfile" \
+  "${DISTRIBUTION_CONTEXT_PATH}/apps/server/dist" \
+  "${DISTRIBUTION_CONTEXT_PATH}/libraries/config/lib" \
+  "${DISTRIBUTION_CONTEXT_PATH}/package.json" \
+  "${DISTRIBUTION_CONTEXT_PATH}/yarn.lock" \
+  "${DISTRIBUTION_CONTEXT_PATH}/.yarnrc.yml" \
+  "${DISTRIBUTION_CONTEXT_PATH}/.npmrc" \
+  "${DISTRIBUTION_CONTEXT_PATH}/.yarn" \
+  "${DISTRIBUTION_CONTEXT_PATH}/bin/yarn" \
+  "${DISTRIBUTION_CONTEXT_PATH}/apps/server/package.json" \
+  "${DISTRIBUTION_CONTEXT_PATH}/libraries/config/package.json" \
+  "${DISTRIBUTION_CONTEXT_PATH}/run.sh" \
+  "${DISTRIBUTION_CONTEXT_PATH}/.env.defaults"; do
+  if [[ ! -e "${required_context_path}" ]]; then
+    echo "Required maintenance Docker context path is missing: ${required_context_path}" >&2
+    exit 1
+  fi
+done
+
+manifest_artifact_checksum="$(jq --raw-output '.artifactChecksum' "${manifest_path}")"
+actual_artifact_checksum="$(sha256sum "${artifact_path}" | awk '{print $1}')"
+if [[ "${actual_artifact_checksum}" != "${manifest_artifact_checksum}" ]]; then
+  echo 'The maintenance distribution context EBS checksum does not match its manifest.' >&2
+  exit 1
+fi


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Complete Phase 11 of ADR 0002 by adding a small, separate release path for on-premises maintenance artifacts.

The new manually dispatched `Release Maintenance WebApp` workflow creates or reuses a maintenance branch, builds the exact branch commit once, validates the artifact through the dedicated precommit environment, and creates an immutable maintenance tag only after validation succeeds.

Maintenance releases remain completely separate from the normal hosted cloud release process.

## Maintenance model

Maintenance lines are created only when a customer-managed release requires later patches.

They use branch names such as:

```text
maintenance/2026-07-27.1-airgap-a
```

and immutable tags such as:

```text
2026-07-27.1-airgap-a-maintenance.1
```

A new maintenance branch is created from an existing ADR Production tag. The release identifier in the maintenance line must match the source Production tag.

When the branch already exists, its current remote head is reused without merging, rebasing, resetting, or otherwise moving it. Maintenance fixes are expected to arrive through reviewed pull requests targeting that branch.

## Validation flow

The workflow:

1. validates the maintenance line and source Production tag
2. creates or reuses the maintenance branch
3. resolves the exact maintenance commit
4. computes the next maintenance tag
5. builds the public production artifact once
6. deploys that artifact to the dedicated `wire-webapp-precommit` validation environment
7. verifies the build version, commit, and Staging backend configuration
8. runs the existing blocking E2E and Testiny validation
9. creates the annotated maintenance tag only after validation succeeds

The existing reusable `precommit-slot-run.yml` workflow is used without modification.

## Isolation from cloud releases

This workflow does not deploy maintenance artifacts to:

* hosted Beta
* hosted Production
* `wire-webapp-staging`
* `wire-webapp-prod`

It does not update:

* `wire-builds/main`
* `wire-builds/dev`

It does not publish Docker or Helm artifacts and does not introduce a second distribution or repair subsystem. Customer deployment and distribution remain outside this workflow.

The normal `Release WebApp` process is unchanged.

## Release metadata

The existing release metadata helpers and CLI now support:

* maintenance line validation
* maintenance branch creation and parsing
* maintenance tag validation
* deterministic selection of the next maintenance tag

The tag sequence uses numeric ordering, so `.10` correctly follows `.9`.

Tags are annotated and immutable. The workflow never moves, deletes, or force-pushes a maintenance tag.

## Tracking

Completes the implementation work for Phase 11 of #21597.