### PR TITLE
fix: Show active 'Newest first ↓' filter by default in Drive(WPB-27863)

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -547,7 +547,7 @@
   "cells.sidebar.title": "Files",
   "cells.tableRow.actions": "More options",
   "cells.tableRow.conversationName": "Conversation",
-  "cells.tableRow.created": "Created",
+  "cells.tableRow.modified": "Modified",
   "cells.tableRow.name": "Name",
   "cells.tableRow.owner": "Uploaded by",
   "cells.tableRow.publicLink": "Shared",

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTable.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTable.tsx
@@ -89,7 +89,7 @@ export const CellsTable = ({
   const {translate} = useApplicationContext();
   const labels = {
     actions: translate('cells.tableRow.actions'),
-    created: translate('cells.tableRow.created'),
+    created: translate('cells.tableRow.modified'),
     name: translate('cells.tableRow.name'),
     owner: translate('cells.tableRow.owner'),
     publicLink: translate('cells.tableRow.publicLink'),

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.test.ts
@@ -106,6 +106,18 @@ describe('useCellsSorting', () => {
     expect(result.current.getDirectionFor('name')).toBeUndefined();
   });
 
+  it('supports a visual-only default sort when configured', () => {
+    const {result} = renderHook(() => useCellsSorting('default', {field: 'mtime', direction: 'desc'}));
+
+    expect(result.current.sort).toBeNull();
+    expect(result.current.getDirectionFor('mtime')).toBe('desc');
+
+    act(() => result.current.toggleSort('mtime'));
+
+    expect(result.current.sort).toEqual({field: 'mtime', direction: 'asc'});
+    expect(result.current.getDirectionFor('mtime')).toBe('asc');
+  });
+
   it('keeps setSort stable across sort changes', () => {
     const {result} = renderHook(() => useCellsSorting());
     const setSort = result.current.setSort;

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/useCellsSorting/useCellsSorting.ts
@@ -63,7 +63,7 @@ interface CellsSortingState {
 
 const DEFAULT_SCOPE_KEY = 'default';
 
-export const useCellsSorting = (scopeKey = DEFAULT_SCOPE_KEY) => {
+export const useCellsSorting = (scopeKey = DEFAULT_SCOPE_KEY, displayedSort?: CellsSort) => {
   const [state, setSortState] = useState<CellsSortingState>({scopeKey, sort: null});
 
   // Scope changes must clear synchronously so request hooks never receive a stale sort.
@@ -72,6 +72,7 @@ export const useCellsSorting = (scopeKey = DEFAULT_SCOPE_KEY) => {
   }
 
   const sort = state.scopeKey === scopeKey ? state.sort : null;
+  const visibleSort = sort !== null ? sort : displayedSort;
 
   const setSort = useCallback(
     (nextSort: CellsSort | null) => {
@@ -83,7 +84,7 @@ export const useCellsSorting = (scopeKey = DEFAULT_SCOPE_KEY) => {
   const toggleSort = useCallback(
     (field: CellsSortField) => {
       setSortState(current => {
-        const currentSort = current.scopeKey === scopeKey ? current.sort : null;
+        const currentSort = (current.scopeKey === scopeKey ? current.sort : null) ?? displayedSort;
 
         // Selecting a different column starts at that column's default direction.
         if (currentSort?.field !== field) {
@@ -94,12 +95,13 @@ export const useCellsSorting = (scopeKey = DEFAULT_SCOPE_KEY) => {
         return {scopeKey, sort: {field, direction: currentSort.direction === 'asc' ? 'desc' : 'asc'}};
       });
     },
-    [scopeKey],
+    [displayedSort, scopeKey],
   );
 
   const getDirectionFor = useCallback(
-    (field: CellsSortField): CellsSortDirection | undefined => (sort?.field === field ? sort.direction : undefined),
-    [sort],
+    (field: CellsSortField): CellsSortDirection | undefined =>
+      visibleSort?.field === field ? visibleSort.direction : undefined,
+    [visibleSort],
   );
 
   return {sort, setSort, toggleSort, getDirectionFor};

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsGlobalView.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsGlobalView.tsx
@@ -49,6 +49,7 @@ interface CellsGlobalViewProps {
 }
 
 export const CellsGlobalView = (properties: CellsGlobalViewProps): ReactElement => {
+  const defaultGlobalFilesSort = {field: 'mtime', direction: 'desc'} as const;
   const {
     cellsRepository = container.resolve(CellsRepository),
     userRepository = container.resolve(UserRepository),
@@ -58,7 +59,7 @@ export const CellsGlobalView = (properties: CellsGlobalViewProps): ReactElement 
   const {nodes, status: nodesStatus, pagination} = useCellsStore();
 
   const {filters, filterState} = useGlobalDriveFilters({cellsRepository, conversationRepository, translate});
-  const {sort, getDirectionFor, toggleSort} = useCellsSorting();
+  const {sort, getDirectionFor, toggleSort} = useCellsSorting('default', defaultGlobalFilesSort);
 
   const {searchValue, handleSearch, handleClearSearch, handleReload, increasePageSize} = useSearchCellsNodes({
     cellsRepository,

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableColumns.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableColumns.tsx
@@ -39,7 +39,7 @@ const columnHelper = createColumnHelper<CellNode>();
 const getCellsTableColumnLabels = (translate: RootContextValue['translate']) => ({
   actions: translate('cells.tableRow.actions'),
   conversationName: translate('cells.tableRow.conversationName'),
-  created: translate('cells.tableRow.created'),
+  created: translate('cells.tableRow.modified'),
   name: translate('cells.tableRow.name'),
   owner: translate('cells.tableRow.owner'),
   publicLink: translate('cells.tableRow.publicLink'),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27863" title="WPB-27863" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27863</a>  [Web] Show active 'Newest first ↓' filter by default in Drive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Drive has the sorting of Newest first is applied by default. It should be reflected to the user when they enter the page by having the title of the column “Modified” in the selected mode.
Arrow should be pointing down. 