### PR TITLE
fix: fullscreen modal profile name(WPB-20724)

### DIFF
--- a/apps/webapp/src/script/components/cells/common/transformCellsNodes/transformCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/cells/common/transformCellsNodes/transformCellsNodes.test.ts
@@ -21,6 +21,8 @@ import {RestNode} from 'cells-sdk-ts';
 
 import {CELLS_SELF_USER_DRIVE_ROLE} from 'Components/conversation/conversationCells/common/cellsSelfUserDriveRole/cellsSelfUserDriveRoleContext';
 import {Conversation} from 'Repositories/entity/Conversation';
+import {User} from 'Repositories/entity/User';
+import {translateForTest} from 'Util/test/translateForTest';
 
 import {transformCellsNodes} from './transformCellsNodes';
 
@@ -72,6 +74,22 @@ describe('transformCellsNodes', () => {
     const [node] = transformCellsNodes({nodes: [createStubNode()], users: [], conversations: [conversation]});
 
     expect(node.conversation).toBe(conversation);
+  });
+
+  it('uses the resolved user profile name as owner when the node has owner metadata', () => {
+    const user = new User('owner-id', 'example.com', translateForTest);
+    user.name('Arjita Team web');
+    user.username('arjitateamweb');
+    const nodeWithOwner = createStubNode({
+      UserMetadata: [
+        {Namespace: 'usermeta-owner', JsonValue: JSON.stringify('arjitateamweb')},
+        {Namespace: 'usermeta-owner-uuid', JsonValue: JSON.stringify('owner-id@example.com')},
+      ],
+    });
+
+    const [node] = transformCellsNodes({nodes: [nodeWithOwner], users: [user]});
+
+    expect(node.owner).toBe('Arjita Team web');
   });
 
   it('marks a node as editor when the conversation and self user belong to the same team', () => {

--- a/apps/webapp/src/script/components/cells/common/transformCellsNodes/transformCellsNodes.ts
+++ b/apps/webapp/src/script/components/cells/common/transformCellsNodes/transformCellsNodes.ts
@@ -25,6 +25,7 @@ import {getSelfUserDriveRole} from 'Components/conversation/conversationCells/co
 import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {CellNode, CellNodeType} from 'src/script/types/cellNode';
+import {matchQualifiedIds} from 'Util/qualifiedId';
 import {TIME_IN_MILLIS} from 'Util/timeUtil';
 import {formatBytes, getFileExtension, getName} from 'Util/util';
 
@@ -43,7 +44,6 @@ export const transformCellsNodes = ({
 }): CellNode[] => {
   return nodes.map(node => {
     const id = node.Uuid;
-    const owner = getOwner(node);
     const name = getName(node.Path);
     const sizeMb = getFileSize(node);
     const uploadedAtTimestamp = getUploadedAtTimestamp(node);
@@ -69,7 +69,8 @@ export const transformCellsNodes = ({
     });
 
     const userQualifiedId = getUserQualifiedIdFromNode(node);
-    const user = users.find(user => user.qualifiedId.id === userQualifiedId?.id) ?? null;
+    const user = users.find(user => matchQualifiedIds(user.qualifiedId, userQualifiedId ?? undefined)) ?? null;
+    const owner = user?.name() || getOwner(node);
 
     if (node.Type === 'COLLECTION') {
       return {

--- a/apps/webapp/src/script/components/cells/common/transformCellsNodes/transformCellsNodes.ts
+++ b/apps/webapp/src/script/components/cells/common/transformCellsNodes/transformCellsNodes.ts
@@ -20,6 +20,7 @@
 import {isNonEmptyString, isNullOrUndefined} from '@sindresorhus/is';
 import {parseQualifiedId} from '@wireapp/core/lib/util/qualifiedIdUtil';
 import {RestNode} from 'cells-sdk-ts';
+import {Maybe} from 'true-myth';
 
 import {getSelfUserDriveRole} from 'Components/conversation/conversationCells/common/cellsSelfUserDriveRole/cellsSelfUserDriveRoleContext';
 import {Conversation} from 'Repositories/entity/Conversation';
@@ -68,8 +69,11 @@ export const transformCellsNodes = ({
       selfUserTeamId,
     });
 
-    const userQualifiedId = getUserQualifiedIdFromNode(node);
-    const user = users.find(user => matchQualifiedIds(user.qualifiedId, userQualifiedId ?? undefined)) ?? null;
+    const userQualifiedId = Maybe.of(getUserQualifiedIdFromNode(node));
+    const matchingUser = userQualifiedId.andThen(userQualifiedId =>
+      Maybe.of(users.find(user => matchQualifiedIds(user.qualifiedId, userQualifiedId))),
+    );
+    const user = matchingUser.unwrapOr(null);
     const owner = user?.name() || getOwner(node);
 
     if (node.Type === 'COLLECTION') {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20724" title="WPB-20724" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20724</a>  [Web] Improve header of the full screen file view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Inside fulscreenmodal users user name was coming instead of profile name when user open a file from cells file list

### BEFORE
<img width="671" height="83" alt="Wire 2026-08-27 at 9_10 AM (1)" src="https://github.com/user-attachments/assets/84c9fbb5-2c6a-4ff5-8936-08c11a9e0997" />
<img width="551" height="175" alt="Wire 2026-08-27 at 10_11 AM" src="https://github.com/user-attachments/assets/8dc5d037-08f3-4e5e-9a9c-0f90369f4679" />

### AFTER
<img width="1510" height="76" alt="Wire 2026-08-27 at 9_10 AM" src="https://github.com/user-attachments/assets/5a60ff3b-8fdc-4368-ba00-06966f556d25" />
