### PR TITLE
fix: treat teamless users as viewers in team-owned Drive conversations(WPB-26111)

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext.test.ts
@@ -32,12 +32,15 @@ describe('getSelfUserDriveRole', () => {
     );
   });
 
-  it('defaults to editor when local team data is missing', () => {
+  it('defaults to editor when the conversation has no owning team', () => {
     expect(getSelfUserDriveRole({conversationTeamId: undefined, selfUserTeamId: 'team-a'})).toBe(
       CELLS_SELF_USER_DRIVE_ROLE.EDITOR,
     );
+  });
+
+  it('returns viewer when a team-owned conversation is accessed by a user without a team', () => {
     expect(getSelfUserDriveRole({conversationTeamId: 'team-a', selfUserTeamId: undefined})).toBe(
-      CELLS_SELF_USER_DRIVE_ROLE.EDITOR,
+      CELLS_SELF_USER_DRIVE_ROLE.VIEWER,
     );
   });
 });

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext.tsx
@@ -35,8 +35,12 @@ export const getSelfUserDriveRole = ({
   conversationTeamId,
   selfUserTeamId,
 }: GetSelfUserDriveRoleParams): CellsSelfUserDriveRole => {
-  if (!conversationTeamId || !selfUserTeamId) {
+  if (!conversationTeamId) {
     return CELLS_SELF_USER_DRIVE_ROLE.EDITOR;
+  }
+
+  if (!selfUserTeamId) {
+    return CELLS_SELF_USER_DRIVE_ROLE.VIEWER;
   }
 
   return conversationTeamId === selfUserTeamId ? CELLS_SELF_USER_DRIVE_ROLE.EDITOR : CELLS_SELF_USER_DRIVE_ROLE.VIEWER;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26111" title="WPB-26111" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26111</a>  [Web] Add self user drive role (editor / viewer) in shared drive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Update `getSelfUserDriveRole` to return `viewer` when:
  - `conversationTeamId` exists
  - `selfUserTeamId` is missing
- Keep `editor` fallback only when the conversation itself has no owning team
- Update tests to cover the teamless-user scenario explicitly

A user without a team in a team-owned Drive conversation falls into that outside-team category and should default to read-only access.


