### PR TITLE
Keep meeting creation modals open when clicking outside [WPB-28020]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetNowModal/meetNowModal.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetNowModal/meetNowModal.test.tsx
@@ -254,6 +254,30 @@ describe('MeetNowModal', () => {
     expect(useMeetNowModal.getState().isOpen).toBe(false);
   });
 
+  it('stays open when the overlay is clicked', () => {
+    renderMeetNowModal();
+
+    act(() => {
+      useMeetNowModal.getState().open();
+    });
+
+    fireEvent.click(getModalOverlay());
+
+    expect(useMeetNowModal.getState().isOpen).toBe(true);
+  });
+
+  it('closes when the close button is clicked', () => {
+    renderMeetNowModal();
+
+    act(() => {
+      useMeetNowModal.getState().open();
+    });
+
+    fireEvent.click(screen.getByRole('button', {name: 'meetings.meetNowModal.closeAriaLabel'}));
+
+    expect(useMeetNowModal.getState().isOpen).toBe(false);
+  });
+
   it('does not dismiss the modal while submission is pending', async () => {
     const {fireAndForgetInvoker, resolveMeetNowMeeting} = renderMeetNowModal();
 

--- a/apps/webapp/src/script/components/meeting/meetNowModal/meetNowModal.tsx
+++ b/apps/webapp/src/script/components/meeting/meetNowModal/meetNowModal.tsx
@@ -103,7 +103,6 @@ export const MeetNowModal = () => {
       wrapperCSS={{...modalWrapperStyles, ...meetNowModalWrapperStyles}}
       isShown={isOpen}
       onClosed={handleClose}
-      onBgClick={handleClose}
       onKeyDown={event => handleEscDown(event, handleClose)}
     >
       <div css={wrapperStyles}>

--- a/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingModal.test.tsx
+++ b/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingModal.test.tsx
@@ -148,6 +148,22 @@ describe('ScheduleMeetingModal', () => {
     expect(useScheduleMeetingModal.getState().isOpen).toBe(false);
   });
 
+  it('stays open when the overlay is clicked', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('dialog'));
+
+    expect(useScheduleMeetingModal.getState().isOpen).toBe(true);
+  });
+
+  it('closes when the close button is clicked', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', {name: 'meetings.scheduleModal.closeAriaLabel'}));
+
+    expect(useScheduleMeetingModal.getState().isOpen).toBe(false);
+  });
+
   it('stays open when Escape is pressed while submission is pending', async () => {
     const deferred = createDeferred<{failedToAdd: User[]}>();
     const scheduleMeeting = jest.fn().mockReturnValue(

--- a/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingModal.tsx
+++ b/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingModal.tsx
@@ -111,7 +111,6 @@ export const ScheduleMeetingModal = () => {
       wrapperCSS={modalWrapperStyles}
       isShown={isOpen}
       onClosed={handleClose}
-      onBgClick={handleClose}
       data-uie-name="schedule-meeting-modal"
       onKeyDown={event => handleEscDown(event, handleClose)}
     >


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28020" title="WPB-28020" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28020</a>  [Web] Meeting host accidentally closes the Schedule Meeting or Meet now modal when the cursor moves outside the modal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Stop Schedule Meeting and Meet Now from closing on overlay clicks so entered details are not lost.
- Close these modals only via the X button or Escape.

## Test plan
- [x] Open Schedule Meeting, enter a title, click outside the modal — it stays open with the title intact.
- [x] Repeat for Meet Now.
- [x] Confirm X and Escape still close both modals.