### PR TITLE
Use Commander for repository tooling CLIs [WPB-26469]

### DIFF
--- a/.github/workflows/dry-run-release-appearance-comments.yml
+++ b/.github/workflows/dry-run-release-appearance-comments.yml
@@ -119,7 +119,7 @@ jobs:
           else
             release_appearance_command_arguments=(production "${RELEASE_TAG}" "${RELEASE_COMMIT}" "${PROMOTED_BETA_TAG}" --dry-run)
           fi
-          node tools/release-appearance/releaseAppearanceCommand.ts "${release_appearance_command_arguments[@]}"
+          node tools/release-cli/releaseAppearanceCommand.mts "${release_appearance_command_arguments[@]}"
 
       - name: Confirm read-only issue permissions
         if: ${{ always() }}

--- a/.github/workflows/preview-next-beta-changes.yml
+++ b/.github/workflows/preview-next-beta-changes.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           set -euo pipefail
           node \
-            tools/release-appearance/previewNextBetaCommand.ts \
+            tools/release-cli/previewNextBetaCommand.mts \
             "${TARGET_MAIN_COMMIT}"
 
       - name: Confirm read-only permissions

--- a/.github/workflows/redeploy-production-from-tag.yml
+++ b/.github/workflows/redeploy-production-from-tag.yml
@@ -58,7 +58,7 @@ jobs:
             exit 1
           fi
 
-          webapp_build_version="$(./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts webapp-build-version "${TAG}" "${GITHUB_SHA}" production)"
+          webapp_build_version="$(node ./tools/release-cli/releaseMetadataCli.mts webapp-build-version "${TAG}" "${GITHUB_SHA}" production)"
 
           {
             echo "webapp_build_version=${webapp_build_version}"

--- a/.github/workflows/release-maintenance-webapp.yml
+++ b/.github/workflows/release-maintenance-webapp.yml
@@ -95,8 +95,8 @@ jobs:
             exit 1
           fi
 
-          maintenance_branch="$(./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts maintenance-branch "${MAINTENANCE_LINE_KEY}")"
-          source_production_tag="$(./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts validate-maintenance-source "${MAINTENANCE_LINE_KEY}" "${SOURCE_PRODUCTION_TAG}")"
+          maintenance_branch="$(node ./tools/release-cli/releaseMetadataCli.mts maintenance-branch "${MAINTENANCE_LINE_KEY}")"
+          source_production_tag="$(node ./tools/release-cli/releaseMetadataCli.mts validate-maintenance-source "${MAINTENANCE_LINE_KEY}" "${SOURCE_PRODUCTION_TAG}")"
 
           {
             echo "maintenance_line_key=${MAINTENANCE_LINE_KEY}"
@@ -150,7 +150,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          validated_source_production_tag="$(./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts validate-production-tag "${SOURCE_PRODUCTION_TAG}")"
+          validated_source_production_tag="$(node ./tools/release-cli/releaseMetadataCli.mts validate-production-tag "${SOURCE_PRODUCTION_TAG}")"
 
           if [[ "${validated_source_production_tag}" != "${SOURCE_PRODUCTION_TAG}" ]]; then
             echo "Validated source Production tag does not match the requested tag: ${SOURCE_PRODUCTION_TAG}" >&2
@@ -307,7 +307,7 @@ jobs:
           valid_tag_names=()
 
           for remote_tag_name in "${remote_tag_names[@]}"; do
-            validated_tag_name="$(./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts validate-maintenance-tag "${remote_tag_name}" 2> /dev/null)" || continue
+            validated_tag_name="$(node ./tools/release-cli/releaseMetadataCli.mts validate-maintenance-tag "${remote_tag_name}" 2> /dev/null)" || continue
             valid_tag_names+=("${validated_tag_name}")
 
             git fetch --no-tags origin "refs/tags/${validated_tag_name}:refs/tags/${validated_tag_name}"
@@ -319,9 +319,9 @@ jobs:
             fi
           done
 
-          candidate_tag="$(./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts next-maintenance-tag "${MAINTENANCE_LINE_KEY}" "${valid_tag_names[@]}")"
+          candidate_tag="$(node ./tools/release-cli/releaseMetadataCli.mts next-maintenance-tag "${MAINTENANCE_LINE_KEY}" "${valid_tag_names[@]}")"
 
-          ./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts validate-maintenance-tag "${candidate_tag}" > /dev/null
+          node ./tools/release-cli/releaseMetadataCli.mts validate-maintenance-tag "${candidate_tag}" > /dev/null
           echo "candidate_tag=${candidate_tag}" >> "$GITHUB_OUTPUT"
           echo "Candidate maintenance tag: ${candidate_tag}"
 
@@ -521,7 +521,7 @@ jobs:
           candidate_tag_commit_sha=''
 
           for remote_tag_name in "${remote_tag_names[@]}"; do
-            validated_tag_name="$(./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts validate-maintenance-tag "${remote_tag_name}" 2> /dev/null)" || continue
+            validated_tag_name="$(node ./tools/release-cli/releaseMetadataCli.mts validate-maintenance-tag "${remote_tag_name}" 2> /dev/null)" || continue
             valid_tag_names+=("${validated_tag_name}")
 
             git fetch --no-tags origin "refs/tags/${validated_tag_name}:refs/tags/${validated_tag_name}"
@@ -553,7 +553,7 @@ jobs:
             done
           fi
 
-          recomputed_candidate_tag="$(./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts next-maintenance-tag "${MAINTENANCE_LINE_KEY}" "${tag_names_for_next_candidate[@]}")"
+          recomputed_candidate_tag="$(node ./tools/release-cli/releaseMetadataCli.mts next-maintenance-tag "${MAINTENANCE_LINE_KEY}" "${tag_names_for_next_candidate[@]}")"
 
           if [[ "${recomputed_candidate_tag}" != "${EXPECTED_CANDIDATE_TAG}" ]]; then
             echo "Remote maintenance tags advanced to ${recomputed_candidate_tag}; expected ${EXPECTED_CANDIDATE_TAG}. Start a fresh workflow run." >&2

--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -565,7 +565,7 @@ jobs:
           WORKFLOW_TOOLING_COMMIT_SHA: ${{ github.sha }}
         run: |
           node \
-            tools/release-appearance/releaseAppearanceCommand.ts \
+            tools/release-cli/releaseAppearanceCommand.mts \
             beta \
             "${BETA_TAG}" \
             "${RELEASE_COMMIT_SHA}"
@@ -950,7 +950,7 @@ jobs:
           WORKFLOW_TOOLING_COMMIT_SHA: ${{ github.sha }}
         run: |
           node \
-            tools/release-appearance/releaseAppearanceCommand.ts \
+            tools/release-cli/releaseAppearanceCommand.mts \
             production \
             "${PRODUCTION_TAG}" \
             "${RELEASE_COMMIT_SHA}" \

--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -105,7 +105,7 @@ jobs:
             exit 1
           fi
 
-          release_branch="$(./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts release-branch "${RELEASE_IDENTIFIER}")"
+          release_branch="$(node ./tools/release-cli/releaseMetadataCli.mts release-branch "${RELEASE_IDENTIFIER}")"
 
           {
             echo "release_identifier=${RELEASE_IDENTIFIER}"
@@ -475,7 +475,7 @@ jobs:
                 print $2;
               }'
           )
-          beta_tag_name="$(./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts next-beta-tag "${RELEASE_IDENTIFIER}" "${existing_beta_tag_names[@]}")"
+          beta_tag_name="$(node ./tools/release-cli/releaseMetadataCli.mts next-beta-tag "${RELEASE_IDENTIFIER}" "${existing_beta_tag_names[@]}")"
 
           git config user.email "zebot@users.noreply.github.com"
           git config user.name "Zebot"
@@ -750,7 +750,7 @@ jobs:
 
           git fetch --tags origin
 
-          production_tag_name="$(./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts production-tag "${RELEASE_IDENTIFIER}")"
+          production_tag_name="$(node ./tools/release-cli/releaseMetadataCli.mts production-tag "${RELEASE_IDENTIFIER}")"
           beta_tag_commit_sha="$(git rev-parse "${BETA_TAG_NAME}^{commit}")"
 
           if [[ "${beta_tag_commit_sha}" != "${RELEASE_COMMIT_SHA}" ]]; then

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          webapp_build_version="$(./bin/yarn ts-node --project ./tsconfig.tools.json ./tools/release-metadata/releaseMetadataCli.ts webapp-build-version "${PRODUCTION_TAG}" "${GITHUB_SHA}" production)"
+          webapp_build_version="$(node ./tools/release-cli/releaseMetadataCli.mts webapp-build-version "${PRODUCTION_TAG}" "${GITHUB_SHA}" production)"
           {
             echo "production_tag=${PRODUCTION_TAG}"
             echo "webapp_build_version=${webapp_build_version}"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "@actions/core": "1.11.1",
     "@sindresorhus/is": "8.1.0",
     "axios": "1.19.0",
+    "commander": "15.0.0",
     "dotenv": "16.6.1",
     "dotenv-extended": "2.9.0",
     "fs-extra": "11.4.0",

--- a/project.json
+++ b/project.json
@@ -43,7 +43,7 @@
     "type-check": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "tsc --project ./tsconfig.tools.json --noEmit && tsc --project ./tools/release-appearance/tsconfig.json --noEmit"
+        "command": "tsc --project ./tsconfig.tools.json --noEmit && tsc --project ./tools/release-appearance/tsconfig.json --noEmit && tsc --project ./tsconfig.release-cli.json --noEmit"
       }
     }
   },

--- a/tools/production-distribution/productionDistribution.ts
+++ b/tools/production-distribution/productionDistribution.ts
@@ -23,8 +23,8 @@ import {Result} from 'true-myth';
 import {isBuildMetadata} from '@wireapp/config';
 import type {BuildMetadata} from '@wireapp/config';
 
-import {isLegacyTimestampBuildVersion} from '../build-artifact/legacyBuildMetadata';
-import {validateProductionTagName} from '../release-metadata/releaseMetadata';
+import {isLegacyTimestampBuildVersion} from '../build-artifact/legacyBuildMetadata.ts';
+import {validateProductionTagName} from '../release-metadata/releaseMetadata.ts';
 
 export type ProductionDistributionManifest = {
   readonly productionTag: null;

--- a/tools/production-distribution/productionDistributionCli.ts
+++ b/tools/production-distribution/productionDistributionCli.ts
@@ -17,70 +17,66 @@
  *
  */
 
-import * as nodeFileSystem from 'node:fs';
-
-import {isArray, isNonEmptyString, isPlainObject, isString} from '@sindresorhus/is';
+import {isArray, isError, isNonEmptyString, isPlainObject, isString} from '@sindresorhus/is';
+import {match} from 'ts-pattern';
 
 import {
   hasExpectedWireBuildsWebappFields,
   selectHelmChartVersion,
   validateProductionDistributionManifest,
-} from './productionDistribution';
-import type {PublishedHelmChart, WireBuildsWebappFields} from './productionDistribution';
+} from './productionDistribution.ts';
+import type {PublishedHelmChart, WireBuildsWebappFields} from './productionDistribution.ts';
 
-type CommandLineOptions = ReadonlyMap<string, string>;
+export type ProductionDistributionCommandDependencies = {
+  readonly readFile: (filePath: string) => string;
+  readonly readStandardInput: () => string;
+  readonly writeOutput: (message: string) => void;
+};
 
-function parseCommandLineOptions(commandLineArguments: readonly string[]): CommandLineOptions {
-  const optionValues = new Map<string, string>();
+type ValidateManifestCommand = {
+  readonly kind: 'validate-manifest';
+  readonly artifactMetadataPath: string;
+  readonly manifestPath: string;
+  readonly productionTag: string;
+  readonly productionTagCommitSha: string;
+  readonly expectedCommitSha: string | undefined;
+  readonly sourceRunId: string;
+};
 
-  for (let argumentIndex = 0; argumentIndex < commandLineArguments.length; argumentIndex += 2) {
-    const optionName = commandLineArguments[argumentIndex];
-    const optionValue = commandLineArguments[argumentIndex + 1];
+type SelectHelmChartCommand = {
+  readonly kind: 'select-helm-chart';
+  readonly chartsPath: string;
+  readonly imageTag: string;
+};
 
-    if (!isNonEmptyString(optionName) || !optionName.startsWith('--') || !isNonEmptyString(optionValue)) {
-      throw new Error('Options must be supplied as non-empty --name value pairs.');
-    }
+type WireBuildsFieldsMatchCommand = {
+  readonly kind: 'wire-builds-fields-match';
+  readonly version: string;
+  readonly repository: string;
+  readonly applicationVersion: string;
+  readonly commitUrl: string;
+  readonly commit: string;
+};
 
-    optionValues.set(optionName.slice(2), optionValue);
-  }
-
-  return optionValues;
-}
-
-function getRequiredOption(optionValues: CommandLineOptions, optionName: string): string {
-  const optionValue = optionValues.get(optionName);
-
-  if (!isNonEmptyString(optionValue)) {
-    throw new Error(`Missing required option: --${optionName}`);
-  }
-
-  return optionValue;
-}
+export type ProductionDistributionCommand =
+  ValidateManifestCommand | SelectHelmChartCommand | WireBuildsFieldsMatchCommand;
 
 function parseJson(jsonText: string): unknown {
   try {
     return JSON.parse(jsonText);
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorMessage = isError(error) ? error.message : String(error);
     throw new Error(`Invalid JSON: ${errorMessage}`);
   }
 }
 
-function readJsonFile(filePath: string): unknown {
-  return parseJson(nodeFileSystem.readFileSync(filePath, 'utf8'));
-}
-
-function readJsonFromStandardInput(): unknown {
-  return parseJson(nodeFileSystem.readFileSync(0, 'utf8'));
-}
-
-function readWireBuildsFields(optionValues: CommandLineOptions): WireBuildsWebappFields {
+function readWireBuildsFields(command: WireBuildsFieldsMatchCommand): WireBuildsWebappFields {
   return {
-    version: getRequiredOption(optionValues, 'version'),
-    repo: getRequiredOption(optionValues, 'repo'),
-    appVersion: getRequiredOption(optionValues, 'app-version'),
-    commitUrl: getRequiredOption(optionValues, 'commit-url'),
-    commit: getRequiredOption(optionValues, 'commit'),
+    version: command.version,
+    repo: command.repository,
+    appVersion: command.applicationVersion,
+    commitUrl: command.commitUrl,
+    commit: command.commit,
   };
 }
 
@@ -105,77 +101,52 @@ function readPublishedHelmCharts(value: unknown): readonly PublishedHelmChart[] 
   });
 }
 
