### PR TITLE
fix: handle 212 and 406 proteus errors [WPB-14946]

### DIFF
--- a/libraries/core/src/messagingProtocols/proteus/proteusService/decryptionErrorGenerator/decryptionErrorGenerator.test.ts
+++ b/libraries/core/src/messagingProtocols/proteus/proteusService/decryptionErrorGenerator/decryptionErrorGenerator.test.ts
@@ -17,13 +17,46 @@
  *
  */
 
-import {generateDecryptionError} from './decryptionErrorGenerator';
+import {generateDecryptionError, ProteusErrors} from './decryptionErrorGenerator';
+
+import {ErrorType, ProteusErrorType} from '@wireapp/core-crypto';
 
 import {DecryptionError} from '../../../../errors/decryptionError';
 
 const basePayload = {userId: {id: 'user1', domain: 'domain'}, clientId: 'client1'};
 
+const createStructuredProteusError = (errorCode?: number) =>
+  Object.assign(new Error('proteus decryption error'), {
+    name: 'ProteusErrorOther',
+    errorStack: [],
+    type: ErrorType.Proteus,
+    context: {
+      type: ProteusErrorType.Other,
+      context: errorCode === undefined ? {} : {errorCode},
+    },
+  });
+
 describe('generateDecryptionError', () => {
+  it.each([ProteusErrors.TooDistantFuture, ProteusErrors.PreKeyMessageUnMatchedSignature])(
+    'preserves structured CoreCrypto Proteus error code %s',
+    errorCode => {
+      const coreCryptoError = createStructuredProteusError(errorCode);
+
+      const error = generateDecryptionError(basePayload, coreCryptoError);
+
+      expect(error).toBeInstanceOf(DecryptionError);
+      expect(error.code).toBe(errorCode);
+    },
+  );
+
+  it('falls back to the unknown code for a malformed structured CoreCrypto Proteus error', () => {
+    const coreCryptoError = createStructuredProteusError();
+
+    const error = generateDecryptionError(basePayload, coreCryptoError);
+
+    expect(error.code).toBe(ProteusErrors.Unknown);
+  });
+
   it.each([Math.floor(Math.random() * 100), 0])('handles coreCrypto error', proteusErrorCode => {
     const coreCryptoError = {proteusErrorCode, message: 'decryption error'};
     const error = generateDecryptionError(basePayload, coreCryptoError);

--- a/libraries/core/src/messagingProtocols/proteus/proteusService/decryptionErrorGenerator/decryptionErrorGenerator.ts
+++ b/libraries/core/src/messagingProtocols/proteus/proteusService/decryptionErrorGenerator/decryptionErrorGenerator.ts
@@ -35,6 +35,8 @@ export const ProteusErrors = {
   RemoteIdentityChanged: 204,
   InvalidSignature: 207,
   DuplicateMessage: 209,
+  TooDistantFuture: 212,
+  PreKeyMessageUnMatchedSignature: 406,
   Unknown: 999,
 } as const;
 
@@ -62,7 +64,9 @@ function getErrorCode(error: unknown): number {
   }
 
   if (isProteusError(error, ProteusErrorType.Other)) {
-    return ProteusErrors.Unknown;
+    return typeof error.context.context.errorCode === 'number'
+      ? error.context.context.errorCode
+      : ProteusErrors.Unknown;
   }
 
   if (hasProteusErrorCode(error)) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14946" title="WPB-14946" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14946</a>  [Web] error 999
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Some customers returning after being offline for an extended period could no longer decrypt new messages. Wire displayed generic `Error 999`, hiding both the actual cause and the available recovery action.

## Root cause

CoreCrypto provided specific Proteus error codes, but WebApp converted every `ProteusErrorOther` into `999`.

The investigation identified:

- `212` — the secure messaging session is more than 1,000 messages behind.
- `406` — the pre-key message signature does not match.

## Changes

- Preserve the underlying error code from `ProteusErrorOther`.
- Add named constants for:
  - `TooDistantFuture: 212`
  - `PreKeyMessageDoesntMatchSignature: 406`
- Keep `999` as the fallback for malformed or genuinely unknown errors.
- Add regression tests for `212`, `406`, and the unknown-error fallback.

## User impact

Error `212` is now recognized as recoverable, restoring the existing **Reset session** action. Resetting the session allows future messages to decrypt normally.

Previously failed messages cannot be recovered.

Error `406` is now reported accurately for diagnosis but does not automatically reset the session.