### PR TITLE
test: ensure Cells upload behavior [WPB-28356]

### DIFF
--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/transformAcceptedFiles/transformAcceptedFiles.test.ts
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/transformAcceptedFiles/transformAcceptedFiles.test.ts
@@ -1,0 +1,29 @@
+import {transformAcceptedFiles} from './transformAcceptedFiles';
+
+const createObjectURL = URL.createObjectURL;
+
+describe('transformAcceptedFiles', () => {
+  beforeEach(() => {
+    URL.createObjectURL = jest.fn((file: File) => `blob:${file.name}`);
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = createObjectURL;
+  });
+
+  it('adds stable local upload state and previews to every accepted file', () => {
+    const files = [new File(['one'], 'one.txt'), new File(['two'], 'two.txt')];
+    const transformed = transformAcceptedFiles(files);
+
+    expect(transformed).toHaveLength(2);
+    expect(transformed.map(file => file.preview)).toEqual(['blob:one.txt', 'blob:two.txt']);
+    expect(transformed.every(file => file.id.length > 0)).toBe(true);
+    expect(new Set(transformed.map(file => file.id)).size).toBe(2);
+    expect(transformed.map(file => file.uploadStatus)).toEqual(['uploading', 'uploading']);
+    expect(transformed.map(file => file.uploadProgress)).toEqual([0, 0]);
+    expect(transformed.map(file => [file.remoteUuid, file.remoteVersionId])).toEqual([
+      ['', ''],
+      ['', ''],
+    ]);
+  });
+});

--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
@@ -1,0 +1,125 @@
+import {act, renderHook, waitFor} from '@testing-library/react';
+
+import {useFileUploadState} from '../useFilesUploadState/useFilesUploadState';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {useFilesUploadDropzone} from './useFilesUploadDropzone';
+
+const conversation = {id: 'conversation-id', qualifiedId: {id: 'conversation-id', domain: 'example.com'}};
+const wrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate: translateForTest}));
+
+const createRepository = () => ({
+  uploadNodeDraft: jest.fn(),
+  cancelUpload: jest.fn(),
+  deleteNodeDraft: jest.fn(),
+});
+
+describe('useFilesUploadDropzone', () => {
+  beforeEach(() => {
+    useFileUploadState.getState().clearAll({conversationId: conversation.id});
+    URL.createObjectURL = jest.fn(() => 'blob:preview');
+  });
+
+  it('adds a local preview before starting an upload and maps repository progress to percent', async () => {
+    let resolveUpload: (result: {uuid: string; versionId: string}) => void = () => undefined;
+    const uploadPromise = new Promise<{uuid: string; versionId: string}>(resolve => {
+      resolveUpload = resolve;
+    });
+    const cellsRepository = createRepository();
+    cellsRepository.uploadNodeDraft.mockImplementation(async ({progressCallback}: {progressCallback: (value: number) => void}) => {
+      progressCallback(0.25);
+      return uploadPromise;
+    });
+    const {result} = renderHook(
+      () =>
+        useFilesUploadDropzone({
+          isTeam: false,
+          isCellsEnabled: true,
+          isDisabled: false,
+          isFileDropAllowed: true,
+          cellsRepository: cellsRepository as never,
+          translate: translateForTest,
+          conversation,
+        }),
+      {wrapper},
+    );
+    const file = new File(['content'], 'document.txt', {type: 'text/plain'});
+
+    let upload!: Promise<void>;
+    await act(async () => {
+      upload = result.current.handlePastedFile(file);
+    });
+    await waitFor(() => expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toHaveLength(1));
+
+    expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledTimes(1);
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
+      name: 'document.txt',
+      preview: 'blob:preview',
+      uploadProgress: 25,
+      uploadStatus: 'uploading',
+    });
+
+    resolveUpload({uuid: 'remote-id', versionId: 'version-id'});
+    await act(async () => await upload);
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
+      remoteUuid: 'remote-id',
+      remoteVersionId: 'version-id',
+      uploadStatus: 'success',
+    });
+  });
+
+  it('marks an upload as retryable when the repository rejects', async () => {
+    const cellsRepository = createRepository();
+    cellsRepository.uploadNodeDraft.mockRejectedValue(new Error('network'));
+    const {result} = renderHook(
+      () =>
+        useFilesUploadDropzone({
+          isTeam: false,
+          isCellsEnabled: true,
+          isDisabled: false,
+          isFileDropAllowed: true,
+          cellsRepository: cellsRepository as never,
+          translate: translateForTest,
+          conversation,
+        }),
+      {wrapper},
+    );
+
+    let uploadError: unknown;
+    await act(async () => {
+      try {
+        await result.current.handlePastedFile(new File(['content'], 'document.txt'));
+      } catch (error: unknown) {
+        uploadError = error;
+      }
+    });
+    expect(uploadError).toEqual(new Error('network'));
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0].uploadStatus).toBe('error');
+  });
+
+  it('does not mark an aborted upload as an error', async () => {
+    const cellsRepository = createRepository();
+    const abortError = Object.assign(new Error('cancelled'), {name: 'AbortError'});
+    cellsRepository.uploadNodeDraft.mockRejectedValue(abortError);
+    const {result} = renderHook(
+      () =>
+        useFilesUploadDropzone({
+          isTeam: false,
+          isCellsEnabled: true,
+          isDisabled: false,
+          isFileDropAllowed: true,
+          cellsRepository: cellsRepository as never,
+          translate: translateForTest,
+          conversation,
+        }),
+      {wrapper},
+    );
+
+    await act(async () => result.current.handlePastedFile(new File(['content'], 'document.txt')));
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0].uploadStatus).toBe('uploading');
+  });
+});

--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
@@ -55,6 +55,9 @@ describe('useFilesUploadDropzone', () => {
     });
     await waitFor(() => expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toHaveLength(1));
 
+    expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
+      expect.objectContaining({uuid: expect.any(String), file, path: 'conversation-id@example.com'}),
+    );
     expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledTimes(1);
     expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
       name: 'document.txt',

--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
@@ -24,16 +24,61 @@ describe('useFilesUploadDropzone', () => {
     URL.createObjectURL = jest.fn(() => 'blob:preview');
   });
 
