### PR TITLE
feat: add viewer only banner showing viewer permission indicator in shared drive(WPB-26056)

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -1082,7 +1082,7 @@
   "fileFullscreenModal.noPreviewAvailable.callToAction": "Download File",
   "fileFullscreenModal.noPreviewAvailable.description": "There is no preview available for this file. Download the file instead.",
   "fileFullscreenModal.noPreviewAvailable.title": "File without preview",
-  "fileFullscreenModal.noPreviewAvailable.viewerDescription": "Previews aren't available for this file type, and viewers can't download files.",
+  "fileFullscreenModal.noPreviewAvailable.viewerDescription": "You can't preview this file type nor download this file.",
   "fileHistoryModal.failedToLoadVersions": "Failed to load versions",
   "fileHistoryModal.failedToRestore": "Failed to restore file version",
   "fileHistoryModal.invalidNodeData": "Invalid file data",

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/CellsHeader/CellsHeader.tsx
@@ -20,6 +20,11 @@
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
 
 import {CellsSearchInput} from 'Components/cellsSearchInput/cellsSearchInput';
+import {
+  CELLS_ACTION,
+  useCellsActionPermissions,
+} from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
+import {CellsViewerAccessLabel} from 'Components/Conversation/ConversationCells/common/CellsViewerAccessLabel';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 
@@ -70,12 +75,14 @@ export const CellsHeader = ({
   filters,
 }: CellsHeaderProps) => {
   const {translate} = useApplicationContext();
+  const canPerformCellsAction = useCellsActionPermissions();
   const breadcrumbs = getBreadcrumbsFromPath({
     baseCrumb: translate('cells.breadcrumb.files', {conversationName}),
     currentPath: getCellsFilesPath(),
     recycleBinLabel: translate('cells.recycleBin.breadcrumb'),
   });
   const isRootLevel = breadcrumbs.length === 1;
+  const shouldShowViewerAccessLabel = !isInRecycleBin && !canPerformCellsAction(CELLS_ACTION.CREATE);
 
   return (
     <div css={wrapperStyles}>
@@ -104,6 +111,9 @@ export const CellsHeader = ({
                 conversationQualifiedId={conversationQualifiedId}
                 onRefresh={onRefresh}
               />
+            )}
+            {shouldShowViewerAccessLabel && (
+              <CellsViewerAccessLabel label={translate('cells.sharedDriveAccess.viewerAccess')} />
             )}
             <CellsRefresh onRefresh={onRefresh} />
             <CellsMoreMenu conversationQualifiedId={conversationQualifiedId} />

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsViewerAccessLabel/CellsViewerAccessLabel.styles.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsViewerAccessLabel/CellsViewerAccessLabel.styles.ts
@@ -1,0 +1,48 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+
+export const viewerAccessLabelStyles: CSSObject = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '8px',
+  padding: '4px',
+  width: '159px',
+  height: '32px',
+  minHeight: '32px',
+  borderRadius: '12px',
+  backgroundColor: 'var(--Backgrounds-Background, #EDEFF0)',
+  color: 'var(--gray-100, #17181A)',
+  fontSize: 'var(--font-size-small)',
+  lineHeight: 'var(--line-height-sm)',
+  whiteSpace: 'nowrap',
+
+  'body.theme-dark &': {
+    backgroundColor: 'var(--gray-100, #17181A)',
+    color: 'var(--white, #FFFFFF)',
+  },
+
+  svg: {
+    color: 'currentColor',
+    fill: 'currentColor',
+    flexShrink: 0,
+  },
+};

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsViewerAccessLabel/CellsViewerAccessLabel.tsx
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsViewerAccessLabel/CellsViewerAccessLabel.tsx
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ViewerAccessIcon} from '@wireapp/react-ui-kit';
+
+import {viewerAccessLabelStyles} from './CellsViewerAccessLabel.styles';
+
+interface CellsViewerAccessLabelProps {
+  label: string;
+  iconUieName?: string;
+}
+
+export const CellsViewerAccessLabel = ({label, iconUieName}: CellsViewerAccessLabelProps) => (
+  <div css={viewerAccessLabelStyles}>
+    <span data-uie-name={iconUieName} aria-hidden="true">
+      <ViewerAccessIcon width={16} height={16} />
+    </span>
+    {label}
+  </div>
+);

--- a/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsViewerAccessLabel/index.ts
+++ b/apps/webapp/src/script/components/Conversation/ConversationCells/common/CellsViewerAccessLabel/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './CellsViewerAccessLabel';

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.styles.ts
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.styles.ts
@@ -176,31 +176,3 @@ export const editModeButtonStyles: CSSObject = {
     },
   },
 };
