### PR TITLE
Populate Production GitHub Release drafts with generated notes [WPB-26469]

### DIFF
--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -1131,7 +1131,7 @@ jobs:
             GitHub Release state: ${{ needs.ensure_github_release.outputs.github_release_state }}
             GitHub Release URL: ${{ needs.ensure_github_release.outputs.github_release_url }}
             GitHub Release handoff: ${{ needs.ensure_github_release.outputs.github_release_action }}
-            ${{ needs.ensure_github_release.outputs.github_release_state == 'draft' && 'The GitHub Release is a draft. Add the customer-facing changelog and publish it manually.' || 'The existing published GitHub Release was preserved.' }}
+            ${{ needs.ensure_github_release.outputs.github_release_state == 'draft' && 'The GitHub Release is a draft. Review or edit the generated customer-facing changelog and publish it manually.' || 'The existing published GitHub Release was preserved.' }}
             Triggering actor: ${{ github.actor }}
             Workflow-run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -1044,99 +1044,33 @@ jobs:
       github_release_url: ${{ steps.ensure_github_release.outputs.github_release_url }}
 
     steps:
+      - name: Checkout release tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
       - name: Ensure GitHub Release for immutable Production tag
         id: ensure_github_release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           PRODUCTION_TAG_NAME: ${{ needs.create_production_tag.outputs.production_tag_name || needs.production_preflight.outputs.production_tag_name }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "${PRODUCTION_TAG_NAME}" ]]; then
-            echo 'The authoritative Production tag name is unavailable.' >&2
-            exit 1
-          fi
-
-          echo "production_tag_name=${PRODUCTION_TAG_NAME}" >> "${GITHUB_OUTPUT}"
-
-          release_lookup_response_path="${RUNNER_TEMP}/github-release-lookup-response"
-          release_lookup_error_path="${RUNNER_TEMP}/github-release-lookup-error"
-          release_lookup_exit_code=0
-
-          set +e
-          gh api \
-            --include \
-            --header 'Accept: application/vnd.github+json' \
-            "repos/${GITHUB_REPOSITORY}/releases/tags/${PRODUCTION_TAG_NAME}" \
-            > "${release_lookup_response_path}" \
-            2> "${release_lookup_error_path}"
-          release_lookup_exit_code="$?"
-          set -e
-
-          http_status="$(
-            awk '$1 ~ /^HTTP\/[0-9.]+$/ { status = $2 } END { print status }' \
-              "${release_lookup_response_path}"
-          )"
-
-          if [[ "${http_status}" == '404' ]]; then
-            manual_changelog_placeholder='Customer-facing changelog must be added manually before publication.'
-            github_release_url="$(
-              gh release create \
-                "${PRODUCTION_TAG_NAME}" \
-                --repo "${GITHUB_REPOSITORY}" \
-                --verify-tag \
-                --draft \
-                --title "${PRODUCTION_TAG_NAME}" \
-                --notes "${manual_changelog_placeholder}"
-            )"
-
-            if [[ -z "${github_release_url}" ]]; then
-              echo 'GitHub CLI created the release but returned no release URL.' >&2
-              exit 1
-            fi
-
-            {
-              echo 'github_release_action=created'
-              echo 'github_release_state=draft'
-              echo "github_release_url=${github_release_url}"
-            } >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          if [[ "${release_lookup_exit_code}" -ne 0 || "${http_status}" != '200' ]]; then
-            echo "Unable to look up the GitHub Release for ${PRODUCTION_TAG_NAME}." >&2
-            echo "HTTP status: ${http_status:-unavailable}" >&2
-            cat "${release_lookup_error_path}" >&2
-            cat "${release_lookup_response_path}" >&2
-            exit 1
-          fi
-
-          release_json="$(sed -n '/^{/,$p' "${release_lookup_response_path}")"
-          release_tag_name="$(jq -r '.tag_name // empty' <<< "${release_json}")"
-          github_release_url="$(jq -r '.html_url // empty' <<< "${release_json}")"
-          is_draft="$(jq -r '.draft // empty' <<< "${release_json}")"
-
-          if [[ "${release_tag_name}" != "${PRODUCTION_TAG_NAME}" || -z "${github_release_url}" ]]; then
-            echo "The GitHub Release lookup did not return a valid release for ${PRODUCTION_TAG_NAME}." >&2
-            exit 1
-          fi
-
-          if [[ "${is_draft}" == 'true' ]]; then
-            github_release_action='already_draft'
-            github_release_state='draft'
-          elif [[ "${is_draft}" == 'false' ]]; then
-            github_release_action='already_published'
-            github_release_state='published'
-          else
-            echo "The GitHub Release for ${PRODUCTION_TAG_NAME} has an invalid draft state." >&2
-            exit 1
-          fi
-
-          {
-            echo "github_release_action=${github_release_action}"
-            echo "github_release_state=${github_release_state}"
-            echo "github_release_url=${github_release_url}"
-          } >> "${GITHUB_OUTPUT}"
+        run: node ./tools/release-cli/ensureProductionGitHubRelease.mts "${PRODUCTION_TAG_NAME}" >> "${GITHUB_OUTPUT}"
 
   notify_production_release_success:
     name: Notify successful Production release

--- a/tools/release-appearance/ensureProductionGitHubRelease.test.ts
+++ b/tools/release-appearance/ensureProductionGitHubRelease.test.ts
@@ -19,10 +19,10 @@
 
 import assert from 'node:assert';
 
-import {Maybe, Result} from 'true-myth';
+import {Maybe, Task} from 'true-myth';
 
 import {ensureProductionGitHubRelease} from './ensureProductionGitHubRelease.ts';
