### PR TITLE
fix: keep Settings tabs from snapping back to Account [WPB-27977]

### DIFF
--- a/apps/webapp/src/script/components/appContainer/appContainer.tsx
+++ b/apps/webapp/src/script/components/appContainer/appContainer.tsx
@@ -98,7 +98,10 @@ export const AppContainer = (properties: AppProps) => {
 
   // Publishing application on the global scope for debug and testing purposes.
   window.wire.app = app;
-  const mainView = useMemo(() => new MainViewModel(app.repository, translate), [app.repository, translate]);
+  const mainView = useMemo(
+    () => new MainViewModel(app.repository, translate, fireAndForgetInvoker),
+    [app.repository, fireAndForgetInvoker, translate],
+  );
   useTheme(() => app.repository.properties.getPreference(PROPERTIES_TYPE.INTERFACE.THEME));
   useAccentColor();
   const themePreference = useUserPropertyValue(

--- a/apps/webapp/src/script/view_model/ListViewModel.test.ts
+++ b/apps/webapp/src/script/view_model/ListViewModel.test.ts
@@ -19,17 +19,22 @@
 import {ListViewModel} from './ListViewModel';
 
 import {SidebarTabs, useSidebarStore} from '../page/leftSidebar/panels/conversations/useSidebarStore';
+import {createExecutingFireAndForgetInvokerForTest} from '../page/testSupport/rootContextTestSupport';
 import {ContentState, ListState, useAppState} from '../page/useAppState';
 import * as Router from '../router/Router';
 import {translateForTest} from 'Util/test/translateForTest';
 
 const createListViewModel = () => {
+  const switchContent = jest.fn((contentState: ContentState) => {
+    useAppState.setState({contentState});
+  });
+
   const mainViewModel = {
     actions: {},
     calling: {},
     content: {
       loadPreviousContent: jest.fn(),
-      switchContent: jest.fn(),
+      switchContent,
     },
     isFederated: false,
   } as unknown as ConstructorParameters<typeof ListViewModel>[0];
@@ -42,10 +47,11 @@ const createListViewModel = () => {
     search: {},
     team: teamRepository,
   } as unknown as ConstructorParameters<typeof ListViewModel>[1];
+  const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
 
-  const listViewModel = new ListViewModel(mainViewModel, repositories, translateForTest);
+  const listViewModel = new ListViewModel(mainViewModel, repositories, translateForTest, fireAndForgetInvoker);
   (listViewModel as unknown as {isActivatedAccount: () => boolean}).isActivatedAccount = () => true;
-  return {listViewModel, teamRepository};
+  return {fireAndForgetInvoker, listViewModel, teamRepository};
 };
 
 describe('ListViewModel', () => {
@@ -161,17 +167,36 @@ describe('ListViewModel', () => {
     expect(setHistoryParam).not.toHaveBeenCalled();
   });
 
-  it('refreshes the team before reopening the active account preference', async () => {
-    const {listViewModel, teamRepository} = createListViewModel();
+  it('refreshes the team when opening the account preference', async () => {
+    const {fireAndForgetInvoker, listViewModel, teamRepository} = createListViewModel();
     const setHistoryParam = jest.spyOn(Router, 'setHistoryParam');
     const switchContent = jest.spyOn(listViewModel.contentViewModel, 'switchContent');
 
     useAppState.setState({listState: ListState.PREFERENCES, contentState: ContentState.PREFERENCES_ACCOUNT});
 
-    await listViewModel.openPreferencesAccount();
+    listViewModel.openPreferencesAccount();
+    await fireAndForgetInvoker.waitUntilAllSettled();
 
     expect(teamRepository.getTeam).toHaveBeenCalledTimes(1);
     expect(setHistoryParam).not.toHaveBeenCalled();
     expect(switchContent).not.toHaveBeenCalled();
+  });
+
+  it('does not switch back to Account if another preference is opened while getTeam is in flight', async () => {
+    const {fireAndForgetInvoker, listViewModel, teamRepository} = createListViewModel();
+    let resolveGetTeam: (value?: unknown) => void = () => undefined;
+    const getTeamPromise = new Promise(resolve => {
+      resolveGetTeam = resolve;
+    });
+    teamRepository.getTeam.mockReturnValue(getTeamPromise);
+
+    listViewModel.openPreferencesAccount();
+    listViewModel.openPreferences(ContentState.PREFERENCES_DEVICES);
+
+    resolveGetTeam();
+    await fireAndForgetInvoker.waitUntilAllSettled();
+
+    expect(useAppState.getState().contentState).toBe(ContentState.PREFERENCES_DEVICES);
+    expect(listViewModel.contentViewModel.switchContent).toHaveBeenLastCalledWith(ContentState.PREFERENCES_DEVICES);
   });
 });

--- a/apps/webapp/src/script/view_model/ListViewModel.ts
+++ b/apps/webapp/src/script/view_model/ListViewModel.ts
@@ -22,6 +22,7 @@ import ko from 'knockout';
 import {container} from 'tsyringe';
 
 import {Runtime} from '@wireapp/commons';
+import type {FireAndForgetInvoker} from '@wireapp/core';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {PrimaryModal, usePrimaryModalState} from 'Components/Modals/PrimaryModal';
@@ -89,6 +90,7 @@ export class ListViewModel {
     mainViewModel: MainViewModel,
     repositories: ViewModelRepositories,
     private readonly translate: Translate,
+    private readonly fireAndForgetInvoker: FireAndForgetInvoker,
   ) {
     this.userState = container.resolve(UserState);
     this.teamState = container.resolve(TeamState);
@@ -265,9 +267,8 @@ export class ListViewModel {
     this.switchList(listState);
   };
 
-  openPreferencesAccount = async (): Promise<void> => {
-    await this.teamRepository.getTeam();
-
+  openPreferencesAccount = (): void => {
+    this.fireAndForgetInvoker.fireAndForget(() => this.teamRepository.getTeam());
     this.openPreferences(ContentState.PREFERENCES_ACCOUNT);
   };
 

--- a/apps/webapp/src/script/view_model/MainViewModel.ts
+++ b/apps/webapp/src/script/view_model/MainViewModel.ts
@@ -19,6 +19,8 @@
 
 import {container} from 'tsyringe';
 
+import type {FireAndForgetInvoker} from '@wireapp/core';
+
 import type {AssetRepository} from 'Repositories/assets/assetRepository';
 import type {AudioRepository} from 'Repositories/audio/audioRepository';
 import type {BackupRepository} from 'Repositories/backup/backupRepository';
@@ -106,7 +108,7 @@ export class MainViewModel {
     return this.core.backendFeatures.isFederated;
   }
 
-  constructor(repositories: ViewModelRepositories, translate: Translate) {
+  constructor(repositories: ViewModelRepositories, translate: Translate, fireAndForgetInvoker: FireAndForgetInvoker) {
     this.translate = translate;
     const userState = container.resolve(UserState);
     const teamState = container.resolve(TeamState);
@@ -137,6 +139,6 @@ export class MainViewModel {
       this.translate,
     );
     this.content = new ContentViewModel(this, repositories, this.translate);
-    this.list = new ListViewModel(this, repositories, this.translate);
+    this.list = new ListViewModel(this, repositories, this.translate, fireAndForgetInvoker);
   }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27977" title="WPB-27977" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27977</a>  User is redirected to All Conversations after refreshing the Wire Meetings page
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Opening Account no longer waits on `getTeam()` before switching the Settings panel.
- A later Devices / Options / Audio Video click is not overwritten when the team refresh finishes.
- Team refresh still runs in the background via `fireAndForgetInvoker`.

This is a regression from URL-based Settings navigation in #22271. E2E clicks Settings tabs immediately after open, so the in-flight Account `getTeam()` was snapping the panel back to Account.

## Test plan
- [x] `yarn nx run webapp:test --testFile=src/script/view_model/ListViewModel.test.ts`
- [x] Playwright against local webapp: TC-1718, TC-1720, TC-713, TC-718, TC-723, TC-2908, TC-2909, TC-8755, TC-8637, TC-8754
- [ ] Open Settings, immediately click Devices / Options / Audio Video. The chosen tab should stay selected.
- [ ] Deep link or refresh on `/preferences/account` still opens Account and refreshes team data.