### PR TITLE
Remove local Meetings developer toggle [WPB-27846]

### DIFF
--- a/apps/webapp/src/script/components/appContainer/appContainer.tsx
+++ b/apps/webapp/src/script/components/appContainer/appContainer.tsx
@@ -207,7 +207,6 @@ export const AppContainer = (properties: AppProps) => {
             <MeetingStoreRoot>
               <AppMain
                 app={app}
-                isFeatureToggleEnabled={isFeatureToggleEnabled}
                 selfUser={selfUser}
                 mainView={mainView}
                 locked={softLockEnabled}

--- a/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.test.tsx
@@ -103,7 +103,6 @@ const renderMeetingStoreRoot = ({
       translate: translateForTest,
       wallClock: createDeterministicWallClock(),
       mainViewModel,
-      isFeatureToggleEnabled: () => true,
     }),
   );
 

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -18,13 +18,11 @@
  */
 
 export const applockRefactoredFeatureToggleName = 'applock-refactored';
-export const meetingsFeatureToggleName = 'meetings';
 export const conversationListCollapseFeatureToggleName = 'conversation-list-collapse';
 export const viewerPermissionFeatureToggleName = 'viewer-permission';
 
 export const startupFeatureToggleNames = [
   applockRefactoredFeatureToggleName,
-  meetingsFeatureToggleName,
   conversationListCollapseFeatureToggleName,
   viewerPermissionFeatureToggleName,
 ] as const;

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {applockRefactoredFeatureToggleName, meetingsFeatureToggleName} from './startupFeatureToggleNames';
+import {applockRefactoredFeatureToggleName, conversationListCollapseFeatureToggleName} from './startupFeatureToggleNames';
 import {startupFeatureToggleQueryParameterName} from './startupFeatureToggles';
 import {updateLocationSearchForStartupFeatureToggle} from './startupFeatureToggleQueryParameters';
 
@@ -36,23 +36,25 @@ describe('updateLocationSearchForStartupFeatureToggle', () => {
 
   it('removes a feature toggle and preserves other enabled toggles', () => {
     const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
-      locationSearch: `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName},${meetingsFeatureToggleName}`,
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName},${conversationListCollapseFeatureToggleName}`,
       featureToggleName: applockRefactoredFeatureToggleName,
       shouldEnableFeatureToggle: false,
     });
 
-    expect(updatedLocationSearch).toBe(`?${startupFeatureToggleQueryParameterName}=${meetingsFeatureToggleName}`);
+    expect(updatedLocationSearch).toBe(
+      `?${startupFeatureToggleQueryParameterName}=${conversationListCollapseFeatureToggleName}`,
+    );
   });
 
   it('adds a startup feature toggle while preserving other enabled toggles', () => {
     const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
-      locationSearch: `?${startupFeatureToggleQueryParameterName}=${meetingsFeatureToggleName}`,
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=${conversationListCollapseFeatureToggleName}`,
       featureToggleName: applockRefactoredFeatureToggleName,
       shouldEnableFeatureToggle: true,
     });
 
     expect(updatedLocationSearch).toBe(
-      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}%2C${meetingsFeatureToggleName}`,
+      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}%2C${conversationListCollapseFeatureToggleName}`,
     );
   });
 

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
@@ -17,7 +17,10 @@
  *
  */
 
-import {applockRefactoredFeatureToggleName, conversationListCollapseFeatureToggleName} from './startupFeatureToggleNames';
+import {
+  applockRefactoredFeatureToggleName,
+  conversationListCollapseFeatureToggleName,
+} from './startupFeatureToggleNames';
 import {startupFeatureToggleQueryParameterName} from './startupFeatureToggles';
 import {updateLocationSearchForStartupFeatureToggle} from './startupFeatureToggleQueryParameters';
 

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -25,14 +25,12 @@ import {
 import {
   applockRefactoredFeatureToggleName,
   conversationListCollapseFeatureToggleName,
-  meetingsFeatureToggleName,
   startupFeatureToggleNames,
   viewerPermissionFeatureToggleName,
 } from './startupFeatureToggleNames';
 
 const featureToggleNamesWithDedicatedExistenceTests = [
   applockRefactoredFeatureToggleName,
-  meetingsFeatureToggleName,
   conversationListCollapseFeatureToggleName,
   viewerPermissionFeatureToggleName,
 ] as const;
@@ -70,6 +68,14 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([]);
   });
 
