### PR TITLE
fix(cells): hide viewer download actions [WPB-27979]

### DIFF
--- a/apps/webapp/src/script/components/Conversation/Conversation.tsx
+++ b/apps/webapp/src/script/components/Conversation/Conversation.tsx
@@ -62,6 +62,10 @@ import {
   tabsHiddenStyles,
   tabsWrapperStyles,
 } from './Conversation.styles';
+import {
+  CellsSelfUserDriveRoleProvider,
+  getSelfUserDriveRole,
+} from './ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
 import {getCellsFilesPath} from './ConversationCells/common/getCellsFilesPath/getCellsFilesPath';
 import {getCurrentFolderName} from './ConversationCells/common/getCurrentFolderName/getCurrentFolderName';
 import {ConversationCells} from './ConversationCells/ConversationCells';
@@ -611,159 +615,165 @@ export const Conversation = ({
     });
 
   const currentFolderName = getCurrentFolderName(getCellsFilesPath());
+  const selfUserDriveRole = getSelfUserDriveRole({
+    conversationTeamId: activeConversation?.teamId,
+    selfUserTeamId: selfUser.teamId,
+  });
 
   return (
-    <ConversationFileDropzone
-      isDragAccept={isDragAccept}
-      isFileDropAllowed={isFileDropAllowed}
-      isCellsEnabled={isCellsEnabled}
-      isConversationLoaded={isConversationLoaded}
-      activeConversationId={activeConversation?.id}
-      onFileDropped={checkFileSharingPermission(uploadDroppedFiles, translate)}
-      rootProps={getRootProps()}
-      inputProps={getInputProps()}
-    >
-      {activeConversation && (
-        <>
-          <TitleBar
-            repositories={repositories}
-            conversation={activeConversation}
-            selfUser={selfUser}
-            teamState={teamState}
-            callActions={mainViewModel.calling.callActions}
-            openRightSidebar={openRightSidebar}
-            isRightSidebarOpen={isRightSidebarOpen}
-            isReadOnlyConversation={isReadOnlyConversation || isSelfUserRemoved}
-            withBottomDivider={!isCellsEnabled || isSharedDriveSearchViewOpen}
-            isSharedDriveSearchViewOpen={isSharedDriveSearchViewOpen}
-            onCloseSharedDriveSearchView={() => setIsSharedDriveSearchViewOpen(false)}
-          />
-
-          {isCellsEnabled && (
-            <>
-              <div css={tabsWrapperStyles}>
-                <div
-                  aria-hidden={isSharedDriveSearchViewOpen || undefined}
-                  css={isSharedDriveSearchViewOpen ? tabsHiddenStyles : undefined}
-                >
-                  <ConversationTabs
-                    activeTabIndex={activeTabIndex}
-                    onIndexChange={setActiveTabIndex}
-                    conversationQualifiedId={activeConversation.qualifiedId}
-                  />
-                </div>
-                {isSharedDriveSearchViewOpen && (
-                  <div css={searchResultsOverlayStyles}>
-                    <h3 css={searchResultsHeadingStyles}>
-                      {currentFolderName
-                        ? translate('cells.search.resultsIn', {folderName: currentFolderName})
-                        : translate('cells.search.results')}
-                    </h3>
-                  </div>
-                )}
-              </div>
-              <ConversationTabPanel id="files" isActive={isFileTabActive}>
-                {isFileTabActive && (
-                  <ConversationCells
-                    activeConversation={activeConversation}
-                    userRepository={repositories.user}
-                    cellsRepository={repositories.cells}
-                    conversationRepository={conversationRepository}
-                    isSearchViewOpen={isSharedDriveSearchViewOpen}
-                    onOpenSearchView={() => setIsSharedDriveSearchViewOpen(true)}
-                    onCloseSearchView={() => setIsSharedDriveSearchViewOpen(false)}
-                  />
-                )}
-              </ConversationTabPanel>
-            </>
-          )}
-
-          <ConversationMessagesWrapper isCellsEnabled={isCellsEnabled} isPanelHidden={isFileTabActive}>
-            {activeCalls.map(call => {
-              const {conversation} = call;
-              const callingViewModel = mainViewModel.calling;
-              const callingRepository = callingViewModel.callingRepository;
-
-              if (!smBreakpoint) {
-                return null;
-              }
-
-              return (
-                <CallingCell
-                  key={conversation.id}
-                  classifiedDomains={classifiedDomains}
-                  call={call}
-                  callActions={callingViewModel.callActions}
-                  callingRepository={callingRepository}
-                  propertiesRepository={repositories.properties}
-                />
-              );
-            })}
-
-            <MessageListWrapper
+    <CellsSelfUserDriveRoleProvider selfUserDriveRole={selfUserDriveRole}>
+      <ConversationFileDropzone
+        isDragAccept={isDragAccept}
+        isFileDropAllowed={isFileDropAllowed}
+        isCellsEnabled={isCellsEnabled}
+        isConversationLoaded={isConversationLoaded}
+        activeConversationId={activeConversation?.id}
+        onFileDropped={checkFileSharingPermission(uploadDroppedFiles, translate)}
+        rootProps={getRootProps()}
+        inputProps={getInputProps()}
+      >
+        {activeConversation && (
+          <>
+            <TitleBar
+              repositories={repositories}
               conversation={activeConversation}
               selfUser={selfUser}
-              conversationRepository={conversationRepository}
-              assetRepository={repositories.asset}
-              messageRepository={repositories.message}
-              messageActions={mainViewModel.actions}
-              invitePeople={clickOnInvitePeople}
-              cancelConnectionRequest={clickOnCancelRequest}
-              showUserDetails={showUserDetails}
-              showMessageDetails={showMessageDetails}
-              showMessageReactions={showMessageReactions}
-              showParticipants={showParticipants}
-              showImageDetails={showDetail}
-              resetSession={onSessionResetClick}
-              onClickMessage={handleClickOnMessage}
-              isConversationLoaded={isConversationLoaded}
-              onLoading={loading => setIsConversationLoaded(!loading)}
-              getVisibleCallback={getInViewportCallback}
-              isMsgElementsFocusable={isMsgElementsFocusable}
-              setMsgElementsFocusable={setMsgElementsFocusable}
+              teamState={teamState}
+              callActions={mainViewModel.calling.callActions}
+              openRightSidebar={openRightSidebar}
               isRightSidebarOpen={isRightSidebarOpen}
-              updateConversationLastRead={updateConversationLastRead}
+              isReadOnlyConversation={isReadOnlyConversation || isSelfUserRemoved}
+              withBottomDivider={!isCellsEnabled || isSharedDriveSearchViewOpen}
+              isSharedDriveSearchViewOpen={isSharedDriveSearchViewOpen}
+              onCloseSharedDriveSearchView={() => setIsSharedDriveSearchViewOpen(false)}
             />
 
-            {isConversationLoaded &&
-              !isSelfUserRemoved &&
-              (isReadOnlyConversation ? (
-                <ReadOnlyConversationMessage reloadApp={reloadApp} conversation={activeConversation} />
-              ) : (
-                <InputBar
-                  key={activeConversation?.id}
-                  conversation={activeConversation}
-                  conversationRepository={repositories.conversation}
-                  cellsRepository={repositories.cells}
-                  eventRepository={repositories.event}
-                  messageRepository={repositories.message}
-                  openGiphy={openGiphy}
-                  propertiesRepository={repositories.properties}
-                  searchRepository={repositories.search}
-                  storageRepository={repositories.storage}
-                  teamState={teamState}
-                  selfUser={selfUser}
-                  isCellsEnabled={isCellsEnabled}
-                  onShiftTab={() => setMsgElementsFocusable(false)}
-                  uploadDroppedFiles={uploadDroppedFiles}
-                  uploadImages={uploadImages}
-                  uploadFiles={uploadFiles}
-                  uploadPastedFiles={checkFileSharingPermission(handlePastedFile, translate)}
-                  onCellImageUpload={openImageFilesView}
-                  onCellAssetUpload={openAllFilesView}
-                />
-              ))}
+            {isCellsEnabled && (
+              <>
+                <div css={tabsWrapperStyles}>
+                  <div
+                    aria-hidden={isSharedDriveSearchViewOpen || undefined}
+                    css={isSharedDriveSearchViewOpen ? tabsHiddenStyles : undefined}
+                  >
+                    <ConversationTabs
+                      activeTabIndex={activeTabIndex}
+                      onIndexChange={setActiveTabIndex}
+                      conversationQualifiedId={activeConversation.qualifiedId}
+                    />
+                  </div>
+                  {isSharedDriveSearchViewOpen && (
+                    <div css={searchResultsOverlayStyles}>
+                      <h3 css={searchResultsHeadingStyles}>
+                        {currentFolderName
+                          ? translate('cells.search.resultsIn', {folderName: currentFolderName})
+                          : translate('cells.search.results')}
+                      </h3>
+                    </div>
+                  )}
+                </div>
+                <ConversationTabPanel id="files" isActive={isFileTabActive}>
+                  {isFileTabActive && (
+                    <ConversationCells
+                      activeConversation={activeConversation}
+                      userRepository={repositories.user}
+                      cellsRepository={repositories.cells}
+                      conversationRepository={conversationRepository}
+                      isSearchViewOpen={isSharedDriveSearchViewOpen}
+                      onOpenSearchView={() => setIsSharedDriveSearchViewOpen(true)}
+                      onCloseSearchView={() => setIsSharedDriveSearchViewOpen(false)}
+                    />
+                  )}
+                </ConversationTabPanel>
+              </>
+            )}
 
-            <div className="conversation-loading">
-              <div className="icon-spinner spin accent-text"></div>
-            </div>
-          </ConversationMessagesWrapper>
-        </>
-      )}
+            <ConversationMessagesWrapper isCellsEnabled={isCellsEnabled} isPanelHidden={isFileTabActive}>
+              {activeCalls.map(call => {
+                const {conversation} = call;
+                const callingViewModel = mainViewModel.calling;
+                const callingRepository = callingViewModel.callingRepository;
 
-      {isGiphyModalOpen && inputValue && (
-        <Giphy giphyRepository={repositories.giphy} inputValue={inputValue} onClose={closeGiphy} />
-      )}
-    </ConversationFileDropzone>
+                if (!smBreakpoint) {
+                  return null;
+                }
+
+                return (
+                  <CallingCell
+                    key={conversation.id}
+                    classifiedDomains={classifiedDomains}
+                    call={call}
+                    callActions={callingViewModel.callActions}
+                    callingRepository={callingRepository}
+                    propertiesRepository={repositories.properties}
+                  />
+                );
+              })}
+
+              <MessageListWrapper
+                conversation={activeConversation}
+                selfUser={selfUser}
+                conversationRepository={conversationRepository}
+                assetRepository={repositories.asset}
+                messageRepository={repositories.message}
+                messageActions={mainViewModel.actions}
+                invitePeople={clickOnInvitePeople}
+                cancelConnectionRequest={clickOnCancelRequest}
+                showUserDetails={showUserDetails}
+                showMessageDetails={showMessageDetails}
+                showMessageReactions={showMessageReactions}
+                showParticipants={showParticipants}
+                showImageDetails={showDetail}
+                resetSession={onSessionResetClick}
+                onClickMessage={handleClickOnMessage}
+                isConversationLoaded={isConversationLoaded}
+                onLoading={loading => setIsConversationLoaded(!loading)}
+                getVisibleCallback={getInViewportCallback}
+                isMsgElementsFocusable={isMsgElementsFocusable}
+                setMsgElementsFocusable={setMsgElementsFocusable}
+                isRightSidebarOpen={isRightSidebarOpen}
+                updateConversationLastRead={updateConversationLastRead}
+              />
+
+              {isConversationLoaded &&
+                !isSelfUserRemoved &&
+                (isReadOnlyConversation ? (
+                  <ReadOnlyConversationMessage reloadApp={reloadApp} conversation={activeConversation} />
+                ) : (
+                  <InputBar
+                    key={activeConversation?.id}
+                    conversation={activeConversation}
+                    conversationRepository={repositories.conversation}
+                    cellsRepository={repositories.cells}
+                    eventRepository={repositories.event}
+                    messageRepository={repositories.message}
+                    openGiphy={openGiphy}
+                    propertiesRepository={repositories.properties}
+                    searchRepository={repositories.search}
+                    storageRepository={repositories.storage}
+                    teamState={teamState}
+                    selfUser={selfUser}
+                    isCellsEnabled={isCellsEnabled}
+                    onShiftTab={() => setMsgElementsFocusable(false)}
+                    uploadDroppedFiles={uploadDroppedFiles}
+                    uploadImages={uploadImages}
+                    uploadFiles={uploadFiles}
+                    uploadPastedFiles={checkFileSharingPermission(handlePastedFile, translate)}
+                    onCellImageUpload={openImageFilesView}
+                    onCellAssetUpload={openAllFilesView}
+                  />
+                ))}
+
+              <div className="conversation-loading">
+                <div className="icon-spinner spin accent-text"></div>
+              </div>
+            </ConversationMessagesWrapper>
+          </>
+        )}
+
+        {isGiphyModalOpen && inputValue && (
+          <Giphy giphyRepository={repositories.giphy} inputValue={inputValue} onClose={closeGiphy} />
+        )}
+      </ConversationFileDropzone>
+    </CellsSelfUserDriveRoleProvider>
   );
 };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsFilePreviewModal/CellsFilePreviewModal.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsFilePreviewModal/CellsFilePreviewModal.tsx
