### PR TITLE
fix: show Attending only on the active recurring meeting instance [WPB-27821]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingStatus/meetingStatus.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/MeetingStatus/meetingStatus.test.tsx
@@ -70,14 +70,14 @@ describe('MeetingStatus', () => {
     expect(screen.queryByRole('button', {name: translateForTest('callJoin')})).not.toBeInTheDocument();
   });
 
-  it('shows Participating even when the meeting is outside its scheduled interval', () => {
+  it('shows Participating even when the meeting is past its scheduled end', () => {
     const {joinMeeting: _joinMeeting, ...props} = createTestProps();
 
     render(
       withThemeAndRootContext(
         <MeetingStatus
           {...props}
-          temporalStatus={MeetingTemporalStatuses.UPCOMING}
+          temporalStatus={MeetingTemporalStatuses.PAST}
           joinMeeting={jest.fn()}
           isJoinDisabled
           isCallActive

--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingListItem.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingListItem.tsx
@@ -39,6 +39,7 @@ import type {MeetingInstance} from 'Components/Meeting/types/meetingInstance';
 import {useJoinMeetingCall} from 'Components/Meeting/useJoinMeetingCall';
 import {
   getMeetingTemporalStatusAt,
+  isAttendingMeetingInstance,
   isMeetingListItemOngoing,
   MeetingTemporalStatuses,
 } from 'Components/Meeting/utils/meetingStatusUtil';
@@ -61,11 +62,14 @@ const MeetingListItemComponent = ({
   const {title, recurrence} = meetingSeries;
   const {translate, wallClock} = useApplicationContext();
   const nowMilliseconds = providedNowMilliseconds ?? wallClock.currentTimestampInMilliseconds;
-  const {joinMeeting, isJoinDisabled, isCallActive} = useJoinMeetingCall(meetingSeries.qualified_conversation);
+  const {joinMeeting, isJoinDisabled, isCallActive: isConversationCallActive} = useJoinMeetingCall(
+    meetingSeries.qualified_conversation,
+  );
 
   const now = useMemo(() => new Date(nowMilliseconds), [nowMilliseconds]);
 
   const temporalStatus = useMemo(() => getMeetingTemporalStatusAt(now, start, end), [now, start, end]);
+  const isCallActive = isAttendingMeetingInstance(isConversationCallActive, temporalStatus);
 
   const time = useMemo(() => {
     if (temporalStatus === MeetingTemporalStatuses.PAST) {

--- a/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingListItem.tsx
+++ b/apps/webapp/src/script/components/Meeting/MeetingList/MeetingListItemGroup/MeetingListItem/meetingListItem.tsx
@@ -62,9 +62,11 @@ const MeetingListItemComponent = ({
   const {title, recurrence} = meetingSeries;
   const {translate, wallClock} = useApplicationContext();
   const nowMilliseconds = providedNowMilliseconds ?? wallClock.currentTimestampInMilliseconds;
-  const {joinMeeting, isJoinDisabled, isCallActive: isConversationCallActive} = useJoinMeetingCall(
-    meetingSeries.qualified_conversation,
-  );
+  const {
+    joinMeeting,
+    isJoinDisabled,
+    isCallActive: isConversationCallActive,
+  } = useJoinMeetingCall(meetingSeries.qualified_conversation);
 
   const now = useMemo(() => new Date(nowMilliseconds), [nowMilliseconds]);
 

--- a/apps/webapp/src/script/components/Meeting/utils/meetingStatusUtil.test.ts
+++ b/apps/webapp/src/script/components/Meeting/utils/meetingStatusUtil.test.ts
@@ -19,6 +19,7 @@
 
 import {
   getMeetingTemporalStatusAt,
+  isAttendingMeetingInstance,
   isMeetingListItemOngoing,
   MeetingTemporalStatuses,
 } from 'Components/Meeting/utils/meetingStatusUtil';
@@ -44,8 +45,22 @@ describe('meetingStatusUtil', () => {
     );
   });
 
-  it('treats active calls as ongoing regardless of the scheduled interval', () => {
-    expect(isMeetingListItemOngoing(MeetingTemporalStatuses.UPCOMING, true)).toBe(true);
+  it('does not treat future recurring instances as attending when the series call is active', () => {
+    expect(isAttendingMeetingInstance(true, MeetingTemporalStatuses.UPCOMING)).toBe(false);
+  });
+
+  it('treats the current or just-ended instance as attending when the series call is active', () => {
+    expect(isAttendingMeetingInstance(true, MeetingTemporalStatuses.ON_GOING)).toBe(true);
+    expect(isAttendingMeetingInstance(true, MeetingTemporalStatuses.PAST)).toBe(true);
+  });
+
+  it('does not treat any instance as attending when there is no active series call', () => {
+    expect(isAttendingMeetingInstance(false, MeetingTemporalStatuses.ON_GOING)).toBe(false);
+    expect(isAttendingMeetingInstance(false, MeetingTemporalStatuses.PAST)).toBe(false);
+    expect(isAttendingMeetingInstance(false, MeetingTemporalStatuses.UPCOMING)).toBe(false);
+  });
+
+  it('treats attending instances as ongoing even outside the scheduled interval', () => {
     expect(isMeetingListItemOngoing(MeetingTemporalStatuses.PAST, true)).toBe(true);
     expect(isMeetingListItemOngoing(MeetingTemporalStatuses.ON_GOING, false)).toBe(true);
     expect(isMeetingListItemOngoing(MeetingTemporalStatuses.UPCOMING, false)).toBe(false);

--- a/apps/webapp/src/script/components/Meeting/utils/meetingStatusUtil.ts
+++ b/apps/webapp/src/script/components/Meeting/utils/meetingStatusUtil.ts
@@ -40,5 +40,16 @@ export const getMeetingTemporalStatusAt = (now: Date, start: Date, end: Date): M
   return MeetingTemporalStatuses.UPCOMING;
 };
 
+/**
+ * Whether this concrete occurrence should show as Attending.
+ *
+ * Recurring instances share one conversation, so a joined call must not mark every
+ * future occurrence — only the current or just-ended instance.
+ */
+export const isAttendingMeetingInstance = (
+  isConversationCallActive: boolean,
+  temporalStatus: MeetingTemporalStatuses,
+): boolean => isConversationCallActive && temporalStatus !== MeetingTemporalStatuses.UPCOMING;
+
 export const isMeetingListItemOngoing = (temporalStatus: MeetingTemporalStatuses, isCallActive: boolean): boolean =>
   temporalStatus === MeetingTemporalStatuses.ON_GOING || isCallActive;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27821" title="WPB-27821" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27821</a>  [Web] Joining one recurring meeting instance shows "Attending" on all future instances
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Scope the Meetings list Attending label to the current or just-ended occurrence when a recurring series call is active, instead of every future instance that shares the conversation.

## Test plan
- [x] Create a recurring meeting with several future instances listed
- [x] Join the current instance and confirm only that row shows Attending
- [x] Confirm other future instances do not show Attending
- [x] Stay in the call past the scheduled end and confirm Attending remains on that instance