### PR TITLE
Preserve meeting participant names and unify avatar rendering [WPB-28046]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingParticipants/meetingParticipants.styles.ts
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingParticipants/meetingParticipants.styles.ts
@@ -24,19 +24,3 @@ export const wrapperStyles: CSSObject = {
   alignItems: 'center',
   minWidth: 0,
 };
-
-export const singleParticipantStyles: CSSObject = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: 8,
-  minWidth: 0,
-};
-
-export const participantNameStyles: CSSObject = {
-  color: 'var(--main-color)',
-  fontSize: 14,
-  fontWeight: 'var(--font-weight-regular)',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-};

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingParticipants/meetingParticipants.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingParticipants/meetingParticipants.test.tsx
@@ -1,0 +1,144 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {act, fireEvent, render, screen} from '@testing-library/react';
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
+import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
+import {ThemeProvider} from '@wireapp/react-ui-kit';
+import {container} from 'tsyringe';
+
+import {User} from 'Repositories/entity/User';
+import {Conversation} from 'Repositories/entity/Conversation';
+import {ConversationState} from 'Repositories/conversation/ConversationState';
+import {UserState} from 'Repositories/user/userState';
+import {setStrings, translate} from 'Util/localizerUtil';
+import en from 'I18n/en-US.json';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {MeetingParticipants} from './meetingParticipants';
+
+const qualifiedConversation: QualifiedId = {id: 'conversation-id', domain: 'example.com'};
+const qualifiedCreator: QualifiedId = {id: 'creator-id', domain: 'example.com'};
+const qualifiedSelf: QualifiedId = {id: 'self-id', domain: 'example.com'};
+const specialCharacterName = `Eldon Bauch ±§!@#{}[]:"|;'\\<>?,./$%^&*()`;
+
+describe('MeetingParticipants', () => {
+  it('preserves special characters in the organizer tooltip', () => {
+    setStrings({en});
+    const userState = container.resolve(UserState);
+    const conversationState = container.resolve(ConversationState);
+    const previousUsers = userState.users();
+    const previousSelf = userState.self();
+    const previousConversations = conversationState.conversations();
+    const organizer = new User(qualifiedCreator.id, qualifiedCreator.domain, translate);
+    organizer.name(specialCharacterName);
+    const selfUser = new User('self-id', 'example.com', translate);
+    const conversation = new Conversation(
+      qualifiedConversation.id,
+      qualifiedConversation.domain,
+      CONVERSATION_PROTOCOL.PROTEUS,
+      translate,
+    );
+    conversation.participating_user_ets([organizer]);
+    userState.self(selfUser);
+    userState.users([organizer]);
+    conversationState.conversations([conversation]);
+    const appRoot = document.createElement('div');
+    appRoot.id = 'wire-app';
+    document.body.appendChild(appRoot);
+
+    try {
+      const rendered = render(
+        <ThemeProvider>
+          <MeetingParticipants qualifiedConversation={qualifiedConversation} qualifiedCreator={qualifiedCreator} />
+        </ThemeProvider>,
+        {wrapper: createRootProviderWrapperForTest(createRootContextValueForTest({translate}))},
+      );
+
+      const avatar = screen.getByLabelText(`${specialCharacterName} (Organizer)`);
+      expect(avatar).toBeInTheDocument();
+      const tooltipWrapper = avatar.closest('[data-testid="tooltip-wrapper"]');
+      expect(tooltipWrapper).toBeInTheDocument();
+      fireEvent.mouseEnter(tooltipWrapper!);
+      expect(document.querySelector('[data-testid="tooltip-content"]')).toHaveTextContent(
+        `${specialCharacterName} (Organizer)`,
+      );
+      expect(screen.queryByText(/&quot;|&#x27;|&lt;|&gt;|&amp;/)).not.toBeInTheDocument();
+      rendered.unmount();
+    } finally {
+      act(() => {
+        userState.users(previousUsers);
+        userState.self(previousSelf);
+        conversationState.conversations(previousConversations);
+      });
+      appRoot.remove();
+    }
+  });
+
+  it('shows the self-organizer avatar with the name only in the tooltip', () => {
+    setStrings({en});
+    const userState = container.resolve(UserState);
+    const conversationState = container.resolve(ConversationState);
+    const previousUsers = userState.users();
+    const previousSelf = userState.self();
+    const previousConversations = conversationState.conversations();
+    const selfUser = new User(qualifiedSelf.id, qualifiedSelf.domain, translate);
+    selfUser.name('Self Organizer');
+    const conversation = new Conversation(
+      qualifiedConversation.id,
+      qualifiedConversation.domain,
+      CONVERSATION_PROTOCOL.PROTEUS,
+      translate,
+    );
+    conversation.participating_user_ets([]);
+    userState.self(selfUser);
+    userState.users([selfUser]);
+    conversationState.conversations([conversation]);
+    const appRoot = document.createElement('div');
+    appRoot.id = 'wire-app';
+    document.body.appendChild(appRoot);
+
+    try {
+      const rendered = render(
+        <ThemeProvider>
+          <MeetingParticipants qualifiedConversation={qualifiedConversation} qualifiedCreator={qualifiedSelf} />
+        </ThemeProvider>,
+        {wrapper: createRootProviderWrapperForTest(createRootContextValueForTest({translate}))},
+      );
+
+      const avatar = screen.getByLabelText('Self Organizer (Organizer)');
+      expect(avatar).toBeInTheDocument();
+      expect(screen.queryByText('Self Organizer')).not.toBeInTheDocument();
+      const tooltipWrapper = avatar.closest('[data-testid="tooltip-wrapper"]');
+      expect(tooltipWrapper).toBeInTheDocument();
+      fireEvent.mouseEnter(tooltipWrapper!);
+      expect(screen.getByText('Self Organizer (Organizer)')).toBeInTheDocument();
+      rendered.unmount();
+    } finally {
+      act(() => {
+        userState.users(previousUsers);
+        userState.self(previousSelf);
+        conversationState.conversations(previousConversations);
+      });
+      appRoot.remove();
+    }
+  });
+});

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingParticipants/meetingParticipants.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingParticipants/meetingParticipants.tsx
@@ -19,15 +19,13 @@
 
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
 
-import {AVATAR_SIZE, StackedAvatars} from 'Components/avatar';
-import {ParticipantAvatarTooltip} from 'Components/avatar/stackedAvatars/participantAvatarTooltip';
-import {UserName} from 'Components/UserName';
+import {StackedAvatars} from 'Components/avatar';
 import type {Conversation} from 'Repositories/entity/Conversation';
 import type {User} from 'Repositories/entity/User';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {matchQualifiedIds} from 'Util/qualifiedId';
 
-import {participantNameStyles, singleParticipantStyles, wrapperStyles} from './meetingParticipants.styles';
+import {wrapperStyles} from './meetingParticipants.styles';
 import {useMeetingConversation} from './useMeetingConversation';
 import {useMeetingParticipants} from './useMeetingParticipants';
 
@@ -49,33 +47,19 @@ const MeetingParticipantsContent = ({conversation, qualifiedCreator, isOngoing}:
   const avatarRingColor = isOngoing ? 'var(--accent-color-highlight)' : 'var(--text-input-background)';
   const getParticipantLabel = (participant: User, name: string) =>
     matchQualifiedIds(participant.qualifiedId, qualifiedCreator)
-      ? translate('meetings.participant.nameWithOrganizer', {
-          name,
-          organizer: translate('meetings.participant.organizer'),
-        })
+      ? translate(
+          'meetings.participant.nameWithOrganizer',
+          {
+            name,
+            organizer: translate('meetings.participant.organizer'),
+          },
+          undefined,
+          true,
+        )
       : name;
 
   if (participants.length === 0) {
     return null;
-  }
-
-  if (participants.length === 1) {
-    const participant = participants[0];
-
-    return (
-      <div css={wrapperStyles} data-uie-name="meeting-participants">
-        <div css={singleParticipantStyles}>
-          <ParticipantAvatarTooltip
-            participant={participant}
-            getLabel={name => getParticipantLabel(participant, name)}
-            avatarSize={AVATAR_SIZE.X_SMALL}
-          />
-          <span css={participantNameStyles}>
-            <UserName user={participant} />
-          </span>
-        </div>
-      </div>
-    );
   }
 
   return (

--- a/apps/webapp/src/script/components/meeting/meetingNotificationCard/meetingNotificationCard.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationCard/meetingNotificationCard.test.tsx
@@ -19,8 +19,11 @@
 import {fireEvent, render, screen} from '@testing-library/react';
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import {ThemeProvider} from '@wireapp/react-ui-kit';
+import {container} from 'tsyringe';
 
 import en from 'I18n/en-US.json';
+import {User} from 'Repositories/entity/User';
+import {UserState} from 'Repositories/user/userState';
 import {MeetingNotificationCard} from './meetingNotificationCard';
 import {
   type MeetingNotification,
@@ -38,6 +41,7 @@ const qualifiedId: QualifiedId = {id: 'meeting-id', domain: 'example.com'};
 const qualifiedCreator: QualifiedId = {id: 'creator-id', domain: 'example.com'};
 const meetingStartTime = '2026-06-01T09:00:00.000Z';
 const ongoingMeetingStartTime = '2026-06-01T09:50:00.000Z';
+const specialCharacterName = `Eldon Bauch ±§!@#{}[]:"|;'\\<>?,./$%^&*()`;
 const translateForNotificationTest: Translate = (key, substitutions) =>
   key === 'meetings.notifications.title'
     ? `${substitutions?.label} ${substitutions?.meetingTitle}`
@@ -229,5 +233,37 @@ describe('MeetingNotificationCard', () => {
     const card = screen.getByRole('listitem');
     expect(card).toHaveTextContent("Invitation: Cleopatra's meeting");
     expect(card).not.toHaveTextContent('&#x27;');
+  });
+
+  it('renders special characters in the organizer name without encoding them', () => {
+    setStrings({en});
+    const user = new User(qualifiedCreator.id, qualifiedCreator.domain, translate);
+    user.name(specialCharacterName);
+    const userState = container.resolve(UserState);
+    const previousUsers = userState.users();
+    userState.users([user]);
+
+    try {
+      render(
+        <ThemeProvider>
+          <MeetingNotificationCard
+            id="notification-invite"
+            kind={MeetingNotificationKind.INVITE}
+            meetingTitle="Meeting Title"
+            qualifiedId={qualifiedId}
+            qualifiedCreator={qualifiedCreator}
+            meetingStartTime={meetingStartTime}
+            onDismiss={jest.fn()}
+          />
+        </ThemeProvider>,
+        {wrapper: createRootProviderWrapperForTest(createRootContextValueForTest({translate}))},
+      );
+
+      const card = screen.getByRole('listitem');
+      expect(card).toHaveTextContent(`By ${specialCharacterName} • ${formatLocale(meetingStartTime, 'PP, p')}`);
+      expect(card).not.toHaveTextContent(/&quot;|&#x27;|&lt;|&gt;|&amp;/);
+    } finally {
+      userState.users(previousUsers);
+    }
   });
 });

--- a/apps/webapp/src/script/components/meeting/meetingNotificationCard/meetingNotificationCard.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationCard/meetingNotificationCard.tsx
@@ -77,7 +77,7 @@ const MeetingNotificationOrganizerAndTimeMetadata = ({
 
   return (
     <>
-      {translate('meetings.notifications.by', {organizer})}
+      {translate('meetings.notifications.by', {organizer}, undefined, true)}
       {organizer && meetingTime && <span aria-hidden="true"> • </span>}
       {meetingTime}
     </>
@@ -114,7 +114,7 @@ const MeetingNotificationMetadata = ({
 
       return (
         <>
-          {translate('meetings.notifications.by', {organizer})}
+          {translate('meetings.notifications.by', {organizer}, undefined, true)}
           {organizer && <span aria-hidden="true"> • </span>}
           <span css={meetingNotificationCardOngoingTimeStyles}>
             {translate('meetings.meetingStatus.startedAt', {time: meetingTime})}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28046" title="WPB-28046" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28046</a>  [Web] Show participant name when hovering avatars
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
