### PR TITLE
fix: Stabilise cells action permission callback(WPB-28079)

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {createContext, type ReactNode, useContext} from 'react';
+import {createContext, type ReactNode, useCallback, useContext} from 'react';
 
 import {viewerPermissionFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
@@ -132,10 +132,13 @@ export const useCellsActionPermissions = () => {
   const selfUserDriveRole = useCellsSelfUserDriveRole();
   const isViewerPermissionFeatureEnabled = isFeatureToggleEnabled(viewerPermissionFeatureToggleName);
 
-  return (action: CellsAction) =>
-    canPerformCellsAction({
-      action,
-      isViewerPermissionFeatureEnabled,
-      selfUserDriveRole,
-    });
+  return useCallback(
+    (action: CellsAction) =>
+      canPerformCellsAction({
+        action,
+        isViewerPermissionFeatureEnabled,
+        selfUserDriveRole,
+      }),
+    [isViewerPermissionFeatureEnabled, selfUserDriveRole],
+  );
 };

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.tsx
@@ -74,7 +74,7 @@ export const FileFullscreenModal = ({
 }: FileFullscreenModalProps) => {
   const notInRecycleBin = !checkIsInRecycleBin();
   const canPerformCellsAction = useCellsActionPermissions();
-  const [isEditableState, setIsEditableState] = useState(
+  const [isInEditMode, setIsInEditMode] = useState(
     isEditMode && notInRecycleBin && canPerformCellsAction(CELLS_ACTION.EDIT),
   );
   const [refreshKey, setRefreshKey] = useState(0);
@@ -85,12 +85,12 @@ export const FileFullscreenModal = ({
   };
 
   const onCloseModal = () => {
-    setIsEditableState(false);
+    setIsInEditMode(false);
     onClose();
   };
 
   useEffect(() => {
-    setIsEditableState(isEditMode && notInRecycleBin && canPerformCellsAction(CELLS_ACTION.EDIT));
+    setIsInEditMode(isEditMode && notInRecycleBin && canPerformCellsAction(CELLS_ACTION.EDIT));
   }, [canPerformCellsAction, isEditMode, notInRecycleBin]);
 
   return (
@@ -103,13 +103,13 @@ export const FileFullscreenModal = ({
         senderName={senderName}
         timestamp={timestamp}
         badges={badges}
-        isInEditMode={isEditableState}
-        onEditModeChange={setIsEditableState}
+        isInEditMode={isInEditMode}
+        onEditModeChange={setIsInEditMode}
         isEditable={isEditable}
         id={id}
         onFileContentRefresh={refreshModalContent}
       />
-      {isEditableState && isEditable ? (
+      {isInEditMode && isEditable ? (
         <FileEditor key={refreshKey} id={id} />
       ) : (
         <ModalContent


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28079" title="WPB-28079" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28079</a>  Unable to switch between edit/view mode inside Collabora files
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

- Memoizes `useCellsActionPermissions()` with `useCallback`
- Prevents consumers from seeing a new permission check function on every render
- Fixes Collabora file preview mode toggling between Viewing and Editing
- improved naming from isEditableState to isInEditMode

## Context

`FileFullscreenModal` syncs its local edit mode state from props in an effect that depends on `canPerformCellsAction`.

Before this change, `useCellsActionPermissions()` returned a new function on each render. Clicking Viewing/Editing updated local modal state, triggered a re-render, changed the callback reference, reran the effect, and reset the modal back to the originally opened mode.

## Follow-Up

A fuller cleanup should be handled separately: first extract the duplicated Cells file-preview modal rendering into a shared component, then make Collabora edit/view mode controlled by the parent preview modal context so there is a single source of truth. [Jira ticket](https://wearezeta.atlassian.net/browse/WPB-28087)