### PR TITLE
Make GitHub Release repository explicit [WPB-26469]

### DIFF
--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -1083,6 +1083,7 @@ jobs:
             github_release_url="$(
               gh release create \
                 "${PRODUCTION_TAG_NAME}" \
+                --repo "${GITHUB_REPOSITORY}" \
                 --verify-tag \
                 --draft \
                 --title "${PRODUCTION_TAG_NAME}" \


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
