### PR TITLE
chore (e2e): Fix jobs that used expected managed team url [WPB-22420]

### DIFF
--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -13,10 +13,6 @@ on:
         options:
           - https://wire-webapp-dev.wire.com/
           - https://wire-webapp-qa.zinfra.io/
-      teamManagementUrl:
-        description: Exact team management URL expected from the selected WebApp
-        required: true
-        type: string
 
 # Only allow one instance of this workflow to run per branch at a time
 concurrency:
@@ -29,7 +25,6 @@ jobs:
     uses: ./.github/workflows/e2e-tests.yml
     with:
       webappUrl: ${{ inputs.webappUrl }}
-      teamManagementUrl: ${{ inputs.teamManagementUrl }}
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       WIRE_E2E_TEST_BOT_WEBHOOK_URL: ${{ secrets.WIRE_E2E_TEST_BOT_WEBHOOK_URL }}

--- a/.github/workflows/e2e-tests-nightly.yml
+++ b/.github/workflows/e2e-tests-nightly.yml
@@ -11,7 +11,7 @@ on:
         required: true
         type: choice
         options:
-          - https://wire-webapp-dev.wire.com/
+          - https://wire-webapp-dev.zinfra.io/
           - https://wire-webapp-qa.zinfra.io/
 
 # Only allow one instance of this workflow to run per branch at a time

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,7 +31,7 @@ on:
         required: true
       teamManagementUrl:
         type: string
-        required: true
+        required: false
         description: Exact team management URL expected from the deployed WebApp artifact
       grep:
         type: string
@@ -186,7 +186,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
-      - name: Run tests (workflow call)
+      - name: Run tests (with team management URL override)
         if: ${{ inputs.teamManagementUrl != '' }}
         env:
           WEBAPP_URL: ${{ inputs.webappUrl }}
@@ -196,7 +196,7 @@ jobs:
           GREP: ${{ inputs.grep }}
         run: ./bin/yarn nx run webapp:e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }} --reporter=blob --grep=\"$GREP\"
 
-      - name: Run tests (workflow dispatch)
+      - name: Run tests
         if: ${{ inputs.teamManagementUrl == '' }}
         env:
           WEBAPP_URL: ${{ inputs.webappUrl }}

--- a/.github/workflows/precommit-e2e-tests.yml
+++ b/.github/workflows/precommit-e2e-tests.yml
@@ -94,7 +94,7 @@ jobs:
     uses: ./.github/workflows/precommit-slot-run.yml
     with:
       env_name: ${{ needs.build.outputs.env_name }}
-      expectedManageTeamUrl: https://wire-teams-staging.zinfra.io/login/
+      teamManagementUrl: https://wire-teams-staging.zinfra.io/login/
       grep: ''
       notify_deployoholics_on_failure: ${{ github.event_name == 'schedule' }}
     secrets:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Some leftover reference fix that was overlooked in the previous [PR](https://github.com/wireapp/wire-webapp/pull/22267)