### PR TITLE
feat: handle conversation.system.member-update event [WPB-25262]

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -3871,6 +3871,7 @@ export class ConversationRepository {
         return this.onMemberLeave(conversationEntity, eventJson);
 
       case CONVERSATION_EVENT.MEMBER_UPDATE:
+      case CONVERSATION_EVENT.SYSTEM_MEMBER_UPDATE:
         return this.onMemberUpdate(conversationEntity, eventJson);
 
       case CONVERSATION_EVENT.TYPING:
@@ -4378,7 +4379,8 @@ export class ConversationRepository {
     const conversationId = {domain: '', id: conversation ?? '' /* TODO(federation) add domain on the sender side */};
 
     if (eventData.conversation_role) {
-      await this.onConversationMemberRoleUpdated(conversationId, eventData, from);
+      // `from` is absent for backend/system-initiated role changes (e.g. `conversation.system.member-update`).
+      await this.onConversationMemberRoleUpdated(conversationId, eventData, from ?? '');
       return;
     }
 

--- a/libraries/api-client/src/event/conversationEvent.ts
+++ b/libraries/api-client/src/event/conversationEvent.ts
@@ -55,6 +55,7 @@ export enum CONVERSATION_EVENT {
   MEMBER_JOIN = 'conversation.member-join',
   MEMBER_LEAVE = 'conversation.member-leave',
   MEMBER_UPDATE = 'conversation.member-update',
+  SYSTEM_MEMBER_UPDATE = 'conversation.system.member-update',
   MESSAGE_TIMER_UPDATE = 'conversation.message-timer-update',
   OTR_MESSAGE_ADD = 'conversation.otr-message-add',
   MLS_MESSAGE_ADD = 'conversation.mls-message-add',
@@ -179,9 +180,11 @@ export interface ConversationMemberLeaveEvent extends BaseConversationEvent {
   type: CONVERSATION_EVENT.MEMBER_LEAVE;
 }
 
-export interface ConversationMemberUpdateEvent extends BaseConversationEvent {
+export interface ConversationMemberUpdateEvent extends Omit<BaseConversationEvent, 'from'> {
   data: ConversationMemberUpdateData;
-  type: CONVERSATION_EVENT.MEMBER_UPDATE;
+  /** Not present for backend/system-initiated updates, e.g. `conversation.system.member-update`. */
+  from?: string;
+  type: CONVERSATION_EVENT.MEMBER_UPDATE | CONVERSATION_EVENT.SYSTEM_MEMBER_UPDATE;
 }
 
 export interface ConversationMessageTimerUpdateEvent extends BaseConversationEvent {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25262" title="WPB-25262" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25262</a>  [Web] Handle Conversation Removal Message (Ghost groups)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Description

Handle conversation.system.member-update event, same as `conversation.member-update` but from is missing.