### PR TITLE
feat: Improve fullscreen file preview header metadata(WPB-20724)

### DIFF
--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsFilePreviewModal/CellsFilePreviewModal.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsFilePreviewModal/CellsFilePreviewModal.tsx
@@ -18,14 +18,19 @@
  */
 
 import {FileFullscreenModal} from 'Components/FileFullscreenModal/FileFullscreenModal';
+import type {Conversation} from 'Repositories/entity/Conversation';
 import {getFileTypeFromExtension} from 'Util/getFileTypeFromExtension/getFileTypeFromExtension';
 
 import {sortTagsAlphabetically} from '../../common/sortTagsAlphabetically/sortTagsAlphabetically';
 import {useCellsFilePreviewModal} from '../common/CellsFilePreviewModalContext/CellsFilePreviewModalContext';
 
+interface CellsFilePreviewModalProps {
+  sourceConversation?: Conversation;
+}
+
 // This component is duplicated across global view and conversation view
 // TODO: Abstract when it starts to grow / feels right
-export const CellsFilePreviewModal = () => {
+export const CellsFilePreviewModal = ({sourceConversation}: CellsFilePreviewModalProps) => {
   const {selectedFile, handleCloseFile, isEditMode} = useCellsFilePreviewModal();
   const isModalOpen = selectedFile !== null;
 
@@ -33,7 +38,8 @@ export const CellsFilePreviewModal = () => {
     return null;
   }
 
-  const {url, extension, name, owner, uploadedAtTimestamp, previewPdfUrl, previewImageUrl, tags} = selectedFile;
+  const {url, extension, name, owner, uploadedAtTimestamp, previewPdfUrl, previewImageUrl, tags, conversationName} =
+    selectedFile;
 
   const getFileUrl = () => {
     const type = getFileTypeFromExtension(extension);
@@ -62,6 +68,8 @@ export const CellsFilePreviewModal = () => {
       status={filePreviewUrl === undefined ? 'unavailable' : 'success'}
       senderName={owner}
       timestamp={uploadedAtTimestamp}
+      fallbackConversationName={conversationName}
+      sourceConversation={selectedFile.conversation ?? sourceConversation}
       badges={sortTagsAlphabetically(tags)}
       isEditMode={isEditMode}
     />

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTable.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsTable/CellsTable.tsx
@@ -21,6 +21,7 @@ import {flexRender, getCoreRowModel, type Header, useReactTable} from '@tanstack
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import type {Conversation} from 'Repositories/entity/Conversation';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {CellNode} from 'src/script/types/cellNode';
 
@@ -43,6 +44,7 @@ import {CellsSortField, SORTABLE_COLUMN_FIELD, toAriaSort} from '../common/useCe
 interface CellsTableProps {
   nodes: Array<CellNode>;
   cellsRepository: CellsRepository;
+  conversation: Conversation;
   conversationQualifiedId: QualifiedId;
   conversationName: string;
   onRefresh: () => void;
@@ -78,6 +80,7 @@ const CellsTableHeaderCell = ({header, getDirectionFor, isSortingEnabled}: Cells
 export const CellsTable = ({
   nodes,
   cellsRepository,
+  conversation,
   conversationQualifiedId,
   conversationName,
   onRefresh,
@@ -156,7 +159,7 @@ export const CellsTable = ({
             </tbody>
           )}
         </table>
-        <CellsFilePreviewModal />
+        <CellsFilePreviewModal sourceConversation={conversation} />
       </div>
     </CellsFilePreviewModalProvider>
   );

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
@@ -252,6 +252,7 @@ export const ConversationCells = memo(
             <CellsTable
               nodes={isLoading ? [] : nodes}
               cellsRepository={cellsRepository}
+              conversation={activeConversation}
               conversationQualifiedId={conversationQualifiedId}
               conversationName={name}
               onRefresh={handleRefresh}

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModal.tsx
@@ -28,12 +28,14 @@ import {
 import {isInRecycleBin} from 'Components/Conversation/ConversationCells/common/recycleBin/recycleBin';
 import {PDFViewer} from 'Components/FileFullscreenModal/PdfViewer/PdfViewer';
 import {FullscreenModal} from 'Components/fullscreenModal/fullscreenModal';
+import type {Conversation} from 'Repositories/entity/Conversation';
 import {isFileEditable} from 'Util/fileTypeUtil';
 import {getFileTypeFromExtension} from 'Util/getFileTypeFromExtension/getFileTypeFromExtension';
 import {getBestPreviewSource} from 'Util/imageUtil';
 import {getFileExtensionFromUrl} from 'Util/util';
 
 import {FileEditor} from './FileEditor/FileEditor';
+import {useFileFullscreenModalSourceConversation} from './FileFullscreenModalSourceConversationContext';
 import {FileHeader} from './FileHeader/FileHeader';
 import {FileLoader} from './FileLoader/FileLoader';
 import {ImageFileView} from './ImageFileView/ImageFileView';
@@ -52,6 +54,8 @@ interface FileFullscreenModalProps {
   status?: Status;
   senderName: string;
   timestamp: number;
+  fallbackConversationName?: string;
+  sourceConversation?: Conversation;
   badges?: string[];
   isEditMode?: boolean;
   checkIsInRecycleBin?: () => boolean;
@@ -68,10 +72,14 @@ export const FileFullscreenModal = ({
   fileExtension,
   senderName,
   timestamp,
+  fallbackConversationName,
+  sourceConversation,
   badges,
   isEditMode = false,
   checkIsInRecycleBin = isInRecycleBin,
 }: FileFullscreenModalProps) => {
+  const sourceConversationFromContext = useFileFullscreenModalSourceConversation();
+  const sourceConversationForMetadata = sourceConversation ?? sourceConversationFromContext;
   const notInRecycleBin = !checkIsInRecycleBin();
   const canPerformCellsAction = useCellsActionPermissions();
   const canEdit = canPerformCellsAction(CELLS_ACTION.EDIT);
@@ -101,6 +109,8 @@ export const FileFullscreenModal = ({
         fileUrl={fileUrl}
         senderName={senderName}
         timestamp={timestamp}
+        fallbackConversationName={fallbackConversationName}
+        sourceConversation={sourceConversationForMetadata}
         badges={badges}
         isInEditMode={isInEditMode}
         onEditModeChange={setIsInEditMode}

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModalSourceConversationContext.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileFullscreenModalSourceConversationContext.tsx
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createContext, ReactNode, useContext} from 'react';
+
+import type {Conversation} from 'Repositories/entity/Conversation';
+
+const FileFullscreenModalSourceConversationContext = createContext<Conversation | undefined>(undefined);
+
+interface FileFullscreenModalSourceConversationProviderProps {
+  children: ReactNode;
+  sourceConversation?: Conversation;
+}
+
+export const FileFullscreenModalSourceConversationProvider = ({
+  children,
+  sourceConversation,
+}: FileFullscreenModalSourceConversationProviderProps) => (
+  <FileFullscreenModalSourceConversationContext.Provider value={sourceConversation}>
+    {children}
+  </FileFullscreenModalSourceConversationContext.Provider>
+);
+
+export const useFileFullscreenModalSourceConversation = () => useContext(FileFullscreenModalSourceConversationContext);

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.styles.ts
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.styles.ts
@@ -19,7 +19,7 @@
 
 import {CSSObject} from '@emotion/react';
 
-import {COLOR_V2} from '@wireapp/react-ui-kit';
+import {COLOR_V2, ellipsis} from '@wireapp/react-ui-kit';
 
 import {fileHeaderHeight} from '../common/fileHeaderHeight';
 
@@ -27,8 +27,11 @@ export const headerStyles: CSSObject = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
+  gap: '16px',
   height: fileHeaderHeight,
   width: '100%',
+  boxSizing: 'border-box',
+  padding: '0 16px',
   lineHeight: 'var(--line-height-sm)',
   borderBottom: '1px solid var(--border-color)',
   backgroundColor: 'var(--app-bg)',
@@ -46,39 +49,80 @@ export const closeButtonStyles: CSSObject = {
   border: 'none',
   background: 'none',
   padding: 0,
-  marginRight: '40px',
+  marginRight: '24px',
+  flexShrink: 0,
 };
 
 export const leftColumnStyles: CSSObject = {
   display: 'flex',
   alignItems: 'center',
   flex: '1 1 auto',
+  minWidth: 0,
 };
 
 export const metadataStyles: CSSObject = {
   display: 'flex',
   alignItems: 'center',
-  gap: '16px',
+  gap: '8px',
   fontSize: 'var(--font-size-small)',
   flex: '1 1 auto',
+  minWidth: 0,
+
+  svg: {
+    flexShrink: 0,
+  },
+};
+
+export const metadataTextStyles: CSSObject = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '16px',
+  minWidth: 0,
+  whiteSpace: 'nowrap',
+};
+
+export const sourceConversationMetadataStyles: CSSObject = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  flex: '0 1 auto',
+  minWidth: 0,
+  maxWidth: '220px',
+};
+
+export const sourceConversationIconStyles: CSSObject = {
+  flexShrink: 0,
+  width: '16px',
+  height: '16px',
 };
 
 export const nameStyles: CSSObject = {
+  ...ellipsis(),
   fontSize: 'var(--font-size-medium)',
   fontWeight: 'var(--font-weight-semibold)',
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  flex: '1 1 auto',
+  margin: 0,
+  flex: '0 1 auto',
+  minWidth: 0,
+  maxWidth: '360px',
 };
 
 export const textStyles: CSSObject = {
+  ...ellipsis(),
   fontSize: 'var(--font-size-small)',
   color: 'var(--gray-70)',
+  flex: '0 1 auto',
+  minWidth: 0,
+  maxWidth: '180px',
 
   'body.theme-dark &': {
     color: 'var(--gray-40)',
   },
+};
+
+export const timeStyles: CSSObject = {
+  ...textStyles,
+  flexShrink: 0,
+  maxWidth: 'none',
 };
 
 export const actionButtonsStyles: CSSObject = {

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.test.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.test.tsx
@@ -31,7 +31,7 @@ import {
   createRootProviderWrapperForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 
-import {FileHeader} from './FileHeader';
+import {FileHeader, getConversationIconType} from './FileHeader';
 
 const translate = (key: string) =>
   ({
@@ -110,6 +110,31 @@ describe('FileHeader', () => {
 
     expect(screen.getByRole('button', {name: 'Download'})).toBeInTheDocument();
   });
+
+  it('shows file metadata beside the file name', () => {
+    const {container: renderContainer} = renderHeader({
+      props: {
+        fallbackConversationName: 'Marketing Channel',
+        senderName: 'Kim Dawson',
+      },
+    });
+
+    expect(screen.getByRole('heading', {name: 'document'})).toBeInTheDocument();
+    expect(screen.getByText('Marketing Channel')).toBeInTheDocument();
+    expect(screen.getByText('Kim Dawson')).toBeInTheDocument();
+    expect(renderContainer.querySelector('[data-uie-name="group-avatar-box-wrapper"]')).toBeInTheDocument();
+  });
+
+  it.each([
+    {isChannel: false, isChannelsEnabled: true, expectedIconType: 'group'},
+    {isChannel: true, isChannelsEnabled: false, expectedIconType: 'group'},
+    {isChannel: true, isChannelsEnabled: true, expectedIconType: 'channel'},
+  ])(
+    'returns $expectedIconType icon when isChannel is $isChannel and isChannelsEnabled is $isChannelsEnabled',
+    ({isChannel, isChannelsEnabled, expectedIconType}) => {
+      expect(getConversationIconType({isChannel, isChannelsEnabled})).toBe(expectedIconType);
+    },
+  );
 
   it('shows viewer access state and removes other action buttons', () => {
     const {container: renderContainer} = renderHeader({

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
@@ -33,6 +33,7 @@ import {
   ViewerAccessIcon,
 } from '@wireapp/react-ui-kit';
 
+import {ChannelAvatar, GroupAvatar} from 'Components/avatar';
 import {FileTypeIcon} from 'Components/Conversation/common/FileTypeIcon/FileTypeIcon';
 import {
   CELLS_ACTION,
@@ -45,7 +46,10 @@ import {MessageTime} from 'Components/MessagesList/Message/MessageTime';
 import {useFileHistoryModal} from 'Components/Modals/FileHistoryModal/hooks/useFileHistoryModal';
 import {createRelativeTimestampFormatter, useRelativeTimestamp} from 'Hooks/useRelativeTimestamp';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import type {Conversation} from 'Repositories/entity/Conversation';
 import {useApplicationContext} from 'src/script/page/rootProvider';
+import {useKoSubscribableChildren} from 'Util/componentUtil';
+import {useChannelsFeatureFlag} from 'Util/useChannelsFeatureFlag';
 import {forcedDownloadFile, getFileNameWithExtension} from 'Util/util';
 
 import {
@@ -53,8 +57,12 @@ import {
   leftColumnStyles,
   closeButtonStyles,
   metadataStyles,
+  metadataTextStyles,
   nameStyles,
+  sourceConversationIconStyles,
+  sourceConversationMetadataStyles,
   textStyles,
+  timeStyles,
   downloadButtonStyles,
   actionButtonsStyles,
   editModeButtonStyles,
@@ -68,6 +76,8 @@ interface FileHeaderProps {
   fileExtension: string;
   senderName: string;
   timestamp: number;
+  fallbackConversationName?: string;
+  sourceConversation?: Conversation;
   badges?: string[];
   fileUrl?: string;
   isEditable?: boolean;
@@ -77,6 +87,16 @@ interface FileHeaderProps {
   onFileContentRefresh: () => void;
 }
 
+type ConversationIconType = 'channel' | 'group';
+
+export const getConversationIconType = ({
+  isChannel,
+  isChannelsEnabled,
+}: {
+  isChannel: boolean;
+  isChannelsEnabled: boolean;
+}): ConversationIconType => (isChannel && isChannelsEnabled ? 'channel' : 'group');
+
 export const FileHeader = ({
   id,
   onClose,
@@ -85,6 +105,8 @@ export const FileHeader = ({
   fileExtension,
   senderName,
   timestamp,
+  fallbackConversationName,
+  sourceConversation,
   badges,
   isEditable,
   isInEditMode,
@@ -128,11 +150,17 @@ export const FileHeader = ({
         </button>
         <div css={metadataStyles}>
           <FileTypeIcon extension={fileExtension} />
-          <h3 css={nameStyles}>{fileName}</h3>
-          <p css={textStyles}>{senderName}</p>
-          <MessageTime timestamp={timestamp} data-timestamp-type="normal" css={textStyles}>
-            {timeAgo}
-          </MessageTime>
+          <div css={metadataTextStyles}>
+            <h3 css={nameStyles}>{fileName}</h3>
+            {(sourceConversation !== undefined ||
+              (fallbackConversationName !== undefined && fallbackConversationName.length > 0)) && (
+              <ConversationLabel conversation={sourceConversation} fallbackName={fallbackConversationName ?? ''} />
+            )}
+            <span css={textStyles}>{senderName}</span>
+            <MessageTime timestamp={timestamp} data-timestamp-type="normal" css={timeStyles}>
+              {timeAgo}
+            </MessageTime>
+          </div>
           {badges && badges.length > 0 && <BadgesWithTooltip items={badges} />}
         </div>
       </div>
@@ -203,5 +231,42 @@ export const FileHeader = ({
           )}
       </div>
     </header>
+  );
+};
+
+const ConversationLabel = ({conversation, fallbackName}: {conversation?: Conversation; fallbackName: string}) => {
+  if (conversation === undefined) {
+    return <FallbackConversationLabel fallbackName={fallbackName} />;
+  }
+
+  return <ConversationEntityLabel conversation={conversation} fallbackName={fallbackName} />;
+};
+
+const FallbackConversationLabel = ({fallbackName}: {fallbackName: string}) => (
+  <span css={sourceConversationMetadataStyles}>
+    <span css={sourceConversationIconStyles} aria-hidden="true">
+      <GroupAvatar size="small" />
+    </span>
+    <span css={textStyles}>{fallbackName}</span>
+  </span>
+);
+
+const ConversationEntityLabel = ({conversation, fallbackName}: {conversation: Conversation; fallbackName: string}) => {
+  const {isChannelsEnabled} = useChannelsFeatureFlag();
+  const {isChannel, display_name: displayName} = useKoSubscribableChildren(conversation, ['isChannel', 'display_name']);
+  const name = displayName || fallbackName;
+  const iconType = getConversationIconType({isChannel, isChannelsEnabled});
+
+  return (
+    <span css={sourceConversationMetadataStyles}>
+      <span css={sourceConversationIconStyles} aria-hidden="true">
+        {iconType === 'channel' ? (
+          <ChannelAvatar conversationID={conversation.id} isLocked={false} size="small" />
+        ) : (
+          <GroupAvatar conversationID={conversation.id} size="small" />
+        )}
+      </span>
+      <span css={textStyles}>{name}</span>
+    </span>
   );
 };

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -25,6 +25,7 @@ import ko from 'knockout';
 
 import {OutlineCheck} from '@wireapp/react-ui-kit';
 
+import {FileFullscreenModalSourceConversationProvider} from 'Components/FileFullscreenModal/FileFullscreenModalSourceConversationContext';
 import {ReadIndicator} from 'Components/MessagesList/Message/ReadIndicator';
 import {useClickOutside} from 'Hooks/useClickOutside';
 import {Conversation} from 'Repositories/entity/Conversation';
@@ -223,62 +224,64 @@ export const ContentMessageComponent = ({
           </div>
         )}
 
-        <div
-          className={cx('message-body', {
-            'message-asset': isAssetMessage,
-            'message-quoted': !!quote,
-            'ephemeral-asset-expired': isObfuscated && isAssetMessage,
-            'icon-file': isObfuscated && isFileMessage,
-            'icon-movie': isObfuscated && isVideoMessage,
-          })}
-        >
-          {quote && (
-            <Quote
-              conversation={conversation}
-              quote={quote}
-              selfId={selfId}
-              findMessage={findMessage}
-              showDetail={onClickImage}
-              focusMessage={onClickTimestamp}
-              handleClickOnMessage={onClickMessage}
-              showUserDetails={onClickAvatar}
-              isMessageFocused={msgFocusState}
-            />
-          )}
+        <FileFullscreenModalSourceConversationProvider sourceConversation={conversation}>
+          <div
+            className={cx('message-body', {
+              'message-asset': isAssetMessage,
+              'message-quoted': !!quote,
+              'ephemeral-asset-expired': isObfuscated && isAssetMessage,
+              'icon-file': isObfuscated && isFileMessage,
+              'icon-movie': isObfuscated && isVideoMessage,
+            })}
+          >
+            {quote && (
+              <Quote
+                conversation={conversation}
+                quote={quote}
+                selfId={selfId}
+                findMessage={findMessage}
+                showDetail={onClickImage}
+                focusMessage={onClickTimestamp}
+                handleClickOnMessage={onClickMessage}
+                showUserDetails={onClickAvatar}
+                isMessageFocused={msgFocusState}
+              />
+            )}
 
-          {assets.map(asset => (
-            <ContentAsset
-              key={asset.type}
-              asset={asset}
-              message={message}
-              selfId={selfId}
-              onClickButton={onClickButton}
-              onClickImage={onClickImage}
-              onClickMessage={onClickMessage}
-              isMessageFocused={msgFocusState}
-              is1to1Conversation={conversation.is1to1()}
-              isFileShareRestricted={isFileShareRestricted}
-              onClickDetails={() => onClickDetails(message)}
-            />
-          ))}
+            {assets.map(asset => (
+              <ContentAsset
+                key={asset.type}
+                asset={asset}
+                message={message}
+                selfId={selfId}
+                onClickButton={onClickButton}
+                onClickImage={onClickImage}
+                onClickMessage={onClickMessage}
+                isMessageFocused={msgFocusState}
+                is1to1Conversation={conversation.is1to1()}
+                isFileShareRestricted={isFileShareRestricted}
+                onClickDetails={() => onClickDetails(message)}
+              />
+            ))}
 
-          {isAssetMessage && (
-            <ReadIndicator message={message} is1to1Conversation={conversation.is1to1()} onClick={onClickDetails} />
-          )}
+            {isAssetMessage && (
+              <ReadIndicator message={message} is1to1Conversation={conversation.is1to1()} onClick={onClickDetails} />
+            )}
 
-          {!isConversationReadonly && isActionMenuVisible && (
-            <MessageActionsMenu
-              isMsgWithHeader={!hideHeader}
-              message={message}
-              handleActionMenuVisibility={setActionMenuVisibility}
-              contextMenu={contextMenu}
-              isMessageFocused={msgFocusState}
-              handleReactionClick={onClickReaction}
-              reactionsTotalCount={reactions.length}
-              isRemovedFromConversation={conversation.isSelfUserRemoved()}
-            />
-          )}
-        </div>
+            {!isConversationReadonly && isActionMenuVisible && (
+              <MessageActionsMenu
+                isMsgWithHeader={!hideHeader}
+                message={message}
+                handleActionMenuVisibility={setActionMenuVisibility}
+                contextMenu={contextMenu}
+                isMessageFocused={msgFocusState}
+                handleReactionClick={onClickReaction}
+                reactionsTotalCount={reactions.length}
+                isRemovedFromConversation={conversation.isSelfUserRemoved()}
+              />
+            )}
+          </div>
+        </FileFullscreenModalSourceConversationProvider>
 
         {message.expectsReadConfirmation && (
           <div css={deliveredMessageIndicator}>

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsFilePreviewModal/cellsFilePreviewModal.test.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsFilePreviewModal/cellsFilePreviewModal.test.tsx
@@ -86,13 +86,15 @@ const file: CellFile = {
 const FakeFilePreviewProvider = ({
   children,
   selfUserDriveRole,
+  selectedFile = file,
 }: {
   children: ReactNode;
   selfUserDriveRole: CellFile['selfUserDriveRole'];
+  selectedFile?: CellFile;
 }) => {
   const value: CellsFilePreviewModalContextValue = {
     id: 'preview-context-id',
-    selectedFile: {...file, selfUserDriveRole},
+    selectedFile: {...selectedFile, selfUserDriveRole},
     isEditMode: true,
     handleOpenFile: jest.fn(),
     handleCloseFile: jest.fn(),
@@ -123,15 +125,17 @@ describe('CellsFilePreviewModal', () => {
   const renderModal = ({
     isViewerPermissionFeatureEnabled = true,
     selfUserDriveRole,
+    selectedFile,
   }: {
     isViewerPermissionFeatureEnabled?: boolean;
     selfUserDriveRole: CellFile['selfUserDriveRole'];
+    selectedFile?: CellFile;
   }) => {
     const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
 
     render(
       withThemeAndRootContext(
-        <FakeFilePreviewProvider selfUserDriveRole={selfUserDriveRole}>
+        <FakeFilePreviewProvider selfUserDriveRole={selfUserDriveRole} selectedFile={selectedFile}>
           <CellsFilePreviewModal />
         </FakeFilePreviewProvider>,
         createRootProviderWrapper({fireAndForgetInvoker, isViewerPermissionFeatureEnabled}),

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsFilePreviewModal/cellsFilePreviewModal.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsFilePreviewModal/cellsFilePreviewModal.tsx
@@ -35,7 +35,8 @@ export const CellsFilePreviewModal = () => {
     return null;
   }
 
-  const {url, extension, name, owner, uploadedAtTimestamp, previewPdfUrl, previewImageUrl, tags} = selectedFile;
+  const {url, extension, name, owner, uploadedAtTimestamp, previewPdfUrl, previewImageUrl, tags, conversationName} =
+    selectedFile;
 
   const getFileUrl = () => {
     const type = getFileTypeFromExtension(extension);
@@ -70,6 +71,8 @@ export const CellsFilePreviewModal = () => {
         status={getFileUrl() === undefined ? 'unavailable' : 'success'}
         senderName={owner}
         timestamp={uploadedAtTimestamp}
+        fallbackConversationName={conversationName}
+        sourceConversation={selectedFile.conversation}
         badges={sortTagsAlphabetically(tags)}
         isEditMode={isEditMode}
       />


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20724" title="WPB-20724" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20724</a>  [Web] Improve header of the full screen file view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Summary

The header needs improvement in terms of spacing, alignment etc. 

Found issues:

- updated spacing between close button and file icon+name
- placement of “owner” and time - should be aligned to the left, besides the file name
- profile name should be displayed, not user name(no change needed)
- text should be always in a single line
- add group/ channel name with the icon

<img width="1512" height="46" alt="Screenshot 2026-08-21 at 10 17 38" src="https://github.com/user-attachments/assets/3b29091e-0a8e-410f-b4e7-54bd66bd330c" />