-
-export const viewOnlyLabelStyles: CSSObject = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  gap: '8px',
-  padding: '4px',
-  width: '159px',
-  height: '32px',
-  minHeight: '32px',
-  borderRadius: '12px',
-  backgroundColor: 'var(--Backgrounds-Background, #EDEFF0)',
-  color: 'var(--gray-100, #17181A)',
-  fontSize: 'var(--font-size-small)',
-  lineHeight: 'var(--line-height-sm)',
-  whiteSpace: 'nowrap',
-
-  'body.theme-dark &': {
-    backgroundColor: 'var(--gray-100, #17181A)',
-    color: 'var(--white, #FFFFFF)',
-  },
-
-  svg: {
-    color: 'currentColor',
-    fill: 'currentColor',
-    flexShrink: 0,
-  },
-};

--- a/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
+++ b/apps/webapp/src/script/components/FileFullscreenModal/FileHeader/FileHeader.tsx
@@ -30,7 +30,6 @@ import {
   DropdownMenu,
   MoreIcon,
   ShowIcon,
-  ViewerAccessIcon,
 } from '@wireapp/react-ui-kit';
 
 import {ChannelAvatar, GroupAvatar} from 'Components/avatar';
@@ -39,6 +38,7 @@ import {
   CELLS_ACTION,
   useCellsActionPermissions,
 } from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
+import {CellsViewerAccessLabel} from 'Components/Conversation/ConversationCells/common/CellsViewerAccessLabel';
 import {isInRecycleBin} from 'Components/Conversation/ConversationCells/common/recycleBin/recycleBin';
 import {EditIcon} from 'Components/icon';
 import {iconStyles} from 'Components/MessagesList/Message/ContentMessage/asset/MultipartAssets/FileAssetCard/common/FileAssetOptions/FileAssetOptions.styles';
