### PR TITLE
Block meeting titles longer than 64 characters [WPB-28021]

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -1351,6 +1351,7 @@
   "meetings.scheduleModal.error.missingTimes": "Start and end times are required.",
   "meetings.scheduleModal.error.removeParticipantsFailed": "The meeting was updated, but some participants could not be removed. Please try again.",
   "meetings.scheduleModal.error.titleRequired": "Title is required",
+  "meetings.scheduleModal.error.titleTooLong": "Title must be 64 characters or fewer",
   "meetings.scheduleModal.error.updateFailed": "Something went wrong while updating the meeting. Please try again.",
   "meetings.scheduleModal.error.updateFailedTitle": "Could not update meeting",
   "meetings.scheduleModal.nextMonthAriaLabel": "Next month",

--- a/apps/webapp/src/script/components/meeting/mapMeetNowFormToMeetingCommand.test.ts
+++ b/apps/webapp/src/script/components/meeting/mapMeetNowFormToMeetingCommand.test.ts
@@ -17,8 +17,13 @@
  *
  */
 
-import {mapMeetNowFormToMeetingCommand} from './mapMeetNowFormToMeetingCommand';
+import {
+  MEETING_TITLE_MAX_LENGTH,
+  meetingTitleErrorKeys,
+} from 'Components/meeting/shared/validation/meetingTitleValidation';
 import {unwrap, unwrapErr} from 'Util/test/resultTestSupport';
+
+import {mapMeetNowFormToMeetingCommand} from './mapMeetNowFormToMeetingCommand';
 
 describe('mapMeetNowFormToMeetingCommand', () => {
   it('maps validated form state to a meeting command', () => {
@@ -44,7 +49,20 @@ describe('mapMeetNowFormToMeetingCommand', () => {
 
     expect(result.isErr).toBe(true);
     expect(unwrapErr(result)).toEqual({
-      title: 'meetings.scheduleModal.error.titleRequired',
+      title: meetingTitleErrorKeys.required,
+    });
+  });
+
+  it('returns title errors for a title that exceeds the maximum length', () => {
+    const result = mapMeetNowFormToMeetingCommand({
+      title: 'a'.repeat(MEETING_TITLE_MAX_LENGTH + 1),
+      selectedUsers: [],
+      participantsFilter: '',
+    });
+
+    expect(result.isErr).toBe(true);
+    expect(unwrapErr(result)).toEqual({
+      title: meetingTitleErrorKeys.tooLong,
     });
   });
 });

--- a/apps/webapp/src/script/components/meeting/meetNowModal/meetNowModal.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetNowModal/meetNowModal.test.tsx
@@ -28,6 +28,10 @@ import type {CreateMeetingSuccess} from 'Components/meeting/shared/service/meeti
 import type {MeetingStoreState} from 'Components/meeting/meetingStore/createMeetingStore';
 import {MeetingStoreProvider} from 'Components/meeting/meetingStore/meetingStoreProvider';
 import {meetingSubmitErrors} from 'Components/meeting/meetingSubmitErrors';
+import {
+  MEETING_TITLE_MAX_LENGTH,
+  meetingTitleErrorKeys,
+} from 'Components/meeting/shared/validation/meetingTitleValidation';
 import {ConversationState} from 'Repositories/conversation/ConversationState';
 import {User} from 'Repositories/entity/User';
 import {TeamState} from 'Repositories/team/TeamState';
@@ -305,6 +309,23 @@ describe('MeetNowModal', () => {
       await fireAndForgetInvoker.waitUntilAllSettled();
     });
 
+    expect(useMeetNowModal.getState().isOpen).toBe(true);
+  });
+
+  it('shows a title error and does not start the meeting when the title is too long', async () => {
+    const meetNowMeeting = jest.fn().mockReturnValue(task.resolve({failedToAdd: [], qualifiedConversation}));
+    renderMeetNowModal({meetNowMeeting});
+
+    act(() => {
+      useMeetNowModal.getState().open();
+      useMeetNowModal.getState().setTitle('a'.repeat(MEETING_TITLE_MAX_LENGTH + 1));
+    });
+
+    expect(screen.getByText(meetingTitleErrorKeys.tooLong)).toBeInTheDocument();
+
+    await submitForm();
+
+    expect(meetNowMeeting).not.toHaveBeenCalled();
     expect(useMeetNowModal.getState().isOpen).toBe(true);
   });
 

