### PR TITLE
feat: Hide global fullscreen file actions for Cells viewers(WPB-27987)

### DIFF
--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsFilePreviewModal/cellsFilePreviewModal.test.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsFilePreviewModal/cellsFilePreviewModal.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {container} from 'tsyringe';
+
+import {CELLS_SELF_USER_DRIVE_ROLE} from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
+import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {viewerPermissionFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {CellFile, CellNodeType} from 'src/script/types/cellNode';
+
+import {CellsFilePreviewModal} from './cellsFilePreviewModal';
+import {FilePreviewProvider, useCellsFilePreviewModal} from '../common/cellsFilePreviewModalContext/cellsFilePreviewModalContext';
+
+const translate = (key: string) =>
+  ({
+    'cells.imageFullScreenModal.closeButton': 'Close',
+    'cells.imageFullScreenModal.downloadButton': 'Download',
+    'cells.options.label': 'More options',
+    'cells.options.versionHistory': 'Version History',
+  })[key] ?? key;
+
+const rootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled: featureName => featureName === viewerPermissionFeatureToggleName,
+    translate,
+  }),
+);
+
+const viewerFile: CellFile = {
+  id: 'file-id',
+  type: CellNodeType.FILE,
+  url: 'https://example.com/document.docx',
+  path: '/document.docx',
+  mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  name: 'document',
+  extension: 'docx',
+  sizeMb: '1 MB',
+  previewImageUrl: 'https://example.com/document-preview.jpg',
+  uploadedAtTimestamp: 1700000000000,
+  owner: 'John Doe',
+  conversationName: 'Team',
+  tags: [],
+  presignedUrlExpiresAt: null,
+  user: null,
+  selfUserDriveRole: CELLS_SELF_USER_DRIVE_ROLE.VIEWER,
+};
+
+const OpenPreviewButton = () => {
+  const {handleOpenFile} = useCellsFilePreviewModal();
+
+  return (
+    <button type="button" onClick={() => handleOpenFile(viewerFile, true)}>
+      Open preview
+    </button>
+  );
+};
+
+describe('CellsFilePreviewModal', () => {
+  beforeEach(() => {
+    container.registerInstance(CellsRepository, {} as CellsRepository);
+  });
+
+  afterEach(() => {
+    container.reset();
+  });
+
+  it('uses the global drive file role when rendering fullscreen actions', async () => {
+    render(
+      withThemeAndRootContext(
+        <FilePreviewProvider>
+          <OpenPreviewButton />
+          <CellsFilePreviewModal />
+        </FilePreviewProvider>,
+        rootProviderWrapper,
+      ),
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Open preview'}));
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Download'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Editing'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'More options'})).not.toBeInTheDocument();
+  });
+});

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsFilePreviewModal/cellsFilePreviewModal.test.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsFilePreviewModal/cellsFilePreviewModal.test.tsx
@@ -17,8 +17,9 @@
  *
  */
 
-import {render, screen} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import {ReactNode} from 'react';
+
+import {act, render, screen} from '@testing-library/react';
 import {container} from 'tsyringe';
 
 import {CELLS_SELF_USER_DRIVE_ROLE} from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
