### PR TITLE
Add maintenance release validation and tagging [WPB-26469]

### DIFF
--- a/.github/workflows/release-maintenance-webapp.yml
+++ b/.github/workflows/release-maintenance-webapp.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       source_production_tag:
-        description: 'Annotated ADR Production tag from which the maintenance line starts, for example 2026-07-27.1-production'
+        description: 'Annotated Production tag from which the maintenance line starts, for example 2026-07-27.1-production'
         required: true
         type: string
       confirm_maintenance_release:
@@ -144,7 +144,7 @@ jobs:
           YARN_ENABLE_SCRIPTS: 'false'
         run: ./bin/yarn install --immutable --mode=skip-build
 
-      - name: Validate ADR Production tag format
+      - name: Validate Production tag format
         env:
           SOURCE_PRODUCTION_TAG: ${{ needs.validate_request.outputs.source_production_tag }}
         run: |

--- a/.github/workflows/release-maintenance-webapp.yml
+++ b/.github/workflows/release-maintenance-webapp.yml
@@ -17,7 +17,7 @@ on:
         default: false
         type: boolean
       reason:
-        description: 'Required reason for creating or validating this maintenance release'
+        description: 'Required non-sensitive reason. Included in public Git tag metadata and the workflow summary.'
         required: true
         type: string
 
@@ -49,7 +49,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 1
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Validate workflow ref
         run: |
@@ -128,7 +128,7 @@ jobs:
         with:
           persist-credentials: true
           fetch-depth: 0
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Add repository Yarn wrapper to PATH
         run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
@@ -255,6 +255,7 @@ jobs:
     name: Select maintenance tag
     runs-on: ubuntu-24.04
     needs: [validate_request, prepare_maintenance_branch]
+    if: ${{ needs.prepare_maintenance_branch.outputs.maintenance_branch_action == 'reused' }}
     permissions:
       contents: read
     outputs:
@@ -266,7 +267,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Add repository Yarn wrapper to PATH
         run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
@@ -319,6 +320,7 @@ jobs:
     name: Build exact maintenance artifact
     runs-on: ubuntu-24.04
     needs: [validate_request, prepare_maintenance_branch, select_maintenance_tag]
+    if: ${{ needs.prepare_maintenance_branch.outputs.maintenance_branch_action == 'reused' }}
     env:
       WIRE_WEBAPP_CONFIGURATION: production
     permissions:
@@ -412,7 +414,8 @@ jobs:
 
   validate_maintenance:
     name: Validate through maintenance precommit path
-    needs: build_maintenance_artifact
+    needs: [prepare_maintenance_branch, build_maintenance_artifact]
+    if: ${{ needs.prepare_maintenance_branch.outputs.maintenance_branch_action == 'reused' }}
     permissions:
       contents: read
     uses: ./.github/workflows/precommit-slot-run.yml
@@ -435,6 +438,7 @@ jobs:
   create_maintenance_tag:
     name: Create immutable maintenance tag
     runs-on: ubuntu-24.04
