### PR TITLE
On edit meeting recurrence attirbute should not be sent if it is undefined [WPB-27887]

### DIFF
--- a/apps/webapp/src/script/components/meeting/mapUpdateCommandToUpdateMeeting.test.ts
+++ b/apps/webapp/src/script/components/meeting/mapUpdateCommandToUpdateMeeting.test.ts
@@ -98,7 +98,7 @@ describe('mapUpdateCommandToUpdateMeeting', () => {
     });
   });
 
-  it('clears recurrence when changed to doesNotRepeat', () => {
+  it('omits recurrence when changed to doesNotRepeat', () => {
     expect(
       mapUpdateCommandToUpdateMeeting(
         baseUpdateCommand({
@@ -110,7 +110,6 @@ describe('mapUpdateCommandToUpdateMeeting', () => {
       title: 'Weekly sync',
       start_time: futureStartIso,
       end_time: futureEndIso,
-      recurrence: null,
     });
   });
 });

--- a/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingRecurrence.ts
+++ b/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingRecurrence.ts
@@ -57,7 +57,7 @@ export const buildUpdateMeetingRecurrence = (
 
   const mappedRecurrence = mapRecurrenceOptionToMeetingRecurrence(recurrence);
 
-  return mappedRecurrence === undefined ? {recurrence: null} : {recurrence: mappedRecurrence};
+  return mappedRecurrence === undefined ? {} : {recurrence: mappedRecurrence};
 };
 
 export const mapRecurrenceOptionToMeetingRecurrence = (


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27887" title="WPB-27887" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27887</a>  [Web] Meeting host cannot change a recurring meeting back to Does not repeat
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
