### PR TITLE
Add meetings CRUD e2e coverage and sync store after edits [WPB-27908]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingStore/createMeetingStore.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/createMeetingStore.ts
@@ -136,7 +136,13 @@ export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: Meetin
           .orElse(() => task.resolve({failedToAdd: result.failedToAdd})),
       ),
     meetNowMeeting: deps.serviceTasks.meetNowMeeting,
-    updateMeeting: deps.serviceTasks.updateMeeting,
+    updateMeeting: command =>
+      deps.serviceTasks.updateMeeting(command).andThen(result =>
+        get()
+          .syncMeetingByQualifiedId(command.meetingId)
+          .map(() => ({failedToAdd: result.failedToAdd}))
+          .orElse(() => task.resolve({failedToAdd: result.failedToAdd})),
+      ),
     deleteMeetingForMe: meetingInstance =>
       deps.serviceTasks.deleteMeetingForMe(toDeleteMeetingCommand(meetingInstance)),
     deleteMeetingForAll: meetingInstance =>

--- a/apps/webapp/test/e2e_tests/pageManager/index.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/index.ts
@@ -54,6 +54,7 @@ import {HistoryExportPage} from './webapp/pages/historyExport.page';
 import {HistoryImportPage} from './webapp/pages/historyImport.page';
 import {HistoryInfoPage} from './webapp/pages/infoHistory.page';
 import {LoginPage} from './webapp/pages/login.page';
+import {MeetingsPage} from './webapp/pages/meetings.page';
 import {MessageDetailsPage} from './webapp/pages/messageDetails.page';
 import {OptionsPage} from './webapp/pages/options.page';
 import {OutgoingConnectionPage} from './webapp/pages/outgoingConnection.page';