-function runCommand(commandName: string, optionValues: CommandLineOptions): void {
-  switch (commandName) {
-    case 'validate-manifest': {
-      const expectedCommitSha = optionValues.get('expected-commit-sha');
+export function executeProductionDistributionCommand(
+  command: ProductionDistributionCommand,
+  dependencies: ProductionDistributionCommandDependencies,
+): number {
+  return match(command)
+    .with({kind: 'validate-manifest'}, validateManifestCommand => {
       const validationResult = validateProductionDistributionManifest({
-        artifactMetadata: readJsonFile(getRequiredOption(optionValues, 'artifact-metadata-path')),
-        manifest: readJsonFile(getRequiredOption(optionValues, 'manifest-path')),
-        productionTag: getRequiredOption(optionValues, 'production-tag'),
-        productionTagCommitSha: getRequiredOption(optionValues, 'production-tag-commit-sha'),
-        expectedCommitSha,
-        sourceRunId: getRequiredOption(optionValues, 'source-run-id'),
+        artifactMetadata: parseJson(dependencies.readFile(validateManifestCommand.artifactMetadataPath)),
+        manifest: parseJson(dependencies.readFile(validateManifestCommand.manifestPath)),
+        productionTag: validateManifestCommand.productionTag,
+        productionTagCommitSha: validateManifestCommand.productionTagCommitSha,
+        expectedCommitSha: validateManifestCommand.expectedCommitSha,
+        sourceRunId: validateManifestCommand.sourceRunId,
       });
 
       if (validationResult.isErr) {
         throw validationResult.error;
       }
 
-      return;
-    }
-
-    case 'select-helm-chart': {
-      const publishedCharts = readPublishedHelmCharts(readJsonFile(getRequiredOption(optionValues, 'charts-path')));
-      const selectionResult = selectHelmChartVersion(publishedCharts, getRequiredOption(optionValues, 'image-tag'));
+      return 0;
+    })
+    .with({kind: 'select-helm-chart'}, selectHelmChartCommand => {
+      const publishedCharts = readPublishedHelmCharts(
+        parseJson(dependencies.readFile(selectHelmChartCommand.chartsPath)),
+      );
+      const selectionResult = selectHelmChartVersion(publishedCharts, selectHelmChartCommand.imageTag);
 
       if (selectionResult.isErr) {
         throw selectionResult.error;
       }
 
       if (selectionResult.value.kind === 'reuse') {
-        console.log(`reuse:${selectionResult.value.version}`);
+        dependencies.writeOutput(`reuse:${selectionResult.value.version}`);
       } else {
-        console.log('publish');
+        dependencies.writeOutput('publish');
       }
 
-      return;
-    }
-
-    case 'wire-builds-fields-match': {
+      return 0;
+    })
+    .with({kind: 'wire-builds-fields-match'}, wireBuildsFieldsMatchCommand => {
       const fieldsMatch = hasExpectedWireBuildsWebappFields(
-        readJsonFromStandardInput(),
-        readWireBuildsFields(optionValues),
+        parseJson(dependencies.readStandardInput()),
+        readWireBuildsFields(wireBuildsFieldsMatchCommand),
       );
 
-      if (!fieldsMatch) {
-        process.exitCode = 1;
-      }
-
-      return;
-    }
-
-    default:
-      throw new Error(`Unknown production distribution command: ${commandName}`);
-  }
-}
-
-function main(): void {
-  try {
-    const commandName = process.argv[2];
-
-    if (!isNonEmptyString(commandName)) {
-      throw new Error('A production distribution command is required.');
-    }
-
-    runCommand(commandName, parseCommandLineOptions(process.argv.slice(3)));
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error(errorMessage);
-    process.exitCode = 1;
-  }
-}
-
-if (process.argv[1]?.endsWith('productionDistributionCli.ts')) {
-  main();
+      return fieldsMatch ? 0 : 1;
+    })
+    .exhaustive();
 }

--- a/tools/production-distribution/run-production-distribution-cli.sh
+++ b/tools/production-distribution/run-production-distribution-cli.sh
@@ -8,7 +8,6 @@ cd "${repository_root}"
 
 "${repository_root}/bin/yarn" nx run config-lib:build >&2
 
-exec "${repository_root}/bin/yarn" ts-node \
-  --project "${repository_root}/tsconfig.tools.json" \
-  "${repository_root}/tools/production-distribution/productionDistributionCli.ts" \
+exec node \
+  "${repository_root}/tools/release-cli/productionDistributionCli.mts" \
   "$@"

--- a/tools/release-appearance/previewNextBetaCommand.test.ts
+++ b/tools/release-appearance/previewNextBetaCommand.test.ts
@@ -1,10 +1,8 @@
-import assert from 'node:assert';
-
 import {isError} from '@sindresorhus/is';
 import {Maybe, Result, task} from 'true-myth';
 import type {Task} from 'true-myth';
 
-import {executePreviewNextBetaCommand, parseCommandLineArguments} from './previewNextBetaCommand.ts';
+import {executePreviewNextBetaCommand} from './previewNextBetaCommand.ts';
 import type {
   ExecutePreviewNextBetaCommandOptions,
   PreviewNextBetaCommandDependencies,
@@ -79,7 +77,7 @@ type CreatePullRequestOptions = {
 };
 
 type RunCommandOptions = {
-  readonly commandLineArguments: readonly string[];
+  readonly targetMainCommit: string;
   readonly executeGitCommand: ExecuteGitCommand;
   readonly githubClient: GitHubClient;
   readonly historyPlanResult?: Result<NextBetaPreviewHistoryPlan, Error>;
@@ -184,7 +182,7 @@ function createFakeHistoryPlanner(
 
 async function runCommand(runCommandOptions: RunCommandOptions): Promise<CommandRun> {
   const {
-    commandLineArguments,
+    targetMainCommit,
     executeGitCommand,
     githubClient,
     historyPlanResult = Result.ok(previewHistoryPlan),
@@ -218,7 +216,7 @@ async function runCommand(runCommandOptions: RunCommandOptions): Promise<Command
     },
   };
   const options: ExecutePreviewNextBetaCommandOptions = {
-    commandLineArguments,
+    targetMainCommit,
     environment: commandEnvironment,
     dependencies,
   };
@@ -227,31 +225,12 @@ async function runCommand(runCommandOptions: RunCommandOptions): Promise<Command
   return {result, historyPlannerState: historyPlannerFixture.state, writerState};
 }
 
-describe('parseCommandLineArguments', () => {
-  test('accepts exactly one full target commit argument', () => {
-    const actualResult = parseCommandLineArguments([targetMainCommit]);
-    const abbreviatedResult = parseCommandLineArguments(['abcdef0']);
-    const missingResult = parseCommandLineArguments([]);
-    const additionalResult = parseCommandLineArguments([targetMainCommit, targetMainCommit]);
-    const flagResult = parseCommandLineArguments(['--target-main-commit']);
-    const malformedResult = parseCommandLineArguments(['g'.repeat(40)]);
-
-    assert(actualResult.isOk);
-    expect(actualResult.value).toBe(targetMainCommit);
-    expect(abbreviatedResult.isErr).toBe(true);
-    expect(missingResult.isErr).toBe(true);
-    expect(additionalResult.isErr).toBe(true);
-    expect(flagResult.isErr).toBe(true);
-    expect(malformedResult.isErr).toBe(true);
-  });
-});
-
 describe('executePreviewNextBetaCommand', () => {
   test('delegates history planning with the exact target commit', async () => {
     const githubClientFixture = createFakeGitHubClient();
 
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
     });
@@ -269,7 +248,7 @@ describe('executePreviewNextBetaCommand', () => {
     };
 
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
       historyPlanResult: Result.ok(unavailableHistory),
@@ -286,7 +265,7 @@ describe('executePreviewNextBetaCommand', () => {
     const githubClientFixture = createFakeGitHubClient();
 
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
       historyPlanResult: Result.err(new Error(`GitHub token ${githubToken} history failure`)),
@@ -315,7 +294,7 @@ describe('executePreviewNextBetaCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
     });
@@ -355,7 +334,7 @@ describe('executePreviewNextBetaCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
       historyPlanResult: Result.ok({...previewHistoryPlan, commits: [firstMainCommit, secondMainCommit]}),
@@ -383,7 +362,7 @@ describe('executePreviewNextBetaCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
       historyPlanResult: Result.ok({...previewHistoryPlan, commits: [firstMainCommit]}),
@@ -404,7 +383,7 @@ describe('executePreviewNextBetaCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
       historyPlanResult: Result.ok({
@@ -429,7 +408,7 @@ describe('executePreviewNextBetaCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
       historyPlanResult: Result.ok({
@@ -449,7 +428,7 @@ describe('executePreviewNextBetaCommand', () => {
     const githubClientFixture = createFakeGitHubClient();
 
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
       historyPlanResult: Result.ok({...previewHistoryPlan, commits: []}),
@@ -468,7 +447,7 @@ describe('executePreviewNextBetaCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
       informationFailureMessage: `token ${githubToken} in information writer`,
@@ -489,7 +468,7 @@ describe('executePreviewNextBetaCommand', () => {
     const githubClientFixture = createFakeGitHubClient();
 
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
       summaryFailureMessage: `token ${githubToken} in summary writer`,
@@ -510,7 +489,7 @@ describe('executePreviewNextBetaCommand', () => {
     const githubClientFixture = createFakeGitHubClient();
 
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
       informationFailureMessage: `token ${githubToken} in information writer`,
@@ -530,7 +509,7 @@ describe('executePreviewNextBetaCommand', () => {
   test('returns non-zero when the history planner fails', async () => {
     const githubClientFixture = createFakeGitHubClient();
     const commandRun = await runCommand({
-      commandLineArguments: [targetMainCommit],
+      targetMainCommit,
       executeGitCommand: createFakeGitCommand(),
       githubClient: githubClientFixture.githubClient,
       historyPlanResult: Result.err(new Error('target commit does not exist')),

--- a/tools/release-appearance/previewNextBetaCommand.ts
+++ b/tools/release-appearance/previewNextBetaCommand.ts
@@ -21,16 +21,8 @@ import {isEmptyArray, isEmptyString, isError} from '@sindresorhus/is';
 import {Maybe, Result} from 'true-myth';
 import type {Task} from 'true-myth';
 
-import {execFile} from 'node:child_process';
-import {appendFile} from 'node:fs/promises';
-import {promisify} from 'node:util';
-
-import {createGitHubClient} from './githubClient.ts';
 import type {GitHubClient, PullRequestRecord} from './githubClient.ts';
-import {createRuntimeKyHttpClient} from './httpClient.ts';
 import {readCommandEnvironment} from './releaseAppearanceCommand.ts';
-import type {CommandEnvironment} from './releaseAppearanceCommand.ts';
-import {planNextBetaPreviewHistory} from './releaseHistory.ts';
 import type {
   BetaReleaseTagReference,
   ExecuteGitCommand,
@@ -50,7 +42,7 @@ export type PreviewNextBetaCommandDependencies = {
 };
 
 export type ExecutePreviewNextBetaCommandOptions = {
-  readonly commandLineArguments: readonly string[];
+  readonly targetMainCommit: string;
   readonly environment: NodeJS.ProcessEnv;
   readonly dependencies: PreviewNextBetaCommandDependencies;
 };
@@ -117,10 +109,8 @@ type WriteSummarySafelyOptions = {
   readonly githubToken: string;
 };
 
-const processArgumentStartIndex = 2;
 const fullGitCommitPattern = /^[0-9a-f]{40}$/i;
 const markdownSpecialCharacterPattern = /[\\`*_\[\]<>~]/gu;
-const executeFile = promisify(execFile);
 const advisoryMessage =
   'This is an advisory preview. These changes are on main but have not been deployed or verified in Beta.';
 
@@ -176,19 +166,12 @@ async function writeSummarySafely(writeSummarySafelyOptions: WriteSummarySafelyO
   }
 }
 
-export function parseCommandLineArguments(commandLineArguments: readonly string[]): Result<string, Error> {
-  if (commandLineArguments.length !== 1) {
-    return Result.err(
-      new Error('Usage: node tools/release-appearance/previewNextBetaCommand.ts <target-main-commit-sha>'),
-    );
-  }
-
-  const targetMainCommit = Maybe.of(commandLineArguments[0]);
-  if (targetMainCommit.isNothing || !fullGitCommitPattern.test(targetMainCommit.value)) {
+export function validateTargetMainCommit(targetMainCommit: string): Result<string, Error> {
+  if (!fullGitCommitPattern.test(targetMainCommit)) {
     return Result.err(new Error('Target main commit SHA must contain exactly 40 hexadecimal characters'));
   }
 
-  return Result.ok(targetMainCommit.value);
+  return Result.ok(targetMainCommit);
 }
 
 async function discoverPullRequests(
@@ -423,11 +406,11 @@ function createReport(createReportOptions: CreateReportOptions): string {
 export async function executePreviewNextBetaCommand(
   executePreviewNextBetaCommandOptions: ExecutePreviewNextBetaCommandOptions,
 ): Promise<PreviewNextBetaCommandResult> {
-  const {commandLineArguments, environment, dependencies} = executePreviewNextBetaCommandOptions;
+  const {targetMainCommit, environment, dependencies} = executePreviewNextBetaCommandOptions;
   const githubToken = Maybe.of(environment.GITHUB_TOKEN).unwrapOr('');
-  const parsedCommandResult = parseCommandLineArguments(commandLineArguments);
-  if (parsedCommandResult.isErr) {
-    await writeFailureSafely(dependencies.writeFailure, parsedCommandResult.error.message);
+  const targetMainCommitResult = validateTargetMainCommit(targetMainCommit);
+  if (targetMainCommitResult.isErr) {
+    await writeFailureSafely(dependencies.writeFailure, targetMainCommitResult.error.message);
 
     return {exitCode: 1, summary: ''};
   }
@@ -442,7 +425,6 @@ export async function executePreviewNextBetaCommand(
     return {exitCode: 1, summary: ''};
   }
 
-  const targetMainCommit = parsedCommandResult.value;
   let previewState: PreviewNextBetaState;
   try {
     previewState = await createPreviewState({
@@ -501,74 +483,4 @@ export async function executePreviewNextBetaCommand(
   }
 
   return {exitCode, summary};
-}
-
-async function executeRuntimeGitCommand(commandArguments: readonly string[]): Promise<string> {
-  const commandResult = await executeFile('git', commandArguments, {encoding: 'utf8'});
-
-  return commandResult.stdout.toString();
-}
-
-async function writeRuntimeFailure(message: string): Promise<void> {
-  process.stderr.write(`${message}\n`);
-}
-
-async function writeRuntimeInformation(message: string): Promise<void> {
-  process.stdout.write(`${message}\n`);
-}
-
-function createRuntimeDependencies(commandEnvironment: CommandEnvironment): PreviewNextBetaCommandDependencies {
-  const httpClient = createRuntimeKyHttpClient();
-  const githubClient = createGitHubClient({
-    httpClient,
-    githubApiUrl: commandEnvironment.githubApiUrl,
-    githubRepository: commandEnvironment.githubRepository,
-    githubToken: commandEnvironment.githubToken,
-  });
-
-  return {
-    executeGitCommand: executeRuntimeGitCommand,
-    githubClient,
-    planNextBetaPreviewHistory,
-    writeFailure: writeRuntimeFailure,
-    writeInformation: writeRuntimeInformation,
-    async writeSummary(summary): Promise<void> {
-      await appendFile(commandEnvironment.githubStepSummary, `${summary}\n`, 'utf8');
-    },
-  };
-}
-
-async function startPreviewNextBetaCommand(): Promise<void> {
-  const githubToken = Maybe.of(process.env.GITHUB_TOKEN).unwrapOr('');
-  try {
-    const commandEnvironmentResult = readCommandEnvironment(process.env);
-    if (commandEnvironmentResult.isErr) {
-      await writeRuntimeFailure(redactSecret(commandEnvironmentResult.error.message, githubToken));
-      process.exitCode = 1;
-
-      return;
-    }
-
-    const commandResult = await executePreviewNextBetaCommand({
-      commandLineArguments: process.argv.slice(processArgumentStartIndex),
-      environment: process.env,
-      dependencies: createRuntimeDependencies(commandEnvironmentResult.value),
-    });
-    process.exitCode = commandResult.exitCode;
-  } catch (error: unknown) {
-    await writeRuntimeFailure(redactSecret(isError(error) ? error.message : 'Unexpected preview failure', githubToken));
-    process.exitCode = 1;
-  }
-}
-
-function isPreviewNextBetaCommandEntrypoint(): boolean {
-  return Maybe.of(process.argv[1])
-    .map(entrypointPath => {
-      return /(?:^|[\\/])previewNextBetaCommand\.ts$/.test(entrypointPath);
-    })
-    .unwrapOr(false);
-}
-
-if (isPreviewNextBetaCommandEntrypoint()) {
-  void startPreviewNextBetaCommand();
 }

--- a/tools/release-appearance/releaseAppearanceCommand.test.ts
+++ b/tools/release-appearance/releaseAppearanceCommand.test.ts
@@ -26,12 +26,12 @@ import {Maybe, Result} from 'true-myth';
 import {renderPersistentComment} from './releaseAppearance.ts';
 import {
   executeReleaseAppearanceCommand,
-  parseCommandLineArguments,
   prepareCommentOperation,
   readCommandEnvironment,
 } from './releaseAppearanceCommand.ts';
 import type {
   ExecuteReleaseAppearanceCommandOptions,
+  ParsedCommand,
   ReleaseAppearanceCommandDependencies,
 } from './releaseAppearanceCommand.ts';
 import {createGitHubClient} from './githubClient.ts';
@@ -57,6 +57,33 @@ const betaTag = '2026-01-02.1-beta.1';
 const betaTwoTag = '2026-01-02.1-beta.2';
 const betaTwoCommit = 'f'.repeat(40);
 const productionTag = '2026-01-02.1-production';
+
+type CreateBetaTestCommandOptions = {
+  readonly releaseTag: string;
+  readonly releaseCommit: string;
+  readonly executionMode: 'write' | 'dry-run';
+};
+
+type CreateProductionTestCommandOptions = {
+  readonly releaseTag: string;
+  readonly releaseCommit: string;
+  readonly promotedBetaTag: string;
+  readonly executionMode: 'write' | 'dry-run';
+};
+
+function createBetaTestCommand(createBetaTestCommandOptions: CreateBetaTestCommandOptions): ParsedCommand {
+  const {releaseTag, releaseCommit, executionMode} = createBetaTestCommandOptions;
+
+  return {stage: 'beta', releaseTag, releaseCommit, executionMode};
+}
+
+function createProductionTestCommand(
+  createProductionTestCommandOptions: CreateProductionTestCommandOptions,
+): ParsedCommand {
+  const {releaseTag, releaseCommit, promotedBetaTag, executionMode} = createProductionTestCommandOptions;
+
+  return {stage: 'production', releaseTag, releaseCommit, promotedBetaTag, executionMode};
+}
 
 const commandEnvironment: NodeJS.ProcessEnv = {
   GITHUB_API_URL: 'https://api.github.com',
@@ -94,7 +121,7 @@ type FakeGitHubClientFixture = {
 };
 
 type RunCommandOptions = {
-  readonly commandLineArguments: readonly string[];
+  readonly command: ParsedCommand;
   readonly executeGitCommand: ExecuteGitCommand;
   readonly githubClient: GitHubClient;
   readonly informationWriteFailure?: string;
@@ -349,7 +376,7 @@ async function runCommand(runCommandOptions: RunCommandOptions): Promise<{
   const informationWriteAttempts: string[] = [];
   const summaries: string[] = [];
   const options: ExecuteReleaseAppearanceCommandOptions = {
-    commandLineArguments: runCommandOptions.commandLineArguments,
+    command: runCommandOptions.command,
     environment: commandEnvironment,
     dependencies: createDependencies({
       executeGitCommand: runCommandOptions.executeGitCommand,
@@ -366,75 +393,6 @@ async function runCommand(runCommandOptions: RunCommandOptions): Promise<{
   const result = await executeReleaseAppearanceCommand(options);
   return {result, failureMessages, informationMessages, informationWriteAttempts, summaries};
 }
-
-describe('parseCommandLineArguments', () => {
-  it('normal Beta parsing defaults to write mode', () => {
-    const actualResult = parseCommandLineArguments(['beta', betaTag, releaseCommit]);
-
-    assert(actualResult.isOk);
-    expect(actualResult.value).toEqual({
-      stage: 'beta',
-      releaseTag: betaTag,
-      releaseCommit,
-      executionMode: 'write',
-    });
-  });
-
-  it('normal Production parsing defaults to write mode', () => {
-    const actualResult = parseCommandLineArguments(['production', productionTag, releaseCommit, betaTag]);
-
-    assert(actualResult.isOk);
-    expect(actualResult.value).toEqual({
-      stage: 'production',
-      releaseTag: productionTag,
-      releaseCommit,
-      promotedBetaTag: betaTag,
-      executionMode: 'write',
-    });
-  });
-
-  it('accepts final --dry-run for Beta', () => {
-    const actualResult = parseCommandLineArguments(['beta', betaTag, releaseCommit, '--dry-run']);
-
-    assert(actualResult.isOk);
-    expect(actualResult.value.executionMode).toBe('dry-run');
-  });
-
-  it('accepts final --dry-run for Production', () => {
-    const actualResult = parseCommandLineArguments(['production', productionTag, releaseCommit, betaTag, '--dry-run']);
-
-    assert(actualResult.isOk);
-    expect(actualResult.value.executionMode).toBe('dry-run');
-  });
-
-  it('rejects repeated --dry-run', () => {
-    const actualResult = parseCommandLineArguments(['beta', betaTag, releaseCommit, '--dry-run', '--dry-run']);
-
-    expect(actualResult.isErr).toBe(true);
-  });
-
-  it('rejects unknown options and additional arguments', () => {
-    const unknownOptionResult = parseCommandLineArguments(['beta', betaTag, releaseCommit, '--write']);
-    const additionalArgumentResult = parseCommandLineArguments(['beta', betaTag, releaseCommit, '--dry-run', 'extra']);
-
-    expect(unknownOptionResult.isErr).toBe(true);
-    expect(additionalArgumentResult.isErr).toBe(true);
-  });
-
-  it('rejects misplaced --dry-run', () => {
-    const actualResult = parseCommandLineArguments(['production', productionTag, '--dry-run', releaseCommit, betaTag]);
-
-    expect(actualResult.isErr).toBe(true);
-  });
-
-  it('requires full release commit SHAs', () => {
-    const abbreviatedCommitResult = parseCommandLineArguments(['beta', betaTag, 'abcdef0']);
-    const longCommitResult = parseCommandLineArguments(['beta', betaTag, 'a'.repeat(64)]);
-
-    expect(abbreviatedCommitResult.isErr).toBe(true);
-    expect(longCommitResult.isErr).toBe(true);
-  });
-});
 
 describe('readCommandEnvironment', () => {
   it('parses and validates required command environment', () => {
@@ -491,7 +449,7 @@ describe('executeReleaseAppearanceCommand', () => {
       },
     });
     const commandPromise = runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'write'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand({commits: commitShas}),
       githubClient: fakeGitHubClient.githubClient,
@@ -524,7 +482,7 @@ describe('executeReleaseAppearanceCommand', () => {
 
   it('formats summary durations in milliseconds below one second and seconds otherwise', async () => {
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'write'}),
       executeGitCommand: createFakeGitCommand(),
       githubClient: createFakeGitHubClient().githubClient,
       now: createTimestampSequence([0, 0, 250, 250, 250, 250, 250, 250, 1500, 1500, 1500, 1500, 1500, 6537, 15618]),
@@ -560,7 +518,7 @@ describe('executeReleaseAppearanceCommand', () => {
       },
     });
     const commandPromise = runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit, '--dry-run'],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'dry-run'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand({commits: commitShas}),
       githubClient: fakeGitHubClient.githubClient,
@@ -614,7 +572,7 @@ describe('executeReleaseAppearanceCommand', () => {
       },
     });
     const commandPromise = runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit, '--dry-run'],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'dry-run'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
@@ -649,7 +607,7 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'write'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
@@ -715,7 +673,7 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTwoTag, betaCommit],
+      command: createBetaTestCommand({releaseTag: betaTwoTag, releaseCommit: betaCommit, executionMode: 'write'}),
       now: readZeroTimestamp,
       executeGitCommand: fakeGitCommand,
       githubClient: fakeGitHubClient.githubClient,
@@ -753,7 +711,11 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTwoTag, betaTwoCommit],
+      command: createBetaTestCommand({
+        releaseTag: betaTwoTag,
+        releaseCommit: betaTwoCommit,
+        executionMode: 'write',
+      }),
       now: readZeroTimestamp,
       executeGitCommand: fakeGitCommand,
       githubClient: fakeGitHubClient.githubClient,
@@ -789,7 +751,11 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTwoTag, betaTwoCommit],
+      command: createBetaTestCommand({
+        releaseTag: betaTwoTag,
+        releaseCommit: betaTwoCommit,
+        executionMode: 'write',
+      }),
       now: readZeroTimestamp,
       executeGitCommand: fakeGitCommand,
       githubClient: fakeGitHubClient.githubClient,
@@ -815,7 +781,12 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['production', productionTag, releaseCommit, betaTag],
+      command: createProductionTestCommand({
+        releaseTag: productionTag,
+        releaseCommit,
+        promotedBetaTag: betaTag,
+        executionMode: 'write',
+      }),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
@@ -844,7 +815,12 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['production', productionTag, releaseCommit, betaTag, '--dry-run'],
+      command: createProductionTestCommand({
+        releaseTag: productionTag,
+        releaseCommit,
+        promotedBetaTag: betaTag,
+        executionMode: 'dry-run',
+      }),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
@@ -948,7 +924,7 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit, '--dry-run'],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'dry-run'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand(),
       githubClient,
@@ -995,7 +971,7 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit, '--dry-run'],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'dry-run'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
@@ -1025,7 +1001,7 @@ describe('executeReleaseAppearanceCommand', () => {
     const fakeGitHubClient = createFakeGitHubClient();
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', 'invalid-beta-tag', releaseCommit, '--dry-run'],
+      command: createBetaTestCommand({releaseTag: 'invalid-beta-tag', releaseCommit, executionMode: 'dry-run'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
@@ -1050,7 +1026,7 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit, '--dry-run'],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'dry-run'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand({commits: [failedDiscoveryCommit, betaCommit]}),
       githubClient: fakeGitHubClient.githubClient,
@@ -1073,7 +1049,7 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'write'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
@@ -1110,7 +1086,7 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'write'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
@@ -1137,7 +1113,7 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'write'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
@@ -1163,7 +1139,7 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'write'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
@@ -1183,7 +1159,7 @@ describe('executeReleaseAppearanceCommand', () => {
     const fakeGitHubClient = createFakeGitHubClient();
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'write'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand({bootstrap: true}),
       githubClient: fakeGitHubClient.githubClient,
@@ -1202,7 +1178,7 @@ describe('executeReleaseAppearanceCommand', () => {
     const fakeGitHubClient = createFakeGitHubClient();
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit, '--dry-run'],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'dry-run'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand({bootstrap: true}),
       githubClient: fakeGitHubClient.githubClient,
@@ -1239,7 +1215,7 @@ describe('executeReleaseAppearanceCommand', () => {
     });
 
     const commandRun = await runCommand({
-      commandLineArguments: ['beta', betaTag, releaseCommit, '--dry-run'],
+      command: createBetaTestCommand({releaseTag: betaTag, releaseCommit, executionMode: 'dry-run'}),
       now: readZeroTimestamp,
       executeGitCommand: createFakeGitCommand(),
       githubClient: fakeGitHubClient.githubClient,
@@ -1257,8 +1233,8 @@ describe('executeReleaseAppearanceCommand', () => {
 });
 
 describe('native release appearance command entrypoint', () => {
-  it('loads dependencies and reports usage failure', async () => {
-    const commandProcess = spawn(process.execPath, ['tools/release-appearance/releaseAppearanceCommand.ts'], {
+  it('reports missing required arguments through the Commander entrypoint', async () => {
+    const commandProcess = spawn(process.execPath, ['tools/release-cli/releaseAppearanceCommand.mts', 'beta'], {
       cwd: process.cwd(),
       env: process.env,
     });
@@ -1280,6 +1256,6 @@ describe('native release appearance command entrypoint', () => {
     const exitCode = await exitCodePromise;
 
     expect(exitCode).toBe(1);
-    expect(standardError).toMatch(/Usage: beta/);
+    expect(standardError).toMatch(/error: missing required argument 'beta-tag'/);
   });
 });

--- a/tools/release-appearance/releaseAppearanceCommand.ts
+++ b/tools/release-appearance/releaseAppearanceCommand.ts
@@ -17,19 +17,12 @@
  *
  */
 
-import * as actionsCore from '@actions/core';
 import {isError, isNonEmptyStringAndNotWhitespace} from '@sindresorhus/is';
 import pMap from 'p-map';
 import {Maybe, Result, Unit} from 'true-myth';
 import {match} from 'ts-pattern';
 
-import {execFile} from 'node:child_process';
-import {promisify} from 'node:util';
-
-import {createDefaultGitHubActionsProgressReporter} from './githubActionsProgressReporter.ts';
-import {createGitHubClient} from './githubClient.ts';
 import type {GitHubClient, IssueCommentRecord, PullRequestRecord} from './githubClient.ts';
-import {createRuntimeKyHttpClient} from './httpClient.ts';
 import {
   mergeReleaseAppearanceComments,
   parsePersistentMarkerComment,
@@ -83,7 +76,7 @@ export type ReleaseAppearanceCommandDependencies = {
 };
 
 export type ExecuteReleaseAppearanceCommandOptions = {
-  readonly commandLineArguments: readonly string[];
+  readonly command: ParsedCommand;
   readonly environment: NodeJS.ProcessEnv;
   readonly dependencies: ReleaseAppearanceCommandDependencies;
 };
@@ -270,14 +263,6 @@ type FinalizeSummaryOptions = {
   readonly commandStartedAtMilliseconds: number;
 };
 
-const betaCommandArgumentCount = 3;
-const productionCommandArgumentCount = 4;
-const processArgumentStartIndex = 2;
-const stageArgumentIndex = 0;
-const releaseTagArgumentIndex = 1;
-const releaseCommitArgumentIndex = 2;
-const promotedBetaTagArgumentIndex = 3;
-const dryRunFlag = '--dry-run';
 const fullGitCommitPattern = /^[0-9a-f]{40}$/i;
 const millisecondsPerSecond = 1000;
 
@@ -293,7 +278,7 @@ function errorMessage(error: unknown): string {
   return isError(error) ? error.message : 'Unknown failure';
 }
 
-function redactSecret(message: string, secret: string): string {
+export function redactSecret(message: string, secret: string): string {
   return secret.length === 0 ? message : message.replaceAll(secret, '[REDACTED]');
 }
 
@@ -305,118 +290,70 @@ function formatPullRequestFailure(pullRequestFailure: PullRequestFailure): strin
   return `Pull request #${pullRequestFailure.pullRequestNumber}: ${pullRequestFailure.message}`;
 }
 
-function usageFailure(): Result<ParsedCommand, Error> {
-  return createFailure(
-    'Usage: beta <beta-tag> <release-commit-sha> [--dry-run] or production <production-tag> <release-commit-sha> <promoted-beta-tag> [--dry-run]',
-  );
-}
+type CreateBetaCommandOptions = {
+  readonly betaTag: string;
+  readonly releaseCommit: string;
+  readonly executionMode: ExecutionMode;
+};
 
-function parseExecutionMode(
-  commandLineArguments: readonly string[],
-  writeArgumentCount: number,
-): Result<ExecutionMode, Error> {
-  if (commandLineArguments.length === writeArgumentCount) {
-    return createSuccess('write');
+type CreateProductionCommandOptions = {
+  readonly productionTag: string;
+  readonly releaseCommit: string;
+  readonly promotedBetaTag: string;
+  readonly executionMode: ExecutionMode;
+};
+
+function validateRequiredCommandValue(value: string, valueName: string): Result<string, Error> {
+  if (!isNonEmptyStringAndNotWhitespace(value)) {
+    return createFailure(`${valueName} must not be empty`);
   }
 
-  const dryRunFlagArgument = Maybe.of(commandLineArguments[writeArgumentCount]);
-  if (
-    commandLineArguments.length === writeArgumentCount + 1 &&
-    dryRunFlagArgument.isJust &&
-    dryRunFlagArgument.value === dryRunFlag
-  ) {
-    return createSuccess('dry-run');
+  return createSuccess(value);
+}
+
+function validateReleaseCommit(releaseCommit: string): Result<string, Error> {
+  if (!fullGitCommitPattern.test(releaseCommit)) {
+    return createFailure('Release commit SHA must contain exactly 40 hexadecimal characters');
   }
 
-  return createFailure('Dry-run mode requires exactly one final --dry-run argument');
+  return createSuccess(releaseCommit);
 }
 
-function readRequiredArgument(
-  commandLineArguments: readonly string[],
-  argumentIndex: number,
-  argumentName: string,
-): Result<string, Error> {
-  const argument = Maybe.of(commandLineArguments[argumentIndex]);
-  if (argument.isNothing || !isNonEmptyStringAndNotWhitespace(argument.value)) {
-    return createFailure(`${argumentName} must not be empty`);
-  }
-
-  return createSuccess(argument.value);
-}
-
-function readReleaseCommit(commandLineArguments: readonly string[]): Result<string, Error> {
-  return readRequiredArgument(commandLineArguments, releaseCommitArgumentIndex, 'Release commit SHA').andThen(
-    releaseCommit => {
-      return fullGitCommitPattern.test(releaseCommit)
-        ? createSuccess(releaseCommit)
-        : createFailure('Release commit SHA must contain exactly 40 hexadecimal characters');
-    },
-  );
-}
-
-function parseBetaCommand(
-  commandLineArguments: readonly string[],
-  executionMode: ExecutionMode,
-): Result<ParsedCommand, Error> {
-  const betaTagResult = readRequiredArgument(commandLineArguments, releaseTagArgumentIndex, 'Beta tag');
+export function createBetaCommand(createBetaCommandOptions: CreateBetaCommandOptions): Result<ParsedCommand, Error> {
+  const {betaTag, releaseCommit, executionMode} = createBetaCommandOptions;
+  const betaTagResult = validateRequiredCommandValue(betaTag, 'Beta tag');
   if (betaTagResult.isErr) {
     return createFailure(betaTagResult.error.message);
   }
 
-  return readReleaseCommit(commandLineArguments).map(releaseCommit => {
-    return {stage: 'beta', releaseTag: betaTagResult.value, releaseCommit, executionMode};
+  return validateReleaseCommit(releaseCommit).map(validatedReleaseCommit => {
+    return {stage: 'beta', releaseTag: betaTagResult.value, releaseCommit: validatedReleaseCommit, executionMode};
   });
 }
 
-function parseProductionCommand(
-  commandLineArguments: readonly string[],
-  executionMode: ExecutionMode,
+export function createProductionCommand(
+  createProductionCommandOptions: CreateProductionCommandOptions,
 ): Result<ParsedCommand, Error> {
-  const productionTagResult = readRequiredArgument(commandLineArguments, releaseTagArgumentIndex, 'Production tag');
+  const {productionTag, releaseCommit, promotedBetaTag, executionMode} = createProductionCommandOptions;
+  const productionTagResult = validateRequiredCommandValue(productionTag, 'Production tag');
   if (productionTagResult.isErr) {
     return createFailure(productionTagResult.error.message);
   }
 
-  const releaseCommitResult = readReleaseCommit(commandLineArguments);
+  const releaseCommitResult = validateReleaseCommit(releaseCommit);
   if (releaseCommitResult.isErr) {
     return createFailure(releaseCommitResult.error.message);
   }
 
-  return readRequiredArgument(commandLineArguments, promotedBetaTagArgumentIndex, 'Promoted Beta tag').map(
-    promotedBetaTag => {
-      return {
-        stage: 'production',
-        releaseTag: productionTagResult.value,
-        releaseCommit: releaseCommitResult.value,
-        promotedBetaTag,
-        executionMode,
-      };
-    },
-  );
-}
-
-export function parseCommandLineArguments(commandLineArguments: readonly string[]): Result<ParsedCommand, Error> {
-  const stage = Maybe.of(commandLineArguments[stageArgumentIndex]);
-  if (stage.isNothing) {
-    return usageFailure();
-  }
-
-  return match(stage.value)
-    .with('beta', () => {
-      const executionModeResult = parseExecutionMode(commandLineArguments, betaCommandArgumentCount);
-      return executionModeResult.isOk
-        ? parseBetaCommand(commandLineArguments, executionModeResult.value)
-        : usageFailure();
-    })
-    .with('production', () => {
-      const executionModeResult = parseExecutionMode(commandLineArguments, productionCommandArgumentCount);
-      return executionModeResult.isOk
-        ? parseProductionCommand(commandLineArguments, executionModeResult.value)
-        : usageFailure();
-    })
-    .otherwise(() => {
-      return usageFailure();
-    });
+  return validateRequiredCommandValue(promotedBetaTag, 'Promoted Beta tag').map(validatedPromotedBetaTag => {
+    return {
+      stage: 'production',
+      releaseTag: productionTagResult.value,
+      releaseCommit: releaseCommitResult.value,
+      promotedBetaTag: validatedPromotedBetaTag,
+      executionMode,
+    };
+  });
 }
 
 function readRequiredEnvironmentValue(environment: NodeJS.ProcessEnv, variableName: string): Result<string, Error> {
@@ -1313,14 +1250,9 @@ async function planReleaseHistory(
 export async function executeReleaseAppearanceCommand(
   executeReleaseAppearanceCommandOptions: ExecuteReleaseAppearanceCommandOptions,
 ): Promise<ReleaseAppearanceCommandResult> {
-  const {commandLineArguments, environment, dependencies} = executeReleaseAppearanceCommandOptions;
+  const {command, environment, dependencies} = executeReleaseAppearanceCommandOptions;
   const commandStartedAtMilliseconds = dependencies.now();
   const githubToken = Maybe.of(environment.GITHUB_TOKEN).unwrapOr('');
-  const parsedCommandResult = parseCommandLineArguments(commandLineArguments);
-  if (parsedCommandResult.isErr) {
-    await writeFailureSafely(dependencies.writeFailure, parsedCommandResult.error.message);
-    return {exitCode: 1, summary: ''};
-  }
 
   const commandEnvironmentResult = readCommandEnvironment(environment);
   if (commandEnvironmentResult.isErr) {
@@ -1331,11 +1263,10 @@ export async function executeReleaseAppearanceCommand(
     return {exitCode: 1, summary: ''};
   }
 
-  const parsedCommand = parsedCommandResult.value;
   const releaseHistoryPlanningStartedAtMilliseconds = dependencies.now();
   let historyPlanResult: Result<ReleaseHistoryPlan, Error>;
   try {
-    historyPlanResult = await planReleaseHistory(parsedCommand, dependencies.executeGitCommand);
+    historyPlanResult = await planReleaseHistory(command, dependencies.executeGitCommand);
   } catch (error: unknown) {
     historyPlanResult = createFailure(
       `Unable to plan release history: ${redactSecret(errorMessage(error), githubToken)}`,
@@ -1344,10 +1275,7 @@ export async function executeReleaseAppearanceCommand(
   }
   const releaseHistoryPlanningDurationMilliseconds = dependencies.now() - releaseHistoryPlanningStartedAtMilliseconds;
 
-  let summaryOptions = createEmptySummaryOptions(
-    parsedCommand,
-    commandEnvironmentResult.value.workflowToolingCommitSha,
-  );
+  let summaryOptions = createEmptySummaryOptions(command, commandEnvironmentResult.value.workflowToolingCommitSha);
   summaryOptions = {...summaryOptions, releaseHistoryPlanningDurationMilliseconds};
   if (historyPlanResult.isErr) {
     const historyFailureMessage = createGeneralFailureMessage(
@@ -1392,14 +1320,14 @@ export async function executeReleaseAppearanceCommand(
     const pullRequestDiscoveryDurationMilliseconds = dependencies.now() - discoveryStartedAtMilliseconds;
     const commentProcessingStartedAtMilliseconds = dependencies.now();
     const processingResult = await processPullRequests({
-      executionMode: parsedCommand.executionMode,
+      executionMode: command.executionMode,
       githubClient: dependencies.githubClient,
       githubToken,
       now: dependencies.now,
       progressReporter: dependencies.progressReporter,
       pullRequests: discoveryResult.pullRequests,
-      releaseTag: parsedCommand.releaseTag,
-      stage: parsedCommand.stage,
+      releaseTag: command.releaseTag,
+      stage: command.stage,
       writeFailure: dependencies.writeFailure,
     });
     const commentProcessingDurationMilliseconds = dependencies.now() - commentProcessingStartedAtMilliseconds;
@@ -1437,89 +1365,4 @@ export async function executeReleaseAppearanceCommand(
     exitCode: 1,
     commandStartedAtMilliseconds,
   });
-}
-
-export async function main(
-  executeReleaseAppearanceCommandOptions: ExecuteReleaseAppearanceCommandOptions,
-): Promise<void> {
-  const commandResult = await executeReleaseAppearanceCommand(executeReleaseAppearanceCommandOptions);
-  process.exitCode = commandResult.exitCode;
-}
-
-async function executeGitCommand(commandArguments: readonly string[]): Promise<string> {
-  const executeFile = promisify(execFile);
-  const commandResult = await executeFile('git', commandArguments, {encoding: 'utf8'});
-  return commandResult.stdout.toString();
-}
-
-async function writeRuntimeFailure(message: string): Promise<void> {
-  process.stderr.write(`${message}\n`);
-}
-
-async function writeRuntimeInformation(message: string): Promise<void> {
-  process.stdout.write(`${message}\n`);
-}
-
-function readMonotonicTime(): number {
-  return performance.now();
-}
-
-function createRuntimeDependencies(commandEnvironment: CommandEnvironment): ReleaseAppearanceCommandDependencies {
-  actionsCore.setSecret(commandEnvironment.githubToken);
-  const httpClient = createRuntimeKyHttpClient();
-  const githubClient = createGitHubClient({
-    httpClient,
-    githubApiUrl: commandEnvironment.githubApiUrl,
-    githubRepository: commandEnvironment.githubRepository,
-    githubToken: commandEnvironment.githubToken,
-  });
-
-  return {
-    executeGitCommand,
-    githubClient,
-    now: readMonotonicTime,
-    progressReporter: createDefaultGitHubActionsProgressReporter(),
-    writeFailure: writeRuntimeFailure,
-    writeInformation: writeRuntimeInformation,
-    async writeSummary(summary): Promise<void> {
-      await actionsCore.summary.addRaw(`${summary}\n`).write();
-    },
-  };
-}
-
-async function startReleaseAppearanceCommand(): Promise<void> {
-  const commandLineArguments = process.argv.slice(processArgumentStartIndex);
-  const parsedCommandResult = parseCommandLineArguments(commandLineArguments);
-  if (parsedCommandResult.isErr) {
-    throw parsedCommandResult.error;
-  }
-
-  const commandEnvironmentResult = readCommandEnvironment(process.env);
-  if (commandEnvironmentResult.isErr) {
-    throw commandEnvironmentResult.error;
-  }
-
-  await main({
-    commandLineArguments,
-    environment: process.env,
-    dependencies: createRuntimeDependencies(commandEnvironmentResult.value),
-  });
-}
-
-async function handleReleaseAppearanceCommandFailure(error: unknown): Promise<void> {
-  const githubToken = Maybe.of(process.env.GITHUB_TOKEN).unwrapOr('');
-  await writeRuntimeFailure(redactSecret(errorMessage(error), githubToken));
-  process.exitCode = 1;
-}
-
-function isReleaseAppearanceCommandEntrypoint(): boolean {
-  return Maybe.of(process.argv[1])
-    .map(entrypointPath => {
-      return /(?:^|[\\/])releaseAppearanceCommand\.ts$/.test(entrypointPath);
-    })
-    .unwrapOr(false);
-}
-
-if (isReleaseAppearanceCommandEntrypoint()) {
-  startReleaseAppearanceCommand().catch(handleReleaseAppearanceCommandFailure);
 }

--- a/tools/release-cli/previewNextBetaCommand.mts
+++ b/tools/release-cli/previewNextBetaCommand.mts
@@ -1,0 +1,181 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isError, isString} from '@sindresorhus/is';
+import {Command, CommanderError} from 'commander';
+
+import process from 'node:process';
+import {appendFile} from 'node:fs/promises';
+import {execFile} from 'node:child_process';
+import {resolve} from 'node:path';
+import {promisify} from 'node:util';
+import {fileURLToPath} from 'node:url';
+
+import {createGitHubClient} from '../release-appearance/githubClient.ts';
+import {createRuntimeKyHttpClient} from '../release-appearance/httpClient.ts';
+import {executePreviewNextBetaCommand} from '../release-appearance/previewNextBetaCommand.ts';
+import {validateTargetMainCommit} from '../release-appearance/previewNextBetaCommand.ts';
+import type {PreviewNextBetaCommandDependencies} from '../release-appearance/previewNextBetaCommand.ts';
+import {planNextBetaPreviewHistory} from '../release-appearance/releaseHistory.ts';
+import {readCommandEnvironment, redactSecret} from '../release-appearance/releaseAppearanceCommand.ts';
+import type {CommandEnvironment} from '../release-appearance/releaseAppearanceCommand.ts';
+
+type CreatePreviewNextBetaCommandOptions = {
+  readonly executeCommand: (targetMainCommit: string) => Promise<number> | number;
+  readonly writeOutput: (message: string) => void;
+  readonly writeError: (message: string) => void;
+};
+
+const executeFile = promisify(execFile);
+
+export function createCommand(createCommandOptions: CreatePreviewNextBetaCommandOptions): Command {
+  const command = new Command()
+    .name('previewNextBetaCommand')
+    .description('Preview changes waiting for the next Beta release.')
+    .argument('<target-main-commit-sha>')
+    .configureOutput({
+      writeOut: createCommandOptions.writeOutput,
+      writeErr: createCommandOptions.writeError,
+    })
+    .exitOverride()
+    .action(async (targetMainCommit: string) => {
+      const targetMainCommitResult = validateTargetMainCommit(targetMainCommit);
+      if (targetMainCommitResult.isErr) {
+        throw targetMainCommitResult.error;
+      }
+
+      await createCommandOptions.executeCommand(targetMainCommit);
+    });
+
+  return command;
+}
+
+export async function runPreviewNextBetaCommand(
+  commandLineArguments: readonly string[],
+  createCommandOptions: CreatePreviewNextBetaCommandOptions,
+): Promise<number> {
+  let executionExitCode = 0;
+  const command = createCommand({
+    ...createCommandOptions,
+    async executeCommand(targetMainCommit: string): Promise<number> {
+      executionExitCode = await createCommandOptions.executeCommand(targetMainCommit);
+
+      return executionExitCode;
+    },
+  });
+
+  try {
+    await command.parseAsync(['node', 'previewNextBetaCommand', ...commandLineArguments]);
+
+    return executionExitCode;
+  } catch (error: unknown) {
+    if (error instanceof CommanderError) {
+      return error.exitCode;
+    }
+
+    throw error;
+  }
+}
+
+async function executeRuntimeGitCommand(commandArguments: readonly string[]): Promise<string> {
+  const commandResult = await executeFile('git', commandArguments, {encoding: 'utf8'});
+
+  return commandResult.stdout.toString();
+}
+
+function writeRuntimeError(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
+function writeRuntimeOutput(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+function writeRuntimeFailure(message: string): Promise<void> {
+  writeRuntimeError(message);
+
+  return Promise.resolve();
+}
+
+function writeRuntimeInformation(message: string): Promise<void> {
+  writeRuntimeOutput(message);
+
+  return Promise.resolve();
+}
+
+function createRuntimeDependencies(commandEnvironment: CommandEnvironment): PreviewNextBetaCommandDependencies {
+  const httpClient = createRuntimeKyHttpClient();
+  const githubClient = createGitHubClient({
+    httpClient,
+    githubApiUrl: commandEnvironment.githubApiUrl,
+    githubRepository: commandEnvironment.githubRepository,
+    githubToken: commandEnvironment.githubToken,
+  });
+
+  return {
+    executeGitCommand: executeRuntimeGitCommand,
+    githubClient,
+    planNextBetaPreviewHistory,
+    writeFailure: writeRuntimeFailure,
+    writeInformation: writeRuntimeInformation,
+    async writeSummary(summary): Promise<void> {
+      await appendFile(commandEnvironment.githubStepSummary, `${summary}\n`, 'utf8');
+    },
+  };
+}
+
+async function executeRuntimeCommand(targetMainCommit: string): Promise<number> {
+  const commandEnvironmentResult = readCommandEnvironment(process.env);
+  if (commandEnvironmentResult.isErr) {
+    throw commandEnvironmentResult.error;
+  }
+
+  const commandResult = await executePreviewNextBetaCommand({
+    targetMainCommit,
+    environment: process.env,
+    dependencies: createRuntimeDependencies(commandEnvironmentResult.value),
+  });
+
+  return commandResult.exitCode;
+}
+
+async function main(): Promise<void> {
+  process.exitCode = await runPreviewNextBetaCommand(process.argv.slice(2), {
+    executeCommand: executeRuntimeCommand,
+    writeError: writeRuntimeError,
+    writeOutput: writeRuntimeOutput,
+  });
+}
+
+function isCurrentModuleEntrypoint(): boolean {
+  const entrypointPath = process.argv[1];
+
+  return isString(entrypointPath) && fileURLToPath(import.meta.url) === resolve(entrypointPath);
+}
+
+function crash(error: unknown): void {
+  const githubToken = isString(process.env.GITHUB_TOKEN) ? process.env.GITHUB_TOKEN : '';
+  const errorMessage = isError(error) ? error.message : String(error);
+  writeRuntimeError(redactSecret(errorMessage, githubToken));
+  process.exitCode = 1;
+}
+
+if (isCurrentModuleEntrypoint()) {
+  main().catch(crash);
+}

--- a/tools/release-cli/productionDistributionCli.mts
+++ b/tools/release-cli/productionDistributionCli.mts
@@ -1,0 +1,206 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {readFileSync} from 'node:fs';
+import process from 'node:process';
+import {resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {isError, isString} from '@sindresorhus/is';
+import {Command, CommanderError} from 'commander';
+
+import {
+  executeProductionDistributionCommand,
+  type ProductionDistributionCommand,
+  type ProductionDistributionCommandDependencies,
+} from '../production-distribution/productionDistributionCli.ts';
+
+type CreateProductionDistributionCommandOptions = {
+  readonly executeCommand: (command: ProductionDistributionCommand) => Promise<number> | number;
+  readonly writeOutput: (message: string) => void;
+  readonly writeError: (message: string) => void;
+};
+
+type ValidateManifestOptionValues = {
+  readonly artifactMetadataPath: string;
+  readonly manifestPath: string;
+  readonly productionTag: string;
+  readonly productionTagCommitSha: string;
+  readonly expectedCommitSha?: string;
+  readonly sourceRunId: string;
+};
+
+type SelectHelmChartOptionValues = {
+  readonly chartsPath: string;
+  readonly imageTag: string;
+};
+
+type WireBuildsFieldsMatchOptionValues = {
+  readonly version: string;
+  readonly repo: string;
+  readonly appVersion: string;
+  readonly commitUrl: string;
+  readonly commit: string;
+};
+
+export function createCommand(createCommandOptions: CreateProductionDistributionCommandOptions): Command {
+  const command = new Command()
+    .name('productionDistributionCli')
+    .description('Validate and select production distribution artifacts.')
+    .configureOutput({
+      writeOut: createCommandOptions.writeOutput,
+      writeErr: createCommandOptions.writeError,
+    })
+    .exitOverride();
+
+  command
+    .command('validate-manifest')
+    .requiredOption('--artifact-metadata-path <path>')
+    .requiredOption('--manifest-path <path>')
+    .requiredOption('--production-tag <tag>')
+    .requiredOption('--production-tag-commit-sha <sha>')
+    .option('--expected-commit-sha <sha>')
+    .requiredOption('--source-run-id <id>')
+    .action(async (optionValues: ValidateManifestOptionValues) => {
+      await createCommandOptions.executeCommand({
+        kind: 'validate-manifest',
+        artifactMetadataPath: optionValues.artifactMetadataPath,
+        manifestPath: optionValues.manifestPath,
+        productionTag: optionValues.productionTag,
+        productionTagCommitSha: optionValues.productionTagCommitSha,
+        expectedCommitSha: optionValues.expectedCommitSha,
+        sourceRunId: optionValues.sourceRunId,
+      });
+    });
+
+  command
+    .command('select-helm-chart')
+    .requiredOption('--charts-path <path>')
+    .requiredOption('--image-tag <tag>')
+    .action(async (optionValues: SelectHelmChartOptionValues) => {
+      await createCommandOptions.executeCommand({
+        kind: 'select-helm-chart',
+        chartsPath: optionValues.chartsPath,
+        imageTag: optionValues.imageTag,
+      });
+    });
+
+  command
+    .command('wire-builds-fields-match')
+    .requiredOption('--version <value>')
+    .requiredOption('--repo <value>')
+    .requiredOption('--app-version <value>')
+    .requiredOption('--commit-url <value>')
+    .requiredOption('--commit <value>')
+    .action(async (optionValues: WireBuildsFieldsMatchOptionValues) => {
+      await createCommandOptions.executeCommand({
+        kind: 'wire-builds-fields-match',
+        version: optionValues.version,
+        repository: optionValues.repo,
+        applicationVersion: optionValues.appVersion,
+        commitUrl: optionValues.commitUrl,
+        commit: optionValues.commit,
+      });
+    });
+
+  return command;
+}
+
+export async function runProductionDistributionCommand(
+  commandLineArguments: readonly string[],
+  createCommandOptions: CreateProductionDistributionCommandOptions,
+): Promise<number> {
+  let executionExitCode = 0;
+  const command = createCommand({
+    ...createCommandOptions,
+    async executeCommand(applicationCommand: ProductionDistributionCommand): Promise<number> {
+      executionExitCode = await createCommandOptions.executeCommand(applicationCommand);
+
+      return executionExitCode;
+    },
+  });
+
+  try {
+    await command.parseAsync(['node', 'productionDistributionCli', ...commandLineArguments]);
+
+    return executionExitCode;
+  } catch (error: unknown) {
+    if (error instanceof CommanderError) {
+      return error.exitCode;
+    }
+
+    const errorMessage = isError(error) ? error.message : String(error);
+    createCommandOptions.writeError(`${errorMessage}\n`);
+
+    return 1;
+  }
+}
+
+function writeRuntimeError(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
+function writeRuntimeCommandOutput(message: string): void {
+  process.stdout.write(message);
+}
+
+function writeRuntimeOutputLine(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+function readRuntimeFile(filePath: string): string {
+  return readFileSync(filePath, 'utf8');
+}
+
+function readRuntimeStandardInput(): string {
+  return readFileSync(0, 'utf8');
+}
+
+function createRuntimeDependencies(): ProductionDistributionCommandDependencies {
+  return {
+    readFile: readRuntimeFile,
+    readStandardInput: readRuntimeStandardInput,
+    writeOutput: writeRuntimeOutputLine,
+  };
+}
+
+async function main(): Promise<void> {
+  process.exitCode = await runProductionDistributionCommand(process.argv.slice(2), {
+    executeCommand(command: ProductionDistributionCommand): number {
+      return executeProductionDistributionCommand(command, createRuntimeDependencies());
+    },
+    writeError: writeRuntimeError,
+    writeOutput: writeRuntimeCommandOutput,
+  });
+}
+
+function isCurrentModuleEntrypoint(): boolean {
+  const entrypointPath = process.argv[1];
+  return isString(entrypointPath) && fileURLToPath(import.meta.url) === resolve(entrypointPath);
+}
+
+function crash(error: unknown): void {
+  const errorMessage = isError(error) ? error.message : String(error);
+  writeRuntimeError(errorMessage);
+  process.exitCode = 1;
+}
+
+if (isCurrentModuleEntrypoint()) {
+  main().catch(crash);
+}

--- a/tools/release-cli/productionDistributionCli.mts
+++ b/tools/release-cli/productionDistributionCli.mts
@@ -42,7 +42,7 @@ type ValidateManifestOptionValues = {
   readonly manifestPath: string;
   readonly productionTag: string;
   readonly productionTagCommitSha: string;
-  readonly expectedCommitSha?: string;
+  readonly expectedCommitSha: string | undefined;
   readonly sourceRunId: string;
 };
 

--- a/tools/release-cli/releaseAppearanceCommand.mts
+++ b/tools/release-cli/releaseAppearanceCommand.mts
@@ -1,0 +1,239 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as actionsCore from '@actions/core';
+import {isError, isString} from '@sindresorhus/is';
+import {Command, CommanderError} from 'commander';
+
+import process from 'node:process';
+import {execFile} from 'node:child_process';
+import {resolve} from 'node:path';
+import {promisify} from 'node:util';
+import {fileURLToPath} from 'node:url';
+
+import {createDefaultGitHubActionsProgressReporter} from '../release-appearance/githubActionsProgressReporter.ts';
+import {createGitHubClient} from '../release-appearance/githubClient.ts';
+import {createRuntimeKyHttpClient} from '../release-appearance/httpClient.ts';
+import {
+  createBetaCommand,
+  createProductionCommand,
+  executeReleaseAppearanceCommand,
+  readCommandEnvironment,
+  redactSecret,
+} from '../release-appearance/releaseAppearanceCommand.ts';
+import type {
+  CommandEnvironment,
+  ExecutionMode,
+  ParsedCommand,
+  ReleaseAppearanceCommandDependencies,
+} from '../release-appearance/releaseAppearanceCommand.ts';
+
+type CreateReleaseAppearanceCommandOptions = {
+  readonly executeCommand: (command: ParsedCommand) => Promise<number> | number;
+  readonly writeOutput: (message: string) => void;
+  readonly writeError: (message: string) => void;
+};
+
+type ReleaseAppearanceOptionValues = {
+  readonly dryRun: boolean;
+};
+
+const executeFile = promisify(execFile);
+
+export function createCommand(createCommandOptions: CreateReleaseAppearanceCommandOptions): Command {
+  const command = new Command()
+    .name('releaseAppearanceCommand')
+    .description('Create or preview release-appearance comments.')
+    .configureOutput({
+      writeOut: createCommandOptions.writeOutput,
+      writeErr: createCommandOptions.writeError,
+    })
+    .exitOverride();
+
+  command
+    .command('beta')
+    .argument('<beta-tag>')
+    .argument('<release-commit-sha>')
+    .option('--dry-run', 'run without writing changes', false)
+    .action(async (betaTag: string, releaseCommit: string, optionValues: ReleaseAppearanceOptionValues) => {
+      const parsedCommandResult = createBetaCommand({
+        betaTag,
+        releaseCommit,
+        executionMode: getExecutionMode(optionValues),
+      });
+      if (parsedCommandResult.isErr) {
+        throw parsedCommandResult.error;
+      }
+
+      await createCommandOptions.executeCommand(parsedCommandResult.value);
+    });
+
+  command
+    .command('production')
+    .argument('<production-tag>')
+    .argument('<release-commit-sha>')
+    .argument('<promoted-beta-tag>')
+    .option('--dry-run', 'run without writing changes', false)
+    .action(
+      async (
+        productionTag: string,
+        releaseCommit: string,
+        promotedBetaTag: string,
+        optionValues: ReleaseAppearanceOptionValues,
+      ) => {
+        const parsedCommandResult = createProductionCommand({
+          productionTag,
+          releaseCommit,
+          promotedBetaTag,
+          executionMode: getExecutionMode(optionValues),
+        });
+        if (parsedCommandResult.isErr) {
+          throw parsedCommandResult.error;
+        }
+
+        await createCommandOptions.executeCommand(parsedCommandResult.value);
+      },
+    );
+
+  return command;
+}
+
+export async function runReleaseAppearanceCommand(
+  commandLineArguments: readonly string[],
+  createCommandOptions: CreateReleaseAppearanceCommandOptions,
+): Promise<number> {
+  let executionExitCode = 0;
+  const command = createCommand({
+    ...createCommandOptions,
+    async executeCommand(applicationCommand: ParsedCommand): Promise<number> {
+      executionExitCode = await createCommandOptions.executeCommand(applicationCommand);
+
+      return executionExitCode;
+    },
+  });
+
+  try {
+    await command.parseAsync(['node', 'releaseAppearanceCommand', ...commandLineArguments]);
+
+    return executionExitCode;
+  } catch (error: unknown) {
+    if (error instanceof CommanderError) {
+      return error.exitCode;
+    }
+
+    throw error;
+  }
+}
+
+function getExecutionMode(optionValues: ReleaseAppearanceOptionValues): ExecutionMode {
+  return optionValues.dryRun === true ? 'dry-run' : 'write';
+}
+
+async function executeRuntimeGitCommand(commandArguments: readonly string[]): Promise<string> {
+  const commandResult = await executeFile('git', commandArguments, {encoding: 'utf8'});
+
+  return commandResult.stdout.toString();
+}
+
+function writeRuntimeError(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
+function writeRuntimeOutput(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+function writeRuntimeFailure(message: string): Promise<void> {
+  writeRuntimeError(message);
+
+  return Promise.resolve();
+}
+
+function writeRuntimeInformation(message: string): Promise<void> {
+  writeRuntimeOutput(message);
+
+  return Promise.resolve();
+}
+
+function readMonotonicTime(): number {
+  return performance.now();
+}
+
+function createRuntimeDependencies(commandEnvironment: CommandEnvironment): ReleaseAppearanceCommandDependencies {
+  actionsCore.setSecret(commandEnvironment.githubToken);
+  const httpClient = createRuntimeKyHttpClient();
+  const githubClient = createGitHubClient({
+    httpClient,
+    githubApiUrl: commandEnvironment.githubApiUrl,
+    githubRepository: commandEnvironment.githubRepository,
+    githubToken: commandEnvironment.githubToken,
+  });
+
+  return {
+    executeGitCommand: executeRuntimeGitCommand,
+    githubClient,
+    now: readMonotonicTime,
+    progressReporter: createDefaultGitHubActionsProgressReporter(),
+    writeFailure: writeRuntimeFailure,
+    writeInformation: writeRuntimeInformation,
+    async writeSummary(summary): Promise<void> {
+      await actionsCore.summary.addRaw(`${summary}\n`).write();
+    },
+  };
+}
+
+async function executeRuntimeCommand(command: ParsedCommand): Promise<number> {
+  const commandEnvironmentResult = readCommandEnvironment(process.env);
+  if (commandEnvironmentResult.isErr) {
+    throw commandEnvironmentResult.error;
+  }
+
+  const commandResult = await executeReleaseAppearanceCommand({
+    command,
+    environment: process.env,
+    dependencies: createRuntimeDependencies(commandEnvironmentResult.value),
+  });
+
+  return commandResult.exitCode;
+}
+
+async function main(): Promise<void> {
+  process.exitCode = await runReleaseAppearanceCommand(process.argv.slice(2), {
+    executeCommand: executeRuntimeCommand,
+    writeError: writeRuntimeError,
+    writeOutput: writeRuntimeOutput,
+  });
+}
+
+function isCurrentModuleEntrypoint(): boolean {
+  const entrypointPath = process.argv[1];
+
+  return isString(entrypointPath) && fileURLToPath(import.meta.url) === resolve(entrypointPath);
+}
+
+function crash(error: unknown): void {
+  const githubToken = isString(process.env.GITHUB_TOKEN) ? process.env.GITHUB_TOKEN : '';
+  const errorMessage = isError(error) ? error.message : String(error);
+  writeRuntimeError(redactSecret(errorMessage, githubToken));
+  process.exitCode = 1;
+}
+
+if (isCurrentModuleEntrypoint()) {
+  main().catch(crash);
+}

--- a/tools/release-cli/releaseCliEntrypoints.test.ts
+++ b/tools/release-cli/releaseCliEntrypoints.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {tmpdir} from 'node:os';
+import process from 'node:process';
+import {spawnSync} from 'node:child_process';
+
+type NativeCommandResult = {
+  readonly exitCode: number | null;
+  readonly standardError: string;
+  readonly standardOutput: string;
+};
+
+const releaseMetadataEntrypointPath = join(process.cwd(), 'tools/release-cli/releaseMetadataCli.mts');
+const productionDistributionEntrypointPath = join(process.cwd(), 'tools/release-cli/productionDistributionCli.mts');
+
+function runNativeCommand(entrypointPath: string, commandLineArguments: readonly string[]): NativeCommandResult {
+  const childProcessResult = spawnSync(process.execPath, [entrypointPath, ...commandLineArguments], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+
+  return {
+    exitCode: childProcessResult.status,
+    standardError: childProcessResult.stderr,
+    standardOutput: childProcessResult.stdout,
+  };
+}
+
+function writeJsonFile(directoryPath: string, fileName: string, value: unknown): string {
+  const filePath = join(directoryPath, fileName);
+  writeFileSync(filePath, JSON.stringify(value), 'utf8');
+  return filePath;
+}
+
+describe('release metadata CLI entrypoint', () => {
+  it('writes help to standard output', () => {
+    const actualResult = runNativeCommand(releaseMetadataEntrypointPath, ['--help']);
+
+    expect(actualResult.exitCode).toBe(0);
+    expect(actualResult.standardOutput).toContain('Usage: releaseMetadataCli');
+  });
+
+  it('preserves the variadic existing-tag contract', () => {
+    const actualResult = runNativeCommand(releaseMetadataEntrypointPath, [
+      'next-beta-tag',
+      '2026-06-19.1',
+      '2026-06-19.1-beta.1',
+      '2026-06-19.1-beta.2',
+    ]);
+
+    expect(actualResult.exitCode).toBe(0);
+    expect(actualResult.standardOutput).toBe('2026-06-19.1-beta.3\n');
+  });
+
+  it('rejects unknown commands with a non-zero exit code', () => {
+    const actualResult = runNativeCommand(releaseMetadataEntrypointPath, ['unknown-command']);
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.standardError).toContain("error: unknown command 'unknown-command'");
+  });
+
+  it('rejects missing required positional arguments with a non-zero exit code', () => {
+    const actualResult = runNativeCommand(releaseMetadataEntrypointPath, ['release-branch']);
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.standardError).toContain("error: missing required argument 'release-identifier'");
+  });
+});
+
+describe('production distribution CLI entrypoint', () => {
+  it('writes help to standard output', () => {
+    const actualResult = runNativeCommand(productionDistributionEntrypointPath, ['--help']);
+
+    expect(actualResult.exitCode).toBe(0);
+    expect(actualResult.standardOutput).toContain('Usage: productionDistributionCli');
+  });
+
+  it('preserves the publish machine-readable output', () => {
+    const temporaryDirectoryPath = mkdtempSync(join(tmpdir(), 'wire-production-distribution-cli-'));
+
+    try {
+      const chartsPath = writeJsonFile(temporaryDirectoryPath, 'charts.json', []);
+      const actualResult = runNativeCommand(productionDistributionEntrypointPath, [
+        'select-helm-chart',
+        '--charts-path',
+        chartsPath,
+        '--image-tag',
+        'dev-test-image',
+      ]);
+
+      expect(actualResult.exitCode).toBe(0);
+      expect(actualResult.standardOutput).toBe('publish\n');
+    } finally {
+      rmSync(temporaryDirectoryPath, {force: true, recursive: true});
+    }
+  });
+
+  it('preserves the reuse machine-readable output', () => {
+    const temporaryDirectoryPath = mkdtempSync(join(tmpdir(), 'wire-production-distribution-cli-'));
+
+    try {
+      const chartsPath = writeJsonFile(temporaryDirectoryPath, 'charts.json', [
+        {version: '1.2.3', app_version: 'dev-test-image'},
+      ]);
+      const actualResult = runNativeCommand(productionDistributionEntrypointPath, [
+        'select-helm-chart',
+        '--charts-path',
+        chartsPath,
+        '--image-tag',
+        'dev-test-image',
+      ]);
+
+      expect(actualResult.exitCode).toBe(0);
+      expect(actualResult.standardOutput).toBe('reuse:1.2.3\n');
+    } finally {
+      rmSync(temporaryDirectoryPath, {force: true, recursive: true});
+    }
+  });
+
+  it('accepts the optional expected commit SHA before domain validation', () => {
+    const temporaryDirectoryPath = mkdtempSync(join(tmpdir(), 'wire-production-distribution-cli-'));
+
+    try {
+      const artifactMetadataPath = writeJsonFile(temporaryDirectoryPath, 'artifact-metadata.json', {});
+      const manifestPath = writeJsonFile(temporaryDirectoryPath, 'manifest.json', {});
+      const actualResult = runNativeCommand(productionDistributionEntrypointPath, [
+        'validate-manifest',
+        '--artifact-metadata-path',
+        artifactMetadataPath,
+        '--manifest-path',
+        manifestPath,
+        '--production-tag',
+        '2026-06-19.1-production',
+        '--production-tag-commit-sha',
+        'a'.repeat(40),
+        '--expected-commit-sha',
+        'b'.repeat(40),
+        '--source-run-id',
+        'run-123',
+      ]);
+
+      expect(actualResult.exitCode).toBe(1);
+      expect(actualResult.standardError).toContain('Production tag commit does not match the expected commit SHA');
+    } finally {
+      rmSync(temporaryDirectoryPath, {force: true, recursive: true});
+    }
+  });
+
+  it('rejects unknown options with a non-zero exit code', () => {
+    const actualResult = runNativeCommand(productionDistributionEntrypointPath, [
+      'select-helm-chart',
+      '--charts-path',
+      '/dev/null',
+      '--image-tag',
+      'dev-test-image',
+      '--unknown-option',
+    ]);
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.standardError).toContain("error: unknown option '--unknown-option'");
+  });
+
+  it('rejects missing required options with a non-zero exit code', () => {
+    const actualResult = runNativeCommand(productionDistributionEntrypointPath, [
+      'select-helm-chart',
+      '--image-tag',
+      'dev-test-image',
+    ]);
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.standardError).toContain("error: required option '--charts-path <path>' not specified");
+  });
+});

--- a/tools/release-cli/releaseCliEntrypoints.test.ts
+++ b/tools/release-cli/releaseCliEntrypoints.test.ts
@@ -29,8 +29,16 @@ type NativeCommandResult = {
   readonly standardOutput: string;
 };
 
+type WriteJsonFileOptions = {
+  readonly directoryPath: string;
+  readonly fileName: string;
+  readonly value: unknown;
+};
+
 const releaseMetadataEntrypointPath = join(process.cwd(), 'tools/release-cli/releaseMetadataCli.mts');
 const productionDistributionEntrypointPath = join(process.cwd(), 'tools/release-cli/productionDistributionCli.mts');
+const releaseAppearanceEntrypointPath = join(process.cwd(), 'tools/release-cli/releaseAppearanceCommand.mts');
+const previewNextBetaEntrypointPath = join(process.cwd(), 'tools/release-cli/previewNextBetaCommand.mts');
 
 function runNativeCommand(entrypointPath: string, commandLineArguments: readonly string[]): NativeCommandResult {
   const childProcessResult = spawnSync(process.execPath, [entrypointPath, ...commandLineArguments], {
@@ -45,9 +53,11 @@ function runNativeCommand(entrypointPath: string, commandLineArguments: readonly
   };
 }
 
-function writeJsonFile(directoryPath: string, fileName: string, value: unknown): string {
+function writeJsonFile(writeJsonFileOptions: WriteJsonFileOptions): string {
+  const {directoryPath, fileName, value} = writeJsonFileOptions;
   const filePath = join(directoryPath, fileName);
   writeFileSync(filePath, JSON.stringify(value), 'utf8');
+
   return filePath;
 }
 
@@ -69,6 +79,19 @@ describe('release metadata CLI entrypoint', () => {
 
     expect(actualResult.exitCode).toBe(0);
     expect(actualResult.standardOutput).toBe('2026-06-19.1-beta.3\n');
+  });
+
+  it('preserves the variadic maintenance-tag contract', () => {
+    const actualResult = runNativeCommand(releaseMetadataEntrypointPath, [
+      'next-maintenance-tag',
+      '2026-07-27.1-airgap-a',
+      '2026-07-27.1-airgap-b-maintenance.9',
+      '2026-07-27.1-airgap-a-maintenance.9',
+      '2026-07-27.1-production',
+    ]);
+
+    expect(actualResult.exitCode).toBe(0);
+    expect(actualResult.standardOutput).toBe('2026-07-27.1-airgap-a-maintenance.10\n');
   });
 
   it('rejects unknown commands with a non-zero exit code', () => {
@@ -98,7 +121,7 @@ describe('production distribution CLI entrypoint', () => {
     const temporaryDirectoryPath = mkdtempSync(join(tmpdir(), 'wire-production-distribution-cli-'));
 
     try {
-      const chartsPath = writeJsonFile(temporaryDirectoryPath, 'charts.json', []);
+      const chartsPath = writeJsonFile({directoryPath: temporaryDirectoryPath, fileName: 'charts.json', value: []});
       const actualResult = runNativeCommand(productionDistributionEntrypointPath, [
         'select-helm-chart',
         '--charts-path',
@@ -118,9 +141,11 @@ describe('production distribution CLI entrypoint', () => {
     const temporaryDirectoryPath = mkdtempSync(join(tmpdir(), 'wire-production-distribution-cli-'));
 
     try {
-      const chartsPath = writeJsonFile(temporaryDirectoryPath, 'charts.json', [
-        {version: '1.2.3', app_version: 'dev-test-image'},
-      ]);
+      const chartsPath = writeJsonFile({
+        directoryPath: temporaryDirectoryPath,
+        fileName: 'charts.json',
+        value: [{version: '1.2.3', app_version: 'dev-test-image'}],
+      });
       const actualResult = runNativeCommand(productionDistributionEntrypointPath, [
         'select-helm-chart',
         '--charts-path',
@@ -140,8 +165,12 @@ describe('production distribution CLI entrypoint', () => {
     const temporaryDirectoryPath = mkdtempSync(join(tmpdir(), 'wire-production-distribution-cli-'));
 
     try {
-      const artifactMetadataPath = writeJsonFile(temporaryDirectoryPath, 'artifact-metadata.json', {});
-      const manifestPath = writeJsonFile(temporaryDirectoryPath, 'manifest.json', {});
+      const artifactMetadataPath = writeJsonFile({
+        directoryPath: temporaryDirectoryPath,
+        fileName: 'artifact-metadata.json',
+        value: {},
+      });
+      const manifestPath = writeJsonFile({directoryPath: temporaryDirectoryPath, fileName: 'manifest.json', value: {}});
       const actualResult = runNativeCommand(productionDistributionEntrypointPath, [
         'validate-manifest',
         '--artifact-metadata-path',
@@ -188,5 +217,95 @@ describe('production distribution CLI entrypoint', () => {
 
     expect(actualResult.exitCode).toBe(1);
     expect(actualResult.standardError).toContain("error: required option '--charts-path <path>' not specified");
+  });
+});
+
+describe('release appearance CLI entrypoint', () => {
+  it('writes help to standard output', () => {
+    const actualResult = runNativeCommand(releaseAppearanceEntrypointPath, ['--help']);
+
+    expect(actualResult.exitCode).toBe(0);
+    expect(actualResult.standardOutput).toContain('Usage: releaseAppearanceCommand');
+  });
+
+  it('supports every release-appearance workflow command shape', () => {
+    const betaWriteResult = runNativeCommand(releaseAppearanceEntrypointPath, [
+      'beta',
+      '2026-06-19.1-beta.1',
+      'a'.repeat(40),
+    ]);
+    const betaDryRunResult = runNativeCommand(releaseAppearanceEntrypointPath, [
+      'beta',
+      '2026-06-19.1-beta.1',
+      'a'.repeat(40),
+      '--dry-run',
+    ]);
+    const productionWriteResult = runNativeCommand(releaseAppearanceEntrypointPath, [
+      'production',
+      '2026-06-19.1-production',
+      'a'.repeat(40),
+      '2026-06-19.1-beta.1',
+    ]);
+    const productionDryRunResult = runNativeCommand(releaseAppearanceEntrypointPath, [
+      'production',
+      '2026-06-19.1-production',
+      'a'.repeat(40),
+      '2026-06-19.1-beta.1',
+      '--dry-run',
+    ]);
+
+    expect(betaWriteResult.exitCode).toBe(1);
+    expect(betaWriteResult.standardError).toContain('GITHUB_API_URL must be set');
+    expect(betaDryRunResult.exitCode).toBe(1);
+    expect(betaDryRunResult.standardError).toContain('GITHUB_API_URL must be set');
+    expect(productionWriteResult.exitCode).toBe(1);
+    expect(productionWriteResult.standardError).toContain('GITHUB_API_URL must be set');
+    expect(productionDryRunResult.exitCode).toBe(1);
+    expect(productionDryRunResult.standardError).toContain('GITHUB_API_URL must be set');
+  });
+
+  it('preserves domain validation for malformed complete commit SHAs', () => {
+    const actualResult = runNativeCommand(releaseAppearanceEntrypointPath, ['beta', '2026-06-19.1-beta.1', 'abcdef0']);
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.standardError).toContain('Release commit SHA must contain exactly 40 hexadecimal characters');
+  });
+
+  it('rejects unknown commands and missing required arguments', () => {
+    const unknownCommandResult = runNativeCommand(releaseAppearanceEntrypointPath, ['unknown-command']);
+    const missingArgumentResult = runNativeCommand(releaseAppearanceEntrypointPath, ['production']);
+
+    expect(unknownCommandResult.exitCode).toBe(1);
+    expect(unknownCommandResult.standardError).toContain("error: unknown command 'unknown-command'");
+    expect(missingArgumentResult.exitCode).toBe(1);
+    expect(missingArgumentResult.standardError).toContain("error: missing required argument 'production-tag'");
+  });
+});
+
+describe('preview next Beta CLI entrypoint', () => {
+  it('writes help to standard output', () => {
+    const actualResult = runNativeCommand(previewNextBetaEntrypointPath, ['--help']);
+
+    expect(actualResult.exitCode).toBe(0);
+    expect(actualResult.standardOutput).toContain('Usage: previewNextBetaCommand');
+  });
+
+  it('preserves target commit validation after Commander parses the argument', () => {
+    const actualResult = runNativeCommand(previewNextBetaEntrypointPath, ['g'.repeat(40)]);
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.standardError).toContain(
+      'Target main commit SHA must contain exactly 40 hexadecimal characters',
+    );
+  });
+
+  it('rejects unknown options and missing required arguments', () => {
+    const unknownOptionResult = runNativeCommand(previewNextBetaEntrypointPath, ['--unknown-option']);
+    const missingArgumentResult = runNativeCommand(previewNextBetaEntrypointPath, []);
+
+    expect(unknownOptionResult.exitCode).toBe(1);
+    expect(unknownOptionResult.standardError).toContain("error: unknown option '--unknown-option'");
+    expect(missingArgumentResult.exitCode).toBe(1);
+    expect(missingArgumentResult.standardError).toContain("error: missing required argument 'target-main-commit-sha'");
   });
 });

--- a/tools/release-cli/releaseMetadataCli.mts
+++ b/tools/release-cli/releaseMetadataCli.mts
@@ -1,0 +1,208 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import process from 'node:process';
+import {resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {isError, isString} from '@sindresorhus/is';
+import {Command, CommanderError} from 'commander';
+
+import {
+  executeReleaseMetadataCommand,
+  type ReleaseMetadataCliDependencies,
+  type ReleaseMetadataCommand,
+} from '../release-metadata/releaseMetadataCli.ts';
+
+type CreateReleaseMetadataCommandOptions = {
+  readonly executeCommand: (command: ReleaseMetadataCommand) => Promise<number> | number;
+  readonly writeOutput: (message: string) => void;
+  readonly writeError: (message: string) => void;
+};
+
+export function createCommand(createCommandOptions: CreateReleaseMetadataCommandOptions): Command {
+  const command = new Command()
+    .name('releaseMetadataCli')
+    .description('Read and create Wire release metadata.')
+    .configureOutput({
+      writeOut: createCommandOptions.writeOutput,
+      writeErr: createCommandOptions.writeError,
+    })
+    .exitOverride();
+
+  command
+    .command('release-identifier-from-branch')
+    .argument('<release-branch>')
+    .action(async (releaseBranch: string) => {
+      await createCommandOptions.executeCommand({kind: 'release-identifier-from-branch', releaseBranch});
+    });
+
+  command
+    .command('release-branch')
+    .argument('<release-identifier>')
+    .action(async (releaseIdentifier: string) => {
+      await createCommandOptions.executeCommand({kind: 'release-branch', releaseIdentifier});
+    });
+
+  command
+    .command('next-beta-tag')
+    .argument('<release-identifier>')
+    .argument('[existing-tag...]')
+    .action(async (releaseIdentifier: string, existingTagNames: string[]) => {
+      await createCommandOptions.executeCommand({kind: 'next-beta-tag', releaseIdentifier, existingTagNames});
+    });
+
+  command
+    .command('production-tag')
+    .argument('<release-identifier>')
+    .action(async (releaseIdentifier: string) => {
+      await createCommandOptions.executeCommand({kind: 'production-tag', releaseIdentifier});
+    });
+
+  command
+    .command('validate-production-tag')
+    .argument('<production-tag>')
+    .action(async (productionTag: string) => {
+      await createCommandOptions.executeCommand({kind: 'validate-production-tag', productionTag});
+    });
+
+  command
+    .command('maintenance-branch')
+    .argument('<maintenance-line-key>')
+    .action(async (maintenanceLineKey: string) => {
+      await createCommandOptions.executeCommand({kind: 'maintenance-branch', maintenanceLineKey});
+    });
+
+  command
+    .command('validate-maintenance-tag')
+    .argument('<maintenance-tag>')
+    .action(async (maintenanceTag: string) => {
+      await createCommandOptions.executeCommand({kind: 'validate-maintenance-tag', maintenanceTag});
+    });
+
+  command
+    .command('next-maintenance-tag')
+    .argument('<maintenance-line-key>')
+    .argument('[existing-tag...]')
+    .action(async (maintenanceLineKey: string, existingTagNames: string[]) => {
+      await createCommandOptions.executeCommand({kind: 'next-maintenance-tag', maintenanceLineKey, existingTagNames});
+    });
+
+  command
+    .command('validate-maintenance-source')
+    .argument('<maintenance-line-key>')
+    .argument('<source-production-tag>')
+    .action(async (maintenanceLineKey: string, sourceProductionTag: string) => {
+      await createCommandOptions.executeCommand({
+        kind: 'validate-maintenance-source',
+        maintenanceLineKey,
+        sourceProductionTag,
+      });
+    });
+
+  command
+    .command('webapp-build-version')
+    .argument('<build-reference-or-empty>')
+    .argument('<full-commit-sha>')
+    .argument('<main|development|production>')
+    .action(async (buildReference: string, fullCommitSha: string, environmentName: string) => {
+      await createCommandOptions.executeCommand({
+        kind: 'webapp-build-version',
+        buildReference,
+        fullCommitSha,
+        environmentName,
+      });
+    });
+
+  return command;
+}
+
+export async function runReleaseMetadataCommand(
+  commandLineArguments: readonly string[],
+  createCommandOptions: CreateReleaseMetadataCommandOptions,
+): Promise<number> {
+  let executionExitCode = 0;
+  const command = createCommand({
+    ...createCommandOptions,
+    async executeCommand(applicationCommand: ReleaseMetadataCommand): Promise<number> {
+      executionExitCode = await createCommandOptions.executeCommand(applicationCommand);
+
+      return executionExitCode;
+    },
+  });
+
+  try {
+    await command.parseAsync(['node', 'releaseMetadataCli', ...commandLineArguments]);
+
+    return executionExitCode;
+  } catch (error: unknown) {
+    if (error instanceof CommanderError) {
+      return error.exitCode;
+    }
+
+    const errorMessage = isError(error) ? error.message : String(error);
+    createCommandOptions.writeError(`${errorMessage}\n`);
+
+    return 1;
+  }
+}
+
+function writeRuntimeError(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
+function writeRuntimeCommandOutput(message: string): void {
+  process.stdout.write(message);
+}
+
+function writeRuntimeOutputLine(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+function createRuntimeDependencies(): ReleaseMetadataCliDependencies {
+  return {
+    writeError: writeRuntimeError,
+    writeOutput: writeRuntimeOutputLine,
+  };
+}
+
+async function main(): Promise<void> {
+  process.exitCode = await runReleaseMetadataCommand(process.argv.slice(2), {
+    executeCommand(command: ReleaseMetadataCommand): number {
+      return executeReleaseMetadataCommand(command, createRuntimeDependencies());
+    },
+    writeError: writeRuntimeError,
+    writeOutput: writeRuntimeCommandOutput,
+  });
+}
+
+function isCurrentModuleEntrypoint(): boolean {
+  const entrypointPath = process.argv[1];
+  return isString(entrypointPath) && fileURLToPath(import.meta.url) === resolve(entrypointPath);
+}
+
+function crash(error: unknown): void {
+  const errorMessage = isError(error) ? error.message : String(error);
+  writeRuntimeError(errorMessage);
+  process.exitCode = 1;
+}
+
+if (isCurrentModuleEntrypoint()) {
+  main().catch(crash);
+}

--- a/tools/release-metadata/releaseMetadataCli.test.ts
+++ b/tools/release-metadata/releaseMetadataCli.test.ts
@@ -17,7 +17,8 @@
  *
  */
 
-import {runReleaseMetadataCli} from './releaseMetadataCli';
+import {executeReleaseMetadataCommand} from './releaseMetadataCli';
+import type {ReleaseMetadataCommand} from './releaseMetadataCli';
 
 type ReleaseMetadataCliTestResult = {
   readonly errors: readonly string[];
@@ -25,10 +26,10 @@ type ReleaseMetadataCliTestResult = {
   readonly outputs: readonly string[];
 };
 
-function runCommand(commandLineArguments: readonly string[]): ReleaseMetadataCliTestResult {
+function runCommand(command: ReleaseMetadataCommand): ReleaseMetadataCliTestResult {
   const errors: string[] = [];
   const outputs: string[] = [];
-  const exitCode = runReleaseMetadataCli(commandLineArguments, {
+  const exitCode = executeReleaseMetadataCommand(command, {
     writeError(message) {
       errors.push(message);
     },
@@ -42,7 +43,7 @@ function runCommand(commandLineArguments: readonly string[]): ReleaseMetadataCli
 
 describe('releaseMetadataCli', () => {
   it('prints the release identifier from a valid release branch name', () => {
-    const actualResult = runCommand(['release-identifier-from-branch', 'release/2026-06-19.1']);
+    const actualResult = runCommand({kind: 'release-identifier-from-branch', releaseBranch: 'release/2026-06-19.1'});
 
     expect(actualResult).toEqual({
       errors: [],
@@ -52,7 +53,7 @@ describe('releaseMetadataCli', () => {
   });
 
   it('rejects an invalid release branch name', () => {
-    const actualResult = runCommand(['release-identifier-from-branch', 'release/2026-06-19.0']);
+    const actualResult = runCommand({kind: 'release-identifier-from-branch', releaseBranch: 'release/2026-06-19.0'});
 
     expect(actualResult).toEqual({
       errors: ['Invalid release branch name: release/2026-06-19.0'],
@@ -62,7 +63,7 @@ describe('releaseMetadataCli', () => {
   });
 
   it('prints the release branch name for the release identifier', () => {
-    const actualResult = runCommand(['release-branch', '2026-06-19.1']);
+    const actualResult = runCommand({kind: 'release-branch', releaseIdentifier: '2026-06-19.1'});
 
     expect(actualResult).toEqual({
       errors: [],
@@ -72,7 +73,7 @@ describe('releaseMetadataCli', () => {
   });
 
   it('rejects an invalid release branch release identifier', () => {
-    const actualResult = runCommand(['release-branch', 'release/2026-06-19.1']);
+    const actualResult = runCommand({kind: 'release-branch', releaseIdentifier: 'release/2026-06-19.1'});
 
     expect(actualResult).toEqual({
       errors: ['Invalid release identifier: release/2026-06-19.1'],
@@ -82,14 +83,16 @@ describe('releaseMetadataCli', () => {
   });
 
   it('prints the next beta tag name for the release identifier', () => {
-    const actualResult = runCommand([
-      'next-beta-tag',
-      '2026-06-19.1',
-      '2026-06-18.1-beta.9',
-      '2026-06-19.1-beta.1',
-      '2026-06-19.1-beta.2',
-      '2026-06-19.1-production',
-    ]);
+    const actualResult = runCommand({
+      kind: 'next-beta-tag',
+      releaseIdentifier: '2026-06-19.1',
+      existingTagNames: [
+        '2026-06-18.1-beta.9',
+        '2026-06-19.1-beta.1',
+        '2026-06-19.1-beta.2',
+        '2026-06-19.1-production',
+      ],
+    });
 
     expect(actualResult).toEqual({
       errors: [],
@@ -99,7 +102,7 @@ describe('releaseMetadataCli', () => {
   });
 
   it('prints the production tag name for the release identifier', () => {
-    const actualResult = runCommand(['production-tag', '2026-06-19.1']);
+    const actualResult = runCommand({kind: 'production-tag', releaseIdentifier: '2026-06-19.1'});
 
     expect(actualResult).toEqual({
       errors: [],
@@ -109,7 +112,7 @@ describe('releaseMetadataCli', () => {
   });
 
   it('rejects an invalid production tag release identifier', () => {
-    const actualResult = runCommand(['production-tag', '2026-06-19']);
+    const actualResult = runCommand({kind: 'production-tag', releaseIdentifier: '2026-06-19'});
 
     expect(actualResult).toEqual({
       errors: ['Invalid release identifier: 2026-06-19'],
@@ -119,7 +122,7 @@ describe('releaseMetadataCli', () => {
   });
 
   it('validates a production tag name', () => {
-    const actualResult = runCommand(['validate-production-tag', '2026-06-19.1-production']);
+    const actualResult = runCommand({kind: 'validate-production-tag', productionTag: '2026-06-19.1-production'});
 
     expect(actualResult).toEqual({
       errors: [],
@@ -129,12 +132,12 @@ describe('releaseMetadataCli', () => {
   });
 
   it('prints the ADR webapp build version', () => {
-    const actualResult = runCommand([
-      'webapp-build-version',
-      '2026-06-19.1-production',
-      '025edc663787b3d2da366f21a5958013201e6cd4',
-      'development',
-    ]);
+    const actualResult = runCommand({
+      kind: 'webapp-build-version',
+      buildReference: '2026-06-19.1-production',
+      fullCommitSha: '025edc663787b3d2da366f21a5958013201e6cd4',
+      environmentName: 'development',
+    });
 
     expect(actualResult).toEqual({
       errors: [],
@@ -144,12 +147,12 @@ describe('releaseMetadataCli', () => {
   });
 
   it('prints the complete legacy webapp build version', () => {
-    const actualResult = runCommand([
-      'webapp-build-version',
-      '2026-06-19-production.1',
-      '025edc663787b3d2da366f21a5958013201e6cd4',
-      'development',
-    ]);
+    const actualResult = runCommand({
+      kind: 'webapp-build-version',
+      buildReference: '2026-06-19-production.1',
+      fullCommitSha: '025edc663787b3d2da366f21a5958013201e6cd4',
+      environmentName: 'development',
+    });
 
     expect(actualResult).toEqual({
       errors: [],
@@ -161,12 +164,12 @@ describe('releaseMetadataCli', () => {
   it.each(['2026-07-20-staging.1'])(
     'prints the development webapp build version for non-production reference "%s"',
     buildReferenceName => {
-      const actualResult = runCommand([
-        'webapp-build-version',
-        buildReferenceName,
-        '025edc663787b3d2da366f21a5958013201e6cd4',
-        'development',
-      ]);
+      const actualResult = runCommand({
+        kind: 'webapp-build-version',
+        buildReference: buildReferenceName,
+        fullCommitSha: '025edc663787b3d2da366f21a5958013201e6cd4',
+        environmentName: 'development',
+      });
 
       expect(actualResult).toEqual({
         errors: [],
@@ -177,7 +180,7 @@ describe('releaseMetadataCli', () => {
   );
 
   it('rejects an invalid production tag name', () => {
-    const actualResult = runCommand(['validate-production-tag', '2026-06-19.0-production']);
+    const actualResult = runCommand({kind: 'validate-production-tag', productionTag: '2026-06-19.0-production'});
 
     expect(actualResult).toEqual({
       errors: ['Invalid production tag name: 2026-06-19.0-production'],
@@ -187,7 +190,7 @@ describe('releaseMetadataCli', () => {
   });
 
   it('prints a maintenance branch name for a valid maintenance line key', () => {
-    const actualResult = runCommand(['maintenance-branch', '2026-07-27.1-airgap-a']);
+    const actualResult = runCommand({kind: 'maintenance-branch', maintenanceLineKey: '2026-07-27.1-airgap-a'});
 
     expect(actualResult).toEqual({
       errors: [],
@@ -197,7 +200,7 @@ describe('releaseMetadataCli', () => {
   });
 
   it('rejects an invalid maintenance line key', () => {
-    const actualResult = runCommand(['maintenance-branch', '2026-07-27.0-airgap-a']);
+    const actualResult = runCommand({kind: 'maintenance-branch', maintenanceLineKey: '2026-07-27.0-airgap-a'});
 
     expect(actualResult).toEqual({
       errors: ['Invalid maintenance line key: 2026-07-27.0-airgap-a'],
@@ -207,7 +210,10 @@ describe('releaseMetadataCli', () => {
   });
 
   it('validates a maintenance tag name', () => {
-    const actualResult = runCommand(['validate-maintenance-tag', '2026-07-27.1-airgap-a-maintenance.1']);
+    const actualResult = runCommand({
+      kind: 'validate-maintenance-tag',
+      maintenanceTag: '2026-07-27.1-airgap-a-maintenance.1',
+    });
 
     expect(actualResult).toEqual({
       errors: [],
@@ -217,7 +223,10 @@ describe('releaseMetadataCli', () => {
   });
 
   it('rejects a malformed maintenance tag name', () => {
-    const actualResult = runCommand(['validate-maintenance-tag', '2026-07-27.1-airgap-a-maintenance.0']);
+    const actualResult = runCommand({
+      kind: 'validate-maintenance-tag',
+      maintenanceTag: '2026-07-27.1-airgap-a-maintenance.0',
+    });
 
     expect(actualResult).toEqual({
       errors: ['Invalid maintenance tag name: 2026-07-27.1-airgap-a-maintenance.0'],
@@ -227,13 +236,15 @@ describe('releaseMetadataCli', () => {
   });
 
   it('prints the next maintenance tag name and ignores unrelated tags', () => {
-    const actualResult = runCommand([
-      'next-maintenance-tag',
-      '2026-07-27.1-airgap-a',
-      '2026-07-27.1-airgap-b-maintenance.9',
-      '2026-07-27.1-airgap-a-maintenance.9',
-      '2026-07-27.1-production',
-    ]);
+    const actualResult = runCommand({
+      kind: 'next-maintenance-tag',
+      maintenanceLineKey: '2026-07-27.1-airgap-a',
+      existingTagNames: [
+        '2026-07-27.1-airgap-b-maintenance.9',
+        '2026-07-27.1-airgap-a-maintenance.9',
+        '2026-07-27.1-production',
+      ],
+    });
 
     expect(actualResult).toEqual({
       errors: [],
@@ -243,7 +254,11 @@ describe('releaseMetadataCli', () => {
   });
 
   it('prints the next maintenance tag name when there is no existing tag', () => {
-    const actualResult = runCommand(['next-maintenance-tag', '2026-07-27.1-airgap-a']);
+    const actualResult = runCommand({
+      kind: 'next-maintenance-tag',
+      maintenanceLineKey: '2026-07-27.1-airgap-a',
+      existingTagNames: [],
+    });
 
     expect(actualResult).toEqual({
       errors: [],
@@ -253,11 +268,11 @@ describe('releaseMetadataCli', () => {
   });
 
   it('validates a matching maintenance source Production tag', () => {
-    const actualResult = runCommand([
-      'validate-maintenance-source',
-      '2026-07-27.1-airgap-a',
-      '2026-07-27.1-production',
-    ]);
+    const actualResult = runCommand({
+      kind: 'validate-maintenance-source',
+      maintenanceLineKey: '2026-07-27.1-airgap-a',
+      sourceProductionTag: '2026-07-27.1-production',
+    });
 
     expect(actualResult).toEqual({
       errors: [],
@@ -267,11 +282,11 @@ describe('releaseMetadataCli', () => {
   });
 
   it('rejects a mismatching maintenance source Production tag', () => {
-    const actualResult = runCommand([
-      'validate-maintenance-source',
-      '2026-07-27.1-airgap-a',
-      '2026-07-28.1-production',
-    ]);
+    const actualResult = runCommand({
+      kind: 'validate-maintenance-source',
+      maintenanceLineKey: '2026-07-27.1-airgap-a',
+      sourceProductionTag: '2026-07-28.1-production',
+    });
 
     expect(actualResult).toEqual({
       errors: [
@@ -283,24 +298,16 @@ describe('releaseMetadataCli', () => {
   });
 
   it('rejects a legacy maintenance source Production tag', () => {
-    const actualResult = runCommand([
-      'validate-maintenance-source',
-      '2026-07-27.1-airgap-a',
-      '2026-07-27-production.1',
-    ]);
+    const actualResult = runCommand({
+      kind: 'validate-maintenance-source',
+      maintenanceLineKey: '2026-07-27.1-airgap-a',
+      sourceProductionTag: '2026-07-27-production.1',
+    });
 
     expect(actualResult).toEqual({
       errors: ['Invalid production tag name: 2026-07-27-production.1'],
       exitCode: 1,
       outputs: [],
     });
-  });
-
-  it('prints usage text for missing command arguments', () => {
-    const actualResult = runCommand(['next-beta-tag']);
-
-    expect(actualResult.exitCode).toBe(1);
-    expect(actualResult.outputs).toEqual([]);
-    expect(actualResult.errors[0]).toContain('Usage:');
   });
 });

--- a/tools/release-metadata/releaseMetadataCli.ts
+++ b/tools/release-metadata/releaseMetadataCli.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import process from 'node:process';
+import {match} from 'ts-pattern';
 
 import {
   createMaintenanceBranchName,
@@ -30,28 +30,59 @@ import {
   validateMaintenanceSource,
   validateMaintenanceTagName,
   validateProductionTagName,
-} from './releaseMetadata';
+} from './releaseMetadata.ts';
 
-type ReleaseMetadataCliDependencies = {
+export type ReleaseMetadataCliDependencies = {
   readonly writeError: (message: string) => void;
   readonly writeOutput: (message: string) => void;
 };
 
-const nodeExecutableAndScriptPathArgumentCount = 2;
-
-const usageText = [
-  'Usage:',
-  '  releaseMetadataCli.ts release-identifier-from-branch <release/YYYY-MM-DD.N>',
-  '  releaseMetadataCli.ts release-branch <YYYY-MM-DD.N>',
-  '  releaseMetadataCli.ts next-beta-tag <YYYY-MM-DD.N> [existing-tag ...]',
-  '  releaseMetadataCli.ts production-tag <YYYY-MM-DD.N>',
-  '  releaseMetadataCli.ts validate-production-tag <YYYY-MM-DD.N-production>',
-  '  releaseMetadataCli.ts maintenance-branch <YYYY-MM-DD.N-qualifier[-qualifier ...]>',
-  '  releaseMetadataCli.ts validate-maintenance-tag <maintenance-line-key-maintenance.X>',
-  '  releaseMetadataCli.ts next-maintenance-tag <maintenance-line-key> [existing-tag ...]',
-  '  releaseMetadataCli.ts validate-maintenance-source <maintenance-line-key> <YYYY-MM-DD.N-production>',
-  '  releaseMetadataCli.ts webapp-build-version <build-reference-or-empty> <full-commit-sha> <main|development|production>',
-].join('\n');
+export type ReleaseMetadataCommand =
+  | {
+      readonly kind: 'release-identifier-from-branch';
+      readonly releaseBranch: string;
+    }
+  | {
+      readonly kind: 'release-branch';
+      readonly releaseIdentifier: string;
+    }
+  | {
+      readonly kind: 'next-beta-tag';
+      readonly releaseIdentifier: string;
+      readonly existingTagNames: readonly string[];
+    }
+  | {
+      readonly kind: 'maintenance-branch';
+      readonly maintenanceLineKey: string;
+    }
+  | {
+      readonly kind: 'validate-maintenance-tag';
+      readonly maintenanceTag: string;
+    }
+  | {
+      readonly kind: 'next-maintenance-tag';
+      readonly maintenanceLineKey: string;
+      readonly existingTagNames: readonly string[];
+    }
+  | {
+      readonly kind: 'validate-maintenance-source';
+      readonly maintenanceLineKey: string;
+      readonly sourceProductionTag: string;
+    }
+  | {
+      readonly kind: 'production-tag';
+      readonly releaseIdentifier: string;
+    }
+  | {
+      readonly kind: 'validate-production-tag';
+      readonly productionTag: string;
+    }
+  | {
+      readonly kind: 'webapp-build-version';
+      readonly buildReference: string;
+      readonly fullCommitSha: string;
+      readonly environmentName: string;
+    };
 
 function writeResult(
   result:
@@ -76,63 +107,62 @@ function writeResult(
   return 0;
 }
 
-export function runReleaseMetadataCli(
-  commandLineArguments: readonly string[],
+export function executeReleaseMetadataCommand(
+  command: ReleaseMetadataCommand,
   dependencies: ReleaseMetadataCliDependencies,
 ): number {
-  const [commandName, primaryValue, ...remainingValues] = commandLineArguments;
-
-  if (commandName === 'release-identifier-from-branch' && primaryValue !== undefined) {
-    return writeResult(extractReleaseIdentifierFromBranchName(primaryValue), dependencies);
-  }
-
-  if (commandName === 'release-branch' && primaryValue !== undefined) {
-    return writeResult(createReleaseBranchName(primaryValue), dependencies);
-  }
-
-  if (commandName === 'next-beta-tag' && primaryValue !== undefined) {
-    return writeResult(createNextBetaTagName(primaryValue, remainingValues), dependencies);
-  }
-
-  if (commandName === 'maintenance-branch' && primaryValue !== undefined && remainingValues.length === 0) {
-    return writeResult(createMaintenanceBranchName(primaryValue), dependencies);
-  }
-
-  if (commandName === 'validate-maintenance-tag' && primaryValue !== undefined && remainingValues.length === 0) {
-    return writeResult(validateMaintenanceTagName(primaryValue), dependencies);
-  }
-
-  if (commandName === 'next-maintenance-tag' && primaryValue !== undefined) {
-    return writeResult(createNextMaintenanceTagName(primaryValue, remainingValues), dependencies);
-  }
-
-  if (commandName === 'validate-maintenance-source' && primaryValue !== undefined && remainingValues.length === 1) {
-    return writeResult(validateMaintenanceSource(primaryValue, remainingValues[0]), dependencies);
-  }
-
-  if (commandName === 'production-tag' && primaryValue !== undefined) {
-    return writeResult(createProductionTagName(primaryValue), dependencies);
-  }
-
-  if (commandName === 'validate-production-tag' && primaryValue !== undefined) {
-    return writeResult(validateProductionTagName(primaryValue), dependencies);
-  }
-
-  if (commandName === 'webapp-build-version' && primaryValue !== undefined && remainingValues.length === 2) {
-    return writeResult(resolveWebappBuildVersion(primaryValue, remainingValues[0], remainingValues[1]), dependencies);
-  }
-
-  dependencies.writeError(usageText);
-  return 1;
-}
-
-if (require.main === module) {
-  process.exitCode = runReleaseMetadataCli(process.argv.slice(nodeExecutableAndScriptPathArgumentCount), {
-    writeError(message): void {
-      console.error(message);
-    },
-    writeOutput(message): void {
-      console.log(message);
-    },
-  });
+  return match(command)
+    .with({kind: 'release-identifier-from-branch'}, releaseIdentifierCommand => {
+      return writeResult(extractReleaseIdentifierFromBranchName(releaseIdentifierCommand.releaseBranch), dependencies);
+    })
+    .with({kind: 'release-branch'}, releaseBranchCommand => {
+      return writeResult(createReleaseBranchName(releaseBranchCommand.releaseIdentifier), dependencies);
+    })
+    .with({kind: 'next-beta-tag'}, nextBetaTagCommand => {
+      return writeResult(
+        createNextBetaTagName(nextBetaTagCommand.releaseIdentifier, nextBetaTagCommand.existingTagNames),
+        dependencies,
+      );
+    })
+    .with({kind: 'maintenance-branch'}, maintenanceBranchCommand => {
+      return writeResult(createMaintenanceBranchName(maintenanceBranchCommand.maintenanceLineKey), dependencies);
+    })
+    .with({kind: 'validate-maintenance-tag'}, validateMaintenanceTagCommand => {
+      return writeResult(validateMaintenanceTagName(validateMaintenanceTagCommand.maintenanceTag), dependencies);
+    })
+    .with({kind: 'next-maintenance-tag'}, nextMaintenanceTagCommand => {
+      return writeResult(
+        createNextMaintenanceTagName(
+          nextMaintenanceTagCommand.maintenanceLineKey,
+          nextMaintenanceTagCommand.existingTagNames,
+        ),
+        dependencies,
+      );
+    })
+    .with({kind: 'validate-maintenance-source'}, validateMaintenanceSourceCommand => {
+      return writeResult(
+        validateMaintenanceSource(
+          validateMaintenanceSourceCommand.maintenanceLineKey,
+          validateMaintenanceSourceCommand.sourceProductionTag,
+        ),
+        dependencies,
+      );
+    })
+    .with({kind: 'production-tag'}, productionTagCommand => {
+      return writeResult(createProductionTagName(productionTagCommand.releaseIdentifier), dependencies);
+    })
+    .with({kind: 'validate-production-tag'}, validateProductionTagCommand => {
+      return writeResult(validateProductionTagName(validateProductionTagCommand.productionTag), dependencies);
+    })
+    .with({kind: 'webapp-build-version'}, webappBuildVersionCommand => {
+      return writeResult(
+        resolveWebappBuildVersion(
+          webappBuildVersionCommand.buildReference,
+          webappBuildVersionCommand.fullCommitSha,
+          webappBuildVersionCommand.environmentName,
+        ),
+        dependencies,
+      );
+    })
+    .exhaustive();
 }

--- a/tsconfig.release-cli.json
+++ b/tsconfig.release-cli.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "es2024",
+    "lib": ["ES2024"],
+    "types": ["node"],
+    "rootDir": ".",
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true
+  },
+  "include": ["tools/release-cli/**/*.mts"],
+  "exclude": ["node_modules", "dist", "tmp"]
+}

--- a/tsconfig.tools.json
+++ b/tsconfig.tools.json
@@ -9,5 +9,12 @@
     "allowImportingTsExtensions": true
   },
   "include": ["tools/**/*.ts", "tools/**/*.mts"],
-  "exclude": ["node_modules", "dist", "tmp", "tools/**/*.test.ts", "tools/jest.config.js", "tools/release-appearance"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tmp",
+    "tools/**/*.test.ts",
+    "tools/release-appearance",
+    "tools/release-cli"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14195,6 +14195,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:15.0.0":
+  version: 15.0.0
+  resolution: "commander@npm:15.0.0"
+  checksum: 10/a5dab1f5c3f1bf2ea19e8089f650f7fb65c3ed88e13ddde62e490d34b20057bcb2cd3de5b6ddc8aae93286083f8256ca0b812df842f574cbebe0e40f5b2f98f7
+  languageName: node
+  linkType: hard
+
 "commander@npm:^11.1.0":
   version: 11.1.0
   resolution: "commander@npm:11.1.0"
@@ -32116,6 +32123,7 @@ __metadata:
     archiver: "npm:7.0.1"
     axios: "npm:1.19.0"
     babel-jest: "npm:30.4.1"
+    commander: "npm:15.0.0"
     cross-env: "npm:10.1.0"
     dotenv: "npm:16.6.1"
     dotenv-extended: "npm:2.9.0"


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

The repository tooling had several command-line entrypoints that parsed `process.argv` manually. As the release tooling has grown, maintaining argument parsing, validation, usage information, and command dispatch independently in each entrypoint has become increasingly unnecessary.

This change introduces [Commander](https://github.com/tj/commander.js) as the shared command-line parsing layer for repository tooling.

The affected CLIs now use `Commander` to define their commands, arguments, options, validation, and help output while keeping the existing application logic independent from the CLI framework.

`Commander` is intentionally restricted to the outer command-line boundary. Application-owned command models and existing orchestration remain independent from Commander types and APIs.

The migration covers the release-related tooling, including release metadata, production distribution, release appearance, and beta preview commands.

Existing command names, arguments, options, exit behavior, and machine-consumed stdout are preserved so that GitHub Actions workflows and other repository automation continue to use the commands without semantic changes.

This also provides a consistent foundation for future repository tooling commands without requiring each entrypoint to implement its own argument parser.
