### PR TITLE
fix: resolve historical reaction names in tooltips

### DIFF
--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -97,7 +97,7 @@ export const ContentMessageComponent = ({
   isFileShareRestricted,
 }: ContentMessageProps) => {
   const messageRef = useRef<HTMLDivElement | null>(null);
-  const {translate} = useApplicationContext();
+  const {mainViewModel, translate} = useApplicationContext();
 
   // check if current message is focused and its elements focusable
   const msgFocusState = useMemo(() => isMsgElementsFocusable && isFocused, [isMsgElementsFocusable, isFocused]);
@@ -315,6 +315,7 @@ export const ContentMessageComponent = ({
         <MessageReactionsList
           translate={translate}
           reactions={reactions}
+          loadUsersFromDb={userIds => mainViewModel.content.userRepository.getUsersByIdFromDb(userIds)}
           selfUserId={selfId}
           handleReactionClick={onClickReaction}
           isMessageFocused={msgFocusState}

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import {useRef, useState} from 'react';
+
 import {Tooltip} from '@wireapp/react-ui-kit';
 
 import {useMessageFocusedTabIndex} from 'Components/MessagesList/Message/util';
@@ -25,6 +27,7 @@ import {getEmojiTitleFromEmojiUnicode} from 'Util/emojiUtil';
 import {isTabKey} from 'Util/keyboardUtil';
 import type {Translate} from 'Util/localizerUtil';
 import {replaceReactComponents} from 'Util/localizerUtil/reactLocalizerUtil';
+import {matchQualifiedIds} from 'Util/qualifiedId';
 
 import {EmojiChar} from './EmojiChar';
 import {
@@ -52,6 +55,7 @@ interface EmojiPillProps {
   emojiCount: number;
   hasUserReacted: boolean;
   reactingUsers: User[];
+  loadAdditionalUsers?: () => Promise<User[]>;
 }
 
 const MAX_USER_NAMES_TO_SHOW = 2;
@@ -70,12 +74,36 @@ export const EmojiPill = ({
   emojiCount,
   hasUserReacted,
   reactingUsers,
+  loadAdditionalUsers,
 }: EmojiPillProps) => {
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
   const emojiName = getEmojiTitleFromEmojiUnicode(emojiUnicode);
   const isActive = hasUserReacted && !isRemovedFromConversation;
+  const [additionalReactingUsers, setAdditionalReactingUsers] = useState<User[]>([]);
+  const hasLoadedAdditionalUsers = useRef(false);
 
-  const reactingUserNames = reactingUsers.slice(0, MAX_USER_NAMES_TO_SHOW).map(user => user.name());
+  const tooltipUsers = [...reactingUsers, ...additionalReactingUsers].filter(
+    (user, index, users) =>
+      users.findIndex(otherUser => matchQualifiedIds(user.qualifiedId, otherUser.qualifiedId)) === index,
+  );
+
+  const loadAdditionalUsersForTooltip = () => {
+    if (!loadAdditionalUsers || hasLoadedAdditionalUsers.current) {
+      return;
+    }
+
+    hasLoadedAdditionalUsers.current = true;
+    void loadAdditionalUsers().then(
+      users => setAdditionalReactingUsers(users),
+      () => undefined,
+    );
+  };
+
+  const fallbackUserName = translate('deletedUser');
+  const tooltipUserCount = Math.min(MAX_USER_NAMES_TO_SHOW, emojiCount);
+  const reactingUserNames = Array(tooltipUserCount)
+    .fill(fallbackUserName)
+    .map((fallbackName, index) => tooltipUsers[index]?.name() || fallbackName);
 
   const conversationReactionCaption = () => {
     if (emojiCount > MAX_USER_NAMES_TO_SHOW) {
@@ -162,6 +190,8 @@ export const EmojiPill = ({
           tabIndex={messageFocusedTabIndex}
           className="button-reset-default"
           data-uie-name="emoji-pill"
+          onMouseEnter={loadAdditionalUsersForTooltip}
+          onFocus={loadAdditionalUsersForTooltip}
           onClick={() => {
             handleReactionClick(emoji);
           }}

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {render, fireEvent, within} from '@testing-library/react';
+import {render, fireEvent, waitFor, within} from '@testing-library/react';
 
 import {User} from 'Repositories/entity/User';
 import {ReactionMap} from 'Repositories/storage';
@@ -45,6 +45,7 @@ const defaultProps: MessageReactionsListProps = {
   translate: translateForTest,
   reactions: reactions,
   handleReactionClick: jest.fn(),
+  loadUsersFromDb: jest.fn().mockResolvedValue([]),
   onTooltipReactionCountClick: jest.fn(),
   isMessageFocused: false,
   onLastReactionKeyEvent: jest.fn(),
@@ -101,6 +102,28 @@ describe('MessageReactionsList', () => {
     );
 
     expect(within(getByTitle('heart')).getByText('4')).toBeDefined();
+  });
+
+  test('loads names for departed users when the reaction tooltip is opened', async () => {
+    const departedUserId = generateQualifiedId();
+    const departedUser = new User(departedUserId.id, departedUserId.domain, translateForTest);
+    departedUser.name('Departed User');
+    const loadUsersFromDb = jest.fn().mockResolvedValue([departedUser]);
+
+    const {getByTitle} = render(
+      withTheme(
+        <MessageReactionsList
+          {...defaultProps}
+          loadUsersFromDb={loadUsersFromDb}
+          reactions={[['❤️', [departedUserId]]]}
+        />,
+      ),
+      {wrapper: rootProviderWrapper},
+    );
+
+    fireEvent.mouseEnter(getByTitle('heart'));
+
+    await waitFor(() => expect(loadUsersFromDb).toHaveBeenCalledWith([departedUserId]));
   });
 
   test('handles click on reaction button', () => {

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.tsx
@@ -32,6 +32,7 @@ export interface MessageReactionsListProps {
   translate: Translate;
   reactions: ReactionMap;
   handleReactionClick: (emoji: string) => void;
+  loadUsersFromDb: (userIds: QualifiedId[]) => Promise<User[]>;
   selfUserId: QualifiedId;
   isMessageFocused: boolean;
   onTooltipReactionCountClick: () => void;
@@ -41,7 +42,7 @@ export interface MessageReactionsListProps {
 }
 
 const MessageReactionsList = ({reactions, ...props}: MessageReactionsListProps) => {
-  const {selfUserId, users: conversationUsers, ...emojiPillProps} = props;
+  const {selfUserId, users: conversationUsers, loadUsersFromDb, ...emojiPillProps} = props;
 
   return (
     <div css={messageReactionWrapper} data-uie-name="message-reactions">
@@ -50,16 +51,19 @@ const MessageReactionsList = ({reactions, ...props}: MessageReactionsListProps) 
         const emojiListCount = users.length;
         const hasUserReacted = users.some(user => matchQualifiedIds(selfUserId, user));
 
-        // Departed users still contribute to the reaction count, but their names are omitted from the tooltip
-        // because only current conversation members are available here.
+        // Use current conversation members immediately and resolve missing historical users when the tooltip opens.
         const reactingUsers = users
           .map(qualifiedId => conversationUsers.find(user => matchQualifiedIds(qualifiedId, user.qualifiedId)))
           .filter((user): user is User => typeof user !== 'undefined');
+        const missingUserIds = users.filter(
+          qualifiedId => !reactingUsers.some(user => matchQualifiedIds(qualifiedId, user.qualifiedId)),
+        );
 
         return (
           <EmojiPill
             reactingUsers={reactingUsers}
             emojiCount={users.length}
+            loadAdditionalUsers={missingUserIds.length ? () => loadUsersFromDb(missingUserIds) : undefined}
             hasUserReacted={hasUserReacted}
             emojiUnicode={emojiUnicode}
             emoji={emoji}

--- a/apps/webapp/src/script/repositories/user/userRepository.test.ts
+++ b/apps/webapp/src/script/repositories/user/userRepository.test.ts
@@ -235,6 +235,22 @@ describe('UserRepository', () => {
       });
     });
 
+    describe('getUsersByIdFromDb', () => {
+      it('maps users from IndexedDB without making a backend request', async () => {
+        const [userRepository, {userService, userState}] = await buildUserRepository(translateForTest);
+        const selfUser = new User('self', 'test.wire.link', translateForTest);
+        userState.self(selfUser);
+        const cachedUser = generateAPIUser(undefined, {name: 'Cached User'});
+        const loadUserFromDb = jest.spyOn(userService, 'loadUserFromDb').mockResolvedValue(cachedUser);
+
+        const users = await userRepository.getUsersByIdFromDb([cachedUser.qualified_id!]);
+
+        expect(loadUserFromDb).toHaveBeenCalledWith(cachedUser.qualified_id);
+        expect(users).toHaveLength(1);
+        expect(users[0].name()).toBe('Cached User');
+      });
+    });
+
     describe('saveUser', () => {
       it('saves a user', async () => {
         const [userRepository, {userState}] = await buildUserRepository(translateForTest);

--- a/apps/webapp/src/script/repositories/user/userRepository.ts
+++ b/apps/webapp/src/script/repositories/user/userRepository.ts
@@ -826,6 +826,20 @@ export class UserRepository extends TypedEventEmitter<Events> {
     return knownUserEntities.concat(userEntities);
   }
 
+  /**
+   * Get users from the local database without making a backend request.
+   *
+   * This is useful for historical message data, such as reactions from users who are no longer conversation members.
+   */
+  async getUsersByIdFromDb(userIds: QualifiedId[] = []): Promise<User[]> {
+    const localDomain = this.userState.self()?.qualifiedId.domain ?? '';
+    const userRecords = await Promise.all(userIds.map(userId => this.userService.loadUserFromDb(userId)));
+
+    return userRecords
+      .filter((userRecord): userRecord is UserRecord => typeof userRecord !== 'undefined')
+      .map(userRecord => this.userMapper.mapUserFromJson(userRecord, localDomain));
+  }
+
   getUserListFromBackend(userIds: QualifiedId[]) {
     return this.userService.getUsers(userIds);
   }


### PR DESCRIPTION
## Summary

Load names for reaction users who are no longer current conversation members when the reaction tooltip opens.

## Root cause

The message list only had the cached conversation member list available for tooltip names. Users who left the conversation were missing from that list, so their reaction slots could produce incomplete or undefined tooltip names even though their reaction IDs were still stored.

## Fix

- Keep current conversation members as the immediate tooltip name source.
- Fetch missing reactor users from IndexedDB on hover or focus.
- Fall back to the translated deleted-user label when no local record is available.
- Keep the inline reaction count based on the complete stored reaction ID list.

## Validation

Added UI and user repository regression coverage for the IndexedDB lookup and tooltip loading behavior.

Follow-up to #22251.