@@ -66,7 +66,6 @@ import {
   downloadButtonStyles,
   actionButtonsStyles,
   editModeButtonStyles,
-  viewOnlyLabelStyles,
 } from './FileHeader.styles';
 
 interface FileHeaderProps {
@@ -190,12 +189,10 @@ export const FileHeader = ({
       )}
       <div css={actionButtonsStyles}>
         {showViewOnlyLabel && (
-          <div css={viewOnlyLabelStyles}>
-            <span data-uie-name="file-header-view-only-icon" aria-hidden="true">
-              <ViewerAccessIcon />
-            </span>
-            {translate('cells.imageFullScreenModal.viewerAccessLabel')}
-          </div>
+          <CellsViewerAccessLabel
+            label={translate('cells.imageFullScreenModal.viewerAccessLabel')}
+            iconUieName="file-header-view-only-icon"
+          />
         )}
         {!showViewOnlyLabel && !isRecycleBin && canPerformCellsAction(CELLS_ACTION.DOWNLOAD) && (
           <Button

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableNameColumn/cellsTableNameColumn.styles.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableNameColumn/cellsTableNameColumn.styles.ts
@@ -71,6 +71,23 @@ export const desktopNameStyles: CSSObject = {
   },
 };
 
+export const fileNameWrapperStyles: CSSObject = {
+  display: 'flex',
+  alignItems: 'center',
+  minWidth: 0,
+  gap: '8px',
+};
+
+export const viewerAccessIconStyles: CSSObject = {
+  color: 'var(--gray-90, #34373D)',
+  fill: 'currentColor',
+  flexShrink: 0,
+
+  'body.theme-dark &': {
+    color: 'var(--white, #FFFFFF)',
+  },
+};
+
 export const mobileNameStyles: CSSObject = {
   [`@media (min-width: ${styleBreakpoint}px)`]: {
     display: 'none',

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableNameColumn/cellsTableNameColumn.test.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableNameColumn/cellsTableNameColumn.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {fireEvent, render} from '@testing-library/react';
+
+import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
+
+import {CELLS_SELF_USER_DRIVE_ROLE} from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
+import {viewerPermissionFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {CellFile, CellNodeType} from 'src/script/types/cellNode';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {CellsTableNameColumn} from './cellsTableNameColumn';
+
+import {FilePreviewProvider} from '../../common/cellsFilePreviewModalContext/cellsFilePreviewModalContext';
+
+const file: CellFile = {
+  id: 'file-id',
+  type: CellNodeType.FILE,
+  url: 'https://example.com/file.pdf',
+  path: '/file.pdf',
+  mimeType: 'application/pdf',
+  name: 'file.pdf',
+  extension: 'pdf',
+  sizeMb: '1 MB',
+  uploadedAtTimestamp: 1700000000000,
+  owner: 'John Doe',
+  conversationName: 'Marketing Team',
+  publicLink: {
+    alreadyShared: false,
+  },
+  tags: [],
+  presignedUrlExpiresAt: null,
+  user: null,
+  selfUserDriveRole: CELLS_SELF_USER_DRIVE_ROLE.VIEWER,
+};
+
+const renderNameColumn = ({
+  isViewerPermissionFeatureEnabled = true,
+  selfUserDriveRole = CELLS_SELF_USER_DRIVE_ROLE.VIEWER,
+}: {
+  isViewerPermissionFeatureEnabled?: boolean;
+  selfUserDriveRole?: CellFile['selfUserDriveRole'];
+} = {}) => {
+  const portalRoot = document.createElement('div');
+  portalRoot.id = 'wire-app';
+  document.body.append(portalRoot);
+
+  const wrapper = createRootProviderWrapperForTest(
+    createRootContextValueForTest({
+      translate: translateForTest,
+      isFeatureToggleEnabled: featureName =>
+        featureName === viewerPermissionFeatureToggleName && isViewerPermissionFeatureEnabled,
+    }),
+  );
+
+  return render(
+    <StyledApp themeId={THEME_ID.DEFAULT}>
+      <FilePreviewProvider>
+        <CellsTableNameColumn node={{...file, selfUserDriveRole}} />
+      </FilePreviewProvider>
+    </StyledApp>,
+    {wrapper},
+  );
+};
+
+describe('CellsTableNameColumn', () => {
+  afterEach(() => {
+    document.getElementById('wire-app')?.remove();
+  });
+
+  it('shows the viewer access icon for viewer-only files', () => {
+    const {container} = renderNameColumn();
+
+    expect(container.querySelector('[data-uie-name="cells-table-viewer-access-icon"]')).toBeInTheDocument();
+  });
+
+  it('does not show the viewer access icon for editor files', () => {
+    const {container} = renderNameColumn({selfUserDriveRole: CELLS_SELF_USER_DRIVE_ROLE.EDITOR});
+
+    expect(container.querySelector('[data-uie-name="cells-table-viewer-access-icon"]')).not.toBeInTheDocument();
+  });
+
+  it('does not show the viewer access icon when the viewer permission feature is disabled', () => {
+    const {container} = renderNameColumn({isViewerPermissionFeatureEnabled: false});
+
+    expect(container.querySelector('[data-uie-name="cells-table-viewer-access-icon"]')).not.toBeInTheDocument();
+  });
+});

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableNameColumn/cellsTableNameColumn.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableNameColumn/cellsTableNameColumn.tsx
@@ -19,19 +19,23 @@
 
 import {isNonEmptyString} from '@sindresorhus/is';
 
-import {FolderIcon, PlayIcon} from '@wireapp/react-ui-kit';
+import {FolderIcon, PlayIcon, Tooltip, ViewerAccessIcon} from '@wireapp/react-ui-kit';
 
 import {openFolder} from 'Components/cellsGlobalView/common/openFolder/openFolder';
+import {useShouldRestrictGlobalDriveNodeActions} from 'Components/cellsGlobalView/common/useShouldRestrictGlobalDriveNodeActions/useShouldRestrictGlobalDriveNodeActions';
 import {FileTypeIcon} from 'Components/Conversation/common/FileTypeIcon/FileTypeIcon';
+import {useApplicationContext} from 'src/script/page/rootProvider';
 import {CellFile, CellNode, CellNodeType} from 'src/script/types/cellNode';
 import {getFileExtension} from 'Util/util';
 
 import {
   desktopNameStyles,
+  fileNameWrapperStyles,
   imagePreviewStyles,
   imagePreviewWrapperStyles,
   mobileNameStyles,
   playIconStyles,
+  viewerAccessIconStyles,
   wrapperStyles,
 } from './cellsTableNameColumn.styles';
 
@@ -56,12 +60,14 @@ export const CellsTableNameColumn = ({node}: CellsTableNameColumnProps) => {
 };
 
 const FileNameColumn = ({file}: {file: CellFile}) => {
+  const {translate} = useApplicationContext();
   const {id, handleOpenFile, selectedFile} = useCellsFilePreviewModal();
 
   const isImage = isNonEmptyString(file.mimeType) && file.mimeType.startsWith('image');
   const isVideo = isNonEmptyString(file.mimeType) && file.mimeType.startsWith('video');
 
   const shouldDisplayImagePreview = (isImage || isVideo) && isNonEmptyString(file.previewImageUrl);
+  const shouldShowViewerAccessIcon = useShouldRestrictGlobalDriveNodeActions(file);
 
   const {previewImageUrl, name} = file;
 
@@ -75,16 +81,30 @@ const FileNameColumn = ({file}: {file: CellFile}) => {
       ) : (
         <FileTypeIcon extension={getFileExtension(name)} size={24} />
       )}
-      <button
-        type="button"
-        css={desktopNameStyles}
-        onClick={() => handleOpenFile(file)}
-        aria-controls={id}
-        aria-expanded={selectedFile !== null}
-        aria-haspopup="dialog"
-      >
-        {name}
-      </button>
+      <div css={fileNameWrapperStyles}>
+        <button
+          type="button"
+          css={desktopNameStyles}
+          onClick={() => handleOpenFile(file)}
+          aria-controls={id}
+          aria-expanded={selectedFile !== null}
+          aria-haspopup="dialog"
+        >
+          {name}
+        </button>
+        {shouldShowViewerAccessIcon && (
+          <Tooltip body={translate('cells.sharedDriveAccess.viewerAccess')}>
+            <ViewerAccessIcon
+              width={14}
+              height={14}
+              css={viewerAccessIconStyles}
+              role="img"
+              aria-label={translate('cells.sharedDriveAccess.viewerAccess')}
+              data-uie-name="cells-table-viewer-access-icon"
+            />
+          </Tooltip>
+        )}
+      </div>
     </>
   );
 };

--- a/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableRowOptions/cellsTableRowOptions.tsx
+++ b/apps/webapp/src/script/components/cellsGlobalView/cellsTable/cellsTableColumns/cellsTableRowOptions/cellsTableRowOptions.tsx
@@ -24,9 +24,8 @@ import {isNonEmptyString} from '@sindresorhus/is';
 import {DropdownMenu, MoreIcon} from '@wireapp/react-ui-kit';
 
 import {openFolder} from 'Components/cellsGlobalView/common/openFolder/openFolder';
-import {shouldRestrictCellsViewerActions} from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
+import {useShouldRestrictGlobalDriveNodeActions} from 'Components/cellsGlobalView/common/useShouldRestrictGlobalDriveNodeActions/useShouldRestrictGlobalDriveNodeActions';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
-import {viewerPermissionFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {CellNode, CellNodeType} from 'src/script/types/cellNode';
 import {forcedDownloadFile} from 'Util/util';
@@ -43,15 +42,12 @@ interface CellsTableRowOptionsProps {
 
 export const CellsTableRowOptions = (properties: CellsTableRowOptionsProps): ReactElement => {
   const {node, cellsRepository} = properties;
-  const {fireAndForgetInvoker, isFeatureToggleEnabled, translate} = useApplicationContext();
+  const {fireAndForgetInvoker, translate} = useApplicationContext();
   const {handleOpenFile} = useCellsFilePreviewModal();
 
   const url = node.url;
   const name = node.type === CellNodeType.FOLDER ? `${node.name}.zip` : node.name;
-  const shouldDisableRestrictedActions = shouldRestrictCellsViewerActions({
-    isViewerPermissionFeatureEnabled: isFeatureToggleEnabled(viewerPermissionFeatureToggleName),
-    selfUserDriveRole: node.selfUserDriveRole,
-  });
+  const shouldDisableRestrictedActions = useShouldRestrictGlobalDriveNodeActions(node);
   // DropdownMenu.Item disabled state is visual/ARIA only for native onClick handlers.
   // Keep restricted actions without a handler so viewer access cannot activate them.
   const restrictedActionClickHandler = <ClickHandler extends () => void>(clickHandler: ClickHandler) =>

--- a/apps/webapp/src/script/components/cellsGlobalView/common/useShouldRestrictGlobalDriveNodeActions/useShouldRestrictGlobalDriveNodeActions.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/common/useShouldRestrictGlobalDriveNodeActions/useShouldRestrictGlobalDriveNodeActions.ts
@@ -1,0 +1,32 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {shouldRestrictCellsViewerActions} from 'Components/Conversation/ConversationCells/common/CellsSelfUserDriveRole/CellsSelfUserDriveRoleContext';
+import {viewerPermissionFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {useApplicationContext} from 'src/script/page/rootProvider';
+import {CellNode} from 'src/script/types/cellNode';
+
+export const useShouldRestrictGlobalDriveNodeActions = (node: CellNode): boolean => {
+  const {isFeatureToggleEnabled} = useApplicationContext();
+
+  return shouldRestrictCellsViewerActions({
+    isViewerPermissionFeatureEnabled: isFeatureToggleEnabled(viewerPermissionFeatureToggleName),
+    selfUserDriveRole: node.selfUserDriveRole,
+  });
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26056" title="WPB-26056" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26056</a>  [Web] add viewer only banner showing viewer permission indicator in shared drive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Problem
A guest browsing the files in the shared drive, not in the conversation, may not know their permissions within that file. If they can open or can view only, it may confuse the users that are trying to edit something 

### Acceptance Criteria
On the list of files show a small indication, with an icon on the title, of the View Access only

The files that are editable should not contain any special icons

Make sure to add the accessible aria label as “Viewer access” in shared drive tab before Refresh icon and inside collabora.

Design should follow as [Drive](https://www.figma.com/design/grnVU2vAihHXwYgHryu2xE/Drive?node-id=19495-38323&m=dev)
