### PR TITLE
Show Meet now meetings in the list immediately [WPB-28019]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingStore/createMeetingStore.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/createMeetingStore.test.ts
@@ -249,6 +249,38 @@ describe('createMeetingStore', () => {
     expect(store.getState().meetingSeries).toEqual([expect.objectContaining(meetingSeriesEntry)]);
   });
 
+  it('syncs a newly created Meet now meeting into the store without reloading the meetings list', async () => {
+    const meetNowMeeting = jest.fn().mockReturnValue(
+      task.resolve({
+        failedToAdd: [],
+        qualifiedConversation: apiMeeting.qualified_conversation,
+        qualifiedMeetingId: apiMeeting.qualified_id,
+      }),
+    );
+    const getMeetingsList = jest.fn().mockReturnValue(task.resolve([apiMeeting]));
+    const getMeeting = jest.fn().mockReturnValue(task.resolve(apiMeeting));
+    const store = createMeetingStore(
+      createDeps({getMeetingsList, getMeeting, serviceTasks: createServiceTasks({meetNowMeeting})}),
+    );
+    const meetNowCommand = {
+      title: 'Standup',
+      selectedUsers: [],
+    };
+
+    const result = await store.getState().meetNowMeeting(meetNowCommand);
+
+    expect(unwrap(result)).toEqual({
+      failedToAdd: [],
+      qualifiedConversation: apiMeeting.qualified_conversation,
+      qualifiedMeetingId: apiMeeting.qualified_id,
+    });
+    expect(meetNowMeeting).toHaveBeenCalledTimes(1);
+    expect(meetNowMeeting).toHaveBeenCalledWith(meetNowCommand);
+    expect(getMeeting).toHaveBeenCalledWith(apiMeeting.qualified_id);
+    expect(getMeetingsList).not.toHaveBeenCalled();
+    expect(store.getState().meetingSeries).toEqual([expect.objectContaining(meetingSeriesEntry)]);
+  });
+
   it('loads meeting data for edit via safeGetConversationById', async () => {
     const conversation = new Conversation(
       'conversation-id',

--- a/apps/webapp/src/script/components/meeting/meetingStore/createMeetingStore.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/createMeetingStore.ts
@@ -135,7 +135,13 @@ export const createMeetingStore = (deps: MeetingStoreDeps, initialState?: Meetin
           .map(() => ({failedToAdd: result.failedToAdd}))
           .orElse(() => task.resolve({failedToAdd: result.failedToAdd})),
       ),
-    meetNowMeeting: deps.serviceTasks.meetNowMeeting,
+    meetNowMeeting: command =>
+      deps.serviceTasks.meetNowMeeting(command).andThen(result =>
+        get()
+          .syncMeetingByQualifiedId(result.qualifiedMeetingId)
+          .map(() => result)
+          .orElse(() => task.resolve(result)),
+      ),
     updateMeeting: command =>
       deps.serviceTasks.updateMeeting(command).andThen(result =>
         get()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28019" title="WPB-28019" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28019</a>  Meeting host cannot see a Meet now meeting in the Meetings list immediately after starting the call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Sync a newly created Meet now meeting into the store so it appears in the Meetings list without leaving the page.

## Test plan
- [x] Open the Meetings page, create a Meet now meeting, and start the call.
- [x] Confirm the meeting appears in the list while the call is still active.