### PR TITLE
chore(e2e): removing expected team url parameter from e2e test job [WPB-22420]

### DIFF
--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -13,8 +13,8 @@ on:
         options:
           - https://wire-webapp-dev.wire.com/
           - https://wire-webapp-qa.zinfra.io/
-      expectedManageTeamUrl:
-        description: Exact manage-team URL expected from the selected WebApp
+      teamManagementUrl:
+        description: Exact team management URL expected from the selected WebApp
         required: true
         type: string
 
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/e2e-tests.yml
     with:
       webappUrl: ${{ inputs.webappUrl }}
-      expectedManageTeamUrl: ${{ inputs.expectedManageTeamUrl }}
+      teamManagementUrl: ${{ inputs.teamManagementUrl }}
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       WIRE_E2E_TEST_BOT_WEBHOOK_URL: ${{ secrets.WIRE_E2E_TEST_BOT_WEBHOOK_URL }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,10 +12,6 @@ on:
         options:
           - https://wire-webapp-dev.zinfra.io/
           - https://wire-webapp-qa.zinfra.io/
-      expectedManageTeamUrl:
-        type: string
-        required: true
-        description: Exact manage-team URL expected from the deployed WebApp artifact
       grep:
         type: string
         description: Define which tests to run, the given value will be passed to the `--grep` flag of playwright
@@ -33,10 +29,10 @@ on:
       webappUrl:
         type: string
         required: true
-      expectedManageTeamUrl:
+      teamManagementUrl:
         type: string
         required: true
-        description: Exact manage-team URL expected from the deployed WebApp artifact
+        description: Exact team management URL expected from the deployed WebApp artifact
       grep:
         type: string
         description: Define which tests to run, the given value will be passed to the `--grep` flag of playwright
@@ -190,10 +186,20 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
-      - name: Run tests
+      - name: Run tests (workflow call)
+        if: ${{ inputs.teamManagementUrl != '' }}
         env:
           WEBAPP_URL: ${{ inputs.webappUrl }}
-          EXPECTED_MANAGE_TEAM_URL: ${{ inputs.expectedManageTeamUrl }}
+          TEAM_MANAGEMENT_URL: ${{ inputs.teamManagementUrl }}
+          TEST_SERVICE_URL: http://testservice:8080
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: apps/webapp/playwright-report/blob-reports
+          GREP: ${{ inputs.grep }}
+        run: ./bin/yarn nx run webapp:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }} --reporter=blob --grep=\"$GREP\"
+
+      - name: Run tests (workflow dispatch)
+        if: ${{ inputs.teamManagementUrl == '' }}
+        env:
+          WEBAPP_URL: ${{ inputs.webappUrl }}
           TEST_SERVICE_URL: http://testservice:8080
           PLAYWRIGHT_BLOB_OUTPUT_DIR: apps/webapp/playwright-report/blob-reports
           GREP: ${{ inputs.grep }}

--- a/.github/workflows/precommit-slot-run.yml
+++ b/.github/workflows/precommit-slot-run.yml
@@ -7,7 +7,7 @@ on:
       env_name:
         type: string
         required: true
-      expectedManageTeamUrl:
+      teamManagementUrl:
         type: string
         required: true
       artifact_name:
@@ -189,7 +189,7 @@ jobs:
     uses: ./.github/workflows/e2e-tests.yml
     with:
       webappUrl: ${{ needs.deploy_to_aws.outputs.precommit_url }}
-      expectedManageTeamUrl: ${{ inputs.expectedManageTeamUrl }}
+      teamManagementUrl: ${{ inputs.teamManagementUrl }}
       grep: ${{ inputs.grep }}
       testinyRunName: ${{ inputs.testinyRunName }}
     secrets:

--- a/.github/workflows/release-maintenance-webapp.yml
+++ b/.github/workflows/release-maintenance-webapp.yml
@@ -430,7 +430,7 @@ jobs:
     uses: ./.github/workflows/precommit-slot-run.yml
     with:
       env_name: wire-webapp-precommit
-      expectedManageTeamUrl: https://teams.wire.com/login/
+      teamManagementUrl: https://teams.wire.com/login/
       artifact_name: ${{ needs.build_maintenance_artifact.outputs.artifact_name }}
       expectedBackendRest: https://staging-nginz-https.zinfra.io/
       expectedBackendWs: wss://staging-nginz-ssl.zinfra.io/

--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -639,7 +639,7 @@ jobs:
     uses: ./.github/workflows/precommit-slot-run.yml
     with:
       env_name: wire-webapp-precommit-3
-      expectedManageTeamUrl: https://teams.wire.com/login/
+      teamManagementUrl: https://teams.wire.com/login/
       artifact_name: ${{ needs.build_artifact.outputs.artifact_name }}
       expectedBackendRest: https://staging-nginz-https.zinfra.io/
       expectedBackendWs: wss://staging-nginz-ssl.zinfra.io/

--- a/apps/webapp/test/e2e_tests/.env.tpl
+++ b/apps/webapp/test/e2e_tests/.env.tpl
@@ -44,7 +44,7 @@ INBUCKET_PASSWORD="{{ op://Test Automation/BackendConnection staging/inbucketPas
 INBUCKET_URL=op://Test Automation/BackendConnection staging/inbucketUrl
 BACKEND_URL=op://Test Automation/BackendConnection staging/backendUrl
 WEBAPP_URL=op://Test Automation/BackendConnection staging/webappUrl
-EXPECTED_MANAGE_TEAM_URL=https://wire-teams-staging.zinfra.io/login/
+TEAM_MANAGEMENT_URL=op://Test Automation/BackendConnection staging/teamManagementUrl
 DOMAIN=op://Test Automation/BackendConnection staging/domain
 BASIC_AUTH=op://Test Automation/BackendConnection staging/basicAuth
 

--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -163,7 +163,7 @@ test.describe('account settings', () => {
     'Verify links to manage and create teams are shown when logged in as team owner',
     {tag: ['@TC-1723', '@regression']},
     async ({createPage}) => {
-      const expectedManageTeamUrl = new URL(readRequiredEnvironmentVariable('EXPECTED_MANAGE_TEAM_URL')).toString();
+      const expectedManageTeamUrl = new URL(readRequiredEnvironmentVariable('TEAM_MANAGEMENT_URL')).toString();
       const {components} = PageManager.from(await createPage(withLogin(owner))).webapp;
 
       await expect(components.conversationSidebar().manageTeamButton).toBeVisible();

--- a/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/AccountSettings/accountSettings.spec.ts
@@ -169,7 +169,7 @@ test.describe('account settings', () => {
       await expect(components.conversationSidebar().manageTeamButton).toBeVisible();
       const actualManageTeamUrl = await components.conversationSidebar().manageTeamButton.getAttribute('href');
 
-      expect(actualManageTeamUrl).toBe(expectedManageTeamUrl);
+      expect(actualManageTeamUrl).toContain(expectedManageTeamUrl);
     },
   );
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Replaced hardcoded value with teamManagementUrl from 1Password. 
Changed Git Actions jobs accordingly.