--- a/apps/webapp/src/script/components/meeting/meetNowModal/useMeetNowModal.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetNowModal/useMeetNowModal.test.ts
@@ -18,6 +18,11 @@
  */
 
 import {
+  MEETING_TITLE_MAX_LENGTH,
+  meetingTitleErrorKeys,
+} from 'Components/meeting/shared/validation/meetingTitleValidation';
+
+import {
   getDefaultMeetNowFormState,
   getMeetNowFormErrors,
   hasMeetNowFormErrors,
@@ -40,7 +45,32 @@ describe('useMeetNowModal', () => {
   it('requires a title before submit', () => {
     const errors = getMeetNowFormErrors(getDefaultMeetNowFormState());
 
-    expect(errors.title).toBe('meetings.scheduleModal.error.titleRequired');
+    expect(errors.title).toBe(meetingTitleErrorKeys.required);
     expect(hasMeetNowFormErrors(errors)).toBe(true);
+  });
+
+  it('rejects a title longer than the maximum length', () => {
+    const errors = getMeetNowFormErrors({
+      ...getDefaultMeetNowFormState(),
+      title: 'a'.repeat(MEETING_TITLE_MAX_LENGTH + 1),
+    });
+
+    expect(errors.title).toBe(meetingTitleErrorKeys.tooLong);
+    expect(hasMeetNowFormErrors(errors)).toBe(true);
+  });
+
+  it('shows a titleTooLong error on the input while typing past the maximum length', () => {
+    useMeetNowModal.getState().open();
+    useMeetNowModal.getState().setTitle('a'.repeat(MEETING_TITLE_MAX_LENGTH + 1));
+
+    expect(useMeetNowModal.getState().errors.title).toBe(meetingTitleErrorKeys.tooLong);
+  });
+
+  it('clears the titleTooLong error when the title is shortened', () => {
+    useMeetNowModal.getState().open();
+    useMeetNowModal.getState().setTitle('a'.repeat(MEETING_TITLE_MAX_LENGTH + 1));
+    useMeetNowModal.getState().setTitle('a'.repeat(MEETING_TITLE_MAX_LENGTH));
+
+    expect(useMeetNowModal.getState().errors.title).toBeUndefined();
   });
 });

--- a/apps/webapp/src/script/components/meeting/meetNowModal/useMeetNowModal.ts
+++ b/apps/webapp/src/script/components/meeting/meetNowModal/useMeetNowModal.ts
@@ -17,10 +17,13 @@
  *
  */
 
-import {isEmptyString} from '@sindresorhus/is';
 import {result, type Result} from 'true-myth';
 import {create} from 'zustand';
 
+import {
+  getMeetingTitleError,
+  getMeetingTitleInputError,
+} from 'Components/meeting/shared/validation/meetingTitleValidation';
 import type {User} from 'Repositories/entity/User';
 
 import {emptyMeetNowFormErrors, type MeetNowFormErrors, type MeetNowFormState} from './meetNowTypes';
@@ -54,7 +57,7 @@ const initialState = {
 };
 
 export const getMeetNowFormErrors = ({title}: MeetNowFormState): MeetNowFormErrors => ({
-  title: isEmptyString(title.trim()) ? 'meetings.scheduleModal.error.titleRequired' : undefined,
+  title: getMeetingTitleError(title),
 });
 
 export const hasMeetNowFormErrors = (errors: MeetNowFormErrors): boolean => errors.title !== undefined;
@@ -86,7 +89,7 @@ export const useMeetNowModal = create<MeetNowModalState>((set, get) => ({
   setTitle: title =>
     set(state => ({
       formState: {...state.formState, title},
-      errors: {...state.errors, title: undefined},
+      errors: {...state.errors, title: getMeetingTitleInputError(title)},
     })),
   setSelectedUsers: selectedUsers =>
     set(state => ({

--- a/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingTypes.ts
+++ b/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingTypes.ts
@@ -36,6 +36,7 @@ export interface ScheduleMeetingFormState {
 
 export type ScheduleMeetingFormErrorKey =
   | 'meetings.scheduleModal.error.titleRequired'
+  | 'meetings.scheduleModal.error.titleTooLong'
   | 'meetings.scheduleModal.error.missingTimes'
   | 'meetings.scheduleModal.error.endBeforeStart'
   | 'meetings.schedule.errors.startInPast'

--- a/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingValidation.test.ts
+++ b/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingValidation.test.ts
@@ -20,6 +20,11 @@
 import {maybe} from 'true-myth';
 import {createDeterministicWallClock} from '@enormora/wall-clock/deterministic-wall-clock';
 
+import {
+  MEETING_TITLE_MAX_LENGTH,
+  meetingTitleErrorKeys,
+} from 'Components/meeting/shared/validation/meetingTitleValidation';
+
 import {getScheduleMeetingFormErrors, hasScheduleMeetingFormErrors} from './scheduleMeetingValidation';
 
 describe('scheduleMeetingValidation', () => {
@@ -35,7 +40,7 @@ describe('scheduleMeetingValidation', () => {
   it('returns titleRequired when title is empty', () => {
     const errors = getScheduleMeetingFormErrors({title: '   ', start: futureStart, end: futureEnd, wallClock});
 
-    expect(errors.title).toBe('meetings.scheduleModal.error.titleRequired');
+    expect(errors.title).toBe(meetingTitleErrorKeys.required);
     expect(errors.startInPast).toBeUndefined();
     expect(errors.endBeforeStart).toBeUndefined();
   });
@@ -86,6 +91,18 @@ describe('scheduleMeetingValidation', () => {
     });
 
     expect(errors.endBeforeStart).toBe('meetings.scheduleModal.error.endBeforeStart');
+  });
+
+  it('returns titleTooLong when the title exceeds the maximum length', () => {
+    const errors = getScheduleMeetingFormErrors({
+      title: 'a'.repeat(MEETING_TITLE_MAX_LENGTH + 1),
+      start: futureStart,
+      end: futureEnd,
+      wallClock,
+    });
+
+    expect(errors.title).toBe(meetingTitleErrorKeys.tooLong);
+    expect(hasScheduleMeetingFormErrors(errors)).toBe(true);
   });
 
   it('returns no errors for valid input', () => {

--- a/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingValidation.ts
+++ b/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingValidation.ts
@@ -18,9 +18,10 @@
  */
 
 import type {WallClock} from '@enormora/wall-clock/wall-clock';
-import {isEmptyString} from '@sindresorhus/is';
 import type {Maybe, Result} from 'true-myth';
 import {result} from 'true-myth';
+
+import {getMeetingTitleError} from 'Components/meeting/shared/validation/meetingTitleValidation';
 
 import {type ScheduleMeetingFormErrors} from './scheduleMeetingTypes';
 
@@ -45,7 +46,7 @@ export const getScheduleMeetingFormErrors = ({
       : undefined;
 
   return {
-    title: isEmptyString(title.trim()) ? 'meetings.scheduleModal.error.titleRequired' : undefined,
+    title: getMeetingTitleError(title),
     missingTimes,
     startInPast:
       missingTimes === undefined && start.isJust && start.value.getTime() <= currentTimestampInMilliseconds

--- a/apps/webapp/src/script/components/meeting/scheduleMeetingModal/useScheduleMeetingModal.ts
+++ b/apps/webapp/src/script/components/meeting/scheduleMeetingModal/useScheduleMeetingModal.ts
@@ -28,6 +28,7 @@ import {
   resolveEndChange,
   resolveStartChange,
 } from 'Components/meeting/shared/defaults/meetingDateTimeDefaults';
+import {getMeetingTitleInputError} from 'Components/meeting/shared/validation/meetingTitleValidation';
 import type {MeetingSeries} from 'Components/meeting/types/meetingSeries';
 import type {User} from 'Repositories/entity/User';
 
@@ -153,7 +154,7 @@ export const useScheduleMeetingModal = create<ScheduleMeetingModalState>((set, g
   setTitle: title =>
     set(state => ({
       formState: {...state.formState, title},
-      errors: {...state.errors, title: undefined},
+      errors: {...state.errors, title: getMeetingTitleInputError(title)},
     })),
   setStart: start =>
     set(state => {

--- a/apps/webapp/src/script/components/meeting/shared/validation/meetingTitleValidation.test.ts
+++ b/apps/webapp/src/script/components/meeting/shared/validation/meetingTitleValidation.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {
+  getMeetingTitleError,
+  getMeetingTitleInputError,
+  MEETING_TITLE_MAX_LENGTH,
+  meetingTitleErrorKeys,
+} from './meetingTitleValidation';
+
+const titleAtMaxLength = 'a'.repeat(MEETING_TITLE_MAX_LENGTH);
+const titleOverMaxLength = `${titleAtMaxLength}x`;
+
+describe('getMeetingTitleError', () => {
+  it('returns titleRequired when the title is empty or whitespace', () => {
+    expect(getMeetingTitleError('')).toBe(meetingTitleErrorKeys.required);
+    expect(getMeetingTitleError('   ')).toBe(meetingTitleErrorKeys.required);
+  });
+
+  it('returns titleTooLong when the trimmed title exceeds the max length', () => {
+    expect(getMeetingTitleError(titleOverMaxLength)).toBe(meetingTitleErrorKeys.tooLong);
+    expect(getMeetingTitleError(`  ${titleOverMaxLength}  `)).toBe(meetingTitleErrorKeys.tooLong);
+  });
+
+  it('returns no error for a title at the max length', () => {
+    expect(getMeetingTitleError(titleAtMaxLength)).toBeUndefined();
+    expect(getMeetingTitleError(`  ${titleAtMaxLength}  `)).toBeUndefined();
+  });
+});
+
+describe('getMeetingTitleInputError', () => {
+  it('shows titleTooLong while typing past the max length', () => {
+    expect(getMeetingTitleInputError(titleOverMaxLength)).toBe(meetingTitleErrorKeys.tooLong);
+  });
+
+  it('does not show titleRequired while the title is still empty', () => {
+    expect(getMeetingTitleInputError('')).toBeUndefined();
+    expect(getMeetingTitleInputError('   ')).toBeUndefined();
+  });
+});

--- a/apps/webapp/src/script/components/meeting/shared/validation/meetingTitleValidation.ts
+++ b/apps/webapp/src/script/components/meeting/shared/validation/meetingTitleValidation.ts
@@ -1,0 +1,49 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isEmptyString} from '@sindresorhus/is';
+
+/** Matches ConversationRepository.CONFIG.GROUP.MAX_NAME_LENGTH — meeting titles become conversation names. */
+export const MEETING_TITLE_MAX_LENGTH = 64;
+
+export const meetingTitleErrorKeys = {
+  required: 'meetings.scheduleModal.error.titleRequired',
+  tooLong: 'meetings.scheduleModal.error.titleTooLong',
+} as const;
+
+export type MeetingTitleErrorKey = (typeof meetingTitleErrorKeys)[keyof typeof meetingTitleErrorKeys];
+
+export const getMeetingTitleError = (title: string): MeetingTitleErrorKey | undefined => {
+  const trimmedTitle = title.trim();
+
+  if (isEmptyString(trimmedTitle)) {
+    return meetingTitleErrorKeys.required;
+  }
+
+  if (trimmedTitle.length > MEETING_TITLE_MAX_LENGTH) {
+    return meetingTitleErrorKeys.tooLong;
+  }
+
+  return undefined;
+};
+
+export const getMeetingTitleInputError = (title: string): MeetingTitleErrorKey | undefined => {
+  const error = getMeetingTitleError(title);
+  return error === meetingTitleErrorKeys.tooLong ? error : undefined;
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28021" title="WPB-28021" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28021</a>  [Web] Meeting host cannot start a Meet now meeting when the title exceeds 64 characters
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Show an inline error when a Meet now or Schedule meeting title exceeds 64 characters
- Block submit so the generic “Something went wrong” failure no longer happens

Fixes [WPB-28021](https://wearezeta.atlassian.net/browse/WPB-28021)

## Test plan
- [x] Open Meet now, enter a title longer than 64 characters, and confirm the input shows “Title must be 64 characters or fewer”
- [x] Confirm Start meeting does not create the meeting while the error is shown
- [x] Confirm a 64-character title still starts successfully
- [x] Repeat with Schedule meeting

[WPB-28021]: https://wearezeta.atlassian.net/browse/WPB-28021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