### PR TITLE
feat: add Cells upload process manager [WPB-28356]

### DIFF
--- a/apps/webapp/src/script/repositories/cells/upload/gateway.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/gateway.ts
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {Task} from 'true-myth';
+
+import type {DraftIdentity, UploadSource} from './identity';
+
+export type CellsUploadGatewayOperation = 'upload' | 'publish' | 'discard';
+export type CellsUploadGatewayError<TOperation extends CellsUploadGatewayOperation = CellsUploadGatewayOperation> = {
+  readonly kind: 'gatewayError';
+  readonly operation: TOperation;
+  readonly cause: unknown;
+};
+
+export type UploadDraftRequest = {
+  readonly uploadId: string;
+  readonly attemptId: string;
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+  readonly path: string;
+  readonly signal: AbortSignal;
+  readonly onProgress: (progress: number) => void;
+};
+
+export interface CellsUploadGateway {
+  readonly uploadDraft: (request: UploadDraftRequest) => Task<void, CellsUploadGatewayError<'upload'>>;
+  readonly publishDraft: (identity: DraftIdentity) => Task<void, CellsUploadGatewayError<'publish'>>;
+  readonly discardDraft: (identity: DraftIdentity) => Task<void, CellsUploadGatewayError<'discard'>>;
+}

--- a/apps/webapp/src/script/repositories/cells/upload/index.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/index.ts
@@ -17,6 +17,9 @@
  *
  */
 
+export * from './gateway';
 export * from './identity';
 export * from './lifecycle';
+export * from './manager';
+export * from './process';
 export * from './transition';

