### PR TITLE
Prevent duplicate scrollbars in conversation search [WPB-28380]

### DIFF
--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationsList.test.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationsList.test.tsx
@@ -117,4 +117,53 @@ describe('ConversationsList', () => {
 
     await Promise.all(userNames.map(async userName => expect(await findByText(userName)).toBeDefined()));
   });
+
+  it('keeps group participant results inside the conversation results scroll container', async () => {
+    const conversationNameResult = create1to1Conversation('Conversation name match');
+    const participantNameResult = create1to1Conversation('Participant name match');
+
+    const {container, findByText} = render(
+      <ConversationsList
+        conversationLabelRepository={conversationLabelRepository}
+        conversations={[conversationNameResult]}
+        conversationsFilter="a"
+        listViewModel={listViewModel}
+        connectRequests={connectRequests}
+        conversationState={conversationState}
+        callState={callState}
+        currentFocus={currentFocus}
+        currentFolder={currentFolder}
+        resetConversationFocus={resetConversationFocus}
+        handleArrowKeyDown={handleArrowKeyDown}
+        clearSearchFilter={clearSearchFilter}
+        groupParticipantsConversations={[participantNameResult]}
+        isGroupParticipantsVisible={true}
+        isEmpty={false}
+        searchInputRef={createRef()}
+      />,
+      {wrapper: rootProviderWrapper},
+    );
+
+    const conversationList = container.querySelector<HTMLUListElement>('[data-uie-name="conversation-view"]');
+    const groupParticipantsList = container.querySelector<HTMLUListElement>(
+      '[data-uie-name="group-participants-conversations-view"]',
+    );
+
+    expect(conversationList).not.toBeNull();
+    expect(groupParticipantsList).not.toBeNull();
+
+    if (!conversationList || !groupParticipantsList) {
+      throw new Error('Expected both conversation result lists to be rendered');
+    }
+
+    const actualGroupParticipantsContainer = groupParticipantsList.parentElement?.parentElement;
+    const expectedGroupParticipantsContainer = conversationList;
+
+    expect(actualGroupParticipantsContainer).toBe(expectedGroupParticipantsContainer);
+    expect(groupParticipantsList.parentElement?.tagName).toBe('LI');
+    await expect(findByText('Conversation name match')).resolves.toBeDefined();
+    await expect(findByText('Participant name match')).resolves.toBeDefined();
+    await expect(findByText('searchConversationNames')).resolves.toBeDefined();
+    await expect(findByText('searchGroupParticipants')).resolves.toBeDefined();
+  });
 });

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationsList.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationsList.tsx
@@ -239,6 +239,29 @@ export const ConversationsList = ({
     }
   }, [clickedFilteredConversationId, conversationsFilter, conversationsToDisplay, rowVirtualizer]);
 
+  function renderGroupParticipants(): React.ReactNode {
+    if (!isGroupParticipantsVisible) {
+      return null;
+    }
+
+    return (
+      <li>
+        <h3 className="conversation-list-heading" css={headingTitle}>
+          {translate('searchGroupParticipants')}
+        </h3>
+        <ul
+          css={conversationsList}
+          data-uie-name="group-participants-conversations-view"
+          className="group-participants-conversations"
+        >
+          {groupParticipantsConversations.map((conversation, index) => (
+            <ConversationListCell key={conversation.id} {...getCommonConversationCellProps(conversation, index)} />
+          ))}
+        </ul>
+      </li>
+    );
+  }
+
   return (
     <>
       <h2 className="visually-hidden">{translate('conversationViewTooltip')}</h2>
@@ -307,24 +330,8 @@ export const ConversationsList = ({
 
           return null;
         })}
+        {renderGroupParticipants()}
       </ul>
-
-      {isGroupParticipantsVisible && (
-        <>
-          <h3 className="conversation-list-heading" css={headingTitle}>
-            {translate('searchGroupParticipants')}
-          </h3>
-          <ul
-            css={conversationsList}
-            data-uie-name="group-participants-conversations-view"
-            className="group-participants-conversations"
-          >
-            {groupParticipantsConversations.map((conversation, index) => (
-              <ConversationListCell key={conversation.id} {...getCommonConversationCellProps(conversation, index)} />
-            ))}
-          </ul>
-        </>
-      )}
     </>
   );
 };


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28380" title="WPB-28380" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28380</a>  [Web] Two scrollbars appear when searching conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Fixes duplicate vertical scrollbars appearing in the conversation search for broad queries.

The conversation list is virtualized and already acts as a scroll container. Group-participant search results were rendered outside that container. When both result sections contained enough content, the surrounding conversation panel could become scrollable as well, resulting in two nested scrollbars.

This change keeps the conversation-name and group-participant search results within the same scrollable results area.

---

<img width="330" height="168" alt="scrollbar" src="https://github.com/user-attachments/assets/78998335-f49e-488d-a20a-18685d6f9755" />
