### PR TITLE
Previously invited participants should not receive another invitation [WPB-22420]

### DIFF
--- a/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
@@ -252,7 +252,7 @@ test.describe('Meeting notifications', () => {
     await expect(secondMemberMeetings.notificationCards()).toHaveCount(1);
   });
 
-  test('adding a participant sends only one invitation to the newly added participant', async ({
+  test('adding a participant only sends an invitation to the newly added participant', async ({
     createUser,
     createTeam,
     createPage,
@@ -277,6 +277,7 @@ test.describe('Meeting notifications', () => {
 
     await expect(firstMemberMeetings.notificationCardContaining(`Invitation: ${MEETING_TITLE}`)).toHaveCount(1);
     await secondMemberMeetings.waitForNotificationContaining(`Invitation: ${MEETING_TITLE}`);
+    await expect(secondMemberMeetings.notificationCardContaining(`Invitation: ${MEETING_TITLE}`)).toHaveCount(1);
   });
 
   test('removed participant sees cancellation notification and stale invitation is dismissed', async ({


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Previously invited participants should not receive another invitation notification when new participants are added to a meeting