### PR TITLE
Clicking the meeting title will not navigate to conversation when the conversation type is meeting [WPB-27851]

### DIFF
--- a/apps/webapp/src/script/components/calling/CallingCell/CallingCell.tsx
+++ b/apps/webapp/src/script/components/calling/CallingCell/CallingCell.tsx
@@ -384,6 +384,7 @@ export const CallingCell = ({
           )}
 
           <CallingHeader
+            isMeeting={isMeeting}
             isGroupCall={isGroupCall}
             isChannel={isChannel}
             isOngoing={isOngoing}

--- a/apps/webapp/src/script/components/calling/CallingCell/CallingHeader/CallingHeader.test.tsx
+++ b/apps/webapp/src/script/components/calling/CallingCell/CallingHeader/CallingHeader.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {fireEvent, render} from '@testing-library/react';
+
+import {User} from 'Repositories/entity/User';
+import * as Router from 'src/script/router/Router';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {CallingHeader} from './CallingHeader';
+
+const navigateSpy = jest.spyOn(Router, 'navigate');
+
+const conversationUrl = '/conversation/1';
+const clearShowAlert = jest.fn();
+const rootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate: translateForTest}),
+);
+
+const createProps = (overrides: Partial<React.ComponentProps<typeof CallingHeader>> = {}) => ({
+  isMeeting: false,
+  isOngoing: false,
+  isGroupCall: false,
+  isChannel: false,
+  showAlert: false,
+  isVideoCall: false,
+  clearShowAlert,
+  conversationUrl,
+  callStartedAlert: 'Call started',
+  ongoingCallAlert: 'Ongoing call',
+  isTemporaryUser: false,
+  conversationParticipants: [] as User[],
+  conversationName: 'Conversation',
+  currentCallStatus: null,
+  isCbrEnabled: false,
+  toggleDetachedWindow: jest.fn(),
+  isDetachedWindow: false,
+  conversationID: 'conversation-id',
+  ...overrides,
+});
+
+const renderHeader = (overrides: Partial<React.ComponentProps<typeof CallingHeader>> = {}) =>
+  render(<CallingHeader {...createProps(overrides)} />, {wrapper: rootProviderWrapper});
+
+describe('CallingHeader', () => {
+  beforeEach(() => {
+    navigateSpy.mockClear();
+    clearShowAlert.mockClear();
+  });
+
+  it.each([
+    ['click', (header: HTMLElement) => fireEvent.click(header)],
+    ['Enter', (header: HTMLElement) => fireEvent.keyDown(header, {key: 'Enter'})],
+    ['Space', (header: HTMLElement) => fireEvent.keyDown(header, {key: ' '})],
+  ])('navigates regular calls on %s', (_interaction, interact) => {
+    const {getByRole} = renderHeader();
+
+    interact(getByRole('button'));
+
+    expect(navigateSpy).toHaveBeenCalledWith(conversationUrl);
+  });
+
+  it.each([
+    ['click', (header: HTMLElement) => fireEvent.click(header)],
+    ['Enter', (header: HTMLElement) => fireEvent.keyDown(header, {key: 'Enter'})],
+    ['Space', (header: HTMLElement) => fireEvent.keyDown(header, {key: ' '})],
+  ])('does not navigate meeting calls on %s', (_interaction, interact) => {
+    const {getByRole} = renderHeader({isMeeting: true});
+
+    interact(getByRole('button'));
+
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps meeting headers rendered and focusable', () => {
+    const {getByRole} = renderHeader({isMeeting: true});
+
+    expect(getByRole('button')).toHaveAttribute('tabindex', '0');
+  });
+});

--- a/apps/webapp/src/script/components/calling/CallingCell/CallingHeader/CallingHeader.tsx
+++ b/apps/webapp/src/script/components/calling/CallingCell/CallingHeader/CallingHeader.tsx
@@ -40,6 +40,7 @@ import {
 import {createNavigate, createNavigateKeyboard} from '../../../../router/routerBindings';
 
 interface CallingHeaderProps {
+  isMeeting: boolean;
   isOngoing: boolean;
   isGroupCall: boolean;
   isChannel: boolean;
@@ -61,6 +62,7 @@ interface CallingHeaderProps {
 }
 
 export const CallingHeader = ({
+  isMeeting,
   isGroupCall,
   isChannel,
   isOngoing,
@@ -108,13 +110,13 @@ export const CallingHeader = ({
           }
         }}
         css={callingHeaderWrapper}
-        onClick={createNavigate(conversationUrl)}
+        onClick={!isMeeting ? createNavigate(conversationUrl) : undefined}
         onBlur={() => {
           if (isGroupCall || isOngoing) {
             clearShowAlert();
           }
         }}
-        onKeyDown={createNavigateKeyboard(conversationUrl)}
+        onKeyDown={!isMeeting ? createNavigateKeyboard(conversationUrl) : undefined}
         tabIndex={TabIndex.FOCUSABLE}
         role="button"
         aria-label={ariaLabel}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27851" title="WPB-27851" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27851</a>  Meeting host can access the underlying MLS conversation from a meeting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
