### PR TITLE
chore (e2e): Implement e2e tests TC-1735 and TC-1756 [WPB-25491]

### DIFF
--- a/apps/webapp/test/e2e_tests/.env.tpl
+++ b/apps/webapp/test/e2e_tests/.env.tpl
@@ -35,6 +35,10 @@ SSO_CLAIMED_USER_EMAIL=op://Test Automation/Staging Claimed Domain User/email
 SSO_CLAIMED_USER_PASSWORD=op://Test Automation/Staging Claimed Domain User/password
 SSO_CLAIMED_DOMAIN_CODE=op://Test Automation/Staging Claimed Domain User/SSO code
 
+KEYCLOAK_URL=op://Test Automation/KEYCLOAK_QA_AUTOMATION/website
+KEYCLOAK_USERNAME=op://Test Automation/KEYCLOAK_QA_AUTOMATION/username
+KEYCLOAK_PASSWORD=op://Test Automation/KEYCLOAK_QA_AUTOMATION/password
+
 INBUCKET_USERNAME=op://Test Automation/BackendConnection staging/inbucketUsername
 INBUCKET_PASSWORD="{{ op://Test Automation/BackendConnection staging/inbucketPassword }}"
 INBUCKET_URL=op://Test Automation/BackendConnection staging/inbucketUrl

--- a/apps/webapp/test/e2e_tests/backend/apiManager.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/apiManager.e2e.ts
@@ -31,6 +31,9 @@ import {PropertiesRepositoryE2E} from './propertiesRepostitory.e2e';
 import {TeamRepositoryE2E} from './teamRepository.e2e';
 import {TestServiceClientE2E} from './testServiceClient.e2e';
 import {UserRepositoryE2E} from './userRepository.e2e';
+import {KeycloakClientE2E} from './keycloakClient.e2e';
+import {IdentityProvidersRepositoryE2E} from './identityProvidersRepository.e2e';
+import {ScimRepositoryE2E} from './scimRepository.e2e';
 
 import {User} from '../data/user';
 
