### PR TITLE
fix(meetings): restrict participant picker to team members (WPB-27970)

### DIFF
--- a/apps/webapp/src/script/components/meeting/getScheduleMeetingParticipantPool.test.ts
+++ b/apps/webapp/src/script/components/meeting/getScheduleMeetingParticipantPool.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {User} from 'Repositories/entity/User';
+import type {TeamState} from 'Repositories/team/TeamState';
+import type {UserState} from 'Repositories/user/userState';
+import {generateQualifiedIds} from 'src/script/auth/util/test/testUtil';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {getScheduleMeetingParticipantPool} from './getScheduleMeetingParticipantPool';
+
+const createUser = (qualifiedId: {id: string; domain: string}, name: string) => {
+  const user = new User(qualifiedId.id, qualifiedId.domain, translateForTest);
+  user.name(name);
+  return user;
+};
+
+describe('getScheduleMeetingParticipantPool', () => {
+  it('returns only team members when the host is on a team', () => {
+    const [teamMemberId, connectedContactId] = generateQualifiedIds(2, 'wire.example');
+    const teamMember = createUser(teamMemberId, 'Team Member');
+    const connectedContact = createUser(connectedContactId, 'External Contact');
+
+    const teamState = {
+      isTeam: () => true,
+      teamMembers: () => [teamMember],
+      teamUsers: () => [teamMember, connectedContact],
+    } as unknown as TeamState;
+
+    const userState = {
+      connectedUsers: () => [connectedContact],
+    } as unknown as UserState;
+
+    const participants = getScheduleMeetingParticipantPool(userState, teamState);
+
+    expect(participants).toEqual([teamMember]);
+  });
+
+  it('returns connected users when the host is not on a team', () => {
+    const [connectedContactId] = generateQualifiedIds(1, 'wire.example');
+    const connectedContact = createUser(connectedContactId, 'Connected Contact');
+
+    const teamState = {
+      isTeam: () => false,
+      teamMembers: () => [],
+    } as unknown as TeamState;
+
+    const userState = {
+      connectedUsers: () => [connectedContact],
+    } as unknown as UserState;
+
+    const participants = getScheduleMeetingParticipantPool(userState, teamState);
+
+    expect(participants).toEqual([connectedContact]);
+  });
+});

--- a/apps/webapp/src/script/components/meeting/getScheduleMeetingParticipantPool.ts
+++ b/apps/webapp/src/script/components/meeting/getScheduleMeetingParticipantPool.ts
@@ -20,9 +20,12 @@
 import type {User} from 'Repositories/entity/User';
 import type {TeamState} from 'Repositories/team/TeamState';
 import type {UserState} from 'Repositories/user/userState';
+import {sortUsersByPriority} from 'Util/stringUtil';
 
 export const getScheduleMeetingParticipantPool = (userState: UserState, teamState: TeamState): User[] => {
-  const contacts = teamState.isTeam() ? teamState.teamUsers() : userState.connectedUsers();
+  const contacts = teamState.isTeam()
+    ? teamState.teamMembers().toSorted(sortUsersByPriority)
+    : userState.connectedUsers();
 
   return contacts.filter(user => user.isAvailable());
 };

--- a/apps/webapp/src/script/components/meeting/shared/participants/useMeetingParticipants.ts
+++ b/apps/webapp/src/script/components/meeting/shared/participants/useMeetingParticipants.ts
@@ -25,19 +25,20 @@ import type {User} from 'Repositories/entity/User';
 import {TeamState} from 'Repositories/team/TeamState';
 import {UserState} from 'Repositories/user/userState';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
+import {sortUsersByPriority} from 'Util/stringUtil';
 
 export const useMeetingParticipants = (): {users: User[]} => {
   const userState = container.resolve(UserState);
   const teamState = container.resolve(TeamState);
 
-  const {isTeam, teamUsers} = useKoSubscribableChildren(teamState, ['isTeam', 'teamUsers']);
+  const {isTeam, teamMembers} = useKoSubscribableChildren(teamState, ['isTeam', 'teamMembers']);
   const {connectedUsers} = useKoSubscribableChildren(userState, ['connectedUsers']);
 
   const users = useMemo(() => {
-    const contacts = isTeam ? teamUsers : connectedUsers;
+    const contacts = isTeam ? teamMembers.toSorted(sortUsersByPriority) : connectedUsers;
 
     return contacts.filter(user => user.isAvailable());
-  }, [connectedUsers, isTeam, teamUsers]);
+  }, [connectedUsers, isTeam, teamMembers]);
 
   return {users};
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27970" title="WPB-27970" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27970</a>  Meeting host can add and schedule a meeting with contacts who are not members of their team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Restrict the meeting participant picker to team members instead of all connected contacts when the host is on a team
- Apply the same filtering in `getScheduleMeetingParticipantPool` for consistency
- Add unit tests verifying non-team connected contacts are excluded from the participant pool

Fixes [WPB-27970](https://wearezeta.atlassian.net/browse/WPB-27970)

## Test plan
- [x] `yarn nx run webapp:test --testFile=src/script/components/meeting/getScheduleMeetingParticipantPool.test.ts`
- [x] `yarn nx run webapp:test --testFile=src/script/components/meeting/meetingParticipantsPicker/meetingParticipantsPicker.test.tsx`
- [x] Schedule a meeting as a team user and confirm only team members appear in the participant search
- [x] Verify a connected non-team contact does not appear in search results and cannot be selected

[WPB-27970]: https://wearezeta.atlassian.net/browse/WPB-27970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