### PR TITLE
Run CI for maintenance branches [WPB-26469]

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,10 +4,10 @@ name: Continuous integration
 on:
   pull_request:
     # we want to run the continuous integration on every pull request targetting those branches
-    branches: [main, release/*]
+    branches: [main, release/*, maintenance/*]
 
   merge_group:
-    branches: [main, release/*]
+    branches: [main, release/*, maintenance/*]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Run the existing continuous integration workflow for pull requests and merge groups targeting `maintenance/*`.

The maintenance branch ruleset already requires the same CI checks as `release/*`, so this ensures reviewed maintenance fixes can satisfy branch protection.

Completes the remaining repository configuration gap for Phase 11 of #21597.