### PR TITLE
Show meeting end time for on-going and completed meetings [WPB-27861]

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -1312,6 +1312,8 @@
   "meetings.meetNowModal.error.createFailedTitle": "Could not start meeting",
   "meetings.meetNowModal.startMeeting": "Start Meeting",
   "meetings.meetNowModal.title": "Meet now",
+  "meetings.meetingStatus.endedAt": "Ended at {time}",
+  "meetings.meetingStatus.endsAt": "Ends at {time}",
   "meetings.meetingStatus.participating": "Attending",
   "meetings.meetingStatus.startedAt": "Started at {time}",
   "meetings.navigation.label": "Meetings",

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingList.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingList.test.tsx
@@ -184,6 +184,7 @@ describe('MeetingList', () => {
     expect(screen.getByRole('heading', {name: /meetings\.list\.today/})).toBeInTheDocument();
     expect(screen.queryByRole('list')).not.toBeInTheDocument();
     expect(document.querySelectorAll('[data-uie-name="item-meeting"]')).toHaveLength(2);
+    expect(screen.getByText(/meetings\.meetingStatus\.startedAt.*meetings\.meetingStatus\.endsAt/)).toBeInTheDocument();
   });
 
   it('renders completed meetings in the today section until local midnight', () => {
@@ -211,6 +212,9 @@ describe('MeetingList', () => {
     expect(screen.getByRole('heading', {name: /meetings\.list\.today/})).toBeInTheDocument();
     expect(screen.getByText('Completed meeting')).toBeInTheDocument();
     expect(screen.getByText('Upcoming meeting')).toBeInTheDocument();
+    expect(
+      screen.getByText(/meetings\.meetingStatus\.startedAt.*meetings\.meetingStatus\.endedAt/),
+    ).toBeInTheDocument();
   });
 
   it('renders the next meeting even when it is more than one year away', () => {

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingListItem.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingListItem.tsx
@@ -86,12 +86,20 @@ const MeetingListItemComponent = ({
       const month = formatLocale(start, 'MMMM');
       const day = formatLocale(start, 'd');
       const startedAtTime = formatLocale(start, 'h:mm a');
-      return `${dayOfWeek}, ${month} ${day} • ${translate('meetings.meetingStatus.startedAt', {time: startedAtTime})}`;
+      const endedAtTime = formatLocale(end, 'h:mm a');
+      return `${dayOfWeek}, ${month} ${day} • ${translate('meetings.meetingStatus.startedAt', {time: startedAtTime})} • ${translate(
+        'meetings.meetingStatus.endedAt',
+        {time: endedAtTime},
+      )}`;
     }
 
     if (temporalStatus === MeetingTemporalStatuses.ON_GOING) {
       const startedAtTime = formatLocale(start, 'h:mm a');
-      return translate('meetings.meetingStatus.startedAt', {time: startedAtTime});
+      const endsAtTime = formatLocale(end, 'h:mm a');
+      return `${translate('meetings.meetingStatus.startedAt', {time: startedAtTime})} • ${translate(
+        'meetings.meetingStatus.endsAt',
+        {time: endsAtTime},
+      )}`;
     }
 
     const sameMeridiem = formatLocale(start, 'a') === formatLocale(end, 'a');


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27861" title="WPB-27861" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27861</a>  Meeting end time disappears from the Meetings list after the meeting starts/completed meeting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