+  it('waits for media metadata before starting an upload', async () => {
+    let resolveMetadata!: (metadata: {image: {width: number; height: number}}) => void;
+    const metadataPromise = new Promise<{image: {width: number; height: number}}>(resolve => {
+      resolveMetadata = resolve;
+    });
+    const cellsRepository = createRepository();
+    cellsRepository.uploadNodeDraft.mockResolvedValue({uuid: 'remote-id', versionId: 'version-id'});
+    const buildFileMetadata = jest.fn(() => metadataPromise);
+    const {result} = renderHook(
+      () =>
+        useFilesUploadDropzone({
+          isTeam: false,
+          isCellsEnabled: true,
+          isDisabled: false,
+          isFileDropAllowed: true,
+          cellsRepository: cellsRepository as never,
+          translate: translateForTest,
+          conversation,
+          buildFileMetadata,
+        }),
+      {wrapper},
+    );
+    const file = new File(['content'], 'image.png', {type: 'image/png'});
+
+    let upload!: Promise<void>;
+    await act(async () => {
+      upload = result.current.handlePastedFile(file);
+      await Promise.resolve();
+    });
+
+    expect(buildFileMetadata).toHaveBeenCalledWith(expect.objectContaining({name: 'image.png'}));
+    expect(cellsRepository.uploadNodeDraft).not.toHaveBeenCalled();
+
+    resolveMetadata({image: {width: 640, height: 480}});
+    await act(async () => await upload);
+
+    expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledTimes(1);
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
+      image: {width: 640, height: 480},
+      uploadStatus: 'success',
+    });
+  });
+
   it('adds a local preview before starting an upload and maps repository progress to percent', async () => {
     let resolveUpload: (result: {uuid: string; versionId: string}) => void = () => undefined;
     const uploadPromise = new Promise<{uuid: string; versionId: string}>(resolve => {
       resolveUpload = resolve;
     });
     const cellsRepository = createRepository();
-    cellsRepository.uploadNodeDraft.mockImplementation(async ({progressCallback}: {progressCallback: (value: number) => void}) => {
-      progressCallback(0.25);
-      return uploadPromise;
-    });
+    cellsRepository.uploadNodeDraft.mockImplementation(
+      async ({progressCallback}: {progressCallback: (value: number) => void}) => {
+        progressCallback(0.25);
+        return uploadPromise;
+      },
+    );
     const {result} = renderHook(
       () =>
         useFilesUploadDropzone({
@@ -53,7 +98,9 @@ describe('useFilesUploadDropzone', () => {
     await act(async () => {
       upload = result.current.handlePastedFile(file);
     });
-    await waitFor(() => expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toHaveLength(1));
+    await waitFor(() =>
+      expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toHaveLength(1),
+    );
 
     expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
       expect.objectContaining({uuid: expect.any(String), file, path: 'conversation-id@example.com'}),

--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
@@ -9,7 +9,10 @@ import {translateForTest} from 'Util/test/translateForTest';
 
 import {useFilesUploadDropzone} from './useFilesUploadDropzone';
 
-const conversation = {id: 'conversation-id', qualifiedId: {id: 'conversation-id', domain: 'example.com'}};
+const conversation = {
+  id: 'local-conversation-id',
+  qualifiedId: {id: 'qualified-conversation-id', domain: 'example.com'},
+};
 const wrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate: translateForTest}));
 
 const createRepository = () => ({
@@ -19,9 +22,15 @@ const createRepository = () => ({
 });
 
 describe('useFilesUploadDropzone', () => {
+  const originalNodeEnvironment = process.env.NODE_ENV;
+
   beforeEach(() => {
     useFileUploadState.getState().clearAll({conversationId: conversation.id});
     URL.createObjectURL = jest.fn(() => 'blob:preview');
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnvironment;
   });
 
   it('waits for media metadata before starting an upload', async () => {
@@ -103,7 +112,7 @@ describe('useFilesUploadDropzone', () => {
     );
 
     expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
-      expect.objectContaining({uuid: expect.any(String), file, path: 'conversation-id@example.com'}),
+      expect.objectContaining({uuid: expect.any(String), file, path: 'qualified-conversation-id@example.com'}),
     );
     expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledTimes(1);
     expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
@@ -120,6 +129,31 @@ describe('useFilesUploadDropzone', () => {
       remoteVersionId: 'version-id',
       uploadStatus: 'success',
     });
+  });
+
+  it('uses the local conversation ID for development uploads', async () => {
+    process.env.NODE_ENV = 'development';
+    const cellsRepository = createRepository();
+    cellsRepository.uploadNodeDraft.mockResolvedValue({uuid: 'remote-id', versionId: 'version-id'});
+    const {result} = renderHook(
+      () =>
+        useFilesUploadDropzone({
+          isTeam: false,
+          isCellsEnabled: true,
+          isDisabled: false,
+          isFileDropAllowed: true,
+          cellsRepository: cellsRepository as never,
+          translate: translateForTest,
+          conversation,
+        }),
+      {wrapper},
+    );
+
+    await act(async () => result.current.handlePastedFile(new File(['content'], 'document.txt')));
+
+    expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
+      expect.objectContaining({path: expect.stringMatching(/^local-conversation-id@/)}),
+    );
   });
 
   it('marks an upload as retryable when the repository rejects', async () => {

--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.ts
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.ts
@@ -34,6 +34,7 @@ import {showFileDropzoneErrorModal} from './showFileDropzoneErrorModal/showFileD
 import {transformAcceptedFiles} from './transformAcceptedFiles/transformAcceptedFiles';
 
 import {FileWithPreview, useFileUploadState} from '../useFilesUploadState/useFilesUploadState';
+import {buildCellsUploadPath} from '../utils/buildCellsUploadPath';
 import {checkFileSharingPermission} from '../utils/checkFileSharingPermission';
 
 const MAX_FILES = 10;
@@ -51,6 +52,7 @@ interface UseFilesUploadDropzoneParams {
   cellsRepository: CellsRepository;
   translate: RootContextValue['translate'];
   conversation?: Pick<Conversation, 'id' | 'qualifiedId'>;
+  buildFileMetadata?: typeof buildCellFileMetadata;
 }
 
 export const useFilesUploadDropzone = ({
@@ -61,6 +63,7 @@ export const useFilesUploadDropzone = ({
   cellsRepository,
   translate,
   conversation = {id: '', qualifiedId: {id: '', domain: ''}},
+  buildFileMetadata = buildCellFileMetadata,
 }: UseFilesUploadDropzoneParams) => {
   const {addFiles, getFiles, updateFile} = useFileUploadState();
   const files = getFiles({conversationId: conversation.id});
@@ -153,10 +156,12 @@ export const useFilesUploadDropzone = ({
   const uploadFile = async (file: FileWithPreview) => {
     // Temporary solution to handle the local development
     // TODO: remove this once we have a proper way to handle the domain per env
-    const path =
-      process.env.NODE_ENV === 'development'
-        ? `${conversation.id}@${CONFIG.CELLS_WIRE_DOMAIN}`
-        : `${conversation.qualifiedId.id}@${conversation.qualifiedId.domain}`;
+    const path = buildCellsUploadPath({
+      conversationId: conversation.id,
+      conversationQualifiedId: conversation.qualifiedId,
+      cellsWireDomain: CONFIG.CELLS_WIRE_DOMAIN,
+      isDevelopment: process.env.NODE_ENV === 'development',
+    });
 
     const decimalMultiplier = 100;
 
@@ -202,7 +207,7 @@ export const useFilesUploadDropzone = ({
     await Promise.all(
       files.map(async file => {
         try {
-          const metadata = await buildCellFileMetadata(file);
+          const metadata = await buildFileMetadata(file);
 
           if (!metadata) {
             return;

--- a/apps/webapp/src/script/components/conversation/useFilesUploadState/useFilesUploadState.test.ts
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadState/useFilesUploadState.test.ts
@@ -1,0 +1,40 @@
+import {useFileUploadState, FileWithPreview} from './useFilesUploadState';
+
+const file = (id: string): FileWithPreview =>
+  Object.assign(new File(['content'], `${id}.txt`, {type: 'text/plain'}), {
+    id,
+    preview: `blob:${id}`,
+    remoteUuid: '',
+    remoteVersionId: '',
+    uploadStatus: 'uploading' as const,
+    uploadProgress: 0,
+  });
+
+describe('useFileUploadState', () => {
+  beforeEach(() => useFileUploadState.getState().clearAll({conversationId: 'conversation'}));
+
+  it('stores and updates upload progress and remote identifiers', () => {
+    const upload = file('local-id');
+    useFileUploadState.getState().addFiles({conversationId: 'conversation', files: [upload]});
+
+    useFileUploadState.getState().updateFile({
+      conversationId: 'conversation',
+      fileId: upload.id,
+      data: {uploadProgress: 42, remoteUuid: 'remote-id', remoteVersionId: 'version-id', uploadStatus: 'success'},
+    });
+
+    expect(useFileUploadState.getState().getFiles({conversationId: 'conversation'})[0]).toMatchObject({
+      id: 'local-id',
+      uploadProgress: 42,
+      remoteUuid: 'remote-id',
+      remoteVersionId: 'version-id',
+      uploadStatus: 'success',
+    });
+  });
+
+  it('removes only the cancelled or deleted file', () => {
+    useFileUploadState.getState().addFiles({conversationId: 'conversation', files: [file('first'), file('second')]});
+    useFileUploadState.getState().deleteFile({conversationId: 'conversation', fileId: 'first'});
+    expect(useFileUploadState.getState().getFiles({conversationId: 'conversation'}).map(({id}) => id)).toEqual(['second']);
+  });
+});

--- a/apps/webapp/src/script/components/conversation/useFilesUploadState/useFilesUploadState.test.ts
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadState/useFilesUploadState.test.ts
@@ -35,6 +35,11 @@ describe('useFileUploadState', () => {
   it('removes only the cancelled or deleted file', () => {
     useFileUploadState.getState().addFiles({conversationId: 'conversation', files: [file('first'), file('second')]});
     useFileUploadState.getState().deleteFile({conversationId: 'conversation', fileId: 'first'});
-    expect(useFileUploadState.getState().getFiles({conversationId: 'conversation'}).map(({id}) => id)).toEqual(['second']);
+    expect(
+      useFileUploadState
+        .getState()
+        .getFiles({conversationId: 'conversation'})
+        .map(({id}) => id),
+    ).toEqual(['second']);
   });
 });

--- a/apps/webapp/src/script/components/conversation/utils/buildCellsUploadPath.test.ts
+++ b/apps/webapp/src/script/components/conversation/utils/buildCellsUploadPath.test.ts
@@ -1,0 +1,20 @@
+import {buildCellsUploadPath} from './buildCellsUploadPath';
+
+const params = {
+  conversationId: 'local-conversation-id',
+  conversationQualifiedId: {id: 'qualified-conversation-id', domain: 'example.com'},
+  cellsWireDomain: 'cells.wire.example',
+};
+
+describe('buildCellsUploadPath', () => {
+  it.each([
+    {isDevelopment: true, expected: 'local-conversation-id@cells.wire.example'},
+    {isDevelopment: false, expected: 'qualified-conversation-id@example.com'},
+  ])('selects the same environment-specific path for initial uploads and retries', ({isDevelopment, expected}) => {
+    const initialPath = buildCellsUploadPath({...params, isDevelopment});
+    const retryPath = buildCellsUploadPath({...params, isDevelopment});
+
+    expect(initialPath).toBe(expected);
+    expect(retryPath).toBe(initialPath);
+  });
+});

--- a/apps/webapp/src/script/components/conversation/utils/buildCellsUploadPath.ts
+++ b/apps/webapp/src/script/components/conversation/utils/buildCellsUploadPath.ts
@@ -1,0 +1,22 @@
+import type {QualifiedId} from '@wireapp/api-client/lib/user/';
+
+interface BuildCellsUploadPathParams {
+  conversationId: string;
+  conversationQualifiedId: QualifiedId;
+  cellsWireDomain: string;
+  isDevelopment: boolean;
+}
+
+/**
+ * Builds the Cells upload path consistently for initial uploads and retries.
+ * Development uses the local conversation ID; deployed environments use the qualified ID.
+ */
+export const buildCellsUploadPath = ({
+  conversationId,
+  conversationQualifiedId,
+  cellsWireDomain,
+  isDevelopment,
+}: BuildCellsUploadPathParams): string =>
+  isDevelopment
+    ? `${conversationId}@${cellsWireDomain}`
+    : `${conversationQualifiedId.id}@${conversationQualifiedId.domain}`;

--- a/apps/webapp/src/script/components/conversation/utils/buildCellsUploadPath.ts
+++ b/apps/webapp/src/script/components/conversation/utils/buildCellsUploadPath.ts
@@ -1,3 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
 import type {QualifiedId} from '@wireapp/api-client/lib/user/';
 
 interface BuildCellsUploadPathParams {

--- a/apps/webapp/src/script/components/inputBar/filePreviews/filePreviews.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/filePreviews.test.tsx
@@ -33,7 +33,8 @@ jest.mock('./filePreviewCard/filePreviewCard', () => ({
 }));
 
 describe('FilePreviews', () => {
-  const conversationQualifiedId = {id: 'conv-id', domain: 'example.com'};
+  const conversationId = 'local-conversation-id';
+  const conversationQualifiedId = {id: 'qualified-conversation-id', domain: 'example.com'};
 
   const createFileWithPreview = (file: File): FileWithPreview =>
     Object.assign(file, {
@@ -48,7 +49,15 @@ describe('FilePreviews', () => {
   it('renders a file preview card for HEIC images', () => {
     const heicFile = createFileWithPreview(new File(['heic'], 'photo.heic', {type: 'image/heic'}));
 
-    render(withTheme(<FilePreviews files={[heicFile]} conversationQualifiedId={conversationQualifiedId} />));
+    render(
+      withTheme(
+        <FilePreviews
+          files={[heicFile]}
+          conversationId={conversationId}
+          conversationQualifiedId={conversationQualifiedId}
+        />,
+      ),
+    );
 
     expect(screen.getByTestId('file-preview-card')).toBeInTheDocument();
     expect(screen.queryByTestId('image-preview-card')).not.toBeInTheDocument();
@@ -57,7 +66,15 @@ describe('FilePreviews', () => {
   it('renders an image preview card for PNG images', () => {
     const pngFile = createFileWithPreview(new File(['png'], 'photo.png', {type: 'image/png'}));
 
-    render(withTheme(<FilePreviews files={[pngFile]} conversationQualifiedId={conversationQualifiedId} />));
+    render(
+      withTheme(
+        <FilePreviews
+          files={[pngFile]}
+          conversationId={conversationId}
+          conversationQualifiedId={conversationQualifiedId}
+        />,
+      ),
+    );
 
     expect(screen.getByTestId('image-preview-card')).toBeInTheDocument();
     expect(screen.queryByTestId('file-preview-card')).not.toBeInTheDocument();

--- a/apps/webapp/src/script/components/inputBar/filePreviews/filePreviews.tsx
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/filePreviews.tsx
@@ -35,16 +35,22 @@ import {VideoPreviewCard} from './videoPreviewCard/videoPreviewCard';
 
 interface FilePreviewsProps {
   files: FileWithPreview[];
+  conversationId: string;
   conversationQualifiedId: QualifiedId;
 }
 
-export const FilePreviews = ({files, conversationQualifiedId}: FilePreviewsProps) => {
+export const FilePreviews = ({files, conversationId, conversationQualifiedId}: FilePreviewsProps) => {
   const [wrapperRef] = useAutoAnimate();
 
   return (
     <div ref={wrapperRef} css={wrapperStyles}>
       {files.map(file => (
-        <FilePreview key={file.id} file={file} conversationQualifiedId={conversationQualifiedId} />
+        <FilePreview
+          key={file.id}
+          file={file}
+          conversationId={conversationId}
+          conversationQualifiedId={conversationQualifiedId}
+        />
       ))}
     </div>
   );
@@ -53,17 +59,20 @@ export const FilePreviews = ({files, conversationQualifiedId}: FilePreviewsProps
 interface FilePreviewProps {
   file: FileWithPreview;
   cellsRepository?: CellsRepository;
+  conversationId: string;
   conversationQualifiedId: QualifiedId;
 }
 
 const FilePreview = ({
   file,
   cellsRepository = container.resolve(CellsRepository),
+  conversationId,
   conversationQualifiedId,
 }: FilePreviewProps) => {
   const {name, extension, size, isError, handleDelete, handleRetry} = useFilePreview({
     file,
     cellsRepository,
+    conversationId,
     conversationQualifiedId,
   });
 

--- a/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.test.tsx
@@ -9,7 +9,8 @@ import {translateForTest} from 'Util/test/translateForTest';
 
 import {useFilePreview} from './useFilePreview';
 
-const conversation = {id: 'conversation-id', domain: 'example.com'};
+const conversationId = 'local-conversation-id';
+const conversation = {id: 'qualified-conversation-id', domain: 'example.com'};
 const fireAndForgetInvoker = {
   fireAndForget: jest.fn((action: () => Promise<void>) => void action()),
   waitUntilAllSettled: jest.fn(async () => undefined),
@@ -30,10 +31,16 @@ const createFile = (overrides: Partial<FileWithPreview> = {}): FileWithPreview =
   });
 
 describe('useFilePreview', () => {
+  const originalNodeEnvironment = process.env.NODE_ENV;
+
   beforeEach(() => {
     jest.clearAllMocks();
-    useFileUploadState.getState().clearAll({conversationId: conversation.id});
+    useFileUploadState.getState().clearAll({conversationId});
     URL.revokeObjectURL = jest.fn();
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnvironment;
   });
 
   it('exposes display metadata and marks failed uploads', () => {
@@ -42,6 +49,7 @@ describe('useFilePreview', () => {
         useFilePreview({
           file: createFile({uploadStatus: 'error'}),
           cellsRepository: {} as never,
+          conversationId,
           conversationQualifiedId: conversation,
         }),
       {wrapper},
@@ -53,9 +61,15 @@ describe('useFilePreview', () => {
   it('cancels loading uploads, revokes the preview, and removes the local preview without deleting a draft', () => {
     const cellsRepository = {cancelUpload: jest.fn(), deleteNodeDraft: jest.fn()};
     const file = createFile({uploadStatus: 'uploading'});
-    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
     const {result} = renderHook(
-      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      () =>
+        useFilePreview({
+          file,
+          cellsRepository: cellsRepository as never,
+          conversationId,
+          conversationQualifiedId: conversation,
+        }),
       {wrapper},
     );
 
@@ -64,15 +78,21 @@ describe('useFilePreview', () => {
     expect(cellsRepository.cancelUpload).toHaveBeenCalledWith('local-id');
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:local-id');
     expect(cellsRepository.deleteNodeDraft).not.toHaveBeenCalled();
-    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toEqual([]);
+    expect(useFileUploadState.getState().getFiles({conversationId})).toEqual([]);
   });
 
   it('revokes the preview and discards a completed remote draft', async () => {
     const cellsRepository = {cancelUpload: jest.fn(), deleteNodeDraft: jest.fn().mockResolvedValue(undefined)};
     const file = createFile();
-    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
     const {result} = renderHook(
-      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      () =>
+        useFilePreview({
+          file,
+          cellsRepository: cellsRepository as never,
+          conversationId,
+          conversationQualifiedId: conversation,
+        }),
       {wrapper},
     );
 
@@ -81,7 +101,7 @@ describe('useFilePreview', () => {
 
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:local-id');
     expect(cellsRepository.deleteNodeDraft).toHaveBeenCalledWith({uuid: 'remote-id', versionId: 'old-version-id'});
-    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toEqual([]);
+    expect(useFileUploadState.getState().getFiles({conversationId})).toEqual([]);
   });
 
   it('retries a failed upload with its local resource ID and stores its new version', async () => {
@@ -89,35 +109,72 @@ describe('useFilePreview', () => {
       uploadNodeDraft: jest.fn().mockResolvedValue({uuid: 'remote-id', versionId: 'new-version-id'}),
     };
     const file = createFile({uploadStatus: 'error', remoteUuid: 'remote-id', remoteVersionId: 'old-version-id'});
-    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
     const {result} = renderHook(
-      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      () =>
+        useFilePreview({
+          file,
+          cellsRepository: cellsRepository as never,
+          conversationId,
+          conversationQualifiedId: conversation,
+        }),
       {wrapper},
     );
 
     await act(async () => result.current.handleRetry());
 
     expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
-      expect.objectContaining({uuid: 'local-id', file, path: 'conversation-id@example.com'}),
+      expect.objectContaining({uuid: 'local-id', file, path: 'qualified-conversation-id@example.com'}),
     );
-    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
+    expect(useFileUploadState.getState().getFiles({conversationId})[0]).toMatchObject({
       remoteUuid: 'remote-id',
       remoteVersionId: 'new-version-id',
       uploadStatus: 'success',
     });
   });
 
-  it('keeps a failed state when retry fails', async () => {
-    const cellsRepository = {uploadNodeDraft: jest.fn().mockRejectedValue(new Error('network'))};
+  it('uses the local conversation ID for development retries', async () => {
+    process.env.NODE_ENV = 'development';
+    const cellsRepository = {
+      uploadNodeDraft: jest.fn().mockResolvedValue({uuid: 'remote-id', versionId: 'new-version-id'}),
+    };
     const file = createFile({uploadStatus: 'error'});
-    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
     const {result} = renderHook(
-      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      () =>
+        useFilePreview({
+          file,
+          cellsRepository: cellsRepository as never,
+          conversationId,
+          conversationQualifiedId: conversation,
+        }),
       {wrapper},
     );
 
     await act(async () => result.current.handleRetry());
 
-    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0].uploadStatus).toBe('error');
+    expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
+      expect.objectContaining({path: expect.stringMatching(/^local-conversation-id@/)}),
+    );
+  });
+
+  it('keeps a failed state when retry fails', async () => {
+    const cellsRepository = {uploadNodeDraft: jest.fn().mockRejectedValue(new Error('network'))};
+    const file = createFile({uploadStatus: 'error'});
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
+    const {result} = renderHook(
+      () =>
+        useFilePreview({
+          file,
+          cellsRepository: cellsRepository as never,
+          conversationId,
+          conversationQualifiedId: conversation,
+        }),
+      {wrapper},
+    );
+
+    await act(async () => result.current.handleRetry());
+
+    expect(useFileUploadState.getState().getFiles({conversationId})[0].uploadStatus).toBe('error');
   });
 });

--- a/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.test.tsx
@@ -1,0 +1,117 @@
+import {act, renderHook} from '@testing-library/react';
+
+import {FileWithPreview, useFileUploadState} from 'Components/conversation/useFilesUploadState/useFilesUploadState';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {useFilePreview} from './useFilePreview';
+
+const conversation = {id: 'conversation-id', domain: 'example.com'};
+const fireAndForgetInvoker = {
+  fireAndForget: jest.fn((action: () => Promise<void>) => void action()),
+  waitUntilAllSettled: jest.fn(async () => undefined),
+};
+const wrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate: translateForTest, fireAndForgetInvoker}),
+);
+
+const createFile = (overrides: Partial<FileWithPreview> = {}): FileWithPreview =>
+  Object.assign(new File(['content'], 'document.txt', {type: 'text/plain'}), {
+    id: 'local-id',
+    preview: 'blob:local-id',
+    remoteUuid: 'remote-id',
+    remoteVersionId: 'old-version-id',
+    uploadStatus: 'success' as const,
+    uploadProgress: 100,
+    ...overrides,
+  });
+
+describe('useFilePreview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useFileUploadState.getState().clearAll({conversationId: conversation.id});
+    URL.revokeObjectURL = jest.fn();
+  });
+
+  it('exposes display metadata and marks failed uploads', () => {
+    const {result} = renderHook(
+      () => useFilePreview({file: createFile({uploadStatus: 'error'}), cellsRepository: {} as never, conversationQualifiedId: conversation}),
+      {wrapper},
+    );
+
+    expect(result.current).toMatchObject({name: 'Upload failed: document', extension: 'txt', isError: true});
+  });
+
+  it('cancels loading uploads and removes the local preview without deleting a draft', () => {
+    const cellsRepository = {cancelUpload: jest.fn(), deleteNodeDraft: jest.fn()};
+    const file = createFile({uploadStatus: 'uploading'});
+    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    const {result} = renderHook(
+      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      {wrapper},
+    );
+
+    act(() => result.current.handleDelete());
+
+    expect(cellsRepository.cancelUpload).toHaveBeenCalledWith('local-id');
+    expect(cellsRepository.deleteNodeDraft).not.toHaveBeenCalled();
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toEqual([]);
+  });
+
+  it('revokes the preview and discards a completed remote draft', async () => {
+    const cellsRepository = {cancelUpload: jest.fn(), deleteNodeDraft: jest.fn().mockResolvedValue(undefined)};
+    const file = createFile();
+    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    const {result} = renderHook(
+      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      {wrapper},
+    );
+
+    act(() => result.current.handleDelete());
+    await act(async () => await fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:local-id');
+    expect(cellsRepository.deleteNodeDraft).toHaveBeenCalledWith({uuid: 'remote-id', versionId: 'old-version-id'});
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toEqual([]);
+  });
+
+  it('retries a failed upload with the same resource and stores its new version', async () => {
+    const cellsRepository = {
+      uploadNodeDraft: jest.fn().mockResolvedValue({uuid: 'remote-id', versionId: 'new-version-id'}),
+    };
+    const file = createFile({uploadStatus: 'error', remoteUuid: 'remote-id', remoteVersionId: 'old-version-id'});
+    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    const {result} = renderHook(
+      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      {wrapper},
+    );
+
+    await act(async () => result.current.handleRetry());
+
+    expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
+      expect.objectContaining({uuid: 'local-id', file, path: 'conversation-id@example.com'}),
+    );
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
+      remoteUuid: 'remote-id',
+      remoteVersionId: 'new-version-id',
+      uploadStatus: 'success',
+    });
+  });
+
+  it('keeps a failed state when retry fails', async () => {
+    const cellsRepository = {uploadNodeDraft: jest.fn().mockRejectedValue(new Error('network'))};
+    const file = createFile({uploadStatus: 'error'});
+    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    const {result} = renderHook(
+      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      {wrapper},
+    );
+
+    await act(async () => result.current.handleRetry());
+
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0].uploadStatus).toBe('error');
+  });
+});

--- a/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.test.tsx
@@ -38,14 +38,19 @@ describe('useFilePreview', () => {
 
   it('exposes display metadata and marks failed uploads', () => {
     const {result} = renderHook(
-      () => useFilePreview({file: createFile({uploadStatus: 'error'}), cellsRepository: {} as never, conversationQualifiedId: conversation}),
+      () =>
+        useFilePreview({
+          file: createFile({uploadStatus: 'error'}),
+          cellsRepository: {} as never,
+          conversationQualifiedId: conversation,
+        }),
       {wrapper},
     );
 
     expect(result.current).toMatchObject({name: 'Upload failed: document', extension: 'txt', isError: true});
   });
 
-  it('cancels loading uploads and removes the local preview without deleting a draft', () => {
+  it('cancels loading uploads, revokes the preview, and removes the local preview without deleting a draft', () => {
     const cellsRepository = {cancelUpload: jest.fn(), deleteNodeDraft: jest.fn()};
     const file = createFile({uploadStatus: 'uploading'});
     useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
@@ -57,6 +62,7 @@ describe('useFilePreview', () => {
     act(() => result.current.handleDelete());
 
     expect(cellsRepository.cancelUpload).toHaveBeenCalledWith('local-id');
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:local-id');
     expect(cellsRepository.deleteNodeDraft).not.toHaveBeenCalled();
     expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toEqual([]);
   });
@@ -78,7 +84,7 @@ describe('useFilePreview', () => {
     expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toEqual([]);
   });
 
-  it('retries a failed upload with the same resource and stores its new version', async () => {
+  it('retries a failed upload with its local resource ID and stores its new version', async () => {
     const cellsRepository = {
       uploadNodeDraft: jest.fn().mockResolvedValue({uuid: 'remote-id', versionId: 'new-version-id'}),
     };

--- a/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.ts
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.ts
@@ -29,10 +29,11 @@ import {getFileExtension, trimFileExtension, formatBytes} from 'Util/util';
 interface FilePreviewParams {
   file: FileWithPreview;
   cellsRepository: CellsRepository;
+  conversationId: string;
   conversationQualifiedId: QualifiedId;
 }
 
-export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}: FilePreviewParams) => {
+export const useFilePreview = ({file, cellsRepository, conversationId, conversationQualifiedId}: FilePreviewParams) => {
   const {fireAndForgetInvoker} = useApplicationContext();
   const {deleteFile, updateFile} = useFileUploadState();
 
@@ -47,7 +48,7 @@ export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}:
 
   const cancelUpload = () => {
     cellsRepository.cancelUpload(file.id);
-    deleteFile({conversationId: conversationQualifiedId.id, fileId: file.id});
+    deleteFile({conversationId, fileId: file.id});
   };
 
   const handleDelete = () => {
@@ -60,7 +61,7 @@ export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}:
       return;
     }
 
-    deleteFile({conversationId: conversationQualifiedId.id, fileId: file.id});
+    deleteFile({conversationId, fileId: file.id});
     fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
       await cellsRepository.deleteNodeDraft({uuid: file.remoteUuid, versionId: file.remoteVersionId});
     });
@@ -68,9 +69,9 @@ export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}:
 
   const handleRetry = async () => {
     try {
-      updateFile({conversationId: conversationQualifiedId.id, fileId: file.id, data: {uploadStatus: 'uploading'}});
+      updateFile({conversationId, fileId: file.id, data: {uploadStatus: 'uploading'}});
       const path = buildCellsUploadPath({
-        conversationId: conversationQualifiedId.id,
+        conversationId,
         conversationQualifiedId,
         cellsWireDomain: Config.getConfig().CELLS_WIRE_DOMAIN,
         isDevelopment: process.env.NODE_ENV === 'development',
@@ -82,12 +83,12 @@ export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}:
         path,
       });
       updateFile({
-        conversationId: conversationQualifiedId.id,
+        conversationId,
         fileId: file.id,
         data: {remoteUuid: uuid, remoteVersionId: versionId, uploadStatus: 'success'},
       });
     } catch (error: unknown) {
-      updateFile({conversationId: conversationQualifiedId.id, fileId: file.id, data: {uploadStatus: 'error'}});
+      updateFile({conversationId, fileId: file.id, data: {uploadStatus: 'error'}});
     }
   };
 

--- a/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.ts
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.ts
@@ -20,6 +20,7 @@
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
 
 import {FileWithPreview, useFileUploadState} from 'Components/conversation/useFilesUploadState/useFilesUploadState';
+import {buildCellsUploadPath} from 'Components/conversation/utils/buildCellsUploadPath';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {Config} from 'src/script/Config';
 import {useApplicationContext} from 'src/script/page/rootProvider';
@@ -68,12 +69,12 @@ export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}:
   const handleRetry = async () => {
     try {
       updateFile({conversationId: conversationQualifiedId.id, fileId: file.id, data: {uploadStatus: 'uploading'}});
-      // Temporary solution to handle the local development
-      // TODO: remove this once we have a proper way to handle the domain per env
-      const path =
-        process.env.NODE_ENV === 'development'
-          ? `${conversationQualifiedId.id}@${Config.getConfig().CELLS_WIRE_DOMAIN}`
-          : `${conversationQualifiedId.id}@${conversationQualifiedId.domain}`;
+      const path = buildCellsUploadPath({
+        conversationId: conversationQualifiedId.id,
+        conversationQualifiedId,
+        cellsWireDomain: Config.getConfig().CELLS_WIRE_DOMAIN,
+        isDevelopment: process.env.NODE_ENV === 'development',
+      });
 
       const {uuid, versionId} = await cellsRepository.uploadNodeDraft({
         uuid: file.id,

--- a/apps/webapp/src/script/components/inputBar/inputBar.tsx
+++ b/apps/webapp/src/script/components/inputBar/inputBar.tsx
@@ -347,7 +347,13 @@ export const InputBar = ({
                   disableMessagePreprocessing={disableMessagePreprocessing}
                   replaceEmojis={shouldReplaceEmoji}
                 >
-                  {!!files.length && <FilePreviews files={files} conversationQualifiedId={conversation.qualifiedId} />}
+                  {!!files.length && (
+                    <FilePreviews
+                      files={files}
+                      conversationId={conversation.id}
+                      conversationQualifiedId={conversation.qualifiedId}
+                    />
+                  )}
                   <InputBarControls
                     conversation={conversation}
                     isCellsFeatureEnabled={isCellsEnabled}

--- a/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.test.tsx
@@ -1,0 +1,206 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {act, renderHook} from '@testing-library/react';
+
+import {FileWithPreview, useFileUploadState} from 'Components/conversation/useFilesUploadState/useFilesUploadState';
+import {Config} from 'src/script/Config';
+
+import {useMessageSend} from './useMessageSend';
+
+const conversationId = 'conversation';
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return {promise, resolve, reject};
+};
+
+const createFile = (
+  id: string,
+  uploadStatus: 'success' | 'uploading' = 'success',
+  media: Pick<FileWithPreview, 'audio' | 'video'> = {},
+): FileWithPreview =>
+  Object.assign(new File(['content'], `${id}.png`, {type: 'image/png'}), {
+    id,
+    preview: `blob:${id}`,
+    remoteUuid: `remote-${id}`,
+    remoteVersionId: `version-${id}`,
+    uploadStatus,
+    uploadProgress: uploadStatus === 'success' ? 100 : 40,
+    image: {width: 10, height: 20},
+    ...media,
+  });
+
+const createProps = (overrides: Record<string, unknown> = {}) => ({
+  replyMessageEntity: null,
+  eventRepository: {eventService: {loadEvent: jest.fn()}} as never,
+  messageRepository: {sendTextWithLinkPreview: jest.fn()} as never,
+  conversation: {id: conversationId, mlsVerificationState: () => 'unverified'} as never,
+  conversationRepository: {refreshMLSConversationVerificationState: jest.fn()} as never,
+  cellsRepository: {promoteNodeDraft: jest.fn().mockResolvedValue(undefined)} as never,
+  draftState: {reset: jest.fn()},
+  cancelMessageEditing: jest.fn(),
+  cancelMessageReply: jest.fn(),
+  editedMessage: undefined,
+  replyMessageCallback: jest.fn(),
+  editorRef: {current: null},
+  pastedFile: null,
+  sendPastedFile: jest.fn(),
+  messageContent: {text: 'hello', mentions: []},
+  translate: ((key: string) => key) as never,
+  ...overrides,
+});
+
+describe('useMessageSend', () => {
+  let configSpy: jest.SpyInstance;
+  let notificationContainer: HTMLDivElement;
+
+  beforeEach(() => {
+    notificationContainer = document.createElement('div');
+    notificationContainer.id = 'app-notification';
+    document.body.appendChild(notificationContainer);
+    useFileUploadState.getState().clearAll({conversationId});
+    configSpy = jest.spyOn(Config, 'getConfig').mockReturnValue({
+      FEATURE: {ENABLE_CELLS: true},
+      MAXIMUM_MESSAGE_LENGTH: 1000,
+    } as never);
+  });
+
+  afterEach(() => {
+    configSpy.mockRestore();
+    notificationContainer.remove();
+  });
+
+  it('keeps sending disabled until every selected file is ready', () => {
+    useFileUploadState
+      .getState()
+      .addFiles({conversationId, files: [createFile('ready'), createFile('loading', 'uploading')]});
+
+    const {result} = renderHook(() => useMessageSend(createProps()));
+
+    expect(result.current.isSendingDisabled).toBe(true);
+  });
+
+  it('publishes every ready draft before sending text with preserved attachment metadata', async () => {
+    const sendTextWithLinkPreview = jest.fn();
+    const publication = createDeferred<void>();
+    const promoteNodeDraft = jest.fn().mockReturnValue(publication.promise);
+    const files = [createFile('image')];
+    useFileUploadState.getState().addFiles({conversationId, files});
+    const props = createProps({
+      cellsRepository: {promoteNodeDraft} as never,
+      messageRepository: {sendTextWithLinkPreview} as never,
+    });
+    const {result} = renderHook(() => useMessageSend(props));
+
+    let sendPromise: Promise<void>;
+    act(() => {
+      sendPromise = result.current.sendMessage();
+    });
+    await act(async () => Promise.resolve());
+
+    expect(promoteNodeDraft).toHaveBeenCalledWith({uuid: 'remote-image', versionId: 'version-image'});
+    expect(sendTextWithLinkPreview).not.toHaveBeenCalled();
+    publication.resolve();
+    await act(async () => sendPromise!);
+    await act(async () => Promise.resolve());
+
+    expect(sendTextWithLinkPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        textMessage: 'hello',
+        attachments: [
+          {
+            cellAsset: {
+              uuid: 'image',
+              contentType: 'image/png',
+              initialName: 'image.png',
+              initialSize: files[0].size,
+              image: {width: 10, height: 20},
+              audio: undefined,
+              video: undefined,
+            },
+          },
+        ],
+      }),
+    );
+    expect(useFileUploadState.getState().getFiles({conversationId})).toEqual([]);
+  });
+
+  it('returns publication failures without sending or clearing retryable files', async () => {
+    const sendTextWithLinkPreview = jest.fn();
+    const promoteNodeDraft = jest.fn().mockRejectedValue(new Error('publication failed'));
+    const file = createFile('failed');
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
+    const {result} = renderHook(() =>
+      useMessageSend(
+        createProps({
+          cellsRepository: {promoteNodeDraft} as never,
+          messageRepository: {sendTextWithLinkPreview} as never,
+        }),
+      ),
+    );
+
+    await act(async () => {
+      await expect(result.current.sendMessage()).rejects.toThrow('publication failed');
+    });
+
+    expect(promoteNodeDraft).toHaveBeenCalledWith({uuid: 'remote-failed', versionId: 'version-failed'});
+    expect(sendTextWithLinkPreview).not.toHaveBeenCalled();
+    expect(useFileUploadState.getState().getFiles({conversationId})).toEqual([file]);
+  });
+
+  it('preserves image, audio, and video attachment metadata', async () => {
+    const sendTextWithLinkPreview = jest.fn();
+    const file = createFile('media', 'success', {
+      audio: {durationInMillis: 3},
+      video: {width: 1920, height: 1080},
+    });
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
+    const {result} = renderHook(() =>
+      useMessageSend(createProps({messageRepository: {sendTextWithLinkPreview} as never})),
+    );
+
+    await act(async () => result.current.sendMessage());
+    await act(async () => Promise.resolve());
+
+    expect(sendTextWithLinkPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            cellAsset: expect.objectContaining({
+              image: {width: 10, height: 20},
+              audio: {durationInMillis: 3},
+              video: {width: 1920, height: 1080},
+            }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('sends text without attachments when no files are selected', async () => {
+    const sendTextWithLinkPreview = jest.fn();
+    const {result} = renderHook(() =>
+      useMessageSend(createProps({messageRepository: {sendTextWithLinkPreview} as never})),
+    );
+
+    await act(async () => result.current.sendMessage());
+    await act(async () => Promise.resolve());
+
+    expect(sendTextWithLinkPreview).toHaveBeenCalledWith(
+      expect.objectContaining({textMessage: 'hello', attachments: []}),
+    );
+  });
+});

--- a/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.ts
+++ b/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.ts
@@ -285,7 +285,8 @@ export const useMessageSend = ({
         translate,
       );
     } else {
-      void sendMessage();
+      // Return the promise so FireAndForgetInvoker can observe publication failures.
+      await sendMessage();
     }
   }, [conversation, conversationRepository, sendMessage, translate]);
 

--- a/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useSendFiles/useSendFiles.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useSendFiles/useSendFiles.test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {act, renderHook} from '@testing-library/react';
+
+import type {FileWithPreview} from 'Components/conversation/useFilesUploadState/useFilesUploadState';
+
+import {useSendFiles} from './useSendFiles';
+
+type Repository = {
+  promoteNodeDraft: jest.Mock<Promise<void>, [{uuid: string; versionId: string}]>;
+};
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return {promise, resolve, reject};
+};
+
+const createFile = (id: string, preview = `blob:${id}`): FileWithPreview =>
+  Object.assign(new File(['content'], `${id}.png`, {type: 'image/png'}), {
+    id,
+    preview,
+    remoteUuid: `remote-${id}`,
+    remoteVersionId: `version-${id}`,
+    uploadStatus: 'success' as const,
+    uploadProgress: 100,
+  });
+
+describe('useSendFiles', () => {
+  it('promotes every draft before completing and revokes previews', async () => {
+    const repository: Repository = {promoteNodeDraft: jest.fn().mockResolvedValue(undefined)};
+    const revoke = jest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    revoke.mockClear();
+    const {result} = renderHook(() =>
+      useSendFiles({
+        files: [createFile('one'), createFile('two')],
+        cellsRepository: repository as never,
+        clearAllFiles: jest.fn(),
+        conversationId: 'conversation',
+        sendFilesErrorMessage: 'send failed',
+      }),
+    );
+
+    await act(async () => result.current.sendFiles());
+
+    expect(repository.promoteNodeDraft).toHaveBeenNthCalledWith(1, {uuid: 'remote-one', versionId: 'version-one'});
+    expect(repository.promoteNodeDraft).toHaveBeenNthCalledWith(2, {uuid: 'remote-two', versionId: 'version-two'});
+    expect(revoke).toHaveBeenCalledWith('blob:one');
+    expect(revoke).toHaveBeenCalledWith('blob:two');
+    revoke.mockRestore();
+  });
+
+  it('starts all publications before completing when one finishes later', async () => {
+    const firstPublication = createDeferred<void>();
+    const secondPublication = createDeferred<void>();
+    const repository: Repository = {
+      promoteNodeDraft: jest
+        .fn()
+        .mockReturnValueOnce(firstPublication.promise)
+        .mockReturnValueOnce(secondPublication.promise),
+    };
+    const files = [createFile('one'), createFile('two')];
+    const {result} = renderHook(() =>
+      useSendFiles({
+        files,
+        cellsRepository: repository as never,
+        clearAllFiles: jest.fn(),
+        conversationId: 'conversation',
+        sendFilesErrorMessage: 'send failed',
+      }),
+    );
+
+    let sending: Promise<void> | undefined;
+    await act(async () => {
+      sending = result.current.sendFiles();
+      await Promise.resolve();
+    });
+
+    expect(repository.promoteNodeDraft).toHaveBeenCalledTimes(2);
+    expect(result.current.isLoading).toBe(true);
+    secondPublication.resolve();
+    firstPublication.resolve();
+    await act(async () => sending);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('does not revoke previews or cancel a promoted draft after another publication fails', async () => {
+    const firstPublication = createDeferred<void>();
+    const secondPublication = createDeferred<void>();
+    const cancelUpload = jest.fn();
+    const repository: Repository & {cancelUpload: jest.Mock} = {
+      promoteNodeDraft: jest
+        .fn()
+        .mockReturnValueOnce(firstPublication.promise)
+        .mockReturnValueOnce(secondPublication.promise),
+      cancelUpload,
+    };
+    const files = [createFile('one'), createFile('two')];
+    const revoke = jest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    revoke.mockClear();
+    const {result} = renderHook(() =>
+      useSendFiles({
+        files,
+        cellsRepository: repository as never,
+        clearAllFiles: jest.fn(),
+        conversationId: 'conversation',
+        sendFilesErrorMessage: 'send failed',
+      }),
+    );
+
+    let sending: Promise<void> | undefined;
+    await act(async () => {
+      sending = result.current.sendFiles();
+      await Promise.resolve();
+    });
+    expect(repository.promoteNodeDraft).toHaveBeenCalledTimes(2);
+
+    firstPublication.resolve();
+    secondPublication.reject(new Error('second publication failed'));
+    await expect(act(async () => sending)).rejects.toThrow();
+
+    expect(revoke).not.toHaveBeenCalled();
+    expect(cancelUpload).not.toHaveBeenCalled();
+    revoke.mockRestore();
+  });
+});


### PR DESCRIPTION




<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28356" title="WPB-28356" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28356</a>  [web] create logic library for handling upload (non-ui)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->




## Problem
Before starting the refactor, I’m adding deterministic coverage for the Cells upload and preview flow. The retry path could also diverge from the initial upload when the local and qualified conversation IDs were different

## Solution
Added focused tests for metadata ordering, progress, success and failure, cancellation, draft cleanup, aborts, retries, and stable previews

Updated InputBar to use the local conversation ID, keeping development paths and upload-state keys consistent while preserving the existing production paths and retry UUID behavior



[WPB-28356](https://wearezeta.atlassian.net/browse/WPB-28356)

[WPB-28356]: https://wearezeta.atlassian.net/browse/WPB-28356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