### PR TITLE
Show meeting cancellation when participant is removed from conversation [WPB-25516]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.test.ts
@@ -70,11 +70,11 @@ describe('createMeetingNotificationEventHandlers', () => {
     const dismissedMeetings: Array<{meetingId: QualifiedId; kinds?: readonly MeetingNotificationKind[]}> = [];
     const warnings: Array<{message: string; context?: unknown}> = [];
 
-    const {notifyUpdate, onMeetingDeleted} = createHandlers({notifications, dismissedMeetings, warnings});
+    const {notifyUpdate, onMeetingCancelled} = createHandlers({notifications, dismissedMeetings, warnings});
 
     notifyUpdate(meetingSeries);
     notifyUpdate(meetingSeries);
-    onMeetingDeleted(meetingId);
+    onMeetingCancelled(meetingId);
 
     expect(notifications).toEqual([
       {
@@ -98,7 +98,10 @@ describe('createMeetingNotificationEventHandlers', () => {
       },
     ]);
 
-    expect(dismissedMeetings).toEqual([{meetingId, kinds: expect.arrayContaining([MeetingNotificationKind.UPDATE])}]);
+    expect(dismissedMeetings).toEqual([
+      {meetingId, kinds: expect.arrayContaining([MeetingNotificationKind.UPDATE])},
+      {meetingId, kinds: [MeetingNotificationKind.CANCELLED]},
+    ]);
     expect(warnings).toEqual([]);
   });
 
@@ -106,13 +109,13 @@ describe('createMeetingNotificationEventHandlers', () => {
     const notifications: AddNotificationInput[] = [];
     const warnings: Array<{message: string; context?: unknown}> = [];
 
-    const {onMeetingDeleted} = createHandlers({
+    const {onMeetingCancelled} = createHandlers({
       getMeetingSeries: () => [],
       notifications,
       warnings,
     });
 
-    onMeetingDeleted(meetingId);
+    onMeetingCancelled(meetingId);
 
     expect(notifications).toEqual([]);
     expect(warnings).toEqual([
@@ -162,12 +165,12 @@ describe('createMeetingNotificationEventHandlers', () => {
     ]);
   });
 
-  it('dismisses stale notifications before creating a cancellation for self-removal', () => {
+  it('dismisses stale notifications before creating a cancellation for involuntary self-removal', () => {
     const dismissedMeetings: Array<{meetingId: QualifiedId; kinds?: readonly MeetingNotificationKind[]}> = [];
     const notifications: AddNotificationInput[] = [];
-    const {onMeetingRemovedForSelf} = createHandlers({notifications, dismissedMeetings});
+    const {onMeetingCancelled} = createHandlers({notifications, dismissedMeetings});
 
-    onMeetingRemovedForSelf(meetingId);
+    onMeetingCancelled(meetingId);
 
     expect(dismissedMeetings).toEqual([
       {
@@ -178,6 +181,10 @@ describe('createMeetingNotificationEventHandlers', () => {
           MeetingNotificationKind.ONGOING,
         ],
       },
+      {
+        meetingId,
+        kinds: [MeetingNotificationKind.CANCELLED],
+      },
     ]);
     expect(notifications).toEqual([
       {
@@ -187,6 +194,80 @@ describe('createMeetingNotificationEventHandlers', () => {
         qualifiedCreator: meetingSeries.qualified_creator,
         qualifiedId: meetingSeries.qualified_id,
       },
+    ]);
+  });
+
+  it('creates only one cancellation notification when cancelled twice', () => {
+    const notifications: AddNotificationInput[] = [];
+    const {onMeetingCancelled} = createHandlers({notifications});
+
+    onMeetingCancelled(meetingId);
+    onMeetingCancelled(meetingId);
+
+    expect(notifications).toEqual([
+      expect.objectContaining({kind: MeetingNotificationKind.CANCELLED, qualifiedId: meetingId}),
+    ]);
+  });
+
+  it('retries pending cancellations with the full cancellation path', () => {
+    const notifications: AddNotificationInput[] = [];
+    const dismissedMeetings: Array<{meetingId: QualifiedId; kinds?: readonly MeetingNotificationKind[]}> = [];
+    let meetingSeriesSnapshot: MeetingSeries[] = [];
+
+    const {onMeetingCancelled, retryPendingNotifications} = createHandlers({
+      getMeetingSeries: () => meetingSeriesSnapshot,
+      notifications,
+      dismissedMeetings,
+    });
+
+    onMeetingCancelled(meetingId);
+    expect(dismissedMeetings).toEqual([
+      {
+        meetingId,
+        kinds: [
+          MeetingNotificationKind.UPDATE,
+          MeetingNotificationKind.INVITE,
+          MeetingNotificationKind.ONGOING,
+        ],
+      },
+      {
+        meetingId,
+        kinds: [MeetingNotificationKind.CANCELLED],
+      },
+    ]);
+    expect(notifications).toEqual([]);
+
+    meetingSeriesSnapshot = [meetingSeries];
+    retryPendingNotifications();
+
+    expect(dismissedMeetings).toEqual([
+      {
+        meetingId,
+        kinds: [
+          MeetingNotificationKind.UPDATE,
+          MeetingNotificationKind.INVITE,
+          MeetingNotificationKind.ONGOING,
+        ],
+      },
+      {
+        meetingId,
+        kinds: [MeetingNotificationKind.CANCELLED],
+      },
+      {
+        meetingId,
+        kinds: [
+          MeetingNotificationKind.UPDATE,
+          MeetingNotificationKind.INVITE,
+          MeetingNotificationKind.ONGOING,
+        ],
+      },
+      {
+        meetingId,
+        kinds: [MeetingNotificationKind.CANCELLED],
+      },
+    ]);
+    expect(notifications).toEqual([
+      expect.objectContaining({kind: MeetingNotificationKind.CANCELLED, qualifiedId: meetingId}),
     ]);
   });
 });

--- a/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.test.ts
@@ -193,11 +193,7 @@ describe('createMeetingNotificationEventHandlers', () => {
     expect(dismissedMeetings).toEqual([
       {
         meetingId,
-        kinds: [
-          MeetingNotificationKind.UPDATE,
-          MeetingNotificationKind.INVITE,
-          MeetingNotificationKind.ONGOING,
-        ],
+        kinds: [MeetingNotificationKind.UPDATE, MeetingNotificationKind.INVITE, MeetingNotificationKind.ONGOING],
       },
       {
         meetingId,
@@ -239,11 +235,7 @@ describe('createMeetingNotificationEventHandlers', () => {
     expect(dismissedMeetings).toEqual([
       {
         meetingId,
-        kinds: [
-          MeetingNotificationKind.UPDATE,
-          MeetingNotificationKind.INVITE,
-          MeetingNotificationKind.ONGOING,
-        ],
+        kinds: [MeetingNotificationKind.UPDATE, MeetingNotificationKind.INVITE, MeetingNotificationKind.ONGOING],
       },
       {
         meetingId,
@@ -267,11 +259,7 @@ describe('createMeetingNotificationEventHandlers', () => {
     expect(dismissedMeetings).toEqual([
       {
         meetingId,
-        kinds: [
-          MeetingNotificationKind.UPDATE,
-          MeetingNotificationKind.INVITE,
-          MeetingNotificationKind.ONGOING,
-        ],
+        kinds: [MeetingNotificationKind.UPDATE, MeetingNotificationKind.INVITE, MeetingNotificationKind.ONGOING],
       },
       {
         meetingId,
@@ -286,11 +274,7 @@ describe('createMeetingNotificationEventHandlers', () => {
     expect(dismissedMeetings).toEqual([
       {
         meetingId,
-        kinds: [
-          MeetingNotificationKind.UPDATE,
-          MeetingNotificationKind.INVITE,
-          MeetingNotificationKind.ONGOING,
-        ],
+        kinds: [MeetingNotificationKind.UPDATE, MeetingNotificationKind.INVITE, MeetingNotificationKind.ONGOING],
       },
       {
         meetingId,
@@ -298,11 +282,7 @@ describe('createMeetingNotificationEventHandlers', () => {
       },
       {
         meetingId,
-        kinds: [
-          MeetingNotificationKind.UPDATE,
-          MeetingNotificationKind.INVITE,
-          MeetingNotificationKind.ONGOING,
-        ],
+        kinds: [MeetingNotificationKind.UPDATE, MeetingNotificationKind.INVITE, MeetingNotificationKind.ONGOING],
       },
       {
         meetingId,

--- a/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.test.ts
@@ -24,6 +24,7 @@ import {
   MeetingNotificationKind,
 } from 'Components/meeting/meetingNotificationStore/meetingNotificationStore';
 import type {MeetingSeries} from 'Components/meeting/types/meetingSeries';
+import {matchQualifiedIds} from 'Util/qualifiedId';
 
 import {createMeetingNotificationEventHandlers} from './meetingNotificationEventHandlers';
 
@@ -44,6 +45,23 @@ const meetingSeries: MeetingSeries = {
 };
 
 describe('createMeetingNotificationEventHandlers', () => {
+  const dismissNotificationsFromList = (
+    notifications: AddNotificationInput[],
+    meetingId: QualifiedId,
+    kinds?: readonly MeetingNotificationKind[],
+  ) => {
+    for (let index = notifications.length - 1; index >= 0; index -= 1) {
+      const notification = notifications[index];
+      if (!matchQualifiedIds(notification.qualifiedId, meetingId)) {
+        continue;
+      }
+
+      if (kinds === undefined || kinds.includes(notification.kind)) {
+        notifications.splice(index, 1);
+      }
+    }
+  };
+
   const createHandlers = ({
     getMeetingSeries = () => [meetingSeries],
     notifications = [] as AddNotificationInput[],
@@ -199,13 +217,38 @@ describe('createMeetingNotificationEventHandlers', () => {
 
   it('creates only one cancellation notification when cancelled twice', () => {
     const notifications: AddNotificationInput[] = [];
-    const {onMeetingCancelled} = createHandlers({notifications});
+    const dismissedMeetings: Array<{meetingId: QualifiedId; kinds?: readonly MeetingNotificationKind[]}> = [];
+    const {onMeetingCancelled} = createMeetingNotificationEventHandlers({
+      getMeetingSeries: () => [meetingSeries],
+      addNotification: notification => {
+        notifications.push(notification);
+      },
+      dismissNotificationsForMeeting: (dismissedMeetingId, kinds) => {
+        dismissedMeetings.push({meetingId: dismissedMeetingId, kinds});
+        dismissNotificationsFromList(notifications, dismissedMeetingId, kinds);
+      },
+      logger: {warn: jest.fn()},
+    });
 
     onMeetingCancelled(meetingId);
     onMeetingCancelled(meetingId);
 
     expect(notifications).toEqual([
       expect.objectContaining({kind: MeetingNotificationKind.CANCELLED, qualifiedId: meetingId}),
+    ]);
+    expect(dismissedMeetings).toEqual([
+      {
+        meetingId,
+        kinds: [
+          MeetingNotificationKind.UPDATE,
+          MeetingNotificationKind.INVITE,
+          MeetingNotificationKind.ONGOING,
+        ],
+      },
+      {
+        meetingId,
+        kinds: [MeetingNotificationKind.CANCELLED],
+      },
     ]);
   });
 

--- a/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.test.ts
@@ -44,14 +44,19 @@ const meetingSeries: MeetingSeries = {
 };
 
 describe('createMeetingNotificationEventHandlers', () => {
-  it('creates meeting notifications from the current meeting series snapshot', () => {
-    const notifications: AddNotificationInput[] = [];
-    const warnings: Array<{message: string; context?: unknown}> = [];
-
-    const {notifyUpdate, onMeetingDeleted} = createMeetingNotificationEventHandlers({
-      getMeetingSeries: () => [meetingSeries],
+  const createHandlers = ({
+    getMeetingSeries = () => [meetingSeries],
+    notifications = [] as AddNotificationInput[],
+    dismissedMeetings = [] as Array<{meetingId: QualifiedId; kinds?: readonly MeetingNotificationKind[]}>,
+    warnings = [] as Array<{message: string; context?: unknown}>,
+  } = {}) =>
+    createMeetingNotificationEventHandlers({
+      getMeetingSeries,
       addNotification: notification => {
         notifications.push(notification);
+      },
+      dismissNotificationsForMeeting: (meetingId, kinds) => {
+        dismissedMeetings.push({meetingId, kinds});
       },
       logger: {
         warn: (message, context) => {
@@ -59,6 +64,13 @@ describe('createMeetingNotificationEventHandlers', () => {
         },
       },
     });
+
+  it('creates meeting notifications from the current meeting series snapshot', () => {
+    const notifications: AddNotificationInput[] = [];
+    const dismissedMeetings: Array<{meetingId: QualifiedId; kinds?: readonly MeetingNotificationKind[]}> = [];
+    const warnings: Array<{message: string; context?: unknown}> = [];
+
+    const {notifyUpdate, onMeetingDeleted} = createHandlers({notifications, dismissedMeetings, warnings});
 
     notifyUpdate(meetingSeries);
     notifyUpdate(meetingSeries);
@@ -86,6 +98,7 @@ describe('createMeetingNotificationEventHandlers', () => {
       },
     ]);
 
+    expect(dismissedMeetings).toEqual([{meetingId, kinds: expect.arrayContaining([MeetingNotificationKind.UPDATE])}]);
     expect(warnings).toEqual([]);
   });
 
@@ -93,16 +106,10 @@ describe('createMeetingNotificationEventHandlers', () => {
     const notifications: AddNotificationInput[] = [];
     const warnings: Array<{message: string; context?: unknown}> = [];
 
-    const {onMeetingDeleted} = createMeetingNotificationEventHandlers({
+    const {onMeetingDeleted} = createHandlers({
       getMeetingSeries: () => [],
-      addNotification: notification => {
-        notifications.push(notification);
-      },
-      logger: {
-        warn: (message, context) => {
-          warnings.push({message, context});
-        },
-      },
+      notifications,
+      warnings,
     });
 
     onMeetingDeleted(meetingId);
@@ -121,13 +128,7 @@ describe('createMeetingNotificationEventHandlers', () => {
 
   it('notifies using the meeting passed by the successful sync', () => {
     const notifications: AddNotificationInput[] = [];
-    const {notifyUpdate} = createMeetingNotificationEventHandlers({
-      getMeetingSeries: () => [],
-      addNotification: notification => {
-        notifications.push(notification);
-      },
-      logger: {warn: () => {}},
-    });
+    const {notifyUpdate} = createHandlers({getMeetingSeries: () => [], notifications});
 
     notifyUpdate({...meetingSeries, title: 'Fresh title'});
 
@@ -139,13 +140,7 @@ describe('createMeetingNotificationEventHandlers', () => {
   it('notifies with INVITE on first change and UPDATE on subsequent changes for the same meeting', () => {
     const notifications: AddNotificationInput[] = [];
 
-    const {notifyMeetingChange} = createMeetingNotificationEventHandlers({
-      getMeetingSeries: () => [meetingSeries],
-      addNotification: notification => {
-        notifications.push(notification);
-      },
-      logger: {warn: () => {}},
-    });
+    const {notifyMeetingChange} = createHandlers({notifications});
 
     notifyMeetingChange(meetingSeries);
     notifyMeetingChange(meetingSeries);
@@ -162,6 +157,34 @@ describe('createMeetingNotificationEventHandlers', () => {
         kind: MeetingNotificationKind.UPDATE,
         meetingStartTime: meetingSeries.series_start_date,
         meetingTitle: meetingSeries.title,
+        qualifiedId: meetingSeries.qualified_id,
+      },
+    ]);
+  });
+
+  it('dismisses stale notifications before creating a cancellation for self-removal', () => {
+    const dismissedMeetings: Array<{meetingId: QualifiedId; kinds?: readonly MeetingNotificationKind[]}> = [];
+    const notifications: AddNotificationInput[] = [];
+    const {onMeetingRemovedForSelf} = createHandlers({notifications, dismissedMeetings});
+
+    onMeetingRemovedForSelf(meetingId);
+
+    expect(dismissedMeetings).toEqual([
+      {
+        meetingId,
+        kinds: [
+          MeetingNotificationKind.UPDATE,
+          MeetingNotificationKind.INVITE,
+          MeetingNotificationKind.ONGOING,
+        ],
+      },
+    ]);
+    expect(notifications).toEqual([
+      {
+        kind: MeetingNotificationKind.CANCELLED,
+        meetingStartTime: meetingSeries.series_start_date,
+        meetingTitle: meetingSeries.title,
+        qualifiedCreator: meetingSeries.qualified_creator,
         qualifiedId: meetingSeries.qualified_id,
       },
     ]);

--- a/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.ts
@@ -49,8 +49,7 @@ export type MeetingNotificationEventHandlersDependencies = {
 export type MeetingNotificationEventHandlers = {
   notifyMeetingChange: (meeting: MeetingSeries) => void;
   notifyUpdate: (meeting: MeetingSeries) => void;
-  onMeetingDeleted: (meetingId: QualifiedId) => void;
-  onMeetingRemovedForSelf: (meetingId: QualifiedId) => void;
+  onMeetingCancelled: (meetingId: QualifiedId) => void;
   /** Retries notifications that couldn't be sent because the meeting wasn't in the store yet. */
   retryPendingNotifications: () => void;
 };
@@ -67,6 +66,7 @@ export const createMeetingNotificationEventHandlers = ({
   // Only deleted events can fire before the meeting store has synced.
   const pending = new Map<string, QualifiedId>();
   const notifiedMeetings = new Set<string>();
+  const cancelledMeetings = new Set<string>();
 
   const notifyForMeeting = (kind: MeetingNotificationKind, meeting: MeetingSeries) => {
     const notificationBase = {
@@ -99,21 +99,31 @@ export const createMeetingNotificationEventHandlers = ({
   };
 
   const addCancellationNotificationForMeeting = (meetingId: QualifiedId): void => {
+    const meetingKey = toMeetingIdKey(meetingId);
+
+    if (cancelledMeetings.has(meetingKey)) {
+      pending.delete(meetingKey);
+      return;
+    }
+
     const meeting = getMeeting(meetingId);
     if (!meeting) {
       logger.warn('meeting notification pending because the meeting is not in the store yet', {
         kind: MeetingNotificationKind.CANCELLED,
         meetingId,
       });
-      pending.set(toMeetingIdKey(meetingId), meetingId);
+      pending.set(meetingKey, meetingId);
       return;
     }
 
+    cancelledMeetings.add(meetingKey);
+    pending.delete(meetingKey);
     notifyForMeeting(MeetingNotificationKind.CANCELLED, meeting);
   };
 
   const notifyMeetingCancellation = (meetingId: QualifiedId): void => {
     dismissStaleNotificationsForMeeting(meetingId);
+    dismissNotificationsForMeeting(meetingId, [MeetingNotificationKind.CANCELLED]);
     addCancellationNotificationForMeeting(meetingId);
   };
 
@@ -124,7 +134,7 @@ export const createMeetingNotificationEventHandlers = ({
         continue;
       }
 
-      notifyForMeeting(MeetingNotificationKind.CANCELLED, meeting);
+      notifyMeetingCancellation(meetingId);
       pending.delete(key);
     }
   };
@@ -137,10 +147,7 @@ export const createMeetingNotificationEventHandlers = ({
       notifyForMeeting(kind, meeting);
     },
     notifyUpdate: meeting => notifyForMeeting(MeetingNotificationKind.UPDATE, meeting),
-    onMeetingDeleted: meetingId => {
-      notifyMeetingCancellation(meetingId);
-    },
-    onMeetingRemovedForSelf: meetingId => {
+    onMeetingCancelled: meetingId => {
       notifyMeetingCancellation(meetingId);
     },
     retryPendingNotifications,

--- a/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.ts
@@ -33,9 +33,16 @@ type MeetingNotificationLogger = {
   warn: (message: string, context?: unknown) => void;
 };
 
+export const staleMeetingNotificationKinds = [
+  MeetingNotificationKind.UPDATE,
+  MeetingNotificationKind.INVITE,
+  MeetingNotificationKind.ONGOING,
+] as const;
+
 export type MeetingNotificationEventHandlersDependencies = {
   getMeetingSeries: () => readonly MeetingSeries[];
   addNotification: (input: AddNotificationInput) => void;
+  dismissNotificationsForMeeting: (meetingId: QualifiedId, kinds?: readonly MeetingNotificationKind[]) => void;
   logger: MeetingNotificationLogger;
 };
 
@@ -43,6 +50,7 @@ export type MeetingNotificationEventHandlers = {
   notifyMeetingChange: (meeting: MeetingSeries) => void;
   notifyUpdate: (meeting: MeetingSeries) => void;
   onMeetingDeleted: (meetingId: QualifiedId) => void;
+  onMeetingRemovedForSelf: (meetingId: QualifiedId) => void;
   /** Retries notifications that couldn't be sent because the meeting wasn't in the store yet. */
   retryPendingNotifications: () => void;
 };
@@ -50,6 +58,7 @@ export type MeetingNotificationEventHandlers = {
 export const createMeetingNotificationEventHandlers = ({
   getMeetingSeries,
   addNotification,
+  dismissNotificationsForMeeting,
   logger,
 }: MeetingNotificationEventHandlersDependencies): MeetingNotificationEventHandlers => {
   const getMeeting = (meetingId: QualifiedId) =>
@@ -85,6 +94,10 @@ export const createMeetingNotificationEventHandlers = ({
       .exhaustive();
   };
 
+  const dismissStaleNotificationsForMeeting = (meetingId: QualifiedId): void => {
+    dismissNotificationsForMeeting(meetingId, staleMeetingNotificationKinds);
+  };
+
   const addCancellationNotificationForMeeting = (meetingId: QualifiedId): void => {
     const meeting = getMeeting(meetingId);
     if (!meeting) {
@@ -97,6 +110,11 @@ export const createMeetingNotificationEventHandlers = ({
     }
 
     notifyForMeeting(MeetingNotificationKind.CANCELLED, meeting);
+  };
+
+  const notifyMeetingCancellation = (meetingId: QualifiedId): void => {
+    dismissStaleNotificationsForMeeting(meetingId);
+    addCancellationNotificationForMeeting(meetingId);
   };
 
   const retryPendingNotifications = () => {
@@ -120,7 +138,10 @@ export const createMeetingNotificationEventHandlers = ({
     },
     notifyUpdate: meeting => notifyForMeeting(MeetingNotificationKind.UPDATE, meeting),
     onMeetingDeleted: meetingId => {
-      addCancellationNotificationForMeeting(meetingId);
+      notifyMeetingCancellation(meetingId);
+    },
+    onMeetingRemovedForSelf: meetingId => {
+      notifyMeetingCancellation(meetingId);
     },
     retryPendingNotifications,
   };

--- a/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.ts
@@ -100,12 +100,6 @@ export const createMeetingNotificationEventHandlers = ({
 
   const addCancellationNotificationForMeeting = (meetingId: QualifiedId): void => {
     const meetingKey = toMeetingIdKey(meetingId);
-
-    if (cancelledMeetings.has(meetingKey)) {
-      pending.delete(meetingKey);
-      return;
-    }
-
     const meeting = getMeeting(meetingId);
     if (!meeting) {
       logger.warn('meeting notification pending because the meeting is not in the store yet', {
@@ -122,6 +116,13 @@ export const createMeetingNotificationEventHandlers = ({
   };
 
   const notifyMeetingCancellation = (meetingId: QualifiedId): void => {
+    const meetingKey = toMeetingIdKey(meetingId);
+
+    if (cancelledMeetings.has(meetingKey)) {
+      pending.delete(meetingKey);
+      return;
+    }
+
     dismissStaleNotificationsForMeeting(meetingId);
     dismissNotificationsForMeeting(meetingId, [MeetingNotificationKind.CANCELLED]);
     addCancellationNotificationForMeeting(meetingId);

--- a/apps/webapp/src/script/components/meeting/meetingNotificationStore/meetingNotificationStore.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationStore/meetingNotificationStore.test.ts
@@ -218,6 +218,65 @@ describe('useMeetingNotificationStore', () => {
     expect(useMeetingNotificationStore.getState().isExpanded).toBe(false);
   });
 
+  it('dismisses all matching notifications for a meeting and keeps other meetings untouched', () => {
+    const store = useMeetingNotificationStore.getState();
+    const otherMeetingId = {id: 'other-meeting-id', domain: 'example.com'};
+
+    store.addNotification({
+      kind: MeetingNotificationKind.UPDATE,
+      qualifiedId,
+      meetingTitle: 'Updated meeting',
+      meetingStartTime,
+    });
+    store.addNotification({
+      kind: MeetingNotificationKind.INVITE,
+      qualifiedId,
+      meetingTitle: 'Invited meeting',
+      qualifiedCreator,
+      meetingStartTime,
+    });
+    store.addNotification({
+      kind: MeetingNotificationKind.UPDATE,
+      qualifiedId: otherMeetingId,
+      meetingTitle: 'Other meeting',
+      meetingStartTime,
+    });
+    store.addNotification({
+      kind: MeetingNotificationKind.CANCELLED,
+      qualifiedId,
+      meetingTitle: 'Cancelled meeting',
+      qualifiedCreator,
+      meetingStartTime,
+    });
+
+    store.dismissNotificationsForMeeting(qualifiedId, [
+      MeetingNotificationKind.UPDATE,
+      MeetingNotificationKind.INVITE,
+      MeetingNotificationKind.ONGOING,
+    ]);
+
+    expect(useMeetingNotificationStore.getState().notifications.map(({kind, qualifiedId: id}) => ({kind, id}))).toEqual([
+      {kind: MeetingNotificationKind.UPDATE, id: otherMeetingId},
+      {kind: MeetingNotificationKind.CANCELLED, id: qualifiedId},
+    ]);
+  });
+
+  it('resets the expanded state when dismissing the last notification for a meeting', () => {
+    const store = useMeetingNotificationStore.getState();
+    store.addNotification({
+      kind: MeetingNotificationKind.UPDATE,
+      qualifiedId,
+      meetingTitle: 'Updated meeting',
+      meetingStartTime,
+    });
+    store.setIsExpanded(true);
+
+    store.dismissNotificationsForMeeting(qualifiedId, [MeetingNotificationKind.UPDATE]);
+
+    expect(useMeetingNotificationStore.getState().notifications).toEqual([]);
+    expect(useMeetingNotificationStore.getState().isExpanded).toBe(false);
+  });
+
   it('clears all notifications explicitly', () => {
     useMeetingNotificationStore.getState().addNotification({
       kind: MeetingNotificationKind.INVITE,

--- a/apps/webapp/src/script/components/meeting/meetingNotificationStore/meetingNotificationStore.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationStore/meetingNotificationStore.test.ts
@@ -255,10 +255,12 @@ describe('useMeetingNotificationStore', () => {
       MeetingNotificationKind.ONGOING,
     ]);
 
-    expect(useMeetingNotificationStore.getState().notifications.map(({kind, qualifiedId: id}) => ({kind, id}))).toEqual([
-      {kind: MeetingNotificationKind.UPDATE, id: otherMeetingId},
-      {kind: MeetingNotificationKind.CANCELLED, id: qualifiedId},
-    ]);
+    expect(useMeetingNotificationStore.getState().notifications.map(({kind, qualifiedId: id}) => ({kind, id}))).toEqual(
+      [
+        {kind: MeetingNotificationKind.UPDATE, id: otherMeetingId},
+        {kind: MeetingNotificationKind.CANCELLED, id: qualifiedId},
+      ],
+    );
   });
 
   it('resets the expanded state when dismissing the last notification for a meeting', () => {

--- a/apps/webapp/src/script/components/meeting/meetingNotificationStore/meetingNotificationStore.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationStore/meetingNotificationStore.ts
@@ -21,6 +21,8 @@ import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import {match} from 'ts-pattern';
 import {create} from 'zustand';
 
+import {matchQualifiedIds} from 'Util/qualifiedId';
+
 export enum MeetingNotificationKind {
   INVITE = 'invite',
   UPDATE = 'update',
@@ -60,6 +62,7 @@ type MeetingNotificationStore = {
   isExpanded: boolean;
   addNotification: (input: AddNotificationInput) => void;
   dismissNotification: (id: string) => void;
+  dismissNotificationsForMeeting: (meetingId: QualifiedId, kinds?: readonly MeetingNotificationKind[]) => void;
   clearNotifications: () => void;
   setIsExpanded: (isExpanded: boolean) => void;
 };
@@ -120,6 +123,21 @@ export const useMeetingNotificationStore = create<MeetingNotificationStore>(set 
   dismissNotification: id =>
     set(state => {
       const notifications = state.notifications.filter(notification => notification.id !== id);
+
+      return {
+        notifications,
+        ...(state.notifications.length > 0 && notifications.length === 0 ? {isExpanded: false} : {}),
+      };
+    }),
+  dismissNotificationsForMeeting: (meetingId, kinds) =>
+    set(state => {
+      const notifications = state.notifications.filter(notification => {
+        if (!matchQualifiedIds(notification.qualifiedId, meetingId)) {
+          return true;
+        }
+
+        return kinds !== undefined && !kinds.includes(notification.kind);
+      });
 
       return {
         notifications,

--- a/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.test.tsx
@@ -345,7 +345,10 @@ describe('MeetingStoreRoot', () => {
     });
 
     act(() => {
-      amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, conversationId);
+      amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, {
+        qualifiedConversationId: conversationId,
+        initiatedBySelf: false,
+      });
     });
 
     expect(useMeetingNotificationStore.getState().notifications).toEqual([

--- a/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.test.tsx
@@ -46,6 +46,7 @@ import {MeetingStoreRoot} from './meetingStoreRoot';
 const meetingId: QualifiedId = {id: 'meeting-id', domain: 'example.com'};
 const selfUserId: QualifiedId = {id: 'self-user-id', domain: 'example.com'};
 const otherUserId: QualifiedId = {id: 'other-user-id', domain: 'example.com'};
+const conversationId: QualifiedId = {id: 'conversation-id', domain: 'example.com'};
 
 const createApiMeeting = (title: string, qualifiedId: QualifiedId = meetingId) => ({
   created_at: '2026-06-15T09:00:00.000Z',
@@ -321,6 +322,42 @@ describe('MeetingStoreRoot', () => {
         qualifiedId: meetingId,
       }),
     ]);
+  });
+
+  it('replaces update notifications with cancellation when self is removed from the meeting conversation', async () => {
+    renderMeetingStoreRoot();
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('Weekly sync');
+    });
+
+    act(() => {
+      amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId, otherUserId);
+    });
+
+    await waitFor(() => {
+      expect(useMeetingNotificationStore.getState().notifications).toEqual([
+        expect.objectContaining({
+          kind: MeetingNotificationKind.INVITE,
+          qualifiedId: meetingId,
+        }),
+      ]);
+    });
+
+    act(() => {
+      amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, conversationId);
+    });
+
+    expect(useMeetingNotificationStore.getState().notifications).toEqual([
+      expect.objectContaining({
+        kind: MeetingNotificationKind.CANCELLED,
+        qualifiedId: meetingId,
+      }),
+    ]);
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('');
+    });
   });
 
   it('reloads meetings when missed events are reported', async () => {

--- a/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.tsx
@@ -95,7 +95,7 @@ export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
       logger,
     });
 
-    amplify.subscribe(WebAppEvents.MEETING.DELETED, notificationHandlers.onMeetingDeleted);
+    amplify.subscribe(WebAppEvents.MEETING.DELETED, notificationHandlers.onMeetingCancelled);
 
     const getSelfUserQualifiedId = () => container.resolve(UserState).self().qualifiedId;
 
@@ -107,7 +107,7 @@ export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
     const unsubscribeFromMeetingConversationEvents = subscribeToMeetingConversationEvents({
       dispatcher,
       getMeetingSeries: () => store.getState().meetingSeries,
-      onMeetingRemovedForSelf: notificationHandlers.onMeetingRemovedForSelf,
+      onMeetingCancelled: notificationHandlers.onMeetingCancelled,
     });
     const unsubscribeFromMeetingStore = store.subscribe((state, previousState) => {
       if (state.meetingSeries !== previousState.meetingSeries) {
@@ -121,7 +121,7 @@ export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
       unsubscribeFromMeetingLifecycleEvents();
       unsubscribeFromMeetingConversationEvents();
       unsubscribeFromMeetingStore();
-      amplify.unsubscribe(WebAppEvents.MEETING.DELETED, notificationHandlers.onMeetingDeleted);
+      amplify.unsubscribe(WebAppEvents.MEETING.DELETED, notificationHandlers.onMeetingCancelled);
     };
   }, [isMeetingsEnabled, store]);
 

--- a/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.tsx
@@ -36,6 +36,7 @@ import {getLogger} from 'Util/logger';
 import {useMeetingsFeatureFlag} from 'Util/useMeetingsFeatureFlag';
 
 import {createMeetingLifecycleDispatcher} from './createMeetingLifecycleDispatcher';
+import {subscribeToMeetingConversationEvents} from './subscribeToMeetingConversationEvents';
 import {subscribeToMeetingLifecycleEvents} from './subscribeToMeetingLifecycleEvents';
 
 const logger = getLogger('MeetingStoreRoot');
@@ -86,18 +87,27 @@ export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
       },
     });
 
+    const notificationStore = useMeetingNotificationStore.getState();
     const notificationHandlers = createMeetingNotificationEventHandlers({
       getMeetingSeries: () => store.getState().meetingSeries,
-      addNotification: useMeetingNotificationStore.getState().addNotification,
+      addNotification: notificationStore.addNotification,
+      dismissNotificationsForMeeting: notificationStore.dismissNotificationsForMeeting,
       logger,
     });
 
     amplify.subscribe(WebAppEvents.MEETING.DELETED, notificationHandlers.onMeetingDeleted);
 
+    const getSelfUserQualifiedId = () => container.resolve(UserState).self().qualifiedId;
+
     const unsubscribeFromMeetingLifecycleEvents = subscribeToMeetingLifecycleEvents({
       dispatcher,
-      getSelfUserQualifiedId: () => container.resolve(UserState).self().qualifiedId,
+      getSelfUserQualifiedId,
       notifyMeetingChange: notificationHandlers.notifyMeetingChange,
+    });
+    const unsubscribeFromMeetingConversationEvents = subscribeToMeetingConversationEvents({
+      dispatcher,
+      getMeetingSeries: () => store.getState().meetingSeries,
+      onMeetingRemovedForSelf: notificationHandlers.onMeetingRemovedForSelf,
     });
     const unsubscribeFromMeetingStore = store.subscribe((state, previousState) => {
       if (state.meetingSeries !== previousState.meetingSeries) {
@@ -109,6 +119,7 @@ export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
 
     return () => {
       unsubscribeFromMeetingLifecycleEvents();
+      unsubscribeFromMeetingConversationEvents();
       unsubscribeFromMeetingStore();
       amplify.unsubscribe(WebAppEvents.MEETING.DELETED, notificationHandlers.onMeetingDeleted);
     };

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingConversationEvents.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingConversationEvents.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
+import {WebAppEvents} from '@wireapp/webapp-events';
+import {amplify} from 'amplify';
+
+import type {MeetingLifecycleDispatcher} from './createMeetingLifecycleDispatcher';
+import {subscribeToMeetingConversationEvents} from './subscribeToMeetingConversationEvents';
+
+const meetingId: QualifiedId = {id: 'meeting-id', domain: 'example.com'};
+const conversationId: QualifiedId = {id: 'conversation-id', domain: 'example.com'};
+
+type MeetingLifecycleDispatcherDouble = {
+  [Key in keyof MeetingLifecycleDispatcher]: jest.Mock;
+};
+
+const createDispatcherDouble = (): MeetingLifecycleDispatcherDouble => ({
+  enqueueInitialLoad: jest.fn(),
+  enqueueMeetingSync: jest.fn(),
+  enqueueMeetingRemoval: jest.fn(),
+  waitUntilAllSettled: jest.fn(async () => undefined),
+});
+
+describe('subscribeToMeetingConversationEvents', () => {
+  const activeUnsubscribeCallbacks: (() => void)[] = [];
+
+  afterEach(() => {
+    activeUnsubscribeCallbacks.splice(0).forEach(unsubscribe => unsubscribe());
+  });
+
+  it('cancels and removes the meeting when self is removed from its MLS conversation', () => {
+    const dispatcher = createDispatcherDouble();
+    const onMeetingRemovedForSelf = jest.fn();
+
+    const unsubscribe = subscribeToMeetingConversationEvents({
+      dispatcher,
+      getMeetingSeries: () => [
+        {
+          conversation_id: '',
+          recurrence: 'weekly',
+          duration_ms: 60 * 60 * 1000,
+          qualified_conversation: conversationId,
+          qualified_creator: {id: 'creator-id', domain: 'example.com'},
+          qualified_id: meetingId,
+          series_end_date: '2026-06-01T11:00:00.000Z',
+          series_start_date: '2026-06-01T10:00:00.000Z',
+          title: 'Weekly sync',
+        },
+      ],
+      onMeetingRemovedForSelf,
+    });
+    activeUnsubscribeCallbacks.push(unsubscribe);
+
+    amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, conversationId);
+
+    expect(onMeetingRemovedForSelf).toHaveBeenCalledWith(meetingId);
+    expect(dispatcher.enqueueMeetingRemoval).toHaveBeenCalledWith(meetingId);
+  });
+
+  it('ignores self-removed events for conversations that are not linked to a meeting in the store', () => {
+    const dispatcher = createDispatcherDouble();
+    const onMeetingRemovedForSelf = jest.fn();
+
+    const unsubscribe = subscribeToMeetingConversationEvents({
+      dispatcher,
+      getMeetingSeries: () => [],
+      onMeetingRemovedForSelf,
+    });
+    activeUnsubscribeCallbacks.push(unsubscribe);
+
+    amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, conversationId);
+
+    expect(onMeetingRemovedForSelf).not.toHaveBeenCalled();
+    expect(dispatcher.enqueueMeetingRemoval).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingConversationEvents.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingConversationEvents.test.ts
@@ -45,9 +45,9 @@ describe('subscribeToMeetingConversationEvents', () => {
     activeUnsubscribeCallbacks.splice(0).forEach(unsubscribe => unsubscribe());
   });
 
-  it('cancels and removes the meeting when self is removed from its MLS conversation', () => {
+  it('cancels and removes the meeting when self is involuntarily removed from its MLS conversation', () => {
     const dispatcher = createDispatcherDouble();
-    const onMeetingRemovedForSelf = jest.fn();
+    const onMeetingCancelled = jest.fn();
 
     const unsubscribe = subscribeToMeetingConversationEvents({
       dispatcher,
@@ -64,30 +64,68 @@ describe('subscribeToMeetingConversationEvents', () => {
           title: 'Weekly sync',
         },
       ],
-      onMeetingRemovedForSelf,
+      onMeetingCancelled,
     });
     activeUnsubscribeCallbacks.push(unsubscribe);
 
-    amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, conversationId);
+    amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, {
+      qualifiedConversationId: conversationId,
+      initiatedBySelf: false,
+    });
 
-    expect(onMeetingRemovedForSelf).toHaveBeenCalledWith(meetingId);
+    expect(onMeetingCancelled).toHaveBeenCalledWith(meetingId);
+    expect(dispatcher.enqueueMeetingRemoval).toHaveBeenCalledWith(meetingId);
+  });
+
+  it('removes the meeting without cancelling when self initiated the leave', () => {
+    const dispatcher = createDispatcherDouble();
+    const onMeetingCancelled = jest.fn();
+
+    const unsubscribe = subscribeToMeetingConversationEvents({
+      dispatcher,
+      getMeetingSeries: () => [
+        {
+          conversation_id: '',
+          recurrence: 'weekly',
+          duration_ms: 60 * 60 * 1000,
+          qualified_conversation: conversationId,
+          qualified_creator: {id: 'creator-id', domain: 'example.com'},
+          qualified_id: meetingId,
+          series_end_date: '2026-06-01T11:00:00.000Z',
+          series_start_date: '2026-06-01T10:00:00.000Z',
+          title: 'Weekly sync',
+        },
+      ],
+      onMeetingCancelled,
+    });
+    activeUnsubscribeCallbacks.push(unsubscribe);
+
+    amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, {
+      qualifiedConversationId: conversationId,
+      initiatedBySelf: true,
+    });
+
+    expect(onMeetingCancelled).not.toHaveBeenCalled();
     expect(dispatcher.enqueueMeetingRemoval).toHaveBeenCalledWith(meetingId);
   });
 
   it('ignores self-removed events for conversations that are not linked to a meeting in the store', () => {
     const dispatcher = createDispatcherDouble();
-    const onMeetingRemovedForSelf = jest.fn();
+    const onMeetingCancelled = jest.fn();
 
     const unsubscribe = subscribeToMeetingConversationEvents({
       dispatcher,
       getMeetingSeries: () => [],
-      onMeetingRemovedForSelf,
+      onMeetingCancelled,
     });
     activeUnsubscribeCallbacks.push(unsubscribe);
 
-    amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, conversationId);
+    amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, {
+      qualifiedConversationId: conversationId,
+      initiatedBySelf: false,
+    });
 
-    expect(onMeetingRemovedForSelf).not.toHaveBeenCalled();
+    expect(onMeetingCancelled).not.toHaveBeenCalled();
     expect(dispatcher.enqueueMeetingRemoval).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingConversationEvents.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingConversationEvents.ts
@@ -20,7 +20,7 @@
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import {amplify} from 'amplify';
 
-import {WebAppEvents} from '@wireapp/webapp-events';
+import {WebAppEvents, type ConversationSelfRemovedPayload} from '@wireapp/webapp-events';
 
 import type {MeetingSeries} from 'Components/meeting/types/meetingSeries';
 import {findMeetingSeriesByQualifiedConversation} from 'Components/meeting/utils/findMeetingSeriesByQualifiedConversation';
@@ -30,7 +30,7 @@ import type {MeetingLifecycleDispatcher} from './createMeetingLifecycleDispatche
 export type SubscribeToMeetingConversationEventsDependencies = {
   dispatcher: MeetingLifecycleDispatcher;
   getMeetingSeries: () => readonly MeetingSeries[];
-  onMeetingRemovedForSelf: (meetingId: QualifiedId) => void;
+  onMeetingCancelled: (meetingId: QualifiedId) => void;
 };
 
 /**
@@ -40,16 +40,19 @@ export type SubscribeToMeetingConversationEventsDependencies = {
 export const subscribeToMeetingConversationEvents = ({
   dispatcher,
   getMeetingSeries,
-  onMeetingRemovedForSelf,
+  onMeetingCancelled,
 }: SubscribeToMeetingConversationEventsDependencies): (() => void) => {
-  const onSelfRemovedFromConversation = (qualifiedConversationId: QualifiedId) => {
+  const onSelfRemovedFromConversation = ({qualifiedConversationId, initiatedBySelf}: ConversationSelfRemovedPayload) => {
     const meeting = findMeetingSeriesByQualifiedConversation(getMeetingSeries(), qualifiedConversationId);
-    if (meeting === undefined) {
+    if (meeting.isNothing) {
       return;
     }
 
-    onMeetingRemovedForSelf(meeting.qualified_id);
-    dispatcher.enqueueMeetingRemoval(meeting.qualified_id);
+    if (!initiatedBySelf) {
+      onMeetingCancelled(meeting.value.qualified_id);
+    }
+
+    dispatcher.enqueueMeetingRemoval(meeting.value.qualified_id);
   };
 
   amplify.subscribe(WebAppEvents.CONVERSATION.SELF_REMOVED, onSelfRemovedFromConversation);

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingConversationEvents.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingConversationEvents.ts
@@ -42,7 +42,10 @@ export const subscribeToMeetingConversationEvents = ({
   getMeetingSeries,
   onMeetingCancelled,
 }: SubscribeToMeetingConversationEventsDependencies): (() => void) => {
-  const onSelfRemovedFromConversation = ({qualifiedConversationId, initiatedBySelf}: ConversationSelfRemovedPayload) => {
+  const onSelfRemovedFromConversation = ({
+    qualifiedConversationId,
+    initiatedBySelf,
+  }: ConversationSelfRemovedPayload) => {
     const meeting = findMeetingSeriesByQualifiedConversation(getMeetingSeries(), qualifiedConversationId);
     if (meeting.isNothing) {
       return;

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingConversationEvents.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingConversationEvents.ts
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
+import {amplify} from 'amplify';
+
+import {WebAppEvents} from '@wireapp/webapp-events';
+
+import type {MeetingSeries} from 'Components/meeting/types/meetingSeries';
+import {findMeetingSeriesByQualifiedConversation} from 'Components/meeting/utils/findMeetingSeriesByQualifiedConversation';
+
+import type {MeetingLifecycleDispatcher} from './createMeetingLifecycleDispatcher';
+
+export type SubscribeToMeetingConversationEventsDependencies = {
+  dispatcher: MeetingLifecycleDispatcher;
+  getMeetingSeries: () => readonly MeetingSeries[];
+  onMeetingRemovedForSelf: (meetingId: QualifiedId) => void;
+};
+
+/**
+ * Reacts when the signed-in user is removed from a conversation that is linked to a meeting.
+ * Returns the callback which removes the subscription again.
+ */
+export const subscribeToMeetingConversationEvents = ({
+  dispatcher,
+  getMeetingSeries,
+  onMeetingRemovedForSelf,
+}: SubscribeToMeetingConversationEventsDependencies): (() => void) => {
+  const onSelfRemovedFromConversation = (qualifiedConversationId: QualifiedId) => {
+    const meeting = findMeetingSeriesByQualifiedConversation(getMeetingSeries(), qualifiedConversationId);
+    if (meeting === undefined) {
+      return;
+    }
+
+    onMeetingRemovedForSelf(meeting.qualified_id);
+    dispatcher.enqueueMeetingRemoval(meeting.qualified_id);
+  };
+
+  amplify.subscribe(WebAppEvents.CONVERSATION.SELF_REMOVED, onSelfRemovedFromConversation);
+
+  return () => {
+    amplify.unsubscribe(WebAppEvents.CONVERSATION.SELF_REMOVED, onSelfRemovedFromConversation);
+  };
+};

--- a/apps/webapp/src/script/components/meeting/utils/findMeetingSeriesByQualifiedConversation.ts
+++ b/apps/webapp/src/script/components/meeting/utils/findMeetingSeriesByQualifiedConversation.ts
@@ -18,6 +18,7 @@
  */
 
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
+import {Maybe} from 'true-myth';
 
 import type {MeetingSeries} from 'Components/meeting/types/meetingSeries';
 import {matchQualifiedIds} from 'Util/qualifiedId';
@@ -25,5 +26,5 @@ import {matchQualifiedIds} from 'Util/qualifiedId';
 export const findMeetingSeriesByQualifiedConversation = (
   meetingSeries: readonly MeetingSeries[],
   qualifiedConversationId: QualifiedId,
-): MeetingSeries | undefined =>
-  meetingSeries.find(series => matchQualifiedIds(series.qualified_conversation, qualifiedConversationId));
+): Maybe<MeetingSeries> =>
+  Maybe.of(meetingSeries.find(series => matchQualifiedIds(series.qualified_conversation, qualifiedConversationId)));

--- a/apps/webapp/src/script/components/meeting/utils/findMeetingSeriesByQualifiedConversation.ts
+++ b/apps/webapp/src/script/components/meeting/utils/findMeetingSeriesByQualifiedConversation.ts
@@ -1,0 +1,29 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
+
+import type {MeetingSeries} from 'Components/meeting/types/meetingSeries';
+import {matchQualifiedIds} from 'Util/qualifiedId';
+
+export const findMeetingSeriesByQualifiedConversation = (
+  meetingSeries: readonly MeetingSeries[],
+  qualifiedConversationId: QualifiedId,
+): MeetingSeries | undefined =>
+  meetingSeries.find(series => matchQualifiedIds(series.qualified_conversation, qualifiedConversationId));

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -4311,6 +4311,7 @@ export class ConversationRepository {
     }
 
     const removesSelfUser = eventData.user_ids.includes(selfUser.id);
+    const initiatedBySelf = removesSelfUser && eventJson.from === selfUser.id;
 
     if (removesSelfUser) {
       conversationEntity.status(ConversationStatus.PAST_MEMBER);
@@ -4346,7 +4347,10 @@ export class ConversationRepository {
     this.proteusVerificationStateHandler.onMemberLeft(conversationEntity);
 
     if (removesSelfUser) {
-      amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, conversationEntity.qualifiedId);
+      amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, {
+        qualifiedConversationId: conversationEntity.qualifiedId,
+        initiatedBySelf,
+      });
     }
 
     return {conversationEntity, messageEntity};

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -4345,6 +4345,10 @@ export class ConversationRepository {
 
     this.proteusVerificationStateHandler.onMemberLeft(conversationEntity);
 
+    if (removesSelfUser) {
+      amplify.publish(WebAppEvents.CONVERSATION.SELF_REMOVED, conversationEntity.qualifiedId);
+    }
+
     return {conversationEntity, messageEntity};
   }
 

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -161,6 +161,7 @@ import {
   TeamMemberLeaveEvent,
 } from './EventBuilder';
 import {EventMapper} from './EventMapper';
+import {isSelfInitiatedConversationLeave} from './isSelfInitiatedConversationLeave';
 import {MessageRepository} from './MessageRepository';
 import {NOTIFICATION_STATE} from './NotificationSetting';
 
@@ -4311,7 +4312,7 @@ export class ConversationRepository {
     }
 
     const removesSelfUser = eventData.user_ids.includes(selfUser.id);
-    const initiatedBySelf = removesSelfUser && eventJson.from === selfUser.id;
+    const initiatedBySelf = removesSelfUser && isSelfInitiatedConversationLeave(eventJson.from, selfUser.id);
 
     if (removesSelfUser) {
       conversationEntity.status(ConversationStatus.PAST_MEMBER);

--- a/apps/webapp/src/script/repositories/conversation/isSelfInitiatedConversationLeave.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/isSelfInitiatedConversationLeave.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isSelfInitiatedConversationLeave} from './isSelfInitiatedConversationLeave';
+
+describe('isSelfInitiatedConversationLeave', () => {
+  it('returns true when the member-leave event sender is the self user', () => {
+    expect(isSelfInitiatedConversationLeave('self-user-id', 'self-user-id')).toBe(true);
+  });
+
+  it('returns false when another user removed self from the conversation', () => {
+    expect(isSelfInitiatedConversationLeave('host-user-id', 'self-user-id')).toBe(false);
+  });
+});

--- a/apps/webapp/src/script/repositories/conversation/isSelfInitiatedConversationLeave.ts
+++ b/apps/webapp/src/script/repositories/conversation/isSelfInitiatedConversationLeave.ts
@@ -1,0 +1,21 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export const isSelfInitiatedConversationLeave = (eventFrom: string, selfUserId: string): boolean =>
+  eventFrom === selfUserId;

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
@@ -307,4 +307,8 @@ export class MeetingsPage {
     await this.expandNotifications();
     await expect(this.notificationCardContaining(text)).toBeVisible({timeout: MEETINGS_LIST_TIMEOUT_MS});
   }
+
+  async expectNoNotificationContaining(text: string) {
+    await expect(this.notificationCardContaining(text)).toHaveCount(0, {timeout: MEETINGS_LIST_TIMEOUT_MS});
+  }
 }

--- a/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
@@ -202,6 +202,7 @@ test.describe('Meetings CRUD', () => {
     await memberMeetings.deleteMeetingForMe(MEETING_TITLE);
 
     await memberMeetings.waitForMeetingAbsentFromList(MEETING_TITLE);
+    await memberMeetings.expectNoNotificationContaining(`Canceled: ${MEETING_TITLE}`);
     await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
   });
 });

--- a/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
@@ -258,4 +258,33 @@ test.describe('Meeting notifications', () => {
     await expect(firstMemberMeetings.notificationCardContaining(`Invitation: ${MEETING_TITLE}`)).toHaveCount(1);
     await secondMemberMeetings.waitForNotificationContaining(`Invitation: ${MEETING_TITLE}`);
   });
+
+  test('removed participant sees cancellation notification and stale invitation is dismissed', async ({
+    createUser,
+    createTeam,
+    createPage,
+  }) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 2);
+    const [firstMember, secondMember] = members;
+
+    const [ownerPage, firstMemberPage] = await loginMeetingsUsers(createPage, [owner, firstMember, secondMember]);
+    const ownerMeetings = PageManager.from(ownerPage).webapp.pages.meetings();
+    const firstMemberMeetings = PageManager.from(firstMemberPage).webapp.pages.meetings();
+
+    await ownerMeetings.openMeetingsTab();
+    await ownerMeetings.scheduleMeeting(MEETING_TITLE, [firstMember.fullName, secondMember.fullName]);
+    await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
+
+    await firstMemberMeetings.openMeetingsTab();
+    await firstMemberMeetings.waitForMeetingInList(MEETING_TITLE);
+    await firstMemberMeetings.waitForNotificationContaining(`Invitation: ${MEETING_TITLE}`);
+
+    await ownerMeetings.editMeeting(MEETING_TITLE, {removeParticipants: [firstMember.fullName]});
+
+    await firstMemberMeetings.waitForMeetingAbsentFromList(MEETING_TITLE);
+    await firstMemberMeetings.waitForNotificationContaining(`Canceled: ${MEETING_TITLE}`);
+    await expect(firstMemberMeetings.notificationCards()).toHaveCount(1);
+    await expect(firstMemberMeetings.notificationCards()).not.toContainText(`Invitation: ${MEETING_TITLE}`);
+    await expect(firstMemberMeetings.notificationCards()).not.toContainText(`Update: ${MEETING_TITLE}`);
+  });
 });

--- a/libraries/webapp-events/src/index.ts
+++ b/libraries/webapp-events/src/index.ts
@@ -273,3 +273,11 @@ export const WebAppEvents = {
     SHOW: 'wire.webapp.warning.show',
   },
 };
+
+export type ConversationSelfRemovedPayload = {
+  qualifiedConversationId: {
+    domain: string;
+    id: string;
+  };
+  initiatedBySelf: boolean;
+};

--- a/libraries/webapp-events/src/index.ts
+++ b/libraries/webapp-events/src/index.ts
@@ -118,6 +118,7 @@ export const WebAppEvents = {
       HIDE: 'wire.webapp.conversation.people.hide',
     },
     PERSIST_STATE: 'wire.webapp.conversation.persist_state',
+    SELF_REMOVED: 'wire.webapp.conversation.self_removed',
     SHOW: 'wire.webapp.conversation.show',
     VERIFICATION_STATE_CHANGED: 'wire.webapp.conversation.verification_state_changed',
   },


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25516" title="WPB-25516" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25516</a>  [Web] Inform participant of a canceled meeting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Publish `CONVERSATION.SELF_REMOVED` from `ConversationRepository` when the signed-in user is removed from a conversation, giving feature layers a clean hook instead of parsing raw `member-leave` backend events.
- Wire the meeting store to dismiss stale invitation/update cards, show a **Canceled** notification, and remove the meeting from the removed participant's list.
- Add e2e coverage for participant removal: canceled notification, list cleanup, and no stale invitation card.

## Test plan
- [x] Unit tests: `meetingNotificationEventHandlers`, `meetingNotificationStore`, `subscribeToMeetingConversationEvents`, `meetingStoreRoot`
- [x] E2E: `removed participant sees cancellation notification and stale invitation is dismissed`
- [x] Manual: host removes participant from scheduled meeting; removed user sees only Canceled card and meeting disappears from Meetings list