--- a/apps/webapp/src/script/repositories/cells/upload/lifecycle.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/lifecycle.ts
@@ -123,7 +123,11 @@ export type PublishFailureError = {readonly kind: 'publishFailed'; readonly caus
 export type DiscardFailureError = {readonly kind: 'discardFailed'; readonly cause: unknown};
 
 export type UploadLifecycleError =
-  | {readonly kind: 'invalidTransition'; readonly from: UploadState['kind']; readonly action: UploadActionType}
+  | {
+      readonly kind: 'invalidTransition';
+      readonly from: UploadState['kind'];
+      readonly action: UploadActionType | 'release';
+    }
   | UploadFailureError
   | PublishFailureError
   | DiscardFailureError;

--- a/apps/webapp/src/script/repositories/cells/upload/manager.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/manager.test.ts
@@ -1,0 +1,188 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {noop} from 'noop-esm';
+import {Task} from 'true-myth';
+
+import type {CellsUploadGateway, CellsUploadGatewayError, UploadDraftRequest} from './gateway';
+import {createCellsUploadManager} from './manager';
+import type {UploadSource} from './identity';
+
+const source: UploadSource = {blob: new Blob(['data']), name: 'file.txt', contentType: 'text/plain', size: 4};
+const path = 'wire-cells-web/conversation-1';
+
+const required = <T>(value: T | undefined): T => {
+  expect(value).toBeDefined();
+  return value as T;
+};
+
+const deferred = () => {
+  let resolve!: (value: void) => void;
+  let reject!: (error: CellsUploadGatewayError<'upload'>) => void;
+  const task = new Task<void, CellsUploadGatewayError<'upload'>>((resolveTask, rejectTask) => {
+    resolve = resolveTask;
+    reject = rejectTask;
+  });
+  return {task, resolve, reject};
+};
+
+const deferredManager = () => {
+  const requests: UploadDraftRequest[] = [];
+  const tasks: ReturnType<typeof deferred>[] = [];
+  const gateway: CellsUploadGateway = {
+    uploadDraft: request => {
+      requests.push(request);
+      const result = deferred();
+      tasks.push(result);
+      return result.task;
+    },
+    publishDraft: () => Task.resolve<void, never>(undefined),
+    discardDraft: () => Task.resolve<void, never>(undefined),
+  };
+  const instance = createCellsUploadManager({
+    gateway,
+    createResourceUuid: () => 'resource-1',
+    createVersionUuid: () => 'version-1',
+    createAttemptId: () => 'attempt-1',
+    createAbortController: () => new AbortController(),
+  });
+  return {instance, requests, tasks};
+};
+
+describe('createCellsUploadManager', () => {
+  const manager = () => {
+    const requests: UploadDraftRequest[] = [];
+    const gateway: CellsUploadGateway = {
+      uploadDraft: request => {
+        requests.push(request);
+        return Task.resolve<void, never>(undefined);
+      },
+      publishDraft: () => Task.resolve<void, never>(undefined),
+      discardDraft: () => Task.resolve<void, never>(undefined),
+    };
+    const instance = createCellsUploadManager({
+      gateway,
+      createResourceUuid: () => 'resource-1',
+      createVersionUuid: () => 'version-1',
+      createAttemptId: () => 'attempt-1',
+      createAbortController: () => new AbortController(),
+    });
+    return {instance, requests};
+  };
+
+  it('registers by caller-owned upload ID and rejects duplicate IDs', () => {
+    const fixture = manager();
+    expect(fixture.instance.register('upload-1', source, path).isOk).toBe(true);
+    expect(fixture.instance.register('upload-1', source, path)).toMatchObject({
+      isErr: true,
+      error: {kind: 'duplicateUpload', uploadId: 'upload-1'},
+    });
+    expect(fixture.instance.snapshot('upload-1')).toMatchObject({isOk: true, value: {kind: 'queued'}});
+  });
+
+  it('returns typed unknown-upload errors for every manager operation', async () => {
+    const fixture = manager();
+    expect(fixture.instance.snapshot('missing')).toMatchObject({
+      isErr: true,
+      error: {kind: 'unknownUpload', uploadId: 'missing'},
+    });
+    expect(fixture.instance.subscribe('missing', noop)).toMatchObject({
+      isErr: true,
+      error: {kind: 'unknownUpload'},
+    });
+    const start = await fixture.instance.start('missing');
+    const cancel = await fixture.instance.cancel('missing');
+    const retryUpload = await fixture.instance.retryUpload('missing');
+    const publish = await fixture.instance.publish('missing');
+    const retryPublish = await fixture.instance.retryPublish('missing');
+    const discard = await fixture.instance.discard('missing');
+    const retryDiscard = await fixture.instance.retryDiscard('missing');
+    expect(start).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(cancel).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(retryUpload).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(publish).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(retryPublish).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(discard).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(retryDiscard).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(fixture.instance.release('missing')).toMatchObject({isErr: true, error: {kind: 'unknownUpload'}});
+  });
+
+  it('ignores an old process success after cancel, release, and re-register', async () => {
+    const fixture = deferredManager();
+    fixture.instance.register('upload-1', source, path);
+    const oldStart = fixture.instance.start('upload-1');
+    const oldTask = required(fixture.tasks[0]);
+    await fixture.instance.cancel('upload-1');
+    expect(fixture.instance.release('upload-1').isOk).toBe(true);
+
+    fixture.instance.register('upload-1', source, path);
+    const events: string[] = [];
+    fixture.instance.subscribe('upload-1', snapshot => events.push(snapshot.kind));
+    const newStart = fixture.instance.start('upload-1');
+    const beforeOldSettlement = fixture.instance.snapshot('upload-1');
+    oldTask.resolve(undefined);
+    await oldStart;
+    expect(fixture.instance.snapshot('upload-1')).toEqual(beforeOldSettlement);
+    expect(events).toEqual(['queued', 'uploading']);
+    required(fixture.tasks[1]).resolve(undefined);
+    await newStart;
+    expect(fixture.instance.snapshot('upload-1')).toMatchObject({isOk: true, value: {kind: 'draftReady'}});
+  });
+
+  it('ignores an old process failure after cancel, release, and re-register', async () => {
+    const fixture = deferredManager();
+    fixture.instance.register('upload-1', source, path);
+    const oldStart = fixture.instance.start('upload-1');
+    const oldTask = required(fixture.tasks[0]);
+    await fixture.instance.cancel('upload-1');
+    expect(fixture.instance.release('upload-1').isOk).toBe(true);
+
+    fixture.instance.register('upload-1', source, path);
+    const events: string[] = [];
+    fixture.instance.subscribe('upload-1', snapshot => events.push(snapshot.kind));
+    const newStart = fixture.instance.start('upload-1');
+    const beforeOldSettlement = fixture.instance.snapshot('upload-1');
+    oldTask.reject({kind: 'gatewayError', operation: 'upload', cause: 'stale'});
+    await oldStart;
+    expect(fixture.instance.snapshot('upload-1')).toEqual(beforeOldSettlement);
+    expect(events).toEqual(['queued', 'uploading']);
+    required(fixture.tasks[1]).resolve(undefined);
+    await newStart;
+    expect(fixture.instance.snapshot('upload-1')).toMatchObject({isOk: true, value: {kind: 'draftReady'}});
+  });
+
+  it('releases terminal uploads and removes the registry entry', async () => {
+    const fixture = manager();
+    fixture.instance.register('upload-1', source, path);
+    await fixture.instance.start('upload-1');
+    expect(fixture.requests[0].path).toBe(path);
+    await fixture.instance.publish('upload-1');
+    expect(fixture.instance.release('upload-1').isOk).toBe(true);
+    expect(fixture.instance.snapshot('upload-1')).toMatchObject({isErr: true, error: {kind: 'unknownUpload'}});
+  });
+
+  it('rejects release while non-terminal', () => {
+    const fixture = manager();
+    fixture.instance.register('upload-1', source, path);
+    expect(fixture.instance.release('upload-1')).toMatchObject({
+      isErr: true,
+      error: {kind: 'invalidTransition', action: 'release'},
+    });
+  });
+});

--- a/apps/webapp/src/script/repositories/cells/upload/manager.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/manager.ts
@@ -1,0 +1,109 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe, Result, maybe} from 'true-myth';
+
+import type {UploadSource} from './identity';
+import type {UploadState} from './lifecycle';
+import {
+  createCellsUploadProcess,
+  type CellsUploadProcess,
+  type CellsUploadProcessDependencies,
+  type UploadProcessError,
+  type UploadSnapshotListener,
+} from './process';
+
+export type CellsUploadManagerError =
+  | UploadProcessError
+  | {readonly kind: 'unknownUpload'; readonly uploadId: string}
+  | {readonly kind: 'duplicateUpload'; readonly uploadId: string};
+
+export type CellsUploadManager = {
+  readonly register: (uploadId: string, source: UploadSource, path: string) => Result<void, CellsUploadManagerError>;
+  readonly snapshot: (uploadId: string) => Result<UploadState, CellsUploadManagerError>;
+  readonly subscribe: (
+    uploadId: string,
+    listener: UploadSnapshotListener,
+  ) => Result<() => void, CellsUploadManagerError>;
+  readonly start: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly cancel: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly retryUpload: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly publish: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly retryPublish: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly discard: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly retryDiscard: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly release: (uploadId: string) => Result<void, CellsUploadManagerError>;
+};
+
+export const createCellsUploadManager = (dependencies: CellsUploadProcessDependencies): CellsUploadManager => {
+  const processes = new Map<string, CellsUploadProcess>();
+  const unknown = <T>(uploadId: string): Result<T, CellsUploadManagerError> =>
+    Result.err({kind: 'unknownUpload', uploadId});
+  const processFor = (uploadId: string): Result<CellsUploadProcess, CellsUploadManagerError> => {
+    const process = Maybe.of(processes.get(uploadId));
+    return maybe.isJust(process) ? Result.ok(process.value) : unknown(uploadId);
+  };
+  const command = (
+    uploadId: string,
+    name: 'start' | 'cancel' | 'retryUpload' | 'publish' | 'retryPublish' | 'discard' | 'retryDiscard',
+  ) => {
+    const process = processFor(uploadId);
+    return process.isErr ? Promise.resolve(Result.err(process.error)) : process.value[name]();
+  };
+
+  const register = (uploadId: string, source: UploadSource, path: string): Result<void, CellsUploadManagerError> => {
+    if (processes.has(uploadId)) {
+      return Result.err({kind: 'duplicateUpload', uploadId});
+    }
+    processes.set(uploadId, createCellsUploadProcess(uploadId, source, path, dependencies));
+    return Result.ok(undefined);
+  };
+
+  const release = (uploadId: string): Result<void, CellsUploadManagerError> => {
+    const process = processFor(uploadId);
+    if (process.isErr) {
+      return Result.err(process.error);
+    }
+    const result = process.value.release();
+    if (result.isOk) {
+      processes.delete(uploadId);
+    }
+    return result;
+  };
+
+  return {
+    register,
+    snapshot: uploadId => {
+      const process = processFor(uploadId);
+      return process.isErr ? Result.err(process.error) : process.value.snapshot();
+    },
+    subscribe: (uploadId, listener) => {
+      const process = processFor(uploadId);
+      return process.isErr ? Result.err(process.error) : process.value.subscribe(listener);
+    },
+    start: uploadId => command(uploadId, 'start'),
+    cancel: uploadId => command(uploadId, 'cancel'),
+    retryUpload: uploadId => command(uploadId, 'retryUpload'),
+    publish: uploadId => command(uploadId, 'publish'),
+    retryPublish: uploadId => command(uploadId, 'retryPublish'),
+    discard: uploadId => command(uploadId, 'discard'),
+    retryDiscard: uploadId => command(uploadId, 'retryDiscard'),
+    release,
+  };
+};

