### PR TITLE
feat(drive): add viewer permissions behind feature flag [WPB-27941]

### DIFF
--- a/apps/webapp/src/script/components/Conversation/Conversation.tsx
+++ b/apps/webapp/src/script/components/Conversation/Conversation.tsx
@@ -46,6 +46,7 @@ import {User} from 'Repositories/entity/User';
 import {ServiceEntity} from 'Repositories/integration/ServiceEntity';
 import {TeamState} from 'Repositories/team/TeamState';
 import {Config} from 'src/script/Config';
+import {viewerPermissionFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext, useMainViewModel} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {isLastReceivedMessage} from 'Util/conversationMessages';
@@ -104,7 +105,7 @@ export const Conversation = ({
   const isVirtualizedMessagesListEnabled = CONFIG.FEATURE.ENABLE_VIRTUALIZED_MESSAGES_LIST;
 
   const mainViewModel = useMainViewModel();
-  const {fireAndForgetInvoker, translate} = useApplicationContext();
+  const {fireAndForgetInvoker, isFeatureToggleEnabled, translate} = useApplicationContext();
   const {content: contentViewModel} = mainViewModel;
   const {conversationRepository, repositories} = contentViewModel;
   const [isConversationLoaded, setIsConversationLoaded] = useState<boolean>(false);
@@ -584,10 +585,12 @@ export const Conversation = ({
 
   const isCellsEnabled =
     Config.getConfig().FEATURE.ENABLE_CELLS && activeConversation?.cellsState() !== CONVERSATION_CELLS_STATE.DISABLED;
+  const isViewerPermissionFeatureEnabled = isFeatureToggleEnabled(viewerPermissionFeatureToggleName);
   const isFileDropAllowed = isConversationFileDropAllowed({
     conversationTeamId: activeConversation?.teamId,
     selfUserTeamId: activeConversation?.selfUser()?.teamId,
     isCellsEnabled,
+    isViewerPermissionFeatureEnabled,
   });
 
   useEffect(() => {

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed.test.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed.test.ts
@@ -21,25 +21,38 @@ import {isConversationFileDropAllowed} from './isConversationFileDropAllowed';
 
 describe('isConversationFileDropAllowed', () => {
   it('allows file drops when Cells is disabled', () => {
-    expect(isConversationFileDropAllowed({isCellsEnabled: false})).toBe(true);
+    expect(isConversationFileDropAllowed({isCellsEnabled: false, isViewerPermissionFeatureEnabled: true})).toBe(true);
   });
 
-  it('allows editor file drops when Cells is enabled', () => {
-    expect(
-      isConversationFileDropAllowed({
-        conversationTeamId: 'team-a',
-        selfUserTeamId: 'team-a',
-        isCellsEnabled: true,
-      }),
-    ).toBe(true);
-  });
-
-  it('prevents viewer file drops when Cells is enabled', () => {
+  it('allows viewer file drops when the viewer permission feature is disabled', () => {
     expect(
       isConversationFileDropAllowed({
         conversationTeamId: 'team-a',
         selfUserTeamId: 'team-b',
         isCellsEnabled: true,
+        isViewerPermissionFeatureEnabled: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows editor file drops when the viewer permission feature is enabled', () => {
+    expect(
+      isConversationFileDropAllowed({
+        conversationTeamId: 'team-a',
+        selfUserTeamId: 'team-a',
+        isCellsEnabled: true,
+        isViewerPermissionFeatureEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('prevents viewer file drops when the viewer permission feature is enabled', () => {
+    expect(
+      isConversationFileDropAllowed({
+        conversationTeamId: 'team-a',
+        selfUserTeamId: 'team-b',
+        isCellsEnabled: true,
+        isViewerPermissionFeatureEnabled: true,
       }),
     ).toBe(false);
   });

--- a/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed.ts
@@ -26,14 +26,16 @@ interface IsConversationFileDropAllowedParams {
   conversationTeamId?: string;
   selfUserTeamId?: string;
   isCellsEnabled: boolean;
+  isViewerPermissionFeatureEnabled: boolean;
 }
 
 export const isConversationFileDropAllowed = ({
   conversationTeamId,
   selfUserTeamId,
   isCellsEnabled,
+  isViewerPermissionFeatureEnabled,
 }: IsConversationFileDropAllowedParams): boolean => {
-  if (!isCellsEnabled) {
+  if (!isCellsEnabled || !isViewerPermissionFeatureEnabled) {
     return true;
   }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27941" title="WPB-27941" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27941</a>  [web] Add feature flag for viewer permission feature
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

### Problem

The Cells viewer file-drop restrictions introduced in #22145 are active unconditionally. The `viewer-permission` startup feature flag added in #22162 needs to control their rollout.

### Solution

- Read the `viewer-permission` startup feature flag in the conversation view.
- Preserve existing file-drop behavior while the flag is disabled.
- Apply editor/viewer drive permissions when the flag is enabled.
- Cover Cells-disabled, flag-disabled, editor, and viewer paths with focused tests.

ref: https://wearezeta.atlassian.net/browse/WPB-27941