@@ -17,7 +17,13 @@
  *
  */
 
+import {
+  shouldRestrictCellsViewerActions,
+  useCellsSelfUserDriveRole,
+} from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
 import {FileFullscreenModal} from 'Components/FileFullscreenModal/FileFullscreenModal';
+import {viewerPermissionFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {useApplicationContext} from 'src/script/page/rootProvider';
 import {getFileTypeFromExtension} from 'Util/getFileTypeFromExtension/getFileTypeFromExtension';
 
 import {sortTagsAlphabetically} from '../../common/sortTagsAlphabetically/sortTagsAlphabetically';
@@ -27,6 +33,8 @@ import {useCellsFilePreviewModal} from '../common/CellsFilePreviewModalContext/C
 // TODO: Abstract when it starts to grow / feels right
 export const CellsFilePreviewModal = () => {
   const {selectedFile, handleCloseFile, isEditMode} = useCellsFilePreviewModal();
+  const {isFeatureToggleEnabled} = useApplicationContext();
+  const selfUserDriveRole = useCellsSelfUserDriveRole();
   const isModalOpen = selectedFile !== null;
 
   if (!isModalOpen) {
@@ -50,6 +58,10 @@ export const CellsFilePreviewModal = () => {
   };
 
   const filePreviewUrl = getFileUrl();
+  const isDownloadRestricted = shouldRestrictCellsViewerActions({
+    isViewerPermissionFeatureEnabled: isFeatureToggleEnabled(viewerPermissionFeatureToggleName),
+    selfUserDriveRole,
+  });
 
   return (
     <FileFullscreenModal
@@ -65,6 +77,7 @@ export const CellsFilePreviewModal = () => {
       timestamp={uploadedAtTimestamp}
       badges={sortTagsAlphabetically(tags)}
       isEditMode={isEditMode}
+      isDownloadRestricted={isDownloadRestricted}
     />
   );
 };

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.test.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.test.tsx
@@ -26,7 +26,11 @@ jest.mock('Components/fullscreenModal/fullscreenModal', () => ({
 }));
 
 jest.mock('./FileHeader/FileHeader', () => ({
-  FileHeader: () => <div data-uie-name="file-header">Header</div>,
+  FileHeader: ({isDownloadRestricted}: {isDownloadRestricted?: boolean}) => (
+    <div data-uie-name="file-header" data-download-restricted={String(isDownloadRestricted === true)}>
+      Header
+    </div>
+  ),
 }));
 
 jest.mock('./FileEditor/FileEditor', () => {
@@ -56,7 +60,11 @@ jest.mock('./ImageFileView/ImageFileView', () => ({
 }));
 
 jest.mock('./NoPreviewAvailable/NoPreviewAvailable', () => ({
-  NoPreviewAvailable: () => <div data-uie-name="no-preview">No preview available</div>,
+  NoPreviewAvailable: ({isDownloadRestricted}: {isDownloadRestricted?: boolean}) => (
+    <div data-uie-name="no-preview" data-download-restricted={String(isDownloadRestricted === true)}>
+      No preview available
+    </div>
+  ),
 }));
 
 jest.mock('./PdfViewer/PdfViewer', () => ({
@@ -143,6 +151,15 @@ describe('FileFullscreenModal - File Version Restore', () => {
       expect(screen.getByTestId('pdf-viewer')).toBeInTheDocument();
     });
 
+    it('keeps rendering PDF preview when download is restricted', () => {
+      render(
+        <FileFullscreenModal {...defaultProps} filePreviewUrl="file.pdf" fileExtension="pdf" isDownloadRestricted />,
+      );
+
+      expect(screen.getByTestId('pdf-viewer')).toBeInTheDocument();
+      expect(screen.getByTestId('file-header')).toHaveAttribute('data-download-restricted', 'true');
+    });
+
     it('should render image viewer for image files', () => {
       render(<FileFullscreenModal {...defaultProps} filePreviewUrl="file.png" fileExtension="png" />);
 
@@ -159,6 +176,12 @@ describe('FileFullscreenModal - File Version Restore', () => {
       render(<FileFullscreenModal {...defaultProps} status="unavailable" />);
 
       expect(screen.getByTestId('no-preview')).toBeInTheDocument();
+    });
+
+    it('restricts download when preview is unavailable', () => {
+      render(<FileFullscreenModal {...defaultProps} status="unavailable" isDownloadRestricted />);
+
+      expect(screen.getByTestId('no-preview')).toHaveAttribute('data-download-restricted', 'true');
     });
 
     it('should show no preview when filePreviewUrl is missing', () => {

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.tsx
@@ -50,6 +50,7 @@ interface FileFullscreenModalProps {
   timestamp: number;
   badges?: string[];
   isEditMode?: boolean;
+  isDownloadRestricted?: boolean;
   checkIsInRecycleBin?: () => boolean;
 }
 
@@ -66,6 +67,7 @@ export const FileFullscreenModal = ({
   timestamp,
   badges,
   isEditMode = false,
+  isDownloadRestricted = false,
   checkIsInRecycleBin = isInRecycleBin,
 }: FileFullscreenModalProps) => {
   const notInRecycleBin = !checkIsInRecycleBin();
@@ -101,6 +103,7 @@ export const FileFullscreenModal = ({
         isEditable={isEditable}
         id={id}
         onFileContentRefresh={refreshModalContent}
+        isDownloadRestricted={isDownloadRestricted}
       />
       {isEditableState && isEditable ? (
         <FileEditor key={refreshKey} id={id} />
@@ -114,6 +117,7 @@ export const FileFullscreenModal = ({
           senderName={senderName}
           timestamp={timestamp}
           status={status}
+          isDownloadRestricted={isDownloadRestricted}
         />
       )}
     </FullscreenModal>
@@ -128,6 +132,7 @@ interface ModalContentProps {
   timestamp: number;
   filePreviewUrl?: string;
   fileUrl?: string;
+  isDownloadRestricted: boolean;
 }
 
 const ModalContent = ({
@@ -138,13 +143,21 @@ const ModalContent = ({
   senderName,
   timestamp,
   status,
+  isDownloadRestricted,
 }: ModalContentProps) => {
   if (status === 'loading' && (filePreviewUrl === undefined || filePreviewUrl.length === 0)) {
     return <FileLoader />;
   }
 
   if (status === 'unavailable' || filePreviewUrl === undefined || filePreviewUrl.length === 0) {
-    return <NoPreviewAvailable fileUrl={fileUrl} fileName={fileName} fileExtension={fileExtension} />;
+    return (
+      <NoPreviewAvailable
+        fileUrl={fileUrl}
+        fileName={fileName}
+        fileExtension={fileExtension}
+        isDownloadRestricted={isDownloadRestricted}
+      />
+    );
   }
 
   const extension = getFileExtensionFromUrl(filePreviewUrl);
@@ -164,5 +177,12 @@ const ModalContent = ({
     return <ImageFileView src={imageSrc} senderName={senderName} timestamp={timestamp} />;
   }
 
-  return <NoPreviewAvailable fileUrl={fileUrl} fileName={fileName} fileExtension={fileExtension} />;
+  return (
+    <NoPreviewAvailable
+      fileUrl={fileUrl}
+      fileName={fileName}
+      fileExtension={fileExtension}
+      isDownloadRestricted={isDownloadRestricted}
+    />
+  );
 };

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.test.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, screen} from '@testing-library/react';
+import {container} from 'tsyringe';
+
+import {ThemeProvider} from '@wireapp/react-ui-kit';
+
+import * as RelativeTimestamp from 'Hooks/useRelativeTimestamp';
+import * as FileHistoryModal from 'Components/Modals/FileHistoryModal/hooks/useFileHistoryModal';
+import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import * as RootProvider from 'src/script/page/rootProvider';
+
+import {FileHeader} from './FileHeader';
+
+const translate = (key: string) =>
+  ({
+    'cells.imageFullScreenModal.closeButton': 'Close',
+    'cells.imageFullScreenModal.downloadButton': 'Download',
+    'cells.options.label': 'More options',
+    'cells.options.versionHistory': 'Version History',
+  })[key] ?? key;
+
+const defaultProps = {
+  id: 'file-id',
+  onClose: jest.fn(),
+  fileName: 'document',
+  fileExtension: 'pdf',
+  fileUrl: 'https://example.com/document.pdf',
+  senderName: 'John Doe',
+  timestamp: 1700000000000,
+  onEditModeChange: jest.fn(),
+  onFileContentRefresh: jest.fn(),
+};
+
+describe('FileHeader', () => {
+  beforeEach(() => {
+    jest.spyOn(RootProvider, 'useApplicationContext').mockReturnValue({translate} as RootProvider.RootContextValue);
+    jest.spyOn(RelativeTimestamp, 'useRelativeTimestamp').mockReturnValue('now');
+    jest.spyOn(FileHistoryModal, 'useFileHistoryModal').mockReturnValue({showModal: jest.fn()});
+    container.registerInstance(CellsRepository, {} as CellsRepository);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    container.reset();
+  });
+
+  const renderHeader = (props: Partial<Parameters<typeof FileHeader>[0]> = {}) =>
+    render(
+      <ThemeProvider>
+        <FileHeader {...defaultProps} {...props} />
+      </ThemeProvider>,
+    );
+
+  it('hides download action when download is restricted', () => {
+    renderHeader({isDownloadRestricted: true});
+
+    expect(screen.queryByRole('button', {name: 'Download'})).not.toBeInTheDocument();
+  });
+
+  it('shows download action when download is allowed', () => {
+    renderHeader({isDownloadRestricted: false});
+
+    expect(screen.getByRole('button', {name: 'Download'})).toBeInTheDocument();
+  });
+});

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.test.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.test.tsx
@@ -20,12 +20,12 @@
 import {render, screen} from '@testing-library/react';
 import {container} from 'tsyringe';
 
-import {ThemeProvider} from '@wireapp/react-ui-kit';
-
-import * as RelativeTimestamp from 'Hooks/useRelativeTimestamp';
-import * as FileHistoryModal from 'Components/Modals/FileHistoryModal/hooks/useFileHistoryModal';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
-import * as RootProvider from 'src/script/page/rootProvider';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
 
 import {FileHeader} from './FileHeader';
 
@@ -49,25 +49,19 @@ const defaultProps = {
   onFileContentRefresh: jest.fn(),
 };
 
+const rootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
+
 describe('FileHeader', () => {
   beforeEach(() => {
-    jest.spyOn(RootProvider, 'useApplicationContext').mockReturnValue({translate} as RootProvider.RootContextValue);
-    jest.spyOn(RelativeTimestamp, 'useRelativeTimestamp').mockReturnValue('now');
-    jest.spyOn(FileHistoryModal, 'useFileHistoryModal').mockReturnValue({showModal: jest.fn()});
     container.registerInstance(CellsRepository, {} as CellsRepository);
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
     container.reset();
   });
 
   const renderHeader = (props: Partial<Parameters<typeof FileHeader>[0]> = {}) =>
-    render(
-      <ThemeProvider>
-        <FileHeader {...defaultProps} {...props} />
-      </ThemeProvider>,
-    );
+    render(withThemeAndRootContext(<FileHeader {...defaultProps} {...props} />, rootProviderWrapper));
 
   it('hides download action when download is restricted', () => {
     renderHeader({isDownloadRestricted: true});

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
@@ -66,6 +66,7 @@ interface FileHeaderProps {
   fileUrl?: string;
   isEditable?: boolean;
   isInEditMode?: boolean;
+  isDownloadRestricted?: boolean;
   onEditModeChange: (isEditable: boolean) => void;
   onFileContentRefresh: () => void;
 }
@@ -81,6 +82,7 @@ export const FileHeader = ({
   badges,
   isEditable,
   isInEditMode,
+  isDownloadRestricted = false,
   onEditModeChange,
   onFileContentRefresh,
 }: FileHeaderProps) => {
@@ -152,7 +154,7 @@ export const FileHeader = ({
         </div>
       )}
       <div css={actionButtonsStyles}>
-        {!isRecycleBin && (
+        {!isRecycleBin && !isDownloadRestricted && (
           <Button
             variant={ButtonVariant.TERTIARY}
             css={downloadButtonStyles}

--- a/apps/webapp/src/script/components/FileFullscreenModal/NoPreviewAvailable/NoPreviewAvailable.test.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/NoPreviewAvailable/NoPreviewAvailable.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, screen} from '@testing-library/react';
+
+import {ThemeProvider} from '@wireapp/react-ui-kit';
+
+import * as RootProvider from 'src/script/page/rootProvider';
+
+import {NoPreviewAvailable} from './NoPreviewAvailable';
+
+const translate = (key: string) =>
+  ({
+    'fileFullscreenModal.noPreviewAvailable.title': 'No preview available',
+    'fileFullscreenModal.noPreviewAvailable.description': 'Download this file to view it.',
+    'fileFullscreenModal.noPreviewAvailable.callToAction': 'Download',
+  })[key] ?? key;
+
+const defaultProps = {
+  fileExtension: 'zip',
+  fileName: 'archive',
+  fileUrl: 'https://example.com/archive.zip',
+};
+
+describe('NoPreviewAvailable', () => {
+  beforeEach(() => {
+    jest.spyOn(RootProvider, 'useApplicationContext').mockReturnValue({translate} as RootProvider.RootContextValue);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const renderPlaceholder = (isDownloadRestricted: boolean) =>
+    render(
+      <ThemeProvider>
+        <NoPreviewAvailable {...defaultProps} isDownloadRestricted={isDownloadRestricted} />
+      </ThemeProvider>,
+    );
+
+  it('hides download action when download is restricted', () => {
+    renderPlaceholder(true);
+
+    expect(screen.queryByRole('button', {name: 'Download'})).not.toBeInTheDocument();
+  });
+
+  it('shows download action when download is allowed', () => {
+    renderPlaceholder(false);
+
+    expect(screen.getByRole('button', {name: 'Download'})).toBeInTheDocument();
+  });
+});

--- a/apps/webapp/src/script/components/FileFullscreenModal/NoPreviewAvailable/NoPreviewAvailable.test.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/NoPreviewAvailable/NoPreviewAvailable.test.tsx
@@ -19,9 +19,11 @@
 
 import {render, screen} from '@testing-library/react';
 
-import {ThemeProvider} from '@wireapp/react-ui-kit';
-
-import * as RootProvider from 'src/script/page/rootProvider';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
 
 import {NoPreviewAvailable} from './NoPreviewAvailable';
 
@@ -38,20 +40,15 @@ const defaultProps = {
   fileUrl: 'https://example.com/archive.zip',
 };
 
+const rootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
+
 describe('NoPreviewAvailable', () => {
-  beforeEach(() => {
-    jest.spyOn(RootProvider, 'useApplicationContext').mockReturnValue({translate} as RootProvider.RootContextValue);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   const renderPlaceholder = (isDownloadRestricted: boolean) =>
     render(
-      <ThemeProvider>
-        <NoPreviewAvailable {...defaultProps} isDownloadRestricted={isDownloadRestricted} />
-      </ThemeProvider>,
+      withThemeAndRootContext(
+        <NoPreviewAvailable {...defaultProps} isDownloadRestricted={isDownloadRestricted} />,
+        rootProviderWrapper,
+      ),
     );
 
   it('hides download action when download is restricted', () => {

--- a/apps/webapp/src/script/components/FileFullscreenModal/NoPreviewAvailable/NoPreviewAvailable.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/NoPreviewAvailable/NoPreviewAvailable.tsx
@@ -28,9 +28,15 @@ interface NoPreviewAvailableProps {
   fileExtension: string;
   fileName: string;
   fileUrl?: string;
+  isDownloadRestricted?: boolean;
 }
 
-export const NoPreviewAvailable = ({fileUrl, fileName, fileExtension}: NoPreviewAvailableProps) => {
+export const NoPreviewAvailable = ({
+  fileUrl,
+  fileName,
+  fileExtension,
+  isDownloadRestricted = false,
+}: NoPreviewAvailableProps) => {
   const {translate} = useApplicationContext();
   const fileNameWithExtension = getFileNameWithExtension(fileName, fileExtension);
 
@@ -39,12 +45,14 @@ export const NoPreviewAvailable = ({fileUrl, fileName, fileExtension}: NoPreview
       title={translate('fileFullscreenModal.noPreviewAvailable.title')}
       description={translate('fileFullscreenModal.noPreviewAvailable.description')}
       callToAction={
-        <Button
-          onClick={() => forcedDownloadFile({url: fileUrl ?? '', name: fileNameWithExtension})}
-          disabled={fileUrl === undefined || fileUrl.length === 0}
-        >
-          {translate('fileFullscreenModal.noPreviewAvailable.callToAction')}
-        </Button>
+        !isDownloadRestricted && (
+          <Button
+            onClick={() => forcedDownloadFile({url: fileUrl ?? '', name: fileNameWithExtension})}
+            disabled={fileUrl === undefined || fileUrl.length === 0}
+          >
+            {translate('fileFullscreenModal.noPreviewAvailable.callToAction')}
+          </Button>
+        )
       }
     />
   );

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FileAssetOptions/FileAssetOptions.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FileAssetOptions/FileAssetOptions.test.tsx
@@ -20,8 +20,14 @@
 import type {ComponentProps} from 'react';
 
 import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-import {withTheme} from 'src/script/auth/util/test/testUtil';
+import {
+  CELLS_SELF_USER_DRIVE_ROLE,
+  CellsSelfUserDriveRoleProvider,
+} from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
+
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
@@ -30,16 +36,26 @@ import {isFileEditable} from 'Util/fileTypeUtil';
 
 import {FileAssetOptions} from './FileAssetOptions';
 
-const rootProviderWrapper = createRootProviderWrapperForTest(
-  createRootContextValueForTest({
-    translate: key => {
-      return key;
-    },
-  }),
-);
+const renderFileAssetOptions = (
+  properties: ComponentProps<typeof FileAssetOptions>,
+  {isViewerPermissionFeatureEnabled = false, isViewer = false} = {},
+) => {
+  const wrapper = createRootProviderWrapperForTest(
+    createRootContextValueForTest({
+      translate: key => key,
+      isFeatureToggleEnabled: () => isViewerPermissionFeatureEnabled,
+    }),
+  );
+  const role = isViewer ? CELLS_SELF_USER_DRIVE_ROLE.VIEWER : CELLS_SELF_USER_DRIVE_ROLE.EDITOR;
 
-const renderFileAssetOptions = (properties: ComponentProps<typeof FileAssetOptions>) => {
-  return render(withTheme(<FileAssetOptions {...properties} />), {wrapper: rootProviderWrapper});
+  return render(
+    withThemeAndRootContext(
+      <CellsSelfUserDriveRoleProvider selfUserDriveRole={role}>
+        <FileAssetOptions {...properties} />
+      </CellsSelfUserDriveRoleProvider>,
+      wrapper,
+    ),
+  );
 };
 
 describe('FileAssetOptions', () => {
@@ -60,6 +76,24 @@ describe('FileAssetOptions', () => {
     renderFileAssetOptions(defaultProps);
     const button = screen.getByLabelText('cells.options.label');
     expect(button).toBeInTheDocument();
+  });
+
+  it('hides download for a conversation viewer when viewer permissions are enabled', async () => {
+    const user = userEvent.setup();
+    renderFileAssetOptions(defaultProps, {isViewer: true, isViewerPermissionFeatureEnabled: true});
+
+    await user.click(screen.getByLabelText('cells.options.label'));
+
+    expect(screen.queryByText('cells.options.download')).not.toBeInTheDocument();
+  });
+
+  it('shows download when viewer permissions are disabled', async () => {
+    const user = userEvent.setup();
+    renderFileAssetOptions(defaultProps, {isViewer: true});
+
+    await user.click(screen.getByLabelText('cells.options.label'));
+
+    expect(screen.getByText('cells.options.download')).toBeInTheDocument();
   });
 
   describe('isFileEditable integration', () => {

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FileAssetOptions/FileAssetOptions.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FileAssetOptions/FileAssetOptions.tsx
@@ -19,7 +19,12 @@
 
 import {DropdownMenu, MoreIcon} from '@wireapp/react-ui-kit';
 
+import {
+  shouldRestrictCellsViewerActions,
+  useCellsSelfUserDriveRole,
+} from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
 import {useFileHistoryModal} from 'Components/Modals/FileHistoryModal/hooks/useFileHistoryModal';
+import {viewerPermissionFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {isFileEditable} from 'Util/fileTypeUtil';
 import {forcedDownloadFile, getFileNameWithExtension} from 'Util/util';
@@ -35,10 +40,15 @@ interface FileAssetOptionsProps {
 }
 
 export const FileAssetOptions = ({id, onOpen, src, name, extension}: FileAssetOptionsProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
+  const selfUserDriveRole = useCellsSelfUserDriveRole();
   const fileNameWithExtension = getFileNameWithExtension(name, extension);
   const isEditable = isFileEditable(extension);
   const {showModal} = useFileHistoryModal();
+  const isDownloadRestricted = shouldRestrictCellsViewerActions({
+    isViewerPermissionFeatureEnabled: isFeatureToggleEnabled(viewerPermissionFeatureToggleName),
+    selfUserDriveRole,
+  });
 
   return (
     <DropdownMenu>
@@ -57,7 +67,7 @@ export const FileAssetOptions = ({id, onOpen, src, name, extension}: FileAssetOp
             </DropdownMenu.Item>
           </>
         )}
-        {src !== undefined && src !== '' && (
+        {!isDownloadRestricted && src !== undefined && src !== '' && (
           <DropdownMenu.Item onClick={() => forcedDownloadFile({url: src, name: fileNameWithExtension})}>
             {translate('cells.options.download')}
           </DropdownMenu.Item>

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FilePreviewModal/FilePreviewModal.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FilePreviewModal/FilePreviewModal.test.tsx
@@ -8,26 +8,27 @@
  * (at your option) any later version.
  */
 
-import {render} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import {container} from 'tsyringe';
 
-import {FileFullscreenModal} from 'Components/FileFullscreenModal/FileFullscreenModal';
 import {
   CELLS_SELF_USER_DRIVE_ROLE,
   CellsSelfUserDriveRoleProvider,
 } from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
-import * as RootProvider from 'src/script/page/rootProvider';
+import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
 
 import {FilePreviewModal} from './FilePreviewModal';
 
-jest.mock('Components/FileFullscreenModal/FileFullscreenModal', () => ({
-  FileFullscreenModal: jest.fn(() => null),
-}));
-
 const defaultProps = {
   id: 'file-id',
-  fileUrl: 'https://example.com/file.pdf',
+  fileUrl: 'https://example.com/file.txt',
   fileName: 'file',
-  fileExtension: 'pdf',
+  fileExtension: 'txt',
   senderName: 'Sender',
   timestamp: 1700000000000,
   isOpen: true,
@@ -36,45 +37,44 @@ const defaultProps = {
   isError: false,
 };
 
-const mockedFileFullscreenModal = jest.mocked(FileFullscreenModal);
+const renderFilePreviewModal = ({isViewerPermissionFeatureEnabled}: {isViewerPermissionFeatureEnabled: boolean}) => {
+  const rootProviderWrapper = createRootProviderWrapperForTest(
+    createRootContextValueForTest({
+      isFeatureToggleEnabled: () => isViewerPermissionFeatureEnabled,
+      translate: key => key,
+    }),
+  );
+
+  return render(
+    withThemeAndRootContext(
+      <CellsSelfUserDriveRoleProvider selfUserDriveRole={CELLS_SELF_USER_DRIVE_ROLE.VIEWER}>
+        <FilePreviewModal {...defaultProps} />
+      </CellsSelfUserDriveRoleProvider>,
+      rootProviderWrapper,
+    ),
+  );
+};
 
 describe('FilePreviewModal', () => {
+  beforeEach(() => {
+    container.registerInstance(CellsRepository, {} as CellsRepository);
+  });
+
   afterEach(() => {
-    jest.restoreAllMocks();
-    mockedFileFullscreenModal.mockClear();
+    container.reset();
   });
 
-  it('restricts download for a conversation viewer when viewer permissions are enabled', () => {
-    jest.spyOn(RootProvider, 'useApplicationContext').mockReturnValue({
-      isFeatureToggleEnabled: jest.fn(() => true),
-    } as unknown as RootProvider.RootContextValue);
+  it('hides download for a conversation viewer when viewer permissions are enabled', async () => {
+    renderFilePreviewModal({isViewerPermissionFeatureEnabled: true});
 
-    render(
-      <CellsSelfUserDriveRoleProvider selfUserDriveRole={CELLS_SELF_USER_DRIVE_ROLE.VIEWER}>
-        <FilePreviewModal {...defaultProps} />
-      </CellsSelfUserDriveRoleProvider>,
-    );
+    await screen.findByRole('dialog');
 
-    expect(mockedFileFullscreenModal).toHaveBeenCalledWith(
-      expect.objectContaining({isDownloadRestricted: true}),
-      expect.anything(),
-    );
+    expect(screen.queryByRole('button', {name: 'cells.imageFullScreenModal.downloadButton'})).not.toBeInTheDocument();
   });
 
-  it('allows download when viewer permissions are disabled', () => {
-    jest.spyOn(RootProvider, 'useApplicationContext').mockReturnValue({
-      isFeatureToggleEnabled: jest.fn(() => false),
-    } as unknown as RootProvider.RootContextValue);
+  it('shows download when viewer permissions are disabled', async () => {
+    renderFilePreviewModal({isViewerPermissionFeatureEnabled: false});
 
-    render(
-      <CellsSelfUserDriveRoleProvider selfUserDriveRole={CELLS_SELF_USER_DRIVE_ROLE.VIEWER}>
-        <FilePreviewModal {...defaultProps} />
-      </CellsSelfUserDriveRoleProvider>,
-    );
-
-    expect(mockedFileFullscreenModal).toHaveBeenCalledWith(
-      expect.objectContaining({isDownloadRestricted: false}),
-      expect.anything(),
-    );
+    expect(await screen.findByRole('button', {name: 'cells.imageFullScreenModal.downloadButton'})).toBeInTheDocument();
   });
 });

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FilePreviewModal/FilePreviewModal.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FilePreviewModal/FilePreviewModal.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {render} from '@testing-library/react';
+
+import {FileFullscreenModal} from 'Components/FileFullscreenModal/FileFullscreenModal';
+import {
+  CELLS_SELF_USER_DRIVE_ROLE,
+  CellsSelfUserDriveRoleProvider,
+} from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
+import * as RootProvider from 'src/script/page/rootProvider';
+
+import {FilePreviewModal} from './FilePreviewModal';
+
+jest.mock('Components/FileFullscreenModal/FileFullscreenModal', () => ({
+  FileFullscreenModal: jest.fn(() => null),
+}));
+
+const defaultProps = {
+  id: 'file-id',
+  fileUrl: 'https://example.com/file.pdf',
+  fileName: 'file',
+  fileExtension: 'pdf',
+  senderName: 'Sender',
+  timestamp: 1700000000000,
+  isOpen: true,
+  onClose: jest.fn(),
+  isLoading: false,
+  isError: false,
+};
+
+const mockedFileFullscreenModal = jest.mocked(FileFullscreenModal);
+
+describe('FilePreviewModal', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockedFileFullscreenModal.mockClear();
+  });
+
+  it('restricts download for a conversation viewer when viewer permissions are enabled', () => {
+    jest.spyOn(RootProvider, 'useApplicationContext').mockReturnValue({
+      isFeatureToggleEnabled: jest.fn(() => true),
+    } as unknown as RootProvider.RootContextValue);
+
+    render(
+      <CellsSelfUserDriveRoleProvider selfUserDriveRole={CELLS_SELF_USER_DRIVE_ROLE.VIEWER}>
+        <FilePreviewModal {...defaultProps} />
+      </CellsSelfUserDriveRoleProvider>,
+    );
+
+    expect(mockedFileFullscreenModal).toHaveBeenCalledWith(
+      expect.objectContaining({isDownloadRestricted: true}),
+      expect.anything(),
+    );
+  });
+
+  it('allows download when viewer permissions are disabled', () => {
+    jest.spyOn(RootProvider, 'useApplicationContext').mockReturnValue({
+      isFeatureToggleEnabled: jest.fn(() => false),
+    } as unknown as RootProvider.RootContextValue);
+
+    render(
+      <CellsSelfUserDriveRoleProvider selfUserDriveRole={CELLS_SELF_USER_DRIVE_ROLE.VIEWER}>
+        <FilePreviewModal {...defaultProps} />
+      </CellsSelfUserDriveRoleProvider>,
+    );
+
+    expect(mockedFileFullscreenModal).toHaveBeenCalledWith(
+      expect.objectContaining({isDownloadRestricted: false}),
+      expect.anything(),
+    );
+  });
+});

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FilePreviewModal/FilePreviewModal.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FilePreviewModal/FilePreviewModal.tsx
@@ -17,7 +17,13 @@
  *
  */
 
+import {
+  shouldRestrictCellsViewerActions,
+  useCellsSelfUserDriveRole,
+} from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
 import {FileFullscreenModal} from 'Components/FileFullscreenModal/FileFullscreenModal';
+import {viewerPermissionFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {useApplicationContext} from 'src/script/page/rootProvider';
 
 interface FilePreviewModalProps {
   id: string;
@@ -50,6 +56,13 @@ export const FilePreviewModal = ({
   isError,
   isEditMode,
 }: FilePreviewModalProps) => {
+  const {isFeatureToggleEnabled} = useApplicationContext();
+  const selfUserDriveRole = useCellsSelfUserDriveRole();
+  const isDownloadRestricted = shouldRestrictCellsViewerActions({
+    isViewerPermissionFeatureEnabled: isFeatureToggleEnabled(viewerPermissionFeatureToggleName),
+    selfUserDriveRole,
+  });
+
   const getFileUrl = () => {
     if (fileExtension === 'pdf') {
       return fileUrl;
@@ -83,6 +96,7 @@ export const FilePreviewModal = ({
       onClose={onClose}
       status={getStatus()}
       isEditMode={isEditMode}
+      isDownloadRestricted={isDownloadRestricted}
     />
   );
 };


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27979" title="WPB-27979" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27979</a>  [web][ui] Hide pdf download button for guests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Hide download controls for conversation viewers across Shared Drive previews, message attachment previews, fallback views, and file option menus while the viewer-permission feature is enabled. Keep preview behavior and editor access unchanged.

ref: https://wearezeta.atlassian.net/browse/WPB-27979

### Demo


https://github.com/user-attachments/assets/9a394ec5-2034-4c93-bed1-301675829477




