### PR TITLE
fix: skip meeting cancel notification on the host's other clients [WPB-27897]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.test.ts
@@ -334,6 +334,27 @@ describe('createMeetingNotificationEventHandlers', () => {
     ]);
   });
 
+  it('dismisses stale notifications without creating a cancellation when notify is false', () => {
+    const dismissedMeetings: Array<{meetingId: QualifiedId; kinds?: readonly MeetingNotificationKind[]}> = [];
+    const notifications: AddNotificationInput[] = [];
+    const {notifyUpdate, onMeetingCancelled} = createHandlers({notifications, dismissedMeetings});
+
+    notifyUpdate(meetingSeries);
+    onMeetingCancelled(meetingId, {notify: false});
+
+    expect(dismissedMeetings).toEqual([
+      {
+        meetingId,
+        kinds: [MeetingNotificationKind.UPDATE, MeetingNotificationKind.INVITE, MeetingNotificationKind.ONGOING],
+      },
+      {
+        meetingId,
+        kinds: [MeetingNotificationKind.CANCELLED],
+      },
+    ]);
+    expect(notifications).toEqual([]);
+  });
+
   it('creates only one cancellation notification when cancelled twice', () => {
     const notifications: AddNotificationInput[] = [];
     const dismissedMeetings: Array<{meetingId: QualifiedId; kinds?: readonly MeetingNotificationKind[]}> = [];

--- a/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationEventHandlers.ts
@@ -48,10 +48,14 @@ export type MeetingNotificationEventHandlersDependencies = {
   logger: MeetingNotificationLogger;
 };
 
+export type MeetingCancellationOptions = {
+  notify?: boolean;
+};
+
 export type MeetingNotificationEventHandlers = {
   notifyMeetingChange: (meeting: MeetingSeries) => void;
   notifyUpdate: (meeting: MeetingSeries) => void;
-  onMeetingCancelled: (meetingId: QualifiedId) => void;
+  onMeetingCancelled: (meetingId: QualifiedId, options?: MeetingCancellationOptions) => void;
   /** Retries notifications that couldn't be sent because the meeting wasn't in the store yet. */
   retryPendingNotifications: () => void;
 };
@@ -102,7 +106,10 @@ export const createMeetingNotificationEventHandlers = ({
     notifyForMeeting(MeetingNotificationKind.CANCELLED, meeting);
   };
 
-  const notifyMeetingCancellation = (meetingId: QualifiedId): void => {
+  const notifyMeetingCancellation = (
+    meetingId: QualifiedId,
+    {notify = true}: MeetingCancellationOptions = {},
+  ): void => {
     const meetingKey = toMeetingIdKey(meetingId);
 
     notifiedMeetings.delete(meetingKey);
@@ -114,6 +121,13 @@ export const createMeetingNotificationEventHandlers = ({
 
     dismissStaleNotificationsForMeeting(meetingId);
     dismissNotificationsForMeeting(meetingId, [MeetingNotificationKind.CANCELLED]);
+
+    if (!notify) {
+      cancelledMeetings.add(meetingKey);
+      pending.delete(meetingKey);
+      return;
+    }
+
     addCancellationNotificationForMeeting(meetingId);
   };
 
@@ -155,8 +169,8 @@ export const createMeetingNotificationEventHandlers = ({
       notifyForMeeting(kind, meeting);
     },
     notifyUpdate: meeting => notifyForMeeting(MeetingNotificationKind.UPDATE, meeting),
-    onMeetingCancelled: meetingId => {
-      notifyMeetingCancellation(meetingId);
+    onMeetingCancelled: (meetingId, options) => {
+      notifyMeetingCancellation(meetingId, options);
     },
     retryPendingNotifications,
   };

--- a/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.test.tsx
@@ -269,7 +269,7 @@ describe('MeetingStoreRoot', () => {
     });
 
     act(() => {
-      amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
+      amplify.publish(WebAppEvents.MEETING.DELETED, meetingId, otherUserId);
     });
 
     expect(useMeetingNotificationStore.getState().notifications).toEqual([
@@ -283,6 +283,24 @@ describe('MeetingStoreRoot', () => {
     await waitFor(() => {
       expect(getRenderedMeetingTitles()).toBe('');
     });
+  });
+
+  it('does not notify the user who deleted the meeting', async () => {
+    renderMeetingStoreRoot();
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('Weekly sync');
+    });
+
+    act(() => {
+      amplify.publish(WebAppEvents.MEETING.DELETED, meetingId, selfUserId);
+    });
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('');
+    });
+
+    expect(useMeetingNotificationStore.getState().notifications).toEqual([]);
   });
 
   it('does not add an update notification when a queued sync is followed by deletion', async () => {

--- a/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.test.tsx
@@ -303,6 +303,37 @@ describe('MeetingStoreRoot', () => {
     expect(useMeetingNotificationStore.getState().notifications).toEqual([]);
   });
 
+  it('dismisses leftover meeting cards without a cancellation when the current user deleted the meeting', async () => {
+    renderMeetingStoreRoot();
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('Weekly sync');
+    });
+
+    act(() => {
+      amplify.publish(WebAppEvents.MEETING.UPDATED, meetingId, otherUserId);
+    });
+
+    await waitFor(() => {
+      expect(useMeetingNotificationStore.getState().notifications).toEqual([
+        expect.objectContaining({
+          kind: MeetingNotificationKind.UPDATE,
+          qualifiedId: meetingId,
+        }),
+      ]);
+    });
+
+    act(() => {
+      amplify.publish(WebAppEvents.MEETING.DELETED, meetingId, selfUserId);
+    });
+
+    await waitFor(() => {
+      expect(getRenderedMeetingTitles()).toBe('');
+    });
+
+    expect(useMeetingNotificationStore.getState().notifications).toEqual([]);
+  });
+
   it('does not add an update notification when a queued sync is followed by deletion', async () => {
     let resolveMeeting: () => void = () => undefined;
     const meetingFetch = new Promise<void>(resolve => {

--- a/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingStore/meetingStoreRoot.tsx
@@ -19,10 +19,7 @@
 
 import {type ReactNode, useEffect, useMemo} from 'react';
 
-import {amplify} from 'amplify';
 import {container} from 'tsyringe';
-
-import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {createMeetingNotificationEventHandlers} from 'Components/meeting/meetingNotificationEventHandlers';
 import {useMeetingNotificationStore} from 'Components/meeting/meetingNotificationStore/meetingNotificationStore';
@@ -96,8 +93,6 @@ export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
       logger,
     });
 
-    amplify.subscribe(WebAppEvents.MEETING.DELETED, notificationHandlers.onMeetingCancelled);
-
     const getSelfUserQualifiedId = () => container.resolve(UserState).self().qualifiedId;
 
     const unsubscribeFromMeetingLifecycleEvents = subscribeToMeetingLifecycleEvents({
@@ -105,6 +100,7 @@ export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
       getSelfUserQualifiedId,
       notifyMeetingChange: notificationHandlers.notifyMeetingChange,
       notifyUpdate: notificationHandlers.notifyUpdate,
+      onMeetingCancelled: notificationHandlers.onMeetingCancelled,
     });
     const unsubscribeFromMeetingConversationEvents = subscribeToMeetingConversationEvents({
       dispatcher,
@@ -123,7 +119,6 @@ export const MeetingStoreRoot = ({children}: MeetingStoreRootProps) => {
       unsubscribeFromMeetingLifecycleEvents();
       unsubscribeFromMeetingConversationEvents();
       unsubscribeFromMeetingStore();
-      amplify.unsubscribe(WebAppEvents.MEETING.DELETED, notificationHandlers.onMeetingCancelled);
     };
   }, [isMeetingsEnabled, store]);
 

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
@@ -98,7 +98,7 @@ describe('subscribeToMeetingLifecycleEvents', () => {
 
     amplify.publish(WebAppEvents.MEETING.DELETED, meetingId, otherUserId);
 
-    expect(onMeetingCancelled).toHaveBeenCalledWith(meetingId);
+    expect(onMeetingCancelled).toHaveBeenCalledWith(meetingId, {notify: true});
     expect(dispatcher.enqueueMeetingRemoval).toHaveBeenCalledWith(meetingId);
     expect(dispatcher.enqueueMeetingSync).not.toHaveBeenCalled();
   });
@@ -109,7 +109,7 @@ describe('subscribeToMeetingLifecycleEvents', () => {
 
     amplify.publish(WebAppEvents.MEETING.DELETED, meetingId, selfUserId);
 
-    expect(onMeetingCancelled).not.toHaveBeenCalled();
+    expect(onMeetingCancelled).toHaveBeenCalledWith(meetingId, {notify: false});
     expect(dispatcher.enqueueMeetingRemoval).toHaveBeenCalledWith(meetingId);
   });
 

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.test.ts
@@ -45,15 +45,17 @@ describe('subscribeToMeetingLifecycleEvents', () => {
   const subscribe = (dispatcher: MeetingLifecycleDispatcherDouble) => {
     const notifyMeetingChange = jest.fn();
     const notifyUpdate = jest.fn();
+    const onMeetingCancelled = jest.fn();
     const unsubscribe = subscribeToMeetingLifecycleEvents({
       dispatcher,
       getSelfUserQualifiedId: () => selfUserId,
       notifyMeetingChange,
       notifyUpdate,
+      onMeetingCancelled,
     });
     activeUnsubscribeCallbacks.push(unsubscribe);
 
-    return {notifyMeetingChange, notifyUpdate, unsubscribe};
+    return {notifyMeetingChange, notifyUpdate, onMeetingCancelled, unsubscribe};
   };
 
   afterEach(() => {
@@ -92,12 +94,23 @@ describe('subscribeToMeetingLifecycleEvents', () => {
 
   it('queues a meeting removal when a meeting deleted event is published', () => {
     const dispatcher = createDispatcherDouble();
-    subscribe(dispatcher);
+    const {onMeetingCancelled} = subscribe(dispatcher);
 
-    amplify.publish(WebAppEvents.MEETING.DELETED, meetingId);
+    amplify.publish(WebAppEvents.MEETING.DELETED, meetingId, otherUserId);
 
+    expect(onMeetingCancelled).toHaveBeenCalledWith(meetingId);
     expect(dispatcher.enqueueMeetingRemoval).toHaveBeenCalledWith(meetingId);
     expect(dispatcher.enqueueMeetingSync).not.toHaveBeenCalled();
+  });
+
+  it('does not notify cancellation when the current user deleted the meeting', () => {
+    const dispatcher = createDispatcherDouble();
+    const {onMeetingCancelled} = subscribe(dispatcher);
+
+    amplify.publish(WebAppEvents.MEETING.DELETED, meetingId, selfUserId);
+
+    expect(onMeetingCancelled).not.toHaveBeenCalled();
+    expect(dispatcher.enqueueMeetingRemoval).toHaveBeenCalledWith(meetingId);
   });
 
   it('queues a sync without a notification callback for an update authored by the current user', () => {

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
@@ -32,6 +32,7 @@ export type SubscribeToMeetingLifecycleEventsDependencies = {
   getSelfUserQualifiedId: () => QualifiedId;
   notifyMeetingChange: (meeting: MeetingSeries) => void;
   notifyUpdate: (meeting: MeetingSeries) => void;
+  onMeetingCancelled: (meetingId: QualifiedId) => void;
 };
 
 /**
@@ -43,6 +44,7 @@ export const subscribeToMeetingLifecycleEvents = ({
   getSelfUserQualifiedId,
   notifyMeetingChange,
   notifyUpdate,
+  onMeetingCancelled,
 }: SubscribeToMeetingLifecycleEventsDependencies): (() => void) => {
   const onMeetingCreated = (meetingId: QualifiedId) => {
     dispatcher.enqueueMeetingSync(meetingId);
@@ -66,7 +68,11 @@ export const subscribeToMeetingLifecycleEvents = ({
     dispatcher.enqueueMeetingSync(meetingId, notifyMeetingChange);
   };
 
-  const onMeetingDeleted = (meetingId: QualifiedId) => {
+  const onMeetingDeleted = (meetingId: QualifiedId, actorId: QualifiedId) => {
+    if (!matchQualifiedIds(actorId, getSelfUserQualifiedId())) {
+      onMeetingCancelled(meetingId);
+    }
+
     dispatcher.enqueueMeetingRemoval(meetingId);
   };
 

--- a/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
+++ b/apps/webapp/src/script/components/meeting/meetingStore/subscribeToMeetingLifecycleEvents.ts
@@ -22,6 +22,7 @@ import {amplify} from 'amplify';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 
+import type {MeetingCancellationOptions} from 'Components/meeting/meetingNotificationEventHandlers';
 import type {MeetingSeries} from 'Components/meeting/types/meetingSeries';
 import {matchQualifiedIds} from 'Util/qualifiedId';
 
@@ -32,7 +33,7 @@ export type SubscribeToMeetingLifecycleEventsDependencies = {
   getSelfUserQualifiedId: () => QualifiedId;
   notifyMeetingChange: (meeting: MeetingSeries) => void;
   notifyUpdate: (meeting: MeetingSeries) => void;
-  onMeetingCancelled: (meetingId: QualifiedId) => void;
+  onMeetingCancelled: (meetingId: QualifiedId, options?: MeetingCancellationOptions) => void;
 };
 
 /**
@@ -69,9 +70,9 @@ export const subscribeToMeetingLifecycleEvents = ({
   };
 
   const onMeetingDeleted = (meetingId: QualifiedId, actorId: QualifiedId) => {
-    if (!matchQualifiedIds(actorId, getSelfUserQualifiedId())) {
-      onMeetingCancelled(meetingId);
-    }
+    onMeetingCancelled(meetingId, {
+      notify: !matchQualifiedIds(actorId, getSelfUserQualifiedId()),
+    });
 
     dispatcher.enqueueMeetingRemoval(meetingId);
   };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27897" title="WPB-27897" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27897</a>  [Web] Support conversation.delete-meeting events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- When a host deletes a meeting for everyone, their other logged-in browsers no longer show the `Canceled:` meeting notification.
- The meeting is still removed from those clients. Other participants still get the cancellation.
- This matches the product agreement on [WPB-27897](https://wearezeta.atlassian.net/browse/WPB-27897?focusedCommentId=170510): the user who caused the action should not be notified.

## Test plan
- [x] Host is logged into two browsers. Delete the meeting for everyone on browser A.
- [x] Browser B: the meeting disappears and there is no `Canceled:` notification.
- [x] Invitee (one or more clients): still sees `Canceled: <title>` and the meeting is removed.
- [x] Host delete-for-me on another session still does not show a cancel notification (existing self-leave skip).

[WPB-27897]: https://wearezeta.atlassian.net/browse/WPB-27897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