@@ -190,6 +191,7 @@ export class PageManager {
       historyInfo: () => this.getOrCreate('webapp.pages.infoHostory', () => new HistoryInfoPage(this.page)),
       historyExport: () => this.getOrCreate('webapp.pages.historyExport', () => new HistoryExportPage(this.page)),
       historyImport: () => this.getOrCreate('webapp.pages.historyImport', () => new HistoryImportPage(this.page)),
+      meetings: () => this.getOrCreate('webapp.pages.meetings', () => new MeetingsPage(this.page)),
       messageDetails: () => this.getOrCreate('webapp.pages.messageDetails', () => new MessageDetailsPage(this.page)),
       participantDetails: () =>
         this.getOrCreate('webapp.pages.participantsDetails', () => new ParticipantDetails(this.page)),

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
@@ -1,0 +1,309 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+import {expect, type Locator, type Page} from '@playwright/test';
+
+import {ConfirmModal} from '../modals/confirm.modal';
+
+const MEETINGS_LIST_TIMEOUT_MS = 30_000;
+
+export class MeetingsPage {
+  private readonly page: Page;
+
+  readonly meetingsTab: Locator;
+  readonly meetingsList: Locator;
+  readonly emptyMeetingsList: Locator;
+  readonly scheduleMeetingButton: Locator;
+  readonly createMeetingButton: Locator;
+  readonly scheduleMeetingModal: Locator;
+  readonly notificationHost: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.meetingsTab = page.locator('[data-uie-name="go-meetings"]');
+    this.meetingsList = page.locator('[data-uie-name="meetings-list"]');
+    this.emptyMeetingsList = page.locator('[data-uie-name="empty-meetings-list"]');
+    this.scheduleMeetingButton = page.locator('[data-uie-name="schedule-meeting"]');
+    this.createMeetingButton = page.locator('[data-uie-name="create-meeting"]');
+    this.scheduleMeetingModal = page.locator('[data-uie-name="schedule-meeting-modal"]');
+    this.notificationHost = page.locator('[data-uie-name="meeting-notification-host"]');
+  }
+
+  async openMeetingsTab() {
+    await this.meetingsTab.click();
+  }
+
+  async openScheduleMeetingModal() {
+    if (await this.emptyMeetingsList.isVisible()) {
+      await this.scheduleMeetingButton.click();
+      return;
+    }
+
+    await this.createMeetingButton.click();
+    await this.page.getByRole('menu').getByRole('button', {name: 'Schedule Meeting'}).click();
+  }
+
+  meetingListItem(title: string) {
+    return this.meetingsList.filter({hasText: title});
+  }
+
+  async waitForMeetingInList(title: string) {
+    await this.openMeetingsTab();
+    await expect
+      .poll(() => this.meetingListItem(title).count(), {timeout: MEETINGS_LIST_TIMEOUT_MS})
+      .toBeGreaterThan(0);
+  }
+
+  async waitForMeetingAbsentFromList(title: string) {
+    await expect
+      .poll(
+        async () => {
+          await this.page.locator('[data-uie-name="go-people"]').click();
+          await this.openMeetingsTab();
+          return this.meetingListItem(title).count();
+        },
+        {timeout: MEETINGS_LIST_TIMEOUT_MS},
+      )
+      .toBe(0);
+  }
+
+  async assertNoSubmitErrorVisible() {
+    await expect(
+      this.page.getByText('The meeting was updated, but some participants could not be removed'),
+    ).toBeHidden();
+  }
+
+  meetingTitleInput() {
+    return this.scheduleMeetingModal.locator('input[data-uie-name="schedule-meeting-title"]');
+  }
+
+  async fillMeetingTitle(title: string) {
+    const titleInput = this.scheduleMeetingModal.getByLabel('Title', {exact: true});
+    await titleInput.click();
+    await this.page.keyboard.press('ControlOrMeta+a');
+    await titleInput.fill(title);
+    await expect(titleInput).toHaveValue(title);
+  }
+
+  async dismissBlockingModals() {
+    const acknowledgeModal = this.page.locator('[data-uie-name="modal-template-acknowledge"]');
+    if (await acknowledgeModal.isVisible()) {
+      await acknowledgeModal.getByTestId('do-action').click();
+      await expect(acknowledgeModal).toBeHidden();
+    }
+  }
+
+  async closeParticipantsPicker() {
+    const dropdown = this.page.locator('[data-uie-name="dropdown-schedule-meeting-participants"]');
+    if (!(await dropdown.isVisible())) {
+      return;
+    }
+
+    await this.scheduleMeetingModal.getByLabel('Title', {exact: true}).click();
+    await expect(dropdown).toBeHidden();
+  }
+
+  async addParticipant(fullName: string) {
+    const participants = this.scheduleMeetingModal.locator('[data-uie-name="schedule-meeting-participants"]');
+    const dropdown = this.page.locator('[data-uie-name="dropdown-schedule-meeting-participants"]');
+    const participantOption = dropdown.locator('[data-uie-name="item-user"]').filter({hasText: fullName});
+
+    await participants.locator('[data-uie-name="schedule-meeting-participants-input"]').fill(fullName);
+    await expect(participantOption).toBeVisible();
+    await participantOption.click();
+    await this.closeParticipantsPicker();
+  }
+
+  async openParticipantsPicker() {
+    const participants = this.scheduleMeetingModal.locator('[data-uie-name="schedule-meeting-participants"]');
+    const dropdown = this.page.locator('[data-uie-name="dropdown-schedule-meeting-participants"]');
+
+    if (!(await dropdown.isVisible())) {
+      await participants.locator('[data-uie-name="schedule-meeting-participants-toggle"]').click();
+    }
+
+    await expect(dropdown).toBeVisible();
+    return dropdown;
+  }
+
+  async removeParticipant(fullName: string) {
+    const participants = this.scheduleMeetingModal.locator('[data-uie-name="schedule-meeting-participants"]');
+    const dropdown = await this.openParticipantsPicker();
+    const selectedSectionToggle = dropdown.locator('[data-uie-name="do-toggle-selected-search-list"]');
+    const selectedList = dropdown.locator('[data-uie-name="selected-search-list"]');
+    const selectedParticipant = selectedList.locator('[data-uie-name="item-user"]').filter({hasText: fullName});
+
+    if (await selectedSectionToggle.isVisible()) {
+      if (!(await selectedParticipant.isVisible())) {
+        await selectedSectionToggle.click();
+      }
+    }
+
+    await expect(selectedParticipant).toBeVisible();
+    await selectedParticipant.click();
+    await expect(participants.locator('[data-uie-name="schedule-meeting-participants-summary"]')).not.toContainText(
+      fullName,
+    );
+    await this.closeParticipantsPicker();
+  }
+
+  startTimeCombobox() {
+    return this.scheduleMeetingModal.getByRole('group', {name: 'Starts'}).getByRole('combobox', {name: 'Select time'});
+  }
+
+  startDateOpenCalendarButton() {
+    return this.scheduleMeetingModal
+      .getByRole('group', {name: 'Starts'})
+      .getByRole('button', {name: 'Open calendar'});
+  }
+
+  async selectLatestAvailableStartTime() {
+    const startTimeCombobox = this.startTimeCombobox();
+    await startTimeCombobox.scrollIntoViewIfNeeded();
+    await startTimeCombobox.click();
+    await this.page.getByRole('option').last().click();
+  }
+
+  async setMeetingStartDateToTomorrow() {
+    await this.startDateOpenCalendarButton().scrollIntoViewIfNeeded();
+    await this.startDateOpenCalendarButton().click();
+
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowLabel = tomorrow.toLocaleDateString('en-US', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
+
+    await this.page.getByRole('button', {name: tomorrowLabel}).click();
+  }
+
+  async fixStartTimeInPastValidationError() {
+    const startInPastError = this.scheduleMeetingModal.getByText('Start time must be in the future');
+    if (!(await startInPastError.isVisible())) {
+      return;
+    }
+
+    await this.selectLatestAvailableStartTime();
+
+    if (await startInPastError.isVisible()) {
+      await this.setMeetingStartDateToTomorrow();
+      await this.selectLatestAvailableStartTime();
+    }
+  }
+
+  async submitScheduleMeetingModal() {
+    await this.scheduleMeetingModal.locator('[data-uie-name="schedule-meeting-modal-submit"]').click();
+
+    const startInPastError = this.scheduleMeetingModal.getByText('Start time must be in the future');
+    if (await startInPastError.isVisible()) {
+      await this.fixStartTimeInPastValidationError();
+      await this.scheduleMeetingModal.locator('[data-uie-name="schedule-meeting-modal-submit"]').click();
+    }
+
+    await expect(this.scheduleMeetingModal).toBeHidden({timeout: MEETINGS_LIST_TIMEOUT_MS});
+    await this.dismissBlockingModals();
+  }
+
+  async scheduleMeeting(title: string, participantNames: string[]) {
+    await this.openScheduleMeetingModal();
+    await this.fillMeetingTitle(title);
+
+    for (const participantName of participantNames) {
+      await this.addParticipant(participantName);
+    }
+
+    await this.submitScheduleMeetingModal();
+  }
+
+  async openMeetingContextMenu(title: string) {
+    await this.openMeetingsTab();
+    await this.dismissBlockingModals();
+    const meetingItem = this.meetingListItem(title);
+    await meetingItem.getByRole('button').last().click();
+    return this.page.getByRole('menu');
+  }
+
+  async editMeeting(title: string, updates: {newTitle?: string; addParticipants?: string[]; removeParticipants?: string[]}) {
+    const menu = await this.openMeetingContextMenu(title);
+    await menu.getByRole('button', {name: 'Edit meeting'}).click();
+    await expect(this.scheduleMeetingModal).toBeVisible();
+    await expect(this.scheduleMeetingModal.locator('[data-uie-name="schedule-meeting-form"]')).toHaveAttribute(
+      'data-uie-mode',
+      'edit',
+    );
+    await expect(this.meetingTitleInput()).toHaveValue(title);
+
+    if (updates.newTitle !== undefined) {
+      await this.fillMeetingTitle(updates.newTitle);
+    }
+
+    for (const participantName of updates.addParticipants ?? []) {
+      await this.addParticipant(participantName);
+    }
+
+    for (const participantName of updates.removeParticipants ?? []) {
+      await this.removeParticipant(participantName);
+    }
+
+    await this.submitScheduleMeetingModal();
+    await this.assertNoSubmitErrorVisible();
+  }
+
+  async deleteMeetingForAll(title: string) {
+    const menu = await this.openMeetingContextMenu(title);
+    await menu.getByRole('button', {name: 'Delete meeting for everyone'}).click();
+
+    const confirmModal = new ConfirmModal(this.page);
+    await confirmModal.clickAction();
+  }
+
+  async deleteMeetingForMe(title: string) {
+    const menu = await this.openMeetingContextMenu(title);
+    await menu.getByRole('button', {name: 'Delete meeting for me'}).click();
+
+    const confirmModal = new ConfirmModal(this.page);
+    await confirmModal.clickAction();
+  }
+
+  async expandNotifications() {
+    await this.notificationHost.getByTestId('meeting-notification-expand').click();
+  }
+
+  notificationCards() {
+    return this.notificationHost.locator('[data-uie-name^="meeting-notification-card-"]');
+  }
+
+  async waitForNotificationHost() {
+    await expect.poll(() => this.notificationHost.count(), {timeout: MEETINGS_LIST_TIMEOUT_MS}).toBe(1);
+    await expect(this.notificationHost).toBeVisible();
+  }
+
+  notificationCardContaining(text: string) {
+    return this.notificationCards().filter({hasText: text});
+  }
+
+  async waitForNotificationContaining(text: string) {
+    await this.waitForNotificationHost();
+    await this.expandNotifications();
+    await expect(this.notificationCardContaining(text)).toBeVisible({timeout: MEETINGS_LIST_TIMEOUT_MS});
+  }
+}

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
@@ -168,9 +168,7 @@ export class MeetingsPage {
   }
 
   startDateOpenCalendarButton() {
-    return this.scheduleMeetingModal
-      .getByRole('group', {name: 'Starts'})
-      .getByRole('button', {name: 'Open calendar'});
+    return this.scheduleMeetingModal.getByRole('group', {name: 'Starts'}).getByRole('button', {name: 'Open calendar'});
   }
 
   async selectLatestAvailableStartTime() {
@@ -242,7 +240,10 @@ export class MeetingsPage {
     return this.page.getByRole('menu');
   }
 
-  async editMeeting(title: string, updates: {newTitle?: string; addParticipants?: string[]; removeParticipants?: string[]}) {
+  async editMeeting(
+    title: string,
+    updates: {newTitle?: string; addParticipants?: string[]; removeParticipants?: string[]},
+  ) {
     const menu = await this.openMeetingContextMenu(title);
     await menu.getByRole('button', {name: 'Edit meeting'}).click();
     await expect(this.scheduleMeetingModal).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
@@ -16,52 +16,195 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-import type {Page} from '@playwright/test';
-
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {expect, LOGIN_TIMEOUT, test} from 'test/e2e_tests/test.fixtures';
+import {expect, test} from 'test/e2e_tests/test.fixtures';
+import {createMeetingsTeam, loginMeetingsUsers} from 'test/e2e_tests/utils/meetings.util';
 
-const loginWithMeetingsEnabled = (user: {email: string; password: string}) => async (page: Page) => {
-  const pageManager = PageManager.from(page);
-  const {pages, components} = pageManager.webapp;
-  await pageManager.openLoginPage();
-  await pages.login().login(user);
-  await components.conversationSidebar().sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
-  const clientUrl = new URL('/?enabled-features=meetings#/clients', page.url());
-  await page.goto(clientUrl.href, {waitUntil: 'domcontentloaded'});
-  await expect.poll(() => new URL(page.url()).searchParams.get('enabled-features')).toBe('meetings');
-  await components.conversationSidebar().sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
-};
+const MEETING_TITLE = 'Team sync';
+const UPDATED_MEETING_TITLE = 'Updated team sync';
 
-test('single participant meeting notification', async ({createUser, createTeam, createPage}) => {
-  const member = await createUser();
-  const team = await createTeam('Meetings', {users: [member], features: {meetings: true}});
-  const owner = team.owner;
+test.describe.configure({mode: 'serial'});
 
-  const [ownerPage, memberPage] = await Promise.all([
-    createPage(loginWithMeetingsEnabled(owner)),
-    createPage(loginWithMeetingsEnabled(member)),
-  ]);
+test.describe('Meetings CRUD', () => {
+  test('create meeting — host sees it in the list', async ({createUser, createTeam, createPage}) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 1);
+    const member = members[0];
 
-  await ownerPage.locator('[data-uie-name="go-meetings"]').click();
-  await ownerPage.locator('[data-uie-name="schedule-meeting"]').click();
+    const [ownerPage] = await loginMeetingsUsers(createPage, [owner, member]);
+    const meetings = PageManager.from(ownerPage).webapp.pages.meetings();
 
-  const modal = ownerPage.locator('[data-uie-name="schedule-meeting-modal"]');
-  await modal.locator('[data-uie-name="schedule-meeting-title"]').fill('Single participant meeting');
+    await meetings.openMeetingsTab();
+    await meetings.scheduleMeeting(MEETING_TITLE, [member.fullName]);
+    await meetings.waitForMeetingInList(MEETING_TITLE);
+    await expect(meetings.meetingListItem(MEETING_TITLE)).toBeVisible();
+  });
 
-  const participants = modal.locator('[data-uie-name="schedule-meeting-participants"]');
-  await participants.locator('[data-uie-name="schedule-meeting-participants-input"]').fill(member.fullName);
-  await modal.locator('[data-uie-name="item-user"]').filter({hasText: member.fullName}).click();
+  test('invitee sees meeting in the list', async ({createUser, createTeam, createPage}) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 1);
+    const member = members[0];
 
-  await modal.locator('[data-uie-name="schedule-meeting-modal-submit"]').click();
-  await expect(modal).toBeHidden();
+    const [ownerPage, memberPage] = await loginMeetingsUsers(createPage, [owner, member]);
+    const ownerMeetings = PageManager.from(ownerPage).webapp.pages.meetings();
+    const memberMeetings = PageManager.from(memberPage).webapp.pages.meetings();
 
-  const host = memberPage.locator('[data-uie-name="meeting-notification-host"]');
-  await expect.poll(() => host.count(), {timeout: 30_000}).toBe(1);
-  await expect(host).toBeVisible();
-  await host.getByTestId('meeting-notification-expand').click();
+    await ownerMeetings.openMeetingsTab();
+    await ownerMeetings.scheduleMeeting(MEETING_TITLE, [member.fullName]);
 
-  const cards = host.locator('[data-uie-name^="meeting-notification-card-"]');
-  await expect(cards).toHaveCount(1);
-  await expect(cards).toContainText('Update: Single participant meeting');
+    await memberMeetings.openMeetingsTab();
+    await memberMeetings.waitForMeetingInList(MEETING_TITLE);
+    await expect(memberMeetings.meetingListItem(MEETING_TITLE)).toBeVisible();
+  });
+
+  test('invitee sees invite notification', async ({createUser, createTeam, createPage}) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 1);
+    const member = members[0];
+
+    const [ownerPage, memberPage] = await loginMeetingsUsers(createPage, [owner, member]);
+    const ownerMeetings = PageManager.from(ownerPage).webapp.pages.meetings();
+    const memberMeetings = PageManager.from(memberPage).webapp.pages.meetings();
+
+    await ownerMeetings.openMeetingsTab();
+    await ownerMeetings.scheduleMeeting(MEETING_TITLE, [member.fullName]);
+
+    await memberMeetings.waitForNotificationContaining(`Update: ${MEETING_TITLE}`);
+    await expect(memberMeetings.notificationCards()).toHaveCount(1);
+  });
+
+  test('host can edit meeting info', async ({createUser, createTeam, createPage}) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 1);
+    const member = members[0];
+
+    const [ownerPage] = await loginMeetingsUsers(createPage, [owner, member]);
+    const meetings = PageManager.from(ownerPage).webapp.pages.meetings();
+
+    await meetings.openMeetingsTab();
+    await meetings.scheduleMeeting(MEETING_TITLE, [member.fullName]);
+    await meetings.waitForMeetingInList(MEETING_TITLE);
+
+    await meetings.editMeeting(MEETING_TITLE, {newTitle: UPDATED_MEETING_TITLE});
+    await meetings.waitForMeetingInList(UPDATED_MEETING_TITLE);
+    await expect(meetings.meetingListItem(UPDATED_MEETING_TITLE)).toBeVisible();
+  });
+
+  test('edited meeting info syncs to invitee list', async ({createUser, createTeam, createPage}) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 1);
+    const member = members[0];
+
+    const [ownerPage, memberPage] = await loginMeetingsUsers(createPage, [owner, member]);
+    const ownerMeetings = PageManager.from(ownerPage).webapp.pages.meetings();
+    const memberMeetings = PageManager.from(memberPage).webapp.pages.meetings();
+
+    await ownerMeetings.openMeetingsTab();
+    await ownerMeetings.scheduleMeeting(MEETING_TITLE, [member.fullName]);
+    await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
+
+    await ownerMeetings.editMeeting(MEETING_TITLE, {newTitle: UPDATED_MEETING_TITLE});
+
+    await memberMeetings.openMeetingsTab();
+    await memberMeetings.waitForMeetingInList(UPDATED_MEETING_TITLE);
+    await expect(memberMeetings.meetingListItem(UPDATED_MEETING_TITLE)).toBeVisible();
+  });
+
+  test('invitee sees update notification after edit', async ({createUser, createTeam, createPage}) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 1);
+    const member = members[0];
+
+    const [ownerPage, memberPage] = await loginMeetingsUsers(createPage, [owner, member]);
+    const ownerMeetings = PageManager.from(ownerPage).webapp.pages.meetings();
+    const memberMeetings = PageManager.from(memberPage).webapp.pages.meetings();
+
+    await ownerMeetings.openMeetingsTab();
+    await ownerMeetings.scheduleMeeting(MEETING_TITLE, [member.fullName]);
+    await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
+
+    await ownerMeetings.editMeeting(MEETING_TITLE, {newTitle: UPDATED_MEETING_TITLE});
+
+    await memberMeetings.waitForNotificationContaining(`Update: ${UPDATED_MEETING_TITLE}`);
+  });
+
+  test('host can add a participant', async ({createUser, createTeam, createPage}) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 2);
+    const [firstMember, secondMember] = members;
+
+    const [ownerPage, , secondMemberPage] = await loginMeetingsUsers(createPage, [owner, firstMember, secondMember]);
+    const ownerMeetings = PageManager.from(ownerPage).webapp.pages.meetings();
+    const secondMemberMeetings = PageManager.from(secondMemberPage).webapp.pages.meetings();
+
+    await ownerMeetings.openMeetingsTab();
+    await ownerMeetings.scheduleMeeting(MEETING_TITLE, [firstMember.fullName]);
+    await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
+
+    await ownerMeetings.editMeeting(MEETING_TITLE, {addParticipants: [secondMember.fullName]});
+
+    await secondMemberMeetings.openMeetingsTab();
+    await secondMemberMeetings.waitForMeetingInList(MEETING_TITLE);
+    await expect(secondMemberMeetings.meetingListItem(MEETING_TITLE)).toBeVisible();
+  });
+
+  test('host can remove a participant', async ({createUser, createTeam, createPage}) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 2);
+    const [firstMember, secondMember] = members;
+
+    const [ownerPage, firstMemberPage] = await loginMeetingsUsers(createPage, [
+      owner,
+      firstMember,
+      secondMember,
+    ]);
+    const ownerMeetings = PageManager.from(ownerPage).webapp.pages.meetings();
+    const firstMemberMeetings = PageManager.from(firstMemberPage).webapp.pages.meetings();
+
+    await ownerMeetings.openMeetingsTab();
+    await ownerMeetings.scheduleMeeting(MEETING_TITLE, [firstMember.fullName, secondMember.fullName]);
+    await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
+
+    await firstMemberMeetings.openMeetingsTab();
+    await firstMemberMeetings.waitForMeetingInList(MEETING_TITLE);
+
+    await ownerMeetings.editMeeting(MEETING_TITLE, {removeParticipants: [firstMember.fullName]});
+
+    await firstMemberMeetings.waitForMeetingAbsentFromList(MEETING_TITLE);
+  });
+
+  test('host can delete meeting for everyone', async ({createUser, createTeam, createPage}) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 1);
+    const member = members[0];
+
+    const [ownerPage, memberPage] = await loginMeetingsUsers(createPage, [owner, member]);
+    const ownerMeetings = PageManager.from(ownerPage).webapp.pages.meetings();
+    const memberMeetings = PageManager.from(memberPage).webapp.pages.meetings();
+
+    await ownerMeetings.openMeetingsTab();
+    await ownerMeetings.scheduleMeeting(MEETING_TITLE, [member.fullName]);
+    await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
+
+    await memberMeetings.openMeetingsTab();
+    await memberMeetings.waitForMeetingInList(MEETING_TITLE);
+
+    await ownerMeetings.deleteMeetingForAll(MEETING_TITLE);
+
+    await ownerMeetings.waitForMeetingAbsentFromList(MEETING_TITLE);
+    await memberMeetings.waitForMeetingAbsentFromList(MEETING_TITLE);
+    await memberMeetings.waitForNotificationContaining(`Canceled: ${MEETING_TITLE}`);
+  });
+
+  test('invitee can delete meeting for themselves', async ({createUser, createTeam, createPage}) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 1);
+    const member = members[0];
+
+    const [ownerPage, memberPage] = await loginMeetingsUsers(createPage, [owner, member]);
+    const ownerMeetings = PageManager.from(ownerPage).webapp.pages.meetings();
+    const memberMeetings = PageManager.from(memberPage).webapp.pages.meetings();
+
+    await ownerMeetings.openMeetingsTab();
+    await ownerMeetings.scheduleMeeting(MEETING_TITLE, [member.fullName]);
+    await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
+
+    await memberMeetings.openMeetingsTab();
+    await memberMeetings.waitForMeetingInList(MEETING_TITLE);
+
+    await memberMeetings.deleteMeetingForMe(MEETING_TITLE);
+
+    await memberMeetings.waitForMeetingAbsentFromList(MEETING_TITLE);
+    await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
+  });
 });

