### PR TITLE
Disable infinite retries on Meetings API requests [WPB-27437]

### DIFF
--- a/libraries/api-client/src/meetings/meetingsApi.test.ts
+++ b/libraries/api-client/src/meetings/meetingsApi.test.ts
@@ -208,11 +208,7 @@ describe('MeetingsAPI', () => {
         meetings.deleteMeeting({id: 'meeting-id', domain: 'example.com'}),
       undefined,
     ],
-    [
-      'getMeetingsList',
-      async (meetings: APIClient['api']['meetings']) => meetings.getMeetingsList(),
-      [validMeeting],
-    ],
+    ['getMeetingsList', async (meetings: APIClient['api']['meetings']) => meetings.getMeetingsList(), [validMeeting]],
     [
       'getMeeting',
       async (meetings: APIClient['api']['meetings']) => meetings.getMeeting({id: 'meeting-id', domain: 'example.com'}),
@@ -226,9 +222,7 @@ describe('MeetingsAPI', () => {
 
     await client.useVersion(MINIMUM_API_VERSION, 16);
 
-    const sendJSONSpy = jest
-      .spyOn(client.transport.http, 'sendJSON')
-      .mockResolvedValue({data: responseData} as never);
+    const sendJSONSpy = jest.spyOn(client.transport.http, 'sendJSON').mockResolvedValue({data: responseData} as never);
 
     await callMeetingsApi(client.api.meetings);
 

--- a/libraries/api-client/src/meetings/meetingsApi.test.ts
+++ b/libraries/api-client/src/meetings/meetingsApi.test.ts
@@ -184,4 +184,58 @@ describe('MeetingsAPI', () => {
       }),
     );
   });
+
+  it.each([
+    [
+      'createMeeting',
+      async (meetings: APIClient['api']['meetings']) =>
+        meetings.createMeeting({
+          title: validMeeting.title,
+          start_time: validMeeting.start_time,
+          end_time: validMeeting.end_time,
+        }),
+      validMeetingWithConversation,
+    ],
+    [
+      'updateMeeting',
+      async (meetings: APIClient['api']['meetings']) =>
+        meetings.updateMeeting({id: 'meeting-id', domain: 'example.com'}, {title: 'Updated title'}),
+      validMeetingWithConversation,
+    ],
+    [
+      'deleteMeeting',
+      async (meetings: APIClient['api']['meetings']) =>
+        meetings.deleteMeeting({id: 'meeting-id', domain: 'example.com'}),
+      undefined,
+    ],
+    [
+      'getMeetingsList',
+      async (meetings: APIClient['api']['meetings']) => meetings.getMeetingsList(),
+      [validMeeting],
+    ],
+    [
+      'getMeeting',
+      async (meetings: APIClient['api']['meetings']) => meetings.getMeeting({id: 'meeting-id', domain: 'example.com'}),
+      validMeeting,
+    ],
+  ] as const)('disables infinite network retries for %s', async (_name, callMeetingsApi, responseData) => {
+    const client = new APIClient(testConfig);
+    jest.spyOn(client.transport.http, 'sendRequest').mockResolvedValue({
+      data: {supported: [MINIMUM_API_VERSION, 16], domain: 'test.zinfra.io'},
+    } as never);
+
+    await client.useVersion(MINIMUM_API_VERSION, 16);
+
+    const sendJSONSpy = jest
+      .spyOn(client.transport.http, 'sendJSON')
+      .mockResolvedValue({data: responseData} as never);
+
+    await callMeetingsApi(client.api.meetings);
+
+    expect(sendJSONSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'axios-retry': {retries: 0},
+      }),
+    );
+  });
 });

--- a/libraries/api-client/src/meetings/meetingsApi.ts
+++ b/libraries/api-client/src/meetings/meetingsApi.ts
@@ -27,6 +27,13 @@ import {UpdateMeeting} from './updateMeeting';
 import {HttpClient} from '../http';
 import {QualifiedId} from '../user/qualifiedId';
 
+const disableInfiniteNetworkRetries = {
+  // Disable infinite retries so offline Meetings actions fail promptly into existing error UI.
+  'axios-retry': {
+    retries: 0,
+  },
+} as const;
+
 export class MeetingsAPI {
   constructor(private readonly client: HttpClient) {}
 
@@ -59,6 +66,7 @@ export class MeetingsAPI {
       data: newMeeting,
       method: 'post',
       url: MeetingsAPI.URL.MEETINGS,
+      ...disableInfiniteNetworkRetries,
     };
 
     const response = await this.client.sendJSON<MeetingWithConversation>(config);
@@ -73,6 +81,7 @@ export class MeetingsAPI {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: MeetingsAPI.URL.LIST,
+      ...disableInfiniteNetworkRetries,
     };
 
     const response = await this.client.sendJSON<Meeting[]>(config);
@@ -86,6 +95,7 @@ export class MeetingsAPI {
     const config: AxiosRequestConfig = {
       method: 'delete',
       url: this.generateMeetingUrl(meetingId),
+      ...disableInfiniteNetworkRetries,
     };
 
     await this.client.sendJSON<void>(config);
@@ -98,6 +108,7 @@ export class MeetingsAPI {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: this.generateMeetingUrl(meetingId),
+      ...disableInfiniteNetworkRetries,
     };
 
     const response = await this.client.sendJSON<Meeting>(config);
@@ -112,6 +123,7 @@ export class MeetingsAPI {
       data: updateMeeting,
       method: 'put',
       url: this.generateMeetingUrl(meetingId),
+      ...disableInfiniteNetworkRetries,
     };
 
     const response = await this.client.sendJSON<MeetingWithConversation>(config);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27437" title="WPB-27437" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-27437</a>  [Web] Handle network/connection errors in Meetings with retry
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Stop Meetings API calls from inheriting HttpClient’s infinite network retries so offline Schedule / Meet Now / update / delete / list fail into the existing error UI promptly.

## Test plan
- [x] Go offline, schedule a meeting — error modal appears within seconds, not after ~10 minutes
- [x] Same for Meet Now
- [x] Retry after reconnect succeeds