### PR TITLE
Fix meeting update notification classification [WPB-25510]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.test.ts
@@ -75,6 +75,7 @@ describe('createMeetingNotificationEventHandlers', () => {
       },
       dismissNotificationsForMeeting: (meetingId, kinds) => {
         dismissedMeetings.push({meetingId, kinds});
+        dismissNotificationsFromList(notifications, meetingId, kinds);
       },
       logger: {
         warn: (message, context) => {
@@ -95,18 +96,6 @@ describe('createMeetingNotificationEventHandlers', () => {
     onMeetingCancelled(meetingId);
 
     expect(notifications).toEqual([
-      {
-        kind: MeetingNotificationKind.UPDATE,
-        meetingStartTime: meetingSeries.series_start_date,
-        meetingTitle: meetingSeries.title,
-        qualifiedId: meetingSeries.qualified_id,
-      },
-      {
-        kind: MeetingNotificationKind.UPDATE,
-        meetingStartTime: meetingSeries.series_start_date,
-        meetingTitle: meetingSeries.title,
-        qualifiedId: meetingSeries.qualified_id,
-      },
       {
         kind: MeetingNotificationKind.CANCELLED,
         meetingStartTime: meetingSeries.series_start_date,
@@ -180,6 +169,20 @@ describe('createMeetingNotificationEventHandlers', () => {
         meetingTitle: meetingSeries.title,
         qualifiedId: meetingSeries.qualified_id,
       },
+    ]);
+  });
+
+  it('creates a new invitation when the user is removed and added again', () => {
+    const notifications: AddNotificationInput[] = [];
+    const {notifyMeetingChange, onMeetingCancelled} = createHandlers({notifications});
+
+    notifyMeetingChange(meetingSeries);
+    onMeetingCancelled(meetingId);
+    notifyMeetingChange(meetingSeries);
+
+    expect(notifications.map(notification => notification.kind)).toEqual([
+      MeetingNotificationKind.CANCELLED,
+      MeetingNotificationKind.INVITE,
     ]);
   });
 

--- a/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.ts
@@ -118,6 +118,8 @@ export const createMeetingNotificationEventHandlers = ({
   const notifyMeetingCancellation = (meetingId: QualifiedId): void => {
     const meetingKey = toMeetingIdKey(meetingId);
 
+    notifiedMeetings.delete(meetingKey);
+
     if (cancelledMeetings.has(meetingKey)) {
       pending.delete(meetingKey);
       return;

--- a/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.test.tsx
@@ -169,7 +169,7 @@ describe('MeetingStoreRoot', () => {
     expect(getMeeting).toHaveBeenCalledWith(meetingId);
   });
 
-  it('creates invite notifications while the meetings view is not mounted', async () => {
+  it('creates update notifications for existing participants while the meetings view is not mounted', async () => {
     renderMeetingStoreRoot();
 
     await waitFor(() => {
@@ -183,7 +183,7 @@ describe('MeetingStoreRoot', () => {
     await waitFor(() => {
       expect(useMeetingNotificationStore.getState().notifications).toEqual([
         expect.objectContaining({
-          kind: MeetingNotificationKind.INVITE,
+          kind: MeetingNotificationKind.UPDATE,
           meetingTitle: 'Weekly sync (updated)',
           qualifiedId: meetingId,
         }),
@@ -337,7 +337,7 @@ describe('MeetingStoreRoot', () => {
     await waitFor(() => {
       expect(useMeetingNotificationStore.getState().notifications).toEqual([
         expect.objectContaining({
-          kind: MeetingNotificationKind.INVITE,
+          kind: MeetingNotificationKind.UPDATE,
           qualifiedId: meetingId,
         }),
       ]);

--- a/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.tsx
@@ -103,6 +103,7 @@ export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
       dispatcher,
       getSelfUserQualifiedId,
       notifyMeetingChange: notificationHandlers.notifyMeetingChange,
+      notifyUpdate: notificationHandlers.notifyUpdate,
     });
     const unsubscribeFromMeetingConversationEvents = subscribeToMeetingConversationEvents({
       dispatcher,

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
@@ -43,15 +43,17 @@ describe('subscribeToMeetingLifecycleEvents', () => {
   const activeUnsubscribeCallbacks: (() => void)[] = [];
 
   const subscribe = (dispatcher: MeetingLifecycleDispatcherDouble) => {
+    const notifyMeetingChange = jest.fn();
+    const notifyUpdate = jest.fn();
     const unsubscribe = subscribeToMeetingLifecycleEvents({
       dispatcher,
       getSelfUserQualifiedId: () => selfUserId,
-      notifyMeetingChange: jest.fn(),
-      notifyUpdate: jest.fn(),
+      notifyMeetingChange,
+      notifyUpdate,
     });
     activeUnsubscribeCallbacks.push(unsubscribe);
 
-    return unsubscribe;
+    return {notifyMeetingChange, notifyUpdate, unsubscribe};
   };
 
   afterEach(() => {
@@ -70,21 +72,21 @@ describe('subscribeToMeetingLifecycleEvents', () => {
 
   it('queues a meeting sync when a meeting updated event is published', () => {
     const dispatcher = createDispatcherDouble();
-    subscribe(dispatcher);
+    const {notifyUpdate} = subscribe(dispatcher);
 
     amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId, otherUserId);
 
-    expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId, expect.any(Function));
+    expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId, notifyUpdate);
     expect(dispatcher.enqueueMeetingRemoval).not.toHaveBeenCalled();
   });
 
   it('queues a meeting sync when a meeting member-added event is published', () => {
     const dispatcher = createDispatcherDouble();
-    subscribe(dispatcher);
+    const {notifyMeetingChange} = subscribe(dispatcher);
 
     amplify.publish(WebAppEvents.MEETING.MEMBER_ADDED, meetingId, otherUserId);
 
-    expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId, expect.any(Function));
+    expect(dispatcher.enqueueMeetingSync).toHaveBeenCalledWith(meetingId, notifyMeetingChange);
     expect(dispatcher.enqueueMeetingRemoval).not.toHaveBeenCalled();
   });
 
@@ -129,7 +131,7 @@ describe('subscribeToMeetingLifecycleEvents', () => {
 
   it('stops handling meeting lifecycle events after unsubscribing', () => {
     const dispatcher = createDispatcherDouble();
-    const unsubscribe = subscribe(dispatcher);
+    const {unsubscribe} = subscribe(dispatcher);
 
     unsubscribe();
 

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
@@ -47,6 +47,7 @@ describe('subscribeToMeetingLifecycleEvents', () => {
       dispatcher,
       getSelfUserQualifiedId: () => selfUserId,
       notifyMeetingChange: jest.fn(),
+      notifyUpdate: jest.fn(),
     });
     activeUnsubscribeCallbacks.push(unsubscribe);
 

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
@@ -31,6 +31,7 @@ export type SubscribeToMeetingLifecycleEventsDependencies = {
   dispatcher: MeetingLifecycleDispatcher;
   getSelfUserQualifiedId: () => QualifiedId;
   notifyMeetingChange: (meeting: MeetingSeries) => void;
+  notifyUpdate: (meeting: MeetingSeries) => void;
 };
 
 /**
@@ -41,13 +42,14 @@ export const subscribeToMeetingLifecycleEvents = ({
   dispatcher,
   getSelfUserQualifiedId,
   notifyMeetingChange,
+  notifyUpdate,
 }: SubscribeToMeetingLifecycleEventsDependencies): (() => void) => {
   const onMeetingCreated = (meetingId: QualifiedId) => {
     dispatcher.enqueueMeetingSync(meetingId);
   };
 
-  const enqueueMeetingSyncWithNotification = (meetingId: QualifiedId) => {
-    dispatcher.enqueueMeetingSync(meetingId, notifyMeetingChange);
+  const enqueueMeetingSyncWithNotification = (meetingId: QualifiedId, onSuccess: (meeting: MeetingSeries) => void) => {
+    dispatcher.enqueueMeetingSync(meetingId, onSuccess);
   };
 
   const onMeetingUpdated = (meetingId: QualifiedId, actorId: QualifiedId) => {
@@ -56,7 +58,7 @@ export const subscribeToMeetingLifecycleEvents = ({
       return;
     }
 
-    enqueueMeetingSyncWithNotification(meetingId);
+    enqueueMeetingSyncWithNotification(meetingId, notifyUpdate);
   };
 
   const onMeetingMemberAdded = (meetingId: QualifiedId, actorId: QualifiedId) => {
@@ -65,7 +67,7 @@ export const subscribeToMeetingLifecycleEvents = ({
       return;
     }
 
-    enqueueMeetingSyncWithNotification(meetingId);
+    enqueueMeetingSyncWithNotification(meetingId, notifyMeetingChange);
   };
 
   const onMeetingDeleted = (meetingId: QualifiedId) => {

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
@@ -48,17 +48,13 @@ export const subscribeToMeetingLifecycleEvents = ({
     dispatcher.enqueueMeetingSync(meetingId);
   };
 
-  const enqueueMeetingSyncWithNotification = (meetingId: QualifiedId, onSuccess: (meeting: MeetingSeries) => void) => {
-    dispatcher.enqueueMeetingSync(meetingId, onSuccess);
-  };
-
   const onMeetingUpdated = (meetingId: QualifiedId, actorId: QualifiedId) => {
     if (matchQualifiedIds(actorId, getSelfUserQualifiedId())) {
       dispatcher.enqueueMeetingSync(meetingId);
       return;
     }
 
-    enqueueMeetingSyncWithNotification(meetingId, notifyUpdate);
+    dispatcher.enqueueMeetingSync(meetingId, notifyUpdate);
   };
 
   const onMeetingMemberAdded = (meetingId: QualifiedId, actorId: QualifiedId) => {
@@ -67,7 +63,7 @@ export const subscribeToMeetingLifecycleEvents = ({
       return;
     }
 
-    enqueueMeetingSyncWithNotification(meetingId, notifyMeetingChange);
+    dispatcher.enqueueMeetingSync(meetingId, notifyMeetingChange);
   };
 
   const onMeetingDeleted = (meetingId: QualifiedId) => {

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
@@ -340,11 +340,6 @@ export class MeetingsPage {
     await expect(this.notificationCardContaining(text)).toBeVisible({timeout: MEETINGS_LIST_TIMEOUT_MS});
   }
 
-  async dismissNotificationContaining(text: string) {
-    await this.waitForNotificationContaining(text);
-    await this.notificationCardContaining(text).getByRole('button', {name: 'Dismiss'}).click();
-  }
-
   async expectNoNotificationContaining(text: string) {
     await expect(this.notificationCardContaining(text)).toHaveCount(0, {timeout: MEETINGS_LIST_TIMEOUT_MS});
   }

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
@@ -269,7 +269,7 @@ export class MeetingsPage {
 
   async editMeeting(
     title: string,
-    updates: {newTitle?: string; addParticipants?: string[]; removeParticipants?: string[]},
+    updates: {newTitle?: string; updateStartTime?: boolean; addParticipants?: string[]; removeParticipants?: string[]},
   ) {
     const menu = await this.openMeetingContextMenu(title);
     await menu.getByRole('button', {name: 'Edit meeting'}).click();
@@ -282,6 +282,11 @@ export class MeetingsPage {
 
     if (updates.newTitle !== undefined) {
       await this.fillMeetingTitle(updates.newTitle);
+    }
+
+    if (updates.updateStartTime) {
+      await this.selectLatestAvailableStartTime();
+      await this.fixStartTimeInPastValidationError();
     }
 
     for (const participantName of updates.addParticipants ?? []) {
@@ -333,6 +338,11 @@ export class MeetingsPage {
     await this.waitForNotificationHost();
     await this.expandNotifications();
     await expect(this.notificationCardContaining(text)).toBeVisible({timeout: MEETINGS_LIST_TIMEOUT_MS});
+  }
+
+  async dismissNotificationContaining(text: string) {
+    await this.waitForNotificationContaining(text);
+    await this.notificationCardContaining(text).getByRole('button', {name: 'Dismiss'}).click();
   }
 
   async expectNoNotificationContaining(text: string) {

--- a/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
@@ -119,9 +119,40 @@ test.describe('Meetings CRUD', () => {
     await ownerMeetings.scheduleMeeting(MEETING_TITLE, [member.fullName]);
     await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
 
+    await memberMeetings.openMeetingsTab();
+    await memberMeetings.waitForMeetingInList(MEETING_TITLE);
+    await memberMeetings.dismissNotificationContaining(`Invitation: ${MEETING_TITLE}`);
+
     await ownerMeetings.editMeeting(MEETING_TITLE, {newTitle: UPDATED_MEETING_TITLE});
 
     await memberMeetings.waitForNotificationContaining(`Update: ${UPDATED_MEETING_TITLE}`);
+    await expect(memberMeetings.notificationCardContaining(`Update: ${UPDATED_MEETING_TITLE}`)).toHaveCount(1);
+    await expect(memberMeetings.notificationCardContaining(`Invitation: ${UPDATED_MEETING_TITLE}`)).toHaveCount(0);
+    await expect(memberMeetings.notificationCards()).toHaveCount(1);
+  });
+
+  test('invitee sees update notification after meeting time edit', async ({createUser, createTeam, createPage}) => {
+    const {owner, members} = await createMeetingsTeam(createUser, createTeam, 1);
+    const member = members[0];
+
+    const [ownerPage, memberPage] = await loginMeetingsUsers(createPage, [owner, member]);
+    const ownerMeetings = PageManager.from(ownerPage).webapp.pages.meetings();
+    const memberMeetings = PageManager.from(memberPage).webapp.pages.meetings();
+
+    await ownerMeetings.openMeetingsTab();
+    await ownerMeetings.scheduleMeeting(MEETING_TITLE, [member.fullName]);
+    await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
+
+    await memberMeetings.openMeetingsTab();
+    await memberMeetings.waitForMeetingInList(MEETING_TITLE);
+    await memberMeetings.dismissNotificationContaining(`Invitation: ${MEETING_TITLE}`);
+
+    await ownerMeetings.editMeeting(MEETING_TITLE, {updateStartTime: true});
+
+    await memberMeetings.waitForNotificationContaining(`Update: ${MEETING_TITLE}`);
+    await expect(memberMeetings.notificationCardContaining(`Update: ${MEETING_TITLE}`)).toHaveCount(1);
+    await expect(memberMeetings.notificationCardContaining(`Invitation: ${MEETING_TITLE}`)).toHaveCount(0);
+    await expect(memberMeetings.notificationCards()).toHaveCount(1);
   });
 
   test('host can add a participant', async ({createUser, createTeam, createPage}) => {

--- a/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Meetings/meetings.spec.ts
@@ -119,9 +119,9 @@ test.describe('Meetings CRUD', () => {
     await ownerMeetings.scheduleMeeting(MEETING_TITLE, [member.fullName]);
     await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
 
+    await memberPage.reload();
     await memberMeetings.openMeetingsTab();
     await memberMeetings.waitForMeetingInList(MEETING_TITLE);
-    await memberMeetings.dismissNotificationContaining(`Invitation: ${MEETING_TITLE}`);
 
     await ownerMeetings.editMeeting(MEETING_TITLE, {newTitle: UPDATED_MEETING_TITLE});
 
@@ -143,9 +143,9 @@ test.describe('Meetings CRUD', () => {
     await ownerMeetings.scheduleMeeting(MEETING_TITLE, [member.fullName]);
     await ownerMeetings.waitForMeetingInList(MEETING_TITLE);
 
+    await memberPage.reload();
     await memberMeetings.openMeetingsTab();
     await memberMeetings.waitForMeetingInList(MEETING_TITLE);
-    await memberMeetings.dismissNotificationContaining(`Invitation: ${MEETING_TITLE}`);
 
     await ownerMeetings.editMeeting(MEETING_TITLE, {updateStartTime: true});
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25510" title="WPB-25510" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25510</a>  [Web] Inform participant of a meeting update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