@@ -27,12 +28,16 @@ import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
 import {viewerPermissionFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {
   createRootContextValueForTest,
+  createExecutingFireAndForgetInvokerForTest,
   createRootProviderWrapperForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 import {CellFile, CellNodeType} from 'src/script/types/cellNode';
 
 import {CellsFilePreviewModal} from './cellsFilePreviewModal';
-import {FilePreviewProvider, useCellsFilePreviewModal} from '../common/cellsFilePreviewModalContext/cellsFilePreviewModalContext';
+import {
+  CellsFilePreviewModalContext,
+  CellsFilePreviewModalContextValue,
+} from '../common/cellsFilePreviewModalContext/cellsFilePreviewModalContext';
 
 const translate = (key: string) =>
   ({
@@ -40,16 +45,26 @@ const translate = (key: string) =>
     'cells.imageFullScreenModal.downloadButton': 'Download',
     'cells.options.label': 'More options',
     'cells.options.versionHistory': 'Version History',
+    'fileFullscreenModal.editor.iframeTitle': 'Collabora editor',
   })[key] ?? key;
 
-const rootProviderWrapper = createRootProviderWrapperForTest(
-  createRootContextValueForTest({
-    isFeatureToggleEnabled: featureName => featureName === viewerPermissionFeatureToggleName,
-    translate,
-  }),
-);
+const createRootProviderWrapper = ({
+  fireAndForgetInvoker,
+  isViewerPermissionFeatureEnabled,
+}: {
+  fireAndForgetInvoker: ReturnType<typeof createExecutingFireAndForgetInvokerForTest>;
+  isViewerPermissionFeatureEnabled: boolean;
+}) =>
+  createRootProviderWrapperForTest(
+    createRootContextValueForTest({
+      fireAndForgetInvoker,
+      isFeatureToggleEnabled: featureName =>
+        featureName === viewerPermissionFeatureToggleName && isViewerPermissionFeatureEnabled,
+      translate,
+    }),
+  );
 
-const viewerFile: CellFile = {
+const file: CellFile = {
   id: 'file-id',
   type: CellNodeType.FILE,
   url: 'https://example.com/document.docx',
@@ -68,41 +83,82 @@ const viewerFile: CellFile = {
   selfUserDriveRole: CELLS_SELF_USER_DRIVE_ROLE.VIEWER,
 };
 
-const OpenPreviewButton = () => {
-  const {handleOpenFile} = useCellsFilePreviewModal();
+const FakeFilePreviewProvider = ({
+  children,
+  selfUserDriveRole,
+}: {
+  children: ReactNode;
+  selfUserDriveRole: CellFile['selfUserDriveRole'];
+}) => {
+  const value: CellsFilePreviewModalContextValue = {
+    id: 'preview-context-id',
+    selectedFile: {...file, selfUserDriveRole},
+    isEditMode: true,
+    handleOpenFile: jest.fn(),
+    handleCloseFile: jest.fn(),
+  };
 
-  return (
-    <button type="button" onClick={() => handleOpenFile(viewerFile, true)}>
-      Open preview
-    </button>
-  );
+  return <CellsFilePreviewModalContext.Provider value={value}>{children}</CellsFilePreviewModalContext.Provider>;
 };
 
 describe('CellsFilePreviewModal', () => {
   beforeEach(() => {
-    container.registerInstance(CellsRepository, {} as CellsRepository);
+    container.registerInstance(CellsRepository, {
+      getNode: jest.fn().mockResolvedValue({
+        EditorURLs: {
+          collabora: {
+            ExpiresAt: '1000',
+            Url: 'https://cells.example.com/editor?token=abc',
+          },
+        },
+        IsRecycled: false,
+      }),
+    } as unknown as CellsRepository);
   });
 
   afterEach(() => {
     container.reset();
   });
 
-  it('uses the global drive file role when rendering fullscreen actions', async () => {
+  const renderModal = ({
+    isViewerPermissionFeatureEnabled = true,
+    selfUserDriveRole,
+  }: {
+    isViewerPermissionFeatureEnabled?: boolean;
+    selfUserDriveRole: CellFile['selfUserDriveRole'];
+  }) => {
+    const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
+
     render(
       withThemeAndRootContext(
-        <FilePreviewProvider>
-          <OpenPreviewButton />
+        <FakeFilePreviewProvider selfUserDriveRole={selfUserDriveRole}>
           <CellsFilePreviewModal />
-        </FilePreviewProvider>,
-        rootProviderWrapper,
+        </FakeFilePreviewProvider>,
+        createRootProviderWrapper({fireAndForgetInvoker, isViewerPermissionFeatureEnabled}),
       ),
     );
 
-    await userEvent.click(screen.getByRole('button', {name: 'Open preview'}));
+    return {fireAndForgetInvoker};
+  };
+
+  it('uses the global drive file role when rendering fullscreen actions', async () => {
+    renderModal({selfUserDriveRole: CELLS_SELF_USER_DRIVE_ROLE.VIEWER});
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Download'})).not.toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Editing'})).not.toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'More options'})).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Collabora editor')).not.toBeInTheDocument();
+  });
+
+  it('keeps fullscreen modification actions available for editors', async () => {
+    const {fireAndForgetInvoker} = renderModal({selfUserDriveRole: CELLS_SELF_USER_DRIVE_ROLE.EDITOR});
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Download'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Editing'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'More options'})).toBeInTheDocument();
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+    expect(screen.getByTitle('Collabora editor')).toBeInTheDocument();
   });
 });

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsFilePreviewModal/cellsFilePreviewModal.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsFilePreviewModal/cellsFilePreviewModal.tsx
@@ -19,6 +19,7 @@
 
 import {isNonEmptyString} from '@sindresorhus/is';
 