+  it('does not treat meetings as a startup feature toggle', () => {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=meetings`,
+    );
+
+    expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([]);
+  });
+
   it('keeps only whitelisted feature toggles when known and unknown values are mixed', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=unknown-feature,${applockRefactoredFeatureToggleName}`,
@@ -85,14 +91,6 @@ describe('startupFeatureToggles', function () {
     );
 
     expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(true);
-  });
-
-  it('enables the meetings feature toggle when present in the query parameter', () => {
-    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
-      `?${startupFeatureToggleQueryParameterName}=${meetingsFeatureToggleName}`,
-    );
-
-    expect(startupFeatureToggles.isFeatureToggleEnabled(meetingsFeatureToggleName)).toBe(true);
   });
 
   it('enables the conversation list collapse feature toggle when present in the query parameter', () => {
@@ -150,7 +148,6 @@ describe('startupFeatureToggles', function () {
   it('contains only whitelisted values in allowedStartupFeatureToggleNames', () => {
     expect(allowedStartupFeatureToggleNames).toEqual([
       applockRefactoredFeatureToggleName,
-      meetingsFeatureToggleName,
       conversationListCollapseFeatureToggleName,
       viewerPermissionFeatureToggleName,
     ]);

--- a/apps/webapp/src/script/page/appMain.tsx
+++ b/apps/webapp/src/script/page/appMain.tsx
@@ -67,8 +67,6 @@ import {PanelEntity, PanelState, RightSidebar} from './rightSidebar';
 import {useAppMainState, ViewType} from './state';
 import {ContentState, useAppState} from './useAppState';
 
-import {meetingsFeatureToggleName} from '../featureToggles/startupFeatureToggleNames';
-import {StartupFeatureToggleName} from '../featureToggles/startupFeatureToggles';
 import {App} from '../main/app';
 import {initialiseMLSMigrationFlow} from '../mls/MLSMigration';
 import {generateConversationUrl} from '../router/routeGenerator';
@@ -85,7 +83,6 @@ export type RightSidebarParams = {
 type AppMainProps = {
   readonly app: App;
   readonly fireAndForgetInvoker: FireAndForgetInvoker;
-  readonly isFeatureToggleEnabled: (featureName: StartupFeatureToggleName) => boolean;
   readonly selfUser: User;
   readonly mainView: MainViewModel;
   readonly conversationState?: ConversationState;
@@ -99,7 +96,6 @@ export const AppMain = (properties: AppMainProps) => {
   const {
     app,
     fireAndForgetInvoker,
-    isFeatureToggleEnabled,
     mainView,
     selfUser,
     conversationState = container.resolve(ConversationState),
@@ -259,10 +255,7 @@ export const AppMain = (properties: AppMainProps) => {
       '/preferences/av': () => mainView.list.openPreferencesAudioVideo(),
       '/preferences/devices': () => mainView.list.openPreferencesDevices(),
       '/preferences/options': () => mainView.list.openPreferencesOptions(),
-      '/meetings': () =>
-        teamState.isMeetingsEnabled() && isFeatureToggleEnabled(meetingsFeatureToggleName)
-          ? mainView.list.openMeetingsList()
-          : navigate('/'),
+      '/meetings': () => (teamState.isMeetingsEnabled() ? mainView.list.openMeetingsList() : navigate('/')),
       '/user/:userId/:domain': showUserProfile,
       '/user/:domain/:userId': showUserProfile,
       '/user/:userId': showUserProfile,

--- a/apps/webapp/src/script/util/useMeetingsFeatureFlag.ts
+++ b/apps/webapp/src/script/util/useMeetingsFeatureFlag.ts
@@ -19,17 +19,12 @@
 
 import {container} from 'tsyringe';
 
-import {meetingsFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
-import {useApplicationContext} from 'src/script/page/rootProvider';
 import {TeamState} from 'src/script/repositories/team/TeamState';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 
 export const useMeetingsFeatureFlag = () => {
-  const {isFeatureToggleEnabled} = useApplicationContext();
   const teamState = container.resolve(TeamState);
-  const {isMeetingsEnabled: isMeetingsEnabledForTeam} = useKoSubscribableChildren(teamState, ['isMeetingsEnabled']);
-
-  const isMeetingsEnabled = isMeetingsEnabledForTeam && isFeatureToggleEnabled(meetingsFeatureToggleName);
+  const {isMeetingsEnabled} = useKoSubscribableChildren(teamState, ['isMeetingsEnabled']);
 
   return {isMeetingsEnabled};
 };

--- a/apps/webapp/test/e2e_tests/utils/meetings.util.ts
+++ b/apps/webapp/test/e2e_tests/utils/meetings.util.ts
@@ -20,17 +20,13 @@ import type {Page} from '@playwright/test';
 
 import type {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
-import {expect, LOGIN_TIMEOUT, type Team} from 'test/e2e_tests/test.fixtures';
+import {LOGIN_TIMEOUT, type Team} from 'test/e2e_tests/test.fixtures';
 
 export const loginWithMeetingsEnabled = (user: Pick<User, 'email' | 'password'>) => async (page: Page) => {
   const pageManager = PageManager.from(page);
   const {pages, components} = pageManager.webapp;
   await pageManager.openLoginPage();
   await pages.login().login(user);
-  await components.conversationSidebar().sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
-  const clientUrl = new URL('/?enabled-features=meetings#/clients', page.url());
-  await page.goto(clientUrl.href, {waitUntil: 'domcontentloaded'});
-  await expect.poll(() => new URL(page.url()).searchParams.get('enabled-features')).toBe('meetings');
   await components.conversationSidebar().sidebar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
 };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27846" title="WPB-27846" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27846</a>  [webapp] Remove local Meetings feature toggle for M1 rollout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Gate Meetings only on the backend team `meetings` feature flag
- Remove the local Ctrl+Shift+2 / `enabled-features=meetings` developer toggle from webapp and e2e login

## Test plan
- [x] With the team `meetings` flag enabled, Meetings is available after login without Ctrl+Shift+2
- [x] With the team `meetings` flag disabled, Meetings stays hidden
- [x] Ctrl+Shift+2 no longer shows a Meetings toggle