--- a/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
@@ -145,11 +145,7 @@ test.describe('Meetings CRUD', () => {
     const {owner, members} = await createMeetingsTeam(createUser, createTeam, 2);
     const [firstMember, secondMember] = members;
 
-    const [ownerPage, firstMemberPage] = await loginMeetingsUsers(createPage, [
-      owner,
-      firstMember,
-      secondMember,
-    ]);
+    const [ownerPage, firstMemberPage] = await loginMeetingsUsers(createPage, [owner, firstMember, secondMember]);
     const ownerMeetings = PageManager.from(ownerPage).webapp.pages.meetings();
     const firstMemberMeetings = PageManager.from(firstMemberPage).webapp.pages.meetings();
 

--- a/apps/webapp/test/e2e_tests/utils/meetings.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/meetings.util.ts
@@ -1,0 +1,54 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+import type {Page} from '@playwright/test';
+
+import type {User} from 'test/e2e_tests/data/user';
+import {PageManager} from 'test/e2e_tests/pageManager';
+import {expect, LOGIN_TIMEOUT, type Team} from 'test/e2e_tests/test.fixtures';
+
+export const loginWithMeetingsEnabled = (user: Pick<User, 'email' | 'password'>) => async (page: Page) => {
+  const pageManager = PageManager.from(page);
+  const {pages, components} = pageManager.webapp;
+  await pageManager.openLoginPage();
+  await pages.login().login(user);
+  await components.conversationSidebar().sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
+  const clientUrl = new URL('/?enabled-features=meetings#/clients', page.url());
+  await page.goto(clientUrl.href, {waitUntil: 'domcontentloaded'});
+  await expect.poll(() => new URL(page.url()).searchParams.get('enabled-features')).toBe('meetings');
+  await components.conversationSidebar().sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
+};
+
+export const createMeetingsTeam = async (
+  createUser: () => Promise<User>,
+  createTeam: (
+    name: string,
+    options: {users: User[]; features: {meetings: true; mls: true}},
+  ) => Promise<Team>,
+  memberCount: number,
+) => {
+  const members = await Promise.all(Array.from({length: memberCount}, () => createUser()));
+  const team = await createTeam('Meetings', {users: members, features: {meetings: true, mls: true}});
+
+  return {team, members, owner: team.owner};
+};
+
+export const loginMeetingsUsers = async (
+  createPage: (setup: ReturnType<typeof loginWithMeetingsEnabled>) => Promise<import('@playwright/test').Page>,
+  users: Pick<User, 'email' | 'password'>[],
+) => Promise.all(users.map(user => createPage(loginWithMeetingsEnabled(user))));

--- a/apps/webapp/test/e2e_tests/utils/meetings.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/meetings.util.ts
@@ -36,10 +36,7 @@ export const loginWithMeetingsEnabled = (user: Pick<User, 'email' | 'password'>)
 
 export const createMeetingsTeam = async (
   createUser: () => Promise<User>,
-  createTeam: (
-    name: string,
-    options: {users: User[]; features: {meetings: true; mls: true}},
-  ) => Promise<Team>,
+  createTeam: (name: string, options: {users: User[]; features: {meetings: true; mls: true}}) => Promise<Team>,
   memberCount: number,
 ) => {
   const members = await Promise.all(Array.from({length: memberCount}, () => createUser()));


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27908" title="WPB-27908" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27908</a>  Meeting host cannot see a newly scheduled meeting in the Meetings list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Add a meetings page object and shared e2e helpers for scheduling, editing, and deleting meetings
- Replace the single notification smoke test with ten serial CRUD Playwright tests covering create, list, notifications, edit, participant add/remove, and delete flows
- Sync the meeting store after `updateMeeting` so the host list reflects edits without waiting on websocket events

## Test plan
- [x] `yarn e2e-test specs/Meetings/meetings.spec.ts --workers=1` (10/10 passed against local webapp)
- [x] Reconcile with #22170 before merge (expected conflict in `meetings.spec.ts`; invite notification assertion may need `Invitation:` instead of `Update:` after that lands)