### PR TITLE
fix: count departed users in message reactions [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
@@ -49,6 +49,7 @@ interface EmojiPillProps {
   isRemovedFromConversation: boolean;
   index: number;
   emojiListCount: number;
+  emojiCount: number;
   hasUserReacted: boolean;
   reactingUsers: User[];
 }
@@ -66,14 +67,13 @@ export const EmojiPill = ({
   isRemovedFromConversation,
   index,
   emojiListCount,
+  emojiCount,
   hasUserReacted,
   reactingUsers,
 }: EmojiPillProps) => {
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
   const emojiName = getEmojiTitleFromEmojiUnicode(emojiUnicode);
   const isActive = hasUserReacted && !isRemovedFromConversation;
-
-  const emojiCount = reactingUsers.length;
 
   const reactingUserNames = reactingUsers.slice(0, MAX_USER_NAMES_TO_SHOW).map(user => user.name());
 

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
@@ -89,6 +89,20 @@ describe('MessageReactionsList', () => {
     expect(smileyFace2Count).toBeDefined();
   });
 
+  test('counts reactions from users who are no longer conversation members', () => {
+    const departedUserId = generateQualifiedId();
+    const reactionsWithDepartedUser: ReactionMap = [
+      ['❤️', [user1.qualifiedId, user2.qualifiedId, user3.qualifiedId, departedUserId]],
+    ];
+
+    const {getByTitle} = render(
+      withTheme(<MessageReactionsList {...defaultProps} reactions={reactionsWithDepartedUser} />),
+      {wrapper: rootProviderWrapper},
+    );
+
+    expect(within(getByTitle('heart')).getByText('4')).toBeDefined();
+  });
+
   test('handles click on reaction button', () => {
     const {getByTitle} = render(withTheme(<MessageReactionsList {...defaultProps} />), {
       wrapper: rootProviderWrapper,

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.tsx
@@ -50,6 +50,8 @@ const MessageReactionsList = ({reactions, ...props}: MessageReactionsListProps) 
         const emojiListCount = users.length;
         const hasUserReacted = users.some(user => matchQualifiedIds(selfUserId, user));
 
+        // Departed users still contribute to the reaction count, but their names are omitted from the tooltip
+        // because only current conversation members are available here.
         const reactingUsers = users
           .map(qualifiedId => conversationUsers.find(user => matchQualifiedIds(qualifiedId, user.qualifiedId)))
           .filter((user): user is User => typeof user !== 'undefined');

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.tsx
@@ -57,6 +57,7 @@ const MessageReactionsList = ({reactions, ...props}: MessageReactionsListProps) 
         return (
           <EmojiPill
             reactingUsers={reactingUsers}
+            emojiCount={users.length}
             hasUserReacted={hasUserReacted}
             emojiUnicode={emojiUnicode}
             emoji={emoji}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Count inline message reactions from the complete stored reaction ID list.
- Keep the current conversation member list only for resolving tooltip names (this is also can be an issue but for now will leave it as is)
- Add a regression test for reactions from users who left the group.

## Root cause

The inline reaction pill derived its count from users matched against the current conversation member list. When a reactor left the group, that lookup filtered them out even though their reaction ID remained on the message. Message details used the complete reaction data, causing the two views to disagree.

## Steps to reproduce

1. Have four group members react to a message with the same emoji.
2. Remove one of those members from the group.
3. Check the reaction pill in the message list and then open message details.
4. The pill shows three reactions while message details shows four.

## Fix

Pass the number of IDs stored for each reaction to the emoji pill. Current conversation members are still used for tooltip names, but they no longer determine the reaction count.

## Impact

Inline reaction counts now stay consistent with message details after a reactor leaves the group.

## Validation

- The focused reaction component tests pass, including the departed-user regression case.
- Workspace type checks pass.
- Affected lint, formatting, and style checks pass.
