### PR TITLE
fix(drive): preview guest PDFs as images [WPB-27965]

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsFilePreviewModal/CellsFilePreviewModal.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsFilePreviewModal/CellsFilePreviewModal.tsx
@@ -17,8 +17,10 @@
  *
  */
 
+import {getFilePreviewUrl} from 'Components/cells/common/getFilePreviewUrl/getFilePreviewUrl';
 import {FileFullscreenModal} from 'Components/FileFullscreenModal/FileFullscreenModal';
-import {getFileTypeFromExtension} from 'Util/getFileTypeFromExtension/getFileTypeFromExtension';
+import {viewerPermissionFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {useApplicationContext} from 'src/script/page/rootProvider';
 
 import {sortTagsAlphabetically} from '../../common/sortTagsAlphabetically/sortTagsAlphabetically';
 import {useCellsFilePreviewModal} from '../common/CellsFilePreviewModalContext/CellsFilePreviewModalContext';
@@ -27,6 +29,7 @@ import {useCellsFilePreviewModal} from '../common/CellsFilePreviewModalContext/C
 // TODO: Abstract when it starts to grow / feels right
 export const CellsFilePreviewModal = () => {
   const {selectedFile, handleCloseFile, isEditMode} = useCellsFilePreviewModal();
+  const {isFeatureToggleEnabled} = useApplicationContext();
   const isModalOpen = selectedFile !== null;
 
   if (!isModalOpen) {
@@ -35,21 +38,14 @@ export const CellsFilePreviewModal = () => {
 
   const {url, extension, name, owner, uploadedAtTimestamp, previewPdfUrl, previewImageUrl, tags} = selectedFile;
 
-  const getFileUrl = () => {
-    const type = getFileTypeFromExtension(extension);
-
-    if (['pdf', 'image'].includes(type)) {
-      return url;
-    }
-
-    if (['audio', 'video'].includes(type)) {
-      return undefined;
-    }
-
-    return previewPdfUrl ?? previewImageUrl;
-  };
-
-  const filePreviewUrl = getFileUrl();
+  const filePreviewUrl = getFilePreviewUrl({
+    extension,
+    url,
+    previewPdfUrl,
+    previewImageUrl,
+    enableGuestPdfImagePreview: isFeatureToggleEnabled(viewerPermissionFeatureToggleName),
+  });
+  const isImagePreview = filePreviewUrl !== undefined && filePreviewUrl === previewImageUrl;
 
   return (
     <FileFullscreenModal
@@ -57,6 +53,7 @@ export const CellsFilePreviewModal = () => {
       isOpen={isModalOpen}
       onClose={handleCloseFile}
       filePreviewUrl={filePreviewUrl}
+      isImagePreview={isImagePreview}
       fileName={name}
       fileExtension={extension}
       fileUrl={url}

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.test.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.test.tsx
@@ -149,6 +149,45 @@ describe('FileFullscreenModal - File Version Restore', () => {
       expect(screen.getByTestId('image-view')).toBeInTheDocument();
     });
 
+    it('should render PDF viewer when its preview URL has no file extension', () => {
+      render(
+        <FileFullscreenModal
+          {...defaultProps}
+          filePreviewUrl="https://storage.example.com/download?node=123"
+          fileExtension="pdf"
+        />,
+      );
+
+      expect(screen.getByTestId('pdf-viewer')).toBeInTheDocument();
+    });
+
+    it('should render PDF viewer from the file URL when no preview URL is available', () => {
+      render(
+        <FileFullscreenModal
+          {...defaultProps}
+          fileExtension="pdf"
+          filePreviewUrl={undefined}
+          fileUrl="https://storage.example.com/download?node=123"
+          status="unavailable"
+        />,
+      );
+
+      expect(screen.getByTestId('pdf-viewer')).toBeInTheDocument();
+    });
+
+    it('should render an image preview for a PDF when the server provides one', () => {
+      render(
+        <FileFullscreenModal
+          {...defaultProps}
+          fileExtension="pdf"
+          filePreviewUrl="https://storage.example.com/preview?node=123"
+          isImagePreview
+        />,
+      );
+
+      expect(screen.getByTestId('image-view')).toBeInTheDocument();
+    });
+
     it('should show loader when loading', () => {
       render(<FileFullscreenModal {...defaultProps} status="loading" filePreviewUrl={undefined} />);
 

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.tsx
@@ -42,6 +42,7 @@ interface FileFullscreenModalProps {
   isOpen: boolean;
   onClose: () => void;
   filePreviewUrl?: string;
+  isImagePreview?: boolean;
   fileName: string;
   fileExtension: string;
   fileUrl?: string;
@@ -58,6 +59,7 @@ export const FileFullscreenModal = ({
   isOpen,
   onClose,
   filePreviewUrl,
+  isImagePreview,
   fileUrl,
   status = 'success',
   fileName,
@@ -109,6 +111,7 @@ export const FileFullscreenModal = ({
           key={refreshKey}
           fileExtension={fileExtension}
           filePreviewUrl={filePreviewUrl}
+          isImagePreview={isImagePreview}
           fileName={fileName}
           fileUrl={fileUrl}
           senderName={senderName}
@@ -127,34 +130,38 @@ interface ModalContentProps {
   senderName: string;
   timestamp: number;
   filePreviewUrl?: string;
+  isImagePreview?: boolean;
   fileUrl?: string;
 }
 
 const ModalContent = ({
   fileExtension,
   filePreviewUrl,
+  isImagePreview,
   fileName,
   fileUrl,
   senderName,
   timestamp,
   status,
 }: ModalContentProps) => {
-  if (status === 'loading' && (filePreviewUrl === undefined || filePreviewUrl.length === 0)) {
+  const fileType = isImagePreview ? 'image' : getFileTypeFromExtension(fileExtension);
+  const previewUrl = fileType === 'pdf' ? (filePreviewUrl ?? fileUrl) : filePreviewUrl;
+
+  if (status === 'loading' && (previewUrl === undefined || previewUrl.length === 0)) {
     return <FileLoader />;
   }
 
-  if (status === 'unavailable' || filePreviewUrl === undefined || filePreviewUrl.length === 0) {
+  if ((status === 'unavailable' && fileType !== 'pdf') || previewUrl === undefined || previewUrl.length === 0) {
     return <NoPreviewAvailable fileUrl={fileUrl} fileName={fileName} fileExtension={fileExtension} />;
   }
 
-  const extension = getFileExtensionFromUrl(filePreviewUrl);
-  const type = getFileTypeFromExtension(extension);
-
-  if (type === 'pdf') {
-    return <PDFViewer src={filePreviewUrl} />;
+  if (fileType === 'pdf') {
+    return <PDFViewer src={previewUrl} />;
   }
 
-  if (type === 'image') {
+  const type = getFileTypeFromExtension(getFileExtensionFromUrl(previewUrl));
+
+  if (isImagePreview || type === 'image') {
     const imageSrc = getBestPreviewSource({
       fileExtension,
       fileUrl: Maybe.of(fileUrl),

--- a/apps/webapp/src/script/components/cells/common/getFilePreviewUrl/getFilePreviewUrl.test.ts
+++ b/apps/webapp/src/script/components/cells/common/getFilePreviewUrl/getFilePreviewUrl.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {getFilePreviewUrl} from './getFilePreviewUrl';
+
+describe('getFilePreviewUrl', () => {
+  it('uses the PDF preview when the original file URL is unavailable', () => {
+    expect(
+      getFilePreviewUrl({
+        extension: 'pdf',
+        url: undefined,
+        previewPdfUrl: 'https://cells.example.com/previews/security-report',
+      }),
+    ).toBe('https://cells.example.com/previews/security-report');
+  });
+
+  it('uses an image preview for a guest PDF when the feature is enabled', () => {
+    expect(
+      getFilePreviewUrl({
+        extension: 'pdf',
+        previewImageUrl: 'https://cells.example.com/previews/security-report',
+        enableGuestPdfImagePreview: true,
+      }),
+    ).toBe('https://cells.example.com/previews/security-report');
+  });
+
+  it('does not use an image preview for a guest PDF when the feature is disabled', () => {
+    expect(
+      getFilePreviewUrl({
+        extension: 'pdf',
+        previewImageUrl: 'https://cells.example.com/previews/security-report',
+        enableGuestPdfImagePreview: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it.each(['mp3', 'mp4'])('does not return a preview for %s files', extension => {
+    expect(
+      getFilePreviewUrl({
+        extension,
+        url: 'https://cells.example.com/files/media',
+        previewPdfUrl: 'https://cells.example.com/previews/media',
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/webapp/src/script/components/cells/common/getFilePreviewUrl/getFilePreviewUrl.ts
+++ b/apps/webapp/src/script/components/cells/common/getFilePreviewUrl/getFilePreviewUrl.ts
@@ -1,0 +1,62 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isNonEmptyString} from '@sindresorhus/is';
+
+import {getFileTypeFromExtension} from 'Util/getFileTypeFromExtension/getFileTypeFromExtension';
+
+interface GetFilePreviewUrlParams {
+  extension: string;
+  url?: string;
+  previewPdfUrl?: string;
+  previewImageUrl?: string;
+  enableGuestPdfImagePreview?: boolean;
+}
+
+export const getFilePreviewUrl = ({
+  extension,
+  url,
+  previewPdfUrl,
+  previewImageUrl,
+  enableGuestPdfImagePreview = false,
+}: GetFilePreviewUrlParams): string | undefined => {
+  const type = getFileTypeFromExtension(extension);
+
+  if (type === 'pdf') {
+    return url ?? previewPdfUrl ?? (enableGuestPdfImagePreview ? previewImageUrl : undefined);
+  }
+
+  if (type === 'image') {
+    return url ?? previewImageUrl;
+  }
+
+  if (['audio', 'video'].includes(type)) {
+    return undefined;
+  }
+
+  if (isNonEmptyString(previewPdfUrl)) {
+    return previewPdfUrl;
+  }
+
+  if (isNonEmptyString(previewImageUrl)) {
+    return previewImageUrl;
+  }
+
+  return undefined;
+};

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsFilePreviewModal/cellsFilePreviewModal.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsFilePreviewModal/cellsFilePreviewModal.tsx
@@ -17,10 +17,10 @@
  *
  */
 
-import {isNonEmptyString} from '@sindresorhus/is';
-
+import {getFilePreviewUrl} from 'Components/cells/common/getFilePreviewUrl/getFilePreviewUrl';
 import {FileFullscreenModal} from 'Components/FileFullscreenModal/FileFullscreenModal';
-import {getFileTypeFromExtension} from 'Util/getFileTypeFromExtension/getFileTypeFromExtension';
+import {viewerPermissionFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {useApplicationContext} from 'src/script/page/rootProvider';
 
 import {sortTagsAlphabetically} from '../../../Conversation/ConversationCells/common/sortTagsAlphabetically/sortTagsAlphabetically';
 import {useCellsFilePreviewModal} from '../common/cellsFilePreviewModalContext/cellsFilePreviewModalContext';
@@ -29,6 +29,7 @@ import {useCellsFilePreviewModal} from '../common/cellsFilePreviewModalContext/c
 // TODO: Abstract when it starts to grow / feels right
 export const CellsFilePreviewModal = () => {
   const {selectedFile, handleCloseFile, isEditMode} = useCellsFilePreviewModal();
+  const {isFeatureToggleEnabled} = useApplicationContext();
 
   if (selectedFile === null) {
     return null;
@@ -36,36 +37,26 @@ export const CellsFilePreviewModal = () => {
 
   const {url, extension, name, owner, uploadedAtTimestamp, previewPdfUrl, previewImageUrl, tags} = selectedFile;
 
-  const getFileUrl = () => {
-    const type = getFileTypeFromExtension(extension);
-
-    if (['pdf', 'image'].includes(type)) {
-      return url;
-    }
-
-    if (['audio', 'video'].includes(type)) {
-      return undefined;
-    }
-
-    if (isNonEmptyString(previewPdfUrl)) {
-      return previewPdfUrl;
-    }
-    if (isNonEmptyString(previewImageUrl)) {
-      return previewImageUrl;
-    }
-    return undefined;
-  };
+  const filePreviewUrl = getFilePreviewUrl({
+    extension,
+    url,
+    previewPdfUrl,
+    previewImageUrl,
+    enableGuestPdfImagePreview: isFeatureToggleEnabled(viewerPermissionFeatureToggleName),
+  });
+  const isImagePreview = filePreviewUrl !== undefined && filePreviewUrl === previewImageUrl;
 
   return (
     <FileFullscreenModal
       id={selectedFile.id}
       isOpen={selectedFile !== null}
       onClose={handleCloseFile}
-      filePreviewUrl={getFileUrl()}
+      filePreviewUrl={filePreviewUrl}
+      isImagePreview={isImagePreview}
       fileUrl={url}
       fileName={name}
       fileExtension={extension}
-      status={getFileUrl() === undefined ? 'unavailable' : 'success'}
+      status={filePreviewUrl === undefined ? 'unavailable' : 'success'}
       senderName={owner}
       timestamp={uploadedAtTimestamp}
       badges={sortTagsAlphabetically(tags)}


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27965" title="WPB-27965" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27965</a>  PDF lightbox components ignore Previews[].PreSignedGET and fall back to node.PreSignedGET — preview breaks for viewers
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

### Problem

Cells viewers cannot access an original PDF URL. Cells supplies a signed JPG preview, but Webapp treated the item as a PDF and showed no preview.

### Solution

- Use the signed image preview when a viewer has no original PDF URL.
- Render that preview through the image viewer.
- Gate the behavior with the existing `viewer-permission` startup feature toggle.


ref: https://wearezeta.atlassian.net/browse/WPB-27965