### PR TITLE
fix: allow the text column to shrink, make the admin hint wrap within available width and keep the switch from shrinking(WPB-26115)

### DIFF
--- a/apps/webapp/src/script/components/toggle/InfoToggle.tsx
+++ b/apps/webapp/src/script/components/toggle/InfoToggle.tsx
@@ -51,7 +51,7 @@ const InfoToggle = ({
   return (
     <div data-uie-name={dataUieName} className={cx('info-toggle', className)}>
       <div className="info-toggle__row">
-        <div>
+        <div className="info-toggle__content">
           <label htmlFor={inputId} className="heading-h3">
             {name}
           </label>

--- a/apps/webapp/src/style/components/info-toggle.less
+++ b/apps/webapp/src/style/components/info-toggle.less
@@ -44,7 +44,7 @@
 
   .info-toggle__content {
     min-width: 0;
-    flex: 1; 
+    flex: 1;
   }
 
   .info-toggle__details {

--- a/apps/webapp/src/style/components/info-toggle.less
+++ b/apps/webapp/src/style/components/info-toggle.less
@@ -42,6 +42,11 @@
     line-height: var(--line-height-lg);
   }
 
+  .info-toggle__content {
+    min-width: 0;
+    flex: 1; 
+  }
+
   .info-toggle__details {
     margin-top: 2px;
     margin-bottom: 0;
@@ -51,7 +56,7 @@
 
   .info-toggle__admin-hint {
     display: flex;
-    width: 364px;
+    width: 100%;
     max-width: 100%;
     align-items: flex-start;
     padding: calc(var(--line-height-sm) / 2) 0;
@@ -61,6 +66,11 @@
     gap: calc(var(--line-height-sm) / 2);
     letter-spacing: 0.25px;
     line-height: var(--line-height-small-plus);
+    overflow-wrap: break-word;
+
+    span:last-child {
+      min-width: 0;
+    }
 
     .info-toggle__admin-hint-icon {
       display: flex;
@@ -83,6 +93,10 @@
   .slider.disabled {
     opacity: 0.4;
     pointer-events: none;
+  }
+
+  .slider {
+    flex-shrink: 0;
   }
 
   .modal-style & {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26115" title="WPB-26115" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26115</a>  [Web] Show admin hint that invited guests are read-only from all entry points of group/channel creation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
remove horizontal scrollbar from the info toggle
<img width="1512" height="982" alt="Screenshot 2026-08-27 at 10 37 07" src="https://github.com/user-attachments/assets/55406eab-9077-4a00-9628-c2db79ec8ba3" />
<img width="579" height="723" alt="Screenshot 2026-08-27 at 11 38 19" src="https://github.com/user-attachments/assets/d5720f32-4b06-4e47-9706-b36063db9fdb" />
