### PR TITLE
fix: Disabled row actions in global drive shouldn't be clickable(WPB-25259)

### DIFF
--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableRowOptions/cellsTableRowOptions.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableRowOptions/cellsTableRowOptions.tsx
@@ -52,6 +52,10 @@ export const CellsTableRowOptions = (properties: CellsTableRowOptionsProps): Rea
     isViewerPermissionFeatureEnabled: isFeatureToggleEnabled(viewerPermissionFeatureToggleName),
     selfUserDriveRole: node.selfUserDriveRole,
   });
+  // DropdownMenu.Item disabled state is visual/ARIA only for native onClick handlers.
+  // Keep restricted actions without a handler so viewer access cannot activate them.
+  const restrictedActionClickHandler = <ClickHandler extends () => void>(clickHandler: ClickHandler) =>
+    shouldDisableRestrictedActions ? undefined : clickHandler;
 
   return (
     <DropdownMenu>
@@ -69,26 +73,21 @@ export const CellsTableRowOptions = (properties: CellsTableRowOptionsProps): Rea
         </DropdownMenu.Item>
         <DropdownMenu.Item
           disabled={shouldDisableRestrictedActions}
-          onClick={
-            shouldDisableRestrictedActions
-              ? undefined
-              : () => showShareModal({type: node.type, uuid: node.id, cellsRepository, fireAndForgetInvoker, translate})
-          }
+          onClick={restrictedActionClickHandler(() =>
+            showShareModal({type: node.type, uuid: node.id, cellsRepository, fireAndForgetInvoker, translate}),
+          )}
         >
           {translate('cells.options.share')}
         </DropdownMenu.Item>
         {isNonEmptyString(url) && (
           <DropdownMenu.Item
             disabled={shouldDisableRestrictedActions}
-            onClick={
-              shouldDisableRestrictedActions
-                ? undefined
-                : () =>
-                    forcedDownloadFile({
-                      url,
-                      name,
-                    })
-            }
+            onClick={restrictedActionClickHandler(() =>
+              forcedDownloadFile({
+                url,
+                name,
+              }),
+            )}
           >
             {translate('cells.options.download')}
           </DropdownMenu.Item>

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableRowOptions/cellsTableRowOptions.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableRowOptions/cellsTableRowOptions.tsx
@@ -69,8 +69,10 @@ export const CellsTableRowOptions = (properties: CellsTableRowOptionsProps): Rea
         </DropdownMenu.Item>
         <DropdownMenu.Item
           disabled={shouldDisableRestrictedActions}
-          onClick={() =>
-            showShareModal({type: node.type, uuid: node.id, cellsRepository, fireAndForgetInvoker, translate})
+          onClick={
+            shouldDisableRestrictedActions
+              ? undefined
+              : () => showShareModal({type: node.type, uuid: node.id, cellsRepository, fireAndForgetInvoker, translate})
           }
         >
           {translate('cells.options.share')}
@@ -78,11 +80,14 @@ export const CellsTableRowOptions = (properties: CellsTableRowOptionsProps): Rea
         {isNonEmptyString(url) && (
           <DropdownMenu.Item
             disabled={shouldDisableRestrictedActions}
-            onClick={() =>
-              forcedDownloadFile({
-                url,
-                name,
-              })
+            onClick={
+              shouldDisableRestrictedActions
+                ? undefined
+                : () =>
+                    forcedDownloadFile({
+                      url,
+                      name,
+                    })
             }
           >
             {translate('cells.options.download')}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25259" title="WPB-25259" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25259</a>  [Web] Hide / Disable download, copy, move to bin, permanent deletion, modification and sharing via public links for shared drive and global files table view each row
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Issue found:

In Global Drive, Share via link and Download appear visually disabled for files where the user has Viewer access, but both actions remain clickable and complete successfully.

Expected:
Action should appear visually disabled and not clickable
