### PR TITLE
feat: Show participant-level indication that guests are read-only(WPB-26116)

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -668,6 +668,8 @@
   "conversationAudioAssetUploading": "Uploading: {name}",
   "conversationButtonSeparator": "or",
   "conversationCellsConversationEnabled": "Shared Drive is on",
+  "conversationCellsConversationEnabledEditor": "Shared Drive is on. You have editor access. People outside your team only have viewer access.",
+  "conversationCellsConversationEnabledViewer": "Shared Drive is on. You can view, but you can’t upload, edit, or manage files.",
   "conversationClassified": "Security level: VS-NfD",
   "conversationCommonFeature1": "Up to [bold]{capacity}[/bold] people",
   "conversationCommonFeature2": "Video conferencing",

--- a/apps/webapp/src/script/components/messagesList/message/memberMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/memberMessage.test.tsx
@@ -81,6 +81,7 @@ const baseProps = {
   shouldShowInvitePeople: false,
   conversationName: 'group 1',
   isCellsConversation: false,
+  isSelfGuest: false,
 };
 
 describe('MemberMessage', () => {
@@ -146,10 +147,32 @@ describe('MemberMessage', () => {
       isCellsConversation: true,
     };
 
-    const {getByText} = render(withTheme(<MemberMessage {...props} />), {wrapper: rootProviderWrapper});
+    const {container, getByText, getByTitle} = render(withTheme(<MemberMessage {...props} />), {
+      wrapper: rootProviderWrapper,
+    });
     // Both banners should be visible
-    expect(getByText('Shared Drive is on')).toBeInTheDocument();
+    expect(
+      getByTitle('Shared Drive is on. You have editor access. People outside your team only have viewer access.'),
+    ).toBeInTheDocument();
+    expect(container.querySelector('[data-uie-name="label-cells-conversation"] .ellipsis')).not.toBeInTheDocument();
     expect(getByText('Self-deleting messages are off')).toBeInTheDocument();
+  });
+
+  it('shows the guest Shared Drive system message for guests', () => {
+    const message = createMemberMessage({systemType: SystemMessageType.CONVERSATION_CREATE}, [generateUser()]);
+    const props = {
+      ...baseProps,
+      message,
+      isCellsConversation: true,
+      isSelfGuest: true,
+    };
+
+    const {container, getByTitle} = render(withTheme(<MemberMessage {...props} />), {wrapper: rootProviderWrapper});
+
+    expect(
+      getByTitle('Shared Drive is on. You can view, but you can’t upload, edit, or manage files.'),
+    ).toBeInTheDocument();
+    expect(container.querySelector('[data-uie-name="cells-conversation-learn-more"]')).toBeInTheDocument();
   });
 
   describe('CONVERSATION_CREATE', () => {

--- a/apps/webapp/src/script/components/messagesList/message/memberMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/memberMessage.tsx
@@ -27,8 +27,8 @@ import {SystemMessageType} from 'src/script/message/systemMessageType';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 
-import {e2eMessageContentLinkCss} from './e2eEncryptionMessage/e2eEncryptionMessage.styles';
 import {E2eEncryptionMessage} from './e2eEncryptionMessage/e2eEncryptionMessage';
+import {e2eMessageContentLinkCss} from './e2eEncryptionMessage/e2eEncryptionMessage.styles';
 import {ConnectedMessage} from './memberMessage/connectedMessage';
 import {MessageContent} from './memberMessage/messageContent';
 import {MessageTime} from './messageTime';
@@ -79,6 +79,7 @@ export const MemberMessage = ({
   );
   const receiptsEnabledLabel = translate('conversationCreateReceiptsEnabled');
   const timedMessagesDisabledLabel = translate('conversationDetailsActionTimedMessagesDisabled');
+  const sharedDriveSupportUrl = Config.getConfig().URL.SUPPORT.SHARED_DRIVE;
 
   const isConnectedMessage = [SystemMessageType.CONNECTION_ACCEPTED, SystemMessageType.CONNECTION_REQUEST].includes(
     message.memberMessageType,
@@ -176,7 +177,7 @@ export const MemberMessage = ({
                   textDecoration: 'underline',
                 }}
                 variant={LinkVariant.PRIMARY}
-                href={Config.getConfig().URL.SUPPORT.E2E_ENCRYPTION}
+                href={sharedDriveSupportUrl}
                 target="_blank"
                 data-uie-name="cells-conversation-learn-more"
               >

--- a/apps/webapp/src/script/components/messagesList/message/memberMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/memberMessage.tsx
@@ -17,15 +17,17 @@
  *
  */
 
-import {Button, ButtonVariant, CollectionIcon} from '@wireapp/react-ui-kit';
+import {Button, ButtonVariant, CollectionIcon, Link, LinkVariant} from '@wireapp/react-ui-kit';
 
 import * as Icon from 'Components/icon';
 import {MemberMessage as MemberMessageEntity} from 'Repositories/entity/message/memberMessage';
 import {User} from 'Repositories/entity/User';
+import {Config} from 'src/script/Config';
 import {SystemMessageType} from 'src/script/message/systemMessageType';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 
+import {e2eMessageContentLinkCss} from './e2eEncryptionMessage/e2eEncryptionMessage.styles';
 import {E2eEncryptionMessage} from './e2eEncryptionMessage/e2eEncryptionMessage';
 import {ConnectedMessage} from './memberMessage/connectedMessage';
 import {MessageContent} from './memberMessage/messageContent';
@@ -43,6 +45,7 @@ interface MemberMessageProps {
   shouldShowInvitePeople: boolean;
   conversationName: string;
   isCellsConversation: boolean;
+  isSelfGuest: boolean;
 }
 
 export const MemberMessage = ({
@@ -57,6 +60,7 @@ export const MemberMessage = ({
   classifiedDomains,
   conversationName,
   isCellsConversation,
+  isSelfGuest,
 }: MemberMessageProps) => {
   const {translate} = useApplicationContext();
   const {otherUser, timestamp, user, htmlGroupCreationHeader, showNamedCreation, hasUsers} = useKoSubscribableChildren(
@@ -70,7 +74,9 @@ export const MemberMessage = ({
   const isMemberLeave = message.isMemberLeave();
   const isMemberChange = message.isMemberChange();
 
-  const cellsConversationLabel = translate('conversationCellsConversationEnabled');
+  const cellsConversationLabel = translate(
+    isSelfGuest ? 'conversationCellsConversationEnabledViewer' : 'conversationCellsConversationEnabledEditor',
+  );
   const receiptsEnabledLabel = translate('conversationCreateReceiptsEnabled');
   const timedMessagesDisabledLabel = translate('conversationDetailsActionTimedMessagesDisabled');
 
@@ -160,8 +166,22 @@ export const MemberMessage = ({
             <CollectionIcon />
           </div>
           <p className="message-header-label">
-            <span className="ellipsis" title={cellsConversationLabel}>
+            <span title={cellsConversationLabel}>
               {cellsConversationLabel}
+              &nbsp;
+              <Link
+                css={{
+                  ...e2eMessageContentLinkCss,
+                  fontWeight: 'var(--font-weight-bold)',
+                  textDecoration: 'underline',
+                }}
+                variant={LinkVariant.PRIMARY}
+                href={Config.getConfig().URL.SUPPORT.E2E_ENCRYPTION}
+                target="_blank"
+                data-uie-name="cells-conversation-learn-more"
+              >
+                {translate('systemMessageLearnMore')}
+              </Link>
             </span>
           </p>
         </div>

--- a/apps/webapp/src/script/components/messagesList/message/messageWrapper.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/messageWrapper.test.tsx
@@ -111,9 +111,9 @@ describe('MessageWrapper', () => {
       const message = createMemberMessage(SystemMessageType.CONVERSATION_CREATE, [generateUser()]);
       const props = createBaseProps(conversation, message);
 
-      const {getByText} = render(withTheme(<MessageWrapper {...props} />), {wrapper: rootProviderWrapper});
+      const {getByTitle} = render(withTheme(<MessageWrapper {...props} />), {wrapper: rootProviderWrapper});
 
-      expect(getByText('conversationCellsConversationEnabled')).toBeInTheDocument();
+      expect(getByTitle('conversationCellsConversationEnabledEditor')).toBeInTheDocument();
     });
 
     it('computes isCellsConversation as true when cellsState is PENDING', () => {
@@ -128,9 +128,9 @@ describe('MessageWrapper', () => {
       const message = createMemberMessage(SystemMessageType.CONVERSATION_CREATE, [generateUser()]);
       const props = createBaseProps(conversation, message);
 
-      const {getByText} = render(withTheme(<MessageWrapper {...props} />), {wrapper: rootProviderWrapper});
+      const {getByTitle} = render(withTheme(<MessageWrapper {...props} />), {wrapper: rootProviderWrapper});
 
-      expect(getByText('conversationCellsConversationEnabled')).toBeInTheDocument();
+      expect(getByTitle('conversationCellsConversationEnabledEditor')).toBeInTheDocument();
     });
 
     it('computes isCellsConversation as false when cellsState is DISABLED', () => {
@@ -147,7 +147,25 @@ describe('MessageWrapper', () => {
 
       const {queryByText} = render(withTheme(<MessageWrapper {...props} />), {wrapper: rootProviderWrapper});
 
-      expect(queryByText('conversationCellsConversationEnabled')).not.toBeInTheDocument();
+      expect(queryByText('conversationCellsConversationEnabledEditor')).not.toBeInTheDocument();
+    });
+
+    it('passes the guest Shared Drive system message when self is a conversation guest', () => {
+      const conversation = new Conversation(
+        createUuid(),
+        'test.wire.link',
+        CONVERSATION_PROTOCOL.PROTEUS,
+        translateForTest,
+      );
+      conversation.cellsState(CONVERSATION_CELLS_STATE.READY);
+      conversation.isGuest(true);
+
+      const message = createMemberMessage(SystemMessageType.CONVERSATION_CREATE, [generateUser()]);
+      const props = createBaseProps(conversation, message);
+
+      const {getByTitle} = render(withTheme(<MessageWrapper {...props} />), {wrapper: rootProviderWrapper});
+
+      expect(getByTitle('conversationCellsConversationEnabledViewer')).toBeInTheDocument();
     });
   });
 
@@ -219,9 +237,9 @@ describe('MessageWrapper', () => {
       const message = createMemberMessage(SystemMessageType.CONVERSATION_CREATE, [generateUser()]);
       const props = createBaseProps(conversation, message);
 
-      const {getByText} = render(withTheme(<MessageWrapper {...props} />), {wrapper: rootProviderWrapper});
+      const {getByText, getByTitle} = render(withTheme(<MessageWrapper {...props} />), {wrapper: rootProviderWrapper});
 
-      expect(getByText('conversationCellsConversationEnabled')).toBeInTheDocument();
+      expect(getByTitle('conversationCellsConversationEnabledEditor')).toBeInTheDocument();
       expect(getByText('conversationDetailsActionTimedMessagesDisabled')).toBeInTheDocument();
     });
   });

--- a/apps/webapp/src/script/components/messagesList/message/messageWrapper.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/messageWrapper.tsx
@@ -124,10 +124,11 @@ export const MessageWrapper = ({
       await messageRepository.retryUploadFile(conversation, file, firstAsset.isImage(), message.id);
     }
   };
-  const {display_name: displayName, hasGlobalMessageTimer} = useKoSubscribableChildren(conversation, [
-    'display_name',
-    'hasGlobalMessageTimer',
-  ]);
+  const {
+    display_name: displayName,
+    hasGlobalMessageTimer,
+    isGuest: isSelfGuest,
+  } = useKoSubscribableChildren(conversation, ['display_name', 'hasGlobalMessageTimer', 'isGuest']);
   const isFileShareRestricted = !teamState.isFileSharingReceivingEnabled();
 
   const isCellsConversation =
@@ -273,6 +274,7 @@ export const MessageWrapper = ({
         isSelfTemporaryGuest={isSelfTemporaryGuest}
         classifiedDomains={teamState.classifiedDomains()}
         isCellsConversation={isCellsConversation}
+        isSelfGuest={isSelfGuest}
       />
     );
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26116" title="WPB-26116" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26116</a>  [Web] Show participant-level indication that guests are read-only
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Show participant-level indication that guests are read-only
https://www.figma.com/design/grnVU2vAihHXwYgHryu2xE/Drive?node-id=19088-39956&m=dev