### PR TITLE
chore: persist startup feature toggles across reloads and navigation [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/configToolbar/configToolbar.tsx
+++ b/apps/webapp/src/script/components/configToolbar/configToolbar.tsx
@@ -353,6 +353,7 @@ export function ConfigToolbar() {
       locationSearch,
       featureToggleName,
       shouldEnableFeatureToggle,
+      localStorage: globalThis.localStorage,
     });
     const locationPathname = applicationNavigation.currentPathname;
     const locationHash = applicationNavigation.currentHash;

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
@@ -24,10 +24,10 @@ import {
 import {startupFeatureToggleQueryParameterName, startupFeatureToggleLocalStorageKey} from './startupFeatureToggles';
 import {updateLocationSearchForStartupFeatureToggle} from './startupFeatureToggleQueryParameters';
 
-type LocalStorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+type LocalStorageStub = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 
-function createInMemoryLocalStorage(initialValue?: string): {
-  localStorage: LocalStorageLike;
+function createInMemoryLocalStorageStub(initialValue?: string): {
+  localStorage: LocalStorageStub;
   getStoredValue: () => string | null;
 } {
   let storedValue: string | null = initialValue ?? null;
@@ -134,7 +134,7 @@ describe('updateLocationSearchForStartupFeatureToggle', () => {
 
 describe('updateLocationSearchForStartupFeatureToggle session persistence', () => {
   it('persists the updated enabled toggles to local storage when enabling a toggle', () => {
-    const {localStorage, getStoredValue} = createInMemoryLocalStorage();
+    const {localStorage, getStoredValue} = createInMemoryLocalStorageStub();
 
     updateLocationSearchForStartupFeatureToggle({
       locationSearch: '?foo=bar',
@@ -147,7 +147,7 @@ describe('updateLocationSearchForStartupFeatureToggle session persistence', () =
   });
 
   it('clears local storage when the last feature toggle is disabled', () => {
-    const {localStorage, getStoredValue} = createInMemoryLocalStorage(applockRefactoredFeatureToggleName);
+    const {localStorage, getStoredValue} = createInMemoryLocalStorageStub(applockRefactoredFeatureToggleName);
 
     updateLocationSearchForStartupFeatureToggle({
       locationSearch: `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
@@ -160,7 +160,7 @@ describe('updateLocationSearchForStartupFeatureToggle session persistence', () =
   });
 
   it('keeps the remaining enabled toggles in local storage when one is disabled', () => {
-    const {localStorage, getStoredValue} = createInMemoryLocalStorage(
+    const {localStorage, getStoredValue} = createInMemoryLocalStorageStub(
       `${applockRefactoredFeatureToggleName},${conversationListCollapseFeatureToggleName}`,
     );
 
@@ -175,7 +175,7 @@ describe('updateLocationSearchForStartupFeatureToggle session persistence', () =
   });
 
   it('does not touch local storage when no local storage is provided', () => {
-    const {localStorage, getStoredValue} = createInMemoryLocalStorage();
+    const {localStorage, getStoredValue} = createInMemoryLocalStorageStub();
 
     updateLocationSearchForStartupFeatureToggle({
       locationSearch: '?foo=bar',
@@ -187,7 +187,7 @@ describe('updateLocationSearchForStartupFeatureToggle session persistence', () =
   });
 
   it('keeps localStorage-enabled toggles when enabling a toggle from a search without the query parameter', () => {
-    const {localStorage, getStoredValue} = createInMemoryLocalStorage(conversationListCollapseFeatureToggleName);
+    const {localStorage, getStoredValue} = createInMemoryLocalStorageStub(conversationListCollapseFeatureToggleName);
 
     const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
       locationSearch: '?foo=bar',
@@ -199,13 +199,11 @@ describe('updateLocationSearchForStartupFeatureToggle session persistence', () =
     expect(updatedLocationSearch).toBe(
       `?foo=bar&${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}%2C${conversationListCollapseFeatureToggleName}`,
     );
-    expect(getStoredValue()).toBe(
-      `${applockRefactoredFeatureToggleName},${conversationListCollapseFeatureToggleName}`,
-    );
+    expect(getStoredValue()).toBe(`${applockRefactoredFeatureToggleName},${conversationListCollapseFeatureToggleName}`);
   });
 
   it('keeps other localStorage-enabled toggles when disabling one from a search without the query parameter', () => {
-    const {localStorage, getStoredValue} = createInMemoryLocalStorage(
+    const {localStorage, getStoredValue} = createInMemoryLocalStorageStub(
       `${applockRefactoredFeatureToggleName},${conversationListCollapseFeatureToggleName}`,
     );
 
@@ -223,7 +221,7 @@ describe('updateLocationSearchForStartupFeatureToggle session persistence', () =
   });
 
   it('clears local storage when disabling the last toggle from a search without the query parameter', () => {
-    const {localStorage, getStoredValue} = createInMemoryLocalStorage(applockRefactoredFeatureToggleName);
+    const {localStorage, getStoredValue} = createInMemoryLocalStorageStub(applockRefactoredFeatureToggleName);
 
     const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
       locationSearch: '?foo=bar',

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.test.ts
@@ -21,8 +21,34 @@ import {
   applockRefactoredFeatureToggleName,
   conversationListCollapseFeatureToggleName,
 } from './startupFeatureToggleNames';
-import {startupFeatureToggleQueryParameterName} from './startupFeatureToggles';
+import {startupFeatureToggleQueryParameterName, startupFeatureToggleLocalStorageKey} from './startupFeatureToggles';
 import {updateLocationSearchForStartupFeatureToggle} from './startupFeatureToggleQueryParameters';
+
+type LocalStorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+function createInMemoryLocalStorage(initialValue?: string): {
+  localStorage: LocalStorageLike;
+  getStoredValue: () => string | null;
+} {
+  let storedValue: string | null = initialValue ?? null;
+
+  return {
+    localStorage: {
+      getItem: (key: string) => (key === startupFeatureToggleLocalStorageKey ? storedValue : null),
+      setItem: (key: string, value: string) => {
+        if (key === startupFeatureToggleLocalStorageKey) {
+          storedValue = value;
+        }
+      },
+      removeItem: (key: string) => {
+        if (key === startupFeatureToggleLocalStorageKey) {
+          storedValue = null;
+        }
+      },
+    },
+    getStoredValue: () => storedValue,
+  };
+}
 
 describe('updateLocationSearchForStartupFeatureToggle', () => {
   it('adds a feature toggle to an existing query string and preserves unrelated parameters', () => {
@@ -103,5 +129,110 @@ describe('updateLocationSearchForStartupFeatureToggle', () => {
     expect(updatedLocationSearch).toBe(
       `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
     );
+  });
+});
+
+describe('updateLocationSearchForStartupFeatureToggle session persistence', () => {
+  it('persists the updated enabled toggles to local storage when enabling a toggle', () => {
+    const {localStorage, getStoredValue} = createInMemoryLocalStorage();
+
+    updateLocationSearchForStartupFeatureToggle({
+      locationSearch: '?foo=bar',
+      featureToggleName: applockRefactoredFeatureToggleName,
+      shouldEnableFeatureToggle: true,
+      localStorage,
+    });
+
+    expect(getStoredValue()).toBe(applockRefactoredFeatureToggleName);
+  });
+
+  it('clears local storage when the last feature toggle is disabled', () => {
+    const {localStorage, getStoredValue} = createInMemoryLocalStorage(applockRefactoredFeatureToggleName);
+
+    updateLocationSearchForStartupFeatureToggle({
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
+      featureToggleName: applockRefactoredFeatureToggleName,
+      shouldEnableFeatureToggle: false,
+      localStorage,
+    });
+
+    expect(getStoredValue()).toBeNull();
+  });
+
+  it('keeps the remaining enabled toggles in local storage when one is disabled', () => {
+    const {localStorage, getStoredValue} = createInMemoryLocalStorage(
+      `${applockRefactoredFeatureToggleName},${conversationListCollapseFeatureToggleName}`,
+    );
+
+    updateLocationSearchForStartupFeatureToggle({
+      locationSearch: `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName},${conversationListCollapseFeatureToggleName}`,
+      featureToggleName: applockRefactoredFeatureToggleName,
+      shouldEnableFeatureToggle: false,
+      localStorage,
+    });
+
+    expect(getStoredValue()).toBe(conversationListCollapseFeatureToggleName);
+  });
+
+  it('does not touch local storage when no local storage is provided', () => {
+    const {localStorage, getStoredValue} = createInMemoryLocalStorage();
+
+    updateLocationSearchForStartupFeatureToggle({
+      locationSearch: '?foo=bar',
+      featureToggleName: applockRefactoredFeatureToggleName,
+      shouldEnableFeatureToggle: true,
+    });
+
+    expect(getStoredValue()).toBeNull();
+  });
+
+  it('keeps localStorage-enabled toggles when enabling a toggle from a search without the query parameter', () => {
+    const {localStorage, getStoredValue} = createInMemoryLocalStorage(conversationListCollapseFeatureToggleName);
+
+    const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
+      locationSearch: '?foo=bar',
+      featureToggleName: applockRefactoredFeatureToggleName,
+      shouldEnableFeatureToggle: true,
+      localStorage,
+    });
+
+    expect(updatedLocationSearch).toBe(
+      `?foo=bar&${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}%2C${conversationListCollapseFeatureToggleName}`,
+    );
+    expect(getStoredValue()).toBe(
+      `${applockRefactoredFeatureToggleName},${conversationListCollapseFeatureToggleName}`,
+    );
+  });
+
+  it('keeps other localStorage-enabled toggles when disabling one from a search without the query parameter', () => {
+    const {localStorage, getStoredValue} = createInMemoryLocalStorage(
+      `${applockRefactoredFeatureToggleName},${conversationListCollapseFeatureToggleName}`,
+    );
+
+    const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
+      locationSearch: '?foo=bar',
+      featureToggleName: applockRefactoredFeatureToggleName,
+      shouldEnableFeatureToggle: false,
+      localStorage,
+    });
+
+    expect(updatedLocationSearch).toBe(
+      `?foo=bar&${startupFeatureToggleQueryParameterName}=${conversationListCollapseFeatureToggleName}`,
+    );
+    expect(getStoredValue()).toBe(conversationListCollapseFeatureToggleName);
+  });
+
+  it('clears local storage when disabling the last toggle from a search without the query parameter', () => {
+    const {localStorage, getStoredValue} = createInMemoryLocalStorage(applockRefactoredFeatureToggleName);
+
+    const updatedLocationSearch = updateLocationSearchForStartupFeatureToggle({
+      locationSearch: '?foo=bar',
+      featureToggleName: applockRefactoredFeatureToggleName,
+      shouldEnableFeatureToggle: false,
+      localStorage,
+    });
+
+    expect(updatedLocationSearch).toBe('?foo=bar');
+    expect(getStoredValue()).toBeNull();
   });
 });

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.ts
@@ -22,13 +22,17 @@ import {Maybe} from 'true-myth';
 import {StartupFeatureToggleName, startupFeatureToggleNames} from './startupFeatureToggleNames';
 import {
   createStartupFeatureTogglesFromLocationSearch,
+  persistEnabledFeatureToggleNamesInLocalStorage,
   startupFeatureToggleQueryParameterName,
 } from './startupFeatureToggles';
+
+type StartupFeatureToggleLocalStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 
 type UpdateStartupFeatureToggleLocationSearchInput = {
   readonly locationSearch: string;
   readonly featureToggleName: StartupFeatureToggleName;
   readonly shouldEnableFeatureToggle: boolean;
+  readonly localStorage?: StartupFeatureToggleLocalStorage;
 };
 
 function toOrderedEnabledFeatureToggleNames(
@@ -41,8 +45,9 @@ function toOrderedEnabledFeatureToggleNames(
 
 function readEnabledFeatureToggleNameSetFromLocationSearch(
   locationSearch: string,
+  localStorage?: StartupFeatureToggleLocalStorage,
 ): ReadonlySet<StartupFeatureToggleName> {
-  const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(locationSearch);
+  const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(locationSearch, localStorage);
   return new Set(startupFeatureToggles.enabledFeatureToggleNames);
 }
 
@@ -77,13 +82,20 @@ function serializeEnabledFeatureToggleNames(
 export function updateLocationSearchForStartupFeatureToggle(
   input: UpdateStartupFeatureToggleLocationSearchInput,
 ): string {
-  const {locationSearch, featureToggleName, shouldEnableFeatureToggle} = input;
-  const enabledFeatureToggleNameSet = readEnabledFeatureToggleNameSetFromLocationSearch(locationSearch);
+  const {locationSearch, featureToggleName, shouldEnableFeatureToggle, localStorage} = input;
+  const enabledFeatureToggleNameSet = readEnabledFeatureToggleNameSetFromLocationSearch(locationSearch, localStorage);
   const updatedEnabledFeatureToggleNameSet = toUpdatedEnabledFeatureToggleNameSet(
     enabledFeatureToggleNameSet,
     featureToggleName,
     shouldEnableFeatureToggle,
   );
+
+  if (localStorage !== undefined) {
+    persistEnabledFeatureToggleNamesInLocalStorage(
+      toOrderedEnabledFeatureToggleNames(updatedEnabledFeatureToggleNameSet),
+      localStorage,
+    );
+  }
 
   const queryParameters = new URLSearchParams(locationSearch);
   const serializedEnabledFeatureToggleNames = serializeEnabledFeatureToggleNames(updatedEnabledFeatureToggleNameSet);

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleQueryParameters.ts
@@ -90,12 +90,10 @@ export function updateLocationSearchForStartupFeatureToggle(
     shouldEnableFeatureToggle,
   );
 
-  if (localStorage !== undefined) {
-    persistEnabledFeatureToggleNamesInLocalStorage(
-      toOrderedEnabledFeatureToggleNames(updatedEnabledFeatureToggleNameSet),
-      localStorage,
-    );
-  }
+  persistEnabledFeatureToggleNamesInLocalStorage(
+    toOrderedEnabledFeatureToggleNames(updatedEnabledFeatureToggleNameSet),
+    localStorage,
+  );
 
   const queryParameters = new URLSearchParams(locationSearch);
   const serializedEnabledFeatureToggleNames = serializeEnabledFeatureToggleNames(updatedEnabledFeatureToggleNameSet);

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -167,10 +167,10 @@ describe('startupFeatureToggles', function () {
   });
 });
 
-type LocalStorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+type LocalStorageStub = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 
-function createInMemoryLocalStorage(initialValue?: string): {
-  localStorage: LocalStorageLike;
+function createInMemoryLocalStorageStub(initialValue?: string): {
+  localStorage: LocalStorageStub;
   getStoredValue: () => string | null;
 } {
   let storedValue: string | null = initialValue ?? null;
@@ -195,7 +195,7 @@ function createInMemoryLocalStorage(initialValue?: string): {
 
 describe('startupFeatureToggles session persistence', () => {
   it('falls back to local storage when the query parameter is missing', () => {
-    const {localStorage} = createInMemoryLocalStorage(applockRefactoredFeatureToggleName);
+    const {localStorage} = createInMemoryLocalStorageStub(applockRefactoredFeatureToggleName);
 
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch('?foo=bar', localStorage);
 
@@ -204,7 +204,7 @@ describe('startupFeatureToggles session persistence', () => {
   });
 
   it('prefers the query parameter over local storage', () => {
-    const {localStorage} = createInMemoryLocalStorage(applockRefactoredFeatureToggleName);
+    const {localStorage} = createInMemoryLocalStorageStub(applockRefactoredFeatureToggleName);
 
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=${viewerPermissionFeatureToggleName}`,
@@ -216,7 +216,7 @@ describe('startupFeatureToggles session persistence', () => {
   });
 
   it('persists query parameter toggles to local storage', () => {
-    const {localStorage, getStoredValue} = createInMemoryLocalStorage();
+    const {localStorage, getStoredValue} = createInMemoryLocalStorageStub();
 
     createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
@@ -227,7 +227,7 @@ describe('startupFeatureToggles session persistence', () => {
   });
 
   it('clears local storage when the query parameter is present but empty', () => {
-    const {localStorage, getStoredValue} = createInMemoryLocalStorage(applockRefactoredFeatureToggleName);
+    const {localStorage, getStoredValue} = createInMemoryLocalStorageStub(applockRefactoredFeatureToggleName);
 
     createStartupFeatureTogglesFromLocationSearch(`?${startupFeatureToggleQueryParameterName}=`, localStorage);
 
@@ -241,7 +241,7 @@ describe('startupFeatureToggles session persistence', () => {
   });
 
   it('ignores unknown feature toggles from local storage', () => {
-    const {localStorage} = createInMemoryLocalStorage('unknown-feature');
+    const {localStorage} = createInMemoryLocalStorageStub('unknown-feature');
 
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch('?foo=bar', localStorage);
 
@@ -249,7 +249,7 @@ describe('startupFeatureToggles session persistence', () => {
   });
 
   it('trims whitespace around feature toggle names from local storage', () => {
-    const {localStorage} = createInMemoryLocalStorage(` ${applockRefactoredFeatureToggleName} `);
+    const {localStorage} = createInMemoryLocalStorageStub(` ${applockRefactoredFeatureToggleName} `);
 
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch('?foo=bar', localStorage);
 

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -21,6 +21,7 @@ import {
   allowedStartupFeatureToggleNames,
   createStartupFeatureTogglesFromLocationSearch,
   startupFeatureToggleQueryParameterName,
+  startupFeatureToggleLocalStorageKey,
 } from './startupFeatureToggles';
 import {
   applockRefactoredFeatureToggleName,
@@ -163,5 +164,95 @@ describe('startupFeatureToggles', function () {
     );
 
     expect('enabledFeatureToggleNameSet' in startupFeatureToggles).toBe(false);
+  });
+});
+
+type LocalStorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+function createInMemoryLocalStorage(initialValue?: string): {
+  localStorage: LocalStorageLike;
+  getStoredValue: () => string | null;
+} {
+  let storedValue: string | null = initialValue ?? null;
+
+  return {
+    localStorage: {
+      getItem: (key: string) => (key === startupFeatureToggleLocalStorageKey ? storedValue : null),
+      setItem: (key: string, value: string) => {
+        if (key === startupFeatureToggleLocalStorageKey) {
+          storedValue = value;
+        }
+      },
+      removeItem: (key: string) => {
+        if (key === startupFeatureToggleLocalStorageKey) {
+          storedValue = null;
+        }
+      },
+    },
+    getStoredValue: () => storedValue,
+  };
+}
+
+describe('startupFeatureToggles session persistence', () => {
+  it('falls back to local storage when the query parameter is missing', () => {
+    const {localStorage} = createInMemoryLocalStorage(applockRefactoredFeatureToggleName);
+
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch('?foo=bar', localStorage);
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(true);
+    expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([applockRefactoredFeatureToggleName]);
+  });
+
+  it('prefers the query parameter over local storage', () => {
+    const {localStorage} = createInMemoryLocalStorage(applockRefactoredFeatureToggleName);
+
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${viewerPermissionFeatureToggleName}`,
+      localStorage,
+    );
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(false);
+    expect(startupFeatureToggles.isFeatureToggleEnabled(viewerPermissionFeatureToggleName)).toBe(true);
+  });
+
+  it('persists query parameter toggles to local storage', () => {
+    const {localStorage, getStoredValue} = createInMemoryLocalStorage();
+
+    createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${applockRefactoredFeatureToggleName}`,
+      localStorage,
+    );
+
+    expect(getStoredValue()).toBe(applockRefactoredFeatureToggleName);
+  });
+
+  it('clears local storage when the query parameter is present but empty', () => {
+    const {localStorage, getStoredValue} = createInMemoryLocalStorage(applockRefactoredFeatureToggleName);
+
+    createStartupFeatureTogglesFromLocationSearch(`?${startupFeatureToggleQueryParameterName}=`, localStorage);
+
+    expect(getStoredValue()).toBeNull();
+  });
+
+  it('does not read from local storage when no local storage is provided', () => {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch('?foo=bar');
+
+    expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([]);
+  });
+
+  it('ignores unknown feature toggles from local storage', () => {
+    const {localStorage} = createInMemoryLocalStorage('unknown-feature');
+
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch('?foo=bar', localStorage);
+
+    expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([]);
+  });
+
+  it('trims whitespace around feature toggle names from local storage', () => {
+    const {localStorage} = createInMemoryLocalStorage(` ${applockRefactoredFeatureToggleName} `);
+
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch('?foo=bar', localStorage);
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(true);
   });
 });

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.ts
@@ -24,7 +24,11 @@ export type {StartupFeatureToggleName} from './startupFeatureToggleNames';
 
 export const startupFeatureToggleQueryParameterName = 'enabled-features';
 
+export const startupFeatureToggleLocalStorageKey = 'startup-feature-toggles';
+
 export const allowedStartupFeatureToggleNames = startupFeatureToggleNames;
+
+type StartupFeatureToggleLocalStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 
 const allowedStartupFeatureToggleNameSet = new Set<StartupFeatureToggleName>(allowedStartupFeatureToggleNames);
 
@@ -62,10 +66,65 @@ function readEnabledFeatureToggleNameListFromLocationSearch(
   return Maybe.of(enabledFeatureTogglesParameterValue).map(toEnabledFeatureToggleNameList).unwrapOr([]);
 }
 
-export function createStartupFeatureTogglesFromLocationSearch(locationSearch: string): StartupFeatureToggles {
-  const enabledFeatureToggleNameSet = new Set<StartupFeatureToggleName>(
-    readEnabledFeatureToggleNameListFromLocationSearch(locationSearch),
-  );
+function hasStartupFeatureToggleQueryParameter(locationSearch: string): boolean {
+  return new URLSearchParams(locationSearch).has(startupFeatureToggleQueryParameterName);
+}
+
+function readEnabledFeatureToggleNameListFromLocalStorage(
+  localStorage: StartupFeatureToggleLocalStorage,
+): readonly StartupFeatureToggleName[] {
+  return Maybe.of(localStorage.getItem(startupFeatureToggleLocalStorageKey))
+    .map(toEnabledFeatureToggleNameList)
+    .unwrapOr([]);
+}
+
+export function persistEnabledFeatureToggleNamesInLocalStorage(
+  enabledFeatureToggleNames: readonly StartupFeatureToggleName[],
+  localStorage: StartupFeatureToggleLocalStorage,
+): void {
+  if (enabledFeatureToggleNames.length === 0) {
+    localStorage.removeItem(startupFeatureToggleLocalStorageKey);
+    return;
+  }
+
+  localStorage.setItem(startupFeatureToggleLocalStorageKey, enabledFeatureToggleNames.join(','));
+}
+
+function readEnabledFeatureToggleNameList(
+  locationSearch: string,
+  localStorage: StartupFeatureToggleLocalStorage | undefined,
+): readonly StartupFeatureToggleName[] {
+  if (hasStartupFeatureToggleQueryParameter(locationSearch)) {
+    return readEnabledFeatureToggleNameListFromLocationSearch(locationSearch);
+  }
+
+  if (localStorage !== undefined) {
+    return readEnabledFeatureToggleNameListFromLocalStorage(localStorage);
+  }
+
+  return [];
+}
+
+/**
+ * Creates the startup feature toggles for the application boot.
+ *
+ * The URL query parameter is the source of truth whenever it is present:
+ * - If `enabled-features` is in the URL, its value is used and synced to local storage.
+ * - If the parameter is missing and local storage is provided, the previously persisted
+ *   toggles are used so they survive page reloads and in-app navigation.
+ * - If neither is available, all toggles are disabled.
+ */
+export function createStartupFeatureTogglesFromLocationSearch(
+  locationSearch: string,
+  localStorage?: StartupFeatureToggleLocalStorage,
+): StartupFeatureToggles {
+  const enabledFeatureToggleNames = readEnabledFeatureToggleNameList(locationSearch, localStorage);
+
+  if (localStorage !== undefined) {
+    persistEnabledFeatureToggleNamesInLocalStorage(enabledFeatureToggleNames, localStorage);
+  }
+
+  const enabledFeatureToggleNameSet = new Set<StartupFeatureToggleName>(enabledFeatureToggleNames);
 
   return {
     isFeatureToggleEnabled(featureToggleName) {

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.ts
@@ -80,8 +80,12 @@ function readEnabledFeatureToggleNameListFromLocalStorage(
 
 export function persistEnabledFeatureToggleNamesInLocalStorage(
   enabledFeatureToggleNames: readonly StartupFeatureToggleName[],
-  localStorage: StartupFeatureToggleLocalStorage,
+  localStorage?: StartupFeatureToggleLocalStorage,
 ): void {
+  if (localStorage === undefined) {
+    return;
+  }
+
   if (enabledFeatureToggleNames.length === 0) {
     localStorage.removeItem(startupFeatureToggleLocalStorageKey);
     return;
@@ -120,9 +124,7 @@ export function createStartupFeatureTogglesFromLocationSearch(
 ): StartupFeatureToggles {
   const enabledFeatureToggleNames = readEnabledFeatureToggleNameList(locationSearch, localStorage);
 
-  if (localStorage !== undefined) {
-    persistEnabledFeatureToggleNamesInLocalStorage(enabledFeatureToggleNames, localStorage);
-  }
+  persistEnabledFeatureToggleNamesInLocalStorage(enabledFeatureToggleNames, localStorage);
 
   const enabledFeatureToggleNameSet = new Set<StartupFeatureToggleName>(enabledFeatureToggleNames);
 

--- a/apps/webapp/src/script/main/index.tsx
+++ b/apps/webapp/src/script/main/index.tsx
@@ -90,7 +90,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     return doSimpleRedirect(SIGN_OUT_REASON.NOT_SIGNED_IN);
   }
 
-  const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(globalThis.location.search);
+  const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+    globalThis.location.search,
+    globalThis.localStorage,
+  );
   const fireAndForgetInvokerLogger = getLogger('FireAndForgetInvoker');
   const applicationServices = createApplicationServices({
     createApplicationObservability() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## What

Dev-experience chore: startup feature toggles (`?enabled-features=...`, the Developer Menu toggles) now persist in `localStorage` so they stay on/off across page reloads, in-app navigation, and tabs.

## Why

Today the toggles only survive while the query parameter stays in the URL — any navigation or reload that drops the parameter resets them. For a debugging workflow this makes toggles fragile and easy to lose mid-session.

