### PR TITLE
test: ensure Cells publish flow [WPB-28356]

### DIFF
--- a/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.test.tsx
@@ -1,0 +1,206 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {act, renderHook} from '@testing-library/react';
+
+import {FileWithPreview, useFileUploadState} from 'Components/conversation/useFilesUploadState/useFilesUploadState';
+import {Config} from 'src/script/Config';
+
+import {useMessageSend} from './useMessageSend';
+
+const conversationId = 'conversation';
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return {promise, resolve, reject};
+};
+
+const createFile = (
+  id: string,
+  uploadStatus: 'success' | 'uploading' = 'success',
+  media: Pick<FileWithPreview, 'audio' | 'video'> = {},
+): FileWithPreview =>
+  Object.assign(new File(['content'], `${id}.png`, {type: 'image/png'}), {
+    id,
+    preview: `blob:${id}`,
+    remoteUuid: `remote-${id}`,
+    remoteVersionId: `version-${id}`,
+    uploadStatus,
+    uploadProgress: uploadStatus === 'success' ? 100 : 40,
+    image: {width: 10, height: 20},
+    ...media,
+  });
+
+const createProps = (overrides: Record<string, unknown> = {}) => ({
+  replyMessageEntity: null,
+  eventRepository: {eventService: {loadEvent: jest.fn()}} as never,
+  messageRepository: {sendTextWithLinkPreview: jest.fn()} as never,
+  conversation: {id: conversationId, mlsVerificationState: () => 'unverified'} as never,
+  conversationRepository: {refreshMLSConversationVerificationState: jest.fn()} as never,
+  cellsRepository: {promoteNodeDraft: jest.fn().mockResolvedValue(undefined)} as never,
+  draftState: {reset: jest.fn()},
+  cancelMessageEditing: jest.fn(),
+  cancelMessageReply: jest.fn(),
+  editedMessage: undefined,
+  replyMessageCallback: jest.fn(),
+  editorRef: {current: null},
+  pastedFile: null,
+  sendPastedFile: jest.fn(),
+  messageContent: {text: 'hello', mentions: []},
+  translate: ((key: string) => key) as never,
+  ...overrides,
+});
+
+describe('useMessageSend', () => {
+  let configSpy: jest.SpyInstance;
+  let notificationContainer: HTMLDivElement;
+
+  beforeEach(() => {
+    notificationContainer = document.createElement('div');
+    notificationContainer.id = 'app-notification';
+    document.body.appendChild(notificationContainer);
+    useFileUploadState.getState().clearAll({conversationId});
+    configSpy = jest.spyOn(Config, 'getConfig').mockReturnValue({
+      FEATURE: {ENABLE_CELLS: true},
+      MAXIMUM_MESSAGE_LENGTH: 1000,
+    } as never);
+  });
+
+  afterEach(() => {
+    configSpy.mockRestore();
+    notificationContainer.remove();
+  });
+
+  it('keeps sending disabled until every selected file is ready', () => {
+    useFileUploadState
+      .getState()
+      .addFiles({conversationId, files: [createFile('ready'), createFile('loading', 'uploading')]});
+
+    const {result} = renderHook(() => useMessageSend(createProps()));
+
+    expect(result.current.isSendingDisabled).toBe(true);
+  });
+
+  it('publishes every ready draft before sending text with preserved attachment metadata', async () => {
+    const sendTextWithLinkPreview = jest.fn();
+    const publication = createDeferred<void>();
+    const promoteNodeDraft = jest.fn().mockReturnValue(publication.promise);
+    const files = [createFile('image')];
+    useFileUploadState.getState().addFiles({conversationId, files});
+    const props = createProps({
+      cellsRepository: {promoteNodeDraft} as never,
+      messageRepository: {sendTextWithLinkPreview} as never,
+    });
+    const {result} = renderHook(() => useMessageSend(props));
+
+    let sendPromise: Promise<void>;
+    act(() => {
+      sendPromise = result.current.sendMessage();
+    });
+    await act(async () => Promise.resolve());
+
+    expect(promoteNodeDraft).toHaveBeenCalledWith({uuid: 'remote-image', versionId: 'version-image'});
+    expect(sendTextWithLinkPreview).not.toHaveBeenCalled();
+    publication.resolve();
+    await act(async () => sendPromise!);
+    await act(async () => Promise.resolve());
+
+    expect(sendTextWithLinkPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        textMessage: 'hello',
+        attachments: [
+          {
+            cellAsset: {
+              uuid: 'image',
+              contentType: 'image/png',
+              initialName: 'image.png',
+              initialSize: files[0].size,
+              image: {width: 10, height: 20},
+              audio: undefined,
+              video: undefined,
+            },
+          },
+        ],
+      }),
+    );
+    expect(useFileUploadState.getState().getFiles({conversationId})).toEqual([]);
+  });
+
+  it('returns publication failures without sending or clearing retryable files', async () => {
+    const sendTextWithLinkPreview = jest.fn();
+    const promoteNodeDraft = jest.fn().mockRejectedValue(new Error('publication failed'));
+    const file = createFile('failed');
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
+    const {result} = renderHook(() =>
+      useMessageSend(
+        createProps({
+          cellsRepository: {promoteNodeDraft} as never,
+          messageRepository: {sendTextWithLinkPreview} as never,
+        }),
+      ),
+    );
+
+    await act(async () => {
+      await expect(result.current.sendMessage()).rejects.toThrow('publication failed');
+    });
+
+    expect(promoteNodeDraft).toHaveBeenCalledWith({uuid: 'remote-failed', versionId: 'version-failed'});
+    expect(sendTextWithLinkPreview).not.toHaveBeenCalled();
+    expect(useFileUploadState.getState().getFiles({conversationId})).toEqual([file]);
+  });
+
+  it('preserves image, audio, and video attachment metadata', async () => {
+    const sendTextWithLinkPreview = jest.fn();
+    const file = createFile('media', 'success', {
+      audio: {durationInMillis: 3},
+      video: {width: 1920, height: 1080},
+    });
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
+    const {result} = renderHook(() =>
+      useMessageSend(createProps({messageRepository: {sendTextWithLinkPreview} as never})),
+    );
+
+    await act(async () => result.current.sendMessage());
+    await act(async () => Promise.resolve());
+
+    expect(sendTextWithLinkPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            cellAsset: expect.objectContaining({
+              image: {width: 10, height: 20},
+              audio: {durationInMillis: 3},
+              video: {width: 1920, height: 1080},
+            }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('sends text without attachments when no files are selected', async () => {
+    const sendTextWithLinkPreview = jest.fn();
+    const {result} = renderHook(() =>
+      useMessageSend(createProps({messageRepository: {sendTextWithLinkPreview} as never})),
+    );
+
+    await act(async () => result.current.sendMessage());
+    await act(async () => Promise.resolve());
+
+    expect(sendTextWithLinkPreview).toHaveBeenCalledWith(
+      expect.objectContaining({textMessage: 'hello', attachments: []}),
+    );
+  });
+});

--- a/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.ts
+++ b/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.ts
@@ -285,7 +285,8 @@ export const useMessageSend = ({
         translate,
       );
     } else {
-      void sendMessage();
+      // Return the promise so FireAndForgetInvoker can observe publication failures.
+      await sendMessage();
     }
   }, [conversation, conversationRepository, sendMessage, translate]);
 

