### PR TITLE
Show loader when meetings request is in flight [WPB-27760]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingList/meetingList.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingList.test.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {createRef, useMemo} from 'react';
+import {useMemo} from 'react';
 
 import {act, fireEvent, render, screen} from '@testing-library/react';
 import type {Virtualizer} from '@tanstack/react-virtual';
@@ -107,6 +107,7 @@ const createMeetingStoreForTest = () =>
     deleteMeetingForAll: jest.fn(),
     removeMeetingByQualifiedId: jest.fn(),
     loadMeetingForEdit: jest.fn(),
+    syncMeetingByQualifiedId: jest.fn(),
   }));
 
 const renderMeetingList = (
@@ -140,6 +141,13 @@ const renderMeetingList = (
 };
 
 describe('MeetingList', () => {
+  it('shows a loading state before the first meetings response is received', () => {
+    renderMeetingList({meetingSeries: [], isLoading: true, hasLoadError: false});
+
+    expect(screen.getByTestId('status-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('empty-meetings-list')).not.toBeInTheDocument();
+  });
+
   it('shows the load error when the first load fails before any meetings are available', () => {
     renderMeetingList({meetingSeries: [], isLoading: false, hasLoadError: true});
 
@@ -334,8 +342,7 @@ describe('MeetingList', () => {
       clientHeight: {value: 100, configurable: true},
       scrollHeight: {value: 1000, configurable: true},
     });
-    const scrollElementRef = createRef<HTMLElement>();
-    scrollElementRef.current = scrollElement;
+    const scrollElementRef = {current: scrollElement};
 
     renderMeetingList({meetingSeries, isLoading: false, hasLoadError: false, scrollElementRef}, wallClock);
     expect(screen.queryByText('Meeting 51')).not.toBeInTheDocument();

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingList.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingList.tsx
@@ -259,7 +259,7 @@ export const MeetingList = ({
   const hasVisibleMeetingInstances = visibleDayGroups.length > 0;
   const now = new Date(nowMilliseconds);
 
-  if (isLoading && isNonEmptyArray(meetingSeries)) {
+  if (isLoading) {
     return (
       <div css={emptyListContainerStyles} data-uie-name="meetings-list-loading">
         <Loading data-uie-name="status-loading" />


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27760" title="WPB-27760" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27760</a>  [Web] “No meetings yet” empty state is displayed while the meeting list is still loading on a slow network
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
