### PR TITLE
fix: resolve historical reaction names in tooltips [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/Conversation/Conversation.tsx
+++ b/apps/webapp/src/script/components/Conversation/Conversation.tsx
@@ -715,6 +715,7 @@ export const Conversation = ({
                 conversationRepository={conversationRepository}
                 assetRepository={repositories.asset}
                 messageRepository={repositories.message}
+                loadUsersByIdsFromDb={repositories.user.getUsersByIdsFromDb}
                 messageActions={mainViewModel.actions}
                 invitePeople={clickOnInvitePeople}
                 cancelConnectionRequest={clickOnCancelRequest}

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.test.tsx
@@ -75,6 +75,7 @@ describe('message', () => {
       selfId: {domain: '', id: createUuid()},
       isMsgElementsFocusable: true,
       isFileShareRestricted: false,
+      loadUsersByIdsFromDb: jest.fn().mockResolvedValue([]),
     };
   });
 

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -31,6 +31,7 @@ import {Conversation} from 'Repositories/entity/Conversation';
 import {CompositeMessage} from 'Repositories/entity/message/compositeMessage';
 import {ContentMessage} from 'Repositories/entity/message/contentMessage';
 import type {FileAsset as FileAssetType} from 'Repositories/entity/message/fileAsset';
+import type {User} from 'Repositories/entity/User';
 import {createRelativeTimestampFormatter, useRelativeTimestamp} from 'src/script/hooks/useRelativeTimestamp';
 import {StatusType} from 'src/script/message/statusType';
 import {useApplicationContext} from 'src/script/page/rootProvider';
@@ -72,6 +73,7 @@ export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetS
   onClickReaction: (emoji: string) => void;
   is1to1?: boolean;
   isFileShareRestricted: boolean;
+  loadUsersByIdsFromDb: (userIds: QualifiedId[]) => Promise<User[]>;
 }
 
 export const ContentMessageComponent = ({
@@ -95,6 +97,7 @@ export const ContentMessageComponent = ({
   onClickDetails,
   is1to1,
   isFileShareRestricted,
+  loadUsersByIdsFromDb,
 }: ContentMessageProps) => {
   const messageRef = useRef<HTMLDivElement | null>(null);
   const {translate} = useApplicationContext();
@@ -322,6 +325,7 @@ export const ContentMessageComponent = ({
           onLastReactionKeyEvent={() => setActionMenuVisibility(false)}
           isRemovedFromConversation={conversation.isSelfUserRemoved()}
           users={conversation.allUserEntities()}
+          loadUsersByIdsFromDb={loadUsersByIdsFromDb}
         />
       )}
     </div>

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/ContentMessage.tsx
@@ -32,6 +32,7 @@ import {Conversation} from 'Repositories/entity/Conversation';
 import {CompositeMessage} from 'Repositories/entity/message/compositeMessage';
 import {ContentMessage} from 'Repositories/entity/message/contentMessage';
 import type {FileAsset as FileAssetType} from 'Repositories/entity/message/fileAsset';
+import type {User} from 'Repositories/entity/User';
 import {createRelativeTimestampFormatter, useRelativeTimestamp} from 'src/script/hooks/useRelativeTimestamp';
 import {StatusType} from 'src/script/message/statusType';
 import {useApplicationContext} from 'src/script/page/rootProvider';
@@ -73,6 +74,7 @@ export interface ContentMessageProps extends Omit<MessageActions, 'onClickResetS
   onClickReaction: (emoji: string) => void;
   is1to1?: boolean;
   isFileShareRestricted: boolean;
+  loadUsersByIdsFromDb: (userIds: QualifiedId[]) => Promise<User[]>;
 }
 
 export const ContentMessageComponent = ({
@@ -96,6 +98,7 @@ export const ContentMessageComponent = ({
   onClickDetails,
   is1to1,
   isFileShareRestricted,
+  loadUsersByIdsFromDb,
 }: ContentMessageProps) => {
   const messageRef = useRef<HTMLDivElement | null>(null);
   const {translate} = useApplicationContext();
@@ -325,6 +328,7 @@ export const ContentMessageComponent = ({
           onLastReactionKeyEvent={() => setActionMenuVisibility(false)}
           isRemovedFromConversation={conversation.isSelfUserRemoved()}
           users={conversation.allUserEntities()}
+          loadUsersByIdsFromDb={loadUsersByIdsFromDb}
         />
       )}
     </div>

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
@@ -26,7 +26,6 @@ import {Tooltip} from '@wireapp/react-ui-kit';
 
 import {useMessageFocusedTabIndex} from 'Components/MessagesList/Message/util';
 import type {User} from 'Repositories/entity/User';
-import {useApplicationContext} from 'src/script/page/rootProvider';
 import {getEmojiTitleFromEmojiUnicode} from 'Util/emojiUtil';
 import {isTabKey} from 'Util/keyboardUtil';
 import type {Translate} from 'Util/localizerUtil';
@@ -82,7 +81,6 @@ export const EmojiPill = ({
   reactorIds,
   loadUsersByIdsFromDb,
 }: EmojiPillProps) => {
-  const {fireAndForgetInvoker} = useApplicationContext();
   const [storedReactingUsers, setStoredReactingUsers] = useState<User[]>([]);
   const isLoadingStoredUsers = useRef(false);
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
@@ -101,18 +99,17 @@ export const EmojiPill = ({
     return user?.name() || translate('deletedUser');
   });
 
-  const loadMissingReactingUsers = () => {
+  async function loadMissingReactingUsers(): Promise<void> {
     if (missingReactorIds.length === 0 || isLoadingStoredUsers.current) {
       return;
     }
 
     isLoadingStoredUsers.current = true;
-    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+    try {
       const loadResult = await task.tryOrElse(
         () => 'failedToLoadReactionUsers' as const,
         () => loadUsersByIdsFromDb(missingReactorIds),
       );
-      isLoadingStoredUsers.current = false;
 
       if (loadResult.isErr) {
         return;
@@ -124,8 +121,10 @@ export const EmojiPill = ({
         );
         return [...currentUsers, ...newUsers];
       });
-    });
-  };
+    } finally {
+      isLoadingStoredUsers.current = false;
+    }
+  }
 
   const conversationReactionCaption = () => {
     if (emojiCount > MAX_USER_NAMES_TO_SHOW) {
@@ -212,8 +211,12 @@ export const EmojiPill = ({
           tabIndex={messageFocusedTabIndex}
           className="button-reset-default"
           data-uie-name="emoji-pill"
-          onMouseEnter={loadMissingReactingUsers}
-          onFocus={loadMissingReactingUsers}
+          onMouseEnter={() => {
+            void loadMissingReactingUsers();
+          }}
+          onFocus={() => {
+            void loadMissingReactingUsers();
+          }}
           onClick={() => {
             handleReactionClick(emoji);
           }}

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/EmojiPill.tsx
@@ -17,14 +17,21 @@
  *
  */
 
+import {useRef, useState} from 'react';
+
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
+import {task} from 'true-myth';
+
 import {Tooltip} from '@wireapp/react-ui-kit';
 
 import {useMessageFocusedTabIndex} from 'Components/MessagesList/Message/util';
-import {User} from 'Repositories/entity/User';
+import type {User} from 'Repositories/entity/User';
+import {useApplicationContext} from 'src/script/page/rootProvider';
 import {getEmojiTitleFromEmojiUnicode} from 'Util/emojiUtil';
 import {isTabKey} from 'Util/keyboardUtil';
 import type {Translate} from 'Util/localizerUtil';
 import {replaceReactComponents} from 'Util/localizerUtil/reactLocalizerUtil';
+import {matchQualifiedIds} from 'Util/qualifiedId';
 
 import {EmojiChar} from './EmojiChar';
 import {
@@ -52,6 +59,8 @@ interface EmojiPillProps {
   emojiCount: number;
   hasUserReacted: boolean;
   reactingUsers: User[];
+  reactorIds: QualifiedId[];
+  loadUsersByIdsFromDb: (userIds: QualifiedId[]) => Promise<User[]>;
 }
 
 const MAX_USER_NAMES_TO_SHOW = 2;
@@ -70,12 +79,53 @@ export const EmojiPill = ({
   emojiCount,
   hasUserReacted,
   reactingUsers,
+  reactorIds,
+  loadUsersByIdsFromDb,
 }: EmojiPillProps) => {
+  const {fireAndForgetInvoker} = useApplicationContext();
+  const [storedReactingUsers, setStoredReactingUsers] = useState<User[]>([]);
+  const isLoadingStoredUsers = useRef(false);
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
   const emojiName = getEmojiTitleFromEmojiUnicode(emojiUnicode);
   const isActive = hasUserReacted && !isRemovedFromConversation;
 
-  const reactingUserNames = reactingUsers.slice(0, MAX_USER_NAMES_TO_SHOW).map(user => user.name());
+  // Prefer the already-cached conversation members and resolve departed reactors from IndexedDB only on demand.
+  const resolvedReactingUsers = [...reactingUsers, ...storedReactingUsers];
+  const tooltipReactorIds = reactorIds.slice(0, MAX_USER_NAMES_TO_SHOW);
+  const missingReactorIds = tooltipReactorIds.filter(
+    reactorId => !resolvedReactingUsers.some(user => matchQualifiedIds(reactorId, user.qualifiedId)),
+  );
+
+  const reactingUserNames = tooltipReactorIds.map(reactorId => {
+    const user = resolvedReactingUsers.find(reactingUser => matchQualifiedIds(reactorId, reactingUser.qualifiedId));
+    return user?.name() || translate('deletedUser');
+  });
+
+  const loadMissingReactingUsers = () => {
+    if (missingReactorIds.length === 0 || isLoadingStoredUsers.current) {
+      return;
+    }
+
+    isLoadingStoredUsers.current = true;
+    fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+      const loadResult = await task.tryOrElse(
+        () => 'failedToLoadReactionUsers' as const,
+        () => loadUsersByIdsFromDb(missingReactorIds),
+      );
+      isLoadingStoredUsers.current = false;
+
+      if (loadResult.isErr) {
+        return;
+      }
+
+      setStoredReactingUsers(currentUsers => {
+        const newUsers = loadResult.value.filter(
+          loadedUser => !currentUsers.some(user => matchQualifiedIds(loadedUser.qualifiedId, user.qualifiedId)),
+        );
+        return [...currentUsers, ...newUsers];
+      });
+    });
+  };
 
   const conversationReactionCaption = () => {
     if (emojiCount > MAX_USER_NAMES_TO_SHOW) {
@@ -162,6 +212,8 @@ export const EmojiPill = ({
           tabIndex={messageFocusedTabIndex}
           className="button-reset-default"
           data-uie-name="emoji-pill"
+          onMouseEnter={loadMissingReactingUsers}
+          onFocus={loadMissingReactingUsers}
           onClick={() => {
             handleReactionClick(emoji);
           }}

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
@@ -21,12 +21,7 @@ import {act, fireEvent, render, waitFor, within} from '@testing-library/react';
 
 import {User} from 'Repositories/entity/User';
 import {ReactionMap} from 'Repositories/storage';
-import {withTheme, withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
-import {
-  createExecutingFireAndForgetInvokerForTest,
-  createRootContextValueForTest,
-  createRootProviderWrapperForTest,
-} from 'src/script/page/testSupport/rootContextTestSupport';
+import {withTheme} from 'src/script/auth/util/test/testUtil';
 import {generateQualifiedId} from 'test/helper/UserGenerator';
 import type {Translate} from 'Util/localizerUtil';
 import {translateForTest} from 'Util/test/translateForTest';
@@ -58,20 +53,14 @@ const defaultProps: MessageReactionsListProps = {
   users: [user1, user2, user3],
   loadUsersByIdsFromDb: jest.fn().mockResolvedValue([]),
 };
-const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
-const rootProviderWrapper = createRootProviderWrapperForTest(
-  createRootContextValueForTest({fireAndForgetInvoker, translate: translateForTest}),
-);
-
 describe('MessageReactionsList', () => {
   afterEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
   });
 
   test('renders a button for each reaction and user count', () => {
-    const {getAllByTitle} = render(withTheme(<MessageReactionsList {...defaultProps} />), {
-      wrapper: rootProviderWrapper,
-    });
+    const {getAllByTitle} = render(withTheme(<MessageReactionsList {...defaultProps} />));
 
     const winkButton = getAllByTitle('wink');
     const smileyFace1 = getAllByTitle('innocent');
@@ -104,7 +93,6 @@ describe('MessageReactionsList', () => {
 
     const {getByTitle} = render(
       withTheme(<MessageReactionsList {...defaultProps} reactions={reactionsWithDepartedUser} />),
-      {wrapper: rootProviderWrapper},
     );
 
     expect(within(getByTitle('heart')).getByText('4')).toBeDefined();
@@ -124,7 +112,7 @@ describe('MessageReactionsList', () => {
     const reactionsWithDepartedUser: ReactionMap = [['❤️', [departedUser.qualifiedId, user1.qualifiedId]]];
 
     const {getByTitle} = render(
-      withThemeAndRootContext(
+      withTheme(
         <div id="wire-app">
           <MessageReactionsList
             {...defaultProps}
@@ -134,15 +122,13 @@ describe('MessageReactionsList', () => {
             loadUsersByIdsFromDb={loadUsersByIdsFromDb}
           />
         </div>,
-        rootProviderWrapper,
       ),
     );
 
     expect(loadUsersByIdsFromDb).not.toHaveBeenCalled();
     fireEvent.focus(getByTitle('heart'));
-    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    expect(loadUsersByIdsFromDb).toHaveBeenCalledWith([departedUser.qualifiedId]);
+    await waitFor(() => expect(loadUsersByIdsFromDb).toHaveBeenCalledWith([departedUser.qualifiedId]));
     await waitFor(() => expect(within(document.body).getByRole('tooltip')).toHaveTextContent('Former Member'));
   });
 
@@ -154,10 +140,7 @@ describe('MessageReactionsList', () => {
     secondDepartedUser.name('Second Former Member');
     thirdDepartedUser.name('Third Former Member');
     const loadUsersByIdsFromDb = jest.fn().mockResolvedValue([secondDepartedUser, firstDepartedUser]);
-    const translate: Translate = (
-      identifier,
-      substitutions,
-    ): string => {
+    const translate: Translate = (identifier, substitutions): string => {
       if (identifier === 'conversationLikesCaptionPluralMoreThan2') {
         return String(substitutions?.userNames ?? '');
       }
@@ -169,7 +152,7 @@ describe('MessageReactionsList', () => {
     ];
 
     const {getByTitle} = render(
-      withThemeAndRootContext(
+      withTheme(
         <div id="wire-app">
           <MessageReactionsList
             {...defaultProps}
@@ -179,14 +162,17 @@ describe('MessageReactionsList', () => {
             loadUsersByIdsFromDb={loadUsersByIdsFromDb}
           />
         </div>,
-        rootProviderWrapper,
       ),
     );
 
     fireEvent.mouseEnter(getByTitle('heart'));
-    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    expect(loadUsersByIdsFromDb).toHaveBeenCalledWith([secondDepartedUser.qualifiedId, firstDepartedUser.qualifiedId]);
+    await waitFor(() =>
+      expect(loadUsersByIdsFromDb).toHaveBeenCalledWith([
+        secondDepartedUser.qualifiedId,
+        firstDepartedUser.qualifiedId,
+      ]),
+    );
     await waitFor(() => {
       expect(within(document.body).getByRole('tooltip')).toHaveTextContent('Second Former Member, First Former Member');
     });
@@ -198,7 +184,7 @@ describe('MessageReactionsList', () => {
     const loadUsersByIdsFromDb = jest.fn().mockResolvedValue([departedUser]);
     const reactionsWithDepartedUser: ReactionMap = [['❤️', [departedUser.qualifiedId]]];
     const {getByTitle} = render(
-      withThemeAndRootContext(
+      withTheme(
         <div id="wire-app">
           <MessageReactionsList
             {...defaultProps}
@@ -207,16 +193,13 @@ describe('MessageReactionsList', () => {
             loadUsersByIdsFromDb={loadUsersByIdsFromDb}
           />
         </div>,
-        rootProviderWrapper,
       ),
     );
 
     fireEvent.focus(getByTitle('heart'));
-    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
     fireEvent.mouseEnter(getByTitle('heart'));
-    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    expect(loadUsersByIdsFromDb).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(loadUsersByIdsFromDb).toHaveBeenCalledTimes(1));
   });
 
   test('allows a later tooltip interaction to retry a failed local lookup', async () => {
@@ -226,10 +209,7 @@ describe('MessageReactionsList', () => {
       .fn()
       .mockRejectedValueOnce(new Error('IndexedDB unavailable'))
       .mockResolvedValueOnce([departedUser]);
-    const translate: Translate = (
-      identifier,
-      substitutions,
-    ): string => {
+    const translate: Translate = (identifier, substitutions): string => {
       if (identifier === 'conversationLikesCaptionSingular') {
         return String(substitutions?.userName ?? '');
       }
@@ -238,7 +218,7 @@ describe('MessageReactionsList', () => {
     };
     const reactionsWithDepartedUser: ReactionMap = [['❤️', [departedUser.qualifiedId]]];
     const {getByTitle} = render(
-      withThemeAndRootContext(
+      withTheme(
         <div id="wire-app">
           <MessageReactionsList
             {...defaultProps}
@@ -248,23 +228,23 @@ describe('MessageReactionsList', () => {
             loadUsersByIdsFromDb={loadUsersByIdsFromDb}
           />
         </div>,
-        rootProviderWrapper,
       ),
     );
 
     fireEvent.focus(getByTitle('heart'));
-    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+    jest.useFakeTimers();
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+    jest.useRealTimers();
     fireEvent.mouseEnter(getByTitle('heart'));
-    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
-    expect(loadUsersByIdsFromDb).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(loadUsersByIdsFromDb).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(within(document.body).getByRole('tooltip')).toHaveTextContent('Former Member'));
   });
 
   test('handles click on reaction button', () => {
-    const {getByTitle} = render(withTheme(<MessageReactionsList {...defaultProps} />), {
-      wrapper: rootProviderWrapper,
-    });
+    const {getByTitle} = render(withTheme(<MessageReactionsList {...defaultProps} />));
 
     fireEvent.click(getByTitle('+1'));
     const {handleReactionClick} = defaultProps;

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
@@ -55,7 +55,6 @@ const defaultProps: MessageReactionsListProps = {
 };
 describe('MessageReactionsList', () => {
   afterEach(() => {
-    jest.useRealTimers();
     jest.clearAllMocks();
   });
 
@@ -205,10 +204,11 @@ describe('MessageReactionsList', () => {
   test('allows a later tooltip interaction to retry a failed local lookup', async () => {
     const departedUser = new User('departed-user', 'test.wire.link', translateForTest);
     departedUser.name('Former Member');
-    const loadUsersByIdsFromDb = jest
-      .fn()
-      .mockRejectedValueOnce(new Error('IndexedDB unavailable'))
-      .mockResolvedValueOnce([departedUser]);
+    let rejectFirstLookup: ((error: Error) => void) | undefined;
+    const firstLookup = new Promise<User[]>((_, reject): void => {
+      rejectFirstLookup = reject;
+    });
+    const loadUsersByIdsFromDb = jest.fn().mockReturnValueOnce(firstLookup).mockResolvedValueOnce([departedUser]);
     const translate: Translate = (identifier, substitutions): string => {
       if (identifier === 'conversationLikesCaptionSingular') {
         return String(substitutions?.userName ?? '');
@@ -232,11 +232,22 @@ describe('MessageReactionsList', () => {
     );
 
     fireEvent.focus(getByTitle('heart'));
-    jest.useFakeTimers();
-    await act(async () => {
-      await jest.runAllTimersAsync();
+    await waitFor(() => expect(loadUsersByIdsFromDb).toHaveBeenCalledTimes(1));
+
+    const rejectLookup = rejectFirstLookup;
+    if (typeof rejectLookup !== 'function') {
+      throw new Error('The first lookup rejector was not initialized');
+    }
+
+    await act(async (): Promise<void> => {
+      rejectLookup(new Error('IndexedDB unavailable'));
+      try {
+        await firstLookup;
+      } catch {
+        // The rejected lookup is expected; the component handles the failure.
+      }
     });
-    jest.useRealTimers();
+
     fireEvent.mouseEnter(getByTitle('heart'));
 
     await waitFor(() => expect(loadUsersByIdsFromDb).toHaveBeenCalledTimes(2));

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
@@ -17,16 +17,18 @@
  *
  */
 
-import {render, fireEvent, within} from '@testing-library/react';
+import {act, fireEvent, render, waitFor, within} from '@testing-library/react';
 
 import {User} from 'Repositories/entity/User';
 import {ReactionMap} from 'Repositories/storage';
-import {withTheme} from 'src/script/auth/util/test/testUtil';
+import {withTheme, withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
 import {
+  createExecutingFireAndForgetInvokerForTest,
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 import {generateQualifiedId} from 'test/helper/UserGenerator';
+import type {Translate} from 'Util/localizerUtil';
 import {translateForTest} from 'Util/test/translateForTest';
 
 import {MessageReactionsList, MessageReactionsListProps} from './MessageReactionsList';
@@ -34,6 +36,9 @@ import {MessageReactionsList, MessageReactionsListProps} from './MessageReaction
 const user1 = new User('', '', translateForTest);
 const user2 = new User('', '', translateForTest);
 const user3 = new User('', '', translateForTest);
+user1.name('User One');
+user2.name('User Two');
+user3.name('User Three');
 const reactions: ReactionMap = [
   ['😇', [user1.qualifiedId, user2.qualifiedId, user3.qualifiedId]],
   ['😊', [user1.qualifiedId, user2.qualifiedId]],
@@ -51,9 +56,11 @@ const defaultProps: MessageReactionsListProps = {
   isRemovedFromConversation: false,
   selfUserId: generateQualifiedId(),
   users: [user1, user2, user3],
+  loadUsersByIdsFromDb: jest.fn().mockResolvedValue([]),
 };
+const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
 const rootProviderWrapper = createRootProviderWrapperForTest(
-  createRootContextValueForTest({translate: translateForTest}),
+  createRootContextValueForTest({fireAndForgetInvoker, translate: translateForTest}),
 );
 
 describe('MessageReactionsList', () => {
@@ -101,6 +108,42 @@ describe('MessageReactionsList', () => {
     );
 
     expect(within(getByTitle('heart')).getByText('4')).toBeDefined();
+  });
+
+  test('loads missing reactor names from the local database when the tooltip is opened', async () => {
+    const departedUser = new User('departed-user', 'test.wire.link', translateForTest);
+    departedUser.name('Former Member');
+    const loadUsersByIdsFromDb = jest.fn().mockResolvedValue([departedUser]);
+    const translate: Translate = (identifier, substitutions, dangerousSubstitutions, skipEscape) => {
+      if (identifier === 'conversationLikesCaptionPlural') {
+        return `${substitutions?.firstUser}, ${substitutions?.secondUser}`;
+      }
+
+      return translateForTest(identifier, substitutions, dangerousSubstitutions, skipEscape);
+    };
+    const reactionsWithDepartedUser: ReactionMap = [['❤️', [departedUser.qualifiedId, user1.qualifiedId]]];
+
+    const {getByTitle} = render(
+      withThemeAndRootContext(
+        <div id="wire-app">
+          <MessageReactionsList
+            {...defaultProps}
+            translate={translate}
+            reactions={reactionsWithDepartedUser}
+            users={[user1]}
+            loadUsersByIdsFromDb={loadUsersByIdsFromDb}
+          />
+        </div>,
+        rootProviderWrapper,
+      ),
+    );
+
+    expect(loadUsersByIdsFromDb).not.toHaveBeenCalled();
+    fireEvent.focus(getByTitle('heart'));
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(loadUsersByIdsFromDb).toHaveBeenCalledWith([departedUser.qualifiedId]);
+    await waitFor(() => expect(within(document.body).getByRole('tooltip')).toHaveTextContent('Former Member'));
   });
 
   test('handles click on reaction button', () => {

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
@@ -114,7 +114,7 @@ describe('MessageReactionsList', () => {
     const departedUser = new User('departed-user', 'test.wire.link', translateForTest);
     departedUser.name('Former Member');
     const loadUsersByIdsFromDb = jest.fn().mockResolvedValue([departedUser]);
-    const translate: Translate = (identifier, substitutions, dangerousSubstitutions, skipEscape) => {
+    const translate: Translate = (identifier, substitutions, dangerousSubstitutions, skipEscape): string => {
       if (identifier === 'conversationLikesCaptionPlural') {
         return `${substitutions?.firstUser}, ${substitutions?.secondUser}`;
       }
@@ -143,6 +143,125 @@ describe('MessageReactionsList', () => {
     await act(() => fireAndForgetInvoker.waitUntilAllSettled());
 
     expect(loadUsersByIdsFromDb).toHaveBeenCalledWith([departedUser.qualifiedId]);
+    await waitFor(() => expect(within(document.body).getByRole('tooltip')).toHaveTextContent('Former Member'));
+  });
+
+  test('loads only the first two missing reactor names in stored reaction order', async () => {
+    const firstDepartedUser = new User('first-departed-user', 'test.wire.link', translateForTest);
+    const secondDepartedUser = new User('second-departed-user', 'test.wire.link', translateForTest);
+    const thirdDepartedUser = new User('third-departed-user', 'test.wire.link', translateForTest);
+    firstDepartedUser.name('First Former Member');
+    secondDepartedUser.name('Second Former Member');
+    thirdDepartedUser.name('Third Former Member');
+    const loadUsersByIdsFromDb = jest.fn().mockResolvedValue([secondDepartedUser, firstDepartedUser]);
+    const translate: Translate = function translateReactionCaption(
+      identifier,
+      substitutions,
+      dangerousSubstitutions,
+      skipEscape,
+    ): string {
+      if (identifier === 'conversationLikesCaptionPluralMoreThan2') {
+        return substitutions?.userNames ?? '';
+      }
+
+      return translateForTest(identifier, substitutions, dangerousSubstitutions, skipEscape);
+    };
+    const reactionsWithThreeDepartedUsers: ReactionMap = [
+      ['❤️', [secondDepartedUser.qualifiedId, firstDepartedUser.qualifiedId, thirdDepartedUser.qualifiedId]],
+    ];
+
+    const {getByTitle} = render(
+      withThemeAndRootContext(
+        <div id="wire-app">
+          <MessageReactionsList
+            {...defaultProps}
+            translate={translate}
+            reactions={reactionsWithThreeDepartedUsers}
+            users={[]}
+            loadUsersByIdsFromDb={loadUsersByIdsFromDb}
+          />
+        </div>,
+        rootProviderWrapper,
+      ),
+    );
+
+    fireEvent.mouseEnter(getByTitle('heart'));
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(loadUsersByIdsFromDb).toHaveBeenCalledWith([secondDepartedUser.qualifiedId, firstDepartedUser.qualifiedId]);
+    await waitFor(() => {
+      expect(within(document.body).getByRole('tooltip')).toHaveTextContent('Second Former Member, First Former Member');
+    });
+  });
+
+  test('does not repeat a local lookup after successfully resolving tooltip names', async () => {
+    const departedUser = new User('departed-user', 'test.wire.link', translateForTest);
+    departedUser.name('Former Member');
+    const loadUsersByIdsFromDb = jest.fn().mockResolvedValue([departedUser]);
+    const reactionsWithDepartedUser: ReactionMap = [['❤️', [departedUser.qualifiedId]]];
+    const {getByTitle} = render(
+      withThemeAndRootContext(
+        <div id="wire-app">
+          <MessageReactionsList
+            {...defaultProps}
+            reactions={reactionsWithDepartedUser}
+            users={[]}
+            loadUsersByIdsFromDb={loadUsersByIdsFromDb}
+          />
+        </div>,
+        rootProviderWrapper,
+      ),
+    );
+
+    fireEvent.focus(getByTitle('heart'));
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+    fireEvent.mouseEnter(getByTitle('heart'));
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(loadUsersByIdsFromDb).toHaveBeenCalledTimes(1);
+  });
+
+  test('allows a later tooltip interaction to retry a failed local lookup', async () => {
+    const departedUser = new User('departed-user', 'test.wire.link', translateForTest);
+    departedUser.name('Former Member');
+    const loadUsersByIdsFromDb = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('IndexedDB unavailable'))
+      .mockResolvedValueOnce([departedUser]);
+    const translate: Translate = function translateReactionCaption(
+      identifier,
+      substitutions,
+      dangerousSubstitutions,
+      skipEscape,
+    ): string {
+      if (identifier === 'conversationLikesCaptionSingular') {
+        return substitutions?.userName ?? '';
+      }
+
+      return translateForTest(identifier, substitutions, dangerousSubstitutions, skipEscape);
+    };
+    const reactionsWithDepartedUser: ReactionMap = [['❤️', [departedUser.qualifiedId]]];
+    const {getByTitle} = render(
+      withThemeAndRootContext(
+        <div id="wire-app">
+          <MessageReactionsList
+            {...defaultProps}
+            translate={translate}
+            reactions={reactionsWithDepartedUser}
+            users={[]}
+            loadUsersByIdsFromDb={loadUsersByIdsFromDb}
+          />
+        </div>,
+        rootProviderWrapper,
+      ),
+    );
+
+    fireEvent.focus(getByTitle('heart'));
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+    fireEvent.mouseEnter(getByTitle('heart'));
+    await act(() => fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(loadUsersByIdsFromDb).toHaveBeenCalledTimes(2);
     await waitFor(() => expect(within(document.body).getByRole('tooltip')).toHaveTextContent('Former Member'));
   });
 

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.test.tsx
@@ -114,12 +114,12 @@ describe('MessageReactionsList', () => {
     const departedUser = new User('departed-user', 'test.wire.link', translateForTest);
     departedUser.name('Former Member');
     const loadUsersByIdsFromDb = jest.fn().mockResolvedValue([departedUser]);
-    const translate: Translate = (identifier, substitutions, dangerousSubstitutions, skipEscape): string => {
+    const translate: Translate = (identifier, substitutions): string => {
       if (identifier === 'conversationLikesCaptionPlural') {
         return `${substitutions?.firstUser}, ${substitutions?.secondUser}`;
       }
 
-      return translateForTest(identifier, substitutions, dangerousSubstitutions, skipEscape);
+      return translateForTest(identifier);
     };
     const reactionsWithDepartedUser: ReactionMap = [['❤️', [departedUser.qualifiedId, user1.qualifiedId]]];
 
@@ -154,17 +154,15 @@ describe('MessageReactionsList', () => {
     secondDepartedUser.name('Second Former Member');
     thirdDepartedUser.name('Third Former Member');
     const loadUsersByIdsFromDb = jest.fn().mockResolvedValue([secondDepartedUser, firstDepartedUser]);
-    const translate: Translate = function translateReactionCaption(
+    const translate: Translate = (
       identifier,
       substitutions,
-      dangerousSubstitutions,
-      skipEscape,
-    ): string {
+    ): string => {
       if (identifier === 'conversationLikesCaptionPluralMoreThan2') {
-        return substitutions?.userNames ?? '';
+        return String(substitutions?.userNames ?? '');
       }
 
-      return translateForTest(identifier, substitutions, dangerousSubstitutions, skipEscape);
+      return translateForTest(identifier);
     };
     const reactionsWithThreeDepartedUsers: ReactionMap = [
       ['❤️', [secondDepartedUser.qualifiedId, firstDepartedUser.qualifiedId, thirdDepartedUser.qualifiedId]],
@@ -228,17 +226,15 @@ describe('MessageReactionsList', () => {
       .fn()
       .mockRejectedValueOnce(new Error('IndexedDB unavailable'))
       .mockResolvedValueOnce([departedUser]);
-    const translate: Translate = function translateReactionCaption(
+    const translate: Translate = (
       identifier,
       substitutions,
-      dangerousSubstitutions,
-      skipEscape,
-    ): string {
+    ): string => {
       if (identifier === 'conversationLikesCaptionSingular') {
-        return substitutions?.userName ?? '';
+        return String(substitutions?.userName ?? '');
       }
 
-      return translateForTest(identifier, substitutions, dangerousSubstitutions, skipEscape);
+      return translateForTest(identifier);
     };
     const reactionsWithDepartedUser: ReactionMap = [['❤️', [departedUser.qualifiedId]]];
     const {getByTitle} = render(

--- a/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/ContentMessage/MessageActions/MessageReactions/MessageReactionsList.tsx
@@ -38,6 +38,7 @@ export interface MessageReactionsListProps {
   onLastReactionKeyEvent: () => void;
   isRemovedFromConversation: boolean;
   users: User[];
+  loadUsersByIdsFromDb: (userIds: QualifiedId[]) => Promise<User[]>;
 }
 
 const MessageReactionsList = ({reactions, ...props}: MessageReactionsListProps) => {
@@ -50,8 +51,6 @@ const MessageReactionsList = ({reactions, ...props}: MessageReactionsListProps) 
         const emojiListCount = users.length;
         const hasUserReacted = users.some(user => matchQualifiedIds(selfUserId, user));
 
-        // Departed users still contribute to the reaction count, but their names are omitted from the tooltip
-        // because only current conversation members are available here.
         const reactingUsers = users
           .map(qualifiedId => conversationUsers.find(user => matchQualifiedIds(qualifiedId, user.qualifiedId)))
           .filter((user): user is User => typeof user !== 'undefined');
@@ -59,6 +58,7 @@ const MessageReactionsList = ({reactions, ...props}: MessageReactionsListProps) 
         return (
           <EmojiPill
             reactingUsers={reactingUsers}
+            reactorIds={users}
             emojiCount={users.length}
             hasUserReacted={hasUserReacted}
             emojiUnicode={emojiUnicode}

--- a/apps/webapp/src/script/components/MessagesList/Message/Message.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/Message.tsx
@@ -32,6 +32,7 @@ import {Message as BaseMessage} from 'Repositories/entity/message/message';
 import type {User} from 'Repositories/entity/User';
 import {ServiceEntity} from 'Repositories/integration/ServiceEntity';
 import {TeamState} from 'Repositories/team/TeamState';
+import type {UserRepository} from 'Repositories/user/userRepository';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {getAllFocusableElements, setElementsTabIndex} from 'Util/focusUtil';
 import {isTabKey} from 'Util/keyboardUtil';
@@ -67,6 +68,7 @@ export interface MessageParams extends MessageActions {
     deleteMessageEveryone: (conversation: Conversation, message: BaseMessage) => void;
   };
   messageRepository: MessageRepository;
+  loadUsersByIdsFromDb: UserRepository['getUsersByIdsFromDb'];
   onVisible?: () => void;
   onVisibilityLost?: () => void;
   selfId: QualifiedId;

--- a/apps/webapp/src/script/components/MessagesList/Message/MessageWrapper.test.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/MessageWrapper.test.tsx
@@ -89,6 +89,7 @@ const createBaseProps = (conversation: Conversation, message: MemberMessageEntit
     retryUploadFile: jest.fn(),
     toggleReaction: jest.fn(),
   } as any,
+  loadUsersByIdsFromDb: jest.fn().mockResolvedValue([]),
   messageActions: {
     deleteMessage: jest.fn(),
     deleteMessageEveryone: jest.fn(),

--- a/apps/webapp/src/script/components/MessagesList/Message/MessageWrapper.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/MessageWrapper.tsx
@@ -81,6 +81,7 @@ export const MessageWrapper = ({
   onClickResetSession,
   onClickCancelRequest,
   messageRepository,
+  loadUsersByIdsFromDb,
   messageActions,
   teamState = container.resolve(TeamState),
   isMsgElementsFocusable,
@@ -224,6 +225,7 @@ export const MessageWrapper = ({
         onClickReaction={handleReactionClick}
         is1to1={conversation.is1to1()}
         isFileShareRestricted={isFileShareRestricted}
+        loadUsersByIdsFromDb={loadUsersByIdsFromDb}
       />
     );
   }

--- a/apps/webapp/src/script/components/MessagesList/Message/VirtualizedMessage.tsx
+++ b/apps/webapp/src/script/components/MessagesList/Message/VirtualizedMessage.tsx
@@ -31,6 +31,7 @@ import {Message as BaseMessage} from 'Repositories/entity/message/message';
 import type {User} from 'Repositories/entity/User';
 import {ServiceEntity} from 'Repositories/integration/ServiceEntity';
 import {TeamState} from 'Repositories/team/TeamState';
+import type {UserRepository} from 'Repositories/user/userRepository';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {getAllFocusableElements, setElementsTabIndex} from 'Util/focusUtil';
 import {isTabKey} from 'Util/keyboardUtil';
@@ -65,6 +66,7 @@ interface MessageParams extends MessageActions {
     deleteMessageEveryone: (conversation: Conversation, message: BaseMessage) => void;
   };
   messageRepository: MessageRepository;
+  loadUsersByIdsFromDb: UserRepository['getUsersByIdsFromDb'];
   selfId: QualifiedId;
   shouldShowInvitePeople: boolean;
   teamState?: TeamState;

--- a/apps/webapp/src/script/components/MessagesList/MessageList.tsx
+++ b/apps/webapp/src/script/components/MessagesList/MessageList.tsx
@@ -36,6 +36,7 @@ import {MemberMessage} from 'Repositories/entity/message/memberMessage';
 import {Message as MessageEntity} from 'Repositories/entity/message/message';
 import {User} from 'Repositories/entity/User';
 import {ServiceEntity} from 'Repositories/integration/ServiceEntity';
+import type {UserRepository} from 'Repositories/user/userRepository';
 import {useRoveFocus} from 'src/script/hooks/useRoveFocus';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {isLastReceivedMessage} from 'Util/conversationMessages';
@@ -61,6 +62,7 @@ interface MessagesListParams {
     deleteMessageEveryone: (conversation: Conversation, message: MessageEntity) => void;
   };
   messageRepository: MessageRepository;
+  loadUsersByIdsFromDb: UserRepository['getUsersByIdsFromDb'];
   onClickMessage: MessageActions['onClickMessage'];
   onLoading: (isLoading: boolean) => void;
   resetSession: (messageError: DecryptErrorMessage) => void;
@@ -82,6 +84,7 @@ export const MessagesList: FC<MessagesListParams> = ({
   selfUser,
   conversationRepository,
   messageRepository,
+  loadUsersByIdsFromDb,
   getVisibleCallback,
   onClickMessage,
   showUserDetails,
@@ -328,6 +331,7 @@ export const MessagesList: FC<MessagesListParams> = ({
                   scrollTo={scrollToElement}
                   isSelfTemporaryGuest={selfUser.isTemporaryGuest()}
                   messageRepository={messageRepository}
+                  loadUsersByIdsFromDb={loadUsersByIdsFromDb}
                   onClickAvatar={showUserDetails}
                   onClickCancelRequest={cancelConnectionRequest}
                   onClickImage={showImageDetails}

--- a/apps/webapp/src/script/components/MessagesList/MessageList.types.ts
+++ b/apps/webapp/src/script/components/MessagesList/MessageList.types.ts
@@ -30,6 +30,7 @@ import {MemberMessage} from 'Repositories/entity/message/memberMessage';
 import {Message as MessageEntity} from 'Repositories/entity/message/message';
 import {User} from 'Repositories/entity/User';
 import {ServiceEntity} from 'Repositories/integration/ServiceEntity';
+import type {UserRepository} from 'Repositories/user/userRepository';
 
 export interface MessagesListParams {
   assetRepository: AssetRepository;
@@ -43,6 +44,7 @@ export interface MessagesListParams {
     deleteMessageEveryone: (conversation: Conversation, message: MessageEntity) => void;
   };
   messageRepository: MessageRepository;
+  loadUsersByIdsFromDb: UserRepository['getUsersByIdsFromDb'];
   onClickMessage: MessageActions['onClickMessage'];
   onLoading: (isLoading: boolean) => void;
   resetSession: (messageError: DecryptErrorMessage) => void;

--- a/apps/webapp/src/script/components/MessagesList/MessageListWrapper.tsx
+++ b/apps/webapp/src/script/components/MessagesList/MessageListWrapper.tsx
@@ -30,6 +30,7 @@ export const MessageListWrapper = ({
   selfUser,
   conversationRepository,
   messageRepository,
+  loadUsersByIdsFromDb,
   getVisibleCallback,
   onClickMessage,
   showUserDetails,
@@ -58,6 +59,7 @@ export const MessageListWrapper = ({
         conversationRepository={conversationRepository}
         assetRepository={assetRepository}
         messageRepository={messageRepository}
+        loadUsersByIdsFromDb={loadUsersByIdsFromDb}
         messageActions={messageActions}
         invitePeople={invitePeople}
         cancelConnectionRequest={cancelConnectionRequest}
@@ -86,6 +88,7 @@ export const MessageListWrapper = ({
       conversationRepository={conversationRepository}
       assetRepository={assetRepository}
       messageRepository={messageRepository}
+      loadUsersByIdsFromDb={loadUsersByIdsFromDb}
       messageActions={messageActions}
       invitePeople={invitePeople}
       cancelConnectionRequest={cancelConnectionRequest}

--- a/apps/webapp/src/script/components/MessagesList/VirtualizedMessageListWrapper.tsx
+++ b/apps/webapp/src/script/components/MessagesList/VirtualizedMessageListWrapper.tsx
@@ -34,6 +34,7 @@ export const VirtualizedMessageListWrapper = ({
   selfUser,
   conversationRepository,
   messageRepository,
+  loadUsersByIdsFromDb,
   getVisibleCallback,
   onClickMessage,
   showUserDetails,
@@ -88,6 +89,7 @@ export const VirtualizedMessageListWrapper = ({
           conversationRepository={conversationRepository}
           assetRepository={assetRepository}
           messageRepository={messageRepository}
+          loadUsersByIdsFromDb={loadUsersByIdsFromDb}
           messageActions={messageActions}
           getVisibleCallback={getVisibleCallback}
           isMsgElementsFocusable={isMsgElementsFocusable}

--- a/apps/webapp/src/script/components/MessagesList/VirtualizedMessagesList/VirtualizedMessagesList.tsx
+++ b/apps/webapp/src/script/components/MessagesList/VirtualizedMessagesList/VirtualizedMessagesList.tsx
@@ -88,6 +88,7 @@ export const VirtualizedMessagesList = ({
   selfUser,
   conversationRepository,
   messageRepository,
+  loadUsersByIdsFromDb,
   getVisibleCallback,
   invitePeople,
   cancelConnectionRequest,
@@ -367,6 +368,7 @@ export const VirtualizedMessagesList = ({
                   }
                   isSelfTemporaryGuest={selfUser.isTemporaryGuest()}
                   messageRepository={messageRepository}
+                  loadUsersByIdsFromDb={loadUsersByIdsFromDb}
                   onClickAvatar={showUserDetails}
                   onClickCancelRequest={cancelConnectionRequest}
                   onClickImage={showImageDetails}

--- a/apps/webapp/src/script/repositories/user/userRepository.test.ts
+++ b/apps/webapp/src/script/repositories/user/userRepository.test.ts
@@ -41,6 +41,7 @@ import {EventRepository} from 'Repositories/event/EventRepository';
 import {PropertiesRepository} from 'Repositories/properties/propertiesRepository';
 import {SelfService} from 'Repositories/self/SelfService';
 import {TeamState} from 'Repositories/team/TeamState';
+import type {UserRecord} from 'Repositories/storage';
 import type {Translate} from 'Util/localizerUtil';
 import {matchQualifiedIds} from 'Util/qualifiedId';
 import {translateForTest} from 'Util/test/translateForTest';
@@ -250,6 +251,32 @@ describe('UserRepository', () => {
         expect(users[0].name()).toBe('Former Member');
         expect(userService.loadUserFromDb).toHaveBeenCalledWith(departedUser.qualified_id);
         expect(backendUsersSpy).not.toHaveBeenCalled();
+      });
+
+      it('preserves requested federated identities for sparse cached users', async () => {
+        const [userRepository, {userService, userState}] = await buildUserRepository(translateForTest);
+        const selfUser = new User('self', 'local.test', translateForTest);
+        const firstRequestedUserId = {id: 'same-user-id', domain: 'first.remote.test'};
+        const secondRequestedUserId = {id: 'same-user-id', domain: 'second.remote.test'};
+        const firstSparseUserRecord = {
+          id: firstRequestedUserId.id,
+          name: 'First Former Member',
+        } as UserRecord;
+        const secondSparseUserRecord = {
+          id: secondRequestedUserId.id,
+          name: 'Second Former Member',
+        } as UserRecord;
+        userState.self(selfUser);
+        jest
+          .spyOn(userService, 'loadUserFromDb')
+          .mockResolvedValueOnce(firstSparseUserRecord)
+          .mockResolvedValueOnce(secondSparseUserRecord);
+
+        const users = await userRepository.getUsersByIdsFromDb([firstRequestedUserId, secondRequestedUserId]);
+
+        expect(users.map(user => user.qualifiedId)).toEqual([firstRequestedUserId, secondRequestedUserId]);
+        expect(users.map(user => user.name())).toEqual(['First Former Member', 'Second Former Member']);
+        expect(users.every(user => user.isFederated)).toBe(true);
       });
     });
 

--- a/apps/webapp/src/script/repositories/user/userRepository.test.ts
+++ b/apps/webapp/src/script/repositories/user/userRepository.test.ts
@@ -235,6 +235,24 @@ describe('UserRepository', () => {
       });
     });
 
+    describe('getUsersByIdsFromDb', () => {
+      it('loads cached users without requesting them from the backend', async () => {
+        const [userRepository, {userService, userState}] = await buildUserRepository(translateForTest);
+        const selfUser = new User('self', 'test.wire.link', translateForTest);
+        const departedUser = generateAPIUser(undefined, {name: 'Former Member'});
+        userState.self(selfUser);
+        jest.spyOn(userService, 'loadUserFromDb').mockResolvedValue(departedUser);
+        const backendUsersSpy = jest.spyOn(userService, 'getUsers');
+
+        const users = await userRepository.getUsersByIdsFromDb([departedUser.qualified_id!]);
+
+        expect(users).toHaveLength(1);
+        expect(users[0].name()).toBe('Former Member');
+        expect(userService.loadUserFromDb).toHaveBeenCalledWith(departedUser.qualified_id);
+        expect(backendUsersSpy).not.toHaveBeenCalled();
+      });
+    });
+
     describe('saveUser', () => {
       it('saves a user', async () => {
         const [userRepository, {userState}] = await buildUserRepository(translateForTest);

--- a/apps/webapp/src/script/repositories/user/userRepository.test.ts
+++ b/apps/webapp/src/script/repositories/user/userRepository.test.ts
@@ -278,6 +278,20 @@ describe('UserRepository', () => {
         expect(users.map(user => user.name())).toEqual(['First Former Member', 'Second Former Member']);
         expect(users.every(user => user.isFederated)).toBe(true);
       });
+
+      it('returns a translated deleted user when the cached user is unavailable', async () => {
+        const [userRepository, {userService, userState}] = await buildUserRepository(translateForTest);
+        const selfUser = new User('self', 'local.test', translateForTest);
+        const requestedUserId = {id: 'departed-user', domain: 'remote.test'};
+        userState.self(selfUser);
+        jest.spyOn(userService, 'loadUserFromDb').mockResolvedValue(undefined);
+
+        const [deletedUser] = await userRepository.getUsersByIdsFromDb([requestedUserId]);
+
+        expect(deletedUser.qualifiedId).toEqual(requestedUserId);
+        expect(deletedUser.name()).toBe('nonexistentUser');
+        expect(deletedUser.isDeleted).toBe(true);
+      });
     });
 
     describe('saveUser', () => {

--- a/apps/webapp/src/script/repositories/user/userRepository.ts
+++ b/apps/webapp/src/script/repositories/user/userRepository.ts
@@ -665,6 +665,23 @@ export class UserRepository extends TypedEventEmitter<Events> {
   }
 
   /**
+   * Load users from the local database without making a backend request.
+   * Users that are no longer cached in IndexedDB are represented as deleted users.
+   */
+  readonly getUsersByIdsFromDb = async (userIds: QualifiedId[]): Promise<User[]> => {
+    const storedUsers = await Promise.all(userIds.map(userId => this.userService.loadUserFromDb(userId)));
+    const localDomain = this.userState.self().domain;
+
+    return storedUsers.map((storedUser, index) => {
+      if (!storedUser?.name) {
+        return this.createDeletedUser(userIds[index]);
+      }
+
+      return this.userMapper.mapUserFromJson(storedUser, localDomain);
+    });
+  };
+
+  /**
    * Find a local user.
    */
   findUserById(userId: QualifiedId): User | undefined {

--- a/apps/webapp/src/script/repositories/user/userRepository.ts
+++ b/apps/webapp/src/script/repositories/user/userRepository.ts
@@ -677,7 +677,13 @@ export class UserRepository extends TypedEventEmitter<Events> {
         return this.createDeletedUser(userIds[index]);
       }
 
-      return this.userMapper.mapUserFromJson(storedUser, localDomain);
+      return this.userMapper.mapUserFromJson(
+        {
+          ...storedUser,
+          qualified_id: storedUser.qualified_id ?? userIds[index],
+        },
+        localDomain,
+      );
     });
   };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Keep the inline reaction count based on every stored reactor ID, including users who left the conversation.
- Keep cached current conversation members as the immediate source for tooltip names.
- Resolve missing tooltip-visible reactor names from IndexedDB only when the tooltip opens.

## Behavior

- No IndexedDB lookup occurs while the message list renders.
- A lookup is triggered only by the hover or focus interaction that opens the tooltip.
- Only reactor IDs missing from the cached conversation members are requested.
- Only the first two reactors whose names can appear in the tooltip are considered; missing users represented by the remaining count are not loaded.
- The lookup is local-only and never requests the backend.
- If a user is not available in IndexedDB, the tooltip shows the translated deleted-user label instead of an undefined name.

## Validation

- `yarn type-check`
- `BASE_REF=main yarn lint:affected`
- Reaction tooltip regression tests
- Content message and message wrapper tests
- User repository local-only lookup test

Follow-up to #22251.
