### PR TITLE
Fix: Don't add member-update event senders to conversation [WPB-28205]

### DIFF
--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
@@ -1822,6 +1822,43 @@ describe('ConversationRepository', () => {
       });
     });
 
+    it.each([
+      {type: CONVERSATION_EVENT.MEMBER_UPDATE, from: messageSenderId},
+      // system-initiated member-updates (e.g. adminless-group autopromotion) carry no `from`
+      {type: CONVERSATION_EVENT.SYSTEM_MEMBER_UPDATE, from: undefined},
+    ])('does not add the sender of a $type event as a participant even when unknown (WPB-28205)', ({type, from}) => {
+      const selfUser = generateUser();
+      const conversationEntity = _generateConversation();
+      const event = {
+        conversation: conversationEntity.id,
+        data: {
+          conversation_role: 'wire_admin',
+          target: selfUser.id,
+          qualified_target: selfUser.qualifiedId,
+        },
+        ...(from && {from}),
+        id: createUuid(),
+        time: '2017-09-06T09:43:36.528Z',
+        type,
+      };
+
+      jest.spyOn(testFactory.user_repository, 'getUserById').mockResolvedValue(new User('', '', translateForTest));
+      spyOn(testFactory.conversation_repository, 'addMissingMember').and.returnValue(
+        Promise.resolve(conversationEntity),
+      );
+      spyOn(testFactory.conversation_repository, 'getConversationById').and.returnValue(
+        Promise.resolve(conversationEntity),
+      );
+      spyOn(testFactory.conversation_repository['userState'], 'self').and.returnValue(selfUser);
+
+      return testFactory.conversation_repository['handleConversationEvent'](event as any).then(() => {
+        expect(testFactory.conversation_repository.addMissingMember).not.toHaveBeenCalled();
+        expect(
+          conversationEntity.participating_user_ids().some(participant => participant.id === messageSenderId),
+        ).toBe(false);
+      });
+    });
+
     describe('conversation.mls-welcome', () => {
       it('should initialise mls 1:1 conversation after receiving a welcome', async () => {
         const conversationRepository = testFactory.conversation_repository!;

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -3746,6 +3746,18 @@ export class ConversationRepository {
               // we ignore leave/join events that are sent by the user actually leaving or joining
               return conversationEntity;
             }
+            break;
+
+          // member-update events can be sent by the team owner or system
+          // without being part of the conversation. This happens e.g. for the
+          // "adminless group prevention" feature when a user gets
+          // auto-promoted to group admin.
+          case CONVERSATION_EVENT.MEMBER_UPDATE:
+          case CONVERSATION_EVENT.SYSTEM_MEMBER_UPDATE:
+            this.logger.info(
+              `Skipping auto-join for unknown sender '${senderId}' of '${eventJson.type}' event in '${conversationEntity.id}'`,
+            );
+            return conversationEntity;
         }
 
         const message = `Received '${type}' event from user '${senderId}' unknown in '${conversationEntity.id}'`;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28205" title="WPB-28205" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28205</a>  [Backend] Team owner automatically joins the group when all team members leave the group, and PU is available
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
These events can e.g. be emitted by the backend in the context of the "adminless groups prevention" feature. The sender can be a team admin or the system itself. This doesn't imply they should be added to the conversation; it just describes who triggered this event.

Before this change, the webapp ended up displaying a ghost user in the conversation. Ghost, because it couldn't be deleted and its presence wasn't rooted in the backend's state.

This commit fixes https://wearezeta.atlassian.net/browse/WPB-28205 (and - hopefully, not tested yet - [WPB-28209](https://wearezeta.atlassian.net/browse/WPB-28209)).




[WPB-28209]: https://wearezeta.atlassian.net/browse/WPB-28209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