### PR TITLE
feat: show viewer access state in file header(WPB-25258)

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -431,6 +431,7 @@
   "cells.heading": "Files",
   "cells.imageFullScreenModal.closeButton": "Close",
   "cells.imageFullScreenModal.downloadButton": "Download",
+  "cells.imageFullScreenModal.viewerAccessLabel": "Viewer access",
   "cells.modal.closeButton": "Close",
   "cells.moveNodeModal.cancelButton": "Cancel",
   "cells.moveNodeModal.createFolder.hintButton": "Create a new folder",

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.test.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.test.tsx
@@ -24,6 +24,7 @@ import {render, screen} from '@testing-library/react';
 import {
   CELLS_SELF_USER_DRIVE_ROLE,
   CellsSelfUserDriveRoleProvider,
+  type CellsSelfUserDriveRole,
 } from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
 import {
   createRootContextValueForTest,
@@ -37,7 +38,11 @@ jest.mock('Components/fullscreenModal/fullscreenModal', () => ({
 }));
 
 jest.mock('./FileHeader/FileHeader', () => ({
-  FileHeader: () => <div data-uie-name="file-header">Header</div>,
+  FileHeader: ({showViewOnlyLabel}: {showViewOnlyLabel?: boolean}) => (
+    <div data-uie-name="file-header" data-show-view-only-label={String(showViewOnlyLabel === true)}>
+      Header
+    </div>
+  ),
 }));
 
 jest.mock('./FileEditor/FileEditor', () => {
@@ -74,20 +79,32 @@ jest.mock('./PdfViewer/PdfViewer', () => ({
   PDFViewer: () => <div data-uie-name="pdf-viewer">PDF Viewer</div>,
 }));
 
+interface CreateWrapperOptions {
+  isViewerPermissionFeatureEnabled?: boolean;
+  selfUserDriveRole?: CellsSelfUserDriveRole;
+}
+
 describe('FileFullscreenModal - File Version Restore', () => {
-  const RootProviderWrapper = createRootProviderWrapperForTest(
-    createRootContextValueForTest({
-      isFeatureToggleEnabled: () => false,
-      translate: key => key,
-    }),
-  );
-  const wrapper = ({children}: {children: ReactNode}) => (
-    <RootProviderWrapper>
-      <CellsSelfUserDriveRoleProvider selfUserDriveRole={CELLS_SELF_USER_DRIVE_ROLE.EDITOR}>
-        {children}
-      </CellsSelfUserDriveRoleProvider>
-    </RootProviderWrapper>
-  );
+  const createWrapper = ({
+    isViewerPermissionFeatureEnabled = false,
+    selfUserDriveRole = CELLS_SELF_USER_DRIVE_ROLE.EDITOR,
+  }: CreateWrapperOptions = {}) => {
+    const RootProviderWrapper = createRootProviderWrapperForTest(
+      createRootContextValueForTest({
+        isFeatureToggleEnabled: () => isViewerPermissionFeatureEnabled,
+        translate: key => key,
+      }),
+    );
+
+    return ({children}: {children: ReactNode}) => (
+      <RootProviderWrapper>
+        <CellsSelfUserDriveRoleProvider selfUserDriveRole={selfUserDriveRole}>
+          {children}
+        </CellsSelfUserDriveRoleProvider>
+      </RootProviderWrapper>
+    );
+  };
+  const wrapper = createWrapper();
 
   const defaultProps = {
     id: 'test-file-id',
@@ -192,6 +209,49 @@ describe('FileFullscreenModal - File Version Restore', () => {
       render(<FileFullscreenModal {...defaultProps} filePreviewUrl={undefined} status="success" />, {wrapper});
 
       expect(screen.getByTestId('no-preview')).toBeInTheDocument();
+    });
+
+    it('should pass viewer access state to header for restricted viewers when preview url is available', () => {
+      render(<FileFullscreenModal {...defaultProps} filePreviewUrl="file.xlsx" fileExtension="xlsx" />, {
+        wrapper: createWrapper({
+          isViewerPermissionFeatureEnabled: true,
+          selfUserDriveRole: CELLS_SELF_USER_DRIVE_ROLE.VIEWER,
+        }),
+      });
+
+      expect(screen.getByTestId('file-header')).toHaveAttribute('data-show-view-only-label', 'true');
+    });
+
+    it('should pass viewer access state to header for restricted viewers when preview is unavailable', () => {
+      render(<FileFullscreenModal {...defaultProps} status="unavailable" />, {
+        wrapper: createWrapper({
+          isViewerPermissionFeatureEnabled: true,
+          selfUserDriveRole: CELLS_SELF_USER_DRIVE_ROLE.VIEWER,
+        }),
+      });
+
+      expect(screen.getByTestId('file-header')).toHaveAttribute('data-show-view-only-label', 'true');
+    });
+
+    it('should pass viewer access state to header for restricted viewers on editable files without preview', () => {
+      render(
+        <FileFullscreenModal
+          {...defaultProps}
+          fileExtension="docx"
+          filePreviewUrl={undefined}
+          status="unavailable"
+          isEditMode
+        />,
+        {
+          wrapper: createWrapper({
+            isViewerPermissionFeatureEnabled: true,
+            selfUserDriveRole: CELLS_SELF_USER_DRIVE_ROLE.VIEWER,
+          }),
+        },
+      );
+
+      expect(screen.getByTestId('file-header')).toHaveAttribute('data-show-view-only-label', 'true');
+      expect(screen.queryByTestId('file-editor')).not.toBeInTheDocument();
     });
   });
 

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.tsx
@@ -74,9 +74,8 @@ export const FileFullscreenModal = ({
 }: FileFullscreenModalProps) => {
   const notInRecycleBin = !checkIsInRecycleBin();
   const canPerformCellsAction = useCellsActionPermissions();
-  const [isInEditMode, setIsInEditMode] = useState(
-    isEditMode && notInRecycleBin && canPerformCellsAction(CELLS_ACTION.EDIT),
-  );
+  const canEdit = canPerformCellsAction(CELLS_ACTION.EDIT);
+  const [isInEditMode, setIsInEditMode] = useState(isEditMode && notInRecycleBin && canEdit);
   const [refreshKey, setRefreshKey] = useState(0);
   const isEditable = isFileEditable(fileExtension);
 
@@ -90,8 +89,8 @@ export const FileFullscreenModal = ({
   };
 
   useEffect(() => {
-    setIsInEditMode(isEditMode && notInRecycleBin && canPerformCellsAction(CELLS_ACTION.EDIT));
-  }, [canPerformCellsAction, isEditMode, notInRecycleBin]);
+    setIsInEditMode(isEditMode && notInRecycleBin && canEdit);
+  }, [canEdit, isEditMode, notInRecycleBin]);
 
   return (
     <FullscreenModal id={id} isOpen={isOpen} onClose={onCloseModal}>
@@ -108,6 +107,7 @@ export const FileFullscreenModal = ({
         isEditable={isEditable}
         id={id}
         onFileContentRefresh={refreshModalContent}
+        showViewOnlyLabel={!canEdit}
       />
       {isInEditMode && isEditable ? (
         <FileEditor key={refreshKey} id={id} />

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.styles.ts
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.styles.ts
@@ -132,3 +132,31 @@ export const editModeButtonStyles: CSSObject = {
     },
   },
 };
+
+export const viewOnlyLabelStyles: CSSObject = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '8px',
+  padding: '4px',
+  width: '159px',
+  height: '32px',
+  minHeight: '32px',
+  borderRadius: '12px',
+  backgroundColor: 'var(--Backgrounds-Background, #EDEFF0)',
+  color: 'var(--gray-100, #17181A)',
+  fontSize: 'var(--font-size-small)',
+  lineHeight: 'var(--line-height-sm)',
+  whiteSpace: 'nowrap',
+
+  'body.theme-dark &': {
+    backgroundColor: 'var(--gray-100, #17181A)',
+    color: 'var(--white, #FFFFFF)',
+  },
+
+  svg: {
+    color: 'currentColor',
+    fill: 'currentColor',
+    flexShrink: 0,
+  },
+};

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.test.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.test.tsx
@@ -37,6 +37,7 @@ const translate = (key: string) =>
   ({
     'cells.imageFullScreenModal.closeButton': 'Close',
     'cells.imageFullScreenModal.downloadButton': 'Download',
+    'cells.imageFullScreenModal.viewerAccessLabel': 'Viewer access',
     'cells.options.label': 'More options',
     'cells.options.versionHistory': 'Version History',
   })[key] ?? key;
@@ -108,5 +109,22 @@ describe('FileHeader', () => {
     renderHeader({isViewerPermissionFeatureEnabled: false});
 
     expect(screen.getByRole('button', {name: 'Download'})).toBeInTheDocument();
+  });
+
+  it('shows viewer access state and removes other action buttons', () => {
+    const {container: renderContainer} = renderHeader({
+      isViewerPermissionFeatureEnabled: true,
+      props: {isEditable: true, showViewOnlyLabel: true},
+    });
+
+    expect(screen.getByText('Viewer access')).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Download'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Viewing'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Editing'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'More options'})).not.toBeInTheDocument();
+    expect(renderContainer.querySelector('[data-uie-name="file-header-view-only-icon"]')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
   });
 });

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
@@ -106,8 +106,6 @@ export const FileHeader = ({
   const isRecycleBin = isInRecycleBin();
   const cellsRepository = container.resolve(CellsRepository);
   const {showModal} = useFileHistoryModal();
-  const canEdit = canPerformCellsAction(CELLS_ACTION.EDIT);
-  const canDownload = canPerformCellsAction(CELLS_ACTION.DOWNLOAD);
   const canViewVersionHistory = canPerformCellsAction(CELLS_ACTION.VIEW_VERSION_HISTORY);
 
   const handleFileDownload = async () => {
@@ -150,7 +148,7 @@ export const FileHeader = ({
             <ShowIcon width={16} height={16} />
             Viewing
           </button>
-          {!isRecycleBin && canEdit && (
+          {!isRecycleBin && canPerformCellsAction(CELLS_ACTION.EDIT) && (
             <button
               title="Editing"
               aria-label="Editing"
@@ -172,7 +170,7 @@ export const FileHeader = ({
             {translate('cells.imageFullScreenModal.viewerAccessLabel')}
           </div>
         )}
-        {!showViewOnlyLabel && !isRecycleBin && canDownload && (
+        {!showViewOnlyLabel && !isRecycleBin && canPerformCellsAction(CELLS_ACTION.DOWNLOAD) && (
           <Button
             variant={ButtonVariant.TERTIARY}
             css={downloadButtonStyles}
@@ -195,7 +193,7 @@ export const FileHeader = ({
               </Button>
             </DropdownMenu.Trigger>
             <DropdownMenu.Content>
-              <DropdownMenu.Item onClick={() => showModal(id, () => onFileContentRefresh(), canDownload)}>
+              <DropdownMenu.Item onClick={() => showModal(id, () => onFileContentRefresh())}>
                 {translate('cells.options.versionHistory')}
               </DropdownMenu.Item>
             </DropdownMenu.Content>

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
@@ -106,7 +106,6 @@ export const FileHeader = ({
   const isRecycleBin = isInRecycleBin();
   const cellsRepository = container.resolve(CellsRepository);
   const {showModal} = useFileHistoryModal();
-  const canViewVersionHistory = canPerformCellsAction(CELLS_ACTION.VIEW_VERSION_HISTORY);
 
   const handleFileDownload = async () => {
     if (fileUrl !== undefined && fileUrl.length > 0) {
@@ -181,24 +180,27 @@ export const FileHeader = ({
             <DownloadIcon />
           </Button>
         )}
-        {!showViewOnlyLabel && !isRecycleBin && isEditable === true && canViewVersionHistory && (
-          <DropdownMenu>
-            <DropdownMenu.Trigger asChild>
-              <Button
-                variant={ButtonVariant.TERTIARY}
-                css={downloadButtonStyles}
-                aria-label={translate('cells.options.label')}
-              >
-                <MoreIcon css={iconStyles} />
-              </Button>
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content>
-              <DropdownMenu.Item onClick={() => showModal(id, () => onFileContentRefresh())}>
-                {translate('cells.options.versionHistory')}
-              </DropdownMenu.Item>
-            </DropdownMenu.Content>
-          </DropdownMenu>
-        )}
+        {!showViewOnlyLabel &&
+          !isRecycleBin &&
+          isEditable === true &&
+          canPerformCellsAction(CELLS_ACTION.VIEW_VERSION_HISTORY) && (
+            <DropdownMenu>
+              <DropdownMenu.Trigger asChild>
+                <Button
+                  variant={ButtonVariant.TERTIARY}
+                  css={downloadButtonStyles}
+                  aria-label={translate('cells.options.label')}
+                >
+                  <MoreIcon css={iconStyles} />
+                </Button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content>
+                <DropdownMenu.Item onClick={() => showModal(id, () => onFileContentRefresh())}>
+                  {translate('cells.options.versionHistory')}
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu>
+          )}
       </div>
     </header>
   );

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
@@ -30,6 +30,7 @@ import {
   DropdownMenu,
   MoreIcon,
   ShowIcon,
+  ViewerAccessIcon,
 } from '@wireapp/react-ui-kit';
 
 import {FileTypeIcon} from 'Components/Conversation/common/FileTypeIcon/FileTypeIcon';
@@ -57,6 +58,7 @@ import {
   downloadButtonStyles,
   actionButtonsStyles,
   editModeButtonStyles,
+  viewOnlyLabelStyles,
 } from './FileHeader.styles';
 
 interface FileHeaderProps {
@@ -70,6 +72,7 @@ interface FileHeaderProps {
   fileUrl?: string;
   isEditable?: boolean;
   isInEditMode?: boolean;
+  showViewOnlyLabel?: boolean;
   onEditModeChange: (isEditable: boolean) => void;
   onFileContentRefresh: () => void;
 }
@@ -85,6 +88,7 @@ export const FileHeader = ({
   badges,
   isEditable,
   isInEditMode,
+  showViewOnlyLabel = false,
   onEditModeChange,
   onFileContentRefresh,
 }: FileHeaderProps) => {
@@ -102,6 +106,8 @@ export const FileHeader = ({
   const isRecycleBin = isInRecycleBin();
   const cellsRepository = container.resolve(CellsRepository);
   const {showModal} = useFileHistoryModal();
+  const canEdit = canPerformCellsAction(CELLS_ACTION.EDIT);
+  const canDownload = canPerformCellsAction(CELLS_ACTION.DOWNLOAD);
   const canViewVersionHistory = canPerformCellsAction(CELLS_ACTION.VIEW_VERSION_HISTORY);
 
   const handleFileDownload = async () => {
@@ -133,7 +139,7 @@ export const FileHeader = ({
           {badges && badges.length > 0 && <BadgesWithTooltip items={badges} />}
         </div>
       </div>
-      {isEditable === true && (
+      {isEditable === true && !showViewOnlyLabel && (
         <div css={editModeButtonStyles}>
           <button
             title="Viewing"
@@ -144,7 +150,7 @@ export const FileHeader = ({
             <ShowIcon width={16} height={16} />
             Viewing
           </button>
-          {!isRecycleBin && canPerformCellsAction(CELLS_ACTION.EDIT) && (
+          {!isRecycleBin && canEdit && (
             <button
               title="Editing"
               aria-label="Editing"
@@ -158,7 +164,15 @@ export const FileHeader = ({
         </div>
       )}
       <div css={actionButtonsStyles}>
-        {!isRecycleBin && canPerformCellsAction(CELLS_ACTION.DOWNLOAD) && (
+        {showViewOnlyLabel && (
+          <div css={viewOnlyLabelStyles}>
+            <span data-uie-name="file-header-view-only-icon" aria-hidden="true">
+              <ViewerAccessIcon />
+            </span>
+            {translate('cells.imageFullScreenModal.viewerAccessLabel')}
+          </div>
+        )}
+        {!showViewOnlyLabel && !isRecycleBin && canDownload && (
           <Button
             variant={ButtonVariant.TERTIARY}
             css={downloadButtonStyles}
@@ -169,7 +183,7 @@ export const FileHeader = ({
             <DownloadIcon />
           </Button>
         )}
-        {!isRecycleBin && isEditable === true && canViewVersionHistory && (
+        {!showViewOnlyLabel && !isRecycleBin && isEditable === true && canViewVersionHistory && (
           <DropdownMenu>
             <DropdownMenu.Trigger asChild>
               <Button
@@ -181,7 +195,7 @@ export const FileHeader = ({
               </Button>
             </DropdownMenu.Trigger>
             <DropdownMenu.Content>
-              <DropdownMenu.Item onClick={() => showModal(id, () => onFileContentRefresh())}>
+              <DropdownMenu.Item onClick={() => showModal(id, () => onFileContentRefresh(), canDownload)}>
                 {translate('cells.options.versionHistory')}
               </DropdownMenu.Item>
             </DropdownMenu.Content>

--- a/libraries/react-ui-kit/src/dataDisplay/icon/index.ts
+++ b/libraries/react-ui-kit/src/dataDisplay/icon/index.ts
@@ -104,6 +104,7 @@ export * from './trashCrossIcon';
 export * from './triangleIcon';
 export * from './uploadIcon';
 export * from './verificationShieldIcon';
+export * from './viewerAccessIcon';
 export * from './wireIcon';
 export * from './shieldIcon';
 export * from './lockClosedIcon';

--- a/libraries/react-ui-kit/src/dataDisplay/icon/viewerAccessIcon.tsx
+++ b/libraries/react-ui-kit/src/dataDisplay/icon/viewerAccessIcon.tsx
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {SVGIcon, SVGIconProps} from './svgIcon';
+
+export const ViewerAccessIcon = (props: SVGIconProps) => (
+  <SVGIcon realWidth={16} realHeight={16} viewBox="20 8 16 16" {...props}>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M35.4506 20.236C34.7419 22.3694 32.8299 23.8979 30.5824 23.8979C28.3349 23.8979 26.4229 22.3694 25.7142 20.236C26.4228 18.1025 28.3349 16.574 30.5824 16.574C32.8299 16.574 34.7419 18.1025 35.4506 20.236ZM30.5824 18.4055C31.5906 18.4055 32.408 19.2253 32.408 20.2365C32.408 21.2478 31.5906 22.0675 30.5824 22.0675C29.5742 22.0675 28.7569 21.2478 28.7569 20.2365C28.7569 19.2253 29.5742 18.4055 30.5824 18.4055Z"
+    />
+    <rect x="23.4286" y="12.5713" width="5.71429" height="1.14286" />
+    <rect x="23.4286" y="14.8569" width="3.42857" height="1.14286" />
+    <path d="M30.5 8C31.8807 8 33 9.11929 33 10.5V14.8574H31.5V10.5C31.5 9.94772 31.0523 9.5 30.5 9.5H22.5C21.9477 9.5 21.5 9.94772 21.5 10.5V21.5C21.5 22.0523 21.9477 22.5 22.5 22.5H24.5713V24H22.5C21.1193 24 20 22.8807 20 21.5V10.5C20 9.20566 20.9836 8.14082 22.2441 8.0127L22.5 8H30.5Z" />
+  </SVGIcon>
+);


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25258" title="WPB-25258" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25258</a>  [Web] Modify Edition buttons for users with Viewer profile (Collabora access)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Summary

- Added `ViewerAccessIcon` to the React UI kit icon exports.
- Show the new `Viewer access` state in the fullscreen file header for restricted Cells viewers.
- Hide the old Viewing/Editing toggle, download action, and version history action when the viewer access state is shown.
- Apply the viewer access state consistently across previewable files, Collabora editable files, and files without previews.

<img width="1510" height="71" alt="Screenshot 2026-08-19 at 12 41 51" src="https://github.com/user-attachments/assets/4ce78d62-7d3f-463e-8b5e-95adfb1aae2d" />
<img width="1512" height="88" alt="Screenshot 2026-08-19 at 12 42 01" src="https://github.com/user-attachments/assets/02a205f0-8e4e-4f28-9332-415194dd7fef" />
