### PR TITLE
Show apostrophes in meeting notification titles [WPB-28018]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingNotificationCard/meetingNotificationCard.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationCard/meetingNotificationCard.test.tsx
@@ -194,9 +194,7 @@ describe('MeetingNotificationCard', () => {
 
   it('renders an apostrophe in the meeting title instead of an HTML entity', () => {
     setStrings({en});
-    const productionTranslateWrapper = createRootProviderWrapperForTest(
-      createRootContextValueForTest({translate}),
-    );
+    const productionTranslateWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
 
     render(
       <ThemeProvider>

--- a/apps/webapp/src/script/components/meeting/meetingNotificationCard/meetingNotificationCard.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationCard/meetingNotificationCard.test.tsx
@@ -20,13 +20,14 @@ import {fireEvent, render, screen} from '@testing-library/react';
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import {ThemeProvider} from '@wireapp/react-ui-kit';
 
+import en from 'I18n/en-US.json';
 import {MeetingNotificationCard} from './meetingNotificationCard';
 import {
   type MeetingNotification,
   MeetingNotificationKind,
 } from 'Components/meeting/meetingNotificationStore/meetingNotificationStore';
 import {formatLocale} from 'Util/timeUtil';
-import type {Translate} from 'Util/localizerUtil';
+import {setStrings, translate, type Translate} from 'Util/localizerUtil';
 import type {ReactElement} from 'react';
 import {
   createRootContextValueForTest,
@@ -189,5 +190,31 @@ describe('MeetingNotificationCard', () => {
     );
 
     expect(screen.getByRole('listitem')).toHaveTextContent(`creator-id • ${formatLocale(meetingStartTime, 'PP, p')}`);
+  });
+
+  it('renders an apostrophe in the meeting title instead of an HTML entity', () => {
+    setStrings({en});
+    const productionTranslateWrapper = createRootProviderWrapperForTest(
+      createRootContextValueForTest({translate}),
+    );
+
+    render(
+      <ThemeProvider>
+        <MeetingNotificationCard
+          id="notification-invite"
+          kind={MeetingNotificationKind.INVITE}
+          meetingTitle="Cleopatra's meeting"
+          qualifiedId={qualifiedId}
+          qualifiedCreator={qualifiedCreator}
+          meetingStartTime={meetingStartTime}
+          onDismiss={jest.fn()}
+        />
+      </ThemeProvider>,
+      {wrapper: productionTranslateWrapper},
+    );
+
+    const card = screen.getByRole('listitem');
+    expect(card).toHaveTextContent("Invitation: Cleopatra's meeting");
+    expect(card).not.toHaveTextContent('&#x27;');
   });
 });

--- a/apps/webapp/src/script/components/meeting/meetingNotificationCard/meetingNotificationCard.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationCard/meetingNotificationCard.tsx
@@ -120,7 +120,12 @@ export const MeetingNotificationCard = (notification: MeetingNotificationCardPro
   return (
     <div css={meetingNotificationCardContainerStyles} role="listitem" data-uie-name={`meeting-notification-card-${id}`}>
       <div css={meetingNotificationCardTitleStyles}>
-        {translate('meetings.notifications.title', {label: translate(notificationLabels[kind]), meetingTitle})}
+        {translate(
+          'meetings.notifications.title',
+          {label: translate(notificationLabels[kind]), meetingTitle},
+          undefined,
+          true,
+        )}
       </div>
       <div css={meetingNotificationCardMetadataStyles}>
         <MeetingNotificationMetadata notification={notification} translate={translate} />


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28018" title="WPB-28018" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28018</a>  Meeting invitation notification displays apostrophe as HTML entity in the meeting title
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Meeting invitation notifications showed apostrophes in titles as `&#x27;` because `translate()` HTML-escapes interpolations that this card then renders as React text.
- Skip escaping for the notification title so titles like "Cleopatra's meeting" display normally.

## Test plan
- [x] Schedule a meeting whose title contains an apostrophe (for example Cleopatra's meeting).
- [x] Open the invitee's Meetings notifications and confirm the title shows a normal apostrophe, not `&#x27;`.