### PR TITLE
Show callingCell of normal conversation in the meetings listing view [WPB-27940]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingCallingView/meetingCallingView.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingCallingView/meetingCallingView.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+import {render} from '@testing-library/react';
+import {container} from 'tsyringe';
+
+import {CALL_TYPE, STATE as CALL_STATE} from '@wireapp/avs';
+import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
+
+import {Call} from 'Repositories/calling/Call';
+import {CallState} from 'Repositories/calling/CallState';
+import {Participant} from 'Repositories/calling/Participant';
+import {Conversation} from 'Repositories/entity/Conversation';
+import {User} from 'Repositories/entity/User';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import type {MainViewModel} from 'src/script/view_model/MainViewModel';
+import {buildMediaDevicesHandler} from 'src/script/auth/util/test/testUtil';
+import {translateForTest} from 'Util/test/translateForTest';
+import {createUuid} from 'Util/uuid';
+
+import {MeetingCallingView} from './meetingCallingView';
+
+const createCall = (): Call => {
+  const id = createUuid();
+  const selfUser = new User(createUuid(), '', translateForTest);
+  const conversation = new Conversation(id, 'example.com', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
+  const call = new Call(
+    {domain: 'example.com', id},
+    conversation,
+    0,
+    new Participant(selfUser, createUuid()),
+    CALL_TYPE.NORMAL,
+    buildMediaDevicesHandler(),
+  );
+  call.state(CALL_STATE.INCOMING);
+  return call;
+};
+
+const createMainViewModel = (): MainViewModel =>
+  ({
+    calling: {
+      callActions: {
+        answer: jest.fn(),
+        reject: jest.fn(),
+      },
+      callingRepository: {},
+      hasAccessToCamera: jest.fn(() => true),
+    },
+    content: {repositories: {properties: {getPreference: jest.fn()}}},
+  }) as unknown as MainViewModel;
+
+describe('MeetingCallingView', () => {
+  const callState = container.resolve(CallState);
+  const mainViewModel = createMainViewModel();
+  const rootProviderWrapper = createRootProviderWrapperForTest(
+    createRootContextValueForTest({
+      mainViewModel,
+      translate: translateForTest,
+    }),
+  );
+
+  it('renders incoming 1:1, group, and meeting calls', () => {
+    const calls = [createCall(), createCall(), createCall()];
+    callState.calls(calls);
+
+    const {container: renderedContainer} = render(<MeetingCallingView />, {wrapper: rootProviderWrapper});
+
+    expect(renderedContainer.querySelectorAll('[data-uie-name="item-call"]')).toHaveLength(calls.length);
+    expect(renderedContainer.querySelectorAll('[data-uie-name="do-call-controls-call-accept"]')).toHaveLength(
+      calls.length,
+    );
+    expect(renderedContainer.querySelectorAll('[data-uie-name="do-call-controls-call-decline"]')).toHaveLength(
+      calls.length,
+    );
+  });
+
+  it('renders nothing when there are no active calls', () => {
+    callState.calls([]);
+    const {container: renderedContainer} = render(<MeetingCallingView />, {wrapper: rootProviderWrapper});
+
+    expect(renderedContainer.querySelector('[data-uie-name="meeting-calling-view"]')).toBeNull();
+  });
+});

--- a/apps/webapp/src/script/components/meeting/meetingCallingView/meetingCallingView.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingCallingView/meetingCallingView.test.tsx
@@ -20,6 +20,7 @@ import {render} from '@testing-library/react';
 import {container} from 'tsyringe';
 
 import {CALL_TYPE, STATE as CALL_STATE} from '@wireapp/avs';
+import {CONVERSATION_TYPE, GROUP_CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 
 import {Call} from 'Repositories/calling/Call';
@@ -38,7 +39,7 @@ import {createUuid} from 'Util/uuid';
 
 import {MeetingCallingView} from './meetingCallingView';
 
-const createCall = (): Call => {
+const createCall = (type: CONVERSATION_TYPE, groupConversationType?: GROUP_CONVERSATION_TYPE): Call => {
   const id = createUuid();
   const selfUser = new User(createUuid(), '', translateForTest);
   const conversation = new Conversation(id, 'example.com', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
@@ -50,6 +51,10 @@ const createCall = (): Call => {
     CALL_TYPE.NORMAL,
     buildMediaDevicesHandler(),
   );
+  conversation.type(type);
+  if (groupConversationType) {
+    conversation.groupConversationType(groupConversationType);
+  }
   call.state(CALL_STATE.INCOMING);
   return call;
 };
@@ -78,7 +83,11 @@ describe('MeetingCallingView', () => {
   );
 
   it('renders incoming 1:1, group, and meeting calls', () => {
-    const calls = [createCall(), createCall(), createCall()];
+    const calls = [
+      createCall(CONVERSATION_TYPE.ONE_TO_ONE),
+      createCall(CONVERSATION_TYPE.REGULAR, GROUP_CONVERSATION_TYPE.GROUP_CONVERSATION),
+      createCall(CONVERSATION_TYPE.REGULAR, GROUP_CONVERSATION_TYPE.MEETING),
+    ];
     callState.calls(calls);
 
     const {container: renderedContainer} = render(<MeetingCallingView />, {wrapper: rootProviderWrapper});

--- a/apps/webapp/src/script/components/meeting/meetingCallingView/meetingCallingView.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingCallingView/meetingCallingView.tsx
@@ -36,15 +36,13 @@ export const MeetingCallingView = () => {
   const {classifiedDomains} = useKoSubscribableChildren(teamState, ['classifiedDomains']);
   const {callingRepository} = callingViewModel;
 
-  const meetingCalls = activeCalls.filter(call => call.conversation.isMeeting());
-
-  if (meetingCalls.length === 0) {
+  if (activeCalls.length === 0) {
     return null;
   }
 
   return (
     <div css={meetingCallingViewStyles} data-uie-name="meeting-calling-view">
-      {meetingCalls.map(call => (
+      {activeCalls.map(call => (
         <CallingCell
           key={`${call.conversation.qualifiedId.id}-${call.conversation.qualifiedId.domain}`}
           classifiedDomains={classifiedDomains}

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/useSidebarStore.ts
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/useSidebarStore.ts
@@ -105,6 +105,9 @@ export const CONVERSATION_LIST_TABS: readonly SidebarTabs[] = [
 
 export const isConversationListTab = (tab: SidebarTabs): boolean => CONVERSATION_LIST_TABS.includes(tab);
 
+export const getConversationListTab = (tab: SidebarTabs): SidebarTabs =>
+  isConversationListTab(tab) ? tab : SidebarTabs.RECENT;
+
 type ConversationListCollapseParams = {
   isFeatureEnabled: boolean;
   currentTab: SidebarTabs;

--- a/apps/webapp/src/script/view_model/ContentViewModel.ts
+++ b/apps/webapp/src/script/view_model/ContentViewModel.ts
@@ -43,7 +43,7 @@ import type {MainViewModel, ViewModelRepositories} from './MainViewModel';
 import {Config} from '../Config';
 import {ConversationError} from '../error/conversationError';
 import '../page/leftSidebar';
-import {SidebarTabs, useSidebarStore} from '../page/leftSidebar/panels/conversations/useSidebarStore';
+import {getConversationListTab, useSidebarStore} from '../page/leftSidebar/panels/conversations/useSidebarStore';
 import '../page/mainContent';
 import {PanelState} from '../page/rightSidebar';
 import {useAppMainState} from '../page/state';
@@ -315,10 +315,7 @@ export class ContentViewModel {
       throw error;
     } finally {
       const {currentTab, setCurrentTab} = useSidebarStore.getState();
-
-      if ([SidebarTabs.PREFERENCES, SidebarTabs.CONNECT].includes(currentTab)) {
-        setCurrentTab(SidebarTabs.RECENT);
-      }
+      setCurrentTab(getConversationListTab(currentTab));
     }
   };
 

--- a/apps/webapp/src/script/view_model/ListViewModel.test.ts
+++ b/apps/webapp/src/script/view_model/ListViewModel.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+import {ListViewModel} from './ListViewModel';
+
+import {SidebarTabs, useSidebarStore} from '../page/leftSidebar/panels/conversations/useSidebarStore';
+import {ListState, useAppState} from '../page/useAppState';
+import {translateForTest} from 'Util/test/translateForTest';
+
+const createListViewModel = (): ListViewModel => {
+  const mainViewModel = {
+    actions: {},
+    calling: {},
+    content: {
+      loadPreviousContent: jest.fn(),
+      switchContent: jest.fn(),
+    },
+    isFederated: false,
+  } as unknown as ConstructorParameters<typeof ListViewModel>[0];
+
+  const repositories = {
+    calling: {},
+    conversation: {},
+    properties: {},
+    search: {},
+    team: {},
+  } as unknown as ConstructorParameters<typeof ListViewModel>[1];
+
+  const listViewModel = new ListViewModel(mainViewModel, repositories, translateForTest);
+  (listViewModel as unknown as {isActivatedAccount: () => boolean}).isActivatedAccount = () => true;
+  return listViewModel;
+};
+
+describe('ListViewModel', () => {
+  beforeEach(() => {
+    useSidebarStore.setState({currentTab: SidebarTabs.RECENT});
+    useAppState.setState({listState: ListState.CONVERSATIONS});
+  });
+
+  it.each([SidebarTabs.MEETINGS, SidebarTabs.CELLS])(
+    'returns to the conversation list when opening a conversation from tab %s',
+    currentTab => {
+      useSidebarStore.setState({currentTab});
+      useAppState.setState({listState: ListState.MEETINGS});
+
+      createListViewModel().openConversations();
+
+      expect(useAppState.getState().listState).toBe(ListState.CONVERSATIONS);
+      expect(useSidebarStore.getState().currentTab).toBe(SidebarTabs.RECENT);
+    },
+  );
+
+  it('keeps the archive list when opening an archived conversation', () => {
+    useSidebarStore.setState({currentTab: SidebarTabs.MEETINGS});
+
+    createListViewModel().openConversations(true);
+
+    expect(useAppState.getState().listState).toBe(ListState.ARCHIVE);
+    expect(useSidebarStore.getState().currentTab).toBe(SidebarTabs.ARCHIVES);
+  });
+});

--- a/apps/webapp/src/script/view_model/ListViewModel.test.ts
+++ b/apps/webapp/src/script/view_model/ListViewModel.test.ts
@@ -56,12 +56,24 @@ describe('ListViewModel', () => {
     'returns to the conversation list when opening a conversation from tab %s',
     currentTab => {
       useSidebarStore.setState({currentTab});
-      useAppState.setState({listState: ListState.MEETINGS});
+      useAppState.setState({listState: currentTab === SidebarTabs.CELLS ? ListState.CELLS : ListState.MEETINGS});
 
       createListViewModel().openConversations();
 
       expect(useAppState.getState().listState).toBe(ListState.CONVERSATIONS);
       expect(useSidebarStore.getState().currentTab).toBe(SidebarTabs.RECENT);
+    },
+  );
+
+  it.each([SidebarTabs.FAVORITES, SidebarTabs.GROUPS])(
+    'keeps conversation list tab %s when opening a conversation',
+    currentTab => {
+      useSidebarStore.setState({currentTab});
+
+      createListViewModel().openConversations();
+
+      expect(useAppState.getState().listState).toBe(ListState.CONVERSATIONS);
+      expect(useSidebarStore.getState().currentTab).toBe(currentTab);
     },
   );
 

--- a/apps/webapp/src/script/view_model/ListViewModel.ts
+++ b/apps/webapp/src/script/view_model/ListViewModel.ts
@@ -45,7 +45,11 @@ import {ContentViewModel} from './ContentViewModel';
 import type {MainViewModel, ViewModelRepositories} from './MainViewModel';
 
 import {Config} from '../Config';
-import {SidebarTabs, useSidebarStore} from '../page/leftSidebar/panels/conversations/useSidebarStore';
+import {
+  isConversationListTab,
+  SidebarTabs,
+  useSidebarStore,
+} from '../page/leftSidebar/panels/conversations/useSidebarStore';
 import {PanelState} from '../page/rightSidebar';
 import {useAppMainState} from '../page/state';
 import {ContentState, ListState, useAppState} from '../page/useAppState';
@@ -320,7 +324,12 @@ export class ListViewModel {
       newState = archive ? ListState.ARCHIVE : ListState.CONVERSATIONS;
     }
     this.switchList(newState, false);
-    setCurrentTab(archive ? SidebarTabs.ARCHIVES : currentTab);
+
+    if (archive) {
+      setCurrentTab(SidebarTabs.ARCHIVES);
+    } else {
+      setCurrentTab(isConversationListTab(currentTab) ? currentTab : SidebarTabs.RECENT);
+    }
   };
 
   private readonly hideList = (): void => {

--- a/apps/webapp/src/script/view_model/ListViewModel.ts
+++ b/apps/webapp/src/script/view_model/ListViewModel.ts
@@ -46,7 +46,7 @@ import type {MainViewModel, ViewModelRepositories} from './MainViewModel';
 
 import {Config} from '../Config';
 import {
-  isConversationListTab,
+  getConversationListTab,
   SidebarTabs,
   useSidebarStore,
 } from '../page/leftSidebar/panels/conversations/useSidebarStore';
@@ -328,7 +328,7 @@ export class ListViewModel {
     if (archive) {
       setCurrentTab(SidebarTabs.ARCHIVES);
     } else {
-      setCurrentTab(isConversationListTab(currentTab) ? currentTab : SidebarTabs.RECENT);
+      setCurrentTab(getConversationListTab(currentTab));
     }
   };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27940" title="WPB-27940" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27940</a>  Incoming call UI is not displayed when the user is on the Meetings page
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Also clicking on callingHeader will navigate to correct conversation UI.


