### PR TITLE
fix(drive): hide Cells uploads for guests [WPB-25255]

### DIFF
--- a/apps/webapp/src/script/components/InputBar/InputBar.test.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBar.test.tsx
@@ -137,7 +137,10 @@ describe('InputBar', () => {
     isViewerPermissionFeatureEnabled = false,
   ): ReturnType<typeof render> {
     return render(
-      withThemeAndRootContext(<InputBar {...properties} />, createRootProviderWrapper(isViewerPermissionFeatureEnabled)),
+      withThemeAndRootContext(
+        <InputBar {...properties} />,
+        createRootProviderWrapper(isViewerPermissionFeatureEnabled),
+      ),
     );
   }
 

--- a/apps/webapp/src/script/components/InputBar/InputBar.test.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBar.test.tsx
@@ -37,7 +37,7 @@ import {SearchRepository} from 'Repositories/search/searchRepository';
 import {SelfService} from 'Repositories/self/SelfService';
 import {StorageRepository} from 'Repositories/storage';
 import {TeamState} from 'Repositories/team/TeamState';
-import {withTheme} from 'src/script/auth/util/test/testUtil';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
 import {Config} from 'src/script/Config';
 import {translate} from 'Util/localizerUtil';
 import {
@@ -84,8 +84,13 @@ beforeAll(async () => {
 
 describe('InputBar', () => {
   let propertiesRepository: PropertiesRepository;
-  const rootContextValue = createRootContextValueForTest({translate: translateForTest});
-  const rootProviderWrapper = createRootProviderWrapperForTest(rootContextValue);
+  const createRootProviderWrapper = (isViewerPermissionFeatureEnabled = false) =>
+    createRootProviderWrapperForTest(
+      createRootContextValueForTest({
+        translate: translateForTest,
+        isFeatureToggleEnabled: () => isViewerPermissionFeatureEnabled,
+      }),
+    );
 
   const getDefaultProps = () => ({
     assetRepository: new AssetRepository(),
@@ -127,20 +132,36 @@ describe('InputBar', () => {
   const testMessage = 'text';
   const pngFile = new File(['(⌐□_□)'], 'wire-example-image.png', {type: 'image/png'});
 
-  function renderInputBar(properties: ReturnType<typeof getDefaultProps>): ReturnType<typeof render> {
-    return render(withTheme(<InputBar {...properties} />), {
-      wrapper: rootProviderWrapper,
-    });
+  function renderInputBar(
+    properties: ReturnType<typeof getDefaultProps>,
+    isViewerPermissionFeatureEnabled = false,
+  ): ReturnType<typeof render> {
+    return render(
+      withThemeAndRootContext(<InputBar {...properties} />, createRootProviderWrapper(isViewerPermissionFeatureEnabled)),
+    );
   }
 
-  it('hides cells upload buttons for viewers', () => {
+  it('shows cells upload buttons for viewers when the viewer permission feature is disabled', () => {
     const props = getDefaultProps();
     props.isCellsEnabled = true;
     props.conversation.teamId = 'conversation-team';
     props.conversation.cellsState(CONVERSATION_CELLS_STATE.READY);
     props.selfUser.teamId = 'guest-team';
 
-    const {queryByTitle} = renderInputBar(props);
+    const {getByTitle} = renderInputBar(props);
+
+    expect(getByTitle('tooltipConversationAddImage')).not.toBe(null);
+    expect(getByTitle('tooltipConversationFile')).not.toBe(null);
+  });
+
+  it('hides cells upload buttons for viewers when the viewer permission feature is enabled', () => {
+    const props = getDefaultProps();
+    props.isCellsEnabled = true;
+    props.conversation.teamId = 'conversation-team';
+    props.conversation.cellsState(CONVERSATION_CELLS_STATE.READY);
+    props.selfUser.teamId = 'guest-team';
+
+    const {queryByTitle} = renderInputBar(props, true);
 
     expect(queryByTitle('tooltipConversationAddImage')).toBe(null);
     expect(queryByTitle('tooltipConversationFile')).toBe(null);

--- a/apps/webapp/src/script/components/InputBar/InputBar.test.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBar.test.tsx
@@ -19,6 +19,9 @@
 
 import {act, fireEvent, render, waitFor} from '@testing-library/react';
 
+import {CONVERSATION_CELLS_STATE} from '@wireapp/api-client/lib/conversation';
+import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
+
 import {FileWithPreview} from 'Components/Conversation/useFilesUploadState/useFilesUploadState';
 import {InputBar} from 'Components/InputBar/index';
 import {AssetRepository} from 'Repositories/assets/assetRepository';
@@ -45,7 +48,6 @@ import {createUuid} from 'Util/uuid';
 
 import {TestFactory} from '../../../../test/helper/TestFactory';
 import {translateForTest} from 'Util/test/translateForTest';
-import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 
 jest.mock('Components/avatar', () => ({
   AVATAR_SIZE: {X_LARGE: 'avatar-xl'},
@@ -76,7 +78,7 @@ beforeAll(async () => {
 
   spyOn(Config, 'getConfig').and.returnValue({
     ALLOWED_IMAGE_TYPES: [],
-    FEATURE: {ALLOWED_FILE_UPLOAD_EXTENSIONS: ['*']},
+    FEATURE: {ALLOWED_FILE_UPLOAD_EXTENSIONS: ['*'], ENABLE_CELLS: true},
   });
 });
 
@@ -130,6 +132,32 @@ describe('InputBar', () => {
       wrapper: rootProviderWrapper,
     });
   }
+
+  it('hides cells upload buttons for viewers', () => {
+    const props = getDefaultProps();
+    props.isCellsEnabled = true;
+    props.conversation.teamId = 'conversation-team';
+    props.conversation.cellsState(CONVERSATION_CELLS_STATE.READY);
+    props.selfUser.teamId = 'guest-team';
+
+    const {queryByTitle} = renderInputBar(props);
+
+    expect(queryByTitle('tooltipConversationAddImage')).toBe(null);
+    expect(queryByTitle('tooltipConversationFile')).toBe(null);
+  });
+
+  it('shows cells upload buttons for editors', () => {
+    const props = getDefaultProps();
+    props.isCellsEnabled = true;
+    props.conversation.teamId = 'conversation-team';
+    props.conversation.cellsState(CONVERSATION_CELLS_STATE.READY);
+    props.selfUser.teamId = 'conversation-team';
+
+    const {getByTitle} = renderInputBar(props);
+
+    expect(getByTitle('tooltipConversationAddImage')).not.toBe(null);
+    expect(getByTitle('tooltipConversationFile')).not.toBe(null);
+  });
 
   it('has passed value', async () => {
     const props = getDefaultProps();

--- a/apps/webapp/src/script/components/InputBar/InputBar.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBar.tsx
@@ -28,6 +28,7 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {Avatar, AVATAR_SIZE} from 'Components/avatar';
 import {ConversationClassifiedBar} from 'Components/classifiedBar/classifiedBar';
+import {isConversationFileDropAllowed} from 'Components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed';
 import {useFileUploadState} from 'Components/Conversation/useFilesUploadState/useFilesUploadState';
 import {EmojiPicker} from 'Components/emojiPicker/emojiPicker';
 import {useUserPropertyValue} from 'Hooks/useUserProperty';
@@ -167,6 +168,11 @@ export const InputBar = ({
     : translate('tooltipConversationInputPlaceholder');
 
   const isConnectionRequest = isOutgoingRequest || isIncomingRequest;
+  const isCellsUploadAllowed = isConversationFileDropAllowed({
+    conversationTeamId: conversation.teamId,
+    selfUserTeamId: selfUser.teamId,
+    isCellsEnabled,
+  });
   const hasLocalEphemeralTimer = isSelfDeletingMessagesEnabled && !!localMessageTimer && !hasGlobalMessageTimer;
   const isTypingRef = useRef(false);
 
@@ -336,6 +342,7 @@ export const InputBar = ({
                   <InputBarControls
                     conversation={conversation}
                     isCellsFeatureEnabled={isCellsEnabled}
+                    isCellsUploadAllowed={isCellsUploadAllowed}
                     isFileSharingSendingEnabled={isFileSharingSendingEnabled}
                     pingDisabled={ping.isPingDisabled}
                     messageContent={messageContent}

--- a/apps/webapp/src/script/components/InputBar/InputBar.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBar.tsx
@@ -65,6 +65,7 @@ import {usePing} from './usePing/usePing';
 import {useTypingIndicator} from './useTypingIndicator/useTypingIndicator';
 
 import {Config} from '../../Config';
+import {viewerPermissionFeatureToggleName} from '../../featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from '../../page/rootProvider';
 
 const CONFIG = {
@@ -116,7 +117,7 @@ export const InputBar = ({
   onCellImageUpload,
   onCellAssetUpload,
 }: InputBarProps) => {
-  const {fireAndForgetInvoker, translate} = useApplicationContext();
+  const {fireAndForgetInvoker, isFeatureToggleEnabled, translate} = useApplicationContext();
   const {classifiedDomains, isSelfDeletingMessagesEnabled, isFileSharingSendingEnabled} = useKoSubscribableChildren(
     teamState,
     ['classifiedDomains', 'isSelfDeletingMessagesEnabled', 'isFileSharingSendingEnabled'],
@@ -168,10 +169,12 @@ export const InputBar = ({
     : translate('tooltipConversationInputPlaceholder');
 
   const isConnectionRequest = isOutgoingRequest || isIncomingRequest;
+  const isViewerPermissionFeatureEnabled = isFeatureToggleEnabled(viewerPermissionFeatureToggleName);
   const isCellsUploadAllowed = isConversationFileDropAllowed({
     conversationTeamId: conversation.teamId,
     selfUserTeamId: selfUser.teamId,
     isCellsEnabled,
+    isViewerPermissionFeatureEnabled,
   });
   const hasLocalEphemeralTimer = isSelfDeletingMessagesEnabled && !!localMessageTimer && !hasGlobalMessageTimer;
   const isTypingRef = useRef(false);

--- a/apps/webapp/src/script/components/InputBar/InputBarControls/ControlButtons.test.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBarControls/ControlButtons.test.tsx
@@ -105,6 +105,40 @@ describe('ControlButtons', () => {
     expect(queryByTitle('tooltipConversationFile')).toBe(null);
   });
 
+  const renderCellsControls = (cellsState: CONVERSATION_CELLS_STATE) => {
+    spyOn(Config, 'getConfig').and.returnValue({
+      FEATURE: {ALLOWED_FILE_UPLOAD_EXTENSIONS: ['*'], ENABLE_CELLS: true},
+    });
+    const conversation = {cellsState: () => cellsState} as Conversation;
+
+    return render(
+      withTheme(
+        <ControlButtons
+          {...defaultParams}
+          conversation={conversation}
+          input="message"
+          isCellsFeatureEnabled
+          isCellsUploadAllowed
+        />,
+      ),
+      {wrapper: rootProviderWrapper},
+    );
+  };
+
+  it('shows cells upload buttons when input has content in a cells conversation', () => {
+    const {getByTitle} = renderCellsControls(CONVERSATION_CELLS_STATE.READY);
+
+    expect(getByTitle('tooltipConversationAddImage')).toBeInTheDocument();
+    expect(getByTitle('tooltipConversationFile')).toBeInTheDocument();
+  });
+
+  it('hides cells upload buttons when input has content outside a cells conversation', () => {
+    const {queryByTitle} = renderCellsControls(CONVERSATION_CELLS_STATE.DISABLED);
+
+    expect(queryByTitle('tooltipConversationAddImage')).not.toBeInTheDocument();
+    expect(queryByTitle('tooltipConversationFile')).not.toBeInTheDocument();
+  });
+
   it.each<[string, string[]]>([
     ['', allButtonTitles.filter(button => button != 'extensionsBubbleButtonGif')],
     ['hello', ['extensionsBubbleButtonGif']],

--- a/apps/webapp/src/script/components/InputBar/InputBarControls/ControlButtons.test.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBarControls/ControlButtons.test.tsx
@@ -19,7 +19,10 @@
 
 import {render} from '@testing-library/react';
 
+import {CONVERSATION_CELLS_STATE} from '@wireapp/api-client/lib/conversation';
+
 import {Conversation} from 'Repositories/entity/Conversation';
+import {Config} from 'src/script/Config';
 import {translateForTest} from 'Util/test/translateForTest';
 import {
   createRootContextValueForTest,
@@ -76,6 +79,32 @@ describe('ControlButtons', () => {
       .filter(button => !buttonTitles.includes(button))
       .forEach(button => expect(queryByTitle(button)).toBe(null));
   });
+  it.each(['', 'message'])('hides cells upload buttons when cells uploads are disallowed (input: %s)', input => {
+    spyOn(Config, 'getConfig').and.returnValue({
+      FEATURE: {ALLOWED_FILE_UPLOAD_EXTENSIONS: ['*'], ENABLE_CELLS: true},
+    });
+    const conversation = {cellsState: () => CONVERSATION_CELLS_STATE.READY} as Conversation;
+
+    const {getByTitle, queryByTitle} = render(
+      withTheme(
+        <ControlButtons
+          {...defaultParams}
+          conversation={conversation}
+          input={input}
+          isCellsFeatureEnabled
+          isCellsUploadAllowed={false}
+        />,
+      ),
+      {wrapper: rootProviderWrapper},
+    );
+
+    if (input.length === 0) {
+      expect(getByTitle('tooltipConversationPing')).not.toBe(null);
+    }
+    expect(queryByTitle('tooltipConversationAddImage')).toBe(null);
+    expect(queryByTitle('tooltipConversationFile')).toBe(null);
+  });
+
   it.each<[string, string[]]>([
     ['', allButtonTitles.filter(button => button != 'extensionsBubbleButtonGif')],
     ['hello', ['extensionsBubbleButtonGif']],

--- a/apps/webapp/src/script/components/InputBar/InputBarControls/ControlButtons.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBarControls/ControlButtons.tsx
@@ -42,6 +42,7 @@ interface ControlButtonsProps {
   disablePing?: boolean;
   disableFilesharing?: boolean;
   isCellsFeatureEnabled?: boolean;
+  isCellsUploadAllowed?: boolean;
   isEditing?: boolean;
   isFormatActive: boolean;
   isEmojiActive: boolean;
@@ -65,6 +66,7 @@ const ControlButtons = ({
   disableFilesharing,
   input,
   isCellsFeatureEnabled,
+  isCellsUploadAllowed = true,
   isEditing,
   isFormatActive,
   isEmojiActive,
@@ -84,6 +86,7 @@ const ControlButtons = ({
   const isCellsEnabled = Config.getConfig().FEATURE.ENABLE_CELLS && isCellsFeatureEnabled === true;
   const isCellsConversation = isCellsEnabled && conversation.cellsState() !== CONVERSATION_CELLS_STATE.DISABLED;
   const isFilesharingEnabled = disableFilesharing !== true;
+  const isCellsUploadEnabled = isFilesharingEnabled && isCellsUploadAllowed;
 
   if (isEditing === true) {
     return (
@@ -125,28 +128,29 @@ const ControlButtons = ({
             <EmojiButton isActive={isEmojiActive} onClick={onEmojiClick} />
           </li>
         )}
-        {isFilesharingEnabled && (
+        {isFilesharingEnabled && isCellsConversation && isCellsUploadEnabled && (
           <>
             <li>
-              {isCellsConversation ? (
-                <CellImageUploadButton onClick={onCellImageUpload} />
-              ) : (
-                <ImageUploadButton
-                  onSelectImages={onSelectImages}
-                  acceptedImageTypes={Config.getConfig().ALLOWED_IMAGE_TYPES}
-                />
-              )}
+              <CellImageUploadButton onClick={onCellImageUpload} />
             </li>
-
             <li>
-              {isCellsConversation ? (
-                <CellAssetUploadButton onClick={onCellAssetUpload} />
-              ) : (
-                <AssetUploadButton
-                  onSelectFiles={onSelectFiles}
-                  acceptedFileTypes={Config.getConfig().FEATURE.ALLOWED_FILE_UPLOAD_EXTENSIONS}
-                />
-              )}
+              <CellAssetUploadButton onClick={onCellAssetUpload} />
+            </li>
+          </>
+        )}
+        {isFilesharingEnabled && !isCellsConversation && (
+          <>
+            <li>
+              <ImageUploadButton
+                onSelectImages={onSelectImages}
+                acceptedImageTypes={Config.getConfig().ALLOWED_IMAGE_TYPES}
+              />
+            </li>
+            <li>
+              <AssetUploadButton
+                onSelectFiles={onSelectFiles}
+                acceptedFileTypes={Config.getConfig().FEATURE.ALLOWED_FILE_UPLOAD_EXTENSIONS}
+              />
             </li>
           </>
         )}
@@ -179,12 +183,12 @@ const ControlButtons = ({
               <EmojiButton isActive={isEmojiActive} onClick={onEmojiClick} />
             </li>
           )}
-          {isFilesharingEnabled && isCellsEnabled && (
+          {isCellsUploadEnabled && isCellsEnabled && (
             <li>
               <CellImageUploadButton onClick={onCellImageUpload} />
             </li>
           )}
-          {isFilesharingEnabled && isCellsEnabled && (
+          {isCellsUploadEnabled && isCellsEnabled && (
             <li>
               <CellAssetUploadButton onClick={onCellAssetUpload} />
             </li>

--- a/apps/webapp/src/script/components/InputBar/InputBarControls/ControlButtons.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBarControls/ControlButtons.tsx
@@ -86,7 +86,7 @@ const ControlButtons = ({
   const isCellsEnabled = Config.getConfig().FEATURE.ENABLE_CELLS && isCellsFeatureEnabled === true;
   const isCellsConversation = isCellsEnabled && conversation.cellsState() !== CONVERSATION_CELLS_STATE.DISABLED;
   const isFilesharingEnabled = disableFilesharing !== true;
-  const isCellsUploadEnabled = isFilesharingEnabled && isCellsUploadAllowed;
+  const isCellsUploadEnabled = isCellsConversation && isFilesharingEnabled && isCellsUploadAllowed;
 
   if (isEditing === true) {
     return (
@@ -128,7 +128,7 @@ const ControlButtons = ({
             <EmojiButton isActive={isEmojiActive} onClick={onEmojiClick} />
           </li>
         )}
-        {isFilesharingEnabled && isCellsConversation && isCellsUploadEnabled && (
+        {isCellsUploadEnabled && (
           <>
             <li>
               <CellImageUploadButton onClick={onCellImageUpload} />
@@ -183,12 +183,12 @@ const ControlButtons = ({
               <EmojiButton isActive={isEmojiActive} onClick={onEmojiClick} />
             </li>
           )}
-          {isCellsUploadEnabled && isCellsEnabled && (
+          {isCellsUploadEnabled && (
             <li>
               <CellImageUploadButton onClick={onCellImageUpload} />
             </li>
           )}
-          {isCellsUploadEnabled && isCellsEnabled && (
+          {isCellsUploadEnabled && (
             <li>
               <CellAssetUploadButton onClick={onCellAssetUpload} />
             </li>

--- a/apps/webapp/src/script/components/InputBar/InputBarControls/InputBarControls.tsx
+++ b/apps/webapp/src/script/components/InputBar/InputBarControls/InputBarControls.tsx
@@ -37,6 +37,7 @@ interface InputBarControlsProps {
   pingDisabled: boolean;
   messageContent: MessageContent;
   isCellsFeatureEnabled: boolean;
+  isCellsUploadAllowed: boolean;
   isEditing: boolean;
   isSendingDisabled: boolean;
   showMarkdownPreview: boolean;
@@ -66,6 +67,7 @@ export const InputBarControls = ({
   pingDisabled,
   messageContent,
   isCellsFeatureEnabled: isCellsFeatureEnabled,
+  isCellsUploadAllowed,
   isEditing,
   isSendingDisabled,
   showMarkdownPreview,
@@ -101,6 +103,7 @@ export const InputBarControls = ({
           disablePing={pingDisabled}
           input={messageContent.text}
           isCellsFeatureEnabled={isCellsFeatureEnabled}
+          isCellsUploadAllowed={isCellsUploadAllowed}
           isEditing={isEditing}
           onCancelEditing={onEscape}
           onClickPing={onClickPing}


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25255" title="WPB-25255" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25255</a>  [Web] Restrict access to upload buttons
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Problem

Guest users in Shared Drive conversations were treated as editors when their `selfUser.teamId` was absent. They could therefore see Cells photo and file upload controls, despite having view-only drive access.

## Solution

- Treat a missing self-user team ID as viewer access when the conversation belongs to a team.
- Hide only Cells drive upload controls for viewers; retain regular non-Cells uploads.
- Cover viewer/editor roles and input states, and validate with the Fulu guest account.

ref: https://wearezeta.atlassian.net/browse/WPB-25255

## Demo


https://github.com/user-attachments/assets/0d70f158-24f3-475b-882f-e051b192f19e



