### PR TITLE
feat(drive): restrict viewer file drops [WPB-25254]

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -757,6 +757,8 @@
   "conversationFileUploadFailedTooManyFilesMessage": "Please select a maximum of {maxFiles} files.",
   "conversationFileUploadOverlayDescription": "Drag & drop to add files",
   "conversationFileUploadOverlayTitle": "Upload files",
+  "conversationFileUploadRestrictedOverlayDescription": "You have view access for this conversation, but you can’t upload, edit, or manage files",
+  "conversationFileUploadRestrictedOverlayTitle": "Files not sharable",
   "conversationFileVideoPreviewLabel": "Video file preview for: {src}",
   "conversationFoldersEmptyText": "Add your conversations to folders to stay organized.",
   "conversationFoldersEmptyTextLearnMore": "Learn more",

--- a/apps/webapp/src/script/components/Conversation/Conversation.tsx
+++ b/apps/webapp/src/script/components/Conversation/Conversation.tsx
@@ -65,6 +65,7 @@ import {getCellsFilesPath} from './ConversationCells/common/getCellsFilesPath/ge
 import {getCurrentFolderName} from './ConversationCells/common/getCurrentFolderName/getCurrentFolderName';
 import {ConversationCells} from './ConversationCells/ConversationCells';
 import {ConversationFileDropzone} from './ConversationFileDropzone/ConversationFileDropzone';
+import {isConversationFileDropAllowed} from './ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed';
 import {ConversationMessagesWrapper} from './ConversationMessagesWrapper/ConversationMessagesWrapper';
 import {ConversationTabPanel} from './ConversationTabPanel/ConversationTabPanel';
 import {ConversationTabs} from './ConversationTabs/ConversationTabs';
