### PR TITLE
feat: show shared drive viewer access [WPB-28147]

### DIFF
--- a/apps/webapp/src/script/components/Conversation/Conversation.tsx
+++ b/apps/webapp/src/script/components/Conversation/Conversation.tsx
@@ -65,6 +65,7 @@ import {
 import {
   CellsSelfUserDriveRoleProvider,
   getSelfUserDriveRole,
+  shouldRestrictCellsViewerActions,
 } from './ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
 import {getCellsFilesPath} from './ConversationCells/common/getCellsFilesPath/getCellsFilesPath';
 import {getCurrentFolderName} from './ConversationCells/common/getCurrentFolderName/getCurrentFolderName';
@@ -74,6 +75,7 @@ import {isConversationFileDropAllowed} from './ConversationFileDropzone/isConver
 import {ConversationMessagesWrapper} from './ConversationMessagesWrapper/ConversationMessagesWrapper';
 import {ConversationTabPanel} from './ConversationTabPanel/ConversationTabPanel';
 import {ConversationTabs} from './ConversationTabs/ConversationTabs';
+import {ConversationViewerPermissionBanner} from './ConversationViewerPermissionBanner/ConversationViewerPermissionBanner';
 import {useReadReceiptSender} from './hooks/useReadReceipt';
 import {ReadOnlyConversationMessage} from './ReadOnlyConversationMessage';
 import {useFilesUploadDropzone} from './useFilesUploadDropzone/useFilesUploadDropzone';
@@ -619,6 +621,12 @@ export const Conversation = ({
     conversationTeamId: activeConversation?.teamId,
     selfUserTeamId: selfUser.teamId,
   });
+  const showViewerPermission =
+    isCellsEnabled &&
+    shouldRestrictCellsViewerActions({
+      isViewerPermissionFeatureEnabled,
+      selfUserDriveRole,
+    });
 
   return (
     <CellsSelfUserDriveRoleProvider selfUserDriveRole={selfUserDriveRole}>
@@ -681,6 +689,7 @@ export const Conversation = ({
                       isSearchViewOpen={isSharedDriveSearchViewOpen}
                       onOpenSearchView={() => setIsSharedDriveSearchViewOpen(true)}
                       onCloseSearchView={() => setIsSharedDriveSearchViewOpen(false)}
+                      showViewerPermission={showViewerPermission}
                     />
                   )}
                 </ConversationTabPanel>
@@ -734,6 +743,8 @@ export const Conversation = ({
                 isRightSidebarOpen={isRightSidebarOpen}
                 updateConversationLastRead={updateConversationLastRead}
               />
+
+              {showViewerPermission && !isFileTabActive && <ConversationViewerPermissionBanner />}
 
               {isConversationLoaded &&
                 !isSelfUserRemoved &&

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.test.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.test.tsx
@@ -82,10 +82,10 @@ describe('CellsHeader', () => {
     expect(screen.getByRole('button', {name: 'Public links'})).toBeInTheDocument();
   });
 
-  it('renders viewer access in the header when restricted', () => {
+  it('renders the viewer permission banner when restricted', () => {
     renderCellsHeader({showViewerPermission: true, isSearchViewOpen: false});
 
-    expect(screen.getByRole('button', {name: /cells.sharedDriveAccess.viewerAccess/})).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.getByText('conversationFileUploadRestrictedOverlayDescription')).toBeInTheDocument();
   });
 

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.test.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.test.tsx
@@ -55,6 +55,7 @@ const defaultProperties = {
   onSearchChange: jest.fn(),
   onSearchClear: jest.fn(),
   filters: [filter],
+  showViewerPermission: false,
 };
 
 const renderCellsHeader = (properties: Partial<typeof defaultProperties> = {}) => {
@@ -79,6 +80,13 @@ describe('CellsHeader', () => {
 
     expect(screen.getByRole('textbox', {name: 'cells.search.placeholder'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Public links'})).toBeInTheDocument();
+  });
+
+  it('renders viewer access in the header when restricted', () => {
+    renderCellsHeader({showViewerPermission: true, isSearchViewOpen: false});
+
+    expect(screen.getByRole('button', {name: /cells.sharedDriveAccess.viewerAccess/})).toBeInTheDocument();
+    expect(screen.getByText('conversationFileUploadRestrictedOverlayDescription')).toBeInTheDocument();
   });
 
   it('renders the new-item menu outside the recycle bin', () => {

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.tsx
@@ -19,6 +19,8 @@
 
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
 
+import {ViewerAccessIcon} from '@wireapp/react-ui-kit';
+
 import {CellsSearchInput} from 'Components/cellsSearchInput/cellsSearchInput';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {useApplicationContext} from 'src/script/page/rootProvider';
@@ -35,6 +37,7 @@ import {CellsNewMenu} from './CellsNewMenu/CellsNewMenu';
 import {CellsRefresh} from './CellsRefresh/CellsRefresh';
 import {CellsRootHomeIcon} from './CellsRootHomeIcon';
 
+import {ConversationViewerPermissionBanner} from '../../ConversationViewerPermissionBanner/ConversationViewerPermissionBanner';
 import {CellsBreadcrumbs} from '../common/CellsBreadcrumbs/CellsBreadcrumbs';
 import {CellsFiltersBar} from '../common/CellsFiltersBar/CellsFiltersBar';
 import type {FilterConfig} from '../common/CellsFiltersBar/filterConfig';
@@ -54,6 +57,7 @@ interface CellsHeaderProps {
   onSearchChange: (value: string) => void;
   onSearchClear: () => void;
   filters: FilterConfig[];
+  showViewerPermission: boolean;
 }
 
 export const CellsHeader = ({
@@ -68,6 +72,7 @@ export const CellsHeader = ({
   onSearchChange,
   onSearchClear,
   filters,
+  showViewerPermission,
 }: CellsHeaderProps) => {
   const {translate} = useApplicationContext();
   const breadcrumbs = getBreadcrumbsFromPath({
@@ -98,6 +103,12 @@ export const CellsHeader = ({
           <CellsFiltersBar filters={filters} />
         ) : (
           <div css={actionsStyles}>
+            {showViewerPermission && !isInRecycleBin && (
+              <button type="button" className="cells-viewer-access-button">
+                <ViewerAccessIcon />
+                {translate('cells.sharedDriveAccess.viewerAccess')}
+              </button>
+            )}
             {!isInRecycleBin && (
               <CellsNewMenu
                 cellsRepository={cellsRepository}
@@ -128,6 +139,8 @@ export const CellsHeader = ({
           )}
         </div>
       )}
+
+      {showViewerPermission && !isSearchViewOpen && !isInRecycleBin && <ConversationViewerPermissionBanner />}
     </div>
   );
 };

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.tsx
@@ -19,8 +19,6 @@
 
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
 
-import {ViewerAccessIcon} from '@wireapp/react-ui-kit';
-
 import {CellsSearchInput} from 'Components/cellsSearchInput/cellsSearchInput';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {useApplicationContext} from 'src/script/page/rootProvider';
@@ -103,12 +101,6 @@ export const CellsHeader = ({
           <CellsFiltersBar filters={filters} />
         ) : (
           <div css={actionsStyles}>
-            {showViewerPermission && !isInRecycleBin && (
-              <button type="button" className="cells-viewer-access-button">
-                <ViewerAccessIcon />
-                {translate('cells.sharedDriveAccess.viewerAccess')}
-              </button>
-            )}
             {!isInRecycleBin && (
               <CellsNewMenu
                 cellsRepository={cellsRepository}

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/ConversationCells.tsx
@@ -64,6 +64,7 @@ interface ConversationCellsProps {
   isSearchViewOpen: boolean;
   onOpenSearchView: () => void;
   onCloseSearchView: () => void;
+  showViewerPermission: boolean;
 }
 
 export const ConversationCells = memo(
@@ -75,6 +76,7 @@ export const ConversationCells = memo(
     isSearchViewOpen,
     onOpenSearchView,
     onCloseSearchView,
+    showViewerPermission,
   }: ConversationCellsProps) => {
     const {fireAndForgetInvoker, translate} = useApplicationContext();
     const {
@@ -247,6 +249,7 @@ export const ConversationCells = memo(
             onSearchChange={handleSearch}
             onSearchClear={handleClearSearch}
             filters={filters}
+            showViewerPermission={showViewerPermission}
           />
           {isTableVisible && (
             <CellsTable

--- a/apps/webapp/src/script/components/Conversation/ConversationViewerPermissionBanner/ConversationViewerPermissionBanner.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationViewerPermissionBanner/ConversationViewerPermissionBanner.tsx
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {useState} from 'react';
+
+import {CloseIcon} from '@wireapp/react-ui-kit';
+
+import {useApplicationContext} from 'src/script/page/rootProvider';
+
+export const ConversationViewerPermissionBanner = () => {
+  const {translate} = useApplicationContext();
+  const [isVisible, setIsVisible] = useState(true);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div className="conversation-viewer-permission-banner" role="status">
+      <div className="conversation-viewer-permission-banner__content">
+        <span>{translate('conversationFileUploadRestrictedOverlayDescription')}</span>
+        <button type="button" className="conversation-viewer-permission-banner__learn-more">
+          {translate('historyInfo.learnMore')}
+        </button>
+      </div>
+      <button
+        type="button"
+        className="conversation-viewer-permission-banner__close"
+        aria-label={translate('fullsearchCancelLabel')}
+        onClick={() => setIsVisible(false)}
+      >
+        <CloseIcon />
+      </button>
+    </div>
+  );
+};

--- a/apps/webapp/src/style/content/conversation.less
+++ b/apps/webapp/src/style/content/conversation.less
@@ -138,15 +138,17 @@
 .cells-viewer-access-button {
   display: inline-flex;
   height: 32px;
+  flex-shrink: 0;
   align-items: center;
   padding: 8px 12px;
   border: 1px solid var(--border-color);
   border-radius: 12px;
-  background: var(--background);
-  color: var(--foreground);
+  background: #fff;
+  color: #000;
   cursor: default;
   font-size: var(--font-size-medium);
   gap: 8px;
+  white-space: nowrap;
 }
 
 .cells-viewer-access-button svg {

--- a/apps/webapp/src/style/content/conversation.less
+++ b/apps/webapp/src/style/content/conversation.less
@@ -135,27 +135,6 @@
   }
 }
 
-.cells-viewer-access-button {
-  display: inline-flex;
-  height: 32px;
-  flex-shrink: 0;
-  align-items: center;
-  padding: 8px 12px;
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-  background: #fff;
-  color: #000;
-  cursor: default;
-  font-size: var(--font-size-medium);
-  gap: 8px;
-  white-space: nowrap;
-}
-
-.cells-viewer-access-button svg {
-  width: 16px;
-  height: 16px;
-}
-
 .conversation-viewer-permission-banner {
   position: relative;
   display: flex;

--- a/apps/webapp/src/style/content/conversation.less
+++ b/apps/webapp/src/style/content/conversation.less
@@ -135,6 +135,78 @@
   }
 }
 
+.cells-viewer-access-button {
+  display: inline-flex;
+  height: 32px;
+  align-items: center;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--background);
+  color: var(--foreground);
+  cursor: default;
+  font-size: var(--font-size-medium);
+  gap: 8px;
+}
+
+.cells-viewer-access-button svg {
+  width: 16px;
+  height: 16px;
+}
+
+.conversation-viewer-permission-banner {
+  position: relative;
+  display: flex;
+  width: 100%;
+  min-height: 28px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 40px;
+  background: #edeff0;
+  color: var(--foreground);
+  font-size: var(--font-size-small);
+}
+
+.conversation-viewer-permission-banner__content {
+  display: flex;
+  min-height: 24px;
+  align-items: center;
+  gap: 10px;
+}
+
+.conversation-viewer-permission-banner__learn-more {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: inherit;
+  font-weight: var(--font-weight-medium);
+  text-decoration: underline;
+}
+
+.conversation-viewer-permission-banner__close {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--foreground);
+  cursor: pointer;
+}
+
+.conversation-viewer-permission-banner__close svg {
+  width: 16px;
+  height: 16px;
+}
+
 .conversation-tabpanel {
   &--messages {
     display: flex;


### PR DESCRIPTION
⁸

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28147" title="WPB-28147" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28147</a>  [web] display permission access status in conversations 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Summary
- Add Figma-aligned viewer access controls and view-only banners for restricted shared-drive guests.
- Show the indicators in both Conversation and Shared Drive views.
- Add CellsHeader regression coverage.

## Jira
ref: https://wearezeta.atlassian.net/browse/WPB-28147

## Screeshots

<img width="1546" height="195" alt="Screenshot 2026-08-25 at 07 21 58" src="https://github.com/user-attachments/assets/30a5b46f-8ff6-4309-977c-8e1a3890d3fa" />
