### PR TITLE
feat: add Cells upload lifecycle module [WPB-28356]

### DIFF
--- a/apps/webapp/src/script/repositories/cells/upload/identity.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/identity.ts
@@ -1,0 +1,34 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export interface UploadSource {
+  readonly blob: Blob;
+  readonly name: string;
+  readonly contentType: string;
+  readonly size: number;
+}
+
+export interface UploadIdentity {
+  readonly uploadId: string;
+}
+
+export interface DraftIdentity extends UploadIdentity {
+  readonly resourceUuid: string;
+  readonly versionId: string;
+}

--- a/apps/webapp/src/script/repositories/cells/upload/index.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './identity';
+export * from './lifecycle';
+export * from './transition';

--- a/apps/webapp/src/script/repositories/cells/upload/lifecycle.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/lifecycle.ts
@@ -1,0 +1,145 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {DraftIdentity, UploadIdentity, UploadSource} from './identity';
+
+export interface QueuedState {
+  readonly kind: 'queued';
+  readonly identity: UploadIdentity;
+  readonly source: UploadSource;
+}
+
+export interface UploadingState {
+  readonly kind: 'uploading';
+  readonly identity: UploadIdentity;
+  readonly source: UploadSource;
+  readonly progress: number;
+}
+
+export interface DraftReadyState {
+  readonly kind: 'draftReady';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface UploadFailedState {
+  readonly kind: 'uploadFailed';
+  readonly identity: UploadIdentity;
+  readonly source: UploadSource;
+  readonly error: UploadLifecycleError;
+}
+
+export interface PublishingState {
+  readonly kind: 'publishing';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface PublishedState {
+  readonly kind: 'published';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface PublishFailedState {
+  readonly kind: 'publishFailed';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+  readonly error: UploadLifecycleError;
+}
+
+export interface DiscardingState {
+  readonly kind: 'discarding';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface DiscardedState {
+  readonly kind: 'discarded';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface DiscardFailedState {
+  readonly kind: 'discardFailed';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+  readonly error: UploadLifecycleError;
+}
+
+export interface CancelledState {
+  readonly kind: 'cancelled';
+  readonly identity: UploadIdentity;
+  readonly source: UploadSource;
+}
+
+export type UploadState =
+  | QueuedState
+  | UploadingState
+  | DraftReadyState
+  | UploadFailedState
+  | PublishingState
+  | PublishedState
+  | PublishFailedState
+  | DiscardingState
+  | DiscardedState
+  | DiscardFailedState
+  | CancelledState;
+
+export type UploadActionType =
+  | 'startUpload'
+  | 'progress'
+  | 'uploadSucceeded'
+  | 'uploadFailed'
+  | 'publish'
+  | 'publishSucceeded'
+  | 'publishFailed'
+  | 'discard'
+  | 'discardSucceeded'
+  | 'discardFailed'
+  | 'retryUpload'
+  | 'retryPublish'
+  | 'retryDiscard'
+  | 'cancel';
+
+export type UploadFailureError = {readonly kind: 'uploadFailed'; readonly cause: unknown};
+export type PublishFailureError = {readonly kind: 'publishFailed'; readonly cause: unknown};
+export type DiscardFailureError = {readonly kind: 'discardFailed'; readonly cause: unknown};
+
+export type UploadLifecycleError =
+  | {readonly kind: 'invalidTransition'; readonly from: UploadState['kind']; readonly action: UploadActionType}
+  | UploadFailureError
+  | PublishFailureError
+  | DiscardFailureError;
+
+export type UploadAction =
+  | {readonly type: 'startUpload'}
+  | {readonly type: 'progress'; readonly progress: number}
+  | {readonly type: 'uploadSucceeded'; readonly resourceUuid: string; readonly versionId: string}
+  | {readonly type: 'uploadFailed'; readonly error: UploadFailureError}
+  | {readonly type: 'publish'}
+  | {readonly type: 'publishSucceeded'}
+  | {readonly type: 'publishFailed'; readonly error: PublishFailureError}
+  | {readonly type: 'discard'}
+  | {readonly type: 'discardSucceeded'}
+  | {readonly type: 'discardFailed'; readonly error: DiscardFailureError}
+  | {readonly type: 'retryUpload'}
+  | {readonly type: 'retryPublish'}
+  | {readonly type: 'retryDiscard'}
+  | {readonly type: 'cancel'};

--- a/apps/webapp/src/script/repositories/cells/upload/transition.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/transition.test.ts
@@ -1,0 +1,188 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {result as resultModule} from 'true-myth';
+
+import type {UploadAction, UploadLifecycleError, UploadState} from './lifecycle';
+import {normalizeProgress, transition} from './transition';
+
+const source = {blob: new Blob(['content']), name: 'file.txt', contentType: 'text/plain', size: 7};
+const queued: UploadState = {kind: 'queued', identity: {uploadId: 'upload-1'}, source};
+const uploading: UploadState = {...queued, kind: 'uploading', progress: 0};
+const draftReady: UploadState = {
+  kind: 'draftReady',
+  identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+  source,
+};
+const publishing: UploadState = {...draftReady, kind: 'publishing'};
+const publishFailed: UploadState = {
+  ...publishing,
+  kind: 'publishFailed',
+  error: {kind: 'publishFailed', cause: 'offline'},
+};
+const discarding: UploadState = {...draftReady, kind: 'discarding'};
+const discardFailed: UploadState = {
+  ...discarding,
+  kind: 'discardFailed',
+  error: {kind: 'discardFailed', cause: 'offline'},
+};
+
+const expectSuccess = (state: UploadState, action: UploadAction): UploadState => {
+  const result = transition(state, action);
+  expect(result.isOk).toBe(true);
+  return resultModule.isOk(result) ? result.value : state;
+};
+
+const expectFailure = (state: UploadState, action: UploadAction): UploadLifecycleError => {
+  const result = transition(state, action);
+  expect(resultModule.isErr(result)).toBe(true);
+  return resultModule.isErr(result)
+    ? result.error
+    : ({kind: 'invalidTransition', from: state.kind, action: action.type} as UploadLifecycleError);
+};
+
+describe('normalizeProgress', () => {
+  it.each([
+    {progress: -0.1, expected: 0},
+    {progress: 0, expected: 0},
+    {progress: 0.25, expected: 0.25},
+    {progress: 1, expected: 1},
+    {progress: 1.5, expected: 1},
+    {progress: Number.NaN, expected: 0},
+  ])('normalizes $progress to the inclusive 0..1 range', ({progress, expected}) => {
+    expect(normalizeProgress(progress)).toBe(expected);
+  });
+});
+
+describe('transition', () => {
+  it.each([
+    {state: queued, action: {type: 'startUpload'} as const, expected: 'uploading'},
+    {
+      state: uploading,
+      action: {type: 'uploadSucceeded', resourceUuid: 'resource-1', versionId: 'version-1'} as const,
+      expected: 'draftReady',
+    },
+    {
+      state: uploading,
+      action: {type: 'uploadFailed', error: {kind: 'uploadFailed', cause: 'offline'}} as const,
+      expected: 'uploadFailed',
+    },
+    {state: draftReady, action: {type: 'publish'} as const, expected: 'publishing'},
+    {state: publishing, action: {type: 'publishSucceeded'} as const, expected: 'published'},
+    {
+      state: publishing,
+      action: {type: 'publishFailed', error: {kind: 'publishFailed', cause: 'offline'}} as const,
+      expected: 'publishFailed',
+    },
+    {state: draftReady, action: {type: 'discard'} as const, expected: 'discarding'},
+    {state: discarding, action: {type: 'discardSucceeded'} as const, expected: 'discarded'},
+    {
+      state: discarding,
+      action: {type: 'discardFailed', error: {kind: 'discardFailed', cause: 'offline'}} as const,
+      expected: 'discardFailed',
+    },
+  ])('allows $state.kind + $action.type -> $expected', ({state, action, expected}) => {
+    expect(expectSuccess(state, action).kind).toBe(expected);
+  });
+
+  it('normalizes progress while uploading and ignores it outside active upload', () => {
+    expect(expectSuccess(uploading, {type: 'progress', progress: 0.5})).toMatchObject({
+      kind: 'uploading',
+      progress: 0.5,
+    });
+    const result = transition(draftReady, {type: 'progress', progress: 0.8});
+    expect(resultModule.isOk(result)).toBe(true);
+    expect(resultModule.isOk(result) && result.value).toBe(draftReady);
+  });
+
+  it('preserves upload and draft identities across transitions', () => {
+    const ready = expectSuccess(uploading, {
+      type: 'uploadSucceeded',
+      resourceUuid: 'resource-2',
+      versionId: 'version-2',
+    });
+    expect(ready).toMatchObject({identity: {uploadId: 'upload-1', resourceUuid: 'resource-2', versionId: 'version-2'}});
+  });
+
+  it('removes active progress when upload fails', () => {
+    expect(expectSuccess(uploading, {type: 'uploadFailed', error: {kind: 'uploadFailed', cause: 'offline'}})).toEqual({
+      kind: 'uploadFailed',
+      identity: queued.identity,
+      source,
+      error: {kind: 'uploadFailed', cause: 'offline'},
+    });
+  });
+
+  it.each([
+    {state: queued, action: {type: 'publish'} as const},
+    {state: uploading, action: {type: 'publish'} as const},
+    {state: publishing, action: {type: 'publish'} as const},
+    {state: publishing, action: {type: 'discard'} as const},
+    {state: publishFailed, action: {type: 'publish'} as const},
+    {state: discardFailed, action: {type: 'discard'} as const},
+    {state: draftReady, action: {type: 'cancel'} as const},
+    {state: publishFailed, action: {type: 'cancel'} as const},
+    {state: discardFailed, action: {type: 'cancel'} as const},
+    {state: {...draftReady, kind: 'published'} as UploadState, action: {type: 'publish'} as const},
+    {state: {...draftReady, kind: 'discarded'} as UploadState, action: {type: 'discard'} as const},
+  ])('returns a typed error for invalid $state.kind + $action.type', ({state, action}) => {
+    expect(expectFailure(state, action)).toMatchObject({
+      kind: 'invalidTransition',
+      from: state.kind,
+      action: action.type,
+    });
+  });
+
+  it('supports recovery from upload, publish, and discard failures without stale fields', () => {
+    expect(
+      expectSuccess(expectSuccess(uploading, {type: 'uploadFailed', error: {kind: 'uploadFailed', cause: 'offline'}}), {
+        type: 'retryUpload',
+      }),
+    ).toEqual({kind: 'queued', identity: queued.identity, source});
+    expect(expectSuccess(publishFailed, {type: 'retryPublish'})).toEqual({
+      kind: 'draftReady',
+      identity: draftReady.identity,
+      source,
+    });
+    expect(expectSuccess(discardFailed, {type: 'retryDiscard'})).toEqual({
+      kind: 'draftReady',
+      identity: draftReady.identity,
+      source,
+    });
+  });
+
+  it.each([
+    {state: queued, action: {type: 'cancel'} as const},
+    {state: uploading, action: {type: 'cancel'} as const},
+  ])('allows cancellation from $state.kind without stale fields', ({state, action}) => {
+    expect(expectSuccess(state, action)).toEqual({kind: 'cancelled', identity: state.identity, source});
+  });
+
+  it('makes repeated cancellation idempotent', () => {
+    const cancelled = expectSuccess(queued, {type: 'cancel'});
+    const result = transition(cancelled, {type: 'cancel'});
+    expect(resultModule.isOk(result)).toBe(true);
+    expect(resultModule.isOk(result) && result.value).toBe(cancelled);
+  });
+
+  it('rejects repeated publish and discard after terminal outcomes', () => {
+    const published = {...draftReady, kind: 'published'} as UploadState;
+    const discarded = {...draftReady, kind: 'discarded'} as UploadState;
+    expect(expectFailure(published, {type: 'publish'}).kind).toBe('invalidTransition');
+    expect(expectFailure(discarded, {type: 'discard'}).kind).toBe('invalidTransition');
+  });
+
+  it('returns a Result instead of throwing for invalid actions', () => {
+    const result = transition(publishedState(), {type: 'startUpload'});
+    expect(result.isErr).toBe(true);
+  });
+});
+
+const publishedState = (): UploadState => ({...draftReady, kind: 'published'}) as UploadState;

--- a/apps/webapp/src/script/repositories/cells/upload/transition.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/transition.ts
@@ -1,0 +1,203 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Result} from 'true-myth';
+
+import type {UploadAction, UploadLifecycleError, UploadState} from './lifecycle';
+
+export const normalizeProgress = (progress: number): number => {
+  if (Number.isNaN(progress)) {
+    return 0;
+  }
+
+  return Math.min(1, Math.max(0, progress));
+};
+
+const invalidTransition = (state: UploadState, action: UploadAction): Result<UploadState, UploadLifecycleError> =>
+  Result.err({kind: 'invalidTransition', from: state.kind, action: action.type});
+
+const transitionFromQueued = (state: Extract<UploadState, {kind: 'queued'}>, action: UploadAction) => {
+  if (action.type === 'startUpload') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'uploading',
+      identity: state.identity,
+      source: state.source,
+      progress: 0,
+    });
+  }
+
+  if (action.type === 'cancel') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'cancelled',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromUploading = (state: Extract<UploadState, {kind: 'uploading'}>, action: UploadAction) => {
+  if (action.type === 'progress') {
+    return Result.ok<UploadState, UploadLifecycleError>({...state, progress: normalizeProgress(action.progress)});
+  }
+
+  if (action.type === 'uploadSucceeded') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'draftReady',
+      identity: {...state.identity, resourceUuid: action.resourceUuid, versionId: action.versionId},
+      source: state.source,
+    });
+  }
+
+  if (action.type === 'uploadFailed') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'uploadFailed',
+      identity: state.identity,
+      source: state.source,
+      error: action.error,
+    });
+  }
+
+  if (action.type === 'cancel') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'cancelled',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromDraftReady = (state: Extract<UploadState, {kind: 'draftReady'}>, action: UploadAction) => {
+  if (action.type === 'publish') {
+    return Result.ok<UploadState, UploadLifecycleError>({...state, kind: 'publishing'});
+  }
+
+  if (action.type === 'discard') {
+    return Result.ok<UploadState, UploadLifecycleError>({...state, kind: 'discarding'});
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromUploadFailed = (state: Extract<UploadState, {kind: 'uploadFailed'}>, action: UploadAction) => {
+  if (action.type === 'retryUpload') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'queued',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromPublishing = (state: Extract<UploadState, {kind: 'publishing'}>, action: UploadAction) => {
+  if (action.type === 'publishSucceeded') {
+    return Result.ok<UploadState, UploadLifecycleError>({...state, kind: 'published'});
+  }
+
+  if (action.type === 'publishFailed') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'publishFailed',
+      identity: state.identity,
+      source: state.source,
+      error: action.error,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromPublishFailed = (state: Extract<UploadState, {kind: 'publishFailed'}>, action: UploadAction) => {
+  if (action.type === 'retryPublish') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'draftReady',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromDiscarding = (state: Extract<UploadState, {kind: 'discarding'}>, action: UploadAction) => {
+  if (action.type === 'discardSucceeded') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'discarded',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  if (action.type === 'discardFailed') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'discardFailed',
+      identity: state.identity,
+      source: state.source,
+      error: action.error,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromDiscardFailed = (state: Extract<UploadState, {kind: 'discardFailed'}>, action: UploadAction) => {
+  if (action.type === 'retryDiscard') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'draftReady',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+export const transition = (state: UploadState, action: UploadAction): Result<UploadState, UploadLifecycleError> => {
+  if (action.type === 'progress' && state.kind !== 'uploading') {
+    return Result.ok(state);
+  }
+
+  switch (state.kind) {
+    case 'queued':
+      return transitionFromQueued(state, action);
+    case 'uploading':
+      return transitionFromUploading(state, action);
+    case 'draftReady':
+      return transitionFromDraftReady(state, action);
+    case 'uploadFailed':
+      return transitionFromUploadFailed(state, action);
+    case 'publishing':
+      return transitionFromPublishing(state, action);
+    case 'published':
+    case 'discarded':
+      return invalidTransition(state, action);
+    case 'publishFailed':
+      return transitionFromPublishFailed(state, action);
+    case 'discarding':
+      return transitionFromDiscarding(state, action);
+    case 'discardFailed':
+      return transitionFromDiscardFailed(state, action);
+    case 'cancelled':
+      return action.type === 'cancel' ? Result.ok(state) : invalidTransition(state, action);
+  }
+};


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28356" title="WPB-28356" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28356</a>  [web] create logic library for handling upload (non-ui)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Problem

The Cells upload rules currently live across the conversation UI and repository code. The thing is, that makes it hard to reuse the same upload flow outside conversation uploads, especially for Shared Drive, without copying behavior or changing the existing paths

## Solution

Added a reusable upload lifecycle module inside the webapp Cells domain. It keeps the upload state and transitions in one place, including progress, cancellation, publishing, discarding, retries, and failures

Added tests for the state transitions and recovery paths. The module does not perform the upload itself, and it is not connected to the UI yet

This PR is stacked directly on #22326

https://wearezeta.atlassian.net/browse/WPB-28356