### PR TITLE
fix(webapp): avoid revoking guest links for app toggles [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationStateHandler.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationStateHandler.test.ts
@@ -30,7 +30,9 @@ import type {ConversationService} from './ConversationService';
 import {Conversation} from '../entity/Conversation';
 
 function buildHandler() {
-  const conversationService: jest.Mocked<Pick<ConversationService, 'deleteConversationCode' | 'putConversationAccess'>> = {
+  const conversationService: jest.Mocked<
+    Pick<ConversationService, 'deleteConversationCode' | 'putConversationAccess'>
+  > = {
     deleteConversationCode: jest.fn(),
     putConversationAccess: jest.fn(),
   };

--- a/apps/webapp/src/script/repositories/conversation/ConversationStateHandler.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationStateHandler.test.ts
@@ -30,7 +30,8 @@ import type {ConversationService} from './ConversationService';
 import {Conversation} from '../entity/Conversation';
 
 function buildHandler() {
-  const conversationService: jest.Mocked<Pick<ConversationService, 'putConversationAccess'>> = {
+  const conversationService: jest.Mocked<Pick<ConversationService, 'deleteConversationCode' | 'putConversationAccess'>> = {
+    deleteConversationCode: jest.fn(),
     putConversationAccess: jest.fn(),
   };
   const translate = jest.fn((key: Parameters<Translate>[0]) => `translated:${key}`) as Translate;
@@ -59,6 +60,35 @@ describe('ConversationStateHandler', () => {
   });
 
   describe('changeAccessState', () => {
+    it.each([
+      [ACCESS_STATE.TEAM.TEAM_ONLY, ACCESS_STATE.TEAM.SERVICES],
+      [ACCESS_STATE.TEAM.SERVICES, ACCESS_STATE.TEAM.TEAM_ONLY],
+    ])('does not revoke an access code when toggling apps from %s to %s', async (previousState, nextState) => {
+      const {conversationService, translate, handler} = buildHandler();
+      const conversation = buildConversation(true);
+      conversation.accessState(previousState);
+
+      await handler.changeAccessState(conversation, nextState);
+
+      expect(conversationService.deleteConversationCode).not.toHaveBeenCalled();
+      expect(conversationService.putConversationAccess).toHaveBeenCalled();
+      expect(translate).not.toHaveBeenCalledWith('modalConversationGuestOptionsRevokeCodeMessage');
+      expect(conversation.accessState()).toBe(nextState);
+    });
+
+    it('revokes the access code when disabling guest access', async () => {
+      const {conversationService, handler} = buildHandler();
+      const conversation = buildConversation(true);
+      conversation.accessState(ACCESS_STATE.TEAM.GUEST_ROOM);
+      conversation.accessCode('access-code');
+
+      await handler.changeAccessState(conversation, ACCESS_STATE.TEAM.TEAM_ONLY);
+
+      expect(conversationService.deleteConversationCode).toHaveBeenCalledWith('conversation-id');
+      expect(conversation.accessCode()).toBe('');
+      expect(conversationService.putConversationAccess).toHaveBeenCalled();
+    });
+
     it('shows the app allow-failure modal with the app translation key when granting service access fails', async () => {
       const {conversationService, translate, handler} = buildHandler();
       conversationService.putConversationAccess.mockRejectedValue(new Error('Expected unit test error'));

--- a/apps/webapp/src/script/repositories/conversation/ConversationStateHandler.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationStateHandler.ts
@@ -33,7 +33,7 @@ import {ACCESS_STATE} from './AccessState';
 import {
   ACCESS_MODES,
   featureFromStateChange,
-  isGettingAccessToFeature,
+  hasAccessToFeature,
   updateAccessRights,
 } from './ConversationAccessPermission';
 import {ConversationMapper} from './ConversationMapper';
@@ -82,8 +82,10 @@ export class ConversationStateHandler extends AbstractConversationEventHandler {
         const {accessModes, accessRole} = updateAccessRights(accessState);
         if (accessModes !== undefined && accessRole !== undefined) {
           try {
-            const isGettingAccessCode = isGettingAccessToFeature(ACCESS_MODES.CODE, prevAccessState, accessState);
-            if (isGettingAccessCode === false) {
+            const isLosingAccessCode =
+              hasAccessToFeature(ACCESS_MODES.CODE, prevAccessState) &&
+              !hasAccessToFeature(ACCESS_MODES.CODE, accessState);
+            if (isLosingAccessCode) {
               conversationEntity.accessCode('');
               await this.revokeAccessCode(conversationEntity);
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Issue

When enabling or disabling apps in an MLS group, the access update succeeds and the apps change state, but the UI also shows this unrelated error:

<img width="381" height="206" alt="image" src="https://github.com/user-attachments/assets/e7f5798c-902e-4c67-9b00-f2f99725f8cb" />

> Could not revoke access link. Please try again.

## Root cause

App-only access transitions between `TEAM_ONLY` and `SERVICES` do not use conversation access codes. The webapp was treating every transition that did not gain `CODE` access as if it had lost code access, so it called the guest-link revoke endpoint. The endpoint error was shown even though the app access update then succeeded.

## Fix

- Revoke the conversation access code only when the transition removes code access.
- Keep guest-link revocation for genuine guest-access removal.
- Add regression coverage for enabling and disabling apps, plus guest-access revocation.
- Include the reported screenshot as a review artifact.

## Validation

- `yarn nx run webapp:test --testFile=src/script/repositories/conversation/ConversationStateHandler.test.ts`
- `yarn nx run webapp:type-check`
- ESLint on the changed TypeScript files
- Prettier check on the changed TypeScript files

