### PR TITLE
Handle conversation.delete-meeting and keep host delete available [WPB-27897]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.test.tsx
@@ -219,7 +219,7 @@ describe('getMeetingActionEntries', () => {
     expect(getDeleteForMeEntryLabel(entries)).toBeUndefined();
   });
 
-  it('omits Delete meeting for everyone when the instance has started', () => {
+  it('includes Delete meeting for everyone when the instance has started', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser(),
@@ -231,7 +231,7 @@ describe('getMeetingActionEntries', () => {
       onDeleteForMe: noop,
     });
 
-    expect(getDeleteForAllEntryLabel(entries)).toBeUndefined();
+    expect(getDeleteForAllEntryLabel(entries)).toBeDefined();
     expect(getDeleteForMeEntryLabel(entries)).toBeUndefined();
   });
 
@@ -267,7 +267,7 @@ describe('getMeetingActionEntries', () => {
     expect(getDeleteForAllEntryLabel(entries)).toBeUndefined();
   });
 
-  it('omits delete actions for past meetings', () => {
+  it('includes Delete meeting for everyone when the instance is in the past', () => {
     const entries = getMeetingActionEntries({
       meetingInstance: createMeetingInstance(),
       selfUser: createSelfUser(),
@@ -279,8 +279,24 @@ describe('getMeetingActionEntries', () => {
       onDeleteForMe: noop,
     });
 
-    expect(getDeleteForAllEntryLabel(entries)).toBeUndefined();
+    expect(getDeleteForAllEntryLabel(entries)).toBeDefined();
     expect(getDeleteForMeEntryLabel(entries)).toBeUndefined();
+  });
+
+  it('includes Delete meeting for me for a participant when the instance is in the past', () => {
+    const entries = getMeetingActionEntries({
+      meetingInstance: createMeetingInstance(),
+      selfUser: createSelfUser('invitee-id'),
+      nowMilliseconds: pastNowMilliseconds,
+      translate,
+      onJoin: noop,
+      onEdit: jest.fn(),
+      onDeleteForAll: noop,
+      onDeleteForMe: noop,
+    });
+
+    expect(getDeleteForMeEntryLabel(entries)).toBeDefined();
+    expect(getDeleteForAllEntryLabel(entries)).toBeUndefined();
   });
 
   it('keeps Join now visible but disables it while joining or in a call', () => {

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.test.tsx
@@ -97,8 +97,8 @@ describe('getMeetingActionEntries', () => {
     expect(getEntryLabels(entries)).not.toContain('meetings.action.startMeeting');
   });
 
-  it.each([futureNowMilliseconds, ongoingNowMilliseconds, pastNowMilliseconds])(
-    'always includes Join now regardless of meeting state',
+  it.each([futureNowMilliseconds, ongoingNowMilliseconds])(
+    'includes Join now for upcoming and ongoing meetings',
     nowMilliseconds => {
       const onJoin = jest.fn();
       const entries = getMeetingActionEntries({
@@ -281,6 +281,7 @@ describe('getMeetingActionEntries', () => {
 
     expect(getDeleteForAllEntryLabel(entries)).toBeDefined();
     expect(getDeleteForMeEntryLabel(entries)).toBeUndefined();
+    expect(getJoinEntry(entries)).toBeUndefined();
   });
 
   it('includes Delete meeting for me for a participant when the instance is in the past', () => {
@@ -297,6 +298,7 @@ describe('getMeetingActionEntries', () => {
 
     expect(getDeleteForMeEntryLabel(entries)).toBeDefined();
     expect(getDeleteForAllEntryLabel(entries)).toBeUndefined();
+    expect(getJoinEntry(entries)).toBeUndefined();
   });
 
   it('keeps Join now visible but disables it while joining or in a call', () => {

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.tsx
@@ -82,8 +82,8 @@ export const getMeetingActionEntries = ({
     click: onDeleteForAll,
   };
 
-  const showDeleteForAll = canDeleteMeetingForAll(meetingInstance, selfUser, nowMilliseconds);
-  const showDeleteForMe = canDeleteMeetingForMe(meetingInstance, selfUser, nowMilliseconds);
+  const showDeleteForAll = canDeleteMeetingForAll(meetingInstance, selfUser);
+  const showDeleteForMe = canDeleteMeetingForMe(meetingInstance, selfUser);
 
   return [
     joinEntry,

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.tsx
@@ -28,6 +28,7 @@ import {MEETING_ACTION_TRANSLATION_KEYS} from 'Components/meeting/meetingList/me
 import type {MeetingInstance} from 'Components/meeting/types/meetingInstance';
 import {canDeleteMeetingForAll, canDeleteMeetingForMe} from 'Components/meeting/utils/canDeleteMeeting';
 import {canEditMeeting} from 'Components/meeting/utils/canEditMeeting';
+import {getMeetingTemporalStatusAt, MeetingTemporalStatuses} from 'Components/meeting/utils/meetingStatusUtil';
 import type {User} from 'Repositories/entity/User';
 import type {ContextMenuEntry} from 'src/script/ui/contextMenu';
 import type {Translate} from 'Util/localizerUtil';
@@ -84,9 +85,15 @@ export const getMeetingActionEntries = ({
 
   const showDeleteForAll = canDeleteMeetingForAll(meetingInstance, selfUser);
   const showDeleteForMe = canDeleteMeetingForMe(meetingInstance, selfUser);
+  const temporalStatus = getMeetingTemporalStatusAt(
+    new Date(nowMilliseconds),
+    meetingInstance.start,
+    meetingInstance.end,
+  );
+  const showJoin = temporalStatus !== MeetingTemporalStatuses.PAST;
 
   return [
-    joinEntry,
+    ...(showJoin ? [joinEntry] : []),
     ...(canEditMeeting(meetingInstance, selfUser, nowMilliseconds) ? [editEntry] : []),
     ...(showDeleteForAll ? [deleteForAllEntry] : []),
     ...(showDeleteForMe ? [deleteForMeEntry] : []),

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/meetingAction.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/meetingAction.test.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import {createDeterministicWallClock} from '@enormora/wall-clock/deterministic-wall-clock';
 import {ThemeProvider} from '@wireapp/react-ui-kit';
 
@@ -76,7 +76,7 @@ const renderAction = (
   render(
     <MeetingStoreProvider store={createMeetingStoreForTest()}>
       <ThemeProvider>
-        <MeetingAction meetingInstance={meetingInstance} selfUser={user} />
+        <MeetingAction meetingInstance={meetingInstance} selfUser={user} joinMeeting={() => undefined} isJoinDisabled={false} />
       </ThemeProvider>
     </MeetingStoreProvider>,
     {
@@ -94,6 +94,7 @@ describe('MeetingAction', () => {
     ['upcoming', '2026-06-15T13:00:00.000Z'],
     ['ongoing', '2026-06-15T14:30:00.000Z'],
     ['ongoing at the scheduled end', '2026-06-15T15:00:00.000Z'],
+    ['past', '2026-06-15T16:00:00.000Z'],
   ])('renders the action button for %s meetings for the host', (_status, now) => {
     renderAction(now);
 
@@ -103,46 +104,10 @@ describe('MeetingAction', () => {
   it.each([
     ['upcoming', '2026-06-15T13:00:00.000Z'],
     ['ongoing', '2026-06-15T14:30:00.000Z'],
+    ['past', '2026-06-15T16:00:00.000Z'],
   ])('renders the action button for %s meetings for an invitee', (_status, now) => {
     renderAction(now, new User('invitee-id', 'example.com', translateForTest));
 
     expect(screen.getByRole('button')).toBeInTheDocument();
-  });
-
-  it.each(['2026-06-15T15:00:00.001Z', '2026-06-15T16:00:00.000Z'])(
-    'hides the action button after the meeting ends at %s for the host',
-    now => {
-      renderAction(now);
-
-      expect(screen.queryByRole('button')).not.toBeInTheDocument();
-    },
-  );
-
-  it('hides the action button after the meeting ends for an invitee', () => {
-    renderAction('2026-06-15T16:00:00.000Z', new User('invitee-id', 'example.com', translateForTest));
-
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
-  });
-
-  it('closes the context menu when the meeting becomes past', async () => {
-    const initialTime = new Date('2026-06-15T13:30:00.000Z');
-    const wallClock = createDeterministicWallClock({initialCurrentTimestampInMilliseconds: initialTime.getTime()});
-    const view = renderAction(initialTime.toISOString(), selfUser, wallClock);
-
-    fireEvent.click(screen.getByRole('button'));
-    await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
-
-    await act(async () => {
-      wallClock.advanceByMilliseconds(end.getTime() - initialTime.getTime() + 1);
-      view.rerender(
-        <MeetingStoreProvider store={createMeetingStoreForTest()}>
-          <ThemeProvider>
-            <MeetingAction meetingInstance={meetingInstance} selfUser={selfUser} />
-          </ThemeProvider>
-        </MeetingStoreProvider>,
-      );
-    });
-
-    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
   });
 });

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/meetingAction.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/meetingAction.test.tsx
@@ -76,7 +76,12 @@ const renderAction = (
   render(
     <MeetingStoreProvider store={createMeetingStoreForTest()}>
       <ThemeProvider>
-        <MeetingAction meetingInstance={meetingInstance} selfUser={user} joinMeeting={() => undefined} isJoinDisabled={false} />
+        <MeetingAction
+          meetingInstance={meetingInstance}
+          selfUser={user}
+          joinMeeting={() => undefined}
+          isJoinDisabled={false}
+        />
       </ThemeProvider>
     </MeetingStoreProvider>,
     {

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/meetingAction.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/meetingAction.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {MouseEvent, useEffect} from 'react';
+import {MouseEvent} from 'react';
 
 import {IconButton, MoreIcon} from '@wireapp/react-ui-kit';
 
@@ -31,11 +31,10 @@ import {useDeleteMeeting} from 'Components/meeting/useDeleteMeeting';
 import {useEditMeeting} from 'Components/meeting/useEditMeeting';
 import {canDeleteMeetingForAll, canDeleteMeetingForMe} from 'Components/meeting/utils/canDeleteMeeting';
 import {canEditMeeting} from 'Components/meeting/utils/canEditMeeting';
-import {getMeetingTemporalStatusAt, MeetingTemporalStatuses} from 'Components/meeting/utils/meetingStatusUtil';
 import type {User} from 'Repositories/entity/User';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 
-import {closeContextMenu, showContextMenu} from '../../../../../../ui/contextMenu';
+import {showContextMenu} from '../../../../../../ui/contextMenu';
 
 interface MeetingActionProps {
   meetingInstance: MeetingInstance;
@@ -48,22 +47,6 @@ export const MeetingAction = ({meetingInstance, selfUser, joinMeeting, isJoinDis
   const {translate, wallClock, fireAndForgetInvoker} = useApplicationContext();
   const {editMeeting} = useEditMeeting();
   const {openDeleteMeetingModal} = useDeleteMeeting();
-
-  const temporalStatus = getMeetingTemporalStatusAt(
-    new Date(wallClock.currentTimestampInMilliseconds),
-    meetingInstance.start,
-    meetingInstance.end,
-  );
-
-  useEffect(() => {
-    if (temporalStatus === MeetingTemporalStatuses.PAST) {
-      closeContextMenu();
-    }
-  }, [temporalStatus]);
-
-  if (temporalStatus === MeetingTemporalStatuses.PAST) {
-    return null;
-  }
 
   const handleActionButton = (event: MouseEvent<HTMLElement>) => {
     if (selfUser === undefined) {
@@ -87,12 +70,12 @@ export const MeetingAction = ({meetingInstance, selfUser, joinMeeting, isJoinDis
           }
         },
         onDeleteForAll: () => {
-          if (canDeleteMeetingForAll(meetingInstance, selfUser, wallClock.currentTimestampInMilliseconds)) {
+          if (canDeleteMeetingForAll(meetingInstance, selfUser)) {
             openDeleteMeetingModal(meetingInstance, 'forAll', selfUser);
           }
         },
         onDeleteForMe: () => {
-          if (canDeleteMeetingForMe(meetingInstance, selfUser, wallClock.currentTimestampInMilliseconds)) {
+          if (canDeleteMeetingForMe(meetingInstance, selfUser)) {
             openDeleteMeetingModal(meetingInstance, 'forMe', selfUser);
           }
         },

--- a/apps/webapp/src/script/components/meeting/shared/submit/submitDeleteMeeting.test.ts
+++ b/apps/webapp/src/script/components/meeting/shared/submit/submitDeleteMeeting.test.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {createDeterministicWallClock} from '@enormora/wall-clock/deterministic-wall-clock';
 import {task} from 'true-myth';
 
 import {meetingSubmitErrors} from 'Components/meeting/meetingSubmitErrors';
@@ -78,18 +77,18 @@ describe('submitDeleteMeeting', () => {
     resetInFlightDeleteMeetingsForTest();
   });
 
-  const createSubmitDeps = (overrides: {
-    deleteMeetingForAll?: jest.Mock;
-    deleteMeetingForMe?: jest.Mock;
-    removeMeetingByQualifiedId?: jest.Mock;
-    loadMeetings?: jest.Mock;
-    wallClock: ReturnType<typeof createDeterministicWallClock>;
-    selfUser?: User | undefined;
-  }) => ({
+  const createSubmitDeps = (
+    overrides: {
+      deleteMeetingForAll?: jest.Mock;
+      deleteMeetingForMe?: jest.Mock;
+      removeMeetingByQualifiedId?: jest.Mock;
+      loadMeetings?: jest.Mock;
+      selfUser?: User | undefined;
+    } = {},
+  ) => ({
     meetingInstance: createMeetingInstance(),
     mode: 'forAll' as const,
     selfUser: 'selfUser' in overrides ? overrides.selfUser : createSelfUser(),
-    wallClock: overrides.wallClock,
     translate: translateForTest,
     deleteMeetingForMe: overrides.deleteMeetingForMe ?? jest.fn().mockReturnValue(task.resolve(undefined)),
     deleteMeetingForAll: overrides.deleteMeetingForAll ?? jest.fn().mockReturnValue(task.resolve(undefined)),
@@ -100,15 +99,11 @@ describe('submitDeleteMeeting', () => {
   it('removes the meeting from the store after a successful delete for all', async () => {
     const removeMeetingByQualifiedId = jest.fn();
     const deleteMeetingForAll = jest.fn().mockReturnValue(task.resolve(undefined));
-    const wallClock = createDeterministicWallClock({
-      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
-    });
 
     const result = await submitDeleteMeeting(
       createSubmitDeps({
         deleteMeetingForAll,
         removeMeetingByQualifiedId,
-        wallClock,
       }),
     );
 
@@ -124,16 +119,12 @@ describe('submitDeleteMeeting', () => {
       .fn()
       .mockReturnValue(task.reject(meetingSubmitErrors.deleteSucceededButLocalCleanupFailed));
     const loadMeetings = jest.fn().mockResolvedValue(undefined);
-    const wallClock = createDeterministicWallClock({
-      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
-    });
 
     const result = await submitDeleteMeeting(
       createSubmitDeps({
         deleteMeetingForAll,
         removeMeetingByQualifiedId,
         loadMeetings,
-        wallClock,
       }),
     );
 
@@ -157,16 +148,12 @@ describe('submitDeleteMeeting', () => {
     const removeMeetingByQualifiedId = jest.fn();
     const deleteMeetingForAll = jest.fn().mockReturnValue(task.reject(meetingSubmitErrors.deleteFailed));
     const loadMeetings = jest.fn().mockResolvedValue(undefined);
-    const wallClock = createDeterministicWallClock({
-      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
-    });
 
     const result = await submitDeleteMeeting(
       createSubmitDeps({
         deleteMeetingForAll,
         removeMeetingByQualifiedId,
         loadMeetings,
-        wallClock,
       }),
     );
 
@@ -176,73 +163,13 @@ describe('submitDeleteMeeting', () => {
     expect(primaryModalShow).toHaveBeenCalledTimes(1);
   });
 
-  it('blocks delete for all when the meeting has started before submit', async () => {
-    const deleteMeetingForAll = jest.fn().mockReturnValue(task.resolve(undefined));
-    const wallClock = createDeterministicWallClock({
-      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T14:30:00.000Z'),
-    });
-
-    const result = await submitDeleteMeeting(
-      createSubmitDeps({
-        deleteMeetingForAll,
-        wallClock,
-      }),
-    );
-
-    expect(result).toBe(deleteMeetingSubmitResults.blocked);
-    expect(deleteMeetingForAll).not.toHaveBeenCalled();
-    expect(primaryModalShow).toHaveBeenCalledWith(
-      PrimaryModal.type.ACKNOWLEDGE,
-      expect.objectContaining({
-        text: expect.objectContaining({
-          title: translateForTest('meetings.deleteModal.error.notAllowedTitle'),
-          message: translateForTest('meetings.deleteModal.error.notAllowed'),
-        }),
-      }),
-      undefined,
-      translateForTest,
-    );
-  });
-
-  it('blocks delete when the meeting became past before submit', async () => {
-    const deleteMeetingForAll = jest.fn().mockReturnValue(task.resolve(undefined));
-    const wallClock = createDeterministicWallClock({
-      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T16:00:00.000Z'),
-    });
-
-    const result = await submitDeleteMeeting(
-      createSubmitDeps({
-        deleteMeetingForAll,
-        wallClock,
-      }),
-    );
-
-    expect(result).toBe(deleteMeetingSubmitResults.blocked);
-    expect(deleteMeetingForAll).not.toHaveBeenCalled();
-    expect(primaryModalShow).toHaveBeenCalledWith(
-      PrimaryModal.type.ACKNOWLEDGE,
-      expect.objectContaining({
-        text: expect.objectContaining({
-          title: translateForTest('meetings.deleteModal.error.notAllowedTitle'),
-          message: translateForTest('meetings.deleteModal.error.notAllowed'),
-        }),
-      }),
-      undefined,
-      translateForTest,
-    );
-  });
-
   it('shows feedback when selfUser is missing', async () => {
     const deleteMeetingForAll = jest.fn().mockReturnValue(task.resolve(undefined));
-    const wallClock = createDeterministicWallClock({
-      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
-    });
 
     const result = await submitDeleteMeeting(
       createSubmitDeps({
         deleteMeetingForAll,
         selfUser: undefined,
-        wallClock,
       }),
     );
 
@@ -275,14 +202,10 @@ describe('submitDeleteMeeting', () => {
       ),
     );
     const removeMeetingByQualifiedId = jest.fn();
-    const wallClock = createDeterministicWallClock({
-      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
-    });
 
     const deps = createSubmitDeps({
       deleteMeetingForAll,
       removeMeetingByQualifiedId,
-      wallClock,
     });
 
     const firstSubmit = submitDeleteMeeting(deps);
@@ -311,16 +234,12 @@ describe('submitDeleteMeeting', () => {
     const removeMeetingByQualifiedId = jest.fn();
     const deleteMeetingForMe = jest.fn().mockReturnValue(task.resolve(undefined));
     const invitee = createSelfUser('invitee-id');
-    const wallClock = createDeterministicWallClock({
-      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
-    });
 
     const result = await submitDeleteMeeting({
       ...createSubmitDeps({
         deleteMeetingForMe,
         removeMeetingByQualifiedId,
         selfUser: invitee,
-        wallClock,
       }),
       mode: 'forMe',
     });
@@ -334,16 +253,12 @@ describe('submitDeleteMeeting', () => {
     const removeMeetingByQualifiedId = jest.fn();
     const deleteMeetingForMe = jest.fn().mockReturnValue(task.reject(meetingSubmitErrors.leaveConversationFailed));
     const invitee = createSelfUser('invitee-id');
-    const wallClock = createDeterministicWallClock({
-      initialCurrentTimestampInMilliseconds: Date.parse('2026-06-15T13:00:00.000Z'),
-    });
 
     const result = await submitDeleteMeeting({
       ...createSubmitDeps({
         deleteMeetingForMe,
         removeMeetingByQualifiedId,
         selfUser: invitee,
-        wallClock,
       }),
       mode: 'forMe',
     });

--- a/apps/webapp/src/script/components/meeting/shared/submit/submitDeleteMeeting.ts
+++ b/apps/webapp/src/script/components/meeting/shared/submit/submitDeleteMeeting.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import type {WallClock} from '@enormora/wall-clock/wall-clock';
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import {task, type Task} from 'true-myth';
 
@@ -49,7 +48,6 @@ export type SubmitDeleteMeetingParams = {
   meetingInstance: MeetingInstance;
   mode: DeleteMeetingModalMode;
   selfUser: User | undefined;
-  wallClock: WallClock;
   translate: Translate;
   deleteMeetingForMe: (meetingInstance: MeetingInstance) => Task<void, MeetingSubmitErrors>;
   deleteMeetingForAll: (meetingInstance: MeetingInstance) => Task<void, MeetingSubmitErrors>;
@@ -95,11 +93,10 @@ const canDeleteMeetingWithMode = (
   meetingInstance: MeetingInstance,
   mode: DeleteMeetingModalMode,
   selfUser: User,
-  nowMilliseconds: number,
 ): boolean =>
   mode === 'forAll'
-    ? canDeleteMeetingForAll(meetingInstance, selfUser, nowMilliseconds)
-    : canDeleteMeetingForMe(meetingInstance, selfUser, nowMilliseconds);
+    ? canDeleteMeetingForAll(meetingInstance, selfUser)
+    : canDeleteMeetingForMe(meetingInstance, selfUser);
 
 export const resetInFlightDeleteMeetingsForTest = (): void => {
   inFlightDeleteMeetingIds.clear();
@@ -109,7 +106,6 @@ export const submitDeleteMeeting = async ({
   meetingInstance,
   mode,
   selfUser,
-  wallClock,
   translate,
   deleteMeetingForMe,
   deleteMeetingForAll,
@@ -121,9 +117,7 @@ export const submitDeleteMeeting = async ({
     return deleteMeetingSubmitResults.blocked;
   }
 
-  const nowMilliseconds = wallClock.currentTimestampInMilliseconds;
-
-  if (!canDeleteMeetingWithMode(meetingInstance, mode, selfUser, nowMilliseconds)) {
+  if (!canDeleteMeetingWithMode(meetingInstance, mode, selfUser)) {
     showDeleteNotAllowedModal(translate);
     return deleteMeetingSubmitResults.blocked;
   }

--- a/apps/webapp/src/script/components/meeting/useDeleteMeeting.ts
+++ b/apps/webapp/src/script/components/meeting/useDeleteMeeting.ts
@@ -30,7 +30,7 @@ import type {User} from 'Repositories/entity/User';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 
 export const useDeleteMeeting = () => {
-  const {translate, wallClock, fireAndForgetInvoker} = useApplicationContext();
+  const {translate, fireAndForgetInvoker} = useApplicationContext();
   const deleteMeetingForMe = useMeetingStore(state => state.deleteMeetingForMe);
   const deleteMeetingForAll = useMeetingStore(state => state.deleteMeetingForAll);
   const removeMeetingByQualifiedId = useMeetingStore(state => state.removeMeetingByQualifiedId);
@@ -43,7 +43,6 @@ export const useDeleteMeeting = () => {
           meetingInstance,
           mode,
           selfUser,
-          wallClock,
           translate,
           deleteMeetingForMe,
           deleteMeetingForAll,
@@ -59,7 +58,6 @@ export const useDeleteMeeting = () => {
       loadMeetings,
       removeMeetingByQualifiedId,
       translate,
-      wallClock,
     ],
   );
 

--- a/apps/webapp/src/script/components/meeting/utils/canDeleteMeeting.test.ts
+++ b/apps/webapp/src/script/components/meeting/utils/canDeleteMeeting.test.ts
@@ -19,17 +19,9 @@
 
 import type {MeetingInstance} from 'Components/meeting/types/meetingInstance';
 import type {MeetingSeries} from 'Components/meeting/types/meetingSeries';
-import {
-  canDeleteMeeting,
-  canDeleteMeetingForAll,
-  canDeleteMeetingForMe,
-} from 'Components/meeting/utils/canDeleteMeeting';
+import {canDeleteMeetingForAll, canDeleteMeetingForMe} from 'Components/meeting/utils/canDeleteMeeting';
 import {User} from 'Repositories/entity/User';
 import {translateForTest} from 'Util/test/translateForTest';
-
-const futureNowMilliseconds = Date.parse('2026-06-15T13:00:00.000Z');
-const ongoingNowMilliseconds = Date.parse('2026-06-15T14:30:00.000Z');
-const pastNowMilliseconds = Date.parse('2026-06-15T16:00:00.000Z');
 
 const createSeries = (overrides: Partial<MeetingSeries> = {}): MeetingSeries => ({
   series_start_date: '2026-06-15T14:00:00.000Z',
@@ -60,51 +52,30 @@ const createSelfUser = (id = 'host-id') => {
   return user;
 };
 
-describe('canDeleteMeeting', () => {
-  it('allows delete for upcoming and ongoing meetings', () => {
-    const meetingInstance = createMeetingInstance();
-
-    expect(canDeleteMeeting(meetingInstance, futureNowMilliseconds)).toBe(true);
-    expect(canDeleteMeeting(meetingInstance, ongoingNowMilliseconds)).toBe(true);
-  });
-
-  it('disallows delete for past meetings', () => {
-    const meetingInstance = createMeetingInstance();
-
-    expect(canDeleteMeeting(meetingInstance, pastNowMilliseconds)).toBe(false);
-  });
-});
-
 describe('canDeleteMeetingForAll', () => {
-  it('allows host delete when the meeting has not started', () => {
+  it('allows host delete regardless of meeting time', () => {
     const meetingInstance = createMeetingInstance();
 
-    expect(canDeleteMeetingForAll(meetingInstance, createSelfUser(), futureNowMilliseconds)).toBe(true);
-  });
-
-  it('disallows host delete when the meeting has started', () => {
-    const meetingInstance = createMeetingInstance();
-
-    expect(canDeleteMeetingForAll(meetingInstance, createSelfUser(), ongoingNowMilliseconds)).toBe(false);
+    expect(canDeleteMeetingForAll(meetingInstance, createSelfUser())).toBe(true);
   });
 
   it('disallows delete for non-host users', () => {
     const meetingInstance = createMeetingInstance();
 
-    expect(canDeleteMeetingForAll(meetingInstance, createSelfUser('invitee-id'), futureNowMilliseconds)).toBe(false);
+    expect(canDeleteMeetingForAll(meetingInstance, createSelfUser('invitee-id'))).toBe(false);
   });
 });
 
 describe('canDeleteMeetingForMe', () => {
-  it('allows participant delete when the meeting is not past', () => {
+  it('allows participant delete regardless of meeting time', () => {
     const meetingInstance = createMeetingInstance();
 
-    expect(canDeleteMeetingForMe(meetingInstance, createSelfUser('invitee-id'), futureNowMilliseconds)).toBe(true);
+    expect(canDeleteMeetingForMe(meetingInstance, createSelfUser('invitee-id'))).toBe(true);
   });
 
   it('disallows delete for the host', () => {
     const meetingInstance = createMeetingInstance();
 
-    expect(canDeleteMeetingForMe(meetingInstance, createSelfUser(), futureNowMilliseconds)).toBe(false);
+    expect(canDeleteMeetingForMe(meetingInstance, createSelfUser())).toBe(false);
   });
 });

--- a/apps/webapp/src/script/components/meeting/utils/canDeleteMeeting.ts
+++ b/apps/webapp/src/script/components/meeting/utils/canDeleteMeeting.ts
@@ -21,32 +21,9 @@ import type {MeetingInstance} from 'Components/meeting/types/meetingInstance';
 import type {User} from 'Repositories/entity/User';
 
 import {isMeetingHost} from './canEditMeeting';
-import {MeetingTemporalStatuses, getMeetingTemporalStatusAt} from './meetingStatusUtil';
 
-export const canDeleteMeeting = (meetingInstance: MeetingInstance, nowMilliseconds: number): boolean => {
-  const {start, end} = meetingInstance;
-  const temporalStatus = getMeetingTemporalStatusAt(new Date(nowMilliseconds), start, end);
+export const canDeleteMeetingForAll = (meetingInstance: MeetingInstance, selfUser: User): boolean =>
+  isMeetingHost(meetingInstance.meetingSeries, selfUser);
 
-  return temporalStatus !== MeetingTemporalStatuses.PAST;
-};
-
-export const canDeleteMeetingForAll = (
-  meetingInstance: MeetingInstance,
-  selfUser: User,
-  nowMilliseconds: number,
-): boolean => {
-  const instanceHasNotStarted = nowMilliseconds < meetingInstance.start.getTime();
-
-  return (
-    canDeleteMeeting(meetingInstance, nowMilliseconds) &&
-    isMeetingHost(meetingInstance.meetingSeries, selfUser) &&
-    instanceHasNotStarted
-  );
-};
-
-export const canDeleteMeetingForMe = (
-  meetingInstance: MeetingInstance,
-  selfUser: User,
-  nowMilliseconds: number,
-): boolean =>
-  canDeleteMeeting(meetingInstance, nowMilliseconds) && !isMeetingHost(meetingInstance.meetingSeries, selfUser);
+export const canDeleteMeetingForMe = (meetingInstance: MeetingInstance, selfUser: User): boolean =>
+  !isMeetingHost(meetingInstance.meetingSeries, selfUser);

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
@@ -2385,7 +2385,9 @@ describe('ConversationRepository', () => {
 
         await conversationRepository['handleConversationEvent'](createDeleteMeetingEvent(conversation));
 
-        expect(conversationRepository['conversationState'].findConversation(conversation.qualifiedId)).toBe(conversation);
+        expect(conversationRepository['conversationState'].findConversation(conversation.qualifiedId)).toBe(
+          conversation,
+        );
       });
 
       it('does not throw when the conversation is unknown', async () => {
@@ -2421,7 +2423,9 @@ describe('ConversationRepository', () => {
         try {
           await conversationRepository['handleConversationEvent'](createDeleteEvent(conversation));
 
-          expect(conversationRepository['conversationState'].findConversation(conversation.qualifiedId)).toBeUndefined();
+          expect(
+            conversationRepository['conversationState'].findConversation(conversation.qualifiedId),
+          ).toBeUndefined();
           expect(publishSpy).toHaveBeenCalledWith(
             WebAppEvents.NOTIFICATION.NOTIFY,
             expect.objectContaining({system_message_type: SystemMessageType.CONVERSATION_DELETE}),

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
@@ -37,6 +37,8 @@ import {
   ConversationProtocolUpdateEvent,
   ConversationCreateEvent,
   ConversationCreateMeetingEvent,
+  ConversationDeleteEvent,
+  ConversationDeleteMeetingEvent,
   ConversationMemberJoinEvent,
   CONVERSATION_EVENT,
   ConversationMLSWelcomeEvent,
@@ -51,10 +53,16 @@ import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import ko from 'knockout';
 import {container} from 'tsyringe';
 
+import {CALL_TYPE, CONV_TYPE, STATE as CALL_STATE} from '@wireapp/avs';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {PrimaryModal} from 'Components/Modals/PrimaryModal';
+import {buildMediaDevicesHandler, createSelfParticipant} from 'src/script/auth/util/test/testUtil';
+import {SystemMessageType} from 'src/script/message/systemMessageType';
+import {Call} from 'Repositories/calling/Call';
 import {CallingRepository} from 'Repositories/calling/CallingRepository';
+import {CallState} from 'Repositories/calling/CallState';
+import {LEAVE_CALL_REASON} from 'Repositories/calling/enum/LeaveCallReason';
 import {ClientEntity} from 'Repositories/client/ClientEntity';
 import {ConnectionEntity} from 'Repositories/connection/connectionEntity';
 import {ConnectionRepository} from 'Repositories/connection/connectionRepository';
@@ -2289,6 +2297,190 @@ describe('ConversationRepository', () => {
           injectEventSpy.mockRestore();
           updateParticipatingUserEntitiesSpy.mockRestore();
           saveConversationSpy.mockRestore();
+        }
+      });
+    });
+
+    describe('conversation.delete-meeting', () => {
+      const createDeleteMeetingEvent = (conversation: Conversation): ConversationDeleteMeetingEvent => ({
+        conversation: conversation.id,
+        data: null,
+        from: createUuid(),
+        qualified_conversation: conversation.qualifiedId,
+        time: '2015-04-27T11:42:31.475Z',
+        type: CONVERSATION_EVENT.DELETE_MEETING,
+      });
+
+      const createDeleteEvent = (conversation: Conversation): ConversationDeleteEvent => ({
+        conversation: conversation.id,
+        data: null,
+        from: createUuid(),
+        qualified_conversation: conversation.qualifiedId,
+        time: '2015-04-27T11:42:31.475Z',
+        type: CONVERSATION_EVENT.DELETE,
+      });
+
+      const saveMeetingConversation = async () => {
+        const conversationRepository = testFactory.conversation_repository!;
+        const meetingConversation = _generateConversation({
+          protocol: CONVERSATION_PROTOCOL.MLS,
+          overwites: {group_conv_type: GROUP_CONVERSATION_TYPE.MEETING},
+        });
+        await conversationRepository['saveConversation'](meetingConversation);
+        return meetingConversation;
+      };
+
+      let deleteFromDbSpy: jest.SpyInstance;
+      let wipeMeetingConversationSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        const conversationRepository = testFactory.conversation_repository!;
+        deleteFromDbSpy = jest
+          .spyOn(conversationRepository['conversationService'], 'deleteConversationFromDb')
+          .mockResolvedValue(1);
+        wipeMeetingConversationSpy = jest
+          .spyOn(conversationRepository, 'wipeMLSCapableConversation')
+          .mockResolvedValue(undefined);
+      });
+
+      afterEach(() => {
+        deleteFromDbSpy.mockRestore();
+        wipeMeetingConversationSpy.mockRestore();
+      });
+
+      it('deletes a local meeting conversation without a delete notification', async () => {
+        const conversationRepository = testFactory.conversation_repository!;
+        const meetingConversation = await saveMeetingConversation();
+        const publishSpy = jest.spyOn(amplify, 'publish');
+
+        try {
+          await conversationRepository['handleConversationEvent'](createDeleteMeetingEvent(meetingConversation));
+
+          expect(
+            conversationRepository['conversationState'].findConversation(meetingConversation.qualifiedId),
+          ).toBeUndefined();
+          expect(publishSpy).not.toHaveBeenCalledWith(WebAppEvents.NOTIFICATION.NOTIFY, expect.anything());
+        } finally {
+          publishSpy.mockRestore();
+        }
+      });
+
+      it.each([
+        {
+          name: 'regular group',
+          params: {type: CONVERSATION_TYPE.REGULAR},
+        },
+        {
+          name: 'channel',
+          params: {overwites: {group_conv_type: GROUP_CONVERSATION_TYPE.CHANNEL}},
+        },
+        {
+          name: '1:1',
+          params: {type: CONVERSATION_TYPE.ONE_TO_ONE},
+        },
+      ])('ignores conversation.delete-meeting for a $name', async ({params}) => {
+        const conversationRepository = testFactory.conversation_repository!;
+        const conversation = _generateConversation(params);
+        await conversationRepository['saveConversation'](conversation);
+
+        await conversationRepository['handleConversationEvent'](createDeleteMeetingEvent(conversation));
+
+        expect(conversationRepository['conversationState'].findConversation(conversation.qualifiedId)).toBe(conversation);
+      });
+
+      it('does not throw when the conversation is unknown', async () => {
+        const conversationRepository = testFactory.conversation_repository!;
+        const getConversationByIdSpy = jest
+          .spyOn(conversationRepository, 'getConversationById')
+          .mockRejectedValue(
+            new ConversationError(
+              ConversationError.TYPE.CONVERSATION_NOT_FOUND,
+              ConversationError.MESSAGE.CONVERSATION_NOT_FOUND,
+            ),
+          );
+
+        const unknownConversation = _generateConversation({
+          overwites: {group_conv_type: GROUP_CONVERSATION_TYPE.MEETING},
+        });
+
+        try {
+          await expect(
+            conversationRepository['handleConversationEvent'](createDeleteMeetingEvent(unknownConversation)),
+          ).resolves.toBeUndefined();
+        } finally {
+          getConversationByIdSpy.mockRestore();
+        }
+      });
+
+      it('still deletes a conversation.delete event and notifies', async () => {
+        const conversationRepository = testFactory.conversation_repository!;
+        const conversation = _generateConversation();
+        await conversationRepository['saveConversation'](conversation);
+        const publishSpy = jest.spyOn(amplify, 'publish');
+
+        try {
+          await conversationRepository['handleConversationEvent'](createDeleteEvent(conversation));
+
+          expect(conversationRepository['conversationState'].findConversation(conversation.qualifiedId)).toBeUndefined();
+          expect(publishSpy).toHaveBeenCalledWith(
+            WebAppEvents.NOTIFICATION.NOTIFY,
+            expect.objectContaining({system_message_type: SystemMessageType.CONVERSATION_DELETE}),
+          );
+        } finally {
+          publishSpy.mockRestore();
+        }
+      });
+
+      it('leaves an active call and clears calling state for a deleted meeting conversation', async () => {
+        const conversationRepository = testFactory.conversation_repository!;
+        const meetingConversation = await saveMeetingConversation();
+        const callState = container.resolve(CallState);
+        const call = new Call(
+          {domain: 'caller.com', id: 'caller-id'},
+          meetingConversation,
+          CONV_TYPE.CONFERENCE_MLS,
+          createSelfParticipant(),
+          CALL_TYPE.NORMAL,
+          buildMediaDevicesHandler(),
+        );
+        call.state(CALL_STATE.MEDIA_ESTAB);
+        callState.calls.push(call);
+
+        const leaveCallSpy = jest.spyOn(conversationRepository['callingRepository'], 'leaveCall');
+
+        try {
+          await conversationRepository['handleConversationEvent'](createDeleteMeetingEvent(meetingConversation));
+
+          expect(leaveCallSpy).toHaveBeenCalledWith(
+            meetingConversation.qualifiedId,
+            LEAVE_CALL_REASON.USER_IS_REMOVED_FROM_CONVERSATION,
+          );
+          expect(conversationRepository['callingRepository'].findCall(meetingConversation.qualifiedId)).toBeUndefined();
+          expect(callState.activeCalls()).toHaveLength(0);
+        } finally {
+          leaveCallSpy.mockRestore();
+          callState.calls.removeAll();
+        }
+      });
+
+      it('succeeds when there is no call for the meeting conversation', async () => {
+        const conversationRepository = testFactory.conversation_repository!;
+        const meetingConversation = await saveMeetingConversation();
+        const leaveCallSpy = jest.spyOn(conversationRepository['callingRepository'], 'leaveCall');
+
+        try {
+          await conversationRepository['handleConversationEvent'](createDeleteMeetingEvent(meetingConversation));
+
+          expect(
+            conversationRepository['conversationState'].findConversation(meetingConversation.qualifiedId),
+          ).toBeUndefined();
+          expect(leaveCallSpy).toHaveBeenCalledWith(
+            meetingConversation.qualifiedId,
+            LEAVE_CALL_REASON.USER_IS_REMOVED_FROM_CONVERSATION,
+          );
+          expect(conversationRepository['callingRepository'].findCall(meetingConversation.qualifiedId)).toBeUndefined();
+        } finally {
+          leaveCallSpy.mockRestore();
         }
       });
     });

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -1249,7 +1249,12 @@ export class ConversationRepository {
       return;
     }
 
-    this.callingRepository.leaveCall(conversationEntity.qualifiedId, LEAVE_CALL_REASON.USER_MANUALY_LEFT_CONVERSATION);
+    this.callingRepository.leaveCall(
+      conversationEntity.qualifiedId,
+      conversationEntity.isMeeting()
+        ? LEAVE_CALL_REASON.USER_IS_REMOVED_FROM_CONVERSATION
+        : LEAVE_CALL_REASON.USER_MANUALY_LEFT_CONVERSATION,
+    );
 
     if (this.conversationState.isActiveConversation(conversationEntity)) {
       const nextConversation = this.getNextConversation(conversationEntity);
@@ -3664,6 +3669,7 @@ export class ConversationRepository {
             CONVERSATION_EVENT.MEMBER_LEAVE,
             CONVERSATION_EVENT.MEMBER_JOIN,
             CONVERSATION_EVENT.DELETE,
+            CONVERSATION_EVENT.DELETE_MEETING,
             CONVERSATION_EVENT.SYSTEM_DELETE,
             CONVERSATION_EVENT.ADMINLESS_DELETE_REMINDER,
             CONVERSATION_EVENT.SYSTEM_ADMINLESS_DELETE_REMINDER,
@@ -3842,6 +3848,12 @@ export class ConversationRepository {
       case CONVERSATION_EVENT.DELETE:
       case CONVERSATION_EVENT.SYSTEM_DELETE:
         return this.deleteConversationLocally({domain: conversationEntity.domain, id: eventJson.conversation}, false);
+
+      case CONVERSATION_EVENT.DELETE_MEETING:
+        if (!conversationEntity.isMeeting()) {
+          return;
+        }
+        return this.deleteConversationLocally({domain: conversationEntity.domain, id: eventJson.conversation}, true);
 
       case CONVERSATION_EVENT.MEMBER_JOIN:
         return this.onMemberJoin(conversationEntity, eventJson);

--- a/libraries/api-client/src/event/conversationEvent.test.ts
+++ b/libraries/api-client/src/event/conversationEvent.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {
+  CONVERSATION_EVENT,
+  type ConversationDeleteEvent,
+  type ConversationDeleteMeetingEvent,
+  type ConversationEvent,
+} from './conversationEvent';
+
+describe('CONVERSATION_EVENT', () => {
+  it('recognizes conversation.delete-meeting with the same payload as conversation.delete', () => {
+    const event: ConversationDeleteMeetingEvent = {
+      conversation: 'conversation-id',
+      data: null,
+      from: 'user-id',
+      qualified_conversation: {domain: 'example.com', id: 'conversation-id'},
+      time: '2026-08-17T10:00:00.000Z',
+      type: CONVERSATION_EVENT.DELETE_MEETING,
+    };
+
+    const asConversationEvent: ConversationEvent = event;
+
+    expect(CONVERSATION_EVENT.DELETE_MEETING).toBe('conversation.delete-meeting');
+    expect(asConversationEvent.type).toBe('conversation.delete-meeting');
+    expect(asConversationEvent.data).toBeNull();
+  });
+
+  it('allows conversation.delete-meeting without from, matching conversation.delete', () => {
+    const event: ConversationDeleteMeetingEvent = {
+      conversation: 'conversation-id',
+      data: null,
+      qualified_conversation: {domain: 'example.com', id: 'conversation-id'},
+      time: '2026-08-17T10:00:00.000Z',
+      type: CONVERSATION_EVENT.DELETE_MEETING,
+    };
+
+    expect(event.from).toBeUndefined();
+    expect(event.data).toBeNull();
+  });
+
+  it('keeps conversation.delete payload unchanged', () => {
+    const event: ConversationDeleteEvent = {
+      conversation: 'conversation-id',
+      data: null,
+      from: 'user-id',
+      time: '2026-08-17T10:00:00.000Z',
+      type: CONVERSATION_EVENT.DELETE,
+    };
+
+    const asConversationEvent: ConversationEvent = event;
+
+    expect(CONVERSATION_EVENT.DELETE).toBe('conversation.delete');
+    expect(asConversationEvent.type).toBe('conversation.delete');
+    expect(asConversationEvent.data).toBeNull();
+  });
+});

--- a/libraries/api-client/src/event/conversationEvent.ts
+++ b/libraries/api-client/src/event/conversationEvent.ts
@@ -49,6 +49,7 @@ export enum CONVERSATION_EVENT {
   CREATE = 'conversation.create',
   CREATE_MEETING = 'conversation.create-meeting',
   DELETE = 'conversation.delete',
+  DELETE_MEETING = 'conversation.delete-meeting',
   SYSTEM_DELETE = 'conversation.system.delete',
   ADMINLESS_DELETE_REMINDER = 'conversation.adminless-reminder',
   SYSTEM_ADMINLESS_DELETE_REMINDER = 'conversation.system.adminless-reminder',
@@ -96,6 +97,7 @@ export type ConversationEvent =
   | ConversationCreateEvent
   | ConversationCreateMeetingEvent
   | ConversationDeleteEvent
+  | ConversationDeleteMeetingEvent
   | ConversationAdminlessDeleteReminderEvent
   | ConversationMemberJoinEvent
   | ConversationMemberLeaveEvent
@@ -161,6 +163,13 @@ export interface ConversationDeleteEvent extends Omit<BaseConversationEvent, 'fr
   /** Not present for backend/system-initiated deletions, e.g. `conversation.system.delete`. */
   from?: string;
   type: CONVERSATION_EVENT.DELETE | CONVERSATION_EVENT.SYSTEM_DELETE;
+}
+
+export interface ConversationDeleteMeetingEvent extends Omit<BaseConversationEvent, 'from'> {
+  data: null;
+  /** Not present for backend/system-initiated deletions. */
+  from?: string;
+  type: CONVERSATION_EVENT.DELETE_MEETING;
 }
 
 export interface ConversationAdminlessDeleteReminderEvent extends Omit<BaseConversationEvent, 'from'> {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27897" title="WPB-27897" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27897</a>  [Web] Support conversation.delete-meeting events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Handle `conversation.delete-meeting` by deleting the local meeting conversation and leaving any active call, without a conversation-deleted notification
- Keep Delete for everyone / Delete for me available after a meeting has started or ended ([WPB-28017](https://wearezeta.atlassian.net/browse/WPB-28017))

## Test plan
- Host deletes an ongoing meeting for everyone
- Invitee drops from the call, loses the meeting conversation, and does not see “User X deleted conversation Y”

[WPB-28017]: https://wearezeta.atlassian.net/browse/WPB-28017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