### PR TITLE
fix(webapp): show scheduled meetings in the list immediately [WPB-27908]

### DIFF
--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.test.ts
@@ -74,12 +74,16 @@ describe('createMeetingStore', () => {
   });
 
   const createServiceTasks = (overrides: Partial<MeetingStoreServiceTasks> = {}): MeetingStoreServiceTasks => ({
-    scheduleMeeting: jest.fn().mockReturnValue(task.resolve({failedToAdd: []})),
-    meetNowMeeting: jest
+    scheduleMeeting: jest
       .fn()
-      .mockReturnValue(
-        task.resolve({failedToAdd: [], qualifiedConversation: {id: 'conversation-id', domain: 'example.com'}}),
-      ),
+      .mockReturnValue(task.resolve({failedToAdd: [], qualifiedMeetingId: apiMeeting.qualified_id})),
+    meetNowMeeting: jest.fn().mockReturnValue(
+      task.resolve({
+        failedToAdd: [],
+        qualifiedConversation: {id: 'conversation-id', domain: 'example.com'},
+        qualifiedMeetingId: apiMeeting.qualified_id,
+      }),
+    ),
     updateMeeting: jest.fn().mockReturnValue(task.resolve({failedToAdd: []})),
     deleteMeetingForMe: jest.fn().mockReturnValue(task.resolve(undefined)),
     deleteMeetingForAll: jest.fn().mockReturnValue(task.resolve(undefined)),
@@ -218,11 +222,14 @@ describe('createMeetingStore', () => {
     expect(store.getState().meetingSeries).toEqual([expect.objectContaining(meetingSeriesEntry)]);
   });
 
-  it('schedules a meeting without refreshing the meetings list', async () => {
-    const scheduleMeeting = jest.fn().mockReturnValue(task.resolve({failedToAdd: []}));
+  it('syncs a newly scheduled meeting into the store without reloading the meetings list', async () => {
+    const scheduleMeeting = jest
+      .fn()
+      .mockReturnValue(task.resolve({failedToAdd: [], qualifiedMeetingId: apiMeeting.qualified_id}));
     const getMeetingsList = jest.fn().mockReturnValue(task.resolve([apiMeeting]));
+    const getMeeting = jest.fn().mockReturnValue(task.resolve(apiMeeting));
     const store = createMeetingStore(
-      createDeps({getMeetingsList, serviceTasks: createServiceTasks({scheduleMeeting})}),
+      createDeps({getMeetingsList, getMeeting, serviceTasks: createServiceTasks({scheduleMeeting})}),
     );
     const scheduleCommand = {
       title: 'Weekly sync',
@@ -237,7 +244,9 @@ describe('createMeetingStore', () => {
     expect(result.isOk).toBe(true);
     expect(scheduleMeeting).toHaveBeenCalledTimes(1);
     expect(scheduleMeeting).toHaveBeenCalledWith(scheduleCommand);
+    expect(getMeeting).toHaveBeenCalledWith(apiMeeting.qualified_id);
     expect(getMeetingsList).not.toHaveBeenCalled();
+    expect(store.getState().meetingSeries).toEqual([expect.objectContaining(meetingSeriesEntry)]);
   });
 
   it('loads meeting data for edit via safeGetConversationById', async () => {

--- a/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/createMeetingStore.ts
@@ -129,7 +129,13 @@ export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: Meetin
 
       set({meetingSeries: listResult.meetingSeries, hasLoadError: listResult.hasLoadError, isLoading: false});
     },
-    scheduleMeeting: deps.serviceTasks.scheduleMeeting,
+    scheduleMeeting: command =>
+      deps.serviceTasks.scheduleMeeting(command).andThen(result =>
+        get()
+          .syncMeetingByQualifiedId(result.qualifiedMeetingId)
+          .map(() => ({failedToAdd: result.failedToAdd}))
+          .orElse(() => task.resolve({failedToAdd: result.failedToAdd})),
+      ),
     meetNowMeeting: deps.serviceTasks.meetNowMeeting,
     updateMeeting: deps.serviceTasks.updateMeeting,
     deleteMeetingForMe: meetingInstance =>

--- a/apps/webapp/src/script/components/Meeting/meetingStore/meetingStoreDeps.ts
+++ b/apps/webapp/src/script/components/Meeting/meetingStore/meetingStoreDeps.ts
@@ -22,7 +22,11 @@ import type {Task} from 'true-myth';
 
 import type {MeetingSubmitErrors} from 'Components/Meeting/meetingSubmitErrors';
 import type {DeleteMeetingCommand} from 'Components/Meeting/shared/service/deleteMeeting';
-import type {CreateMeetingSuccess, MeetingSubmitSuccess} from 'Components/Meeting/shared/service/meetingService';
+import type {
+  CreateMeetingSuccess,
+  MeetingSubmitSuccess,
+  ScheduleMeetingSuccess,
+} from 'Components/Meeting/shared/service/meetingService';
 import type {
   MeetNowMeetingCommand,
   ScheduleMeetingCommand,
@@ -33,7 +37,7 @@ import type {ConversationRepository} from 'Repositories/conversation/Conversatio
 import type {MeetingsRepository} from 'Repositories/meetings/meetingsRepository';
 
 export type MeetingStoreServiceTasks = {
-  scheduleMeeting: (command: ScheduleMeetingCommand) => Task<MeetingSubmitSuccess, MeetingSubmitErrors>;
+  scheduleMeeting: (command: ScheduleMeetingCommand) => Task<ScheduleMeetingSuccess, MeetingSubmitErrors>;
   meetNowMeeting: (command: MeetNowMeetingCommand) => Task<CreateMeetingSuccess, MeetingSubmitErrors>;
   updateMeeting: (command: UpdateMeetingCommand) => Task<MeetingSubmitSuccess, MeetingSubmitErrors>;
   deleteMeetingForMe: (command: DeleteMeetingCommand) => Task<void, MeetingSubmitErrors>;

--- a/apps/webapp/src/script/components/Meeting/shared/service/meetingService.test.ts
+++ b/apps/webapp/src/script/components/Meeting/shared/service/meetingService.test.ts
@@ -173,7 +173,10 @@ describe('scheduleMeeting', () => {
     const result = await scheduleMeeting(scheduleCommand, deps);
 
     expect(result.isOk).toBe(true);
-    expect(result.match({Ok: value => value.failedToAdd, Err: () => null})).toEqual([]);
+    expect(result.match({Ok: value => value, Err: () => null})).toEqual({
+      failedToAdd: [],
+      qualifiedMeetingId: meetingId,
+    });
     expect(createMeetingMock).toHaveBeenCalledWith({
       title: 'Weekly sync',
       start_time: futureStartIso,
@@ -301,6 +304,7 @@ describe('meetNowMeeting', () => {
     expect(result.match({Ok: value => value, Err: () => null})).toEqual({
       failedToAdd: [],
       qualifiedConversation,
+      qualifiedMeetingId: meetingId,
     });
     expect(createMeetingMock).toHaveBeenCalledWith({
       title: 'Standup',

--- a/apps/webapp/src/script/components/Meeting/shared/service/meetingService.ts
+++ b/apps/webapp/src/script/components/Meeting/shared/service/meetingService.ts
@@ -45,7 +45,12 @@ import type {User} from 'Repositories/entity/User';
 
 export type MeetingSubmitSuccess = {failedToAdd: AddUsersFailure[]};
 
-export type CreateMeetingSuccess = MeetingSubmitSuccess & {qualifiedConversation: QualifiedId};
+export type CreateMeetingSuccess = MeetingSubmitSuccess & {
+  qualifiedConversation: QualifiedId;
+  qualifiedMeetingId: QualifiedId;
+};
+
+export type ScheduleMeetingSuccess = MeetingSubmitSuccess & {qualifiedMeetingId: QualifiedId};
 
 const mapSyncErrorToSubmitError = (error: MeetingConversationSyncError): MeetingSubmitErrors => {
   switch (error) {
@@ -96,6 +101,7 @@ const createMeetingAndSyncParticipants = (
           .map(syncResult => ({
             ...syncResult,
             qualifiedConversation: createdMeeting.qualified_conversation,
+            qualifiedMeetingId: createdMeeting.qualified_id,
           })),
       ),
     );
@@ -106,10 +112,11 @@ const createMeetingAndSyncParticipants = (
 export const scheduleMeeting = (
   command: ScheduleMeetingCommand,
   deps: MeetingServiceDeps,
-): Task<MeetingSubmitSuccess, MeetingSubmitErrors> =>
+): Task<ScheduleMeetingSuccess, MeetingSubmitErrors> =>
   createMeetingAndSyncParticipants(mapScheduleCommandToCreateMeeting(command), command.selectedUsers, deps).map(
-    ({failedToAdd}) => ({
+    ({failedToAdd, qualifiedMeetingId}) => ({
       failedToAdd,
+      qualifiedMeetingId,
     }),
   );
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27908" title="WPB-27908" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27908</a>  Meeting host cannot see a newly scheduled meeting in the Meetings list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Sync newly scheduled meetings into the meeting store from the create API response
- Keeps the list up to date without waiting for lifecycle WebSocket events or navigating away

## Test plan
- [x] Schedule a meeting and confirm it appears in the Meetings list immediately
- [x] `yarn nx run webapp:test --testFile=src/script/components/Meeting/meetingStore/createMeetingStore.test.ts`
- [x] `yarn nx run webapp:test --testFile=src/script/components/Meeting/shared/service/meetingService.test.ts`
- [x] `yarn nx run webapp:test --testFile=src/script/components/Meeting/ScheduleMeetingModal/useScheduleMeetingSubmit.test.tsx`