--- a/apps/webapp/src/script/repositories/cells/upload/process.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.test.ts
@@ -187,7 +187,9 @@ describe('createCellsUploadProcess', () => {
     required(fixture.process.subscribe(snapshot => snapshots.push(snapshot.kind)));
     firstRequest.onProgress(0.9);
     firstRequest.onProgress(1);
-    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toMatchObject({
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
       kind: 'uploading',
       progress: 0,
     });
@@ -207,7 +209,9 @@ describe('createCellsUploadProcess', () => {
     const secondRequest = required(fixture.uploads[1]);
     expect(secondRequest.attemptId).toBe(firstRequest.attemptId);
     firstRequest.onProgress(0.9);
-    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toMatchObject({
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
       kind: 'uploading',
       progress: 0,
     });
@@ -226,7 +230,9 @@ describe('createCellsUploadProcess', () => {
         cause: {kind: 'gatewayError', operation: 'publish', cause: 'mismatched-operation'},
       },
     });
-    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toMatchObject({
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
       kind: 'uploadFailed',
       error: {
         kind: 'uploadFailed',
@@ -243,7 +249,9 @@ describe('createCellsUploadProcess', () => {
     request.onProgress(0.9);
     required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'late'});
     await unwrap(start);
-    expect(fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source})).toMatchObject({
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
       kind: 'cancelled',
     });
   });
@@ -284,7 +292,9 @@ describe('createCellsUploadProcess', () => {
     await publishFixture.process.publish();
     publishFixture.setFailure();
     await unwrap(publishFixture.process.retryPublish());
-    expect(publishFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source})).toEqual({
+    expect(
+      publishFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toEqual({
       kind: 'published',
       identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
       source,
@@ -297,7 +307,9 @@ describe('createCellsUploadProcess', () => {
     await discardFixture.process.discard();
     discardFixture.setFailure();
     await unwrap(discardFixture.process.retryDiscard());
-    expect(discardFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source})).toEqual({
+    expect(
+      discardFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toEqual({
       kind: 'discarded',
       identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
       source,

--- a/apps/webapp/src/script/repositories/cells/upload/process.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.test.ts
@@ -1,0 +1,350 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Task} from 'true-myth';
+import type {Result} from 'true-myth';
+
+import type {CellsUploadGateway, CellsUploadGatewayError, UploadDraftRequest} from './gateway';
+import type {UploadSource} from './identity';
+import {createCellsUploadProcess, type CellsUploadProcessDependencies} from './process';
+
+const source: UploadSource = {blob: new Blob(['data']), name: 'file.txt', contentType: 'text/plain', size: 4};
+const path = 'wire-cells-web/conversation-1';
+
+const required = <T>(value: T | undefined): T => {
+  expect(value).toBeDefined();
+  return value as T;
+};
+
+const unwrapResult = <T, E>(result: Result<T, E>): T => {
+  expect(result.isOk).toBe(true);
+  return result.unwrapOr(undefined as never);
+};
+
+const deferred = <T, E>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: E) => void;
+  const value = new Task<T, E>((resolveTask, rejectTask) => {
+    resolve = resolveTask;
+    reject = rejectTask;
+  });
+  return {value, resolve, reject};
+};
+
+const setup = (failure?: 'publish' | 'discard' | 'mismatch', duplicateAttemptIds = false) => {
+  const uploads: UploadDraftRequest[] = [];
+  const uploadTasks: ReturnType<typeof deferred<void, CellsUploadGatewayError<'upload'>>>[] = [];
+  const aborts: AbortController[] = [];
+  const published = [] as string[];
+  const discarded = [] as string[];
+  let failureMode = failure;
+  const gateway: CellsUploadGateway = {
+    uploadDraft: request => {
+      uploads.push(request);
+      if (failureMode === 'mismatch') {
+        return Task.reject<void, CellsUploadGatewayError<'publish'>>({
+          kind: 'gatewayError',
+          operation: 'publish',
+          cause: 'mismatched-operation',
+        }) as unknown as Task<void, CellsUploadGatewayError<'upload'>>;
+      }
+      const task = deferred<void, CellsUploadGatewayError<'upload'>>();
+      uploadTasks.push(task);
+      return task.value;
+    },
+    publishDraft: identity => {
+      published.push(identity.versionId);
+      return failureMode === 'publish'
+        ? Task.reject<void, CellsUploadGatewayError<'publish'>>({
+            kind: 'gatewayError',
+            operation: 'publish',
+            cause: 'offline',
+          })
+        : Task.resolve<void, never>(undefined);
+    },
+    discardDraft: identity => {
+      discarded.push(identity.versionId);
+      return failureMode === 'discard'
+        ? Task.reject<void, CellsUploadGatewayError<'discard'>>({
+            kind: 'gatewayError',
+            operation: 'discard',
+            cause: 'offline',
+          })
+        : Task.resolve<void, never>(undefined);
+    },
+  };
+  let version = 0;
+  let attempt = 0;
+  const dependencies: CellsUploadProcessDependencies = {
+    gateway,
+    createResourceUuid: () => 'resource-1',
+    createVersionUuid: () => `version-${++version}`,
+    createAttemptId: () => (duplicateAttemptIds ? 'attempt-1' : `attempt-${++attempt}`),
+    createAbortController: () => {
+      const controller = new AbortController();
+      aborts.push(controller);
+      return controller;
+    },
+  };
+  return {
+    process: createCellsUploadProcess('upload-1', source, path, dependencies),
+    uploads,
+    uploadTasks,
+    aborts,
+    published,
+    discarded,
+    setFailure: (mode?: 'publish' | 'discard') => {
+      failureMode = mode;
+    },
+  };
+};
+
+const unwrap = async <T, E>(promise: PromiseLike<{isOk: boolean; value?: T; error?: E}>) => {
+  const result = await promise;
+  expect(result.isOk).toBe(true);
+  return result;
+};
+
+describe('createCellsUploadProcess', () => {
+  it('uploads successfully and emits ordered snapshots', async () => {
+    const fixture = setup();
+    const snapshots: string[] = [];
+    const subscription = fixture.process.subscribe(snapshot => snapshots.push(snapshot.kind));
+    expect(subscription.isOk).toBe(true);
+    const start = fixture.process.start();
+    required(fixture.uploads[0]).onProgress(0.25);
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+    expect(snapshots).toEqual(['queued', 'uploading', 'uploading', 'draftReady']);
+  });
+
+  it('reports typed upload failure and aborts only the active attempt', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'offline'});
+    const result = await start;
+    expect(result.isErr).toBe(true);
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({kind: 'uploadFailed'});
+    expect(required(fixture.aborts[0]).signal.aborted).toBe(false);
+  });
+
+  it('cancels queued work without creating a controller and is idempotent', async () => {
+    const fixture = setup();
+    await unwrap(fixture.process.cancel());
+    expect(fixture.aborts).toHaveLength(0);
+    await unwrap(fixture.process.cancel());
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({kind: 'cancelled'});
+  });
+
+  it('aborts an active upload and suppresses its late result', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    await unwrap(fixture.process.cancel());
+    required(fixture.uploads[0]).onProgress(0.9);
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+    expect(required(fixture.aborts[0]).signal.aborted).toBe(true);
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({kind: 'cancelled'});
+  });
+
+  it('suppresses stale progress callbacks after a retry starts', async () => {
+    const fixture = setup();
+    const first = fixture.process.start();
+    const firstRequest = required(fixture.uploads[0]);
+    expect(firstRequest.path).toBe(path);
+    firstRequest.onProgress(0.25);
+    required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'offline'});
+    await first;
+
+    const retry = fixture.process.retryUpload();
+    const secondRequest = required(fixture.uploads[1]);
+    expect(secondRequest.path).toBe(path);
+    expect(secondRequest.identity).toMatchObject({resourceUuid: 'resource-1', versionId: 'version-2'});
+    expect(secondRequest.attemptId).toBe('attempt-2');
+    const snapshots: string[] = [];
+    required(fixture.process.subscribe(snapshot => snapshots.push(snapshot.kind)));
+    firstRequest.onProgress(0.9);
+    firstRequest.onProgress(1);
+    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toMatchObject({
+      kind: 'uploading',
+      progress: 0,
+    });
+    required(fixture.uploadTasks[1]).resolve(undefined);
+    await unwrap(retry);
+    expect(snapshots).toEqual(['uploading', 'draftReady']);
+  });
+
+  it('isolates retries when the injected attempt IDs are duplicated', async () => {
+    const fixture = setup(undefined, true);
+    const first = fixture.process.start();
+    const firstRequest = required(fixture.uploads[0]);
+    required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'offline'});
+    await first;
+
+    const retry = fixture.process.retryUpload();
+    const secondRequest = required(fixture.uploads[1]);
+    expect(secondRequest.attemptId).toBe(firstRequest.attemptId);
+    firstRequest.onProgress(0.9);
+    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toMatchObject({
+      kind: 'uploading',
+      progress: 0,
+    });
+    required(fixture.uploadTasks[1]).resolve(undefined);
+    await unwrap(retry);
+  });
+
+  it('normalizes a mismatched gateway operation at the process boundary', async () => {
+    const fixture = setup('mismatch');
+    const result = await fixture.process.start();
+    expect(result).toMatchObject({
+      isErr: true,
+      error: {
+        kind: 'gatewayError',
+        operation: 'upload',
+        cause: {kind: 'gatewayError', operation: 'publish', cause: 'mismatched-operation'},
+      },
+    });
+    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toMatchObject({
+      kind: 'uploadFailed',
+      error: {
+        kind: 'uploadFailed',
+        cause: {kind: 'gatewayError', operation: 'upload'},
+      },
+    });
+  });
+
+  it('suppresses a late failure after cancellation', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    const request = required(fixture.uploads[0]);
+    await unwrap(fixture.process.cancel());
+    request.onProgress(0.9);
+    required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'late'});
+    await unwrap(start);
+    expect(fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source})).toMatchObject({
+      kind: 'cancelled',
+    });
+  });
+
+  it('reports publish and discard failures with recoverable clean states', async () => {
+    const publishFailure = setup('publish');
+    const publishStart = publishFailure.process.start();
+    required(publishFailure.uploadTasks[0]).resolve(undefined);
+    await publishStart;
+    expect((await publishFailure.process.publish()).isErr).toBe(true);
+    expect(
+      publishFailure.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toEqual({
+      kind: 'publishFailed',
+      identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+      source,
+      error: {kind: 'publishFailed', cause: {kind: 'gatewayError', operation: 'publish', cause: 'offline'}},
+    });
+
+    const discardFailure = setup('discard');
+    const discardStart = discardFailure.process.start();
+    required(discardFailure.uploadTasks[0]).resolve(undefined);
+    await discardStart;
+    expect((await discardFailure.process.discard()).isErr).toBe(true);
+    expect(
+      discardFailure.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
+      kind: 'discardFailed',
+      error: {kind: 'discardFailed', cause: {kind: 'gatewayError', operation: 'discard', cause: 'offline'}},
+    });
+  });
+
+  it('retries publish and discard successfully after their failures', async () => {
+    const publishFixture = setup('publish');
+    const publishStart = publishFixture.process.start();
+    required(publishFixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(publishStart);
+    await publishFixture.process.publish();
+    publishFixture.setFailure();
+    await unwrap(publishFixture.process.retryPublish());
+    expect(publishFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source})).toEqual({
+      kind: 'published',
+      identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+      source,
+    });
+
+    const discardFixture = setup('discard');
+    const discardStart = discardFixture.process.start();
+    required(discardFixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(discardStart);
+    await discardFixture.process.discard();
+    discardFixture.setFailure();
+    await unwrap(discardFixture.process.retryDiscard());
+    expect(discardFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source})).toEqual({
+      kind: 'discarded',
+      identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+      source,
+    });
+  });
+
+  it('publishes and discards through the gateway', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+    await unwrap(fixture.process.publish());
+    expect(fixture.published).toEqual(['version-1']);
+
+    const second = setup();
+    const secondStart = second.process.start();
+    required(second.uploadTasks[0]).resolve(undefined);
+    await unwrap(secondStart);
+    await unwrap(second.process.discard());
+    expect(second.discarded).toEqual(['version-1']);
+  });
+
+  it('notifies subscribers synchronously in registration order and supports unsubscribe', async () => {
+    const fixture = setup();
+    const events: string[] = [];
+    const first = fixture.process.subscribe(() => events.push('first'));
+    const second = fixture.process.subscribe(() => events.push('second'));
+    expect(events).toEqual(['first', 'second']);
+    unwrapResult(first)();
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await start;
+    expect(events).toEqual(['first', 'second', 'second', 'second']);
+    const before = events.length;
+    unwrapResult(fixture.process.subscribe(() => events.push('third')))();
+    expect(events.length).toBe(before + 1);
+    expect(second.isOk).toBe(true);
+  });
+
+  it('releases terminal process state and rejects later snapshots', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await start;
+    await fixture.process.publish();
+    expect(fixture.process.release().isOk).toBe(true);
+    expect(fixture.process.snapshot().isErr).toBe(true);
+    expect(fixture.process.start().then(result => result.isErr)).resolves.toBe(true);
+  });
+});

