### PR TITLE
feat: add feature flag for drive permission feature(WPB-27941)

### DIFF
--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -20,11 +20,13 @@
 export const applockRefactoredFeatureToggleName = 'applock-refactored';
 export const meetingsFeatureToggleName = 'meetings';
 export const conversationListCollapseFeatureToggleName = 'conversation-list-collapse';
+export const viewerPermissionFeatureToggleName = 'viewer-permission';
 
 export const startupFeatureToggleNames = [
   applockRefactoredFeatureToggleName,
   meetingsFeatureToggleName,
   conversationListCollapseFeatureToggleName,
+  viewerPermissionFeatureToggleName,
 ] as const;
 
 export type StartupFeatureToggleName = (typeof startupFeatureToggleNames)[number];

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -27,12 +27,14 @@ import {
   conversationListCollapseFeatureToggleName,
   meetingsFeatureToggleName,
   startupFeatureToggleNames,
+  viewerPermissionFeatureToggleName,
 } from './startupFeatureToggleNames';
 
 const featureToggleNamesWithDedicatedExistenceTests = [
   applockRefactoredFeatureToggleName,
   meetingsFeatureToggleName,
   conversationListCollapseFeatureToggleName,
+  viewerPermissionFeatureToggleName,
 ] as const;
 
 describe('startupFeatureToggles', function () {
@@ -101,6 +103,14 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.isFeatureToggleEnabled(conversationListCollapseFeatureToggleName)).toBe(true);
   });
 
+  it('enables the viewer permission feature toggle when present in the query parameter', () => {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${viewerPermissionFeatureToggleName}`,
+    );
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(viewerPermissionFeatureToggleName)).toBe(true);
+  });
+
   it('trims whitespace around feature toggle names', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}= ${applockRefactoredFeatureToggleName} `,
@@ -142,6 +152,7 @@ describe('startupFeatureToggles', function () {
       applockRefactoredFeatureToggleName,
       meetingsFeatureToggleName,
       conversationListCollapseFeatureToggleName,
+      viewerPermissionFeatureToggleName,
     ]);
   });
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27941" title="WPB-27941" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27941</a>  [web] Add feature flag for viewer permission feature
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Query param based feature flag development
<img width="401" height="206" alt="Screenshot 2026-08-11 at 11 14 17" src="https://github.com/user-attachments/assets/6245134e-c064-4b54-af8a-70a0c2f3d511" />
