### PR TITLE
Enhance meeting sync functionality by unifying meeting event subscription [WPB-25516]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/meetingNotificationEventHandlers.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationEventHandlers.test.ts
@@ -30,7 +30,6 @@ import {createMeetingNotificationEventHandlers} from './meetingNotificationEvent
 const meetingId: QualifiedId = {id: 'meeting-id', domain: 'example.com'};
 const creatorId: QualifiedId = {id: 'creator-id', domain: 'example.com'};
 const conversationId: QualifiedId = {id: 'conversation-id', domain: 'example.com'};
-const currentUserId: QualifiedId = {id: 'current-user-id', domain: 'example.com'};
 
 const meetingSeries: MeetingSeries = {
   conversation_id: '',
@@ -49,9 +48,8 @@ describe('createMeetingNotificationEventHandlers', () => {
     const notifications: AddNotificationInput[] = [];
     const warnings: Array<{message: string; context?: unknown}> = [];
 
-    const {onMeetingUpdated, onMeetingMemberAdded, onMeetingDeleted} = createMeetingNotificationEventHandlers({
+    const {notifyUpdate, onMeetingDeleted} = createMeetingNotificationEventHandlers({
       getMeetingSeries: () => [meetingSeries],
-      getSelfUserQualifiedId: () => currentUserId,
       addNotification: notification => {
         notifications.push(notification);
       },
@@ -62,8 +60,8 @@ describe('createMeetingNotificationEventHandlers', () => {
       },
     });
 
-    onMeetingUpdated(meetingId, creatorId);
-    onMeetingMemberAdded(meetingId);
+    notifyUpdate(meetingSeries);
+    notifyUpdate(meetingSeries);
     onMeetingDeleted(meetingId);
 
     expect(notifications).toEqual([
@@ -95,9 +93,8 @@ describe('createMeetingNotificationEventHandlers', () => {
     const notifications: AddNotificationInput[] = [];
     const warnings: Array<{message: string; context?: unknown}> = [];
 
-    const {onMeetingMemberAdded, onMeetingDeleted} = createMeetingNotificationEventHandlers({
+    const {onMeetingDeleted} = createMeetingNotificationEventHandlers({
       getMeetingSeries: () => [],
-      getSelfUserQualifiedId: () => currentUserId,
       addNotification: notification => {
         notifications.push(notification);
       },
@@ -108,18 +105,10 @@ describe('createMeetingNotificationEventHandlers', () => {
       },
     });
 
-    onMeetingMemberAdded(meetingId);
     onMeetingDeleted(meetingId);
 
     expect(notifications).toEqual([]);
     expect(warnings).toEqual([
-      {
-        message: 'Meeting notification pending because the meeting is not in the store yet',
-        context: {
-          kind: MeetingNotificationKind.UPDATE,
-          meetingId,
-        },
-      },
       {
         message: 'Meeting notification pending because the meeting is not in the store yet',
         context: {
@@ -130,21 +119,20 @@ describe('createMeetingNotificationEventHandlers', () => {
     ]);
   });
 
-  it('discards update notifications originated by the current user', () => {
+  it('notifies using the meeting passed by the successful sync', () => {
     const notifications: AddNotificationInput[] = [];
-    const {onMeetingUpdated} = createMeetingNotificationEventHandlers({
-      getMeetingSeries: () => [meetingSeries],
-      getSelfUserQualifiedId: () => currentUserId,
+    const {notifyUpdate} = createMeetingNotificationEventHandlers({
+      getMeetingSeries: () => [],
       addNotification: notification => {
         notifications.push(notification);
       },
-      logger: {
-        warn: () => {},
-      },
+      logger: {warn: () => {}},
     });
 
-    onMeetingUpdated(meetingId, currentUserId);
+    notifyUpdate({...meetingSeries, title: 'Fresh title'});
 
-    expect(notifications).toEqual([]);
+    expect(notifications).toEqual([
+      expect.objectContaining({kind: MeetingNotificationKind.UPDATE, meetingTitle: 'Fresh title'}),
+    ]);
   });
 });

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationEventHandlers.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationEventHandlers.ts
@@ -33,14 +33,12 @@ type MeetingNotificationLogger = {
 
 export type MeetingNotificationEventHandlersDependencies = {
   getMeetingSeries: () => readonly MeetingSeries[];
-  getSelfUserQualifiedId: () => QualifiedId;
   addNotification: (input: AddNotificationInput) => void;
   logger: MeetingNotificationLogger;
 };
 
 export type MeetingNotificationEventHandlers = {
-  onMeetingUpdated: (meetingId: QualifiedId, actorId: QualifiedId) => void;
-  onMeetingMemberAdded: (meetingId: QualifiedId) => void;
+  notifyUpdate: (meeting: MeetingSeries) => void;
   onMeetingDeleted: (meetingId: QualifiedId) => void;
   /** Retries notifications that couldn't be sent because the meeting wasn't in the store yet. */
   retryPendingNotifications: () => void;
@@ -48,16 +46,14 @@ export type MeetingNotificationEventHandlers = {
 
 export const createMeetingNotificationEventHandlers = ({
   getMeetingSeries,
-  getSelfUserQualifiedId,
   addNotification,
   logger,
 }: MeetingNotificationEventHandlersDependencies): MeetingNotificationEventHandlers => {
   const getMeeting = (meetingId: QualifiedId) =>
     getMeetingSeries().find(meeting => matchQualifiedIds(meeting.qualified_id, meetingId));
 
-  // Meeting notification events only carry the meetingId and can fire before the
-  // meeting store has synced, so a lookup miss is retried once the store updates rather than dropped.
-  const pending = new Map<string, {meetingId: QualifiedId; kind: MeetingNotificationKind}>();
+  // Only deleted events can fire before the meeting store has synced.
+  const pending = new Map<string, QualifiedId>();
   const pendingKey = (meetingId: QualifiedId) => `${meetingId.domain}@${meetingId.id}`;
 
   const notifyForMeeting = (kind: MeetingNotificationKind, meeting: MeetingSeries) => {
@@ -86,43 +82,36 @@ export const createMeetingNotificationEventHandlers = ({
       .exhaustive();
   };
 
-  const addNotificationForMeeting = (meetingId: QualifiedId, kind: MeetingNotificationKind): boolean => {
+  const addCancellationNotificationForMeeting = (meetingId: QualifiedId): void => {
     const meeting = getMeeting(meetingId);
     if (!meeting) {
-      logger.warn('Meeting notification pending because the meeting is not in the store yet', {kind, meetingId});
-      pending.set(pendingKey(meetingId), {meetingId, kind});
-      return false;
+      logger.warn('Meeting notification pending because the meeting is not in the store yet', {
+        kind: MeetingNotificationKind.CANCELLED,
+        meetingId,
+      });
+      pending.set(pendingKey(meetingId), meetingId);
+      return;
     }
 
-    notifyForMeeting(kind, meeting);
-    return true;
+    notifyForMeeting(MeetingNotificationKind.CANCELLED, meeting);
   };
 
   const retryPendingNotifications = () => {
-    for (const [key, {meetingId, kind}] of pending) {
+    for (const [key, meetingId] of pending) {
       const meeting = getMeeting(meetingId);
       if (!meeting) {
         continue;
       }
 
-      notifyForMeeting(kind, meeting);
+      notifyForMeeting(MeetingNotificationKind.CANCELLED, meeting);
       pending.delete(key);
     }
   };
 
   return {
-    onMeetingUpdated: (meetingId, actorId) => {
-      if (matchQualifiedIds(actorId, getSelfUserQualifiedId())) {
-        return;
-      }
-
-      addNotificationForMeeting(meetingId, MeetingNotificationKind.UPDATE);
-    },
-    onMeetingMemberAdded: meetingId => {
-      addNotificationForMeeting(meetingId, MeetingNotificationKind.UPDATE);
-    },
+    notifyUpdate: meeting => notifyForMeeting(MeetingNotificationKind.UPDATE, meeting),
     onMeetingDeleted: meetingId => {
-      addNotificationForMeeting(meetingId, MeetingNotificationKind.CANCELLED);
+      addCancellationNotificationForMeeting(meetingId);
     },
     retryPendingNotifications,
   };

--- a/apps/webapp/src/script/components/Meeting/meetingNotificationEventHandlers.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingNotificationEventHandlers.ts
@@ -54,7 +54,7 @@ export const createMeetingNotificationEventHandlers = ({
 
   // Only deleted events can fire before the meeting store has synced.
   const pending = new Map<string, QualifiedId>();
-  const pendingKey = (meetingId: QualifiedId) => `${meetingId.domain}@${meetingId.id}`;
+  const pendingKey = (meetingId: QualifiedId) => `${meetingId.domain}:${meetingId.id}`;
 
   const notifyForMeeting = (kind: MeetingNotificationKind, meeting: MeetingSeries) => {
     const notificationBase = {

--- a/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.test.tsx
@@ -180,13 +180,15 @@ describe('MeetingStoreRoot', () => {
       amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId, otherUserId);
     });
 
-    expect(useMeetingNotificationStore.getState().notifications).toEqual([
-      expect.objectContaining({
-        kind: MeetingNotificationKind.UPDATE,
-        meetingTitle: 'Weekly sync',
-        qualifiedId: meetingId,
-      }),
-    ]);
+    await waitFor(() => {
+      expect(useMeetingNotificationStore.getState().notifications).toEqual([
+        expect.objectContaining({
+          kind: MeetingNotificationKind.UPDATE,
+          meetingTitle: 'Weekly sync (updated)',
+          qualifiedId: meetingId,
+        }),
+      ]);
+    });
   });
 
   it('does not notify the user who updated the meeting', async () => {
@@ -198,6 +200,10 @@ describe('MeetingStoreRoot', () => {
 
     act(() => {
       amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId, selfUserId);
+    });
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('Weekly sync (updated)');
     });
 
     expect(useMeetingNotificationStore.getState().notifications).toEqual([]);
@@ -218,7 +224,7 @@ describe('MeetingStoreRoot', () => {
     expect(getMeeting).toHaveBeenCalledWith(meetingId);
   });
 
-  it('retries a pending update notification after a member-added meeting is synced', async () => {
+  it('creates an update notification from the freshly synced member-added meeting', async () => {
     const {getMeeting} = renderMeetingStoreRoot({
       getMeetingsList: jest.fn(() => task.resolve([])),
       getMeeting: jest.fn(() => task.resolve(createApiMeeting('Late joiner meeting'))),

--- a/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.test.tsx
@@ -285,6 +285,44 @@ describe('MeetingStoreRoot', () => {
     });
   });
 
+  it('does not add an update notification when a queued sync is followed by deletion', async () => {
+    let resolveMeeting: () => void = () => undefined;
+    const meetingFetch = new Promise<void>(resolve => {
+      resolveMeeting = resolve;
+    });
+    const getMeeting = jest.fn(() =>
+      task.tryOrElse(
+        () => new Error('fetch failed'),
+        async () => {
+          await meetingFetch;
+          return createApiMeeting('Weekly sync (updated)');
+        },
+      ),
+    );
+    renderMeetingStoreRoot({getMeeting});
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('Weekly sync');
+    });
+
+    act(() => {
+      amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId, otherUserId);
+      amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
+      resolveMeeting();
+    });
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('');
+    });
+
+    expect(useMeetingNotificationStore.getState().notifications).toEqual([
+      expect.objectContaining({
+        kind: MeetingNotificationKind.CANCELLED,
+        qualifiedId: meetingId,
+      }),
+    ]);
+  });
+
   it('reloads meetings when missed events are reported', async () => {
     const getMeetingsList = jest
       .fn()

--- a/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.test.tsx
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.test.tsx
@@ -215,7 +215,7 @@ describe('MeetingStoreRoot', () => {
       getMeeting: jest.fn(() => task.resolve(createApiMeeting('Late joiner meeting'))),
     });
 
-    amplify.publish(WebAppEvents.MEETING.MEMBER_ADDED, meetingId);
+    amplify.publish(WebAppEvents.MEETING.MEMBER_ADDED, meetingId, otherUserId);
 
     await waitFor(() => {
       expect(getRenderedMeetingTitles()).toBe('Late joiner meeting');
@@ -231,7 +231,7 @@ describe('MeetingStoreRoot', () => {
     });
 
     act(() => {
-      amplify.publish(WebAppEvents.MEETING.MEMBER_ADDED, meetingId);
+      amplify.publish(WebAppEvents.MEETING.MEMBER_ADDED, meetingId, otherUserId);
     });
 
     await waitFor(() => {

--- a/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.tsx
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/MeetingStoreRoot.tsx
@@ -88,16 +88,17 @@ export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
 
     const notificationHandlers = createMeetingNotificationEventHandlers({
       getMeetingSeries: () => store.getState().meetingSeries,
-      getSelfUserQualifiedId: () => container.resolve(UserState).self().qualifiedId,
       addNotification: useMeetingNotificationStore.getState().addNotification,
       logger,
     });
 
-    amplify.subscribe(WebAppEvents.MEETING.UPDATED, notificationHandlers.onMeetingUpdated);
-    amplify.subscribe(WebAppEvents.MEETING.MEMBER_ADDED, notificationHandlers.onMeetingMemberAdded);
     amplify.subscribe(WebAppEvents.MEETING.DELETED, notificationHandlers.onMeetingDeleted);
 
-    const unsubscribeFromMeetingLifecycleEvents = subscribeToMeetingLifecycleEvents({dispatcher});
+    const unsubscribeFromMeetingLifecycleEvents = subscribeToMeetingLifecycleEvents({
+      dispatcher,
+      getSelfUserQualifiedId: () => container.resolve(UserState).self().qualifiedId,
+      notifyUpdate: notificationHandlers.notifyUpdate,
+    });
     const unsubscribeFromMeetingStore = store.subscribe((state, previousState) => {
       if (state.meetingSeries !== previousState.meetingSeries) {
         notificationHandlers.retryPendingNotifications();
@@ -109,8 +110,6 @@ export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
     return () => {
       unsubscribeFromMeetingLifecycleEvents();
       unsubscribeFromMeetingStore();
-      amplify.unsubscribe(WebAppEvents.MEETING.UPDATED, notificationHandlers.onMeetingUpdated);
-      amplify.unsubscribe(WebAppEvents.MEETING.MEMBER_ADDED, notificationHandlers.onMeetingMemberAdded);
       amplify.unsubscribe(WebAppEvents.MEETING.DELETED, notificationHandlers.onMeetingDeleted);
     };
   }, [isMeetingsEnabled, store]);

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.test.ts
@@ -215,6 +215,28 @@ describe('createMeetingLifecycleDispatcher', () => {
     expect(reportOperationFailure).toHaveBeenCalledWith('meetingSync');
   });
 
+  it('invokes the sync success callback with the fetched meeting', async () => {
+    const onSuccess = jest.fn();
+    const dispatcher = createMeetingLifecycleDispatcher(createDependencies());
+
+    dispatcher.enqueueMeetingSync(meetingId, onSuccess);
+    await dispatcher.waitUntilAllSettled();
+
+    expect(onSuccess).toHaveBeenCalledWith(meetingSeries);
+  });
+
+  it('does not invoke the sync success callback when syncing fails', async () => {
+    const onSuccess = jest.fn();
+    const dispatcher = createMeetingLifecycleDispatcher(
+      createDependencies({syncMeeting: () => task.reject(syncMeetingErrors.fetchFailed)}),
+    );
+
+    dispatcher.enqueueMeetingSync(meetingId, onSuccess);
+    await dispatcher.waitUntilAllSettled();
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
   it('keeps running queued work after the initial load throws', async () => {
     const removeMeeting = jest.fn();
     const dispatcher = createMeetingLifecycleDispatcher(

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.test.ts
@@ -65,7 +65,7 @@ const createDependencies = (
   overrides: Partial<MeetingLifecycleDispatcherDependencies> = {},
 ): MeetingLifecycleDispatcherDependencies => ({
   loadMeetings: async () => undefined,
-  syncMeeting: () => task.resolve(meetingSeries),
+  syncMeeting: () => task.resolve({meeting: meetingSeries, applied: true}),
   removeMeeting: () => undefined,
   reportOperationFailure: jest.fn(),
   ...overrides,
@@ -84,7 +84,7 @@ describe('createMeetingLifecycleDispatcher', () => {
         },
         syncMeeting: id => {
           completedSteps.push(`sync:${id.id}`);
-          return task.resolve(meetingSeries);
+          return task.resolve({meeting: meetingSeries, applied: true});
         },
       }),
     );
@@ -115,7 +115,7 @@ describe('createMeetingLifecycleDispatcher', () => {
               await pendingSync.promise;
               completedSteps.push(`sync:${id.id}:finished`);
 
-              return meetingSeries;
+              return {meeting: meetingSeries, applied: true};
             },
           ),
         removeMeeting: id => {
@@ -158,7 +158,7 @@ describe('createMeetingLifecycleDispatcher', () => {
 
               completedSteps.push(`sync:${id.id}:finished`);
 
-              return meetingSeries;
+              return {meeting: meetingSeries, applied: true};
             },
           ),
       }),
@@ -232,6 +232,42 @@ describe('createMeetingLifecycleDispatcher', () => {
     );
 
     dispatcher.enqueueMeetingSync(meetingId, onSuccess);
+    await dispatcher.waitUntilAllSettled();
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke the sync success callback when the store did not apply the result', async () => {
+    const onSuccess = jest.fn();
+    const dispatcher = createMeetingLifecycleDispatcher(
+      createDependencies({syncMeeting: () => task.resolve({meeting: meetingSeries, applied: false})}),
+    );
+
+    dispatcher.enqueueMeetingSync(meetingId, onSuccess);
+    await dispatcher.waitUntilAllSettled();
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke a sync success callback after a removal is queued for the same meeting', async () => {
+    const onSuccess = jest.fn();
+    const pendingSync = createDeferred();
+    const dispatcher = createMeetingLifecycleDispatcher(
+      createDependencies({
+        syncMeeting: () =>
+          task.tryOrElse(
+            () => syncMeetingErrors.fetchFailed,
+            async () => {
+              await pendingSync.promise;
+              return {meeting: meetingSeries, applied: true};
+            },
+          ),
+      }),
+    );
+
+    dispatcher.enqueueMeetingSync(meetingId, onSuccess);
+    dispatcher.enqueueMeetingRemoval(meetingId);
+    pendingSync.resolve();
     await dispatcher.waitUntilAllSettled();
 
     expect(onSuccess).not.toHaveBeenCalled();

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.ts
@@ -37,7 +37,7 @@ export type MeetingLifecycleDispatcher = {
   /** Queues the initial meetings list load. */
   enqueueInitialLoad: () => void;
   /** Queues a refetch of a single meeting, used for created and updated events. */
-  enqueueMeetingSync: (meetingId: QualifiedId) => void;
+  enqueueMeetingSync: (meetingId: QualifiedId, onSuccess?: (meeting: MeetingSeries) => void) => void;
   /** Queues the removal of a single meeting from the store. */
   enqueueMeetingRemoval: (meetingId: QualifiedId) => void;
   /** Resolves once all work queued before this call has settled. */
@@ -68,13 +68,16 @@ export const createMeetingLifecycleDispatcher = (
     enqueueInitialLoad: () => {
       enqueue('initialLoad', dependencies.loadMeetings);
     },
-    enqueueMeetingSync: meetingId => {
+    enqueueMeetingSync: (meetingId, onSuccess) => {
       enqueue('meetingSync', async () => {
         const syncResult = await dependencies.syncMeeting(meetingId);
 
         if (syncResult.isErr) {
           dependencies.reportOperationFailure('meetingSync');
+          return;
         }
+
+        onSuccess?.(syncResult.value);
       });
     },
     enqueueMeetingRemoval: meetingId => {

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingLifecycleDispatcher.ts
@@ -22,13 +22,13 @@ import {task, type Task} from 'true-myth';
 
 import type {MeetingSeries} from 'Components/Meeting/types/meetingSeries';
 
-import type {SyncMeetingError} from './createMeetingStore';
+import type {SyncMeetingError, SyncMeetingResult} from './createMeetingStore';
 
 const dispatcherOperationFailed = 'dispatcherOperationFailed';
 
 export type MeetingLifecycleDispatcherDependencies = {
   loadMeetings: () => Promise<void>;
-  syncMeeting: (meetingId: QualifiedId) => Task<MeetingSeries, SyncMeetingError>;
+  syncMeeting: (meetingId: QualifiedId) => Task<SyncMeetingResult, SyncMeetingError>;
   removeMeeting: (meetingId: QualifiedId) => void;
   reportOperationFailure: (operationName: string) => void;
 };
@@ -53,6 +53,15 @@ export const createMeetingLifecycleDispatcher = (
   dependencies: MeetingLifecycleDispatcherDependencies,
 ): MeetingLifecycleDispatcher => {
   let queuedOperations: Promise<void> = Promise.resolve();
+  const latestOperationVersions = new Map<string, number>();
+
+  const meetingIdKey = (meetingId: QualifiedId): string => `${meetingId.domain}:${meetingId.id}`;
+  const bumpOperationVersion = (meetingId: QualifiedId): number => {
+    const key = meetingIdKey(meetingId);
+    const version = (latestOperationVersions.get(key) ?? 0) + 1;
+    latestOperationVersions.set(key, version);
+    return version;
+  };
 
   const enqueue = (operationName: string, operation: () => Promise<unknown>): void => {
     queuedOperations = queuedOperations.then(async () => {
@@ -69,6 +78,8 @@ export const createMeetingLifecycleDispatcher = (
       enqueue('initialLoad', dependencies.loadMeetings);
     },
     enqueueMeetingSync: (meetingId, onSuccess) => {
+      const operationVersion = bumpOperationVersion(meetingId);
+
       enqueue('meetingSync', async () => {
         const syncResult = await dependencies.syncMeeting(meetingId);
 
@@ -77,10 +88,15 @@ export const createMeetingLifecycleDispatcher = (
           return;
         }
 
-        onSuccess?.(syncResult.value);
+        const currentVersion = latestOperationVersions.get(meetingIdKey(meetingId));
+        if (syncResult.value.applied && currentVersion === operationVersion) {
+          onSuccess?.(syncResult.value.meeting);
+        }
       });
     },
     enqueueMeetingRemoval: meetingId => {
+      bumpOperationVersion(meetingId);
+
       enqueue('meetingRemoval', async () => {
         dependencies.removeMeeting(meetingId);
       });

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
@@ -189,10 +189,7 @@ describe('createMeetingStore', () => {
 
     await pendingReload;
 
-    expect(store.getState()).toMatchObject({
-      isLoading: false,
-      meetingSeries: [],
-    });
+    expect(store.getState()).toMatchObject({isLoading: false, meetingSeries: []});
   });
 
   it('does not remove a newly synchronized meeting when an older list reload finishes', async () => {

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
@@ -372,7 +372,7 @@ describe('createMeetingStore', () => {
 
       const result = await store.getState().syncMeetingByQualifiedId(apiMeeting.qualified_id);
 
-      expect(unwrap(result)).toMatchObject(meetingSeriesEntry);
+      expect(unwrap(result)).toEqual({meeting: expect.objectContaining(meetingSeriesEntry), applied: true});
       expect(getMeeting).toHaveBeenCalledWith(apiMeeting.qualified_id);
       expect(store.getState().meetingSeries).toHaveLength(1);
       expect(store.getState().meetingSeries[0]).toMatchObject(meetingSeriesEntry);
@@ -385,7 +385,7 @@ describe('createMeetingStore', () => {
 
       const result = await store.getState().syncMeetingByQualifiedId(apiMeeting.qualified_id);
 
-      expect(unwrap(result).title).toBe('Weekly sync (updated)');
+      expect(unwrap(result).meeting.title).toBe('Weekly sync (updated)');
       expect(store.getState().meetingSeries).toHaveLength(1);
       expect(store.getState().meetingSeries[0]?.title).toBe('Weekly sync (updated)');
     });
@@ -410,7 +410,9 @@ describe('createMeetingStore', () => {
       store.getState().removeMeetingByQualifiedId(apiMeeting.qualified_id);
       finishFetch();
 
-      expect((await pendingSync).isOk).toBe(true);
+      const result = await pendingSync;
+
+      expect(unwrap(result)).toEqual({meeting: expect.objectContaining(meetingSeriesEntry), applied: false});
       expect(store.getState().meetingSeries).toEqual([]);
     });
 

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.ts
@@ -63,6 +63,11 @@ export const syncMeetingErrors = {
 
 export type SyncMeetingError = (typeof syncMeetingErrors)[keyof typeof syncMeetingErrors];
 
+export type SyncMeetingResult = {
+  meeting: MeetingSeries;
+  applied: boolean;
+};
+
 export type EditMeetingData = {
   formState: ScheduleMeetingFormState;
   qualifiedConversation: MeetingSeries['qualified_conversation'];
@@ -80,7 +85,7 @@ export type MeetingStoreState = {
   deleteMeetingForMe: (meetingInstance: MeetingInstance) => Task<void, MeetingSubmitErrors>;
   deleteMeetingForAll: (meetingInstance: MeetingInstance) => Task<void, MeetingSubmitErrors>;
   removeMeetingByQualifiedId: (meetingId: QualifiedId) => void;
-  syncMeetingByQualifiedId: (meetingId: QualifiedId) => Task<MeetingSeries, SyncMeetingError>;
+  syncMeetingByQualifiedId: (meetingId: QualifiedId) => Task<SyncMeetingResult, SyncMeetingError>;
   loadMeetingForEdit: (meetingInstance: MeetingInstance) => Task<EditMeetingData, MeetingSubmitErrors>;
 };
 
@@ -154,18 +159,19 @@ export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: Meetin
               error: mapResult.error,
               qualifiedId: meetingId,
             });
-            return task.reject<MeetingSeries, SyncMeetingError>(syncMeetingErrors.mapFailed);
+            return task.reject<SyncMeetingResult, SyncMeetingError>(syncMeetingErrors.mapFailed);
           }
 
-          return task.resolve<MeetingSeries, SyncMeetingError>(mapResult.value);
+          return task.resolve<SyncMeetingResult, SyncMeetingError>({meeting: mapResult.value, applied: false});
         })
-        .map(updatedSeries => {
-          if (getMeetingMutationVersion(meetingId) === mutationVersionBeforeFetch) {
-            set(state => ({meetingSeries: upsertMeetingSeries(state.meetingSeries, updatedSeries)}));
+        .map(({meeting}) => {
+          const applied = getMeetingMutationVersion(meetingId) === mutationVersionBeforeFetch;
+          if (applied) {
+            set(state => ({meetingSeries: upsertMeetingSeries(state.meetingSeries, meeting)}));
             meetingStoreMutationVersion += 1;
           }
 
-          return updatedSeries;
+          return {meeting, applied};
         });
     },
     loadMeetingForEdit: meetingInstance => {

--- a/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
@@ -81,7 +81,7 @@ describe('subscribeToMeetingLifecycleEvents', () => {
     const dispatcher = createDispatcherDouble();
     subscribe(dispatcher);
 
-    amplify.publish(WebAppEvents.MEETING.MEMBER_ADDED, meetingId);
+    amplify.publish(WebAppEvents.MEETING.MEMBER_ADDED, meetingId, otherUserId);
 
     expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId, expect.any(Function));
     expect(dispatcher.enqueueMeetingRemoval).not.toHaveBeenCalled();
@@ -102,6 +102,16 @@ describe('subscribeToMeetingLifecycleEvents', () => {
     subscribe(dispatcher);
 
     amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId, selfUserId);
+
+    expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId);
+    expect(dispatcher.enqueueMeetingSync).not.toHaveBeenCalledWith(meetingId, expect.any(Function));
+  });
+
+  it('queues a sync without a notification callback for a member-added event authored by the current user', () => {
+    const dispatcher = createDispatcherDouble();
+    subscribe(dispatcher);
+
+    amplify.publish(WebAppEvents.MEETING.MEMBER_ADDED, meetingId, selfUserId);
 
     expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId);
     expect(dispatcher.enqueueMeetingSync).not.toHaveBeenCalledWith(meetingId, expect.any(Function));

--- a/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
@@ -25,6 +25,8 @@ import type {MeetingLifecycleDispatcher} from './createMeetingLifecycleDispatche
 import {subscribeToMeetingLifecycleEvents} from './subscribeToMeetingLifecycleEvents';
 
 const meetingId: QualifiedId = {id: 'meeting-id', domain: 'example.com'};
+const selfUserId: QualifiedId = {id: 'self-user-id', domain: 'example.com'};
+const otherUserId: QualifiedId = {id: 'other-user-id', domain: 'example.com'};
 
 type MeetingLifecycleDispatcherDouble = {
   [Key in keyof MeetingLifecycleDispatcher]: jest.Mock;
@@ -41,7 +43,11 @@ describe('subscribeToMeetingLifecycleEvents', () => {
   const activeUnsubscribeCallbacks: (() => void)[] = [];
 
   const subscribe = (dispatcher: MeetingLifecycleDispatcherDouble) => {
-    const unsubscribe = subscribeToMeetingLifecycleEvents({dispatcher});
+    const unsubscribe = subscribeToMeetingLifecycleEvents({
+      dispatcher,
+      getSelfUserQualifiedId: () => selfUserId,
+      notifyUpdate: jest.fn(),
+    });
     activeUnsubscribeCallbacks.push(unsubscribe);
 
     return unsubscribe;
@@ -65,9 +71,9 @@ describe('subscribeToMeetingLifecycleEvents', () => {
     const dispatcher = createDispatcherDouble();
     subscribe(dispatcher);
 
-    amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId);
+    amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId, otherUserId);
 
-    expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId);
+    expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId, expect.any(Function));
     expect(dispatcher.enqueueMeetingRemoval).not.toHaveBeenCalled();
   });
 
@@ -77,7 +83,7 @@ describe('subscribeToMeetingLifecycleEvents', () => {
 
     amplify.publish(WebAppEvents.MEETING.MEMBER_ADDED, meetingId);
 
-    expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId);
+    expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId, expect.any(Function));
     expect(dispatcher.enqueueMeetingRemoval).not.toHaveBeenCalled();
   });
 
@@ -89,6 +95,16 @@ describe('subscribeToMeetingLifecycleEvents', () => {
 
     expect(dispatcher.enqueueMeetingRemoval).toHaveBeenCalledWith(meetingId);
     expect(dispatcher.enqueueMeetingSync).not.toHaveBeenCalled();
+  });
+
+  it('queues a sync without a notification callback for an update authored by the current user', () => {
+    const dispatcher = createDispatcherDouble();
+    subscribe(dispatcher);
+
+    amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId, selfUserId);
+
+    expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId);
+    expect(dispatcher.enqueueMeetingSync).not.toHaveBeenCalledWith(meetingId, expect.any(Function));
   });
 
   it('queues a meetings reload when missed events are reported', () => {

--- a/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
@@ -59,7 +59,12 @@ export const subscribeToMeetingLifecycleEvents = ({
     enqueueMeetingSyncWithUpdateNotification(meetingId);
   };
 
-  const onMeetingMemberAdded = (meetingId: QualifiedId) => {
+  const onMeetingMemberAdded = (meetingId: QualifiedId, actorId: QualifiedId) => {
+    if (matchQualifiedIds(actorId, getSelfUserQualifiedId())) {
+      dispatcher.enqueueMeetingSync(meetingId);
+      return;
+    }
+
     enqueueMeetingSyncWithUpdateNotification(meetingId);
   };
 

--- a/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
@@ -22,10 +22,15 @@ import {amplify} from 'amplify';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 
+import type {MeetingSeries} from 'Components/Meeting/types/meetingSeries';
+import {matchQualifiedIds} from 'Util/qualifiedId';
+
 import type {MeetingLifecycleDispatcher} from './createMeetingLifecycleDispatcher';
 
 export type SubscribeToMeetingLifecycleEventsDependencies = {
   dispatcher: MeetingLifecycleDispatcher;
+  getSelfUserQualifiedId: () => QualifiedId;
+  notifyUpdate: (meeting: MeetingSeries) => void;
 };
 
 /**
@@ -34,21 +39,32 @@ export type SubscribeToMeetingLifecycleEventsDependencies = {
  */
 export const subscribeToMeetingLifecycleEvents = ({
   dispatcher,
+  getSelfUserQualifiedId,
+  notifyUpdate,
 }: SubscribeToMeetingLifecycleEventsDependencies): (() => void) => {
   const onMeetingCreated = (meetingId: QualifiedId) => {
     dispatcher.enqueueMeetingSync(meetingId);
   };
 
-  const onMeetingUpdated = (meetingId: QualifiedId) => {
-    dispatcher.enqueueMeetingSync(meetingId);
+  const enqueueMeetingSyncWithUpdateNotification = (meetingId: QualifiedId) => {
+    dispatcher.enqueueMeetingSync(meetingId, notifyUpdate);
+  };
+
+  const onMeetingUpdated = (meetingId: QualifiedId, actorId: QualifiedId) => {
+    if (matchQualifiedIds(actorId, getSelfUserQualifiedId())) {
+      dispatcher.enqueueMeetingSync(meetingId);
+      return;
+    }
+
+    enqueueMeetingSyncWithUpdateNotification(meetingId);
+  };
+
+  const onMeetingMemberAdded = (meetingId: QualifiedId) => {
+    enqueueMeetingSyncWithUpdateNotification(meetingId);
   };
 
   const onMeetingDeleted = (meetingId: QualifiedId) => {
     dispatcher.enqueueMeetingRemoval(meetingId);
-  };
-
-  const onMeetingMemberAdded = (meetingId: QualifiedId) => {
-    dispatcher.enqueueMeetingSync(meetingId);
   };
 
   const onMissedEvents = () => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25516" title="WPB-25516" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25516</a>  [Web] Inform participant of a canceled meeting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Enhance meeting sync functionality by unifying meeting event subscription and gives success callback to show notifications after syncing


