### PR TITLE
Preserve production artifact metadata through HTML minification [WPB-22420]

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -339,5 +339,11 @@ jobs:
           WIRE_WEBAPP_BUILD_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           short_commit_sha="${WIRE_WEBAPP_BUILD_COMMIT::7}"
-          WIRE_WEBAPP_BUILD_VERSION="dev-${short_commit_sha}" \
-          ./bin/yarn build:prod:public
+          expected_version="dev-${short_commit_sha}"
+          WIRE_WEBAPP_BUILD_VERSION="${expected_version}" \
+            ./bin/yarn build:prod:public
+
+          BUILD_ARTIFACT_PATH=apps/server/dist/s3/ebs.zip \
+          EXPECTED_COMMIT="${WIRE_WEBAPP_BUILD_COMMIT}" \
+          EXPECTED_VERSION="${expected_version}" \
+            node ./tools/build-artifact/validateBuildArtifact.mts

--- a/apps/webapp/webpack.config.js
+++ b/apps/webapp/webpack.config.js
@@ -26,7 +26,11 @@ module.exports = {
   mode: 'production',
   optimization: {
     ...commonConfig.optimization,
-    minimize: true,
+    minimize: {
+      html: {
+        comments: /^! /,
+      },
+    },
   },
   plugins: [
     ...commonConfig.plugins,

--- a/tools/build-artifact/buildArtifactMetadata.test.ts
+++ b/tools/build-artifact/buildArtifactMetadata.test.ts
@@ -68,6 +68,22 @@ describe('build artifact metadata validation', () => {
     expect(validationResult.isOk).toBe(true);
   });
 
+  it('accepts single-quoted and unquoted local cache-busted assets', () => {
+    const validationResult = validateBuildArtifactMetadata({
+      expectedCommit: mainBuildMetadata.commit,
+      expectedVersion: mainBuildMetadata.version,
+      htmlDocuments: [
+        {
+          archiveFilePath: 'static/unsupported/index.html',
+          contents: `<!--! ${mainBuildMetadata.version} --><link href=/image/favicon.ico?${mainBuildMetadata.assetVersion}><script src='/min/app.js?v=${mainBuildMetadata.assetVersion}'>`,
+        },
+      ],
+      metadata: mainBuildMetadata,
+    });
+
+    expect(validationResult.isOk).toBe(true);
+  });
+
   it('ignores query strings outside intentional local cache-busted asset URLs', () => {
     const htmlDocument = createHtmlDocument(mainBuildMetadata);
     const validationResult = validateBuildArtifactMetadata({

--- a/tools/build-artifact/buildArtifactMetadata.test.ts
+++ b/tools/build-artifact/buildArtifactMetadata.test.ts
@@ -68,14 +68,30 @@ describe('build artifact metadata validation', () => {
     expect(validationResult.isOk).toBe(true);
   });
 
-  it('accepts single-quoted and unquoted local cache-busted assets', () => {
+  it('accepts a single-quoted local cache-busted asset', () => {
+    const validationResult = validateBuildArtifactMetadata({
+      expectedCommit: mainBuildMetadata.commit,
+      expectedVersion: mainBuildMetadata.version,
+      htmlDocuments: [
+        {
+          archiveFilePath: 'static/index.html',
+          contents: `<!--! ${mainBuildMetadata.version} --><script src='/min/app.js?v=${mainBuildMetadata.assetVersion}'>`,
+        },
+      ],
+      metadata: mainBuildMetadata,
+    });
+
+    expect(validationResult.isOk).toBe(true);
+  });
+
+  it('accepts an unquoted local cache-busted asset', () => {
     const validationResult = validateBuildArtifactMetadata({
       expectedCommit: mainBuildMetadata.commit,
       expectedVersion: mainBuildMetadata.version,
       htmlDocuments: [
         {
           archiveFilePath: 'static/unsupported/index.html',
-          contents: `<!--! ${mainBuildMetadata.version} --><link href=/image/favicon.ico?${mainBuildMetadata.assetVersion}><script src='/min/app.js?v=${mainBuildMetadata.assetVersion}'>`,
+          contents: `<!--! ${mainBuildMetadata.version} --><link href=/image/favicon.ico?${mainBuildMetadata.assetVersion}>`,
         },
       ],
       metadata: mainBuildMetadata,

--- a/tools/build-artifact/buildArtifactMetadata.ts
+++ b/tools/build-artifact/buildArtifactMetadata.ts
@@ -19,6 +19,7 @@
 
 import {Maybe, Result} from 'true-myth';
 
+import {isString} from '@sindresorhus/is';
 import {isBuildMetadata} from '@wireapp/config';
 import type {BuildMetadata} from '@wireapp/config';
 
@@ -35,12 +36,29 @@ export type BuildArtifactMetadataValidationInput = {
 };
 
 const localStaticAssetDirectoryNames = ['assets', 'audio', 'ext', 'font', 'image', 'min', 'proto', 'style', 'worker'];
+const htmlResourceAttributePattern = /\b(?:src|href)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'`=<>]+))/giu;
 
 function readHtmlResourceAttributeValues(htmlContents: string): readonly string[] {
-  return [...htmlContents.matchAll(/\b(?:src|href)\s*=\s*(["'])(.*?)\1/giu)].flatMap(attributeMatch => {
-    return Maybe.of(attributeMatch[2])
-      .map(attributeValue => [attributeValue])
-      .unwrapOr([]);
+  return [...htmlContents.matchAll(htmlResourceAttributePattern)].flatMap(attributeMatch => {
+    const doubleQuotedAttributeValue = attributeMatch[1];
+
+    if (isString(doubleQuotedAttributeValue)) {
+      return [doubleQuotedAttributeValue];
+    }
+
+    const singleQuotedAttributeValue = attributeMatch[2];
+
+    if (isString(singleQuotedAttributeValue)) {
+      return [singleQuotedAttributeValue];
+    }
+
+    const unquotedAttributeValue = attributeMatch[3];
+
+    if (isString(unquotedAttributeValue)) {
+      return [unquotedAttributeValue];
+    }
+
+    return [];
   });
 }
 

--- a/tools/build-artifact/buildArtifactMetadata.ts
+++ b/tools/build-artifact/buildArtifactMetadata.ts
@@ -19,9 +19,9 @@
 
 import {Maybe, Result} from 'true-myth';
 
-import {isString} from '@sindresorhus/is';
 import {isBuildMetadata} from '@wireapp/config';
 import type {BuildMetadata} from '@wireapp/config';
+import {match, P} from 'ts-pattern';
 
 export type BuildArtifactHtmlDocument = {
   readonly archiveFilePath: string;
@@ -40,25 +40,21 @@ const htmlResourceAttributePattern = /\b(?:src|href)\s*=\s*(?:"([^"]*)"|'([^']*)
 
 function readHtmlResourceAttributeValues(htmlContents: string): readonly string[] {
   return [...htmlContents.matchAll(htmlResourceAttributePattern)].flatMap(attributeMatch => {
-    const doubleQuotedAttributeValue = attributeMatch[1];
+    const attributeValueCaptures = attributeMatch.slice(1, 4);
 
-    if (isString(doubleQuotedAttributeValue)) {
-      return [doubleQuotedAttributeValue];
-    }
-
-    const singleQuotedAttributeValue = attributeMatch[2];
-
-    if (isString(singleQuotedAttributeValue)) {
-      return [singleQuotedAttributeValue];
-    }
-
-    const unquotedAttributeValue = attributeMatch[3];
-
-    if (isString(unquotedAttributeValue)) {
-      return [unquotedAttributeValue];
-    }
-
-    return [];
+    return match(attributeValueCaptures)
+      .with([P.string, P._, P._], ([doubleQuotedAttributeValue]) => {
+        return [doubleQuotedAttributeValue];
+      })
+      .with([P._, P.string, P._], ([, singleQuotedAttributeValue]) => {
+        return [singleQuotedAttributeValue];
+      })
+      .with([P._, P._, P.string], ([, , unquotedAttributeValue]) => {
+        return [unquotedAttributeValue];
+      })
+      .otherwise(() => {
+        return [];
+      });
   });
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Preserve WebApp build metadata when Webpack minifies generated HTML and update artifact validation to support valid unquoted `src` and `href` attributes.

Also validate the existing production artifact in pull-request CI so build-metadata regressions are caught before merge.

The CI check reuses the existing public production build and does not add another full build job.