### PR TITLE
Remove date from completed meetings [WPB-28023]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingListItem.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingListItem.tsx
@@ -82,12 +82,9 @@ const MeetingListItemComponent = ({
 
   const time = useMemo(() => {
     if (temporalStatus === MeetingTemporalStatuses.PAST) {
-      const dayOfWeek = formatLocale(start, 'EEEE');
-      const month = formatLocale(start, 'MMMM');
-      const day = formatLocale(start, 'd');
       const startedAtTime = formatLocale(start, 'h:mm a');
       const endedAtTime = formatLocale(end, 'h:mm a');
-      return `${dayOfWeek}, ${month} ${day} • ${translate('meetings.meetingStatus.startedAt', {time: startedAtTime})} • ${translate(
+      return `${translate('meetings.meetingStatus.startedAt', {time: startedAtTime})} • ${translate(
         'meetings.meetingStatus.endedAt',
         {time: endedAtTime},
       )}`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28023" title="WPB-28023" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28023</a>  User can see redundant current date on a completed meeting under the Today section
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