+import {CellsSelfUserDriveRoleProvider} from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
 import {FileFullscreenModal} from 'Components/FileFullscreenModal/FileFullscreenModal';
 import {getFileTypeFromExtension} from 'Util/getFileTypeFromExtension/getFileTypeFromExtension';
 
@@ -57,19 +58,21 @@ export const CellsFilePreviewModal = () => {
   };
 
   return (
-    <FileFullscreenModal
-      id={selectedFile.id}
-      isOpen={selectedFile !== null}
-      onClose={handleCloseFile}
-      filePreviewUrl={getFileUrl()}
-      fileUrl={url}
-      fileName={name}
-      fileExtension={extension}
-      status={getFileUrl() === undefined ? 'unavailable' : 'success'}
-      senderName={owner}
-      timestamp={uploadedAtTimestamp}
-      badges={sortTagsAlphabetically(tags)}
-      isEditMode={isEditMode}
-    />
+    <CellsSelfUserDriveRoleProvider selfUserDriveRole={selectedFile.selfUserDriveRole}>
+      <FileFullscreenModal
+        id={selectedFile.id}
+        isOpen={selectedFile !== null}
+        onClose={handleCloseFile}
+        filePreviewUrl={getFileUrl()}
+        fileUrl={url}
+        fileName={name}
+        fileExtension={extension}
+        status={getFileUrl() === undefined ? 'unavailable' : 'success'}
+        senderName={owner}
+        timestamp={uploadedAtTimestamp}
+        badges={sortTagsAlphabetically(tags)}
+        isEditMode={isEditMode}
+      />
+    </CellsSelfUserDriveRoleProvider>
   );
 };

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/common/cellsFilePreviewModalContext/cellsFilePreviewModalContext.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/common/cellsFilePreviewModalContext/cellsFilePreviewModalContext.tsx
@@ -21,7 +21,7 @@ import {createContext, ReactNode, useContext, useId, useMemo, useState} from 're
 
 import {CellFile} from 'src/script/types/cellNode';
 
-interface CellsFilePreviewModalContextValue {
+export interface CellsFilePreviewModalContextValue {
   id: string;
   selectedFile: CellFile | null;
   isEditMode: boolean;
@@ -29,7 +29,7 @@ interface CellsFilePreviewModalContextValue {
   handleCloseFile: () => void;
 }
 
-const CellsFilePreviewModalContext = createContext<CellsFilePreviewModalContextValue | null>(null);
+export const CellsFilePreviewModalContext = createContext<CellsFilePreviewModalContextValue | null>(null);
 
 interface FilePreviewProviderProps {
   children: ReactNode;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27987" title="WPB-27987" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27987</a>  Hide all modification action like edit, version history etc at conversation level and full screen modal including collabora
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Pass the selected global Cells file role into the fullscreen preview via `CellsSelfUserDriveRoleProvider`
- Add focused global preview coverage for viewer and editor roles
- Verify restricted viewers cannot access download, edit, version history, or Collabora from the global fullscreen modal