### PR TITLE
feat: add shared drive direct upload startup toggle [WPB-28285]

### DIFF
--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -21,12 +21,14 @@ export const applockRefactoredFeatureToggleName = 'applock-refactored';
 export const conversationListCollapseFeatureToggleName = 'conversation-list-collapse';
 export const viewerPermissionFeatureToggleName = 'viewer-permission';
 export const disableMessagePreprocessingFeatureToggleName = 'disable-message-preprocessing';
+export const sharedDriveDirectUploadFeatureToggleName = 'shared-drive-direct-upload';
 
 export const startupFeatureToggleNames = [
   applockRefactoredFeatureToggleName,
   conversationListCollapseFeatureToggleName,
   viewerPermissionFeatureToggleName,
   disableMessagePreprocessingFeatureToggleName,
+  sharedDriveDirectUploadFeatureToggleName,
 ] as const;
 
 export type StartupFeatureToggleName = (typeof startupFeatureToggleNames)[number];

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -26,6 +26,7 @@ import {
   applockRefactoredFeatureToggleName,
   conversationListCollapseFeatureToggleName,
   disableMessagePreprocessingFeatureToggleName,
+  sharedDriveDirectUploadFeatureToggleName,
   startupFeatureToggleNames,
   viewerPermissionFeatureToggleName,
 } from './startupFeatureToggleNames';
@@ -35,6 +36,7 @@ const featureToggleNamesWithDedicatedExistenceTests = [
   conversationListCollapseFeatureToggleName,
   viewerPermissionFeatureToggleName,
   disableMessagePreprocessingFeatureToggleName,
+  sharedDriveDirectUploadFeatureToggleName,
 ] as const;
 
 describe('startupFeatureToggles', function () {
@@ -119,6 +121,14 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.isFeatureToggleEnabled(disableMessagePreprocessingFeatureToggleName)).toBe(true);
   });
 
+  it('enables the shared drive direct upload feature toggle when present in the query parameter', () => {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${sharedDriveDirectUploadFeatureToggleName}`,
+    );
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(sharedDriveDirectUploadFeatureToggleName)).toBe(true);
+  });
+
   it('trims whitespace around feature toggle names', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}= ${applockRefactoredFeatureToggleName} `,
@@ -161,6 +171,7 @@ describe('startupFeatureToggles', function () {
       conversationListCollapseFeatureToggleName,
       viewerPermissionFeatureToggleName,
       disableMessagePreprocessingFeatureToggleName,
+      sharedDriveDirectUploadFeatureToggleName,
     ]);
   });
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28285" title="WPB-28285" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28285</a>  [web] add Feature flag: shared-drive-direct-upload 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem
The Shared Drive direct-upload rollout needs an independent client-side gate, but `shared-drive-direct-upload` was not registered as a typed startup feature toggle.

## Solution
Added `shared-drive-direct-upload` to the typed, allow-listed startup toggles so it can be enabled through the existing query-parameter mechanism without changing existing editor/viewer permissions.

ref: https://wearezeta.atlassian.net/browse/WPB-28285