@@ -582,6 +583,7 @@ export const Conversation = ({
 
   const isCellsEnabled =
     Config.getConfig().FEATURE.ENABLE_CELLS && activeConversation?.cellsState() !== CONVERSATION_CELLS_STATE.DISABLED;
+  const isFileDropAllowed = isConversationFileDropAllowed({conversation: activeConversation, isCellsEnabled});
 
   useEffect(() => {
     if (!isFileTabActive && isSharedDriveSearchViewOpen) {
@@ -596,6 +598,7 @@ export const Conversation = ({
       conversation: activeConversation,
       isCellsEnabled: isCellsEnabled,
       isDisabled: isFileTabActive,
+      isFileDropAllowed,
       translate,
     });
 
@@ -604,6 +607,7 @@ export const Conversation = ({
   return (
     <ConversationFileDropzone
       isDragAccept={isDragAccept}
+      isFileDropAllowed={isFileDropAllowed}
       isCellsEnabled={isCellsEnabled}
       isConversationLoaded={isConversationLoaded}
       activeConversationId={activeConversation?.id}

--- a/apps/webapp/src/script/components/Conversation/Conversation.tsx
+++ b/apps/webapp/src/script/components/Conversation/Conversation.tsx
@@ -130,6 +130,7 @@ export const Conversation = ({
       'connection',
       'isReadOnlyConversation',
       'isSelfUserRemoved',
+      'selfUser',
     ],
   );
 
@@ -583,7 +584,11 @@ export const Conversation = ({
 
   const isCellsEnabled =
     Config.getConfig().FEATURE.ENABLE_CELLS && activeConversation?.cellsState() !== CONVERSATION_CELLS_STATE.DISABLED;
-  const isFileDropAllowed = isConversationFileDropAllowed({conversation: activeConversation, isCellsEnabled});
+  const isFileDropAllowed = isConversationFileDropAllowed({
+    conversationTeamId: activeConversation?.teamId,
+    selfUserTeamId: activeConversation?.selfUser()?.teamId,
+    isCellsEnabled,
+  });
 
   useEffect(() => {
     if (!isFileTabActive && isSharedDriveSearchViewOpen) {

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/ConversationFileDropzone.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/ConversationFileDropzone.tsx
@@ -33,6 +33,7 @@ interface ConversationFileDropzoneProps {
   activeConversationId?: string;
   onFileDropped: (files: File[]) => void;
   isDragAccept: boolean;
+  isFileDropAllowed: boolean;
   rootProps: DropzoneRootProps;
   inputProps: DropzoneInputProps;
   children: ReactNode;
@@ -44,13 +45,19 @@ export const ConversationFileDropzone = ({
   activeConversationId,
   onFileDropped,
   isDragAccept,
+  isFileDropAllowed,
   rootProps,
   inputProps,
   children,
 }: ConversationFileDropzoneProps) => {
   if (isCellsEnabled) {
     return (
-      <FileDropzone isDragAccept={isDragAccept} rootProps={rootProps} inputProps={inputProps}>
+      <FileDropzone
+        isDragAccept={isDragAccept}
+        isFileDropAllowed={isFileDropAllowed}
+        rootProps={rootProps}
+        inputProps={inputProps}
+      >
         <div
           id="conversation"
           className={cx('conversation', {[incomingCssClass]: isConversationLoaded, loading: !isConversationLoaded})}

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzone.test.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzone.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+
+import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
+
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {FileDropzone} from './FileDropzone';
+
+const rootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate: translateForTest}),
+);
+
+const renderFileDropzone = (isFileDropAllowed: boolean) => {
+  const result = render(
+    <StyledApp themeId={THEME_ID.DEFAULT}>
+      <FileDropzone
+        isDragAccept
+        isFileDropAllowed={isFileDropAllowed}
+        rootProps={{}}
+        inputProps={{}}
+      >
+        <div>Conversation content</div>
+      </FileDropzone>
+    </StyledApp>,
+    {wrapper: rootProviderWrapper},
+  );
+
+  const dropzoneWrapper = result.container.firstElementChild?.firstElementChild;
+
+  if (!dropzoneWrapper) {
+    throw new Error('Dropzone wrapper was not rendered');
+  }
+
+  fireEvent.dragEnter(dropzoneWrapper);
+};
+
+describe('FileDropzone', () => {
+  it('shows the upload overlay while an editor drags files', () => {
+    renderFileDropzone(true);
+
+    expect(screen.getByText('conversationFileUploadOverlayTitle').closest('[aria-hidden]')).toHaveAttribute(
+      'aria-hidden',
+      'false',
+    );
+  });
+
+  it('shows the restricted overlay while a viewer drags files', () => {
+    renderFileDropzone(false);
+
+    expect(screen.getByText('conversationFileUploadRestrictedOverlayTitle').closest('[aria-hidden]')).toHaveAttribute(
+      'aria-hidden',
+      'false',
+    );
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzone.test.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzone.test.tsx
@@ -36,12 +36,7 @@ const rootProviderWrapper = createRootProviderWrapperForTest(
 const renderFileDropzone = (isFileDropAllowed: boolean) => {
   const result = render(
     <StyledApp themeId={THEME_ID.DEFAULT}>
-      <FileDropzone
-        isDragAccept
-        isFileDropAllowed={isFileDropAllowed}
-        rootProps={{}}
-        inputProps={{}}
-      >
+      <FileDropzone isDragAccept isFileDropAllowed={isFileDropAllowed} rootProps={{}} inputProps={{}}>
         <div>Conversation content</div>
       </FileDropzone>
     </StyledApp>,

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzone.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzone.tsx
@@ -27,19 +27,21 @@ import {useIsDragging} from './useIsDragging/useIsDragging';
 
 interface FileDropzoneProps {
   isDragAccept: boolean;
+  isFileDropAllowed: boolean;
   rootProps: DropzoneRootProps;
   inputProps: DropzoneInputProps;
   children: ReactNode;
 }
 
-export const FileDropzone = ({isDragAccept, rootProps, inputProps, children}: FileDropzoneProps) => {
+export const FileDropzone = ({isDragAccept, isFileDropAllowed, rootProps, inputProps, children}: FileDropzoneProps) => {
   const {isDragging, wrapperRef} = useIsDragging();
+  const overlayMode = isFileDropAllowed ? 'upload' : 'restricted';
 
   return (
     <div ref={wrapperRef} css={wrapperStyles}>
       <div {...rootProps}>
         <input {...inputProps} />
-        <FileDropzoneOverlay isActive={isDragging && isDragAccept} />
+        <FileDropzoneOverlay isActive={isDragging && isDragAccept} mode={overlayMode} />
         {children}
       </div>
     </div>

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.styles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.styles.ts
@@ -63,9 +63,14 @@ export const titleStyles: CSSObject = {
 
 export const descriptionStyles: CSSObject = {
   fontSize: 'var(--font-size-small)',
+  maxWidth: '240px',
+  textAlign: 'center',
 };
 
 export const iconStyles: CSSObject = {
-  transform: 'rotate(180deg)',
   marginBottom: '16px',
+};
+
+export const uploadIconStyles: CSSObject = {
+  transform: 'rotate(180deg)',
 };

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.test.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, screen} from '@testing-library/react';
+
+import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
+
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {FileDropzoneOverlay} from './FileDropzoneOverlay';
+
+const rootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate: translateForTest}),
+);
+
+const renderOverlay = (mode: 'upload' | 'restricted') =>
+  render(
+    <StyledApp themeId={THEME_ID.DEFAULT}>
+      <FileDropzoneOverlay isActive mode={mode} />
+    </StyledApp>,
+    {wrapper: rootProviderWrapper},
+  );
+
+describe('FileDropzoneOverlay', () => {
+  it('explains how to upload files when sharing is allowed', () => {
+    renderOverlay('upload');
+
+    expect(screen.getByText('conversationFileUploadOverlayTitle')).toBeInTheDocument();
+    expect(screen.getByText('conversationFileUploadOverlayDescription')).toBeInTheDocument();
+  });
+
+  it('explains why files cannot be shared when viewer drags files', () => {
+    renderOverlay('restricted');
+
+    expect(screen.getByText('conversationFileUploadRestrictedOverlayTitle')).toBeInTheDocument();
+    expect(screen.getByText('conversationFileUploadRestrictedOverlayDescription')).toBeInTheDocument();
+    expect(screen.queryByText('conversationFileUploadOverlayTitle')).not.toBeInTheDocument();
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.test.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.test.tsx
@@ -42,18 +42,22 @@ const renderOverlay = (mode: 'upload' | 'restricted') =>
   );
 
 describe('FileDropzoneOverlay', () => {
-  it('explains how to upload files when sharing is allowed', () => {
-    renderOverlay('upload');
+  it('announces how to upload files while hiding the decorative icon', () => {
+    const {container} = renderOverlay('upload');
 
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
     expect(screen.getByText('conversationFileUploadOverlayTitle')).toBeInTheDocument();
     expect(screen.getByText('conversationFileUploadOverlayDescription')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true');
   });
 
-  it('explains why files cannot be shared when viewer drags files', () => {
-    renderOverlay('restricted');
+  it('announces why files cannot be shared while hiding the decorative icon', () => {
+    const {container} = renderOverlay('restricted');
 
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
     expect(screen.getByText('conversationFileUploadRestrictedOverlayTitle')).toBeInTheDocument();
     expect(screen.getByText('conversationFileUploadRestrictedOverlayDescription')).toBeInTheDocument();
     expect(screen.queryByText('conversationFileUploadOverlayTitle')).not.toBeInTheDocument();
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true');
   });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.tsx
@@ -17,30 +17,46 @@
  *
  */
 
-import {SaveIcon} from '@wireapp/react-ui-kit';
+import {BlockIcon, SaveIcon} from '@wireapp/react-ui-kit';
 
 import {useApplicationContext} from 'src/script/page/rootProvider';
 
 import {
   iconStyles,
+  uploadIconStyles,
   overlayActiveStyles,
   overlayStyles,
   descriptionStyles,
   titleStyles,
 } from './FileDropzoneOverlay.styles';
 
+export type FileDropzoneOverlayMode = 'upload' | 'restricted';
+
 interface FileDropzoneOverlayProps {
   isActive: boolean;
+  mode: FileDropzoneOverlayMode;
 }
 
-export const FileDropzoneOverlay = ({isActive}: FileDropzoneOverlayProps) => {
+export const FileDropzoneOverlay = ({isActive, mode}: FileDropzoneOverlayProps) => {
   const {translate} = useApplicationContext();
+
+  const isRestricted = mode === 'restricted';
+  const title = isRestricted
+    ? translate('conversationFileUploadRestrictedOverlayTitle')
+    : translate('conversationFileUploadOverlayTitle');
+  const description = isRestricted
+    ? translate('conversationFileUploadRestrictedOverlayDescription')
+    : translate('conversationFileUploadOverlayDescription');
 
   return (
     <div css={isActive ? overlayActiveStyles : overlayStyles} aria-hidden={!isActive}>
-      <SaveIcon width={24} height={24} css={iconStyles} />
-      <p css={titleStyles}>{translate('conversationFileUploadOverlayTitle')}</p>
-      <p css={descriptionStyles}>{translate('conversationFileUploadOverlayDescription')}</p>
+      {isRestricted ? (
+        <BlockIcon width={24} height={24} css={iconStyles} />
+      ) : (
+        <SaveIcon width={24} height={24} css={[iconStyles, uploadIconStyles]} />
+      )}
+      <p css={titleStyles}>{title}</p>
+      <p css={descriptionStyles}>{description}</p>
     </div>
   );
 };

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.tsx
@@ -19,7 +19,7 @@
 
 import {BlockIcon, SaveIcon} from '@wireapp/react-ui-kit';
 
-import {useApplicationContext} from 'src/script/page/rootProvider';
+import {useApplicationContext, type RootContextValue} from 'src/script/page/rootProvider';
 
 import {
   iconStyles,
@@ -37,24 +37,37 @@ interface FileDropzoneOverlayProps {
   mode: FileDropzoneOverlayMode;
 }
 
+const getOverlayContent = (mode: FileDropzoneOverlayMode, translate: RootContextValue['translate']) => {
+  if (mode === 'restricted') {
+    return {
+      icon: <BlockIcon width={24} height={24} css={iconStyles} />,
+      title: translate('conversationFileUploadRestrictedOverlayTitle'),
+      description: translate('conversationFileUploadRestrictedOverlayDescription'),
+    };
+  }
+
+  return {
+    icon: <SaveIcon width={24} height={24} css={[iconStyles, uploadIconStyles]} />,
+    title: translate('conversationFileUploadOverlayTitle'),
+    description: translate('conversationFileUploadOverlayDescription'),
+  };
+};
+
+const getOverlayStyles = (isActive: boolean) => {
+  if (isActive) {
+    return overlayActiveStyles;
+  }
+
+  return overlayStyles;
+};
+
 export const FileDropzoneOverlay = ({isActive, mode}: FileDropzoneOverlayProps) => {
   const {translate} = useApplicationContext();
-
-  const isRestricted = mode === 'restricted';
-  const title = isRestricted
-    ? translate('conversationFileUploadRestrictedOverlayTitle')
-    : translate('conversationFileUploadOverlayTitle');
-  const description = isRestricted
-    ? translate('conversationFileUploadRestrictedOverlayDescription')
-    : translate('conversationFileUploadOverlayDescription');
+  const {icon, title, description} = getOverlayContent(mode, translate);
 
   return (
-    <div css={isActive ? overlayActiveStyles : overlayStyles} aria-hidden={!isActive}>
-      {isRestricted ? (
-        <BlockIcon width={24} height={24} css={iconStyles} />
-      ) : (
-        <SaveIcon width={24} height={24} css={[iconStyles, uploadIconStyles]} />
-      )}
+    <div css={getOverlayStyles(isActive)} aria-hidden={!isActive}>
+      {icon}
       <p css={titleStyles}>{title}</p>
       <p css={descriptionStyles}>{description}</p>
     </div>

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.tsx
@@ -40,14 +40,14 @@ interface FileDropzoneOverlayProps {
 const getOverlayContent = (mode: FileDropzoneOverlayMode, translate: RootContextValue['translate']) => {
   if (mode === 'restricted') {
     return {
-      icon: <BlockIcon width={24} height={24} css={iconStyles} />,
+      icon: <BlockIcon width={24} height={24} css={iconStyles} aria-hidden="true" />,
       title: translate('conversationFileUploadRestrictedOverlayTitle'),
       description: translate('conversationFileUploadRestrictedOverlayDescription'),
     };
   }
 
   return {
-    icon: <SaveIcon width={24} height={24} css={[iconStyles, uploadIconStyles]} />,
+    icon: <SaveIcon width={24} height={24} css={[iconStyles, uploadIconStyles]} aria-hidden="true" />,
     title: translate('conversationFileUploadOverlayTitle'),
     description: translate('conversationFileUploadOverlayDescription'),
   };
@@ -66,7 +66,7 @@ export const FileDropzoneOverlay = ({isActive, mode}: FileDropzoneOverlayProps) 
   const {icon, title, description} = getOverlayContent(mode, translate);
 
   return (
-    <div css={getOverlayStyles(isActive)} aria-hidden={!isActive}>
+    <div css={getOverlayStyles(isActive)} aria-hidden={!isActive} role="status" aria-live="polite">
       {icon}
       <p css={titleStyles}>{title}</p>
       <p css={descriptionStyles}>{description}</p>

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/FileDropzone/FileDropzoneOverlay/FileDropzoneOverlay.tsx
@@ -37,9 +37,19 @@ interface FileDropzoneOverlayProps {
   mode: FileDropzoneOverlayMode;
 }
 
-const getOverlayContent = (mode: FileDropzoneOverlayMode, translate: RootContextValue['translate']) => {
+const getOverlayProperties = (
+  mode: FileDropzoneOverlayMode,
+  isActive: boolean,
+  translate: RootContextValue['translate'],
+) => {
+  let styles = overlayStyles;
+  if (isActive) {
+    styles = overlayActiveStyles;
+  }
+
   if (mode === 'restricted') {
     return {
+      styles,
       icon: <BlockIcon width={24} height={24} css={iconStyles} aria-hidden="true" />,
       title: translate('conversationFileUploadRestrictedOverlayTitle'),
       description: translate('conversationFileUploadRestrictedOverlayDescription'),
@@ -47,26 +57,19 @@ const getOverlayContent = (mode: FileDropzoneOverlayMode, translate: RootContext
   }
 
   return {
+    styles,
     icon: <SaveIcon width={24} height={24} css={[iconStyles, uploadIconStyles]} aria-hidden="true" />,
     title: translate('conversationFileUploadOverlayTitle'),
     description: translate('conversationFileUploadOverlayDescription'),
   };
 };
 
-const getOverlayStyles = (isActive: boolean) => {
-  if (isActive) {
-    return overlayActiveStyles;
-  }
-
-  return overlayStyles;
-};
-
 export const FileDropzoneOverlay = ({isActive, mode}: FileDropzoneOverlayProps) => {
   const {translate} = useApplicationContext();
-  const {icon, title, description} = getOverlayContent(mode, translate);
+  const {styles, icon, title, description} = getOverlayProperties(mode, isActive, translate);
 
   return (
-    <div css={getOverlayStyles(isActive)} aria-hidden={!isActive} role="status" aria-live="polite">
+    <div css={styles} aria-hidden={!isActive} role="status" aria-live="polite">
       {icon}
       <p css={titleStyles}>{title}</p>
       <p css={descriptionStyles}>{description}</p>

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isConversationFileDropAllowed} from './isConversationFileDropAllowed';
+
+describe('isConversationFileDropAllowed', () => {
+  it('allows conversation guests to drop files when Cells is disabled', () => {
+    const conversation = {isGuest: () => true};
+
+    expect(isConversationFileDropAllowed({conversation, isCellsEnabled: false})).toBe(true);
+  });
+
+  it('allows conversation editors to drop files when Cells is enabled', () => {
+    const conversation = {isGuest: () => false};
+
+    expect(isConversationFileDropAllowed({conversation, isCellsEnabled: true})).toBe(true);
+  });
+
+  it('prevents conversation guests from dropping files when Cells is enabled', () => {
+    const conversation = {isGuest: () => true};
+
+    expect(isConversationFileDropAllowed({conversation, isCellsEnabled: true})).toBe(false);
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed.test.ts
@@ -20,21 +20,27 @@
 import {isConversationFileDropAllowed} from './isConversationFileDropAllowed';
 
 describe('isConversationFileDropAllowed', () => {
-  it('allows conversation guests to drop files when Cells is disabled', () => {
-    const conversation = {isGuest: () => true};
-
-    expect(isConversationFileDropAllowed({conversation, isCellsEnabled: false})).toBe(true);
+  it('allows file drops when Cells is disabled', () => {
+    expect(isConversationFileDropAllowed({isCellsEnabled: false})).toBe(true);
   });
 
-  it('allows conversation editors to drop files when Cells is enabled', () => {
-    const conversation = {isGuest: () => false};
-
-    expect(isConversationFileDropAllowed({conversation, isCellsEnabled: true})).toBe(true);
+  it('allows editor file drops when Cells is enabled', () => {
+    expect(
+      isConversationFileDropAllowed({
+        conversationTeamId: 'team-a',
+        selfUserTeamId: 'team-a',
+        isCellsEnabled: true,
+      }),
+    ).toBe(true);
   });
 
-  it('prevents conversation guests from dropping files when Cells is enabled', () => {
-    const conversation = {isGuest: () => true};
-
-    expect(isConversationFileDropAllowed({conversation, isCellsEnabled: true})).toBe(false);
+  it('prevents viewer file drops when Cells is enabled', () => {
+    expect(
+      isConversationFileDropAllowed({
+        conversationTeamId: 'team-a',
+        selfUserTeamId: 'team-b',
+        isCellsEnabled: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {Conversation} from 'Repositories/entity/Conversation';
+
+interface IsConversationFileDropAllowedParams {
+  conversation?: Pick<Conversation, 'isGuest'>;
+  isCellsEnabled: boolean;
+}
+
+export const isConversationFileDropAllowed = ({
+  conversation,
+  isCellsEnabled,
+}: IsConversationFileDropAllowedParams): boolean => !isCellsEnabled || !conversation?.isGuest();

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed.ts
@@ -17,14 +17,25 @@
  *
  */
 
-import type {Conversation} from 'Repositories/entity/Conversation';
+import {
+  CELLS_SELF_USER_DRIVE_ROLE,
+  getSelfUserDriveRole,
+} from '../../ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
 
 interface IsConversationFileDropAllowedParams {
-  conversation?: Pick<Conversation, 'isGuest'>;
+  conversationTeamId?: string;
+  selfUserTeamId?: string;
   isCellsEnabled: boolean;
 }
 
 export const isConversationFileDropAllowed = ({
-  conversation,
+  conversationTeamId,
+  selfUserTeamId,
   isCellsEnabled,
-}: IsConversationFileDropAllowedParams): boolean => !isCellsEnabled || !conversation?.isGuest();
+}: IsConversationFileDropAllowedParams): boolean => {
+  if (!isCellsEnabled) {
+    return true;
+  }
+
+  return getSelfUserDriveRole({conversationTeamId, selfUserTeamId}) === CELLS_SELF_USER_DRIVE_ROLE.EDITOR;
+};

--- a/apps/webapp/src/script/components/Conversation/useFilesUploadDropzone/createFileDropHandler/createFileDropHandler.test.ts
+++ b/apps/webapp/src/script/components/Conversation/useFilesUploadDropzone/createFileDropHandler/createFileDropHandler.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createFileDropHandler} from './createFileDropHandler';
+
+const file = new File(['content'], 'document.txt', {type: 'text/plain'});
+
+describe('createFileDropHandler', () => {
+  it('processes dropped files when uploads are allowed', () => {
+    const onFileDrop = jest.fn();
+    const handleFileDrop = createFileDropHandler({isFileDropAllowed: true, onFileDrop});
+
+    handleFileDrop([file], []);
+
+    expect(onFileDrop).toHaveBeenCalledWith([file], []);
+  });
+
+  it('ignores dropped files when uploads are restricted', () => {
+    const onFileDrop = jest.fn();
+    const handleFileDrop = createFileDropHandler({isFileDropAllowed: false, onFileDrop});
+
+    handleFileDrop([file], []);
+
+    expect(onFileDrop).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/src/script/components/Conversation/useFilesUploadDropzone/createFileDropHandler/createFileDropHandler.ts
+++ b/apps/webapp/src/script/components/Conversation/useFilesUploadDropzone/createFileDropHandler/createFileDropHandler.ts
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {FileRejection} from 'react-dropzone';
+
+interface CreateFileDropHandlerParams {
+  isFileDropAllowed: boolean;
+  onFileDrop: (acceptedFiles: File[], rejectedFiles: FileRejection[]) => void;
+}
+
+export const createFileDropHandler = ({isFileDropAllowed, onFileDrop}: CreateFileDropHandlerParams) => {
+  return (acceptedFiles: File[], rejectedFiles: FileRejection[]) => {
+    if (!isFileDropAllowed) {
+      return;
+    }
+
+    onFileDrop(acceptedFiles, rejectedFiles);
+  };
+};

--- a/apps/webapp/src/script/components/Conversation/useFilesUploadDropzone/useFilesUploadDropzone.ts
+++ b/apps/webapp/src/script/components/Conversation/useFilesUploadDropzone/useFilesUploadDropzone.ts
@@ -28,6 +28,7 @@ import type {RootContextValue} from 'src/script/page/rootProvider';
 import {getLogger} from 'Util/logger';
 
 import {buildCellFileMetadata} from './buildCellFileMetadata/buildCellFileMetadata';
+import {createFileDropHandler} from './createFileDropHandler/createFileDropHandler';
 import {validateFiles, ValidationResult} from './fileValidation/fileValidation';
 import {showFileDropzoneErrorModal} from './showFileDropzoneErrorModal/showFileDropzoneErrorModal';
 import {transformAcceptedFiles} from './transformAcceptedFiles/transformAcceptedFiles';
@@ -46,6 +47,7 @@ interface UseFilesUploadDropzoneParams {
   isTeam: boolean;
   isCellsEnabled: boolean;
   isDisabled: boolean;
+  isFileDropAllowed: boolean;
   cellsRepository: CellsRepository;
   translate: RootContextValue['translate'];
   conversation?: Pick<Conversation, 'id' | 'qualifiedId'>;
@@ -55,6 +57,7 @@ export const useFilesUploadDropzone = ({
   isTeam,
   isDisabled,
   isCellsEnabled,
+  isFileDropAllowed,
   cellsRepository,
   translate,
   conversation = {id: '', qualifiedId: {id: '', domain: ''}},
@@ -74,13 +77,16 @@ export const useFilesUploadDropzone = ({
     noKeyboard: true,
     disabled: isDisabled,
     accept,
-    onDrop: checkFileSharingPermission((acceptedFiles: File[], rejectedFiles: FileRejection[]) => {
-      void processIncomingFiles(acceptedFiles, rejectedFiles, files, MAX_SIZE, MAX_FILES, conversation.id).catch(
-        (error: unknown) => {
-          logger.error('Processing incoming files failed', error);
-        },
-      );
-    }, translate),
+    onDrop: createFileDropHandler({
+      isFileDropAllowed,
+      onFileDrop: checkFileSharingPermission((acceptedFiles: File[], rejectedFiles: FileRejection[]) => {
+        void processIncomingFiles(acceptedFiles, rejectedFiles, files, MAX_SIZE, MAX_FILES, conversation.id).catch(
+          (error: unknown) => {
+            logger.error('Processing incoming files failed', error);
+          },
+        );
+      }, translate),
+    }),
     onError: (error: Error) => {
       logger.error('Dropping files failed', error);
       showFileDropzoneErrorModal({


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25254" title="WPB-25254" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25254</a>  [Web] Restrict access to upload / sending assets (drag n drop)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Problem

Guests inside teams as of now have the same type of file permissions as team members. That isn't correct, unless explicit allowed, they shouldn't be able to upload new files.

### Solution 

Prevent guests in Cells-enabled conversations from processing dropped files and show the read-only overlay while preserving the existing editor upload flow.

Cover allowed and restricted drag states and drop handling with focused tests.

ref: https://wearezeta.atlassian.net/browse/WPB-25254


### Demo

https://github.com/user-attachments/assets/1af37bfd-c163-4261-8bfa-6eb4dddfa975