--- a/apps/webapp/src/script/repositories/cells/upload/process.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.ts
@@ -1,0 +1,354 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe, Result, maybe, result as resultModule, task} from 'true-myth';
+
+import type {CellsUploadGateway, CellsUploadGatewayError} from './gateway';
+import type {DraftIdentity, UploadSource} from './identity';
+import type {UploadAction, UploadLifecycleError, UploadState} from './lifecycle';
+import {transition} from './transition';
+
+export type UploadProcessError = UploadLifecycleError | CellsUploadGatewayError | {readonly kind: 'released'};
+export type UploadSnapshotListener = (snapshot: UploadState) => void;
+export type AbortControllerFactory = () => AbortController;
+export type IdFactory = () => string;
+
+export type CellsUploadProcessDependencies = {
+  readonly gateway: CellsUploadGateway;
+  readonly createResourceUuid: IdFactory;
+  readonly createVersionUuid: IdFactory;
+  readonly createAttemptId: IdFactory;
+  readonly createAbortController: AbortControllerFactory;
+};
+
+export type CellsUploadProcess = {
+  readonly snapshot: () => Result<UploadState, UploadProcessError>;
+  readonly subscribe: (listener: UploadSnapshotListener) => Result<() => void, UploadProcessError>;
+  readonly start: () => Promise<Result<void, UploadProcessError>>;
+  readonly cancel: () => Promise<Result<void, UploadProcessError>>;
+  readonly retryUpload: () => Promise<Result<void, UploadProcessError>>;
+  readonly publish: () => Promise<Result<void, UploadProcessError>>;
+  readonly retryPublish: () => Promise<Result<void, UploadProcessError>>;
+  readonly discard: () => Promise<Result<void, UploadProcessError>>;
+  readonly retryDiscard: () => Promise<Result<void, UploadProcessError>>;
+  readonly release: () => Result<void, UploadProcessError>;
+};
+
+type Attempt = {
+  readonly id: string;
+  readonly controller: AbortController;
+  readonly identity: DraftIdentity;
+};
+
+const isSameState = (left: UploadState, right: UploadState): boolean => {
+  if (left === right || left.kind !== right.kind) {
+    return left === right;
+  }
+  const leftRecord = left as unknown as Record<string, unknown>;
+  const rightRecord = right as unknown as Record<string, unknown>;
+  const keys = new Set([...Object.keys(leftRecord), ...Object.keys(rightRecord)]);
+  return [...keys].every(key => leftRecord[key] === rightRecord[key]);
+};
+
+export const createCellsUploadProcess = (
+  uploadId: string,
+  source: UploadSource,
+  path: string,
+  dependencies: CellsUploadProcessDependencies,
+): CellsUploadProcess => {
+  let state: Maybe<UploadState> = Maybe.just({kind: 'queued', identity: {uploadId}, source});
+  let activeSource: Maybe<UploadSource> = Maybe.just(source);
+  let resourceUuid: Maybe<string> = Maybe.nothing();
+  let currentAttempt: Maybe<Attempt> = Maybe.nothing();
+  let operationId = 0;
+  let released = false;
+  const subscribers = new Set<UploadSnapshotListener>();
+
+  const releasedResult = <T>(): Result<T, UploadProcessError> => Result.err({kind: 'released'});
+  const snapshot = (): Result<UploadState, UploadProcessError> =>
+    maybe.isJust(state) ? Result.ok(state.value) : releasedResult();
+
+  const notify = (previous: UploadState, next: UploadState): void => {
+    if (isSameState(previous, next)) {
+      return;
+    }
+    state = Maybe.just(next);
+    subscribers.forEach(listener => listener(next));
+  };
+
+  const apply = (action: UploadAction): Result<UploadState, UploadLifecycleError> => {
+    if (maybe.isNothing(state)) {
+      return Result.err({kind: 'invalidTransition', from: 'cancelled', action: action.type});
+    }
+    const result = transition(state.value, action);
+    if (resultModule.isErr(result)) {
+      return result;
+    }
+    notify(state.value, result.value);
+    return result;
+  };
+
+  const isGatewayError = (
+    reason: unknown,
+    operation: CellsUploadGatewayError['operation'],
+  ): reason is CellsUploadGatewayError =>
+    typeof reason === 'object' &&
+    reason !== null &&
+    (reason as {kind?: unknown; operation?: unknown}).kind === 'gatewayError' &&
+    (reason as {kind?: unknown; operation?: unknown}).operation === operation;
+
+  const safeGateway = <T>(
+    operation: CellsUploadGatewayError['operation'],
+    call: () => PromiseLike<Result<T, CellsUploadGatewayError>>,
+  ) =>
+    task.tryOrElse(
+      reason =>
+        isGatewayError(reason, operation) ? reason : {kind: 'gatewayError' as const, operation, cause: reason},
+      async () => {
+        const result = await call();
+        return resultModule.isErr(result) ? Promise.reject(result.error) : result.value;
+      },
+    );
+
+  const isCurrentAttempt = (attempt: Attempt): boolean => {
+    const activeAttempt = currentAttempt;
+    const currentState = state;
+    return (
+      maybe.isJust(activeAttempt) &&
+      activeAttempt.value === attempt &&
+      maybe.isJust(currentState) &&
+      currentState.value.kind === 'uploading'
+    );
+  };
+
+  const runUpload = async (): Promise<Result<void, UploadProcessError>> => {
+    const currentState = state;
+    const currentResourceUuid = resourceUuid;
+    const currentSource = activeSource;
+    if (
+      maybe.isNothing(currentState) ||
+      currentState.value.kind !== 'uploading' ||
+      maybe.isNothing(currentResourceUuid) ||
+      maybe.isNothing(currentSource)
+    ) {
+      return Result.err({
+        kind: 'invalidTransition',
+        from: maybe.isJust(currentState) ? currentState.value.kind : 'cancelled',
+        action: 'startUpload',
+      });
+    }
+    const attempt: Attempt = {
+      id: dependencies.createAttemptId(),
+      controller: dependencies.createAbortController(),
+      identity: {uploadId, resourceUuid: currentResourceUuid.value, versionId: dependencies.createVersionUuid()},
+    };
+    currentAttempt = Maybe.just(attempt);
+    const gatewayResult = await safeGateway('upload', () =>
+      dependencies.gateway.uploadDraft({
+        uploadId,
+        attemptId: attempt.id,
+        identity: attempt.identity,
+        source: currentSource.value,
+        path,
+        signal: attempt.controller.signal,
+        onProgress: progress => {
+          if (isCurrentAttempt(attempt)) {
+            apply({type: 'progress', progress});
+          }
+        },
+      }),
+    );
+
+    if (!isCurrentAttempt(attempt)) {
+      return Result.ok(undefined);
+    }
+    currentAttempt = Maybe.nothing();
+    if (resultModule.isErr(gatewayResult)) {
+      apply({type: 'uploadFailed', error: {kind: 'uploadFailed', cause: gatewayResult.error}});
+      return Result.err(gatewayResult.error);
+    }
+    apply({
+      type: 'uploadSucceeded',
+      resourceUuid: attempt.identity.resourceUuid,
+      versionId: attempt.identity.versionId,
+    });
+    return Result.ok(undefined);
+  };
+
+  const start = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    if (maybe.isNothing(resourceUuid)) {
+      resourceUuid = Maybe.just(dependencies.createResourceUuid());
+    }
+    const result = apply({type: 'startUpload'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    return runUpload();
+  };
+
+  const cancel = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    if (maybe.isJust(state) && state.value.kind === 'cancelled') {
+      return Result.ok(undefined);
+    }
+    const result = apply({type: 'cancel'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    const attempt = currentAttempt;
+    currentAttempt = Maybe.nothing();
+    if (maybe.isJust(attempt)) {
+      attempt.value.controller.abort();
+    }
+    return Result.ok(undefined);
+  };
+
+  const retryUpload = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'retryUpload'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    return start();
+  };
+
+  const runDraftOperation = async (
+    operation: 'publish' | 'discard',
+    identity: DraftIdentity,
+    completion: UploadAction,
+  ): Promise<Result<void, UploadProcessError>> => {
+    const operationToken = ++operationId;
+    const gatewayResult = await safeGateway(operation, () =>
+      operation === 'publish'
+        ? dependencies.gateway.publishDraft(identity)
+        : dependencies.gateway.discardDraft(identity),
+    );
+    if (
+      released ||
+      operationToken !== operationId ||
+      maybe.isNothing(state) ||
+      state.value.kind !== `${operation}ing`
+    ) {
+      return Result.ok(undefined);
+    }
+    if (resultModule.isErr(gatewayResult)) {
+      apply(
+        operation === 'publish'
+          ? {type: 'publishFailed', error: {kind: 'publishFailed', cause: gatewayResult.error}}
+          : {type: 'discardFailed', error: {kind: 'discardFailed', cause: gatewayResult.error}},
+      );
+      return Result.err(gatewayResult.error);
+    }
+    apply(completion);
+    return Result.ok(undefined);
+  };
+
+  const publish = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'publish'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    if (result.value.kind !== 'publishing') {
+      return Result.err({kind: 'invalidTransition', from: result.value.kind, action: 'publish'});
+    }
+    return runDraftOperation('publish', result.value.identity, {type: 'publishSucceeded'});
+  };
+
+  const retryPublish = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'retryPublish'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    return publish();
+  };
+
+  const discard = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'discard'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    if (result.value.kind !== 'discarding') {
+      return Result.err({kind: 'invalidTransition', from: result.value.kind, action: 'discard'});
+    }
+    return runDraftOperation('discard', result.value.identity, {type: 'discardSucceeded'});
+  };
+
+  const retryDiscard = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'retryDiscard'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    return discard();
+  };
+
+  const subscribe = (listener: UploadSnapshotListener): Result<() => void, UploadProcessError> => {
+    if (maybe.isNothing(state)) {
+      return releasedResult();
+    }
+    subscribers.add(listener);
+    listener(state.value);
+    return Result.ok(() => subscribers.delete(listener));
+  };
+
+  const release = (): Result<void, UploadProcessError> => {
+    if (released) {
+      return releasedResult();
+    }
+    if (maybe.isNothing(state) || !['published', 'discarded', 'cancelled'].includes(state.value.kind)) {
+      return Result.err({
+        kind: 'invalidTransition',
+        from: maybe.isJust(state) ? state.value.kind : 'cancelled',
+        action: 'release',
+      });
+    }
+    const attempt = currentAttempt;
+    currentAttempt = Maybe.nothing();
+    if (maybe.isJust(attempt)) {
+      attempt.value.controller.abort();
+    }
+    operationId += 1;
+    subscribers.clear();
+    state = Maybe.nothing();
+    activeSource = Maybe.nothing();
+    resourceUuid = Maybe.nothing();
+    released = true;
+    return Result.ok(undefined);
+  };
+
+  return {snapshot, subscribe, start, cancel, retryUpload, publish, retryPublish, discard, retryDiscard, release};
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28356" title="WPB-28356" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28356</a>  [web] create logic library for handling upload (non-ui)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem

The lifecycle model does not handle the actual async upload attempts yet. Conversation components still manage process lifetime, cancellation, retry IDs, progress, and remote operations in separate places. This means an old callback can update the state after a newer attempt has started

## Solution

Added a Cells upload gateway contract, a process for each upload, and a manager that keeps track of them by upload ID. It handles snapshots and subscriptions, cancellation of the active attempt, retry IDs, ignoring results from old attempts, recovery after publish and discard failures, typed errors, and releasing finished uploads

Existing Cells paths can use the module without changing the UI. The real gateway, UI integration, composition wiring, and standalone package are not included yet

This PR is stacked on #22336

https://wearezeta.atlassian.net/browse/WPB-28356