--- a/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useSendFiles/useSendFiles.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useSendFiles/useSendFiles.test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {act, renderHook} from '@testing-library/react';
+
+import type {FileWithPreview} from 'Components/conversation/useFilesUploadState/useFilesUploadState';
+
+import {useSendFiles} from './useSendFiles';
+
+type Repository = {
+  promoteNodeDraft: jest.Mock<Promise<void>, [{uuid: string; versionId: string}]>;
+};
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return {promise, resolve, reject};
+};
+
+const createFile = (id: string, preview = `blob:${id}`): FileWithPreview =>
+  Object.assign(new File(['content'], `${id}.png`, {type: 'image/png'}), {
+    id,
+    preview,
+    remoteUuid: `remote-${id}`,
+    remoteVersionId: `version-${id}`,
+    uploadStatus: 'success' as const,
+    uploadProgress: 100,
+  });
+
+describe('useSendFiles', () => {
+  it('promotes every draft before completing and revokes previews', async () => {
+    const repository: Repository = {promoteNodeDraft: jest.fn().mockResolvedValue(undefined)};
+    const revoke = jest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    revoke.mockClear();
+    const {result} = renderHook(() =>
+      useSendFiles({
+        files: [createFile('one'), createFile('two')],
+        cellsRepository: repository as never,
+        clearAllFiles: jest.fn(),
+        conversationId: 'conversation',
+        sendFilesErrorMessage: 'send failed',
+      }),
+    );
+
+    await act(async () => result.current.sendFiles());
+
+    expect(repository.promoteNodeDraft).toHaveBeenNthCalledWith(1, {uuid: 'remote-one', versionId: 'version-one'});
+    expect(repository.promoteNodeDraft).toHaveBeenNthCalledWith(2, {uuid: 'remote-two', versionId: 'version-two'});
+    expect(revoke).toHaveBeenCalledWith('blob:one');
+    expect(revoke).toHaveBeenCalledWith('blob:two');
+    revoke.mockRestore();
+  });
+
+  it('starts all publications before completing when one finishes later', async () => {
+    const firstPublication = createDeferred<void>();
+    const secondPublication = createDeferred<void>();
+    const repository: Repository = {
+      promoteNodeDraft: jest
+        .fn()
+        .mockReturnValueOnce(firstPublication.promise)
+        .mockReturnValueOnce(secondPublication.promise),
+    };
+    const files = [createFile('one'), createFile('two')];
+    const {result} = renderHook(() =>
+      useSendFiles({
+        files,
+        cellsRepository: repository as never,
+        clearAllFiles: jest.fn(),
+        conversationId: 'conversation',
+        sendFilesErrorMessage: 'send failed',
+      }),
+    );
+
+    let sending: Promise<void> | undefined;
+    await act(async () => {
+      sending = result.current.sendFiles();
+      await Promise.resolve();
+    });
+
+    expect(repository.promoteNodeDraft).toHaveBeenCalledTimes(2);
+    expect(result.current.isLoading).toBe(true);
+    secondPublication.resolve();
+    firstPublication.resolve();
+    await act(async () => sending);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('does not revoke previews or cancel a promoted draft after another publication fails', async () => {
+    const firstPublication = createDeferred<void>();
+    const secondPublication = createDeferred<void>();
+    const cancelUpload = jest.fn();
+    const repository: Repository & {cancelUpload: jest.Mock} = {
+      promoteNodeDraft: jest
+        .fn()
+        .mockReturnValueOnce(firstPublication.promise)
+        .mockReturnValueOnce(secondPublication.promise),
+      cancelUpload,
+    };
+    const files = [createFile('one'), createFile('two')];
+    const revoke = jest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    revoke.mockClear();
+    const {result} = renderHook(() =>
+      useSendFiles({
+        files,
+        cellsRepository: repository as never,
+        clearAllFiles: jest.fn(),
+        conversationId: 'conversation',
+        sendFilesErrorMessage: 'send failed',
+      }),
+    );
+
+    let sending: Promise<void> | undefined;
+    await act(async () => {
+      sending = result.current.sendFiles();
+      await Promise.resolve();
+    });
+    expect(repository.promoteNodeDraft).toHaveBeenCalledTimes(2);
+
+    firstPublication.resolve();
+    secondPublication.reject(new Error('second publication failed'));
+    await expect(act(async () => sending)).rejects.toThrow();
+
+    expect(revoke).not.toHaveBeenCalled();
+    expect(cancelUpload).not.toHaveBeenCalled();
+    revoke.mockRestore();
+  });
+});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28356" title="WPB-28356" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28356</a>  [web] create logic library for handling upload (non-ui)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem

Before starting the refactor, I’m adding deterministic coverage around the Cells publish and send flow. This logic is currently coupled to conversation publication and message sending, so extracting it could accidentally change when a draft is ready, the publish and send order, retry state, attachment metadata, or partial multi-file failures

## Solution

Added focused tests for successful and failed publication, metadata, cleanup, and partial multi-file failures

Kept the normal send promise in the flow so `FireAndForgetInvoker` can see publication failures

This PR is stacked on #22326

https://wearezeta.atlassian.net/browse/WPB-28356