+    if: ${{ needs.prepare_maintenance_branch.outputs.maintenance_branch_action == 'reused' }}
     needs:
       [
         validate_request,
@@ -455,7 +459,7 @@ jobs:
         with:
           persist-credentials: true
           fetch-depth: 0
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Add repository Yarn wrapper to PATH
         run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
@@ -621,6 +625,7 @@ jobs:
       contents: read
     env:
       ARTIFACT_CHECKSUM: ${{ needs.build_maintenance_artifact.outputs.artifact_checksum || 'unavailable' }}
+      ARTIFACT_NAME: ${{ needs.build_maintenance_artifact.outputs.artifact_name || 'not built' }}
       ARTIFACT_VERSION: ${{ needs.build_maintenance_artifact.outputs.artifact_version || 'unavailable' }}
       BRANCH_ACTION: ${{ needs.prepare_maintenance_branch.outputs.maintenance_branch_action || 'unavailable' }}
       MAINTENANCE_BRANCH: ${{ needs.validate_request.outputs.maintenance_branch || 'unavailable' }}
@@ -633,11 +638,17 @@ jobs:
       SOURCE_PRODUCTION_TAG: ${{ needs.validate_request.outputs.source_production_tag || inputs.source_production_tag }}
       TESTINY_RUN_NAME: WebApp maintenance ${{ needs.select_maintenance_tag.outputs.candidate_tag || 'unavailable' }}
       VALIDATION_RESULT: ${{ needs.validate_maintenance.result }}
-      VALIDATION_URL: ${{ needs.validate_maintenance.outputs.precommit_url || 'https://wire-webapp-precommit.zinfra.io/' }}
+      VALIDATION_URL: ${{ needs.validate_maintenance.outputs.precommit_url || 'unavailable' }}
       WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Write GitHub Actions summary
         run: |
+          validation_result="${VALIDATION_RESULT}"
+
+          if [[ "${validation_result}" == 'skipped' ]]; then
+            validation_result='not run'
+          fi
+
           {
             echo '# WebApp maintenance release summary'
             echo
@@ -648,11 +659,12 @@ jobs:
             echo "- Source Production commit: ${SOURCE_COMMIT_SHA}"
             echo "- Maintenance commit: ${MAINTENANCE_COMMIT_SHA}"
             echo "- Maintenance tag: ${MAINTENANCE_TAG}"
+            echo "- Artifact: ${ARTIFACT_NAME}"
             echo "- Artifact version: ${ARTIFACT_VERSION}"
             echo "- Artifact checksum: ${ARTIFACT_CHECKSUM}"
             echo '- Validation environment: wire-webapp-precommit'
             echo "- Validation URL: ${VALIDATION_URL}"
-            echo "- Validation result: ${VALIDATION_RESULT}"
+            echo "- Validation result: ${validation_result}"
             echo "- Testiny run name: ${TESTINY_RUN_NAME}"
             echo "- Playwright report URL: ${PLAYWRIGHT_REPORT_URL}"
             echo "- Dispatch reason: ${REASON}"
@@ -661,4 +673,8 @@ jobs:
             echo 'Hosted Beta and Production were not touched.'
             echo 'wire-builds/main and wire-builds/dev were not touched.'
             echo 'Docker and Helm were not published.'
+
+            if [[ "${BRANCH_ACTION}" == 'created' ]]; then
+              echo "- Next action: merge the maintenance fix through a reviewed pull request targeting ${MAINTENANCE_BRANCH}, then rerun this workflow."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-maintenance-webapp.yml
+++ b/.github/workflows/release-maintenance-webapp.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       confirm_maintenance_release:
-        description: 'I understand that this builds and validates a maintenance artifact without touching hosted Beta or Production.'
+        description: 'I understand that this creates or reuses a maintenance branch and, when a maintenance fix exists, builds, validates, and tags its artifact without touching hosted Beta or Production.'
         required: true
         default: false
         type: boolean
@@ -196,10 +196,10 @@ jobs:
           set -euo pipefail
 
           maintenance_branch_remote_ref="refs/remotes/origin/${MAINTENANCE_BRANCH}"
-          maintenance_branch_action=''
+          maintenance_branch_was_created='false'
 
           if git ls-remote --exit-code --heads origin "${MAINTENANCE_BRANCH}" > /dev/null; then
-            maintenance_branch_action='reused'
+            :
           else
             branch_lookup_exit_code="$?"
 
@@ -209,7 +209,7 @@ jobs:
             fi
 
             if git push origin "${SOURCE_COMMIT_SHA}:refs/heads/${MAINTENANCE_BRANCH}"; then
-              maintenance_branch_action='created'
+              maintenance_branch_was_created='true'
             else
               push_exit_code="$?"
 
@@ -218,21 +218,30 @@ jobs:
                 exit "${push_exit_code}"
               fi
 
-              maintenance_branch_action='reused'
             fi
           fi
 
           git fetch --no-tags origin "+refs/heads/${MAINTENANCE_BRANCH}:${maintenance_branch_remote_ref}"
           maintenance_commit_sha="$(git rev-parse --verify "${maintenance_branch_remote_ref}^{commit}")"
 
-          if [[ "${maintenance_branch_action}" == 'created' && "${maintenance_commit_sha}" != "${SOURCE_COMMIT_SHA}" ]]; then
-            echo "Created maintenance branch ${MAINTENANCE_BRANCH} resolved to ${maintenance_commit_sha}, expected source Production commit ${SOURCE_COMMIT_SHA}." >&2
-            exit 1
-          fi
+          if [[ "${maintenance_branch_was_created}" == 'true' ]]; then
+            maintenance_branch_action='created'
 
-          if [[ "${maintenance_branch_action}" == 'reused' ]] && ! git merge-base --is-ancestor "${SOURCE_COMMIT_SHA}" "${maintenance_commit_sha}"; then
-            echo "Existing maintenance branch ${MAINTENANCE_BRANCH} is unrelated to source Production commit ${SOURCE_COMMIT_SHA}." >&2
-            exit 1
+            if [[ "${maintenance_commit_sha}" != "${SOURCE_COMMIT_SHA}" ]]; then
+              echo "Created maintenance branch ${MAINTENANCE_BRANCH} resolved to ${maintenance_commit_sha}, expected source Production commit ${SOURCE_COMMIT_SHA}." >&2
+              exit 1
+            fi
+          else
+            if ! git merge-base --is-ancestor "${SOURCE_COMMIT_SHA}" "${maintenance_commit_sha}"; then
+              echo "Existing maintenance branch ${MAINTENANCE_BRANCH} is unrelated to source Production commit ${SOURCE_COMMIT_SHA}." >&2
+              exit 1
+            fi
+
+            if [[ "${maintenance_commit_sha}" == "${SOURCE_COMMIT_SHA}" ]]; then
+              maintenance_branch_action='awaiting-fix'
+            else
+              maintenance_branch_action='reused'
+            fi
           fi
 
           {
@@ -626,7 +635,7 @@ jobs:
     env:
       ARTIFACT_CHECKSUM: ${{ needs.build_maintenance_artifact.outputs.artifact_checksum || 'unavailable' }}
       ARTIFACT_NAME: ${{ needs.build_maintenance_artifact.outputs.artifact_name || 'not built' }}
-      ARTIFACT_VERSION: ${{ needs.build_maintenance_artifact.outputs.artifact_version || 'unavailable' }}
+      ARTIFACT_VERSION: ${{ needs.build_maintenance_artifact.outputs.artifact_version || 'not built' }}
       BRANCH_ACTION: ${{ needs.prepare_maintenance_branch.outputs.maintenance_branch_action || 'unavailable' }}
       MAINTENANCE_BRANCH: ${{ needs.validate_request.outputs.maintenance_branch || 'unavailable' }}
       MAINTENANCE_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha || 'unavailable' }}
@@ -675,6 +684,11 @@ jobs:
             echo 'Docker and Helm were not published.'
 
             if [[ "${BRANCH_ACTION}" == 'created' ]]; then
+              echo '- Maintenance branch was created from the source Production commit.'
               echo "- Next action: merge the maintenance fix through a reviewed pull request targeting ${MAINTENANCE_BRANCH}, then rerun this workflow."
+            elif [[ "${BRANCH_ACTION}" == 'awaiting-fix' ]]; then
+              echo '- Maintenance branch already exists and still points to the source Production commit.'
+              echo '- No maintenance change is present yet.'
+              echo "- Next action: merge a reviewed maintenance fix targeting ${MAINTENANCE_BRANCH} before rerunning this workflow."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-maintenance-webapp.yml
+++ b/.github/workflows/release-maintenance-webapp.yml
@@ -1,0 +1,664 @@
+name: Release Maintenance WebApp
+
+on:
+  workflow_dispatch:
+    inputs:
+      maintenance_line_key:
+        description: 'Maintenance line key, for example 2026-07-27.1-airgap-a. This becomes public Git metadata and must not contain customer-identifying or sensitive information.'
+        required: true
+        type: string
+      source_production_tag:
+        description: 'Annotated ADR Production tag from which the maintenance line starts, for example 2026-07-27.1-production'
+        required: true
+        type: string
+      confirm_maintenance_release:
+        description: 'I understand that this builds and validates a maintenance artifact without touching hosted Beta or Production.'
+        required: true
+        default: false
+        type: boolean
+      reason:
+        description: 'Required reason for creating or validating this maintenance release'
+        required: true
+        type: string
+
+concurrency:
+  group: release-maintenance-${{ inputs.maintenance_line_key }}
+  cancel-in-progress: false
+  queue: max
+
+permissions: {}
+
+env:
+  AWS_REGION: eu-central-1
+  ARTIFACT_PATH: apps/server/dist/s3/ebs.zip
+
+jobs:
+  validate_request:
+    name: Validate maintenance request
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      maintenance_line_key: ${{ steps.validate_request.outputs.maintenance_line_key }}
+      maintenance_branch: ${{ steps.validate_request.outputs.maintenance_branch }}
+      source_production_tag: ${{ steps.validate_request.outputs.source_production_tag }}
+
+    steps:
+      - name: Checkout main workflow tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: main
+
+      - name: Validate workflow ref
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" != 'refs/heads/main' ]]; then
+            echo 'Release Maintenance WebApp must be started with "Use workflow from: main".' >&2
+            echo "Received workflow ref: ${GITHUB_REF}" >&2
+            exit 1
+          fi
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Validate maintenance request
+        id: validate_request
+        env:
+          CONFIRM_MAINTENANCE_RELEASE: ${{ inputs.confirm_maintenance_release }}
+          MAINTENANCE_LINE_KEY: ${{ inputs.maintenance_line_key }}
+          REASON: ${{ inputs.reason }}
+          SOURCE_PRODUCTION_TAG: ${{ inputs.source_production_tag }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${CONFIRM_MAINTENANCE_RELEASE}" != 'true' ]]; then
+            echo 'confirm_maintenance_release must be true to start a WebApp maintenance release.' >&2
+            exit 1
+          fi
+
+          if [[ -z "${REASON//[[:space:]]/}" ]]; then
+            echo 'reason must contain non-whitespace text.' >&2
+            exit 1
+          fi
+
+          maintenance_branch="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts maintenance-branch "${MAINTENANCE_LINE_KEY}")"
+          source_production_tag="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts validate-maintenance-source "${MAINTENANCE_LINE_KEY}" "${SOURCE_PRODUCTION_TAG}")"
+
+          {
+            echo "maintenance_line_key=${MAINTENANCE_LINE_KEY}"
+            echo "maintenance_branch=${maintenance_branch}"
+            echo "source_production_tag=${source_production_tag}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Maintenance line key: ${MAINTENANCE_LINE_KEY}"
+          echo "Maintenance branch: ${maintenance_branch}"
+          echo "Source Production tag: ${source_production_tag}"
+
+  prepare_maintenance_branch:
+    name: Prepare maintenance branch
+    runs-on: ubuntu-24.04
+    needs: validate_request
+    permissions:
+      contents: write
+    outputs:
+      maintenance_line_key: ${{ steps.prepare_maintenance_branch.outputs.maintenance_line_key }}
+      maintenance_branch: ${{ steps.prepare_maintenance_branch.outputs.maintenance_branch }}
+      maintenance_branch_action: ${{ steps.prepare_maintenance_branch.outputs.maintenance_branch_action }}
+      source_production_tag: ${{ steps.prepare_maintenance_branch.outputs.source_production_tag }}
+      source_commit_sha: ${{ steps.prepare_maintenance_branch.outputs.source_commit_sha }}
+      maintenance_commit_sha: ${{ steps.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+
+    steps:
+      - name: Checkout main workflow tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: true
+          fetch-depth: 0
+          ref: main
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Validate ADR Production tag format
+        env:
+          SOURCE_PRODUCTION_TAG: ${{ needs.validate_request.outputs.source_production_tag }}
+        run: |
+          set -euo pipefail
+
+          validated_source_production_tag="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts validate-production-tag "${SOURCE_PRODUCTION_TAG}")"
+
+          if [[ "${validated_source_production_tag}" != "${SOURCE_PRODUCTION_TAG}" ]]; then
+            echo "Validated source Production tag does not match the requested tag: ${SOURCE_PRODUCTION_TAG}" >&2
+            exit 1
+          fi
+
+      - name: Fetch and verify source Production tag
+        id: source_tag
+        env:
+          SOURCE_PRODUCTION_TAG: ${{ needs.validate_request.outputs.source_production_tag }}
+        run: |
+          set -euo pipefail
+
+          if ! git fetch --no-tags origin "refs/tags/${SOURCE_PRODUCTION_TAG}:refs/tags/${SOURCE_PRODUCTION_TAG}"; then
+            echo "Unable to fetch source Production tag: ${SOURCE_PRODUCTION_TAG}" >&2
+            exit 1
+          fi
+
+          if ! git rev-parse --verify "refs/tags/${SOURCE_PRODUCTION_TAG}^{tag}" > /dev/null; then
+            echo "Source Production tag is missing or is not an annotated tag: ${SOURCE_PRODUCTION_TAG}" >&2
+            exit 1
+          fi
+
+          source_commit_sha="$(git rev-parse --verify "refs/tags/${SOURCE_PRODUCTION_TAG}^{commit}")"
+
+          if [[ -z "${source_commit_sha}" ]]; then
+            echo "Source Production tag has no resolvable peeled commit: ${SOURCE_PRODUCTION_TAG}" >&2
+            exit 1
+          fi
+
+          echo "source_commit_sha=${source_commit_sha}" >> "$GITHUB_OUTPUT"
+          echo "Source Production tag: ${SOURCE_PRODUCTION_TAG}"
+          echo "Source Production commit: ${source_commit_sha}"
+
+      - name: Prepare maintenance branch
+        id: prepare_maintenance_branch
+        env:
+          MAINTENANCE_BRANCH: ${{ needs.validate_request.outputs.maintenance_branch }}
+          MAINTENANCE_LINE_KEY: ${{ needs.validate_request.outputs.maintenance_line_key }}
+          SOURCE_COMMIT_SHA: ${{ steps.source_tag.outputs.source_commit_sha }}
+          SOURCE_PRODUCTION_TAG: ${{ needs.validate_request.outputs.source_production_tag }}
+        run: |
+          set -euo pipefail
+
+          maintenance_branch_remote_ref="refs/remotes/origin/${MAINTENANCE_BRANCH}"
+          maintenance_branch_action=''
+
+          if git ls-remote --exit-code --heads origin "${MAINTENANCE_BRANCH}" > /dev/null; then
+            maintenance_branch_action='reused'
+          else
+            branch_lookup_exit_code="$?"
+
+            if [[ "${branch_lookup_exit_code}" -ne 2 ]]; then
+              echo "Unable to check whether maintenance branch exists on origin: ${MAINTENANCE_BRANCH}" >&2
+              exit "${branch_lookup_exit_code}"
+            fi
+
+            if git push origin "${SOURCE_COMMIT_SHA}:refs/heads/${MAINTENANCE_BRANCH}"; then
+              maintenance_branch_action='created'
+            else
+              push_exit_code="$?"
+
+              if ! git ls-remote --exit-code --heads origin "${MAINTENANCE_BRANCH}" > /dev/null; then
+                echo "Unable to resolve the maintenance branch after an unsuccessful push: ${MAINTENANCE_BRANCH}" >&2
+                exit "${push_exit_code}"
+              fi
+
+              maintenance_branch_action='reused'
+            fi
+          fi
+
+          git fetch --no-tags origin "+refs/heads/${MAINTENANCE_BRANCH}:${maintenance_branch_remote_ref}"
+          maintenance_commit_sha="$(git rev-parse --verify "${maintenance_branch_remote_ref}^{commit}")"
+
+          if [[ "${maintenance_branch_action}" == 'created' && "${maintenance_commit_sha}" != "${SOURCE_COMMIT_SHA}" ]]; then
+            echo "Created maintenance branch ${MAINTENANCE_BRANCH} resolved to ${maintenance_commit_sha}, expected source Production commit ${SOURCE_COMMIT_SHA}." >&2
+            exit 1
+          fi
+
+          if [[ "${maintenance_branch_action}" == 'reused' ]] && ! git merge-base --is-ancestor "${SOURCE_COMMIT_SHA}" "${maintenance_commit_sha}"; then
+            echo "Existing maintenance branch ${MAINTENANCE_BRANCH} is unrelated to source Production commit ${SOURCE_COMMIT_SHA}." >&2
+            exit 1
+          fi
+
+          {
+            echo "maintenance_line_key=${MAINTENANCE_LINE_KEY}"
+            echo "maintenance_branch=${MAINTENANCE_BRANCH}"
+            echo "maintenance_branch_action=${maintenance_branch_action}"
+            echo "source_production_tag=${SOURCE_PRODUCTION_TAG}"
+            echo "source_commit_sha=${SOURCE_COMMIT_SHA}"
+            echo "maintenance_commit_sha=${maintenance_commit_sha}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Maintenance line key: ${MAINTENANCE_LINE_KEY}"
+          echo "Maintenance branch: ${MAINTENANCE_BRANCH}"
+          echo "Branch action: ${maintenance_branch_action}"
+          echo "Source Production tag: ${SOURCE_PRODUCTION_TAG}"
+          echo "Source Production commit: ${SOURCE_COMMIT_SHA}"
+          echo "Maintenance commit: ${maintenance_commit_sha}"
+
+  select_maintenance_tag:
+    name: Select maintenance tag
+    runs-on: ubuntu-24.04
+    needs: [validate_request, prepare_maintenance_branch]
+    permissions:
+      contents: read
+    outputs:
+      candidate_tag: ${{ steps.select_maintenance_tag.outputs.candidate_tag }}
+
+    steps:
+      - name: Checkout main workflow tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: main
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Select next maintenance tag
+        id: select_maintenance_tag
+        env:
+          MAINTENANCE_LINE_KEY: ${{ needs.validate_request.outputs.maintenance_line_key }}
+          MAINTENANCE_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t remote_tag_names < <(
+            git ls-remote --tags --refs origin "refs/tags/${MAINTENANCE_LINE_KEY}-maintenance.*" |
+              awk '{sub("refs/tags/", "", $2); print $2}'
+          )
+          valid_tag_names=()
+
+          for remote_tag_name in "${remote_tag_names[@]}"; do
+            validated_tag_name="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts validate-maintenance-tag "${remote_tag_name}" 2> /dev/null)" || continue
+            valid_tag_names+=("${validated_tag_name}")
+
+            git fetch --no-tags origin "refs/tags/${validated_tag_name}:refs/tags/${validated_tag_name}"
+            tag_commit_sha="$(git rev-parse --verify "refs/tags/${validated_tag_name}^{commit}")"
+
+            if [[ "${tag_commit_sha}" == "${MAINTENANCE_COMMIT_SHA}" ]]; then
+              echo "Maintenance commit ${MAINTENANCE_COMMIT_SHA} has already been released as ${validated_tag_name}." >&2
+              exit 1
+            fi
+          done
+
+          candidate_tag="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts next-maintenance-tag "${MAINTENANCE_LINE_KEY}" "${valid_tag_names[@]}")"
+
+          ./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts validate-maintenance-tag "${candidate_tag}" > /dev/null
+          echo "candidate_tag=${candidate_tag}" >> "$GITHUB_OUTPUT"
+          echo "Candidate maintenance tag: ${candidate_tag}"
+
+  build_maintenance_artifact:
+    name: Build exact maintenance artifact
+    runs-on: ubuntu-24.04
+    needs: [validate_request, prepare_maintenance_branch, select_maintenance_tag]
+    env:
+      WIRE_WEBAPP_CONFIGURATION: production
+    permissions:
+      contents: read
+    outputs:
+      artifact_checksum: ${{ steps.artifact_metadata.outputs.artifact_checksum }}
+      artifact_name: ${{ steps.artifact_metadata.outputs.artifact_name }}
+      artifact_version: ${{ steps.validate_artifact_metadata.outputs.artifact_version }}
+      artifact_commit: ${{ steps.validate_artifact_metadata.outputs.artifact_commit }}
+
+    steps:
+      - name: Checkout exact maintenance application commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+
+      - name: Verify exact maintenance application commit
+        env:
+          EXPECTED_MAINTENANCE_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+        run: |
+          set -euo pipefail
+
+          maintenance_commit_sha="$(git rev-parse HEAD)"
+
+          if [[ "${maintenance_commit_sha}" != "${EXPECTED_MAINTENANCE_COMMIT_SHA}" ]]; then
+            echo "Checked out ${maintenance_commit_sha}, expected maintenance commit ${EXPECTED_MAINTENANCE_COMMIT_SHA}." >&2
+            exit 1
+          fi
+
+          echo "Building application source from maintenance commit ${maintenance_commit_sha}."
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install maintenance source dependencies
+        run: ./bin/yarn --immutable
+
+      - name: Update WebApp configuration
+        run: ./bin/yarn nx run webapp:configure
+
+      - name: Build and package public production artifact
+        env:
+          WIRE_WEBAPP_BUILD_COMMIT: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+          WIRE_WEBAPP_BUILD_VERSION: ${{ needs.select_maintenance_tag.outputs.candidate_tag }}
+        run: ./bin/yarn build:prod:public
+
+      - name: Validate maintenance artifact metadata
+        id: validate_artifact_metadata
+        env:
+          BUILD_ARTIFACT_PATH: ${{ env.ARTIFACT_PATH }}
+          EXPECTED_COMMIT: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+          EXPECTED_VERSION: ${{ needs.select_maintenance_tag.outputs.candidate_tag }}
+        run: node ./bin/validateBuildArtifact.mts
+
+      - name: Compute maintenance artifact metadata
+        id: artifact_metadata
+        env:
+          ARTIFACT_COMMIT: ${{ steps.validate_artifact_metadata.outputs.artifact_commit }}
+          ARTIFACT_VERSION: ${{ steps.validate_artifact_metadata.outputs.artifact_version }}
+          MAINTENANCE_LINE_KEY: ${{ needs.validate_request.outputs.maintenance_line_key }}
+        run: |
+          set -euo pipefail
+
+          artifact_name="maintenance-ebs-${MAINTENANCE_LINE_KEY}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_checksum="$(sha256sum "${ARTIFACT_PATH}" | awk '{print $1}')"
+
+          {
+            echo "artifact_name=${artifact_name}"
+            echo "artifact_checksum=${artifact_checksum}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Artifact name: ${artifact_name}"
+          echo "Artifact version: ${ARTIFACT_VERSION}"
+          echo "Artifact commit: ${ARTIFACT_COMMIT}"
+          echo "Artifact checksum: ${artifact_checksum}"
+
+      - name: Upload maintenance artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ steps.artifact_metadata.outputs.artifact_name }}
+          path: ${{ env.ARTIFACT_PATH }}
+          if-no-files-found: error
+
+  validate_maintenance:
+    name: Validate through maintenance precommit path
+    needs: build_maintenance_artifact
+    permissions:
+      contents: read
+    uses: ./.github/workflows/precommit-slot-run.yml
+    with:
+      env_name: wire-webapp-precommit
+      expectedManageTeamUrl: https://teams.wire.com/login/
+      artifact_name: ${{ needs.build_maintenance_artifact.outputs.artifact_name }}
+      expectedBackendRest: https://staging-nginz-https.zinfra.io/
+      expectedBackendWs: wss://staging-nginz-ssl.zinfra.io/
+      expectedVersion: ${{ needs.build_maintenance_artifact.outputs.artifact_version }}
+      expectedCommit: ${{ needs.build_maintenance_artifact.outputs.artifact_commit }}
+      grep: '@regression|@crit-flow-web'
+      testinyRunName: WebApp maintenance ${{ needs.build_maintenance_artifact.outputs.artifact_version }}
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      WEBTEAM_AWS_ACCESS_KEY_ID: ${{ secrets.WEBTEAM_AWS_ACCESS_KEY_ID }}
+      WEBTEAM_AWS_SECRET_ACCESS_KEY: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
+      TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
+
+  create_maintenance_tag:
+    name: Create immutable maintenance tag
+    runs-on: ubuntu-24.04
+    needs:
+      [
+        validate_request,
+        prepare_maintenance_branch,
+        select_maintenance_tag,
+        build_maintenance_artifact,
+        validate_maintenance,
+      ]
+    permissions:
+      contents: write
+    outputs:
+      maintenance_tag: ${{ steps.create_maintenance_tag.outputs.maintenance_tag }}
+      maintenance_tag_action: ${{ steps.create_maintenance_tag.outputs.maintenance_tag_action }}
+
+    steps:
+      - name: Checkout main workflow tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: true
+          fetch-depth: 0
+          ref: main
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Recompute tag from current remote state
+        id: create_maintenance_tag
+        env:
+          DISPATCH_REASON: ${{ inputs.reason }}
+          EXPECTED_CANDIDATE_TAG: ${{ needs.select_maintenance_tag.outputs.candidate_tag }}
+          MAINTENANCE_BRANCH: ${{ needs.prepare_maintenance_branch.outputs.maintenance_branch }}
+          MAINTENANCE_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha }}
+          MAINTENANCE_LINE_KEY: ${{ needs.validate_request.outputs.maintenance_line_key }}
+          SOURCE_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.source_commit_sha }}
+          SOURCE_PRODUCTION_TAG: ${{ needs.prepare_maintenance_branch.outputs.source_production_tag }}
+        run: |
+          set -euo pipefail
+
+          maintenance_branch_remote_ref="refs/remotes/origin/${MAINTENANCE_BRANCH}"
+          git fetch --no-tags origin "+refs/heads/${MAINTENANCE_BRANCH}:${maintenance_branch_remote_ref}"
+
+          current_maintenance_branch_commit="$(git rev-parse --verify "${maintenance_branch_remote_ref}^{commit}")"
+
+          if [[ "${current_maintenance_branch_commit}" != "${MAINTENANCE_COMMIT_SHA}" ]]; then
+            echo "Maintenance branch ${MAINTENANCE_BRANCH} moved from the validated commit ${MAINTENANCE_COMMIT_SHA} to ${current_maintenance_branch_commit}; start a fresh workflow run." >&2
+            exit 1
+          fi
+
+          if ! git cat-file -e "${MAINTENANCE_COMMIT_SHA}^{commit}"; then
+            echo "Maintenance commit is not available after fetching the maintenance branch: ${MAINTENANCE_COMMIT_SHA}" >&2
+            exit 1
+          fi
+
+          mapfile -t remote_tag_names < <(
+            git ls-remote --tags --refs origin "refs/tags/${MAINTENANCE_LINE_KEY}-maintenance.*" |
+              awk '{sub("refs/tags/", "", $2); print $2}'
+          )
+          valid_tag_names=()
+          candidate_tag_exists='false'
+          candidate_tag_commit_sha=''
+
+          for remote_tag_name in "${remote_tag_names[@]}"; do
+            validated_tag_name="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts validate-maintenance-tag "${remote_tag_name}" 2> /dev/null)" || continue
+            valid_tag_names+=("${validated_tag_name}")
+
+            git fetch --no-tags origin "refs/tags/${validated_tag_name}:refs/tags/${validated_tag_name}"
+            tag_commit_sha="$(git rev-parse --verify "refs/tags/${validated_tag_name}^{commit}")"
+
+            if [[ "${validated_tag_name}" == "${EXPECTED_CANDIDATE_TAG}" ]]; then
+              candidate_tag_exists='true'
+              candidate_tag_commit_sha="${tag_commit_sha}"
+            elif [[ "${tag_commit_sha}" == "${MAINTENANCE_COMMIT_SHA}" ]]; then
+              echo "Maintenance commit ${MAINTENANCE_COMMIT_SHA} is already tagged as ${validated_tag_name}; start a fresh workflow run." >&2
+              exit 1
+            fi
+          done
+
+          if [[ "${candidate_tag_exists}" == 'true' ]] && [[ "${candidate_tag_commit_sha}" != "${MAINTENANCE_COMMIT_SHA}" ]]; then
+            echo "Candidate tag ${EXPECTED_CANDIDATE_TAG} already exists for ${candidate_tag_commit_sha}, not ${MAINTENANCE_COMMIT_SHA}." >&2
+            exit 1
+          fi
+
+          tag_names_for_next_candidate=("${valid_tag_names[@]}")
+
+          if [[ "${candidate_tag_exists}" == 'true' ]]; then
+            tag_names_for_next_candidate=()
+
+            for valid_tag_name in "${valid_tag_names[@]}"; do
+              if [[ "${valid_tag_name}" != "${EXPECTED_CANDIDATE_TAG}" ]]; then
+                tag_names_for_next_candidate+=("${valid_tag_name}")
+              fi
+            done
+          fi
+
+          recomputed_candidate_tag="$(./bin/yarn ts-node --project ./tsconfig.bin.json ./bin/releaseMetadataCli.ts next-maintenance-tag "${MAINTENANCE_LINE_KEY}" "${tag_names_for_next_candidate[@]}")"
+
+          if [[ "${recomputed_candidate_tag}" != "${EXPECTED_CANDIDATE_TAG}" ]]; then
+            echo "Remote maintenance tags advanced to ${recomputed_candidate_tag}; expected ${EXPECTED_CANDIDATE_TAG}. Start a fresh workflow run." >&2
+            exit 1
+          fi
+
+          if [[ "${candidate_tag_exists}" == 'true' ]]; then
+            if ! git rev-parse --verify "refs/tags/${EXPECTED_CANDIDATE_TAG}^{tag}" > /dev/null; then
+              echo "Candidate tag ${EXPECTED_CANDIDATE_TAG} exists but is not annotated." >&2
+              exit 1
+            fi
+
+            maintenance_tag_action='reused'
+          else
+            workflow_run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            tag_message="$(
+              printf '%s\n' \
+                "Maintenance line key: ${MAINTENANCE_LINE_KEY}" \
+                "Maintenance branch: ${MAINTENANCE_BRANCH}" \
+                "Source Production tag: ${SOURCE_PRODUCTION_TAG}" \
+                "Source Production commit: ${SOURCE_COMMIT_SHA}" \
+                "Maintenance commit: ${MAINTENANCE_COMMIT_SHA}" \
+                "Workflow run URL: ${workflow_run_url}" \
+                "Dispatch reason: ${DISPATCH_REASON}"
+            )"
+
+            git tag --annotate "${EXPECTED_CANDIDATE_TAG}" "${MAINTENANCE_COMMIT_SHA}" --message "${tag_message}"
+
+            if git push origin "refs/tags/${EXPECTED_CANDIDATE_TAG}"; then
+              maintenance_tag_action='created'
+            else
+              push_exit_code="$?"
+
+              if ! git fetch --no-tags origin "refs/tags/${EXPECTED_CANDIDATE_TAG}:refs/maintenance-tags/${EXPECTED_CANDIDATE_TAG}"; then
+                echo "Unable to resolve maintenance tag after an unsuccessful push: ${EXPECTED_CANDIDATE_TAG}" >&2
+                exit "${push_exit_code}"
+              fi
+
+              pushed_tag_commit_sha="$(git rev-parse --verify "refs/maintenance-tags/${EXPECTED_CANDIDATE_TAG}^{commit}")"
+
+              if [[ "${pushed_tag_commit_sha}" != "${MAINTENANCE_COMMIT_SHA}" ]] || ! git rev-parse --verify "refs/maintenance-tags/${EXPECTED_CANDIDATE_TAG}^{tag}" > /dev/null; then
+                echo "Maintenance tag ${EXPECTED_CANDIDATE_TAG} was created concurrently for a different commit or with a different tag type." >&2
+                exit "${push_exit_code}"
+              fi
+
+              maintenance_tag_action='reused'
+            fi
+          fi
+
+          git fetch --no-tags origin "refs/tags/${EXPECTED_CANDIDATE_TAG}:refs/maintenance-tags/${EXPECTED_CANDIDATE_TAG}"
+          final_tag_commit_sha="$(git rev-parse --verify "refs/maintenance-tags/${EXPECTED_CANDIDATE_TAG}^{commit}")"
+
+          if [[ "${final_tag_commit_sha}" != "${MAINTENANCE_COMMIT_SHA}" ]] || ! git rev-parse --verify "refs/maintenance-tags/${EXPECTED_CANDIDATE_TAG}^{tag}" > /dev/null; then
+            echo "Maintenance tag ${EXPECTED_CANDIDATE_TAG} does not point to the expected annotated maintenance commit." >&2
+            exit 1
+          fi
+
+          {
+            echo "maintenance_tag=${EXPECTED_CANDIDATE_TAG}"
+            echo "maintenance_tag_action=${maintenance_tag_action}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Maintenance tag: ${EXPECTED_CANDIDATE_TAG}"
+          echo "Tag action: ${maintenance_tag_action}"
+
+  maintenance_summary:
+    name: Write maintenance release summary
+    runs-on: ubuntu-24.04
+    if: ${{ always() }}
+    needs:
+      - validate_request
+      - prepare_maintenance_branch
+      - select_maintenance_tag
+      - build_maintenance_artifact
+      - validate_maintenance
+      - create_maintenance_tag
+    permissions:
+      contents: read
+    env:
+      ARTIFACT_CHECKSUM: ${{ needs.build_maintenance_artifact.outputs.artifact_checksum || 'unavailable' }}
+      ARTIFACT_VERSION: ${{ needs.build_maintenance_artifact.outputs.artifact_version || 'unavailable' }}
+      BRANCH_ACTION: ${{ needs.prepare_maintenance_branch.outputs.maintenance_branch_action || 'unavailable' }}
+      MAINTENANCE_BRANCH: ${{ needs.validate_request.outputs.maintenance_branch || 'unavailable' }}
+      MAINTENANCE_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.maintenance_commit_sha || 'unavailable' }}
+      MAINTENANCE_LINE_KEY: ${{ needs.validate_request.outputs.maintenance_line_key || inputs.maintenance_line_key }}
+      MAINTENANCE_TAG: ${{ needs.create_maintenance_tag.outputs.maintenance_tag || 'not created' }}
+      PLAYWRIGHT_REPORT_URL: ${{ needs.validate_maintenance.outputs.reportUrl || 'unavailable' }}
+      REASON: ${{ inputs.reason }}
+      SOURCE_COMMIT_SHA: ${{ needs.prepare_maintenance_branch.outputs.source_commit_sha || 'unavailable' }}
+      SOURCE_PRODUCTION_TAG: ${{ needs.validate_request.outputs.source_production_tag || inputs.source_production_tag }}
+      TESTINY_RUN_NAME: WebApp maintenance ${{ needs.select_maintenance_tag.outputs.candidate_tag || 'unavailable' }}
+      VALIDATION_RESULT: ${{ needs.validate_maintenance.result }}
+      VALIDATION_URL: ${{ needs.validate_maintenance.outputs.precommit_url || 'https://wire-webapp-precommit.zinfra.io/' }}
+      WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Write GitHub Actions summary
+        run: |
+          {
+            echo '# WebApp maintenance release summary'
+            echo
+            echo "- Maintenance line key: ${MAINTENANCE_LINE_KEY}"
+            echo "- Maintenance branch: ${MAINTENANCE_BRANCH}"
+            echo "- Branch action: ${BRANCH_ACTION}"
+            echo "- Source Production tag: ${SOURCE_PRODUCTION_TAG}"
+            echo "- Source Production commit: ${SOURCE_COMMIT_SHA}"
+            echo "- Maintenance commit: ${MAINTENANCE_COMMIT_SHA}"
+            echo "- Maintenance tag: ${MAINTENANCE_TAG}"
+            echo "- Artifact version: ${ARTIFACT_VERSION}"
+            echo "- Artifact checksum: ${ARTIFACT_CHECKSUM}"
+            echo '- Validation environment: wire-webapp-precommit'
+            echo "- Validation URL: ${VALIDATION_URL}"
+            echo "- Validation result: ${VALIDATION_RESULT}"
+            echo "- Testiny run name: ${TESTINY_RUN_NAME}"
+            echo "- Playwright report URL: ${PLAYWRIGHT_REPORT_URL}"
+            echo "- Dispatch reason: ${REASON}"
+            echo "- Workflow run URL: ${WORKFLOW_RUN_URL}"
+            echo
+            echo 'Hosted Beta and Production were not touched.'
+            echo 'wire-builds/main and wire-builds/dev were not touched.'
+            echo 'Docker and Helm were not published.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/bin/releaseMetadata.test.ts
+++ b/bin/releaseMetadata.test.ts
@@ -81,7 +81,7 @@ describe('releaseMetadata', () => {
 
     const actualReleaseIdentifier = extractReleaseIdentifierFromBranchName(branchName);
 
-    assert(actualReleaseIdentifier.isOk);
+    assert(actualReleaseIdentifier.isOk === true);
 
     expect(actualReleaseIdentifier.value).toBe('2026-06-19.1');
   });
@@ -91,7 +91,7 @@ describe('releaseMetadata', () => {
 
     const actualReleaseIdentifier = extractReleaseIdentifierFromBranchName(invalidBranchName);
 
-    assert(actualReleaseIdentifier.isErr);
+    assert(actualReleaseIdentifier.isErr === true);
 
     expect(actualReleaseIdentifier.error.message).toBe('Invalid release branch name: release/2026-06-01');
   });
@@ -101,7 +101,7 @@ describe('releaseMetadata', () => {
 
     const actualReleaseBranchName = createReleaseBranchName(releaseIdentifier);
 
-    assert(actualReleaseBranchName.isOk);
+    assert(actualReleaseBranchName.isOk === true);
 
     expect(actualReleaseBranchName.value).toBe('release/2026-06-19.1');
   });
@@ -111,7 +111,7 @@ describe('releaseMetadata', () => {
     invalidReleaseIdentifier => {
       const actualReleaseBranchName = createReleaseBranchName(invalidReleaseIdentifier);
 
-      assert(actualReleaseBranchName.isErr);
+      assert(actualReleaseBranchName.isErr === true);
 
       expect(actualReleaseBranchName.error.message).toBe(`Invalid release identifier: ${invalidReleaseIdentifier}`);
     },
@@ -122,7 +122,7 @@ describe('releaseMetadata', () => {
 
     const actualProductionTagName = createProductionTagName(releaseIdentifier);
 
-    assert(actualProductionTagName.isOk);
+    assert(actualProductionTagName.isOk === true);
 
     expect(actualProductionTagName.value).toBe('2026-06-19.1-production');
   });
@@ -132,7 +132,7 @@ describe('releaseMetadata', () => {
 
     const actualProductionTagName = createProductionTagName(invalidReleaseIdentifier);
 
-    assert(actualProductionTagName.isErr);
+    assert(actualProductionTagName.isErr === true);
 
     expect(actualProductionTagName.error.message).toBe('Invalid release identifier: 2026-06-19');
   });
@@ -142,12 +142,12 @@ describe('releaseMetadata', () => {
 
     const actualProductionTagName = validateProductionTagName(productionTagName);
 
-    assert(actualProductionTagName.isOk);
+    assert(actualProductionTagName.isOk === true);
 
     expect(actualProductionTagName.value).toBe(productionTagName);
   });
 
-  it.each(['2026-07-27.1-airgap-a', '2026-07-27.1-customer2-hotfix'])(
+  it.each(['2026-07-27.1-airgap-a', '2026-07-27.1-airgap-hotfix'])(
     'validateMaintenanceLineKey() accepts valid maintenance line key "%s"',
     maintenanceLineKey => {
       const actualMaintenanceLineKey = validateMaintenanceLineKey(maintenanceLineKey);
@@ -302,7 +302,7 @@ describe('releaseMetadata', () => {
   ])('validateProductionTagName() rejects invalid production tag name "%s"', invalidProductionTagName => {
     const actualProductionTagName = validateProductionTagName(invalidProductionTagName);
 
-    assert(actualProductionTagName.isErr);
+    assert(actualProductionTagName.isErr === true);
 
     expect(actualProductionTagName.error.message).toBe(`Invalid production tag name: ${invalidProductionTagName}`);
   });
@@ -319,7 +319,7 @@ describe('releaseMetadata', () => {
         'development',
       );
 
-      assert(actualBuildVersion.isOk);
+      assert(actualBuildVersion.isOk === true);
 
       expect(actualBuildVersion.value).toBe(expectedVersion);
     },
@@ -338,7 +338,7 @@ describe('releaseMetadata', () => {
         buildChannel,
       );
 
-      assert(actualBuildVersion.isOk);
+      assert(actualBuildVersion.isOk === true);
 
       expect(actualBuildVersion.value).toBe(expectedVersion);
     },
@@ -347,7 +347,7 @@ describe('releaseMetadata', () => {
   it('resolveWebappBuildVersion() uses the explicit unknown fallback without a commit', () => {
     const actualBuildVersion = resolveWebappBuildVersion('', '', 'development');
 
-    assert(actualBuildVersion.isOk);
+    assert(actualBuildVersion.isOk === true);
 
     expect(actualBuildVersion.value).toBe('dev-unknown');
   });
@@ -355,7 +355,7 @@ describe('releaseMetadata', () => {
   it('resolveWebappBuildVersion() rejects unknown non-empty tags', () => {
     const actualBuildVersion = resolveWebappBuildVersion('2026-06-19.1-production.unknown', '025edc6', 'development');
 
-    assert(actualBuildVersion.isErr);
+    assert(actualBuildVersion.isErr === true);
 
     expect(actualBuildVersion.error.message).toBe('Invalid production tag name: 2026-06-19.1-production.unknown');
   });
@@ -363,7 +363,7 @@ describe('releaseMetadata', () => {
   it('resolveWebappBuildVersion() requires a production tag on the production channel', () => {
     const actualBuildVersion = resolveWebappBuildVersion('', '025edc663787b3d2da366f21a5958013201e6cd4', 'production');
 
-    assert(actualBuildVersion.isErr);
+    assert(actualBuildVersion.isErr === true);
 
     expect(actualBuildVersion.error.message).toBe('A production webapp build requires a production tag name');
   });
@@ -375,7 +375,7 @@ describe('releaseMetadata', () => {
       'production',
     );
 
-    assert(actualBuildVersion.isErr);
+    assert(actualBuildVersion.isErr === true);
 
     expect(actualBuildVersion.error.message).toBe('Invalid production tag name: 2026-07-20-staging.1');
   });
@@ -386,7 +386,7 @@ describe('releaseMetadata', () => {
 
     const actualNextBetaTagName = createNextBetaTagName(releaseIdentifier, existingTagNames);
 
-    assert(actualNextBetaTagName.isOk);
+    assert(actualNextBetaTagName.isOk === true);
 
     expect(actualNextBetaTagName.value).toBe('2026-06-19.1-beta.3');
   });
@@ -403,7 +403,7 @@ describe('releaseMetadata', () => {
 
     const actualNextBetaTagName = createNextBetaTagName(releaseIdentifier, existingTagNames);
 
-    assert(actualNextBetaTagName.isOk);
+    assert(actualNextBetaTagName.isOk === true);
 
     expect(actualNextBetaTagName.value).toBe('2026-06-19.1-beta.2');
   });
@@ -414,7 +414,7 @@ describe('releaseMetadata', () => {
 
     const actualNextBetaTagName = createNextBetaTagName(releaseIdentifier, existingTagNames);
 
-    assert(actualNextBetaTagName.isOk);
+    assert(actualNextBetaTagName.isOk === true);
 
     expect(actualNextBetaTagName.value).toBe('2026-06-19.1-beta.1');
   });
@@ -424,7 +424,7 @@ describe('releaseMetadata', () => {
 
     const actualNextBetaTagName = createNextBetaTagName(invalidReleaseIdentifier, []);
 
-    assert(actualNextBetaTagName.isErr);
+    assert(actualNextBetaTagName.isErr === true);
 
     expect(actualNextBetaTagName.error.message).toBe('Invalid release identifier: 2026-06-19');
   });
@@ -435,7 +435,7 @@ describe('releaseMetadata', () => {
 
     const actualProductionTagExists = productionTagExists(releaseIdentifier, existingTagNames);
 
-    assert(actualProductionTagExists.isOk);
+    assert(actualProductionTagExists.isOk === true);
 
     expect(actualProductionTagExists.value).toBe(true);
   });
@@ -446,7 +446,7 @@ describe('releaseMetadata', () => {
 
     const actualProductionTagExists = productionTagExists(releaseIdentifier, existingTagNames);
 
-    assert(actualProductionTagExists.isOk);
+    assert(actualProductionTagExists.isOk === true);
 
     expect(actualProductionTagExists.value).toBe(false);
   });
@@ -465,7 +465,7 @@ describe('releaseMetadata', () => {
       releaseTagMetadata,
     });
 
-    assert(actualProductionTagPointsToCommit.isOk);
+    assert(actualProductionTagPointsToCommit.isOk === true);
 
     expect(actualProductionTagPointsToCommit.value).toBe(true);
   });
@@ -483,7 +483,7 @@ describe('releaseMetadata', () => {
       releaseTagMetadata,
     });
 
-    assert(actualProductionTagPointsToCommit.isOk);
+    assert(actualProductionTagPointsToCommit.isOk === true);
 
     expect(actualProductionTagPointsToCommit.value).toBe(false);
   });
@@ -499,7 +499,7 @@ describe('releaseMetadata', () => {
       releaseTagMetadata,
     });
 
-    assert(actualProductionTagPointsToCommit.isOk);
+    assert(actualProductionTagPointsToCommit.isOk === true);
 
     expect(actualProductionTagPointsToCommit.value).toBe(false);
   });

--- a/bin/releaseMetadata.test.ts
+++ b/bin/releaseMetadata.test.ts
@@ -20,6 +20,8 @@
 import assert from 'node:assert';
 
 import {
+  createMaintenanceBranchName,
+  createNextMaintenanceTagName,
   createNextBetaTagName,
   createProductionTagName,
   createReleaseBranchName,
@@ -28,6 +30,10 @@ import {
   productionTagExists,
   productionTagPointsToCommit,
   resolveWebappBuildVersion,
+  validateMaintenanceBranchName,
+  validateMaintenanceLineKey,
+  validateMaintenanceSource,
+  validateMaintenanceTagName,
   validateProductionTagName,
 } from './releaseMetadata';
 import type {CommitHash, ReleaseTagMetadata} from './releaseMetadata';
@@ -75,7 +81,7 @@ describe('releaseMetadata', () => {
 
     const actualReleaseIdentifier = extractReleaseIdentifierFromBranchName(branchName);
 
-    assert(actualReleaseIdentifier.isOk === true);
+    assert(actualReleaseIdentifier.isOk);
 
     expect(actualReleaseIdentifier.value).toBe('2026-06-19.1');
   });
@@ -85,7 +91,7 @@ describe('releaseMetadata', () => {
 
     const actualReleaseIdentifier = extractReleaseIdentifierFromBranchName(invalidBranchName);
 
-    assert(actualReleaseIdentifier.isErr === true);
+    assert(actualReleaseIdentifier.isErr);
 
     expect(actualReleaseIdentifier.error.message).toBe('Invalid release branch name: release/2026-06-01');
   });
@@ -95,7 +101,7 @@ describe('releaseMetadata', () => {
 
     const actualReleaseBranchName = createReleaseBranchName(releaseIdentifier);
 
-    assert(actualReleaseBranchName.isOk === true);
+    assert(actualReleaseBranchName.isOk);
 
     expect(actualReleaseBranchName.value).toBe('release/2026-06-19.1');
   });
@@ -105,7 +111,7 @@ describe('releaseMetadata', () => {
     invalidReleaseIdentifier => {
       const actualReleaseBranchName = createReleaseBranchName(invalidReleaseIdentifier);
 
-      assert(actualReleaseBranchName.isErr === true);
+      assert(actualReleaseBranchName.isErr);
 
       expect(actualReleaseBranchName.error.message).toBe(`Invalid release identifier: ${invalidReleaseIdentifier}`);
     },
@@ -116,7 +122,7 @@ describe('releaseMetadata', () => {
 
     const actualProductionTagName = createProductionTagName(releaseIdentifier);
 
-    assert(actualProductionTagName.isOk === true);
+    assert(actualProductionTagName.isOk);
 
     expect(actualProductionTagName.value).toBe('2026-06-19.1-production');
   });
@@ -126,7 +132,7 @@ describe('releaseMetadata', () => {
 
     const actualProductionTagName = createProductionTagName(invalidReleaseIdentifier);
 
-    assert(actualProductionTagName.isErr === true);
+    assert(actualProductionTagName.isErr);
 
     expect(actualProductionTagName.error.message).toBe('Invalid release identifier: 2026-06-19');
   });
@@ -136,9 +142,156 @@ describe('releaseMetadata', () => {
 
     const actualProductionTagName = validateProductionTagName(productionTagName);
 
-    assert(actualProductionTagName.isOk === true);
+    assert(actualProductionTagName.isOk);
 
     expect(actualProductionTagName.value).toBe(productionTagName);
+  });
+
+  it.each(['2026-07-27.1-airgap-a', '2026-07-27.1-customer2-hotfix'])(
+    'validateMaintenanceLineKey() accepts valid maintenance line key "%s"',
+    maintenanceLineKey => {
+      const actualMaintenanceLineKey = validateMaintenanceLineKey(maintenanceLineKey);
+
+      assert(actualMaintenanceLineKey.isOk);
+
+      expect(actualMaintenanceLineKey.value).toBe(maintenanceLineKey);
+    },
+  );
+
+  it.each([
+    '2026-07-27.0-airgap-a',
+    '2026-07-27-airgap-a',
+    '2026-7-27.1-airgap-a',
+    '2026-07-27.1',
+    '2026-07-27.1-Airgap-a',
+    '2026-07-27.1-airgap--a',
+    '2026-07-27.1-airgap-',
+    '2026-07-27.1-air_gap',
+    '2026-07-27.1-airgap/a',
+    '2026-07-27.1-airgap a',
+  ])('validateMaintenanceLineKey() rejects malformed maintenance line key "%s"', invalidMaintenanceLineKey => {
+    const actualMaintenanceLineKey = validateMaintenanceLineKey(invalidMaintenanceLineKey);
+
+    assert(actualMaintenanceLineKey.isErr);
+
+    expect(actualMaintenanceLineKey.error.message).toBe(`Invalid maintenance line key: ${invalidMaintenanceLineKey}`);
+  });
+
+  it('createMaintenanceBranchName() creates the maintenance branch name', () => {
+    const maintenanceLineKey = '2026-07-27.1-airgap-a';
+
+    const actualMaintenanceBranchName = createMaintenanceBranchName(maintenanceLineKey);
+
+    assert(actualMaintenanceBranchName.isOk);
+
+    expect(actualMaintenanceBranchName.value).toBe('maintenance/2026-07-27.1-airgap-a');
+  });
+
+  it('validateMaintenanceBranchName() accepts a generated maintenance branch name', () => {
+    const maintenanceBranchName = 'maintenance/2026-07-27.1-airgap-a';
+
+    const actualMaintenanceBranchName = validateMaintenanceBranchName(maintenanceBranchName);
+
+    assert(actualMaintenanceBranchName.isOk);
+
+    expect(actualMaintenanceBranchName.value).toBe(maintenanceBranchName);
+  });
+
+  it.each(['maintenance/2026-07-27.0-airgap-a', 'release/2026-07-27.1-airgap-a', 'maintenance/2026-07-27.1-airgap--a'])(
+    'validateMaintenanceBranchName() rejects invalid maintenance branch name "%s"',
+    invalidMaintenanceBranchName => {
+      const actualMaintenanceBranchName = validateMaintenanceBranchName(invalidMaintenanceBranchName);
+
+      assert(actualMaintenanceBranchName.isErr);
+
+      expect(actualMaintenanceBranchName.error.message).toBe(
+        `Invalid maintenance branch name: ${invalidMaintenanceBranchName}`,
+      );
+    },
+  );
+
+  it.each(['2026-07-27.1-airgap-a-maintenance.1', '2026-07-27.1-airgap-a-hotfix-maintenance.10'])(
+    'validateMaintenanceTagName() accepts a valid maintenance tag "%s"',
+    maintenanceTagName => {
+      const actualMaintenanceTagName = validateMaintenanceTagName(maintenanceTagName);
+
+      assert(actualMaintenanceTagName.isOk);
+
+      expect(actualMaintenanceTagName.value).toBe(maintenanceTagName);
+    },
+  );
+
+  it.each([
+    '2026-07-27.0-airgap-a-maintenance.1',
+    '2026-07-27.1-airgap-a-maintenance.0',
+    '2026-07-27.1-airgap-a-maintenance.x',
+    '2026-07-27.1-Airgap-a-maintenance.1',
+    '2026-07-27.1-airgap--a-maintenance.1',
+    '2026-07-27.1-airgap-a-maintenance-1',
+    '2026-07-27.1-airgap-a-maintenance.1/extra',
+  ])('validateMaintenanceTagName() rejects invalid maintenance tag "%s"', invalidMaintenanceTagName => {
+    const actualMaintenanceTagName = validateMaintenanceTagName(invalidMaintenanceTagName);
+
+    assert(actualMaintenanceTagName.isErr);
+
+    expect(actualMaintenanceTagName.error.message).toBe(`Invalid maintenance tag name: ${invalidMaintenanceTagName}`);
+  });
+
+  it('createNextMaintenanceTagName() starts at maintenance.1 with an empty history', () => {
+    const actualNextMaintenanceTagName = createNextMaintenanceTagName('2026-07-27.1-airgap-a', []);
+
+    assert(actualNextMaintenanceTagName.isOk);
+
+    expect(actualNextMaintenanceTagName.value).toBe('2026-07-27.1-airgap-a-maintenance.1');
+  });
+
+  it('createNextMaintenanceTagName() increments maintenance.9 to maintenance.10', () => {
+    const actualNextMaintenanceTagName = createNextMaintenanceTagName('2026-07-27.1-airgap-a', [
+      '2026-07-27.1-airgap-a-maintenance.9',
+    ]);
+
+    assert(actualNextMaintenanceTagName.isOk);
+
+    expect(actualNextMaintenanceTagName.value).toBe('2026-07-27.1-airgap-a-maintenance.10');
+  });
+
+  it('createNextMaintenanceTagName() ignores unrelated tags', () => {
+    const actualNextMaintenanceTagName = createNextMaintenanceTagName('2026-07-27.1-airgap-a', [
+      '2026-07-27.1-airgap-b-maintenance.9',
+      '2026-07-27.1-airgap-a-maintenance.2',
+      '2026-07-27.1-production',
+      'unrelated-tag',
+    ]);
+
+    assert(actualNextMaintenanceTagName.isOk);
+
+    expect(actualNextMaintenanceTagName.value).toBe('2026-07-27.1-airgap-a-maintenance.3');
+  });
+
+  it('validateMaintenanceSource() accepts a matching ADR Production tag', () => {
+    const actualSourceProductionTag = validateMaintenanceSource('2026-07-27.1-airgap-a', '2026-07-27.1-production');
+
+    assert(actualSourceProductionTag.isOk);
+
+    expect(actualSourceProductionTag.value).toBe('2026-07-27.1-production');
+  });
+
+  it('validateMaintenanceSource() rejects a Production tag from a different release identifier', () => {
+    const actualSourceProductionTag = validateMaintenanceSource('2026-07-27.1-airgap-a', '2026-07-28.1-production');
+
+    assert(actualSourceProductionTag.isErr);
+
+    expect(actualSourceProductionTag.error.message).toBe(
+      'Source production tag 2026-07-28.1-production does not belong to maintenance line 2026-07-27.1-airgap-a',
+    );
+  });
+
+  it('validateMaintenanceSource() rejects a legacy Production tag', () => {
+    const actualSourceProductionTag = validateMaintenanceSource('2026-07-27.1-airgap-a', '2026-07-27-production.1');
+
+    assert(actualSourceProductionTag.isErr);
+
+    expect(actualSourceProductionTag.error.message).toBe('Invalid production tag name: 2026-07-27-production.1');
   });
 
   it.each([
@@ -149,7 +302,7 @@ describe('releaseMetadata', () => {
   ])('validateProductionTagName() rejects invalid production tag name "%s"', invalidProductionTagName => {
     const actualProductionTagName = validateProductionTagName(invalidProductionTagName);
 
-    assert(actualProductionTagName.isErr === true);
+    assert(actualProductionTagName.isErr);
 
     expect(actualProductionTagName.error.message).toBe(`Invalid production tag name: ${invalidProductionTagName}`);
   });
@@ -166,7 +319,7 @@ describe('releaseMetadata', () => {
         'development',
       );
 
-      assert(actualBuildVersion.isOk === true);
+      assert(actualBuildVersion.isOk);
 
       expect(actualBuildVersion.value).toBe(expectedVersion);
     },
@@ -185,7 +338,7 @@ describe('releaseMetadata', () => {
         buildChannel,
       );
 
-      assert(actualBuildVersion.isOk === true);
+      assert(actualBuildVersion.isOk);
 
       expect(actualBuildVersion.value).toBe(expectedVersion);
     },
@@ -194,7 +347,7 @@ describe('releaseMetadata', () => {
   it('resolveWebappBuildVersion() uses the explicit unknown fallback without a commit', () => {
     const actualBuildVersion = resolveWebappBuildVersion('', '', 'development');
 
-    assert(actualBuildVersion.isOk === true);
+    assert(actualBuildVersion.isOk);
 
     expect(actualBuildVersion.value).toBe('dev-unknown');
   });
@@ -202,7 +355,7 @@ describe('releaseMetadata', () => {
   it('resolveWebappBuildVersion() rejects unknown non-empty tags', () => {
     const actualBuildVersion = resolveWebappBuildVersion('2026-06-19.1-production.unknown', '025edc6', 'development');
 
-    assert(actualBuildVersion.isErr === true);
+    assert(actualBuildVersion.isErr);
 
     expect(actualBuildVersion.error.message).toBe('Invalid production tag name: 2026-06-19.1-production.unknown');
   });
@@ -210,7 +363,7 @@ describe('releaseMetadata', () => {
   it('resolveWebappBuildVersion() requires a production tag on the production channel', () => {
     const actualBuildVersion = resolveWebappBuildVersion('', '025edc663787b3d2da366f21a5958013201e6cd4', 'production');
 
-    assert(actualBuildVersion.isErr === true);
+    assert(actualBuildVersion.isErr);
 
     expect(actualBuildVersion.error.message).toBe('A production webapp build requires a production tag name');
   });
@@ -222,7 +375,7 @@ describe('releaseMetadata', () => {
       'production',
     );
 
-    assert(actualBuildVersion.isErr === true);
+    assert(actualBuildVersion.isErr);
 
     expect(actualBuildVersion.error.message).toBe('Invalid production tag name: 2026-07-20-staging.1');
   });
@@ -233,7 +386,7 @@ describe('releaseMetadata', () => {
 
     const actualNextBetaTagName = createNextBetaTagName(releaseIdentifier, existingTagNames);
 
-    assert(actualNextBetaTagName.isOk === true);
+    assert(actualNextBetaTagName.isOk);
 
     expect(actualNextBetaTagName.value).toBe('2026-06-19.1-beta.3');
   });
@@ -250,7 +403,7 @@ describe('releaseMetadata', () => {
 
     const actualNextBetaTagName = createNextBetaTagName(releaseIdentifier, existingTagNames);
 
-    assert(actualNextBetaTagName.isOk === true);
+    assert(actualNextBetaTagName.isOk);
 
     expect(actualNextBetaTagName.value).toBe('2026-06-19.1-beta.2');
   });
@@ -261,7 +414,7 @@ describe('releaseMetadata', () => {
 
     const actualNextBetaTagName = createNextBetaTagName(releaseIdentifier, existingTagNames);
 
-    assert(actualNextBetaTagName.isOk === true);
+    assert(actualNextBetaTagName.isOk);
 
     expect(actualNextBetaTagName.value).toBe('2026-06-19.1-beta.1');
   });
@@ -271,7 +424,7 @@ describe('releaseMetadata', () => {
 
     const actualNextBetaTagName = createNextBetaTagName(invalidReleaseIdentifier, []);
 
-    assert(actualNextBetaTagName.isErr === true);
+    assert(actualNextBetaTagName.isErr);
 
     expect(actualNextBetaTagName.error.message).toBe('Invalid release identifier: 2026-06-19');
   });
@@ -282,7 +435,7 @@ describe('releaseMetadata', () => {
 
     const actualProductionTagExists = productionTagExists(releaseIdentifier, existingTagNames);
 
-    assert(actualProductionTagExists.isOk === true);
+    assert(actualProductionTagExists.isOk);
 
     expect(actualProductionTagExists.value).toBe(true);
   });
@@ -293,7 +446,7 @@ describe('releaseMetadata', () => {
 
     const actualProductionTagExists = productionTagExists(releaseIdentifier, existingTagNames);
 
-    assert(actualProductionTagExists.isOk === true);
+    assert(actualProductionTagExists.isOk);
 
     expect(actualProductionTagExists.value).toBe(false);
   });
@@ -312,7 +465,7 @@ describe('releaseMetadata', () => {
       releaseTagMetadata,
     });
 
-    assert(actualProductionTagPointsToCommit.isOk === true);
+    assert(actualProductionTagPointsToCommit.isOk);
 
     expect(actualProductionTagPointsToCommit.value).toBe(true);
   });
@@ -330,7 +483,7 @@ describe('releaseMetadata', () => {
       releaseTagMetadata,
     });
 
-    assert(actualProductionTagPointsToCommit.isOk === true);
+    assert(actualProductionTagPointsToCommit.isOk);
 
     expect(actualProductionTagPointsToCommit.value).toBe(false);
   });
@@ -346,7 +499,7 @@ describe('releaseMetadata', () => {
       releaseTagMetadata,
     });
 
-    assert(actualProductionTagPointsToCommit.isOk === true);
+    assert(actualProductionTagPointsToCommit.isOk);
 
     expect(actualProductionTagPointsToCommit.value).toBe(false);
   });

--- a/bin/releaseMetadata.test.ts
+++ b/bin/releaseMetadata.test.ts
@@ -268,7 +268,7 @@ describe('releaseMetadata', () => {
     expect(actualNextMaintenanceTagName.value).toBe('2026-07-27.1-airgap-a-maintenance.3');
   });
 
-  it('validateMaintenanceSource() accepts a matching ADR Production tag', () => {
+  it('validateMaintenanceSource() accepts a matching Production tag', () => {
     const actualSourceProductionTag = validateMaintenanceSource('2026-07-27.1-airgap-a', '2026-07-27.1-production');
 
     assert(actualSourceProductionTag.isOk);

--- a/bin/releaseMetadata.ts
+++ b/bin/releaseMetadata.ts
@@ -29,6 +29,9 @@ export type ReleaseIdentifier =
 export type ReleaseBranchName = NonEmptyString<`release/${ReleaseIdentifier}`>;
 export type BetaTagName = NonEmptyString<`${ReleaseIdentifier}-beta.${number}`>;
 export type ProductionTagName = NonEmptyString<`${ReleaseIdentifier}-production`>;
+export type MaintenanceLineKey = NonEmptyString<`${ReleaseIdentifier}-${string}`>;
+export type MaintenanceBranchName = NonEmptyString<`maintenance/${MaintenanceLineKey}`>;
+export type MaintenanceTagName = NonEmptyString<`${MaintenanceLineKey}-maintenance.${number}`>;
 export type ReleaseTagName = BetaTagName | ProductionTagName;
 export type CommitHash = string & {readonly [commitHashBrand]: 'CommitHash'};
 export type WebappBuildChannel = 'main' | 'development' | 'production';
@@ -49,6 +52,13 @@ const releaseIdentifierPattern = String.raw`${releaseDatePattern}\.[1-9]\d*`;
 const releaseBranchNamePattern = new RegExp(`^release/(${releaseIdentifierPattern})$`);
 const productionTagNamePattern = new RegExp(`^(${releaseIdentifierPattern})-production$`);
 const legacyProductionTagNamePattern = new RegExp(String.raw`^${releaseDatePattern}-production\.\d+$`);
+const maintenanceLineKeyPattern = new RegExp(String.raw`^${releaseIdentifierPattern}-[a-z0-9]+(?:-[a-z0-9]+)*$`);
+const maintenanceBranchNamePattern = new RegExp(
+  String.raw`^maintenance/${releaseIdentifierPattern}-[a-z0-9]+(?:-[a-z0-9]+)*$`,
+);
+const maintenanceTagNamePattern = new RegExp(
+  String.raw`^${releaseIdentifierPattern}-[a-z0-9]+(?:-[a-z0-9]+)*-maintenance\.[1-9]\d*$`,
+);
 
 function isWebappBuildChannel(value: string): value is WebappBuildChannel {
   return value === 'main' || value === 'development' || value === 'production';
@@ -66,6 +76,18 @@ function validateReleaseIdentifier(releaseIdentifier: string): Result<ReleaseIde
   }
 
   return Result.ok(releaseIdentifier as ReleaseIdentifier);
+}
+
+function isMaintenanceLineKey(value: string): value is MaintenanceLineKey {
+  return maintenanceLineKeyPattern.test(value);
+}
+
+function isMaintenanceBranchName(value: string): value is MaintenanceBranchName {
+  return maintenanceBranchNamePattern.test(value);
+}
+
+function isMaintenanceTagName(value: string): value is MaintenanceTagName {
+  return maintenanceTagNamePattern.test(value);
 }
 
 export function isReleaseBranchName(branchName: string): boolean {
@@ -110,6 +132,102 @@ export function validateProductionTagName(productionTagName: string): Result<Pro
   }
 
   return Result.ok(productionTagName as ProductionTagName);
+}
+
+export function validateMaintenanceLineKey(maintenanceLineKey: string): Result<MaintenanceLineKey, Error> {
+  if (!isMaintenanceLineKey(maintenanceLineKey)) {
+    return Result.err(new Error(`Invalid maintenance line key: ${maintenanceLineKey}`));
+  }
+
+  return Result.ok(maintenanceLineKey);
+}
+
+export function createMaintenanceBranchName(maintenanceLineKey: string): Result<MaintenanceBranchName, Error> {
+  const maintenanceLineKeyResult = validateMaintenanceLineKey(maintenanceLineKey);
+
+  if (maintenanceLineKeyResult.isErr) {
+    return Result.err(maintenanceLineKeyResult.error);
+  }
+
+  return validateMaintenanceBranchName(`maintenance/${maintenanceLineKeyResult.value}`);
+}
+
+export function validateMaintenanceBranchName(maintenanceBranchName: string): Result<MaintenanceBranchName, Error> {
+  if (!isMaintenanceBranchName(maintenanceBranchName)) {
+    return Result.err(new Error(`Invalid maintenance branch name: ${maintenanceBranchName}`));
+  }
+
+  return Result.ok(maintenanceBranchName);
+}
+
+export function validateMaintenanceTagName(maintenanceTagName: string): Result<MaintenanceTagName, Error> {
+  if (!isMaintenanceTagName(maintenanceTagName)) {
+    return Result.err(new Error(`Invalid maintenance tag name: ${maintenanceTagName}`));
+  }
+
+  return Result.ok(maintenanceTagName);
+}
+
+export function createNextMaintenanceTagName(
+  maintenanceLineKey: string,
+  existingTagNames: readonly string[],
+): Result<MaintenanceTagName, Error> {
+  const maintenanceLineKeyResult = validateMaintenanceLineKey(maintenanceLineKey);
+
+  if (maintenanceLineKeyResult.isErr) {
+    return Result.err(maintenanceLineKeyResult.error);
+  }
+
+  const escapedMaintenanceLineKey = escapeRegularExpression(maintenanceLineKeyResult.value);
+  const maintenanceTagPattern = new RegExp(String.raw`^${escapedMaintenanceLineKey}-maintenance\.([1-9]\d*)$`);
+  const existingMaintenanceTagNumbers = existingTagNames.flatMap(existingTagName => {
+    const existingTagNameMatch = maintenanceTagPattern.exec(existingTagName);
+
+    if (existingTagNameMatch === null) {
+      return [];
+    }
+
+    return [Number(existingTagNameMatch[1])];
+  });
+  const latestMaintenanceTagNumber =
+    existingMaintenanceTagNumbers.length > 0 ? Math.max(...existingMaintenanceTagNumbers) : 0;
+  const nextMaintenanceTagNumber = latestMaintenanceTagNumber + 1;
+
+  return validateMaintenanceTagName(`${maintenanceLineKeyResult.value}-maintenance.${nextMaintenanceTagNumber}`);
+}
+
+export function validateMaintenanceSource(
+  maintenanceLineKey: string,
+  sourceProductionTag: string,
+): Result<ProductionTagName, Error> {
+  const maintenanceLineKeyResult = validateMaintenanceLineKey(maintenanceLineKey);
+
+  if (maintenanceLineKeyResult.isErr) {
+    return Result.err(maintenanceLineKeyResult.error);
+  }
+
+  const sourceProductionTagResult = validateProductionTagName(sourceProductionTag);
+
+  if (sourceProductionTagResult.isErr) {
+    return Result.err(sourceProductionTagResult.error);
+  }
+
+  const releaseIdentifierEndIndex = maintenanceLineKeyResult.value.indexOf(
+    '-',
+    maintenanceLineKeyResult.value.indexOf('.') + 1,
+  );
+  const releaseIdentifier = maintenanceLineKeyResult.value.slice(0, releaseIdentifierEndIndex);
+  const expectedSourceProductionTag = `${releaseIdentifier}-production`;
+
+  if (sourceProductionTagResult.value !== expectedSourceProductionTag) {
+    return Result.err(
+      new Error(
+        `Source production tag ${sourceProductionTag} does not belong to maintenance line ${maintenanceLineKey}`,
+      ),
+    );
+  }
+
+  return Result.ok(sourceProductionTagResult.value);
 }
 
 export function resolveWebappBuildVersion(

--- a/bin/releaseMetadataCli.test.ts
+++ b/bin/releaseMetadataCli.test.ts
@@ -186,6 +186,116 @@ describe('releaseMetadataCli', () => {
     });
   });
 
+  it('prints a maintenance branch name for a valid maintenance line key', () => {
+    const actualResult = runCommand(['maintenance-branch', '2026-07-27.1-airgap-a']);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['maintenance/2026-07-27.1-airgap-a'],
+    });
+  });
+
+  it('rejects an invalid maintenance line key', () => {
+    const actualResult = runCommand(['maintenance-branch', '2026-07-27.0-airgap-a']);
+
+    expect(actualResult).toEqual({
+      errors: ['Invalid maintenance line key: 2026-07-27.0-airgap-a'],
+      exitCode: 1,
+      outputs: [],
+    });
+  });
+
+  it('validates a maintenance tag name', () => {
+    const actualResult = runCommand(['validate-maintenance-tag', '2026-07-27.1-airgap-a-maintenance.1']);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['2026-07-27.1-airgap-a-maintenance.1'],
+    });
+  });
+
+  it('rejects a malformed maintenance tag name', () => {
+    const actualResult = runCommand(['validate-maintenance-tag', '2026-07-27.1-airgap-a-maintenance.0']);
+
+    expect(actualResult).toEqual({
+      errors: ['Invalid maintenance tag name: 2026-07-27.1-airgap-a-maintenance.0'],
+      exitCode: 1,
+      outputs: [],
+    });
+  });
+
+  it('prints the next maintenance tag name and ignores unrelated tags', () => {
+    const actualResult = runCommand([
+      'next-maintenance-tag',
+      '2026-07-27.1-airgap-a',
+      '2026-07-27.1-airgap-b-maintenance.9',
+      '2026-07-27.1-airgap-a-maintenance.9',
+      '2026-07-27.1-production',
+    ]);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['2026-07-27.1-airgap-a-maintenance.10'],
+    });
+  });
+
+  it('prints the next maintenance tag name when there is no existing tag', () => {
+    const actualResult = runCommand(['next-maintenance-tag', '2026-07-27.1-airgap-a']);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['2026-07-27.1-airgap-a-maintenance.1'],
+    });
+  });
+
+  it('validates a matching maintenance source Production tag', () => {
+    const actualResult = runCommand([
+      'validate-maintenance-source',
+      '2026-07-27.1-airgap-a',
+      '2026-07-27.1-production',
+    ]);
+
+    expect(actualResult).toEqual({
+      errors: [],
+      exitCode: 0,
+      outputs: ['2026-07-27.1-production'],
+    });
+  });
+
+  it('rejects a mismatching maintenance source Production tag', () => {
+    const actualResult = runCommand([
+      'validate-maintenance-source',
+      '2026-07-27.1-airgap-a',
+      '2026-07-28.1-production',
+    ]);
+
+    expect(actualResult).toEqual({
+      errors: [
+        'Source production tag 2026-07-28.1-production does not belong to maintenance line 2026-07-27.1-airgap-a',
+      ],
+      exitCode: 1,
+      outputs: [],
+    });
+  });
+
+  it('rejects a legacy maintenance source Production tag', () => {
+    const actualResult = runCommand([
+      'validate-maintenance-source',
+      '2026-07-27.1-airgap-a',
+      '2026-07-27-production.1',
+    ]);
+
+    expect(actualResult).toEqual({
+      errors: ['Invalid production tag name: 2026-07-27-production.1'],
+      exitCode: 1,
+      outputs: [],
+    });
+  });
+
   it('prints usage text for missing command arguments', () => {
     const actualResult = runCommand(['next-beta-tag']);
 

--- a/bin/releaseMetadataCli.ts
+++ b/bin/releaseMetadataCli.ts
@@ -20,11 +20,15 @@
 import process from 'node:process';
 
 import {
+  createMaintenanceBranchName,
+  createNextMaintenanceTagName,
   createNextBetaTagName,
   createProductionTagName,
   createReleaseBranchName,
   extractReleaseIdentifierFromBranchName,
   resolveWebappBuildVersion,
+  validateMaintenanceSource,
+  validateMaintenanceTagName,
   validateProductionTagName,
 } from './releaseMetadata';
 
@@ -42,6 +46,10 @@ const usageText = [
   '  releaseMetadataCli.ts next-beta-tag <YYYY-MM-DD.N> [existing-tag ...]',
   '  releaseMetadataCli.ts production-tag <YYYY-MM-DD.N>',
   '  releaseMetadataCli.ts validate-production-tag <YYYY-MM-DD.N-production>',
+  '  releaseMetadataCli.ts maintenance-branch <YYYY-MM-DD.N-qualifier[-qualifier ...]>',
+  '  releaseMetadataCli.ts validate-maintenance-tag <maintenance-line-key-maintenance.X>',
+  '  releaseMetadataCli.ts next-maintenance-tag <maintenance-line-key> [existing-tag ...]',
+  '  releaseMetadataCli.ts validate-maintenance-source <maintenance-line-key> <YYYY-MM-DD.N-production>',
   '  releaseMetadataCli.ts webapp-build-version <build-reference-or-empty> <full-commit-sha> <main|development|production>',
 ].join('\n');
 
@@ -50,8 +58,12 @@ function writeResult(
     | ReturnType<typeof extractReleaseIdentifierFromBranchName>
     | ReturnType<typeof createReleaseBranchName>
     | ReturnType<typeof createNextBetaTagName>
+    | ReturnType<typeof createMaintenanceBranchName>
+    | ReturnType<typeof createNextMaintenanceTagName>
     | ReturnType<typeof createProductionTagName>
     | ReturnType<typeof resolveWebappBuildVersion>
+    | ReturnType<typeof validateMaintenanceSource>
+    | ReturnType<typeof validateMaintenanceTagName>
     | ReturnType<typeof validateProductionTagName>,
   dependencies: ReleaseMetadataCliDependencies,
 ): number {
@@ -80,6 +92,22 @@ export function runReleaseMetadataCli(
 
   if (commandName === 'next-beta-tag' && primaryValue !== undefined) {
     return writeResult(createNextBetaTagName(primaryValue, remainingValues), dependencies);
+  }
+
+  if (commandName === 'maintenance-branch' && primaryValue !== undefined && remainingValues.length === 0) {
+    return writeResult(createMaintenanceBranchName(primaryValue), dependencies);
+  }
+
+  if (commandName === 'validate-maintenance-tag' && primaryValue !== undefined && remainingValues.length === 0) {
+    return writeResult(validateMaintenanceTagName(primaryValue), dependencies);
+  }
+
+  if (commandName === 'next-maintenance-tag' && primaryValue !== undefined) {
+    return writeResult(createNextMaintenanceTagName(primaryValue, remainingValues), dependencies);
+  }
+
+  if (commandName === 'validate-maintenance-source' && primaryValue !== undefined && remainingValues.length === 1) {
+    return writeResult(validateMaintenanceSource(primaryValue, remainingValues[0]), dependencies);
   }
 
   if (commandName === 'production-tag' && primaryValue !== undefined) {

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -120,7 +120,7 @@ Each Beta candidate processes only its delta. Production reconstructs candidate 
 - The development distribution retains the external channel name `dev`: it publishes the Docker image and a matching prerelease Helm chart, then updates `wire-builds/dev`.
 - `wire-builds/dev` remains the development distribution consumed by downstream internal integration environments; it is separate from the hosted Dev frontend deployment.
 - The legacy tag-driven `publish-and-deploy-webapp.yml` workflow has been deleted. Its obsolete `dev`, `master`, staging-tag, Production-tag, and maintenance publication paths are not restored.
-- The arbitrary manual release-artifact workflow and local staging and Production tag commands have been deleted. `q1-2024` and `q2-2025` publication handling was retired rather than migrated; recovery from existing historical Production tags remains available, and maintenance-release automation remains separate future work for Phase 11.
+- The arbitrary manual release-artifact workflow and local staging and Production tag commands have been deleted. `q1-2024` and `q2-2025` publication handling was retired rather than migrated; recovery from existing historical Production tags remains available, and maintenance-release automation remains separate from the normal cloud release path.
 - The legacy path was retired before the first complete Production run of the final workflow. Any issue discovered during the next release will be repaired in the new pipeline rather than falling back to the retired path.
 - `wire-builds/main` remains Production-only and is never updated by an ordinary `main` push.
 - Development and Production distributions share the same Helm repository and prerelease version namespace. Their Docker, Helm, and `wire-builds` publications use one shared, non-cancellable distribution lock.
@@ -232,6 +232,18 @@ On-premises maintenance releases replace the previous "long-term-support release
 - The webapp team produces the branch, artifact, and tags; customer deployment is handled outside this workflow by the integration or customer deployment process.
 - Maintenance branches do not implicitly deploy to the normal Beta or Production environments.
 - Maintenance validation happens in a dedicated maintenance validation path before a maintenance artifact is handed off.
+
+The final normal cloud workflow was proven with the following release:
+
+```text
+Release identifier: 2026-07-27.1
+Workflow run: 30271304258
+Beta tag: 2026-07-27.1-beta.1
+Production tag: 2026-07-27.1-production
+Commit: 770c6a14cdd2e10c8e32b251b16fab106cec0e1c
+```
+
+Phase 11 uses the matching immutable ADR Production tag as its source, keeps orchestration tooling on `main`, and builds the exact maintenance branch head once. Fixes land on `main` first and reach the maintenance branch through reviewed cherry-pick pull requests. The artifact is validated through `wire-webapp-precommit` with Staging backends before its immutable maintenance tag is created; hosted Beta and Production, `wire-builds`, Docker, Helm, and customer deployment remain outside this workflow.
 
 Branch and tag cleanup follows these rules:
 

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -121,7 +121,7 @@ Each Beta candidate processes only its delta. Production reconstructs candidate 
 - `wire-builds/dev` remains the development distribution consumed by downstream internal integration environments; it is separate from the hosted Dev frontend deployment.
 - The legacy tag-driven `publish-and-deploy-webapp.yml` workflow has been deleted. Its obsolete `dev`, `master`, staging-tag, Production-tag, and maintenance publication paths are not restored.
 - The arbitrary manual release-artifact workflow and local staging and Production tag commands have been deleted. `q1-2024` and `q2-2025` publication handling was retired rather than migrated; recovery from existing historical Production tags remains available, and maintenance-release automation remains separate from the normal cloud release path.
-- The legacy path was retired before the first complete Production run of the final workflow. Any issue discovered during the next release will be repaired in the new pipeline rather than falling back to the retired path.
+- The legacy path was retired before the first complete Production run of the final workflow. The final workflow was subsequently proven by release `2026-07-27.1`.
 - `wire-builds/main` remains Production-only and is never updated by an ordinary `main` push.
 - Development and Production distributions share the same Helm repository and prerelease version namespace. Their Docker, Helm, and `wire-builds` publications use one shared, non-cancellable distribution lock.
 - Edge verifies that its artifact still belongs to the current `main` commit after acquiring the deployment slot; stale Edge builds skip instead of moving Edge backwards.
@@ -243,7 +243,7 @@ Production tag: 2026-07-27.1-production
 Commit: 770c6a14cdd2e10c8e32b251b16fab106cec0e1c
 ```
 
-Phase 11 uses the matching immutable Production tag as its source, keeps orchestration tooling on `main`, and builds the exact maintenance branch head once. Fixes land on `main` first and reach the maintenance branch through reviewed cherry-pick pull requests. The artifact is validated through `wire-webapp-precommit` with Staging backends before its immutable maintenance tag is created; hosted Beta and Production, `wire-builds`, Docker, Helm, and customer deployment remain outside this workflow.
+Phase 11 first creates a missing maintenance branch from the matching immutable Production tag and stops. Fixes arrive through reviewed pull requests; a later run builds and validates the patched branch head through `wire-webapp-precommit` before creating its first `<maintenance-line-key>-maintenance.1` tag. Orchestration tooling comes from the dispatch commit on `main`, while the artifact comes from the maintenance branch; hosted Beta and Production, `wire-builds`, Docker, Helm, and customer deployment remain outside this workflow.
 
 Branch and tag cleanup follows these rules:
 

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -243,7 +243,7 @@ Production tag: 2026-07-27.1-production
 Commit: 770c6a14cdd2e10c8e32b251b16fab106cec0e1c
 ```
 
-Phase 11 uses the matching immutable ADR Production tag as its source, keeps orchestration tooling on `main`, and builds the exact maintenance branch head once. Fixes land on `main` first and reach the maintenance branch through reviewed cherry-pick pull requests. The artifact is validated through `wire-webapp-precommit` with Staging backends before its immutable maintenance tag is created; hosted Beta and Production, `wire-builds`, Docker, Helm, and customer deployment remain outside this workflow.
+Phase 11 uses the matching immutable Production tag as its source, keeps orchestration tooling on `main`, and builds the exact maintenance branch head once. Fixes land on `main` first and reach the maintenance branch through reviewed cherry-pick pull requests. The artifact is validated through `wire-webapp-precommit` with Staging backends before its immutable maintenance tag is created; hosted Beta and Production, `wire-builds`, Docker, Helm, and customer deployment remain outside this workflow.
 
 Branch and tag cleanup follows these rules:
 

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -243,7 +243,7 @@ Production tag: 2026-07-27.1-production
 Commit: 770c6a14cdd2e10c8e32b251b16fab106cec0e1c
 ```
 
-Phase 11 first creates a missing maintenance branch from the matching immutable Production tag and stops. Fixes arrive through reviewed pull requests; a later run builds and validates the patched branch head through `wire-webapp-precommit` before creating its first `<maintenance-line-key>-maintenance.1` tag. Orchestration tooling comes from the dispatch commit on `main`, while the artifact comes from the maintenance branch; hosted Beta and Production, `wire-builds`, Docker, Helm, and customer deployment remain outside this workflow.
+Phase 11 creates a missing maintenance branch and stops; an existing branch still pointing to its source Production commit also stops. Build, validation, and tagging begin only after a reviewed fix advances the branch, and the first patched artifact receives `<maintenance-line-key>-maintenance.1` through `wire-webapp-precommit`. Orchestration tooling comes from the dispatch commit on `main`, while the artifact comes from the maintenance branch; hosted Beta and Production, `wire-builds`, Docker, Helm, and customer deployment remain outside this workflow.
 
 Branch and tag cleanup follows these rules:
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Implement the repository changes for Phase 11 of ADR 0002.

The new manually dispatched `Release Maintenance WebApp` workflow:

* creates or reuses `maintenance/<maintenance-line-key>` from an existing ADR Production tag
* builds the exact maintenance branch commit once
* validates the artifact through `wire-webapp-precommit`
* creates `<maintenance-line-key>-maintenance.X` only after successful validation

Release tooling always comes from `main`; only the application build checks out the maintenance commit. This allows maintenance lines to start from historical Production tags that do not contain the new automation.

The workflow does not deploy to hosted Beta or Production and does not publish Docker, Helm, or either `wire-builds` channel.

ADR 0002 is updated to document the maintenance path and the first successful complete cloud release.

## Post-merge

Equivalent branch protection still needs to be configured for `maintenance/*`, and the workflow secrets and validation-slot ownership must be verified.

Implements the repository changes for Phase 11 of #21597.