@@ -45,14 +48,18 @@ export class ApiManagerE2E {
   conversation: ConversationRepositoryE2E;
   featureConfig: FeatureConfigRepositoryE2E;
   inbucket: InbucketClientE2E;
+  keycloak: KeycloakClientE2E;
   connection: ConnectionRepositoryE2E;
   callingService: CallingServiceClientE2E;
   properties: PropertiesRepositoryE2E;
+  identityProviders: IdentityProvidersRepositoryE2E;
+  scim: ScimRepositoryE2E;
 
   constructor(config: {backendUrl: string; basicAuth: string}) {
     const backendConfig = {backendUrl: config.backendUrl, apiVersion: TEST_API_VERSION};
 
     this.inbucket = new InbucketClientE2E();
+    this.keycloak = new KeycloakClientE2E();
     this.testService = new TestServiceClientE2E();
     this.callingService = new CallingServiceClientE2E();
 
@@ -64,6 +71,8 @@ export class ApiManagerE2E {
     this.featureConfig = new FeatureConfigRepositoryE2E(backendConfig);
     this.connection = new ConnectionRepositoryE2E(backendConfig);
     this.properties = new PropertiesRepositoryE2E(backendConfig);
+    this.identityProviders = new IdentityProvidersRepositoryE2E(backendConfig);
+    this.scim = new ScimRepositoryE2E(backendConfig);
   }
 
   async addDevicesToUser(user: User, numberOfDevices: number) {

--- a/apps/webapp/test/e2e_tests/backend/brigRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/brigRepository.e2e.ts
@@ -179,4 +179,10 @@ export class BrigRepositoryE2E {
   public async deleteDomainClaim(domain: string) {
     await this.axiosInstance.delete(`i/domain-registration/${domain}`);
   }
+
+  public async enableSSOFeature(teamId: string) {
+    await this.axiosInstance.patch(`i/teams/${teamId}/features/sso`, {
+      status: 'enabled',
+    });
+  }
 }

--- a/apps/webapp/test/e2e_tests/backend/identityProvidersRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/identityProvidersRepository.e2e.ts
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {User} from '../data/user';
+import {BackendClientE2E} from './backendClient.e2e';
+
+export class IdentityProvidersRepositoryE2E extends BackendClientE2E {
+  async createIdentityProviderV2(user: User, metadata: string) {
+    const response = await this.axiosInstance.post('identity-providers?api_version=v2', metadata, {
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+        'Content-Type': 'application/xml',
+      },
+    });
+    return response.data.id;
+  }
+}

--- a/apps/webapp/test/e2e_tests/backend/keycloakClient.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/keycloakClient.e2e.ts
@@ -50,7 +50,7 @@ export class KeycloakClientE2E {
       throw new Error('BACKEND_URL is not defined');
     }
 
-    const finalizeUrl = `${this.backendUrl}sso/finalize-login/${user.teamId}`;
+    const finalizeUrl = new URL(`sso/finalize-login/${user.teamId}`, this.backendUrl).toString();
 
     const response = await this.axiosInstance.post(
       `admin/realms/${this.keycloakRealm}/clients`,
@@ -68,7 +68,7 @@ export class KeycloakClientE2E {
         attributes: {
           'display.on.consent.screen': 'false',
           'saml.encrypt': 'false',
-          saml_assertion_consumer_url_post: finalizeUrl,
+          'saml_assertion_consumer_url_post': finalizeUrl,
           'saml.client.signature': 'false',
           'saml.artifact.binding': 'false',
           'saml.assertion.signature': 'true',

--- a/apps/webapp/test/e2e_tests/backend/keycloakClient.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/keycloakClient.e2e.ts
@@ -1,0 +1,157 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import axios, {AxiosInstance} from 'axios';
+import {User} from '../data/user';
+
+export class KeycloakClientE2E {
+  private readonly axiosInstance: AxiosInstance;
+  private readonly keycloakUsername: string;
+  private readonly keycloakPassword: string;
+  private readonly keycloakRealm = 'master';
+  private readonly backendUrl = process.env.BACKEND_URL;
+  public clientId: string | undefined;
+
+  constructor() {
+    this.axiosInstance = axios.create({
+      baseURL: process.env.KEYCLOAK_URL,
+      withCredentials: true,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    this.keycloakUsername = process.env.KEYCLOAK_USERNAME || '';
+    this.keycloakPassword = process.env.KEYCLOAK_PASSWORD || '';
+  }
+
+  async getMetaData() {
+    const response = await this.axiosInstance.get(`realms/${this.keycloakRealm}/protocol/saml/descriptor`);
+    return response.data;
+  }
+
+  async createSamlClient(user: User) {
+    if (!this.backendUrl) {
+      throw new Error('BACKEND_URL is not defined');
+    }
+
+    const finalizeUrl = `${this.backendUrl}sso/finalize-login/${user.teamId}`;
+
+    const response = await this.axiosInstance.post(
+      `admin/realms/${this.keycloakRealm}/clients`,
+      {
+        clientId: finalizeUrl,
+        enabled: true,
+        adminUrl: '',
+        baseUrl: '',
+        rootUrl: '',
+        name: '',
+        description: '',
+        redirectUris: [finalizeUrl],
+        webOrigins: [this.backendUrl.replace(/\/$/, '')],
+        protocol: 'saml',
+        attributes: {
+          'display.on.consent.screen': 'false',
+          'saml.encrypt': 'false',
+          saml_assertion_consumer_url_post: finalizeUrl,
+          'saml.client.signature': 'false',
+          'saml.artifact.binding': 'false',
+          'saml.assertion.signature': 'true',
+          'saml.onetimeuse.condition': 'false',
+          'saml.server.signature.keyinfo.ext': 'false',
+          'saml.server.signature.keyinfo.xmlSigKeyInfoKeyNameTransformer': 'NONE',
+        },
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${await this.authorize()}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    return response.headers['location'].split('/').pop();
+  }
+
+  async createUser(user: User) {
+    const response = await this.axiosInstance.post(
+      `admin/realms/${this.keycloakRealm}/users`,
+      {
+        username: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+        emailVerified: true,
+        enabled: true,
+        credentials: [{type: 'password', value: user.password, temporary: false}],
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${await this.authorize()}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    return response.headers['location'].split('/').pop();
+  }
+
+  async cleanUp(clientId?: string, userIds?: string[]) {
+    if (clientId) {
+      await this.deleteSamlClient(clientId);
+    }
+    if (userIds) {
+      for (const userId of userIds) {
+        await this.deleteUser(userId);
+      }
+    }
+  }
+
+  private async authorize(): Promise<string> {
+    const response = await this.axiosInstance.post(
+      `realms/${this.keycloakRealm}/protocol/openid-connect/token`,
+      new URLSearchParams({
+        client_id: 'admin-cli',
+        username: this.keycloakUsername,
+        password: this.keycloakPassword,
+        grant_type: 'password',
+      }),
+      {headers: {'Content-Type': 'application/x-www-form-urlencoded'}},
+    );
+
+    return response.data.access_token;
+  }
+
+  private async deleteSamlClient(clientId: string) {
+    await this.axiosInstance.delete(`admin/realms/${this.keycloakRealm}/clients/${clientId}`, {
+      headers: {
+        Authorization: `Bearer ${await this.authorize()}`,
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  private async deleteUser(userId: string) {
+    await this.axiosInstance.delete(`admin/realms/${this.keycloakRealm}/users/${userId}`, {
+      headers: {
+        Authorization: `Bearer ${await this.authorize()}`,
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+}

--- a/apps/webapp/test/e2e_tests/backend/keycloakClient.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/keycloakClient.e2e.ts
@@ -68,7 +68,7 @@ export class KeycloakClientE2E {
         attributes: {
           'display.on.consent.screen': 'false',
           'saml.encrypt': 'false',
-          'saml_assertion_consumer_url_post': finalizeUrl,
+          saml_assertion_consumer_url_post: finalizeUrl,
           'saml.client.signature': 'false',
           'saml.artifact.binding': 'false',
           'saml.assertion.signature': 'true',

--- a/apps/webapp/test/e2e_tests/backend/scimRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/scimRepository.e2e.ts
@@ -22,12 +22,6 @@ import {User} from '../data/user';
 
 export class ScimRepositoryE2E extends BackendClientE2E {
   async createSCIMAccessToken(user: User, identityProviderId: string) {
-    const backendUrl = process.env.BACKEND_URL;
-
-    if (!backendUrl) {
-      throw new Error('BACKEND_URL is not defined');
-    }
-
     const response = await this.axiosInstance.post(
       'scim/auth-tokens',
       {

--- a/apps/webapp/test/e2e_tests/backend/scimRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/scimRepository.e2e.ts
@@ -1,0 +1,72 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {BackendClientE2E} from './backendClient.e2e';
+import {User} from '../data/user';
+
+export class ScimRepositoryE2E extends BackendClientE2E {
+  async createSCIMAccessToken(user: User, identityProviderId: string) {
+    const backendUrl = process.env.BACKEND_URL;
+
+    if (!backendUrl) {
+      throw new Error('BACKEND_URL is not defined');
+    }
+
+    const response = await this.axiosInstance.post(
+      'scim/auth-tokens',
+      {
+        description: 'SCIM',
+        idp: identityProviderId,
+        name: user.fullName,
+        password: user.password,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${user.token}`,
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    return response.data.token;
+  }
+
+  async createSCIMUser(user: User, scimToken: string) {
+    const scimUsername = user.email.replace(/[^A-Za-z0-9]/g, '').substring(0, 21);
+
+    const response = await this.axiosInstance.post(
+      'scim/v2/Users',
+      {
+        externalId: user.email,
+        userName: scimUsername,
+        displayName: user.fullName,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${scimToken}`,
+          Accept: 'application/json',
+          'Content-Type': 'application/scim+json',
+        },
+      },
+    );
+
+    return response.data.id;
+  }
+}

--- a/apps/webapp/test/e2e_tests/backend/teamRepository.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/teamRepository.e2e.ts
@@ -23,7 +23,6 @@ import {Service} from '../data/serviceInfo';
 import {User} from '../data/user';
 import {Role} from '@wireapp/api-client/lib/team';
 import {faker} from '@faker-js/faker';
-
 export class TeamRepositoryE2E extends BackendClientE2E {
   async inviteUserToTeam(emailOfInvitee: string, teamOwner: User, role: Role = Role.MEMBER): Promise<string> {
     const response = this.axiosInstance.post(

--- a/apps/webapp/test/e2e_tests/pageManager/index.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/index.ts
@@ -118,7 +118,7 @@ export class PageManager {
   };
 
   openSSOPage = async (baseUrl: string = webAppPath) => {
-    await this.page.goto(new URL(`/auth/#/sso`, baseUrl).toString());
+    await this.page.goto(new URL(`/auth/#/sso`, baseUrl).toString(), {waitUntil: 'commit', timeout: 120_000});
   };
 
   openUrl = (url: string) => {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/account.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/account.page.ts
@@ -57,8 +57,8 @@ export class AccountPage {
     this.restoreBackupButton = page.locator("[data-uie-name='do-backup-import']+button");
     this.logoutButton = page.getByTestId('do-logout');
     this.editEmailButton = page.getByTestId('go-edit-email');
-    this.editDisplayNameButton = page.getByTestId('go-edit-email');
-    this.editUserNameButton = page.getByRole('button', {name: 'Username'});
+    this.editDisplayNameButton = page.getByTestId('go-edit-displayname');
+    this.editUserNameButton = page.getByTestId('go-edit-username');
     this.emailInput = page.getByTestId('enter-email-input');
     this.displayNameInput = page.getByTestId('enter-displayname-input');
     this.userNameInput = page.getByLabel('Username');

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/singleSignOn.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/singleSignOn.page.ts
@@ -36,6 +36,7 @@ export class SingleSignOnPage {
   }
 
   async isSSOPageVisible() {
-    return this.ssoCodeEmailInput.waitFor({state: 'visible'});
+    // The SSO page can take a while to finish booting on slower or restricted networks.
+    return this.ssoCodeEmailInput.waitFor({state: 'visible', timeout: 120_000});
   }
 }

--- a/apps/webapp/test/e2e_tests/specs/SSOAndSCIM/SSOAndSCIM.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SSOAndSCIM/SSOAndSCIM.spec.ts
@@ -64,6 +64,7 @@ test.describe('SSO and SCIM', () => {
 
       const {pages, modals, components} = pageManager.webapp;
       await pageManager.openSSOPage();
+      await pages.singleSignOn().isSSOPageVisible();
 
       await test.step('User enters SSO code into SSO field and clicks login', async () => {
         [idpPage] = await Promise.all([
@@ -105,6 +106,7 @@ test.describe('SSO and SCIM', () => {
 
       const {pages, modals, components} = pageManager.webapp;
       await pageManager.openSSOPage();
+      await pages.singleSignOn().isSSOPageVisible();
 
       await test.step('Precondition: User B is created as SCIM user', async () => {
         const scimToken = await api.scim.createSCIMAccessToken(userA, identityProviderId);

--- a/apps/webapp/test/e2e_tests/specs/SSOAndSCIM/SSOAndSCIM.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SSOAndSCIM/SSOAndSCIM.spec.ts
@@ -1,0 +1,142 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {getUser, User} from 'test/e2e_tests/data/user';
+import {test, expect} from 'test/e2e_tests/test.fixtures';
+import {Page} from '@playwright/test';
+import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
+
+import {FEATURE_KEY} from '@wireapp/api-client/lib/team/feature';
+import {PageManager} from 'test/e2e_tests/pageManager';
+
+test.describe('SSO and SCIM', () => {
+  test.describe.configure({timeout: 180_000});
+  let userA: User;
+  let userB: User;
+  let samlClientId: string;
+  let identityProviderId: string;
+  let keycloakUserId: string;
+
+  test.beforeEach(async ({createTeam, api}) => {
+    // Creating a team and enabling SSO feature.
+    const team = await createTeam('Test Team');
+    userA = team.owner;
+
+    await api.team.upgradeTeam(userA.teamId, userA);
+    await api.brig.enableSSOFeature(userA.teamId);
+    await api.waitForFeatureToBeEnabled(FEATURE_KEY.SSO, userA.teamId, userA.token);
+
+    // Register a Keycloak user. This user will be used to log in via SSO and SCIM.
+    userB = getUser();
+    const metadata = await api.keycloak.getMetaData();
+    identityProviderId = await api.identityProviders.createIdentityProviderV2(userA, metadata);
+    samlClientId = await api.keycloak.createSamlClient(userA);
+    keycloakUserId = await api.keycloak.createUser(userB);
+  });
+
+  test.afterEach(async ({api}) => {
+    await api.keycloak.cleanUp(samlClientId, [keycloakUserId]);
+  });
+
+  test(
+    'I want to register a new account with SSO',
+    {tag: ['@TC-1735', '@regression']},
+    async ({context, createPage}) => {
+      const page = await createPage(context);
+      const pageManager = PageManager.from(page);
+      let idpPage: Page;
+
+      const {pages, modals, components} = pageManager.webapp;
+      await pageManager.openSSOPage();
+
+      await test.step('User enters SSO code into SSO field and clicks login', async () => {
+        [idpPage] = await Promise.all([
+          context.waitForEvent('page'),
+          pages.singleSignOn().enterEmailOnSSOPage(`wire-${identityProviderId}`),
+        ]);
+      });
+
+      await test.step('User enters Keycloak email and Keycloak password in the popup and clicks sign in.', async () => {
+        await idpPage.getByRole('textbox', {name: 'Username'}).fill(userB.email, {timeout: 20_000});
+        await idpPage.getByRole('textbox', {name: 'Password'}).fill(userB.password);
+        await idpPage.getByRole('button', {name: 'Sign In'}).click();
+      });
+
+      await test.step('User clicks next on set username page in Wire', async () => {
+        await modals.marketingConsent().clickConfirmButton();
+        await pages.setUsername().clickNextButton();
+        await modals.confirm().clickAction();
+      });
+
+      await test.step('User opens Account Settings', async () => {
+        await components.conversationSidebar().clickPreferencesButton();
+        await pages.settings().clickAccountButton();
+      });
+
+      await test.step("User doesn't see Reset Password button", async () => {
+        await expect(pages.account().resetPasswordButton).not.toBeVisible();
+      });
+    },
+  );
+
+  test(
+    'I should not be able to change name, unique username, profile color, email of user managed by SCIM',
+    {tag: ['@TC-1756', '@regression']},
+    async ({context, api, createPage}) => {
+      const page = await createPage(context);
+      const pageManager = PageManager.from(page);
+      let idpPage: Page;
+
+      const {pages, modals, components} = pageManager.webapp;
+      await pageManager.openSSOPage();
+
+      await test.step('Precondition: User B is created as SCIM user', async () => {
+        const scimToken = await api.scim.createSCIMAccessToken(userA, identityProviderId);
+        await api.scim.createSCIMUser(userB, scimToken);
+      });
+
+      await test.step('User B logs in', async () => {
+        [idpPage] = await Promise.all([
+          context.waitForEvent('page'),
+          pages.singleSignOn().enterEmailOnSSOPage(`wire-${identityProviderId}`),
+        ]);
+
+        await idpPage.getByRole('textbox', {name: 'Username'}).fill(userB.email, {timeout: 20_000});
+        await idpPage.getByRole('textbox', {name: 'Password'}).fill(userB.password);
+        await idpPage.getByRole('button', {name: 'Sign In'}).click();
+        await modals.confirm().clickAction();
+      });
+
+      await test.step('User B opens account settings', async () => {
+        await components.conversationSidebar().clickPreferencesButton();
+        await pages.settings().clickAccountButton();
+      });
+
+      await test.step('User B changes profile image', async () => {
+        await pages.account().uploadProfilePicture(getImageFilePath());
+      });
+
+      await test.step('User B tries to change name, username, and email', async () => {
+        await expect(pages.account().editDisplayNameButton).not.toBeVisible();
+        await expect(pages.account().editUserNameButton).not.toBeVisible();
+        await expect(pages.account().editEmailButton).not.toBeVisible();
+      });
+    },
+  );
+});

--- a/apps/webapp/test/e2e_tests/specs/SSOAndSCIM/SSOAndSCIM.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SSOAndSCIM/SSOAndSCIM.spec.ts
@@ -97,7 +97,7 @@ test.describe('SSO and SCIM', () => {
   );
 
   test(
-    'I should not be able to change name, unique username, profile color, email of user managed by SCIM',
+    'I should not be able to change name, unique username, email of user managed by SCIM',
     {tag: ['@TC-1756', '@regression']},
     async ({context, api, createPage}) => {
       const page = await createPage(context);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25491" title="WPB-25491" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25491</a>  [Web][QA] Write Regression -> SSO & SCIM tests 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

- Implemented TC-1735 and TC-1756
- Added Identity provider and Keycloak API clients