### PR TITLE
fix: keep Join now in the overflow menu for completed meetings [WPB-28276]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.test.tsx
@@ -97,8 +97,8 @@ describe('getMeetingActionEntries', () => {
     expect(getEntryLabels(entries)).not.toContain('meetings.action.startMeeting');
   });
 
-  it.each([futureNowMilliseconds, ongoingNowMilliseconds])(
-    'includes Join now for upcoming and ongoing meetings',
+  it.each([futureNowMilliseconds, ongoingNowMilliseconds, pastNowMilliseconds])(
+    'includes Join now for upcoming, ongoing, and completed meetings',
     nowMilliseconds => {
       const onJoin = jest.fn();
       const entries = getMeetingActionEntries({
@@ -115,6 +115,7 @@ describe('getMeetingActionEntries', () => {
 
       const joinEntry = getJoinEntry(entries);
       expect(joinEntry).toBeDefined();
+      expect(joinEntry?.isDisabled).toBe(false);
       joinEntry?.click?.();
       expect(onJoin).toHaveBeenCalledTimes(1);
     },
@@ -281,7 +282,7 @@ describe('getMeetingActionEntries', () => {
 
     expect(getDeleteForAllEntryLabel(entries)).toBeDefined();
     expect(getDeleteForMeEntryLabel(entries)).toBeUndefined();
-    expect(getJoinEntry(entries)).toBeUndefined();
+    expect(getJoinEntry(entries)).toBeDefined();
   });
 
   it('includes Delete meeting for me for a participant when the instance is in the past', () => {
@@ -298,7 +299,7 @@ describe('getMeetingActionEntries', () => {
 
     expect(getDeleteForMeEntryLabel(entries)).toBeDefined();
     expect(getDeleteForAllEntryLabel(entries)).toBeUndefined();
-    expect(getJoinEntry(entries)).toBeUndefined();
+    expect(getJoinEntry(entries)).toBeDefined();
   });
 
   it('keeps Join now visible but disables it while joining or in a call', () => {

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingAction/getMeetingActionEntries.tsx
@@ -28,7 +28,6 @@ import {MEETING_ACTION_TRANSLATION_KEYS} from 'Components/meeting/meetingList/me
 import type {MeetingInstance} from 'Components/meeting/types/meetingInstance';
 import {canDeleteMeetingForAll, canDeleteMeetingForMe} from 'Components/meeting/utils/canDeleteMeeting';
 import {canEditMeeting} from 'Components/meeting/utils/canEditMeeting';
-import {getMeetingTemporalStatusAt, MeetingTemporalStatuses} from 'Components/meeting/utils/meetingStatusUtil';
 import type {User} from 'Repositories/entity/User';
 import type {ContextMenuEntry} from 'src/script/ui/contextMenu';
 import type {Translate} from 'Util/localizerUtil';
@@ -85,15 +84,9 @@ export const getMeetingActionEntries = ({
 
   const showDeleteForAll = canDeleteMeetingForAll(meetingInstance, selfUser);
   const showDeleteForMe = canDeleteMeetingForMe(meetingInstance, selfUser);
-  const temporalStatus = getMeetingTemporalStatusAt(
-    new Date(nowMilliseconds),
-    meetingInstance.start,
-    meetingInstance.end,
-  );
-  const showJoin = temporalStatus !== MeetingTemporalStatuses.PAST;
 
   return [
-    ...(showJoin ? [joinEntry] : []),
+    joinEntry,
     ...(canEditMeeting(meetingInstance, selfUser, nowMilliseconds) ? [editEntry] : []),
     ...(showDeleteForAll ? [deleteForAllEntry] : []),
     ...(showDeleteForMe ? [deleteForMeEntry] : []),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28276" title="WPB-28276" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28276</a>  [Web] Join now option is not available for completed meetings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary
- Keep **Join now** in the meeting overflow menu for completed meetings, not only upcoming and ongoing ones.
- Product requires Join now for every meeting entry regardless of scheduled time ([WPB-28276](https://wearezeta.atlassian.net/browse/WPB-28276)). The previous `PAST` temporal gate hid it, leaving hosts with only Delete.
- Edit and delete eligibility are unchanged: Edit stays hidden after the instance end time.

## Test plan
- [x] Open Meetings and find a host meeting whose end time has passed (still listed under Today).
- [x] Open the three-dot menu: **Join now** and **Delete meeting for everyone** are both present; Edit is not.
- [x] Select Join now: the call starts and the row shows Attending.
- [x] Open the menu on an upcoming meeting: Join now, Edit (host), and Delete are still present.
- [x] While already in a call, Join now remains visible but disabled.

[WPB-28276]: https://wearezeta.atlassian.net/browse/WPB-28276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