### PR TITLE
Update the color of "Open in a new window" icon in dark theme [WPB-27893]

### DIFF
--- a/apps/webapp/src/script/components/calling/CallingCell/CallingHeader/CallingHeader.styles.ts
+++ b/apps/webapp/src/script/components/calling/CallingCell/CallingHeader/CallingHeader.styles.ts
@@ -79,10 +79,14 @@ export const detachedWindowButton: CSSObject = {
   padding: '8px 12px',
 
   '& svg': {
-    fill: 'var(--text-color)',
+    fill: 'currentColor',
   },
 
   '& svg path': {
-    fill: 'var(--text-color)',
+    fill: 'currentColor',
+  },
+
+  '&:hover, &:focus-visible, &:active': {
+    color: 'var(--accent-color)',
   },
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27893" title="WPB-27893" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27893</a>  User cannot see the "Open in a new window" icon in a call in Dark theme because it is displayed in black
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