-import type {GitHubReleaseClient, GitHubReleaseRecord} from './githubReleaseClient.ts';
+import type {GitHubGeneratedReleaseNotes, GitHubReleaseClient, GitHubReleaseRecord} from './githubReleaseClient.ts';
 
 type FakeGitHubReleaseClientOptions = {
   readonly existingRelease: Maybe<GitHubReleaseRecord>;
@@ -33,31 +33,40 @@ type FakeGitHubReleaseClientFixture = {
   readonly githubReleaseClient: GitHubReleaseClient;
   readonly findReleaseTagNames: string[];
   readonly listTagNamesCallCount: number[];
-  readonly createProductionDraftOptions: Parameters<GitHubReleaseClient['createProductionDraft']>[0][];
+  readonly generateReleaseNotesOptions: Parameters<GitHubReleaseClient['generateReleaseNotes']>[0][];
+  readonly createDraftReleaseOptions: Parameters<GitHubReleaseClient['createDraftRelease']>[0][];
 };
+
+const generatedReleaseNotesBody = 'Generated release notes';
 
 function createFakeGitHubReleaseClient(
   fakeGitHubReleaseClientOptions: FakeGitHubReleaseClientOptions,
 ): FakeGitHubReleaseClientFixture {
   const findReleaseTagNames: string[] = [];
   const listTagNamesCallCount: number[] = [];
-  const createProductionDraftOptions: Parameters<GitHubReleaseClient['createProductionDraft']>[0][] = [];
+  const generateReleaseNotesOptions: Parameters<GitHubReleaseClient['generateReleaseNotes']>[0][] = [];
+  const createDraftReleaseOptions: Parameters<GitHubReleaseClient['createDraftRelease']>[0][] = [];
   return {
     findReleaseTagNames,
     listTagNamesCallCount,
-    createProductionDraftOptions,
+    generateReleaseNotesOptions,
+    createDraftReleaseOptions,
     githubReleaseClient: {
-      async listTagNames(): Promise<Result<readonly string[], Error>> {
+      listTagNames(): Task<readonly string[], Error> {
         listTagNamesCallCount.push(1);
-        return Result.ok(fakeGitHubReleaseClientOptions.tagNames);
+        return Task.resolve(fakeGitHubReleaseClientOptions.tagNames);
       },
-      async findReleaseByTag(options): Promise<Result<Maybe<GitHubReleaseRecord>, Error>> {
+      findReleaseByTag(options): Task<Maybe<GitHubReleaseRecord>, Error> {
         findReleaseTagNames.push(options.tagName);
-        return Result.ok(fakeGitHubReleaseClientOptions.existingRelease);
+        return Task.resolve(fakeGitHubReleaseClientOptions.existingRelease);
       },
-      async createProductionDraft(options): Promise<Result<GitHubReleaseRecord, Error>> {
-        createProductionDraftOptions.push(options);
-        return Result.ok({
+      generateReleaseNotes(options): Task<GitHubGeneratedReleaseNotes, Error> {
+        generateReleaseNotesOptions.push(options);
+        return Task.resolve({name: options.productionTagName, body: generatedReleaseNotesBody});
+      },
+      createDraftRelease(options): Task<GitHubReleaseRecord, Error> {
+        createDraftReleaseOptions.push(options);
+        return Task.resolve({
           tagName: options.productionTagName,
           htmlUrl: `https://github.com/wireapp/wire-webapp/releases/tag/${options.productionTagName}`,
           isDraft: true,
@@ -96,10 +105,16 @@ describe('ensureProductionGitHubRelease', () => {
     });
     expect(fakeGitHubReleaseClient.findReleaseTagNames).toEqual(['2026-08-28.1-production']);
     expect(fakeGitHubReleaseClient.listTagNamesCallCount).toHaveLength(1);
-    expect(fakeGitHubReleaseClient.createProductionDraftOptions).toEqual([
+    expect(fakeGitHubReleaseClient.generateReleaseNotesOptions).toEqual([
       {
         productionTagName: '2026-08-28.1-production',
-        precedingProductionTagName: Maybe.just('2026-08-07.1-production'),
+        precedingProductionTagName: '2026-08-07.1-production',
+      },
+    ]);
+    expect(fakeGitHubReleaseClient.createDraftReleaseOptions).toEqual([
+      {
+        productionTagName: '2026-08-28.1-production',
+        body: generatedReleaseNotesBody,
       },
     ]);
   });
@@ -124,7 +139,8 @@ describe('ensureProductionGitHubRelease', () => {
       url: existingRelease.htmlUrl,
     });
     expect(fakeGitHubReleaseClient.listTagNamesCallCount).toHaveLength(0);
-    expect(fakeGitHubReleaseClient.createProductionDraftOptions).toHaveLength(0);
+    expect(fakeGitHubReleaseClient.generateReleaseNotesOptions).toHaveLength(0);
+    expect(fakeGitHubReleaseClient.createDraftReleaseOptions).toHaveLength(0);
   });
 
   it('preserves an existing published Release without listing tags or creating a Release', async (): Promise<void> => {
@@ -143,7 +159,8 @@ describe('ensureProductionGitHubRelease', () => {
     expect(actualResult.value.action).toBe('already_published');
     expect(actualResult.value.state).toBe('published');
     expect(fakeGitHubReleaseClient.listTagNamesCallCount).toHaveLength(0);
-    expect(fakeGitHubReleaseClient.createProductionDraftOptions).toHaveLength(0);
+    expect(fakeGitHubReleaseClient.generateReleaseNotesOptions).toHaveLength(0);
+    expect(fakeGitHubReleaseClient.createDraftReleaseOptions).toHaveLength(0);
   });
 
   it('creates a bootstrap draft without using the entire tag history as release notes', async (): Promise<void> => {
@@ -158,10 +175,11 @@ describe('ensureProductionGitHubRelease', () => {
     });
 
     assert(actualResult.isOk);
-    expect(fakeGitHubReleaseClient.createProductionDraftOptions).toEqual([
+    expect(fakeGitHubReleaseClient.generateReleaseNotesOptions).toHaveLength(0);
+    expect(fakeGitHubReleaseClient.createDraftReleaseOptions).toEqual([
       {
         productionTagName: '2026-07-27.1-production',
-        precedingProductionTagName: Maybe.nothing(),
+        body: 'No preceding ADR Production release was found. Add the customer-facing changelog manually before publication.',
       },
     ]);
   });
@@ -181,6 +199,7 @@ describe('ensureProductionGitHubRelease', () => {
     expect(actualResult.error.message).toBe('Invalid production tag name: 2026-08-28.1-beta.1');
     expect(fakeGitHubReleaseClient.findReleaseTagNames).toHaveLength(0);
     expect(fakeGitHubReleaseClient.listTagNamesCallCount).toHaveLength(0);
-    expect(fakeGitHubReleaseClient.createProductionDraftOptions).toHaveLength(0);
+    expect(fakeGitHubReleaseClient.generateReleaseNotesOptions).toHaveLength(0);
+    expect(fakeGitHubReleaseClient.createDraftReleaseOptions).toHaveLength(0);
   });
 });

--- a/tools/release-appearance/ensureProductionGitHubRelease.test.ts
+++ b/tools/release-appearance/ensureProductionGitHubRelease.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+
+import {Maybe, Result} from 'true-myth';
+
+import {ensureProductionGitHubRelease} from './ensureProductionGitHubRelease.ts';
+import type {GitHubReleaseClient, GitHubReleaseRecord} from './githubReleaseClient.ts';
+
+type FakeGitHubReleaseClientOptions = {
+  readonly existingRelease: Maybe<GitHubReleaseRecord>;
+  readonly tagNames: readonly string[];
+};
+
+type FakeGitHubReleaseClientFixture = {
+  readonly githubReleaseClient: GitHubReleaseClient;
+  readonly findReleaseTagNames: string[];
+  readonly listTagNamesCallCount: number[];
+  readonly createProductionDraftOptions: Array<Parameters<GitHubReleaseClient['createProductionDraft']>[0]>;
+};
+
+function createFakeGitHubReleaseClient(
+  fakeGitHubReleaseClientOptions: FakeGitHubReleaseClientOptions,
+): FakeGitHubReleaseClientFixture {
+  const findReleaseTagNames: string[] = [];
+  const listTagNamesCallCount: number[] = [];
+  const createProductionDraftOptions: Array<
+    Parameters<GitHubReleaseClient['createProductionDraft']>[0]
+  > = [];
+  return {
+    findReleaseTagNames,
+    listTagNamesCallCount,
+    createProductionDraftOptions,
+    githubReleaseClient: {
+      listTagNames: async function listTagNames(): Promise<Result<readonly string[], Error>> {
+        listTagNamesCallCount.push(1);
+        return Result.ok(fakeGitHubReleaseClientOptions.tagNames);
+      },
+      findReleaseByTag: async function findReleaseByTag(
+        options,
+      ): Promise<Result<Maybe<GitHubReleaseRecord>, Error>> {
+        findReleaseTagNames.push(options.tagName);
+        return Result.ok(fakeGitHubReleaseClientOptions.existingRelease);
+      },
+      createProductionDraft: async function createProductionDraft(
+        options,
+      ): Promise<Result<GitHubReleaseRecord, Error>> {
+        createProductionDraftOptions.push(options);
+        return Result.ok({
+          tagName: options.productionTagName,
+          htmlUrl: `https://github.com/wireapp/wire-webapp/releases/tag/${options.productionTagName}`,
+          isDraft: true,
+        });
+      },
+    },
+  };
+}
+
+function createExistingRelease(isDraft: boolean): GitHubReleaseRecord {
+  return {
+    tagName: '2026-08-28.1-production',
+    htmlUrl: 'https://github.com/wireapp/wire-webapp/releases/tag/2026-08-28.1-production',
+    isDraft,
+  };
+}
+
+describe('ensureProductionGitHubRelease', () => {
+  it('creates a new draft with the preceding Production tag when no Release exists', async (): Promise<void> => {
+    const fakeGitHubReleaseClient = createFakeGitHubReleaseClient({
+      existingRelease: Maybe.nothing(),
+      tagNames: [
+        '2026-08-07.1-production',
+        '2026-08-28.1-beta.1',
+        '2026-08-28-staging.0',
+        '2026-08-28-production.0',
+      ],
+    });
+
+    const actualResult = await ensureProductionGitHubRelease({
+      currentProductionTagName: '2026-08-28.1-production',
+      githubReleaseClient: fakeGitHubReleaseClient.githubReleaseClient,
+    });
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toEqual({
+      action: 'created',
+      state: 'draft',
+      tagName: '2026-08-28.1-production',
+      url: 'https://github.com/wireapp/wire-webapp/releases/tag/2026-08-28.1-production',
+    });
+    expect(fakeGitHubReleaseClient.findReleaseTagNames).toEqual(['2026-08-28.1-production']);
+    expect(fakeGitHubReleaseClient.listTagNamesCallCount).toHaveLength(1);
+    expect(fakeGitHubReleaseClient.createProductionDraftOptions).toEqual([
+      {
+        productionTagName: '2026-08-28.1-production',
+        precedingProductionTagName: Maybe.just('2026-08-07.1-production'),
+      },
+    ]);
+  });
+
+  it('preserves an existing draft without listing tags or creating a Release', async (): Promise<void> => {
+    const existingRelease = createExistingRelease(true);
+    const fakeGitHubReleaseClient = createFakeGitHubReleaseClient({
+      existingRelease: Maybe.just(existingRelease),
+      tagNames: [],
+    });
+
+    const actualResult = await ensureProductionGitHubRelease({
+      currentProductionTagName: '2026-08-28.1-production',
+      githubReleaseClient: fakeGitHubReleaseClient.githubReleaseClient,
+    });
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toEqual({
+      action: 'already_draft',
+      state: 'draft',
+      tagName: existingRelease.tagName,
+      url: existingRelease.htmlUrl,
+    });
+    expect(fakeGitHubReleaseClient.listTagNamesCallCount).toHaveLength(0);
+    expect(fakeGitHubReleaseClient.createProductionDraftOptions).toHaveLength(0);
+  });
+
+  it('preserves an existing published Release without listing tags or creating a Release', async (): Promise<void> => {
+    const existingRelease = createExistingRelease(false);
+    const fakeGitHubReleaseClient = createFakeGitHubReleaseClient({
+      existingRelease: Maybe.just(existingRelease),
+      tagNames: [],
+    });
+
+    const actualResult = await ensureProductionGitHubRelease({
+      currentProductionTagName: '2026-08-28.1-production',
+      githubReleaseClient: fakeGitHubReleaseClient.githubReleaseClient,
+    });
+
+    assert(actualResult.isOk);
+    expect(actualResult.value.action).toBe('already_published');
+    expect(actualResult.value.state).toBe('published');
+    expect(fakeGitHubReleaseClient.listTagNamesCallCount).toHaveLength(0);
+    expect(fakeGitHubReleaseClient.createProductionDraftOptions).toHaveLength(0);
+  });
+
+  it('creates a bootstrap draft without using the entire tag history as release notes', async (): Promise<void> => {
+    const fakeGitHubReleaseClient = createFakeGitHubReleaseClient({
+      existingRelease: Maybe.nothing(),
+      tagNames: ['2026-07-27.1-beta.1', '2026-07-27-staging.0', '2026-07-27-production.0'],
+    });
+
+    const actualResult = await ensureProductionGitHubRelease({
+      currentProductionTagName: '2026-07-27.1-production',
+      githubReleaseClient: fakeGitHubReleaseClient.githubReleaseClient,
+    });
+
+    assert(actualResult.isOk);
+    expect(fakeGitHubReleaseClient.createProductionDraftOptions).toEqual([
+      {
+        productionTagName: '2026-07-27.1-production',
+        precedingProductionTagName: Maybe.nothing(),
+      },
+    ]);
+  });
+
+  it('rejects a Beta tag without making any GitHub Release requests', async (): Promise<void> => {
+    const fakeGitHubReleaseClient = createFakeGitHubReleaseClient({
+      existingRelease: Maybe.nothing(),
+      tagNames: [],
+    });
+
+    const actualResult = await ensureProductionGitHubRelease({
+      currentProductionTagName: '2026-08-28.1-beta.1',
+      githubReleaseClient: fakeGitHubReleaseClient.githubReleaseClient,
+    });
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('Invalid production tag name: 2026-08-28.1-beta.1');
+    expect(fakeGitHubReleaseClient.findReleaseTagNames).toHaveLength(0);
+    expect(fakeGitHubReleaseClient.listTagNamesCallCount).toHaveLength(0);
+    expect(fakeGitHubReleaseClient.createProductionDraftOptions).toHaveLength(0);
+  });
+});

--- a/tools/release-appearance/ensureProductionGitHubRelease.test.ts
+++ b/tools/release-appearance/ensureProductionGitHubRelease.test.ts
@@ -33,7 +33,7 @@ type FakeGitHubReleaseClientFixture = {
   readonly githubReleaseClient: GitHubReleaseClient;
   readonly findReleaseTagNames: string[];
   readonly listTagNamesCallCount: number[];
-  readonly createProductionDraftOptions: Array<Parameters<GitHubReleaseClient['createProductionDraft']>[0]>;
+  readonly createProductionDraftOptions: Parameters<GitHubReleaseClient['createProductionDraft']>[0][];
 };
 
 function createFakeGitHubReleaseClient(
@@ -41,27 +41,21 @@ function createFakeGitHubReleaseClient(
 ): FakeGitHubReleaseClientFixture {
   const findReleaseTagNames: string[] = [];
   const listTagNamesCallCount: number[] = [];
-  const createProductionDraftOptions: Array<
-    Parameters<GitHubReleaseClient['createProductionDraft']>[0]
-  > = [];
+  const createProductionDraftOptions: Parameters<GitHubReleaseClient['createProductionDraft']>[0][] = [];
   return {
     findReleaseTagNames,
     listTagNamesCallCount,
     createProductionDraftOptions,
     githubReleaseClient: {
-      listTagNames: async function listTagNames(): Promise<Result<readonly string[], Error>> {
+      async listTagNames(): Promise<Result<readonly string[], Error>> {
         listTagNamesCallCount.push(1);
         return Result.ok(fakeGitHubReleaseClientOptions.tagNames);
       },
-      findReleaseByTag: async function findReleaseByTag(
-        options,
-      ): Promise<Result<Maybe<GitHubReleaseRecord>, Error>> {
+      async findReleaseByTag(options): Promise<Result<Maybe<GitHubReleaseRecord>, Error>> {
         findReleaseTagNames.push(options.tagName);
         return Result.ok(fakeGitHubReleaseClientOptions.existingRelease);
       },
-      createProductionDraft: async function createProductionDraft(
-        options,
-      ): Promise<Result<GitHubReleaseRecord, Error>> {
+      async createProductionDraft(options): Promise<Result<GitHubReleaseRecord, Error>> {
         createProductionDraftOptions.push(options);
         return Result.ok({
           tagName: options.productionTagName,
@@ -85,12 +79,7 @@ describe('ensureProductionGitHubRelease', () => {
   it('creates a new draft with the preceding Production tag when no Release exists', async (): Promise<void> => {
     const fakeGitHubReleaseClient = createFakeGitHubReleaseClient({
       existingRelease: Maybe.nothing(),
-      tagNames: [
-        '2026-08-07.1-production',
-        '2026-08-28.1-beta.1',
-        '2026-08-28-staging.0',
-        '2026-08-28-production.0',
-      ],
+      tagNames: ['2026-08-07.1-production', '2026-08-28.1-beta.1', '2026-08-28-staging.0', '2026-08-28-production.0'],
     });
 
     const actualResult = await ensureProductionGitHubRelease({

--- a/tools/release-appearance/ensureProductionGitHubRelease.ts
+++ b/tools/release-appearance/ensureProductionGitHubRelease.ts
@@ -1,0 +1,136 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Result} from 'true-myth';
+
+import type {GitHubReleaseClient, GitHubReleaseRecord} from './githubReleaseClient.ts';
+
+import {selectPrecedingProductionTag, validateProductionTagName} from '../release-metadata/releaseMetadata.ts';
+
+export type ProductionGitHubReleaseAction = 'created' | 'already_draft' | 'already_published';
+export type ProductionGitHubReleaseState = 'draft' | 'published';
+
+export type ProductionGitHubReleaseHandoff = {
+  readonly action: ProductionGitHubReleaseAction;
+  readonly state: ProductionGitHubReleaseState;
+  readonly tagName: string;
+  readonly url: string;
+};
+
+export type EnsureProductionGitHubReleaseOptions = {
+  readonly currentProductionTagName: string;
+  readonly githubReleaseClient: GitHubReleaseClient;
+};
+
+function createExistingReleaseHandoff(
+  currentProductionTagName: string,
+  existingRelease: GitHubReleaseRecord,
+): Result<ProductionGitHubReleaseHandoff, Error> {
+  if (existingRelease.tagName !== currentProductionTagName) {
+    return Result.err(
+      new Error(
+        `The GitHub Release lookup returned tag ${existingRelease.tagName} instead of ${currentProductionTagName}.`,
+      ),
+    );
+  }
+
+  if (existingRelease.isDraft) {
+    return Result.ok({
+      action: 'already_draft',
+      state: 'draft',
+      tagName: existingRelease.tagName,
+      url: existingRelease.htmlUrl,
+    });
+  }
+
+  return Result.ok({
+    action: 'already_published',
+    state: 'published',
+    tagName: existingRelease.tagName,
+    url: existingRelease.htmlUrl,
+  });
+}
+
+function createNewReleaseHandoff(
+  productionTagName: string,
+  createdRelease: GitHubReleaseRecord,
+): Result<ProductionGitHubReleaseHandoff, Error> {
+  if (createdRelease.tagName !== productionTagName) {
+    return Result.err(
+      new Error(`The GitHub Release creation returned tag ${createdRelease.tagName} instead of ${productionTagName}.`),
+    );
+  }
+
+  if (createdRelease.isDraft === false) {
+    return Result.err(new Error(`The GitHub Release for ${productionTagName} was not created as a draft.`));
+  }
+
+  return Result.ok({
+    action: 'created',
+    state: 'draft',
+    tagName: createdRelease.tagName,
+    url: createdRelease.htmlUrl,
+  });
+}
+
+export async function ensureProductionGitHubRelease(
+  options: EnsureProductionGitHubReleaseOptions,
+): Promise<Result<ProductionGitHubReleaseHandoff, Error>> {
+  const validatedProductionTagNameResult = validateProductionTagName(options.currentProductionTagName);
+
+  if (validatedProductionTagNameResult.isErr) {
+    return Result.err(validatedProductionTagNameResult.error);
+  }
+
+  const productionTagName = validatedProductionTagNameResult.value;
+  const existingReleaseResult = await options.githubReleaseClient.findReleaseByTag({
+    tagName: productionTagName,
+  });
+
+  if (existingReleaseResult.isErr) {
+    return Result.err(existingReleaseResult.error);
+  }
+
+  if (existingReleaseResult.value.isJust) {
+    return createExistingReleaseHandoff(productionTagName, existingReleaseResult.value.value);
+  }
+
+  const existingTagNamesResult = await options.githubReleaseClient.listTagNames();
+
+  if (existingTagNamesResult.isErr) {
+    return Result.err(existingTagNamesResult.error);
+  }
+
+  const precedingProductionTagResult = selectPrecedingProductionTag(productionTagName, existingTagNamesResult.value);
+
+  if (precedingProductionTagResult.isErr) {
+    return Result.err(precedingProductionTagResult.error);
+  }
+
+  const createdReleaseResult = await options.githubReleaseClient.createProductionDraft({
+    productionTagName,
+    precedingProductionTagName: precedingProductionTagResult.value,
+  });
+
+  if (createdReleaseResult.isErr) {
+    return Result.err(createdReleaseResult.error);
+  }
+
+  return createNewReleaseHandoff(productionTagName, createdReleaseResult.value);
+}

--- a/tools/release-appearance/ensureProductionGitHubRelease.ts
+++ b/tools/release-appearance/ensureProductionGitHubRelease.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Result} from 'true-myth';
+import {Result, Task} from 'true-myth';
 
 import type {GitHubReleaseClient, GitHubReleaseRecord} from './githubReleaseClient.ts';
 
@@ -37,6 +37,9 @@ export type EnsureProductionGitHubReleaseOptions = {
   readonly currentProductionTagName: string;
   readonly githubReleaseClient: GitHubReleaseClient;
 };
+
+const noPrecedingProductionReleaseNotes =
+  'No preceding ADR Production release was found. Add the customer-facing changelog manually before publication.';
 
 function createExistingReleaseHandoff(
   currentProductionTagName: string,
@@ -89,48 +92,57 @@ function createNewReleaseHandoff(
   });
 }
 
-export async function ensureProductionGitHubRelease(
+export function ensureProductionGitHubRelease(
   options: EnsureProductionGitHubReleaseOptions,
-): Promise<Result<ProductionGitHubReleaseHandoff, Error>> {
+): Task<ProductionGitHubReleaseHandoff, Error> {
   const validatedProductionTagNameResult = validateProductionTagName(options.currentProductionTagName);
 
   if (validatedProductionTagNameResult.isErr) {
-    return Result.err(validatedProductionTagNameResult.error);
+    return Task.reject<ProductionGitHubReleaseHandoff, Error>(validatedProductionTagNameResult.error);
   }
 
   const productionTagName = validatedProductionTagNameResult.value;
-  const existingReleaseResult = await options.githubReleaseClient.findReleaseByTag({
-    tagName: productionTagName,
-  });
+  return options.githubReleaseClient
+    .findReleaseByTag({
+      tagName: productionTagName,
+    })
+    .andThen(existingRelease => {
+      if (existingRelease.isJust) {
+        return createExistingReleaseHandoff(productionTagName, existingRelease.value);
+      }
 
-  if (existingReleaseResult.isErr) {
-    return Result.err(existingReleaseResult.error);
-  }
+      return options.githubReleaseClient.listTagNames().andThen(existingTagNames => {
+        const precedingProductionTagResult = selectPrecedingProductionTag(productionTagName, existingTagNames);
 
-  if (existingReleaseResult.value.isJust) {
-    return createExistingReleaseHandoff(productionTagName, existingReleaseResult.value.value);
-  }
+        if (precedingProductionTagResult.isErr) {
+          return Task.reject<ProductionGitHubReleaseHandoff, Error>(precedingProductionTagResult.error);
+        }
 
-  const existingTagNamesResult = await options.githubReleaseClient.listTagNames();
+        if (precedingProductionTagResult.value.isJust) {
+          return options.githubReleaseClient
+            .generateReleaseNotes({
+              productionTagName,
+              precedingProductionTagName: precedingProductionTagResult.value.value,
+            })
+            .andThen(generatedReleaseNotes => {
+              return options.githubReleaseClient.createDraftRelease({
+                productionTagName,
+                body: generatedReleaseNotes.body,
+              });
+            })
+            .andThen(createdRelease => {
+              return createNewReleaseHandoff(productionTagName, createdRelease);
+            });
+        }
 
-  if (existingTagNamesResult.isErr) {
-    return Result.err(existingTagNamesResult.error);
-  }
-
-  const precedingProductionTagResult = selectPrecedingProductionTag(productionTagName, existingTagNamesResult.value);
-
-  if (precedingProductionTagResult.isErr) {
-    return Result.err(precedingProductionTagResult.error);
-  }
-
-  const createdReleaseResult = await options.githubReleaseClient.createProductionDraft({
-    productionTagName,
-    precedingProductionTagName: precedingProductionTagResult.value,
-  });
-
-  if (createdReleaseResult.isErr) {
-    return Result.err(createdReleaseResult.error);
-  }
-
-  return createNewReleaseHandoff(productionTagName, createdReleaseResult.value);
+        return options.githubReleaseClient
+          .createDraftRelease({
+            productionTagName,
+            body: noPrecedingProductionReleaseNotes,
+          })
+          .andThen(createdRelease => {
+            return createNewReleaseHandoff(productionTagName, createdRelease);
+          });
+      });
+    });
 }

--- a/tools/release-appearance/githubReleaseClient.test.ts
+++ b/tools/release-appearance/githubReleaseClient.test.ts
@@ -1,0 +1,219 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+
+import {Maybe} from 'true-myth';
+
+import {createGitHubReleaseClient} from './githubReleaseClient.ts';
+import type {HttpRequest, HttpRequestFailure} from './httpClient.ts';
+
+type FakeHttpClientOptions = {
+  readonly responseForRequest: (request: HttpRequest) => unknown;
+};
+
+type FakeHttpClientFixture = {
+  readonly httpClient: {
+    readonly requestJson: (request: HttpRequest) => Promise<unknown>;
+  };
+  readonly requests: HttpRequest[];
+};
+
+function createFakeHttpClient(fakeHttpClientOptions: FakeHttpClientOptions): FakeHttpClientFixture {
+  const requests: HttpRequest[] = [];
+
+  return {
+    requests,
+    httpClient: {
+      async requestJson(request): Promise<unknown> {
+        requests.push(request);
+        return fakeHttpClientOptions.responseForRequest(request);
+      },
+    },
+  };
+}
+
+function createHttpResponseFailure(statusCode: number): HttpRequestFailure {
+  return {
+    kind: 'http-response-failure',
+    method: 'get',
+    url: new URL('https://api.github.example/'),
+    response: {
+      statusCode,
+      githubMessage: Maybe.nothing<string>(),
+      documentationUrl: Maybe.nothing<string>(),
+      githubRequestId: Maybe.nothing<string>(),
+      acceptedGithubPermissions: Maybe.nothing<string>(),
+      retryAfter: Maybe.nothing<string>(),
+      rateLimitRemaining: Maybe.nothing<string>(),
+      rateLimitReset: Maybe.nothing<string>(),
+    },
+  };
+}
+
+function createClient(fakeHttpClient: FakeHttpClientFixture['httpClient'] = createFakeHttpClient({
+  responseForRequest() {
+    return [];
+  },
+}).httpClient): ReturnType<typeof createGitHubReleaseClient> {
+  return createGitHubReleaseClient({
+    httpClient: fakeHttpClient,
+    githubApiUrl: new URL('https://api.github.example/'),
+    githubRepository: 'wireapp/wire-webapp',
+    githubToken: 'github-token',
+  });
+}
+
+describe('GitHub Release client', () => {
+  it('lists all GitHub tag names with pagination', async () => {
+    const firstPage = Array.from({length: 100}, (_, tagIndex) => {
+      return {name: `tag-${tagIndex + 1}`};
+    });
+    const fakeHttpClient = createFakeHttpClient({
+      responseForRequest(request) {
+        return request.url.searchParams.get('page') === '1' ? firstPage : [{name: 'tag-101'}];
+      },
+    });
+    const githubReleaseClient = createClient(fakeHttpClient.httpClient);
+
+    const actualResult = await githubReleaseClient.listTagNames();
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toHaveLength(101);
+    expect(actualResult.value[100]).toBe('tag-101');
+    expect(
+      fakeHttpClient.requests.map(request => {
+        return request.url.toString();
+      }),
+    ).toEqual([
+      'https://api.github.example/repos/wireapp/wire-webapp/tags?per_page=100&page=1',
+      'https://api.github.example/repos/wireapp/wire-webapp/tags?per_page=100&page=2',
+    ]);
+  });
+
+  it('maps an existing GitHub Release and treats a missing release as absent', async () => {
+    const productionTagName = '2026-08-28.1-production';
+    const existingRelease = {
+      tag_name: productionTagName,
+      html_url: `https://github.com/wireapp/wire-webapp/releases/tag/${productionTagName}`,
+      draft: true,
+    };
+    const fakeHttpClient = createFakeHttpClient({
+      responseForRequest(request) {
+        if (request.url.pathname.endsWith('/2026-08-28.1-production')) {
+          return existingRelease;
+        }
+
+        throw createHttpResponseFailure(404);
+      },
+    });
+    const githubReleaseClient = createClient(fakeHttpClient.httpClient);
+
+    const existingReleaseResult = await githubReleaseClient.findReleaseByTag({tagName: productionTagName});
+    const missingReleaseResult = await githubReleaseClient.findReleaseByTag({tagName: '2026-09-01.1-production'});
+
+    assert(existingReleaseResult.isOk);
+    expect(existingReleaseResult.value).toEqual(
+      Maybe.just({
+        tagName: productionTagName,
+        htmlUrl: existingRelease.html_url,
+        isDraft: true,
+      }),
+    );
+    assert(missingReleaseResult.isOk);
+    expect(missingReleaseResult.value.isNothing).toBe(true);
+  });
+
+  it('requests GitHub-generated notes from the preceding Production tag', async () => {
+    const fakeHttpClient = createFakeHttpClient({
+      responseForRequest(request) {
+        return {
+          tag_name: '2026-08-28.1-production',
+          html_url: 'https://github.com/wireapp/wire-webapp/releases/tag/2026-08-28.1-production',
+          draft: true,
+        };
+      },
+    });
+    const githubReleaseClient = createClient(fakeHttpClient.httpClient);
+
+    const actualResult = await githubReleaseClient.createProductionDraft({
+      productionTagName: '2026-08-28.1-production',
+      precedingProductionTagName: Maybe.just('2026-08-07.1-production'),
+    });
+
+    assert(actualResult.isOk);
+    const request = Maybe.of(fakeHttpClient.requests[0]);
+    assert(request.isJust);
+    expect(request.value.method).toBe('post');
+    expect(request.value.url.toString()).toBe('https://api.github.example/repos/wireapp/wire-webapp/releases');
+    expect(request.value.json).toEqual(
+      Maybe.just({
+        tag_name: '2026-08-28.1-production',
+        name: '2026-08-28.1-production',
+        draft: true,
+        generate_release_notes: true,
+        previous_tag_name: '2026-08-07.1-production',
+      }),
+    );
+  });
+
+  it('uses a deterministic manual placeholder when no preceding Production tag exists', async () => {
+    const fakeHttpClient = createFakeHttpClient({
+      responseForRequest() {
+        return {
+          tag_name: '2026-07-27.1-production',
+          html_url: 'https://github.com/wireapp/wire-webapp/releases/tag/2026-07-27.1-production',
+          draft: true,
+        };
+      },
+    });
+    const githubReleaseClient = createClient(fakeHttpClient.httpClient);
+
+    const actualResult = await githubReleaseClient.createProductionDraft({
+      productionTagName: '2026-07-27.1-production',
+      precedingProductionTagName: Maybe.nothing(),
+    });
+
+    assert(actualResult.isOk);
+    const request = Maybe.of(fakeHttpClient.requests[0]);
+    assert(request.isJust);
+    expect(request.value.json).toEqual(
+      Maybe.just({
+        tag_name: '2026-07-27.1-production',
+        name: '2026-07-27.1-production',
+        draft: true,
+        body: 'No preceding ADR Production release was found. Add the customer-facing changelog manually before publication.',
+      }),
+    );
+  });
+
+  it('rejects malformed GitHub Release responses at the API boundary', async () => {
+    const fakeHttpClient = createFakeHttpClient({
+      responseForRequest() {
+        return {tag_name: '2026-08-28.1-production', draft: true};
+      },
+    });
+    const githubReleaseClient = createClient(fakeHttpClient.httpClient);
+
+    const actualResult = await githubReleaseClient.findReleaseByTag({tagName: '2026-08-28.1-production'});
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('Malformed GitHub Release response');
+  });
+});

--- a/tools/release-appearance/githubReleaseClient.test.ts
+++ b/tools/release-appearance/githubReleaseClient.test.ts
@@ -28,11 +28,19 @@ type FakeHttpClientOptions = {
   readonly responseForRequest: (request: HttpRequest) => unknown;
 };
 
+type FakeHttpClient = {
+  readonly requestJson: (request: HttpRequest) => Promise<unknown>;
+};
+
 type FakeHttpClientFixture = {
-  readonly httpClient: {
-    readonly requestJson: (request: HttpRequest) => Promise<unknown>;
-  };
+  readonly httpClient: FakeHttpClient;
   readonly requests: HttpRequest[];
+};
+
+type GitHubReleaseResponse = {
+  readonly tag_name: string;
+  readonly html_url: string;
+  readonly draft: boolean;
 };
 
 function createFakeHttpClient(fakeHttpClientOptions: FakeHttpClientOptions): FakeHttpClientFixture {
@@ -64,6 +72,14 @@ function createHttpResponseFailure(statusCode: number): HttpRequestFailure {
       rateLimitRemaining: Maybe.nothing<string>(),
       rateLimitReset: Maybe.nothing<string>(),
     },
+  };
+}
+
+function createReleaseResponse(tagName: string, isDraft: boolean): GitHubReleaseResponse {
+  return {
+    tag_name: tagName,
+    html_url: `https://github.com/wireapp/wire-webapp/releases/tag/${tagName}`,
+    draft: isDraft,
   };
 }
 
@@ -109,26 +125,17 @@ describe('GitHub Release client', () => {
     ]);
   });
 
-  it('maps an existing GitHub Release and treats a missing release as absent', async () => {
+  it('finds an existing draft GitHub Release in the releases collection', async () => {
     const productionTagName = '2026-08-28.1-production';
-    const existingRelease = {
-      tag_name: productionTagName,
-      html_url: `https://github.com/wireapp/wire-webapp/releases/tag/${productionTagName}`,
-      draft: true,
-    };
+    const existingRelease = createReleaseResponse(productionTagName, true);
     const fakeHttpClient = createFakeHttpClient({
-      responseForRequest(request) {
-        if (request.url.pathname.endsWith('/2026-08-28.1-production')) {
-          return existingRelease;
-        }
-
-        throw createHttpResponseFailure(404);
+      responseForRequest() {
+        return [existingRelease];
       },
     });
     const githubReleaseClient = createClient(fakeHttpClient.httpClient);
 
     const existingReleaseResult = await githubReleaseClient.findReleaseByTag({tagName: productionTagName});
-    const missingReleaseResult = await githubReleaseClient.findReleaseByTag({tagName: '2026-09-01.1-production'});
 
     assert(existingReleaseResult.isOk);
     expect(existingReleaseResult.value).toEqual(
@@ -138,58 +145,138 @@ describe('GitHub Release client', () => {
         isDraft: true,
       }),
     );
-    assert(missingReleaseResult.isOk);
-    expect(missingReleaseResult.value.isNothing).toBe(true);
+    expect(fakeHttpClient.requests[0]?.url.toString()).toBe(
+      'https://api.github.example/repos/wireapp/wire-webapp/releases?per_page=100&page=1',
+    );
   });
 
-  it('requests GitHub-generated notes from the preceding Production tag', async () => {
+  it('finds an existing published GitHub Release in the releases collection', async () => {
+    const productionTagName = '2026-08-28.1-production';
+    const existingRelease = createReleaseResponse(productionTagName, false);
     const fakeHttpClient = createFakeHttpClient({
-      responseForRequest(request) {
-        return {
-          tag_name: '2026-08-28.1-production',
-          html_url: 'https://github.com/wireapp/wire-webapp/releases/tag/2026-08-28.1-production',
-          draft: true,
-        };
+      responseForRequest() {
+        return [existingRelease];
       },
     });
     const githubReleaseClient = createClient(fakeHttpClient.httpClient);
 
-    const actualResult = await githubReleaseClient.createProductionDraft({
+    const existingReleaseResult = await githubReleaseClient.findReleaseByTag({tagName: productionTagName});
+
+    assert(existingReleaseResult.isOk);
+    expect(existingReleaseResult.value).toEqual(
+      Maybe.just({
+        tagName: productionTagName,
+        htmlUrl: existingRelease.html_url,
+        isDraft: false,
+      }),
+    );
+  });
+
+  it('finds a matching release on a later page and stops fetching after the match', async () => {
+    const productionTagName = '2026-08-28.1-production';
+    const firstPage = Array.from({length: 100}, (_, releaseIndex) => {
+      return createReleaseResponse(`release-${releaseIndex + 1}`, false);
+    });
+    const secondPage = [
+      createReleaseResponse(productionTagName, true),
+      ...Array.from({length: 99}, (_, releaseIndex) => {
+        return createReleaseResponse(`later-release-${releaseIndex + 1}`, false);
+      }),
+    ];
+    const fakeHttpClient = createFakeHttpClient({
+      responseForRequest(request) {
+        const page = request.url.searchParams.get('page');
+
+        if (page === '1') {
+          return firstPage;
+        }
+
+        if (page === '2') {
+          return secondPage;
+        }
+
+        throw new Error('The releases collection was fetched after the matching release was found.');
+      },
+    });
+    const githubReleaseClient = createClient(fakeHttpClient.httpClient);
+
+    const actualResult = await githubReleaseClient.findReleaseByTag({tagName: productionTagName});
+
+    assert(actualResult.isOk);
+    expect(actualResult.value.isJust).toBe(true);
+    expect(
+      fakeHttpClient.requests.map(request => {
+        return request.url.searchParams.get('page');
+      }),
+    ).toEqual(['1', '2']);
+  });
+
+  it('returns no release after the releases collection is exhausted', async () => {
+    const firstPage = Array.from({length: 100}, (_, releaseIndex) => {
+      return createReleaseResponse(`release-${releaseIndex + 1}`, false);
+    });
+    const fakeHttpClient = createFakeHttpClient({
+      responseForRequest(request) {
+        return request.url.searchParams.get('page') === '1'
+          ? firstPage
+          : [createReleaseResponse('other-release', false)];
+      },
+    });
+    const githubReleaseClient = createClient(fakeHttpClient.httpClient);
+
+    const actualResult = await githubReleaseClient.findReleaseByTag({tagName: '2026-08-28.1-production'});
+
+    assert(actualResult.isOk);
+    expect(actualResult.value.isNothing).toBe(true);
+    expect(fakeHttpClient.requests).toHaveLength(2);
+  });
+
+  it('requests generated GitHub Release notes with the explicit Production range', async () => {
+    const generatedReleaseNotes = {
+      name: 'Generated Production release',
+      body: '## Changes\n\n- Generated change',
+    };
+    const fakeHttpClient = createFakeHttpClient({
+      responseForRequest(request) {
+        expect(request.method).toBe('post');
+        expect(request.url.toString()).toBe(
+          'https://api.github.example/repos/wireapp/wire-webapp/releases/generate-notes',
+        );
+        return generatedReleaseNotes;
+      },
+    });
+    const githubReleaseClient = createClient(fakeHttpClient.httpClient);
+
+    const actualResult = await githubReleaseClient.generateReleaseNotes({
       productionTagName: '2026-08-28.1-production',
-      precedingProductionTagName: Maybe.just('2026-08-07.1-production'),
+      precedingProductionTagName: '2026-08-07.1-production',
     });
 
     assert(actualResult.isOk);
+    expect(actualResult.value).toEqual(generatedReleaseNotes);
     const request = Maybe.of(fakeHttpClient.requests[0]);
     assert(request.isJust);
-    expect(request.value.method).toBe('post');
-    expect(request.value.url.toString()).toBe('https://api.github.example/repos/wireapp/wire-webapp/releases');
     expect(request.value.json).toEqual(
       Maybe.just({
         tag_name: '2026-08-28.1-production',
-        name: '2026-08-28.1-production',
-        draft: true,
-        generate_release_notes: true,
         previous_tag_name: '2026-08-07.1-production',
       }),
     );
   });
 
-  it('uses a deterministic manual placeholder when no preceding Production tag exists', async () => {
+  it('passes the supplied generated body to draft release creation', async () => {
+    const productionTagName = '2026-08-28.1-production';
+    const generatedBody = '## Changes\n\n- Generated change';
     const fakeHttpClient = createFakeHttpClient({
       responseForRequest() {
-        return {
-          tag_name: '2026-07-27.1-production',
-          html_url: 'https://github.com/wireapp/wire-webapp/releases/tag/2026-07-27.1-production',
-          draft: true,
-        };
+        return createReleaseResponse(productionTagName, true);
       },
     });
     const githubReleaseClient = createClient(fakeHttpClient.httpClient);
 
-    const actualResult = await githubReleaseClient.createProductionDraft({
-      productionTagName: '2026-07-27.1-production',
-      precedingProductionTagName: Maybe.nothing(),
+    const actualResult = await githubReleaseClient.createDraftRelease({
+      productionTagName,
+      body: generatedBody,
     });
 
     assert(actualResult.isOk);
@@ -197,18 +284,18 @@ describe('GitHub Release client', () => {
     assert(request.isJust);
     expect(request.value.json).toEqual(
       Maybe.just({
-        tag_name: '2026-07-27.1-production',
-        name: '2026-07-27.1-production',
+        tag_name: productionTagName,
+        name: productionTagName,
         draft: true,
-        body: 'No preceding ADR Production release was found. Add the customer-facing changelog manually before publication.',
+        body: generatedBody,
       }),
     );
   });
 
-  it('rejects malformed GitHub Release responses at the API boundary', async () => {
+  it('rejects malformed GitHub Release collection responses at the API boundary', async () => {
     const fakeHttpClient = createFakeHttpClient({
       responseForRequest() {
-        return {tag_name: '2026-08-28.1-production', draft: true};
+        return [{tag_name: '2026-08-28.1-production', draft: true}];
       },
     });
     const githubReleaseClient = createClient(fakeHttpClient.httpClient);
@@ -216,6 +303,51 @@ describe('GitHub Release client', () => {
     const actualResult = await githubReleaseClient.findReleaseByTag({tagName: '2026-08-28.1-production'});
 
     assert(actualResult.isErr);
-    expect(actualResult.error.message).toBe('Malformed GitHub Release response');
+    expect(actualResult.error.message).toBe('Malformed GitHub Release collection response');
+  });
+
+  it('rejects malformed generated GitHub Release notes responses at the API boundary', async () => {
+    const fakeHttpClient = createFakeHttpClient({
+      responseForRequest() {
+        return {name: 'Generated Production release'};
+      },
+    });
+    const githubReleaseClient = createClient(fakeHttpClient.httpClient);
+
+    const actualResult = await githubReleaseClient.generateReleaseNotes({
+      productionTagName: '2026-08-28.1-production',
+      precedingProductionTagName: '2026-08-07.1-production',
+    });
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('Malformed generated GitHub Release notes response');
+  });
+
+  it('handles GitHub API and transport failures without exposing the token', async () => {
+    const apiFailureClient = createClient(
+      createFakeHttpClient({
+        responseForRequest() {
+          throw createHttpResponseFailure(500);
+        },
+      }).httpClient,
+    );
+    const transportFailureClient = createClient(
+      createFakeHttpClient({
+        responseForRequest() {
+          throw new Error('transport failure for github-token');
+        },
+      }).httpClient,
+    );
+
+    const apiFailureResult = await apiFailureClient.findReleaseByTag({tagName: '2026-08-28.1-production'});
+    const transportFailureResult = await transportFailureClient.findReleaseByTag({
+      tagName: '2026-08-28.1-production',
+    });
+
+    assert(apiFailureResult.isErr);
+    expect(apiFailureResult.error.message).toContain('Unable to find GitHub Release');
+    assert(transportFailureResult.isErr);
+    expect(transportFailureResult.error.message).not.toContain('github-token');
+    expect(transportFailureResult.error.message).toContain('[REDACTED]');
   });
 });

--- a/tools/release-appearance/githubReleaseClient.test.ts
+++ b/tools/release-appearance/githubReleaseClient.test.ts
@@ -67,11 +67,13 @@ function createHttpResponseFailure(statusCode: number): HttpRequestFailure {
   };
 }
 
-function createClient(fakeHttpClient: FakeHttpClientFixture['httpClient'] = createFakeHttpClient({
-  responseForRequest() {
-    return [];
-  },
-}).httpClient): ReturnType<typeof createGitHubReleaseClient> {
+function createClient(
+  fakeHttpClient: FakeHttpClientFixture['httpClient'] = createFakeHttpClient({
+    responseForRequest() {
+      return [];
+    },
+  }).httpClient,
+): ReturnType<typeof createGitHubReleaseClient> {
   return createGitHubReleaseClient({
     httpClient: fakeHttpClient,
     githubApiUrl: new URL('https://api.github.example/'),

--- a/tools/release-appearance/githubReleaseClient.ts
+++ b/tools/release-appearance/githubReleaseClient.ts
@@ -17,12 +17,12 @@
  *
  */
 
-import {isError} from '@sindresorhus/is';
-import {Maybe, Result} from 'true-myth';
+import {isError, isUndefined} from '@sindresorhus/is';
+import {Maybe, Result, Task, task} from 'true-myth';
 import {z} from 'zod';
 
 import {formatHttpRequestFailure, isHttpRequestFailure} from './httpClient.ts';
-import type {HttpClient, HttpMethod, HttpRequest, HttpRequestFailure} from './httpClient.ts';
+import type {HttpClient, HttpMethod, HttpRequest} from './httpClient.ts';
 
 export type GitHubReleaseRecord = {
   readonly tagName: string;
@@ -34,17 +34,26 @@ export type FindGitHubReleaseOptions = {
   readonly tagName: string;
 };
 
-export type CreateProductionDraftOptions = {
+export type GenerateReleaseNotesOptions = {
   readonly productionTagName: string;
-  readonly precedingProductionTagName: Maybe<string>;
+  readonly precedingProductionTagName: string;
+};
+
+export type GitHubGeneratedReleaseNotes = {
+  readonly name: string;
+  readonly body: string;
+};
+
+export type CreateDraftReleaseOptions = {
+  readonly productionTagName: string;
+  readonly body: string;
 };
 
 export type GitHubReleaseClient = {
-  readonly listTagNames: () => Promise<Result<readonly string[], Error>>;
-  readonly findReleaseByTag: (options: FindGitHubReleaseOptions) => Promise<Result<Maybe<GitHubReleaseRecord>, Error>>;
-  readonly createProductionDraft: (
-    options: CreateProductionDraftOptions,
-  ) => Promise<Result<GitHubReleaseRecord, Error>>;
+  readonly listTagNames: () => Task<readonly string[], Error>;
+  readonly findReleaseByTag: (options: FindGitHubReleaseOptions) => Task<Maybe<GitHubReleaseRecord>, Error>;
+  readonly generateReleaseNotes: (options: GenerateReleaseNotesOptions) => Task<GitHubGeneratedReleaseNotes, Error>;
+  readonly createDraftRelease: (options: CreateDraftReleaseOptions) => Task<GitHubReleaseRecord, Error>;
 };
 
 export type CreateGitHubReleaseClientOptions = {
@@ -59,20 +68,27 @@ type ParsedGitHubTagPage = {
   readonly tagNames: readonly string[];
 };
 
+type GitHubReleasePage = {
+  readonly rawItemCount: number;
+  readonly releases: readonly GitHubReleaseRecord[];
+};
+
 type GitHubCreateReleaseRequestBody = {
   readonly tag_name: string;
   readonly name: string;
   readonly draft: true;
-  readonly generate_release_notes?: true;
-  readonly previous_tag_name?: string;
-  readonly body?: string;
+  readonly body: string;
+};
+
+type RequestGitHubJsonOptions = {
+  readonly httpClient: HttpClient;
+  readonly request: HttpRequest;
+  readonly failureMessage: string;
+  readonly githubToken: string;
 };
 
 const githubPageSize = 100;
 const githubApiVersion = '2022-11-28';
-const notFoundHttpStatusCode = 404;
-const noPrecedingProductionReleaseNotes =
-  'No preceding ADR Production release was found. Add the customer-facing changelog manually before publication.';
 
 const githubTagResponseSchema = z.object({
   name: z.string().min(1),
@@ -84,6 +100,13 @@ const githubReleaseResponseSchema = z.object({
   tag_name: z.string().min(1),
   html_url: z.string().url(),
   draft: z.boolean(),
+});
+
+const githubReleasePageResponseSchema = z.array(githubReleaseResponseSchema);
+
+const githubGeneratedReleaseNotesResponseSchema = z.object({
+  name: z.string(),
+  body: z.string(),
 });
 
 function createSuccess<valueType>(value: valueType): Result<valueType, Error> {
@@ -112,14 +135,6 @@ function redactSecret(message: string, secret: string): string {
   }
 
   return message.replaceAll(secret, '[REDACTED]');
-}
-
-function isNotFoundHttpRequestFailure(error: unknown): error is HttpRequestFailure {
-  return (
-    isHttpRequestFailure(error) &&
-    error.kind === 'http-response-failure' &&
-    error.response.statusCode === notFoundHttpStatusCode
-  );
 }
 
 function createGitHubApiRoot(githubApiUrl: URL): URL {
@@ -195,23 +210,55 @@ function parseGitHubRelease(githubResponse: unknown): Result<GitHubReleaseRecord
   });
 }
 
-function createProductionDraftRequestBody(options: CreateProductionDraftOptions): GitHubCreateReleaseRequestBody {
-  if (options.precedingProductionTagName.isJust) {
-    return {
-      tag_name: options.productionTagName,
-      name: options.productionTagName,
-      draft: true,
-      generate_release_notes: true,
-      previous_tag_name: options.precedingProductionTagName.value,
-    };
+function parseGitHubReleasePage(githubResponse: unknown): Result<GitHubReleasePage, Error> {
+  const validationResult = githubReleasePageResponseSchema.safeParse(githubResponse);
+
+  if (validationResult.success === false) {
+    return createFailure('Malformed GitHub Release collection response');
   }
 
+  return createSuccess({
+    rawItemCount: validationResult.data.length,
+    releases: validationResult.data.map(release => {
+      return {
+        tagName: release.tag_name,
+        htmlUrl: release.html_url,
+        isDraft: release.draft,
+      };
+    }),
+  });
+}
+
+function parseGitHubGeneratedReleaseNotes(githubResponse: unknown): Result<GitHubGeneratedReleaseNotes, Error> {
+  const validationResult = githubGeneratedReleaseNotesResponseSchema.safeParse(githubResponse);
+
+  if (validationResult.success === false) {
+    return createFailure('Malformed generated GitHub Release notes response');
+  }
+
+  return createSuccess(validationResult.data);
+}
+
+function createDraftReleaseRequestBody(options: CreateDraftReleaseOptions): GitHubCreateReleaseRequestBody {
   return {
     tag_name: options.productionTagName,
     name: options.productionTagName,
     draft: true,
-    body: noPrecedingProductionReleaseNotes,
+    body: options.body,
   };
+}
+
+function requestGitHubJson(options: RequestGitHubJsonOptions): Task<unknown, Error> {
+  return task.tryOrElse(
+    (error: unknown): Error => {
+      return new Error(`${options.failureMessage}: ${redactSecret(errorMessage(error), options.githubToken)}`, {
+        cause: error,
+      });
+    },
+    (): Promise<unknown> => {
+      return options.httpClient.requestJson(options.request);
+    },
+  );
 }
 
 export function createGitHubReleaseClient(
@@ -224,78 +271,119 @@ export function createGitHubReleaseClient(
   const writeHeaders = createGitHubHeaders(githubToken, true);
 
   return {
-    async listTagNames(): Promise<Result<readonly string[], Error>> {
-      const tagNames: string[] = [];
+    listTagNames(): Task<readonly string[], Error> {
       const endpoint = new URL(`repos/${encodedRepositoryName}/tags`, githubApiRoot);
 
-      for (let page = 1; ; page += 1) {
-        let githubResponse: unknown;
+      function listTagNamesPage(page: number, accumulatedTagNames: readonly string[]): Task<readonly string[], Error> {
+        const request = createHttpRequest('get', createPageUrl(endpoint, page), readHeaders, Maybe.nothing());
 
-        try {
-          githubResponse = await httpClient.requestJson(
-            createHttpRequest('get', createPageUrl(endpoint, page), readHeaders, Maybe.nothing()),
-          );
-        } catch (error: unknown) {
-          return createFailure(`Unable to list GitHub tag names: ${redactSecret(errorMessage(error), githubToken)}`);
-        }
+        return requestGitHubJson({
+          httpClient,
+          request,
+          failureMessage: 'Unable to list GitHub tag names',
+          githubToken,
+        }).andThen(githubResponse => {
+          const pageResult = parseGitHubTagPage(githubResponse);
 
-        const pageResult = parseGitHubTagPage(githubResponse);
+          if (pageResult.isErr) {
+            return Result.err<readonly string[], Error>(pageResult.error);
+          }
 
-        if (pageResult.isErr) {
-          return createFailure(pageResult.error.message);
-        }
+          const tagNames = [...accumulatedTagNames, ...pageResult.value.tagNames];
 
-        tagNames.push(...pageResult.value.tagNames);
+          if (pageResult.value.rawItemCount !== githubPageSize) {
+            return Result.ok<readonly string[], Error>(tagNames);
+          }
 
-        if (pageResult.value.rawItemCount !== githubPageSize) {
-          break;
-        }
+          return listTagNamesPage(page + 1, tagNames);
+        });
       }
 
-      return createSuccess(tagNames);
+      return listTagNamesPage(1, []);
     },
 
-    async findReleaseByTag(options: FindGitHubReleaseOptions): Promise<Result<Maybe<GitHubReleaseRecord>, Error>> {
-      const endpoint = new URL(
-        `repos/${encodedRepositoryName}/releases/tags/${encodeURIComponent(options.tagName)}`,
-        githubApiRoot,
-      );
-
-      try {
-        const githubResponse = await httpClient.requestJson(
-          createHttpRequest('get', endpoint, readHeaders, Maybe.nothing()),
-        );
-        const releaseResult = parseGitHubRelease(githubResponse);
-
-        if (releaseResult.isErr) {
-          return createFailure(releaseResult.error.message);
-        }
-
-        return createSuccess(Maybe.just(releaseResult.value));
-      } catch (error: unknown) {
-        if (isNotFoundHttpRequestFailure(error)) {
-          return createSuccess(Maybe.nothing<GitHubReleaseRecord>());
-        }
-
-        return createFailure(
-          `Unable to find GitHub Release for tag ${options.tagName}: ${redactSecret(errorMessage(error), githubToken)}`,
-        );
-      }
-    },
-
-    async createProductionDraft(options: CreateProductionDraftOptions): Promise<Result<GitHubReleaseRecord, Error>> {
+    findReleaseByTag(options: FindGitHubReleaseOptions): Task<Maybe<GitHubReleaseRecord>, Error> {
       const endpoint = new URL(`repos/${encodedRepositoryName}/releases`, githubApiRoot);
 
-      try {
-        const githubResponse = await httpClient.requestJson(
-          createHttpRequest('post', endpoint, writeHeaders, Maybe.just(createProductionDraftRequestBody(options))),
-        );
-        return parseGitHubRelease(githubResponse);
-      } catch (error: unknown) {
-        return createFailure(
-          `Unable to create GitHub Release for tag ${options.productionTagName}: ${redactSecret(errorMessage(error), githubToken)}`,
-        );
+      function findReleasePage(page: number): Task<Maybe<GitHubReleaseRecord>, Error> {
+        const request = createHttpRequest('get', createPageUrl(endpoint, page), readHeaders, Maybe.nothing());
+
+        return requestGitHubJson({
+          httpClient,
+          request,
+          failureMessage: `Unable to find GitHub Release for tag ${options.tagName}`,
+          githubToken,
+        }).andThen(githubResponse => {
+          const pageResult = parseGitHubReleasePage(githubResponse);
+
+          if (pageResult.isErr) {
+            return Result.err<Maybe<GitHubReleaseRecord>, Error>(pageResult.error);
+          }
+
+          const matchingRelease = pageResult.value.releases.find(release => {
+            return release.tagName === options.tagName;
+          });
+
+          if (isUndefined(matchingRelease) === false) {
+            return Result.ok<Maybe<GitHubReleaseRecord>, Error>(Maybe.just(matchingRelease));
+          }
+
+          if (pageResult.value.rawItemCount !== githubPageSize) {
+            return Result.ok<Maybe<GitHubReleaseRecord>, Error>(Maybe.nothing<GitHubReleaseRecord>());
+          }
+
+          return findReleasePage(page + 1);
+        });
       }
+
+      return findReleasePage(1);
+    },
+
+    generateReleaseNotes(options: GenerateReleaseNotesOptions): Task<GitHubGeneratedReleaseNotes, Error> {
+      const endpoint = new URL(`repos/${encodedRepositoryName}/releases/generate-notes`, githubApiRoot);
+      const request = createHttpRequest(
+        'post',
+        endpoint,
+        writeHeaders,
+        Maybe.just({
+          tag_name: options.productionTagName,
+          previous_tag_name: options.precedingProductionTagName,
+        }),
+      );
+
+      return requestGitHubJson({
+        httpClient,
+        request,
+        failureMessage: `Unable to generate GitHub Release notes for tag ${options.productionTagName}`,
+        githubToken,
+      }).andThen(githubResponse => {
+        const generatedReleaseNotesResult = parseGitHubGeneratedReleaseNotes(githubResponse);
+
+        if (generatedReleaseNotesResult.isErr) {
+          return generatedReleaseNotesResult;
+        }
+
+        return generatedReleaseNotesResult;
+      });
+    },
+
+    createDraftRelease(options: CreateDraftReleaseOptions): Task<GitHubReleaseRecord, Error> {
+      const endpoint = new URL(`repos/${encodedRepositoryName}/releases`, githubApiRoot);
+      const request = createHttpRequest(
+        'post',
+        endpoint,
+        writeHeaders,
+        Maybe.just(createDraftReleaseRequestBody(options)),
+      );
+
+      return requestGitHubJson({
+        httpClient,
+        request,
+        failureMessage: `Unable to create GitHub Release for tag ${options.productionTagName}`,
+        githubToken,
+      }).andThen(githubResponse => {
+        return parseGitHubRelease(githubResponse);
+      });
     },
   };
 }

--- a/tools/release-appearance/githubReleaseClient.ts
+++ b/tools/release-appearance/githubReleaseClient.ts
@@ -1,0 +1,301 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isError} from '@sindresorhus/is';
+import {Maybe, Result} from 'true-myth';
+import {z} from 'zod';
+
+import {formatHttpRequestFailure, isHttpRequestFailure} from './httpClient.ts';
+import type {HttpClient, HttpMethod, HttpRequest, HttpRequestFailure} from './httpClient.ts';
+
+export type GitHubReleaseRecord = {
+  readonly tagName: string;
+  readonly htmlUrl: string;
+  readonly isDraft: boolean;
+};
+
+export type FindGitHubReleaseOptions = {
+  readonly tagName: string;
+};
+
+export type CreateProductionDraftOptions = {
+  readonly productionTagName: string;
+  readonly precedingProductionTagName: Maybe<string>;
+};
+
+export type GitHubReleaseClient = {
+  readonly listTagNames: () => Promise<Result<readonly string[], Error>>;
+  readonly findReleaseByTag: (options: FindGitHubReleaseOptions) => Promise<Result<Maybe<GitHubReleaseRecord>, Error>>;
+  readonly createProductionDraft: (
+    options: CreateProductionDraftOptions,
+  ) => Promise<Result<GitHubReleaseRecord, Error>>;
+};
+
+export type CreateGitHubReleaseClientOptions = {
+  readonly httpClient: HttpClient;
+  readonly githubApiUrl: URL;
+  readonly githubRepository: string;
+  readonly githubToken: string;
+};
+
+type ParsedGitHubTagPage = {
+  readonly rawItemCount: number;
+  readonly tagNames: readonly string[];
+};
+
+type GitHubCreateReleaseRequestBody = {
+  readonly tag_name: string;
+  readonly name: string;
+  readonly draft: true;
+  readonly generate_release_notes?: true;
+  readonly previous_tag_name?: string;
+  readonly body?: string;
+};
+
+const githubPageSize = 100;
+const githubApiVersion = '2022-11-28';
+const notFoundHttpStatusCode = 404;
+const noPrecedingProductionReleaseNotes =
+  'No preceding ADR Production release was found. Add the customer-facing changelog manually before publication.';
+
+const githubTagResponseSchema = z.object({
+  name: z.string().min(1),
+});
+
+const githubTagPageResponseSchema = z.array(githubTagResponseSchema);
+
+const githubReleaseResponseSchema = z.object({
+  tag_name: z.string().min(1),
+  html_url: z.string().url(),
+  draft: z.boolean(),
+});
+
+function createSuccess<valueType>(value: valueType): Result<valueType, Error> {
+  return Result.ok<valueType, Error>(value);
+}
+
+function createFailure<valueType>(message: string): Result<valueType, Error> {
+  return Result.err<valueType, Error>(new Error(message));
+}
+
+function errorMessage(error: unknown): string {
+  if (isHttpRequestFailure(error)) {
+    return formatHttpRequestFailure(error);
+  }
+
+  if (isError(error)) {
+    return error.message;
+  }
+
+  return 'Unknown failure';
+}
+
+function redactSecret(message: string, secret: string): string {
+  if (secret.length === 0) {
+    return message;
+  }
+
+  return message.replaceAll(secret, '[REDACTED]');
+}
+
+function isNotFoundHttpRequestFailure(error: unknown): error is HttpRequestFailure {
+  return (
+    isHttpRequestFailure(error) &&
+    error.kind === 'http-response-failure' &&
+    error.response.statusCode === notFoundHttpStatusCode
+  );
+}
+
+function createGitHubApiRoot(githubApiUrl: URL): URL {
+  const githubApiUrlString = githubApiUrl.toString();
+  return new URL(githubApiUrlString.endsWith('/') ? githubApiUrlString : `${githubApiUrlString}/`);
+}
+
+function encodeRepositoryName(githubRepository: string): string {
+  return githubRepository
+    .split('/')
+    .map(repositoryPart => {
+      return encodeURIComponent(repositoryPart);
+    })
+    .join('/');
+}
+
+function createGitHubHeaders(githubToken: string, includesBody: boolean): Readonly<Record<string, string>> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${githubToken}`,
+    'X-GitHub-Api-Version': githubApiVersion,
+  };
+
+  if (includesBody) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  return headers;
+}
+
+function createPageUrl(endpoint: URL, page: number): URL {
+  const pageUrl = new URL(endpoint);
+  pageUrl.searchParams.set('per_page', githubPageSize.toString());
+  pageUrl.searchParams.set('page', page.toString());
+  return pageUrl;
+}
+
+function createHttpRequest(
+  method: HttpMethod,
+  url: URL,
+  headers: Readonly<Record<string, string>>,
+  json: Maybe<NonNullable<unknown>>,
+): HttpRequest {
+  return {method, url, headers, json};
+}
+
+function parseGitHubTagPage(githubResponse: unknown): Result<ParsedGitHubTagPage, Error> {
+  const validationResult = githubTagPageResponseSchema.safeParse(githubResponse);
+
+  if (validationResult.success === false) {
+    return createFailure('Malformed GitHub tag response');
+  }
+
+  return createSuccess({
+    rawItemCount: validationResult.data.length,
+    tagNames: validationResult.data.map(tag => {
+      return tag.name;
+    }),
+  });
+}
+
+function parseGitHubRelease(githubResponse: unknown): Result<GitHubReleaseRecord, Error> {
+  const validationResult = githubReleaseResponseSchema.safeParse(githubResponse);
+
+  if (validationResult.success === false) {
+    return createFailure('Malformed GitHub Release response');
+  }
+
+  return createSuccess({
+    tagName: validationResult.data.tag_name,
+    htmlUrl: validationResult.data.html_url,
+    isDraft: validationResult.data.draft,
+  });
+}
+
+function createProductionDraftRequestBody(options: CreateProductionDraftOptions): GitHubCreateReleaseRequestBody {
+  if (options.precedingProductionTagName.isJust) {
+    return {
+      tag_name: options.productionTagName,
+      name: options.productionTagName,
+      draft: true,
+      generate_release_notes: true,
+      previous_tag_name: options.precedingProductionTagName.value,
+    };
+  }
+
+  return {
+    tag_name: options.productionTagName,
+    name: options.productionTagName,
+    draft: true,
+    body: noPrecedingProductionReleaseNotes,
+  };
+}
+
+export function createGitHubReleaseClient(
+  createGitHubReleaseClientOptions: CreateGitHubReleaseClientOptions,
+): GitHubReleaseClient {
+  const {httpClient, githubApiUrl, githubRepository, githubToken} = createGitHubReleaseClientOptions;
+  const githubApiRoot = createGitHubApiRoot(githubApiUrl);
+  const encodedRepositoryName = encodeRepositoryName(githubRepository);
+  const readHeaders = createGitHubHeaders(githubToken, false);
+  const writeHeaders = createGitHubHeaders(githubToken, true);
+
+  return {
+    async listTagNames(): Promise<Result<readonly string[], Error>> {
+      const tagNames: string[] = [];
+      const endpoint = new URL(`repos/${encodedRepositoryName}/tags`, githubApiRoot);
+
+      for (let page = 1; ; page += 1) {
+        let githubResponse: unknown;
+
+        try {
+          githubResponse = await httpClient.requestJson(
+            createHttpRequest('get', createPageUrl(endpoint, page), readHeaders, Maybe.nothing()),
+          );
+        } catch (error: unknown) {
+          return createFailure(`Unable to list GitHub tag names: ${redactSecret(errorMessage(error), githubToken)}`);
+        }
+
+        const pageResult = parseGitHubTagPage(githubResponse);
+
+        if (pageResult.isErr) {
+          return createFailure(pageResult.error.message);
+        }
+
+        tagNames.push(...pageResult.value.tagNames);
+
+        if (pageResult.value.rawItemCount !== githubPageSize) {
+          break;
+        }
+      }
+
+      return createSuccess(tagNames);
+    },
+
+    async findReleaseByTag(options: FindGitHubReleaseOptions): Promise<Result<Maybe<GitHubReleaseRecord>, Error>> {
+      const endpoint = new URL(
+        `repos/${encodedRepositoryName}/releases/tags/${encodeURIComponent(options.tagName)}`,
+        githubApiRoot,
+      );
+
+      try {
+        const githubResponse = await httpClient.requestJson(
+          createHttpRequest('get', endpoint, readHeaders, Maybe.nothing()),
+        );
+        const releaseResult = parseGitHubRelease(githubResponse);
+
+        if (releaseResult.isErr) {
+          return createFailure(releaseResult.error.message);
+        }
+
+        return createSuccess(Maybe.just(releaseResult.value));
+      } catch (error: unknown) {
+        if (isNotFoundHttpRequestFailure(error)) {
+          return createSuccess(Maybe.nothing<GitHubReleaseRecord>());
+        }
+
+        return createFailure(
+          `Unable to find GitHub Release for tag ${options.tagName}: ${redactSecret(errorMessage(error), githubToken)}`,
+        );
+      }
+    },
+
+    async createProductionDraft(options: CreateProductionDraftOptions): Promise<Result<GitHubReleaseRecord, Error>> {
+      const endpoint = new URL(`repos/${encodedRepositoryName}/releases`, githubApiRoot);
+
+      try {
+        const githubResponse = await httpClient.requestJson(
+          createHttpRequest('post', endpoint, writeHeaders, Maybe.just(createProductionDraftRequestBody(options))),
+        );
+        return parseGitHubRelease(githubResponse);
+      } catch (error: unknown) {
+        return createFailure(
+          `Unable to create GitHub Release for tag ${options.productionTagName}: ${redactSecret(errorMessage(error), githubToken)}`,
+        );
+      }
+    },
+  };
+}

--- a/tools/release-appearance/releaseAppearanceCommand.test.ts
+++ b/tools/release-appearance/releaseAppearanceCommand.test.ts
@@ -903,7 +903,7 @@ describe('executeReleaseAppearanceCommand', () => {
       githubRepository: 'wireapp/wire-webapp',
       githubToken: 'github-token',
       httpClient: {
-        requestJson: async function requestJson(request): Promise<unknown> {
+        async requestJson(request): Promise<unknown> {
           githubRequests.push(request);
           if (request.url.pathname.endsWith('/pulls')) {
             return [

--- a/tools/release-appearance/tsconfig.json
+++ b/tools/release-appearance/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "es2024",
     "lib": ["ES2024"],
     "types": ["node", "jest"],
-    "rootDir": ".",
+    "rootDir": "..",
     "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true
   },

--- a/tools/release-cli/ensureProductionGitHubRelease.mts
+++ b/tools/release-cli/ensureProductionGitHubRelease.mts
@@ -42,7 +42,10 @@ type RuntimeEnvironment = {
   readonly githubToken: string;
 };
 
-function readRequiredEnvironmentValue(environment: NodeJS.ProcessEnv, environmentVariableName: string): Result<string, Error> {
+function readRequiredEnvironmentValue(
+  environment: NodeJS.ProcessEnv,
+  environmentVariableName: string,
+): Result<string, Error> {
   const environmentValue = environment[environmentVariableName];
 
   if (isNonEmptyStringAndNotWhitespace(environmentValue) === false) {
@@ -95,9 +98,7 @@ function writeProductionReleaseOutputs(
   writeOutput(`github_release_url=${handoff.url}`);
 }
 
-export function createCommand(
-  createCommandOptions: CreateEnsureProductionGitHubReleaseCommandOptions,
-): Command {
+export function createCommand(createCommandOptions: CreateEnsureProductionGitHubReleaseCommandOptions): Command {
   return new Command()
     .name('ensureProductionGitHubRelease')
     .description('Ensure the draft GitHub Release for a verified Production tag.')
@@ -119,7 +120,7 @@ export async function runEnsureProductionGitHubReleaseCommand(
   let executionExitCode = 0;
   const command = createCommand({
     ...createCommandOptions,
-    executeCommand: async function executeCommand(productionTagName: string): Promise<void> {
+    async executeCommand(productionTagName: string): Promise<void> {
       await createCommandOptions.executeCommand(productionTagName);
       executionExitCode = 0;
     },

--- a/tools/release-cli/ensureProductionGitHubRelease.mts
+++ b/tools/release-cli/ensureProductionGitHubRelease.mts
@@ -1,0 +1,204 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import process from 'node:process';
+import {resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {isError, isNonEmptyStringAndNotWhitespace, isString} from '@sindresorhus/is';
+import {Command, CommanderError} from 'commander';
+import {Result} from 'true-myth';
+
+import {ensureProductionGitHubRelease} from '../release-appearance/ensureProductionGitHubRelease.ts';
+import {createGitHubReleaseClient} from '../release-appearance/githubReleaseClient.ts';
+import type {ProductionGitHubReleaseHandoff} from '../release-appearance/ensureProductionGitHubRelease.ts';
+import {createRuntimeKyHttpClient} from '../release-appearance/httpClient.ts';
+
+type CreateEnsureProductionGitHubReleaseCommandOptions = {
+  readonly executeCommand: (productionTagName: string) => Promise<void> | void;
+  readonly writeOutput: (message: string) => void;
+  readonly writeError: (message: string) => void;
+};
+
+type RuntimeEnvironment = {
+  readonly githubApiUrl: URL;
+  readonly githubRepository: string;
+  readonly githubToken: string;
+};
+
+function readRequiredEnvironmentValue(environment: NodeJS.ProcessEnv, environmentVariableName: string): Result<string, Error> {
+  const environmentValue = environment[environmentVariableName];
+
+  if (isNonEmptyStringAndNotWhitespace(environmentValue) === false) {
+    return Result.err(new Error(`Required environment variable is missing: ${environmentVariableName}`));
+  }
+
+  return Result.ok(environmentValue);
+}
+
+function readRuntimeEnvironment(environment: NodeJS.ProcessEnv): Result<RuntimeEnvironment, Error> {
+  const githubApiUrlValueResult = readRequiredEnvironmentValue(environment, 'GITHUB_API_URL');
+  const githubRepositoryResult = readRequiredEnvironmentValue(environment, 'GITHUB_REPOSITORY');
+  const githubTokenResult = readRequiredEnvironmentValue(environment, 'GITHUB_TOKEN');
+
+  if (githubApiUrlValueResult.isErr) {
+    return Result.err(githubApiUrlValueResult.error);
+  }
+
+  if (githubRepositoryResult.isErr) {
+    return Result.err(githubRepositoryResult.error);
+  }
+
+  if (githubTokenResult.isErr) {
+    return Result.err(githubTokenResult.error);
+  }
+
+  let githubApiUrl: URL;
+
+  try {
+    githubApiUrl = new URL(githubApiUrlValueResult.value);
+  } catch (error: unknown) {
+    const errorMessage = isError(error) ? error.message : String(error);
+    return Result.err(new Error(`Invalid GITHUB_API_URL: ${errorMessage}`, {cause: error}));
+  }
+
+  return Result.ok({
+    githubApiUrl,
+    githubRepository: githubRepositoryResult.value,
+    githubToken: githubTokenResult.value,
+  });
+}
+
+function writeProductionReleaseOutputs(
+  handoff: ProductionGitHubReleaseHandoff,
+  writeOutput: (message: string) => void,
+): void {
+  writeOutput(`production_tag_name=${handoff.tagName}`);
+  writeOutput(`github_release_action=${handoff.action}`);
+  writeOutput(`github_release_state=${handoff.state}`);
+  writeOutput(`github_release_url=${handoff.url}`);
+}
+
+export function createCommand(
+  createCommandOptions: CreateEnsureProductionGitHubReleaseCommandOptions,
+): Command {
+  return new Command()
+    .name('ensureProductionGitHubRelease')
+    .description('Ensure the draft GitHub Release for a verified Production tag.')
+    .argument('<production-tag>')
+    .configureOutput({
+      writeOut: createCommandOptions.writeOutput,
+      writeErr: createCommandOptions.writeError,
+    })
+    .exitOverride()
+    .action(async (productionTagName: string): Promise<void> => {
+      await createCommandOptions.executeCommand(productionTagName);
+    });
+}
+
+export async function runEnsureProductionGitHubReleaseCommand(
+  commandLineArguments: readonly string[],
+  createCommandOptions: CreateEnsureProductionGitHubReleaseCommandOptions,
+): Promise<number> {
+  let executionExitCode = 0;
+  const command = createCommand({
+    ...createCommandOptions,
+    executeCommand: async function executeCommand(productionTagName: string): Promise<void> {
+      await createCommandOptions.executeCommand(productionTagName);
+      executionExitCode = 0;
+    },
+  });
+
+  try {
+    await command.parseAsync(['node', 'ensureProductionGitHubRelease', ...commandLineArguments]);
+
+    return executionExitCode;
+  } catch (error: unknown) {
+    if (error instanceof CommanderError) {
+      return error.exitCode;
+    }
+
+    const errorMessage = isError(error) ? error.message : String(error);
+    createCommandOptions.writeError(`${errorMessage}\n`);
+
+    return 1;
+  }
+}
+
+function writeRuntimeError(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
+function writeRuntimeOutput(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+async function executeRuntimeCommand(productionTagName: string): Promise<void> {
+  const runtimeEnvironmentResult = readRuntimeEnvironment(process.env);
+
+  if (runtimeEnvironmentResult.isErr) {
+    throw runtimeEnvironmentResult.error;
+  }
+
+  const runtimeEnvironment = runtimeEnvironmentResult.value;
+  const githubReleaseClient = createGitHubReleaseClient({
+    httpClient: createRuntimeKyHttpClient(),
+    githubApiUrl: runtimeEnvironment.githubApiUrl,
+    githubRepository: runtimeEnvironment.githubRepository,
+    githubToken: runtimeEnvironment.githubToken,
+  });
+  const handoffResult = await ensureProductionGitHubRelease({
+    currentProductionTagName: productionTagName,
+    githubReleaseClient,
+  });
+
+  if (handoffResult.isErr) {
+    throw handoffResult.error;
+  }
+
+  writeProductionReleaseOutputs(handoffResult.value, writeRuntimeOutput);
+}
+
+async function main(): Promise<void> {
+  process.exitCode = await runEnsureProductionGitHubReleaseCommand(process.argv.slice(2), {
+    executeCommand: executeRuntimeCommand,
+    writeError: writeRuntimeError,
+    writeOutput: writeRuntimeOutput,
+  });
+}
+
+function isCurrentModuleEntrypoint(): boolean {
+  const entrypointPath = process.argv[1];
+
+  return isString(entrypointPath) && fileURLToPath(import.meta.url) === resolve(entrypointPath);
+}
+
+function crash(error: unknown): void {
+  const errorMessage = isError(error) ? error.message : String(error);
+  writeRuntimeError(errorMessage);
+  process.exitCode = 1;
+}
+
+if (isCurrentModuleEntrypoint()) {
+  try {
+    await main();
+  } catch (error: unknown) {
+    crash(error);
+  }
+}

--- a/tools/release-cli/releaseCliEntrypoints.test.ts
+++ b/tools/release-cli/releaseCliEntrypoints.test.ts
@@ -39,6 +39,10 @@ const releaseMetadataEntrypointPath = join(process.cwd(), 'tools/release-cli/rel
 const productionDistributionEntrypointPath = join(process.cwd(), 'tools/release-cli/productionDistributionCli.mts');
 const releaseAppearanceEntrypointPath = join(process.cwd(), 'tools/release-cli/releaseAppearanceCommand.mts');
 const previewNextBetaEntrypointPath = join(process.cwd(), 'tools/release-cli/previewNextBetaCommand.mts');
+const ensureProductionGitHubReleaseEntrypointPath = join(
+  process.cwd(),
+  'tools/release-cli/ensureProductionGitHubRelease.mts',
+);
 
 function runNativeCommand(entrypointPath: string, commandLineArguments: readonly string[]): NativeCommandResult {
   const childProcessResult = spawnSync(process.execPath, [entrypointPath, ...commandLineArguments], {
@@ -106,6 +110,22 @@ describe('release metadata CLI entrypoint', () => {
 
     expect(actualResult.exitCode).toBe(1);
     expect(actualResult.standardError).toContain("error: missing required argument 'release-identifier'");
+  });
+});
+
+describe('ensure Production GitHub Release CLI entrypoint', () => {
+  it('writes help to standard output', () => {
+    const actualResult = runNativeCommand(ensureProductionGitHubReleaseEntrypointPath, ['--help']);
+
+    expect(actualResult.exitCode).toBe(0);
+    expect(actualResult.standardOutput).toContain('Usage: ensureProductionGitHubRelease [options] <production-tag>');
+  });
+
+  it('rejects a missing Production tag without contacting GitHub', () => {
+    const actualResult = runNativeCommand(ensureProductionGitHubReleaseEntrypointPath, []);
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.standardError).toContain("error: missing required argument 'production-tag'");
   });
 });
 

--- a/tools/release-metadata/releaseMetadata.test.ts
+++ b/tools/release-metadata/releaseMetadata.test.ts
@@ -30,6 +30,7 @@ import {
   productionTagExists,
   productionTagPointsToCommit,
   resolveWebappBuildVersion,
+  selectPrecedingProductionTag,
   validateMaintenanceBranchName,
   validateMaintenanceLineKey,
   validateMaintenanceSource,
@@ -145,6 +146,44 @@ describe('releaseMetadata', () => {
     assert(actualProductionTagName.isOk === true);
 
     expect(actualProductionTagName.value).toBe(productionTagName);
+  });
+
+  it('selectPrecedingProductionTag() selects the latest preceding ADR Production tag numerically', () => {
+    const actualPrecedingProductionTag = selectPrecedingProductionTag('2026-09-10.10-production', [
+      '2026-09-10.9-production',
+      '2026-09-10.10-production',
+      '2026-09-10.11-beta.1',
+      '2026-09-10-staging.1',
+      '2026-09-10-production.9',
+      '2026-09-09.3-production',
+    ]);
+
+    assert(actualPrecedingProductionTag.isOk);
+    assert(actualPrecedingProductionTag.value.isJust);
+    expect(actualPrecedingProductionTag.value.value).toBe('2026-09-10.9-production');
+  });
+
+  it('selectPrecedingProductionTag() returns no tag for the first ADR Production release', () => {
+    const actualPrecedingProductionTag = selectPrecedingProductionTag('2026-07-27.1-production', [
+      '2026-07-27.1-beta.1',
+      '2026-07-27-staging.1',
+      '2026-07-27-production.0',
+    ]);
+
+    assert(actualPrecedingProductionTag.isOk);
+    expect(actualPrecedingProductionTag.value.isNothing).toBe(true);
+  });
+
+  it('selectPrecedingProductionTag() fails closed when a newer ADR Production tag exists', () => {
+    const actualPrecedingProductionTag = selectPrecedingProductionTag('2026-09-10.10-production', [
+      '2026-09-10.9-production',
+      '2026-09-10.11-production',
+    ]);
+
+    assert(actualPrecedingProductionTag.isErr);
+    expect(actualPrecedingProductionTag.error.message).toBe(
+      'Cannot select a preceding Production tag because a newer ADR Production tag exists: 2026-09-10.11-production',
+    );
   });
 
   it.each(['2026-07-27.1-airgap-a', '2026-07-27.1-airgap-hotfix'])(

--- a/tools/release-metadata/releaseMetadata.ts
+++ b/tools/release-metadata/releaseMetadata.ts
@@ -17,7 +17,8 @@
  *
  */
 
-import {maybe, Result} from 'true-myth';
+import {isUndefined} from '@sindresorhus/is';
+import {Maybe, maybe, Result} from 'true-myth';
 import type {NonEmptyString} from 'type-fest';
 
 declare const commitHashBrand: unique symbol;
@@ -47,6 +48,11 @@ export type ProductionTagPointsToCommitParameters = {
   readonly releaseTagMetadata: readonly ReleaseTagMetadata[];
 };
 
+type ParsedProductionTag = {
+  readonly tagName: ProductionTagName;
+  readonly releaseIdentifier: ReleaseIdentifier;
+};
+
 const releaseDatePattern = String.raw`\d{4}-\d{2}-\d{2}`;
 const releaseIdentifierPattern = String.raw`${releaseDatePattern}\.[1-9]\d*`;
 const releaseBranchNamePattern = new RegExp(`^release/(${releaseIdentifierPattern})$`);
@@ -59,6 +65,9 @@ const maintenanceBranchNamePattern = new RegExp(
 const maintenanceTagNamePattern = new RegExp(
   String.raw`^${releaseIdentifierPattern}-[a-z0-9]+(?:-[a-z0-9]+)*-maintenance\.[1-9]\d*$`,
 );
+const productionTagSuffix = '-production';
+const releaseDateLength = 10;
+const releaseSequenceStartIndex = 11;
 
 function isWebappBuildChannel(value: string): value is WebappBuildChannel {
   return value === 'main' || value === 'development' || value === 'production';
@@ -132,6 +141,99 @@ export function validateProductionTagName(productionTagName: string): Result<Pro
   }
 
   return Result.ok(productionTagName as ProductionTagName);
+}
+
+function parseProductionTag(productionTagName: string): Result<ParsedProductionTag, Error> {
+  const validatedProductionTagNameResult = validateProductionTagName(productionTagName);
+
+  if (validatedProductionTagNameResult.isErr) {
+    return Result.err(validatedProductionTagNameResult.error);
+  }
+
+  const validatedProductionTagName = validatedProductionTagNameResult.value;
+
+  return Result.ok({
+    tagName: validatedProductionTagName,
+    releaseIdentifier: validatedProductionTagName.slice(0, -productionTagSuffix.length) as ReleaseIdentifier,
+  });
+}
+
+function compareReleaseIdentifiers(leftReleaseIdentifier: string, rightReleaseIdentifier: string): number {
+  const leftReleaseDate = leftReleaseIdentifier.slice(0, releaseDateLength);
+  const rightReleaseDate = rightReleaseIdentifier.slice(0, releaseDateLength);
+
+  if (leftReleaseDate < rightReleaseDate) {
+    return -1;
+  }
+
+  if (leftReleaseDate > rightReleaseDate) {
+    return 1;
+  }
+
+  const leftReleaseSequence = BigInt(leftReleaseIdentifier.slice(releaseSequenceStartIndex));
+  const rightReleaseSequence = BigInt(rightReleaseIdentifier.slice(releaseSequenceStartIndex));
+
+  if (leftReleaseSequence < rightReleaseSequence) {
+    return -1;
+  }
+
+  if (leftReleaseSequence > rightReleaseSequence) {
+    return 1;
+  }
+
+  return 0;
+}
+
+export function selectPrecedingProductionTag(
+  currentProductionTagName: string,
+  existingTagNames: readonly string[],
+): Result<Maybe<ProductionTagName>, Error> {
+  const currentProductionTagResult = parseProductionTag(currentProductionTagName);
+
+  if (currentProductionTagResult.isErr) {
+    return Result.err(currentProductionTagResult.error);
+  }
+
+  const currentProductionTag = currentProductionTagResult.value;
+  const validProductionTags = existingTagNames.flatMap(existingTagName => {
+    const parsedProductionTagResult = parseProductionTag(existingTagName);
+
+    if (parsedProductionTagResult.isErr) {
+      return [];
+    }
+
+    return [parsedProductionTagResult.value];
+  });
+  const laterProductionTags = validProductionTags
+    .filter(productionTag => {
+      return compareReleaseIdentifiers(productionTag.releaseIdentifier, currentProductionTag.releaseIdentifier) > 0;
+    })
+    .toSorted((leftProductionTag, rightProductionTag) => {
+      return compareReleaseIdentifiers(leftProductionTag.releaseIdentifier, rightProductionTag.releaseIdentifier);
+    });
+
+  const laterProductionTag = laterProductionTags[0];
+
+  if (isUndefined(laterProductionTag) === false) {
+    return Result.err(
+      new Error(
+        `Cannot select a preceding Production tag because a newer ADR Production tag exists: ${laterProductionTag.tagName}`,
+      ),
+    );
+  }
+
+  const precedingProductionTags = validProductionTags.filter(productionTag => {
+    return compareReleaseIdentifiers(productionTag.releaseIdentifier, currentProductionTag.releaseIdentifier) < 0;
+  });
+  const precedingProductionTag = precedingProductionTags.toSorted((leftProductionTag, rightProductionTag) => {
+    return compareReleaseIdentifiers(leftProductionTag.releaseIdentifier, rightProductionTag.releaseIdentifier);
+  })[precedingProductionTags.length - 1];
+
+  if (isUndefined(precedingProductionTag)) {
+    return Result.ok(Maybe.nothing<ProductionTagName>());
+  }
+
+  return Result.ok(Maybe.just(precedingProductionTag.tagName));
 }
 
 export function validateMaintenanceLineKey(maintenanceLineKey: string): Result<MaintenanceLineKey, Error> {

--- a/tools/release-summary/renderWebappReleaseSummary.test.ts
+++ b/tools/release-summary/renderWebappReleaseSummary.test.ts
@@ -338,7 +338,7 @@ describe('WebApp release summary renderer', () => {
     expect(detailsContent).toContain('- Action: new draft created');
     expect(detailsContent).toContain(`- Release URL: [GitHub Release](${githubReleaseUrl})`);
     expect(detailsContent).toContain(
-      '- Manual follow-up: Customer-facing changelog completion and GitHub Release publication remain manual.',
+      '- Manual follow-up: Review or edit the generated customer-facing changelog and publish the GitHub Release manually.',
     );
   });
 
@@ -379,7 +379,7 @@ describe('WebApp release summary renderer', () => {
       `- GitHub Release handoff: completed successfully; action: existing draft verified; state: draft; URL: [GitHub Release](${githubReleaseUrl})`,
     );
     expect(detailsContent).toContain(
-      '- Manual follow-up: Customer-facing changelog completion and GitHub Release publication remain manual.',
+      '- Manual follow-up: Review or edit the generated customer-facing changelog and publish the GitHub Release manually.',
     );
   });
 

--- a/tools/release-summary/renderWebappReleaseSummary.ts
+++ b/tools/release-summary/renderWebappReleaseSummary.ts
@@ -602,7 +602,7 @@ function formatGitHubReleaseManualHandoff(state: Maybe<GitHubReleaseState>): str
   return state.mapOr('not available', actualState => {
     return match(actualState)
       .with('draft', () => {
-        return 'Customer-facing changelog completion and GitHub Release publication remain manual.';
+        return 'Review or edit the generated customer-facing changelog and publish the GitHub Release manually.';
       })
       .with('published', () => {
         return 'The existing published GitHub Release was preserved; no automated publication was performed.';


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

Populate newly created Production GitHub Release drafts with generated release notes covering the complete delta since the preceding Production release.

GitHub Releases remain Production-only. Beta candidates continue to use immutable Beta tags without creating GitHub Releases.

Existing draft or published releases are preserved unchanged on reruns.

The historical [broken characters](https://github.com/wireapp/wire-webapp/releases/tag/untagged-a0d5c2650dddfc160880) were caused by the retired changelog workflow capturing `Nx` ANSI/status output into Markdown. This change does not restore or sanitize that legacy path; release notes now come from GitHub's release-notes API.