### PR TITLE
Add option "delete for everyone" as an ongoing meeting organizer [WPB-28017]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.test.tsx
@@ -219,7 +219,7 @@ describe('getMeetingActionEntries', () => {
     expect(getDeleteForMeEntryLabel(entries)).toBeUndefined();
   });
 
-  it('omits Delete meeting for everyone when the instance has started', () => {
+  it('includes Delete meeting for everyone when the instance is ongoing', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser(),
@@ -231,7 +231,7 @@ describe('getMeetingActionEntries', () => {
       onDeleteForMe: noop,
     });
 
-    expect(getDeleteForAllEntryLabel(entries)).toBeUndefined();
+    expect(getDeleteForAllEntryLabel(entries)).toBeDefined();
     expect(getDeleteForMeEntryLabel(entries)).toBeUndefined();
   });
 

--- a/apps/webapp/src/script/components/meeting/shared/submit/submitDeleteMeeting.test.ts
+++ b/apps/webapp/src/script/components/meeting/shared/submit/submitDeleteMeeting.test.ts
@@ -176,7 +176,7 @@ describe('submitDeleteMeeting', () => {
     expect(primaryModalShow).toHaveBeenCalledTimes(1);
   });
 
-  it('blocks delete for all when the meeting has started before submit', async () => {
+  it('deletes for all when the meeting is ongoing at submit time', async () => {
     const deleteMeetingForAll = jest.fn().mockReturnValue(task.resolve(undefined));
     const wallClock = createDeterministicWallClock({
       initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T14:30:00.000Z'),
@@ -189,19 +189,9 @@ describe('submitDeleteMeeting', () => {
       }),
     );
 
-    expect(result).toBe(deleteMeetingSubmitResults.blocked);
-    expect(deleteMeetingForAll).not.toHaveBeenCalled();
-    expect(primaryModalShow).toHaveBeenCalledWith(
-      PrimaryModal.type.ACKNOWLEDGE,
-      expect.objectContaining({
-        text: expect.objectContaining({
-          title: translateForTest('meetings.deleteModal.error.notAllowedTitle'),
-          message: translateForTest('meetings.deleteModal.error.notAllowed'),
-        }),
-      }),
-      undefined,
-      translateForTest,
-    );
+    expect(result).toBe(deleteMeetingSubmitResults.succeeded);
+    expect(deleteMeetingForAll).toHaveBeenCalledTimes(1);
+    expect(primaryModalShow).not.toHaveBeenCalled();
   });
 
   it('blocks delete when the meeting became past before submit', async () => {

--- a/apps/webapp/src/script/components/meeting/utils/canDeleteMeeting.test.ts
+++ b/apps/webapp/src/script/components/meeting/utils/canDeleteMeeting.test.ts
@@ -82,10 +82,10 @@ describe('canDeleteMeetingForAll', () => {
     expect(canDeleteMeetingForAll(meetingInstance, createSelfUser(), futureNowMilliseconds)).toBe(true);
   });
 
-  it('disallows host delete when the meeting has started', () => {
+  it('allows host delete when the meeting is ongoing', () => {
     const meetingInstance = createMeetingInstance();
 
-    expect(canDeleteMeetingForAll(meetingInstance, createSelfUser(), ongoingNowMilliseconds)).toBe(false);
+    expect(canDeleteMeetingForAll(meetingInstance, createSelfUser(), ongoingNowMilliseconds)).toBe(true);
   });
 
   it('disallows delete for non-host users', () => {

--- a/apps/webapp/src/script/components/meeting/utils/canDeleteMeeting.ts
+++ b/apps/webapp/src/script/components/meeting/utils/canDeleteMeeting.ts
@@ -35,13 +35,7 @@ export const canDeleteMeetingForAll = (
   selfUser: User,
   nowMilliseconds: number,
 ): boolean => {
-  const instanceHasNotStarted = nowMilliseconds < meetingInstance.start.getTime();
-
-  return (
-    canDeleteMeeting(meetingInstance, nowMilliseconds) &&
-    isMeetingHost(meetingInstance.meetingSeries, selfUser) &&
-    instanceHasNotStarted
-  );
+  return canDeleteMeeting(meetingInstance, nowMilliseconds) && isMeetingHost(meetingInstance.meetingSeries, selfUser);
 };
 
 export const canDeleteMeetingForMe = (

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
@@ -100,6 +100,11 @@ export class MeetingsPage {
       .toBeGreaterThan(0);
   }
 
+  async waitForMeetingAttending(title: string) {
+    await this.waitForMeetingInList(title);
+    await expect(this.meetingListItem(title)).toContainText('Attending');
+  }
+
   async waitForMeetingAbsentFromList(title: string) {
     await expect
       .poll(
@@ -111,6 +116,11 @@ export class MeetingsPage {
         {timeout: MEETINGS_LIST_TIMEOUT_MS},
       )
       .toBe(0);
+  }
+
+  async joinMeeting(title: string) {
+    await this.openMeetingsTab();
+    await this.meetingListItem(title).locator('[data-uie-name="join-meeting-call"]').click();
   }
 
   async assertNoSubmitErrorVisible() {
@@ -331,8 +341,21 @@ export class MeetingsPage {
 
   async waitForNotificationContaining(text: string) {
     await this.waitForNotificationHost();
-    await this.expandNotifications();
-    await expect(this.notificationCardContaining(text)).toBeVisible({timeout: MEETINGS_LIST_TIMEOUT_MS});
+
+    const expandButton = this.notificationHost.getByTestId('meeting-notification-expand');
+    const notification = this.notificationCardContaining(text);
+    await expect
+      .poll(
+        async () => {
+          if ((await expandButton.getAttribute('aria-expanded')) !== 'true') {
+            await expandButton.click();
+          }
+
+          return notification.isVisible();
+        },
+        {timeout: MEETINGS_LIST_TIMEOUT_MS},
+      )
+      .toBe(true);
   }
 
   async expectNoNotificationContaining(text: string) {

--- a/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
@@ -227,6 +227,48 @@ test.describe('Meeting calls', () => {
 });
 
 test.describe('Meeting notifications', () => {
+  test('participants receive cancellation notifications when the organizer deletes an ongoing meeting', async ({
+    createUser,
+    createTeam,
+    createPage,
+  }) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 2);
+    const [firstMember, secondMember] = members;
+
+    const [ownerPage, firstMemberPage, secondMemberPage] = await loginMeetingsUsers(createPage, [
+      owner,
+      firstMember,
+      secondMember,
+    ]);
+    const ownerMeetings = PageManager.from(ownerPage).webapp.pages.meetings();
+    const firstMemberMeetings = PageManager.from(firstMemberPage).webapp.pages.meetings();
+    const secondMemberMeetings = PageManager.from(secondMemberPage).webapp.pages.meetings();
+
+    await ownerMeetings.startMeetNow(MEETING_TITLE, [firstMember.fullName, secondMember.fullName]);
+
+    await Promise.all([
+      firstMemberMeetings.joinMeeting(MEETING_TITLE),
+      secondMemberMeetings.joinMeeting(MEETING_TITLE),
+    ]);
+
+    const firstMemberCalling = PageManager.from(firstMemberPage).webapp.pages.calling();
+    const secondMemberCalling = PageManager.from(secondMemberPage).webapp.pages.calling();
+    await Promise.all([firstMemberCalling.waitForCell(), secondMemberCalling.waitForCell()]);
+
+    await Promise.all([
+      ownerMeetings.waitForMeetingAttending(MEETING_TITLE),
+      firstMemberMeetings.waitForMeetingAttending(MEETING_TITLE),
+      secondMemberMeetings.waitForMeetingAttending(MEETING_TITLE),
+    ]);
+
+    await ownerMeetings.deleteMeetingForAll(MEETING_TITLE);
+
+    await Promise.all([
+      firstMemberMeetings.waitForNotificationContaining(`Canceled: ${MEETING_TITLE}`),
+      secondMemberMeetings.waitForNotificationContaining(`Canceled: ${MEETING_TITLE}`),
+    ]);
+  });
+
   test('two participants each receive exactly one invitation', async ({createUser, createTeam, createPage}) => {
     const {owner, members} = await createMeetingsTeam(createUser, createTeam, 2);
     const [firstMember, secondMember] = members;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28017" title="WPB-28017" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28017</a>  [Web] Meeting host should see "Delete meeting for everyone" after the meeting has started
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
