### PR TITLE
Prevent contact avatars from flickering on rerender [WPB-22441]

### DIFF
--- a/apps/webapp/src/script/components/userList/components/userListItem/userListItem.test.tsx
+++ b/apps/webapp/src/script/components/userList/components/userListItem/userListItem.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render} from '@testing-library/react';
+import {noop} from 'noop-esm';
+
+import {User} from 'Repositories/entity/User';
+import {translateForTest} from 'Util/test/translateForTest';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+
+import {UserlistMode} from '../../userList';
+
+import {UserListItem, type UserListItemProps} from './userListItem';
+
+const rootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate: translateForTest}),
+);
+
+describe('UserListItem', () => {
+  it('keeps the avatar node when an unrelated prop changes', () => {
+    const user = new User('user-id', 'example.com', translateForTest);
+    user.name('Alice Example');
+
+    const properties: UserListItemProps = {
+      canSelect: false,
+      external: false,
+      isHighlighted: false,
+      isSelected: false,
+      isSelfVerified: false,
+      mode: UserlistMode.COMPACT,
+      noInteraction: false,
+      noUnderline: false,
+      onClick: noop,
+      onKeyDown: noop,
+      showArrow: false,
+      user,
+    };
+
+    const {container, rerender} = render(
+      <UserListItem
+        canSelect={properties.canSelect}
+        external={properties.external}
+        isHighlighted={properties.isHighlighted}
+        isSelected={properties.isSelected}
+        isSelfVerified={properties.isSelfVerified}
+        mode={properties.mode}
+        noInteraction={properties.noInteraction}
+        noUnderline={properties.noUnderline}
+        onClick={properties.onClick}
+        onKeyDown={properties.onKeyDown}
+        showArrow={properties.showArrow}
+        user={properties.user}
+      />,
+      {wrapper: rootProviderWrapper},
+    );
+    const initialAvatar = container.querySelector('[data-uie-name="element-avatar-user"]');
+
+    rerender(
+      <UserListItem
+        canSelect={properties.canSelect}
+        external={properties.external}
+        isHighlighted={true}
+        isSelected={properties.isSelected}
+        isSelfVerified={properties.isSelfVerified}
+        mode={properties.mode}
+        noInteraction={properties.noInteraction}
+        noUnderline={properties.noUnderline}
+        onClick={properties.onClick}
+        onKeyDown={properties.onKeyDown}
+        showArrow={properties.showArrow}
+        user={properties.user}
+      />,
+    );
+
+    const rerenderedAvatar = container.querySelector('[data-uie-name="element-avatar-user"]');
+    expect(rerenderedAvatar).toBe(initialAvatar);
+  });
+});

--- a/apps/webapp/src/script/components/userList/components/userListItem/userListItem.tsx
+++ b/apps/webapp/src/script/components/userList/components/userListItem/userListItem.tsx
@@ -32,7 +32,7 @@ import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {capitalizeFirstChar} from 'Util/stringUtil';
 
-interface UserListItemProps {
+export interface UserListItemProps {
   groupId?: string;
   canSelect: boolean;
   customInfo?: string;
@@ -102,29 +102,27 @@ export const UserListItem = ({
 
   const contentInfoText = getContentInfoText();
 
-  const RenderParticipant = () => {
-    return (
-      <div css={listItem(noInteraction)} data-uie-name="item-user" data-uie-value={userName}>
-        <Avatar avatarSize={AVATAR_SIZE.SMALL} participant={user} aria-hidden="true" css={{margin: '0 16px'}} />
+  const participantContent = (
+    <div css={listItem(noInteraction)} data-uie-name="item-user" data-uie-value={userName}>
+      <Avatar avatarSize={AVATAR_SIZE.SMALL} participant={user} aria-hidden="true" css={{margin: '0 16px'}} />
 
-        <ParticipantItemContent
-          groupId={groupId}
-          participant={user}
-          shortDescription={contentInfoText}
-          {...(isSelf && {selfString})}
-          hasUsernameInfo={hasUsernameInfo}
-        />
+      <ParticipantItemContent
+        groupId={groupId}
+        participant={user}
+        shortDescription={contentInfoText}
+        {...(isSelf && {selfString})}
+        hasUsernameInfo={hasUsernameInfo}
+      />
 
-        <UserStatusBadges
-          config={{
-            guest: !isOthersMode && isDirectGuest && !isFederated,
-            federated: isFederated,
-            external,
-          }}
-        />
-      </div>
-    );
-  };
+      <UserStatusBadges
+        config={{
+          guest: !isOthersMode && isDirectGuest && !isFederated,
+          federated: isFederated,
+          external,
+        }}
+      />
+    </div>
+  );
 
   const dataUieValues = {
     'data-uie-name': 'highlighted',
@@ -147,9 +145,7 @@ export const UserListItem = ({
             outlineOffset="0"
           >
             <CheckboxLabel htmlFor={checkboxId}>
-              <div {...dataUieValues}>
-                <RenderParticipant />
-              </div>
+              <div {...dataUieValues}>{participantContent}</div>
             </CheckboxLabel>
           </Checkbox>
         </div>
@@ -165,7 +161,7 @@ export const UserListItem = ({
           })}
           {...dataUieValues}
         >
-          <RenderParticipant />
+          {participantContent}
         </div>
       )}
     </>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22441" title="WPB-22441" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22441</a>  [Web] Avatar flickers / switches continuously between initials and image
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Fix avatar flickering in the Add Contact view where profile pictures repeatedly switched between the user's initials and the loaded image while typing in the conversation input.

The issue was caused by `UserListItem` defining the participant renderer as a nested React component. Because that component function was recreated on every `UserListItem` render, React treated it as a new component type and remounted the participant subtree.

This also remounted `AvatarImage`, whose image URL is local state initialized as empty. Until the cached object URL was resolved again, the initials underneath became visible, producing the flicker.

The fix removes the unstable nested component boundary so the avatar subtree keeps its identity across normal parent rerenders.