### PR TITLE
WIP feat: connect Cells upload manager to CellsRepository [WPB-28356]

### DIFF
--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/transformAcceptedFiles/transformAcceptedFiles.test.ts
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/transformAcceptedFiles/transformAcceptedFiles.test.ts
@@ -1,0 +1,29 @@
+import {transformAcceptedFiles} from './transformAcceptedFiles';
+
+const createObjectURL = URL.createObjectURL;
+
+describe('transformAcceptedFiles', () => {
+  beforeEach(() => {
+    URL.createObjectURL = jest.fn((file: File) => `blob:${file.name}`);
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = createObjectURL;
+  });
+
+  it('adds stable local upload state and previews to every accepted file', () => {
+    const files = [new File(['one'], 'one.txt'), new File(['two'], 'two.txt')];
+    const transformed = transformAcceptedFiles(files);
+
+    expect(transformed).toHaveLength(2);
+    expect(transformed.map(file => file.preview)).toEqual(['blob:one.txt', 'blob:two.txt']);
+    expect(transformed.every(file => file.id.length > 0)).toBe(true);
+    expect(new Set(transformed.map(file => file.id)).size).toBe(2);
+    expect(transformed.map(file => file.uploadStatus)).toEqual(['uploading', 'uploading']);
+    expect(transformed.map(file => file.uploadProgress)).toEqual([0, 0]);
+    expect(transformed.map(file => [file.remoteUuid, file.remoteVersionId])).toEqual([
+      ['', ''],
+      ['', ''],
+    ]);
+  });
+});

--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
@@ -1,0 +1,125 @@
+import {act, renderHook, waitFor} from '@testing-library/react';
+
+import {useFileUploadState} from '../useFilesUploadState/useFilesUploadState';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {useFilesUploadDropzone} from './useFilesUploadDropzone';
+
+const conversation = {id: 'conversation-id', qualifiedId: {id: 'conversation-id', domain: 'example.com'}};
+const wrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate: translateForTest}));
+
+const createRepository = () => ({
+  uploadNodeDraft: jest.fn(),
+  cancelUpload: jest.fn(),
+  deleteNodeDraft: jest.fn(),
+});
+
+describe('useFilesUploadDropzone', () => {
+  beforeEach(() => {
+    useFileUploadState.getState().clearAll({conversationId: conversation.id});
+    URL.createObjectURL = jest.fn(() => 'blob:preview');
+  });
+
+  it('adds a local preview before starting an upload and maps repository progress to percent', async () => {
+    let resolveUpload: (result: {uuid: string; versionId: string}) => void = () => undefined;
+    const uploadPromise = new Promise<{uuid: string; versionId: string}>(resolve => {
+      resolveUpload = resolve;
+    });
+    const cellsRepository = createRepository();
+    cellsRepository.uploadNodeDraft.mockImplementation(async ({progressCallback}: {progressCallback: (value: number) => void}) => {
+      progressCallback(0.25);
+      return uploadPromise;
+    });
+    const {result} = renderHook(
+      () =>
+        useFilesUploadDropzone({
+          isTeam: false,
+          isCellsEnabled: true,
+          isDisabled: false,
+          isFileDropAllowed: true,
+          cellsRepository: cellsRepository as never,
+          translate: translateForTest,
+          conversation,
+        }),
+      {wrapper},
+    );
+    const file = new File(['content'], 'document.txt', {type: 'text/plain'});
+
+    let upload!: Promise<void>;
+    await act(async () => {
+      upload = result.current.handlePastedFile(file);
+    });
+    await waitFor(() => expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toHaveLength(1));
+
+    expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledTimes(1);
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
+      name: 'document.txt',
+      preview: 'blob:preview',
+      uploadProgress: 25,
+      uploadStatus: 'uploading',
+    });
+
+    resolveUpload({uuid: 'remote-id', versionId: 'version-id'});
+    await act(async () => await upload);
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
+      remoteUuid: 'remote-id',
+      remoteVersionId: 'version-id',
+      uploadStatus: 'success',
+    });
+  });
+
+  it('marks an upload as retryable when the repository rejects', async () => {
+    const cellsRepository = createRepository();
+    cellsRepository.uploadNodeDraft.mockRejectedValue(new Error('network'));
+    const {result} = renderHook(
+      () =>
+        useFilesUploadDropzone({
+          isTeam: false,
+          isCellsEnabled: true,
+          isDisabled: false,
+          isFileDropAllowed: true,
+          cellsRepository: cellsRepository as never,
+          translate: translateForTest,
+          conversation,
+        }),
+      {wrapper},
+    );
+
+    let uploadError: unknown;
+    await act(async () => {
+      try {
+        await result.current.handlePastedFile(new File(['content'], 'document.txt'));
+      } catch (error: unknown) {
+        uploadError = error;
+      }
+    });
+    expect(uploadError).toEqual(new Error('network'));
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0].uploadStatus).toBe('error');
+  });
+
+  it('does not mark an aborted upload as an error', async () => {
+    const cellsRepository = createRepository();
+    const abortError = Object.assign(new Error('cancelled'), {name: 'AbortError'});
+    cellsRepository.uploadNodeDraft.mockRejectedValue(abortError);
+    const {result} = renderHook(
+      () =>
+        useFilesUploadDropzone({
+          isTeam: false,
+          isCellsEnabled: true,
+          isDisabled: false,
+          isFileDropAllowed: true,
+          cellsRepository: cellsRepository as never,
+          translate: translateForTest,
+          conversation,
+        }),
+      {wrapper},
+    );
+
+    await act(async () => result.current.handlePastedFile(new File(['content'], 'document.txt')));
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0].uploadStatus).toBe('uploading');
+  });
+});

--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
@@ -55,6 +55,9 @@ describe('useFilesUploadDropzone', () => {
     });
     await waitFor(() => expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toHaveLength(1));
 
+    expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
+      expect.objectContaining({uuid: expect.any(String), file, path: 'conversation-id@example.com'}),
+    );
     expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledTimes(1);
     expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
       name: 'document.txt',

--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
@@ -24,16 +24,61 @@ describe('useFilesUploadDropzone', () => {
     URL.createObjectURL = jest.fn(() => 'blob:preview');
   });
 
+  it('waits for media metadata before starting an upload', async () => {
+    let resolveMetadata!: (metadata: {image: {width: number; height: number}}) => void;
+    const metadataPromise = new Promise<{image: {width: number; height: number}}>(resolve => {
+      resolveMetadata = resolve;
+    });
+    const cellsRepository = createRepository();
+    cellsRepository.uploadNodeDraft.mockResolvedValue({uuid: 'remote-id', versionId: 'version-id'});
+    const buildFileMetadata = jest.fn(() => metadataPromise);
+    const {result} = renderHook(
+      () =>
+        useFilesUploadDropzone({
+          isTeam: false,
+          isCellsEnabled: true,
+          isDisabled: false,
+          isFileDropAllowed: true,
+          cellsRepository: cellsRepository as never,
+          translate: translateForTest,
+          conversation,
+          buildFileMetadata,
+        }),
+      {wrapper},
+    );
+    const file = new File(['content'], 'image.png', {type: 'image/png'});
+
+    let upload!: Promise<void>;
+    await act(async () => {
+      upload = result.current.handlePastedFile(file);
+      await Promise.resolve();
+    });
+
+    expect(buildFileMetadata).toHaveBeenCalledWith(expect.objectContaining({name: 'image.png'}));
+    expect(cellsRepository.uploadNodeDraft).not.toHaveBeenCalled();
+
+    resolveMetadata({image: {width: 640, height: 480}});
+    await act(async () => await upload);
+
+    expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledTimes(1);
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
+      image: {width: 640, height: 480},
+      uploadStatus: 'success',
+    });
+  });
+
   it('adds a local preview before starting an upload and maps repository progress to percent', async () => {
     let resolveUpload: (result: {uuid: string; versionId: string}) => void = () => undefined;
     const uploadPromise = new Promise<{uuid: string; versionId: string}>(resolve => {
       resolveUpload = resolve;
     });
     const cellsRepository = createRepository();
-    cellsRepository.uploadNodeDraft.mockImplementation(async ({progressCallback}: {progressCallback: (value: number) => void}) => {
-      progressCallback(0.25);
-      return uploadPromise;
-    });
+    cellsRepository.uploadNodeDraft.mockImplementation(
+      async ({progressCallback}: {progressCallback: (value: number) => void}) => {
+        progressCallback(0.25);
+        return uploadPromise;
+      },
+    );
     const {result} = renderHook(
       () =>
         useFilesUploadDropzone({
@@ -53,7 +98,9 @@ describe('useFilesUploadDropzone', () => {
     await act(async () => {
       upload = result.current.handlePastedFile(file);
     });
-    await waitFor(() => expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toHaveLength(1));
+    await waitFor(() =>
+      expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toHaveLength(1),
+    );
 
     expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
       expect.objectContaining({uuid: expect.any(String), file, path: 'conversation-id@example.com'}),

--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
@@ -9,7 +9,10 @@ import {translateForTest} from 'Util/test/translateForTest';
 
 import {useFilesUploadDropzone} from './useFilesUploadDropzone';
 
-const conversation = {id: 'conversation-id', qualifiedId: {id: 'conversation-id', domain: 'example.com'}};
+const conversation = {
+  id: 'local-conversation-id',
+  qualifiedId: {id: 'qualified-conversation-id', domain: 'example.com'},
+};
 const wrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate: translateForTest}));
 
 const createRepository = () => ({
@@ -19,9 +22,15 @@ const createRepository = () => ({
 });
 
 describe('useFilesUploadDropzone', () => {
+  const originalNodeEnvironment = process.env.NODE_ENV;
+
   beforeEach(() => {
     useFileUploadState.getState().clearAll({conversationId: conversation.id});
     URL.createObjectURL = jest.fn(() => 'blob:preview');
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnvironment;
   });
 
   it('waits for media metadata before starting an upload', async () => {
@@ -103,7 +112,7 @@ describe('useFilesUploadDropzone', () => {
     );
 
     expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
-      expect.objectContaining({uuid: expect.any(String), file, path: 'conversation-id@example.com'}),
+      expect.objectContaining({uuid: expect.any(String), file, path: 'qualified-conversation-id@example.com'}),
     );
     expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledTimes(1);
     expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
@@ -120,6 +129,31 @@ describe('useFilesUploadDropzone', () => {
       remoteVersionId: 'version-id',
       uploadStatus: 'success',
     });
+  });
+
+  it('uses the local conversation ID for development uploads', async () => {
+    process.env.NODE_ENV = 'development';
+    const cellsRepository = createRepository();
+    cellsRepository.uploadNodeDraft.mockResolvedValue({uuid: 'remote-id', versionId: 'version-id'});
+    const {result} = renderHook(
+      () =>
+        useFilesUploadDropzone({
+          isTeam: false,
+          isCellsEnabled: true,
+          isDisabled: false,
+          isFileDropAllowed: true,
+          cellsRepository: cellsRepository as never,
+          translate: translateForTest,
+          conversation,
+        }),
+      {wrapper},
+    );
+
+    await act(async () => result.current.handlePastedFile(new File(['content'], 'document.txt')));
+
+    expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
+      expect.objectContaining({path: expect.stringMatching(/^local-conversation-id@/)}),
+    );
   });
 
   it('marks an upload as retryable when the repository rejects', async () => {

--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.ts
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.ts
@@ -34,6 +34,7 @@ import {showFileDropzoneErrorModal} from './showFileDropzoneErrorModal/showFileD
 import {transformAcceptedFiles} from './transformAcceptedFiles/transformAcceptedFiles';
 
 import {FileWithPreview, useFileUploadState} from '../useFilesUploadState/useFilesUploadState';
+import {buildCellsUploadPath} from '../utils/buildCellsUploadPath';
 import {checkFileSharingPermission} from '../utils/checkFileSharingPermission';
 
 const MAX_FILES = 10;
@@ -51,6 +52,7 @@ interface UseFilesUploadDropzoneParams {
   cellsRepository: CellsRepository;
   translate: RootContextValue['translate'];
   conversation?: Pick<Conversation, 'id' | 'qualifiedId'>;
+  buildFileMetadata?: typeof buildCellFileMetadata;
 }
 
 export const useFilesUploadDropzone = ({
@@ -61,6 +63,7 @@ export const useFilesUploadDropzone = ({
   cellsRepository,
   translate,
   conversation = {id: '', qualifiedId: {id: '', domain: ''}},
+  buildFileMetadata = buildCellFileMetadata,
 }: UseFilesUploadDropzoneParams) => {
   const {addFiles, getFiles, updateFile} = useFileUploadState();
   const files = getFiles({conversationId: conversation.id});
@@ -153,10 +156,12 @@ export const useFilesUploadDropzone = ({
   const uploadFile = async (file: FileWithPreview) => {
     // Temporary solution to handle the local development
     // TODO: remove this once we have a proper way to handle the domain per env
-    const path =
-      process.env.NODE_ENV === 'development'
-        ? `${conversation.id}@${CONFIG.CELLS_WIRE_DOMAIN}`
-        : `${conversation.qualifiedId.id}@${conversation.qualifiedId.domain}`;
+    const path = buildCellsUploadPath({
+      conversationId: conversation.id,
+      conversationQualifiedId: conversation.qualifiedId,
+      cellsWireDomain: CONFIG.CELLS_WIRE_DOMAIN,
+      isDevelopment: process.env.NODE_ENV === 'development',
+    });
 
     const decimalMultiplier = 100;
 
@@ -202,7 +207,7 @@ export const useFilesUploadDropzone = ({
     await Promise.all(
       files.map(async file => {
         try {
-          const metadata = await buildCellFileMetadata(file);
+          const metadata = await buildFileMetadata(file);
 
           if (!metadata) {
             return;

--- a/apps/webapp/src/script/components/conversation/useFilesUploadState/useFilesUploadState.test.ts
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadState/useFilesUploadState.test.ts
@@ -1,0 +1,40 @@
+import {useFileUploadState, FileWithPreview} from './useFilesUploadState';
+
+const file = (id: string): FileWithPreview =>
+  Object.assign(new File(['content'], `${id}.txt`, {type: 'text/plain'}), {
+    id,
+    preview: `blob:${id}`,
+    remoteUuid: '',
+    remoteVersionId: '',
+    uploadStatus: 'uploading' as const,
+    uploadProgress: 0,
+  });
+
+describe('useFileUploadState', () => {
+  beforeEach(() => useFileUploadState.getState().clearAll({conversationId: 'conversation'}));
+
+  it('stores and updates upload progress and remote identifiers', () => {
+    const upload = file('local-id');
+    useFileUploadState.getState().addFiles({conversationId: 'conversation', files: [upload]});
+
+    useFileUploadState.getState().updateFile({
+      conversationId: 'conversation',
+      fileId: upload.id,
+      data: {uploadProgress: 42, remoteUuid: 'remote-id', remoteVersionId: 'version-id', uploadStatus: 'success'},
+    });
+
+    expect(useFileUploadState.getState().getFiles({conversationId: 'conversation'})[0]).toMatchObject({
+      id: 'local-id',
+      uploadProgress: 42,
+      remoteUuid: 'remote-id',
+      remoteVersionId: 'version-id',
+      uploadStatus: 'success',
+    });
+  });
+
+  it('removes only the cancelled or deleted file', () => {
+    useFileUploadState.getState().addFiles({conversationId: 'conversation', files: [file('first'), file('second')]});
+    useFileUploadState.getState().deleteFile({conversationId: 'conversation', fileId: 'first'});
+    expect(useFileUploadState.getState().getFiles({conversationId: 'conversation'}).map(({id}) => id)).toEqual(['second']);
+  });
+});

--- a/apps/webapp/src/script/components/conversation/useFilesUploadState/useFilesUploadState.test.ts
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadState/useFilesUploadState.test.ts
@@ -35,6 +35,11 @@ describe('useFileUploadState', () => {
   it('removes only the cancelled or deleted file', () => {
     useFileUploadState.getState().addFiles({conversationId: 'conversation', files: [file('first'), file('second')]});
     useFileUploadState.getState().deleteFile({conversationId: 'conversation', fileId: 'first'});
-    expect(useFileUploadState.getState().getFiles({conversationId: 'conversation'}).map(({id}) => id)).toEqual(['second']);
+    expect(
+      useFileUploadState
+        .getState()
+        .getFiles({conversationId: 'conversation'})
+        .map(({id}) => id),
+    ).toEqual(['second']);
   });
 });

--- a/apps/webapp/src/script/components/conversation/utils/buildCellsUploadPath.test.ts
+++ b/apps/webapp/src/script/components/conversation/utils/buildCellsUploadPath.test.ts
@@ -1,0 +1,20 @@
+import {buildCellsUploadPath} from './buildCellsUploadPath';
+
+const params = {
+  conversationId: 'local-conversation-id',
+  conversationQualifiedId: {id: 'qualified-conversation-id', domain: 'example.com'},
+  cellsWireDomain: 'cells.wire.example',
+};
+
+describe('buildCellsUploadPath', () => {
+  it.each([
+    {isDevelopment: true, expected: 'local-conversation-id@cells.wire.example'},
+    {isDevelopment: false, expected: 'qualified-conversation-id@example.com'},
+  ])('selects the same environment-specific path for initial uploads and retries', ({isDevelopment, expected}) => {
+    const initialPath = buildCellsUploadPath({...params, isDevelopment});
+    const retryPath = buildCellsUploadPath({...params, isDevelopment});
+
+    expect(initialPath).toBe(expected);
+    expect(retryPath).toBe(initialPath);
+  });
+});

--- a/apps/webapp/src/script/components/conversation/utils/buildCellsUploadPath.ts
+++ b/apps/webapp/src/script/components/conversation/utils/buildCellsUploadPath.ts
@@ -1,0 +1,22 @@
+import type {QualifiedId} from '@wireapp/api-client/lib/user/';
+
+interface BuildCellsUploadPathParams {
+  conversationId: string;
+  conversationQualifiedId: QualifiedId;
+  cellsWireDomain: string;
+  isDevelopment: boolean;
+}
+
+/**
+ * Builds the Cells upload path consistently for initial uploads and retries.
+ * Development uses the local conversation ID; deployed environments use the qualified ID.
+ */
+export const buildCellsUploadPath = ({
+  conversationId,
+  conversationQualifiedId,
+  cellsWireDomain,
+  isDevelopment,
+}: BuildCellsUploadPathParams): string =>
+  isDevelopment
+    ? `${conversationId}@${cellsWireDomain}`
+    : `${conversationQualifiedId.id}@${conversationQualifiedId.domain}`;

--- a/apps/webapp/src/script/components/conversation/utils/buildCellsUploadPath.ts
+++ b/apps/webapp/src/script/components/conversation/utils/buildCellsUploadPath.ts
@@ -1,3 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
 import type {QualifiedId} from '@wireapp/api-client/lib/user/';
 
 interface BuildCellsUploadPathParams {

--- a/apps/webapp/src/script/components/inputBar/filePreviews/filePreviews.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/filePreviews.test.tsx
@@ -33,7 +33,8 @@ jest.mock('./filePreviewCard/filePreviewCard', () => ({
 }));
 
 describe('FilePreviews', () => {
-  const conversationQualifiedId = {id: 'conv-id', domain: 'example.com'};
+  const conversationId = 'local-conversation-id';
+  const conversationQualifiedId = {id: 'qualified-conversation-id', domain: 'example.com'};
 
   const createFileWithPreview = (file: File): FileWithPreview =>
     Object.assign(file, {
@@ -48,7 +49,15 @@ describe('FilePreviews', () => {
   it('renders a file preview card for HEIC images', () => {
     const heicFile = createFileWithPreview(new File(['heic'], 'photo.heic', {type: 'image/heic'}));
 
-    render(withTheme(<FilePreviews files={[heicFile]} conversationQualifiedId={conversationQualifiedId} />));
+    render(
+      withTheme(
+        <FilePreviews
+          files={[heicFile]}
+          conversationId={conversationId}
+          conversationQualifiedId={conversationQualifiedId}
+        />,
+      ),
+    );
 
     expect(screen.getByTestId('file-preview-card')).toBeInTheDocument();
     expect(screen.queryByTestId('image-preview-card')).not.toBeInTheDocument();
@@ -57,7 +66,15 @@ describe('FilePreviews', () => {
   it('renders an image preview card for PNG images', () => {
     const pngFile = createFileWithPreview(new File(['png'], 'photo.png', {type: 'image/png'}));
 
-    render(withTheme(<FilePreviews files={[pngFile]} conversationQualifiedId={conversationQualifiedId} />));
+    render(
+      withTheme(
+        <FilePreviews
+          files={[pngFile]}
+          conversationId={conversationId}
+          conversationQualifiedId={conversationQualifiedId}
+        />,
+      ),
+    );
 
     expect(screen.getByTestId('image-preview-card')).toBeInTheDocument();
     expect(screen.queryByTestId('file-preview-card')).not.toBeInTheDocument();

--- a/apps/webapp/src/script/components/inputBar/filePreviews/filePreviews.tsx
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/filePreviews.tsx
@@ -35,16 +35,22 @@ import {VideoPreviewCard} from './videoPreviewCard/videoPreviewCard';
 
 interface FilePreviewsProps {
   files: FileWithPreview[];
+  conversationId: string;
   conversationQualifiedId: QualifiedId;
 }
 
-export const FilePreviews = ({files, conversationQualifiedId}: FilePreviewsProps) => {
+export const FilePreviews = ({files, conversationId, conversationQualifiedId}: FilePreviewsProps) => {
   const [wrapperRef] = useAutoAnimate();
 
   return (
     <div ref={wrapperRef} css={wrapperStyles}>
       {files.map(file => (
-        <FilePreview key={file.id} file={file} conversationQualifiedId={conversationQualifiedId} />
+        <FilePreview
+          key={file.id}
+          file={file}
+          conversationId={conversationId}
+          conversationQualifiedId={conversationQualifiedId}
+        />
       ))}
     </div>
   );
@@ -53,17 +59,20 @@ export const FilePreviews = ({files, conversationQualifiedId}: FilePreviewsProps
 interface FilePreviewProps {
   file: FileWithPreview;
   cellsRepository?: CellsRepository;
+  conversationId: string;
   conversationQualifiedId: QualifiedId;
 }
 
 const FilePreview = ({
   file,
   cellsRepository = container.resolve(CellsRepository),
+  conversationId,
   conversationQualifiedId,
 }: FilePreviewProps) => {
   const {name, extension, size, isError, handleDelete, handleRetry} = useFilePreview({
     file,
     cellsRepository,
+    conversationId,
     conversationQualifiedId,
   });
 

--- a/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.test.tsx
@@ -9,7 +9,8 @@ import {translateForTest} from 'Util/test/translateForTest';
 
 import {useFilePreview} from './useFilePreview';
 
-const conversation = {id: 'conversation-id', domain: 'example.com'};
+const conversationId = 'local-conversation-id';
+const conversation = {id: 'qualified-conversation-id', domain: 'example.com'};
 const fireAndForgetInvoker = {
   fireAndForget: jest.fn((action: () => Promise<void>) => void action()),
   waitUntilAllSettled: jest.fn(async () => undefined),
@@ -30,10 +31,16 @@ const createFile = (overrides: Partial<FileWithPreview> = {}): FileWithPreview =
   });
 
 describe('useFilePreview', () => {
+  const originalNodeEnvironment = process.env.NODE_ENV;
+
   beforeEach(() => {
     jest.clearAllMocks();
-    useFileUploadState.getState().clearAll({conversationId: conversation.id});
+    useFileUploadState.getState().clearAll({conversationId});
     URL.revokeObjectURL = jest.fn();
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnvironment;
   });
 
   it('exposes display metadata and marks failed uploads', () => {
@@ -42,6 +49,7 @@ describe('useFilePreview', () => {
         useFilePreview({
           file: createFile({uploadStatus: 'error'}),
           cellsRepository: {} as never,
+          conversationId,
           conversationQualifiedId: conversation,
         }),
       {wrapper},
@@ -53,9 +61,15 @@ describe('useFilePreview', () => {
   it('cancels loading uploads, revokes the preview, and removes the local preview without deleting a draft', () => {
     const cellsRepository = {cancelUpload: jest.fn(), deleteNodeDraft: jest.fn()};
     const file = createFile({uploadStatus: 'uploading'});
-    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
     const {result} = renderHook(
-      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      () =>
+        useFilePreview({
+          file,
+          cellsRepository: cellsRepository as never,
+          conversationId,
+          conversationQualifiedId: conversation,
+        }),
       {wrapper},
     );
 
@@ -64,15 +78,21 @@ describe('useFilePreview', () => {
     expect(cellsRepository.cancelUpload).toHaveBeenCalledWith('local-id');
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:local-id');
     expect(cellsRepository.deleteNodeDraft).not.toHaveBeenCalled();
-    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toEqual([]);
+    expect(useFileUploadState.getState().getFiles({conversationId})).toEqual([]);
   });
 
   it('revokes the preview and discards a completed remote draft', async () => {
     const cellsRepository = {cancelUpload: jest.fn(), deleteNodeDraft: jest.fn().mockResolvedValue(undefined)};
     const file = createFile();
-    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
     const {result} = renderHook(
-      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      () =>
+        useFilePreview({
+          file,
+          cellsRepository: cellsRepository as never,
+          conversationId,
+          conversationQualifiedId: conversation,
+        }),
       {wrapper},
     );
 
@@ -81,7 +101,7 @@ describe('useFilePreview', () => {
 
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:local-id');
     expect(cellsRepository.deleteNodeDraft).toHaveBeenCalledWith({uuid: 'remote-id', versionId: 'old-version-id'});
-    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toEqual([]);
+    expect(useFileUploadState.getState().getFiles({conversationId})).toEqual([]);
   });
 
   it('retries a failed upload with its local resource ID and stores its new version', async () => {
@@ -89,35 +109,72 @@ describe('useFilePreview', () => {
       uploadNodeDraft: jest.fn().mockResolvedValue({uuid: 'remote-id', versionId: 'new-version-id'}),
     };
     const file = createFile({uploadStatus: 'error', remoteUuid: 'remote-id', remoteVersionId: 'old-version-id'});
-    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
     const {result} = renderHook(
-      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      () =>
+        useFilePreview({
+          file,
+          cellsRepository: cellsRepository as never,
+          conversationId,
+          conversationQualifiedId: conversation,
+        }),
       {wrapper},
     );
 
     await act(async () => result.current.handleRetry());
 
     expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
-      expect.objectContaining({uuid: 'local-id', file, path: 'conversation-id@example.com'}),
+      expect.objectContaining({uuid: 'local-id', file, path: 'qualified-conversation-id@example.com'}),
     );
-    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
+    expect(useFileUploadState.getState().getFiles({conversationId})[0]).toMatchObject({
       remoteUuid: 'remote-id',
       remoteVersionId: 'new-version-id',
       uploadStatus: 'success',
     });
   });
 
-  it('keeps a failed state when retry fails', async () => {
-    const cellsRepository = {uploadNodeDraft: jest.fn().mockRejectedValue(new Error('network'))};
+  it('uses the local conversation ID for development retries', async () => {
+    process.env.NODE_ENV = 'development';
+    const cellsRepository = {
+      uploadNodeDraft: jest.fn().mockResolvedValue({uuid: 'remote-id', versionId: 'new-version-id'}),
+    };
     const file = createFile({uploadStatus: 'error'});
-    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
     const {result} = renderHook(
-      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      () =>
+        useFilePreview({
+          file,
+          cellsRepository: cellsRepository as never,
+          conversationId,
+          conversationQualifiedId: conversation,
+        }),
       {wrapper},
     );
 
     await act(async () => result.current.handleRetry());
 
-    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0].uploadStatus).toBe('error');
+    expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
+      expect.objectContaining({path: expect.stringMatching(/^local-conversation-id@/)}),
+    );
+  });
+
+  it('keeps a failed state when retry fails', async () => {
+    const cellsRepository = {uploadNodeDraft: jest.fn().mockRejectedValue(new Error('network'))};
+    const file = createFile({uploadStatus: 'error'});
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
+    const {result} = renderHook(
+      () =>
+        useFilePreview({
+          file,
+          cellsRepository: cellsRepository as never,
+          conversationId,
+          conversationQualifiedId: conversation,
+        }),
+      {wrapper},
+    );
+
+    await act(async () => result.current.handleRetry());
+
+    expect(useFileUploadState.getState().getFiles({conversationId})[0].uploadStatus).toBe('error');
   });
 });

--- a/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.test.tsx
@@ -1,0 +1,117 @@
+import {act, renderHook} from '@testing-library/react';
+
+import {FileWithPreview, useFileUploadState} from 'Components/conversation/useFilesUploadState/useFilesUploadState';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {useFilePreview} from './useFilePreview';
+
+const conversation = {id: 'conversation-id', domain: 'example.com'};
+const fireAndForgetInvoker = {
+  fireAndForget: jest.fn((action: () => Promise<void>) => void action()),
+  waitUntilAllSettled: jest.fn(async () => undefined),
+};
+const wrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate: translateForTest, fireAndForgetInvoker}),
+);
+
+const createFile = (overrides: Partial<FileWithPreview> = {}): FileWithPreview =>
+  Object.assign(new File(['content'], 'document.txt', {type: 'text/plain'}), {
+    id: 'local-id',
+    preview: 'blob:local-id',
+    remoteUuid: 'remote-id',
+    remoteVersionId: 'old-version-id',
+    uploadStatus: 'success' as const,
+    uploadProgress: 100,
+    ...overrides,
+  });
+
+describe('useFilePreview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useFileUploadState.getState().clearAll({conversationId: conversation.id});
+    URL.revokeObjectURL = jest.fn();
+  });
+
+  it('exposes display metadata and marks failed uploads', () => {
+    const {result} = renderHook(
+      () => useFilePreview({file: createFile({uploadStatus: 'error'}), cellsRepository: {} as never, conversationQualifiedId: conversation}),
+      {wrapper},
+    );
+
+    expect(result.current).toMatchObject({name: 'Upload failed: document', extension: 'txt', isError: true});
+  });
+
+  it('cancels loading uploads and removes the local preview without deleting a draft', () => {
+    const cellsRepository = {cancelUpload: jest.fn(), deleteNodeDraft: jest.fn()};
+    const file = createFile({uploadStatus: 'uploading'});
+    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    const {result} = renderHook(
+      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      {wrapper},
+    );
+
+    act(() => result.current.handleDelete());
+
+    expect(cellsRepository.cancelUpload).toHaveBeenCalledWith('local-id');
+    expect(cellsRepository.deleteNodeDraft).not.toHaveBeenCalled();
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toEqual([]);
+  });
+
+  it('revokes the preview and discards a completed remote draft', async () => {
+    const cellsRepository = {cancelUpload: jest.fn(), deleteNodeDraft: jest.fn().mockResolvedValue(undefined)};
+    const file = createFile();
+    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    const {result} = renderHook(
+      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      {wrapper},
+    );
+
+    act(() => result.current.handleDelete());
+    await act(async () => await fireAndForgetInvoker.waitUntilAllSettled());
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:local-id');
+    expect(cellsRepository.deleteNodeDraft).toHaveBeenCalledWith({uuid: 'remote-id', versionId: 'old-version-id'});
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toEqual([]);
+  });
+
+  it('retries a failed upload with the same resource and stores its new version', async () => {
+    const cellsRepository = {
+      uploadNodeDraft: jest.fn().mockResolvedValue({uuid: 'remote-id', versionId: 'new-version-id'}),
+    };
+    const file = createFile({uploadStatus: 'error', remoteUuid: 'remote-id', remoteVersionId: 'old-version-id'});
+    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    const {result} = renderHook(
+      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      {wrapper},
+    );
+
+    await act(async () => result.current.handleRetry());
+
+    expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledWith(
+      expect.objectContaining({uuid: 'local-id', file, path: 'conversation-id@example.com'}),
+    );
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
+      remoteUuid: 'remote-id',
+      remoteVersionId: 'new-version-id',
+      uploadStatus: 'success',
+    });
+  });
+
+  it('keeps a failed state when retry fails', async () => {
+    const cellsRepository = {uploadNodeDraft: jest.fn().mockRejectedValue(new Error('network'))};
+    const file = createFile({uploadStatus: 'error'});
+    useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
+    const {result} = renderHook(
+      () => useFilePreview({file, cellsRepository: cellsRepository as never, conversationQualifiedId: conversation}),
+      {wrapper},
+    );
+
+    await act(async () => result.current.handleRetry());
+
+    expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0].uploadStatus).toBe('error');
+  });
+});

--- a/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.test.tsx
@@ -38,14 +38,19 @@ describe('useFilePreview', () => {
 
   it('exposes display metadata and marks failed uploads', () => {
     const {result} = renderHook(
-      () => useFilePreview({file: createFile({uploadStatus: 'error'}), cellsRepository: {} as never, conversationQualifiedId: conversation}),
+      () =>
+        useFilePreview({
+          file: createFile({uploadStatus: 'error'}),
+          cellsRepository: {} as never,
+          conversationQualifiedId: conversation,
+        }),
       {wrapper},
     );
 
     expect(result.current).toMatchObject({name: 'Upload failed: document', extension: 'txt', isError: true});
   });
 
-  it('cancels loading uploads and removes the local preview without deleting a draft', () => {
+  it('cancels loading uploads, revokes the preview, and removes the local preview without deleting a draft', () => {
     const cellsRepository = {cancelUpload: jest.fn(), deleteNodeDraft: jest.fn()};
     const file = createFile({uploadStatus: 'uploading'});
     useFileUploadState.getState().addFiles({conversationId: conversation.id, files: [file]});
@@ -57,6 +62,7 @@ describe('useFilePreview', () => {
     act(() => result.current.handleDelete());
 
     expect(cellsRepository.cancelUpload).toHaveBeenCalledWith('local-id');
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:local-id');
     expect(cellsRepository.deleteNodeDraft).not.toHaveBeenCalled();
     expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toEqual([]);
   });
@@ -78,7 +84,7 @@ describe('useFilePreview', () => {
     expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toEqual([]);
   });
 
-  it('retries a failed upload with the same resource and stores its new version', async () => {
+  it('retries a failed upload with its local resource ID and stores its new version', async () => {
     const cellsRepository = {
       uploadNodeDraft: jest.fn().mockResolvedValue({uuid: 'remote-id', versionId: 'new-version-id'}),
     };

--- a/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.ts
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.ts
@@ -29,10 +29,11 @@ import {getFileExtension, trimFileExtension, formatBytes} from 'Util/util';
 interface FilePreviewParams {
   file: FileWithPreview;
   cellsRepository: CellsRepository;
+  conversationId: string;
   conversationQualifiedId: QualifiedId;
 }
 
-export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}: FilePreviewParams) => {
+export const useFilePreview = ({file, cellsRepository, conversationId, conversationQualifiedId}: FilePreviewParams) => {
   const {fireAndForgetInvoker} = useApplicationContext();
   const {deleteFile, updateFile} = useFileUploadState();
 
@@ -47,7 +48,7 @@ export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}:
 
   const cancelUpload = () => {
     cellsRepository.cancelUpload(file.id);
-    deleteFile({conversationId: conversationQualifiedId.id, fileId: file.id});
+    deleteFile({conversationId, fileId: file.id});
   };
 
   const handleDelete = () => {
@@ -60,7 +61,7 @@ export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}:
       return;
     }
 
-    deleteFile({conversationId: conversationQualifiedId.id, fileId: file.id});
+    deleteFile({conversationId, fileId: file.id});
     fireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
       await cellsRepository.deleteNodeDraft({uuid: file.remoteUuid, versionId: file.remoteVersionId});
     });
@@ -68,9 +69,9 @@ export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}:
 
   const handleRetry = async () => {
     try {
-      updateFile({conversationId: conversationQualifiedId.id, fileId: file.id, data: {uploadStatus: 'uploading'}});
+      updateFile({conversationId, fileId: file.id, data: {uploadStatus: 'uploading'}});
       const path = buildCellsUploadPath({
-        conversationId: conversationQualifiedId.id,
+        conversationId,
         conversationQualifiedId,
         cellsWireDomain: Config.getConfig().CELLS_WIRE_DOMAIN,
         isDevelopment: process.env.NODE_ENV === 'development',
@@ -82,12 +83,12 @@ export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}:
         path,
       });
       updateFile({
-        conversationId: conversationQualifiedId.id,
+        conversationId,
         fileId: file.id,
         data: {remoteUuid: uuid, remoteVersionId: versionId, uploadStatus: 'success'},
       });
     } catch (error: unknown) {
-      updateFile({conversationId: conversationQualifiedId.id, fileId: file.id, data: {uploadStatus: 'error'}});
+      updateFile({conversationId, fileId: file.id, data: {uploadStatus: 'error'}});
     }
   };
 

--- a/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.ts
+++ b/apps/webapp/src/script/components/inputBar/filePreviews/useFilePreview/useFilePreview.ts
@@ -20,6 +20,7 @@
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
 
 import {FileWithPreview, useFileUploadState} from 'Components/conversation/useFilesUploadState/useFilesUploadState';
+import {buildCellsUploadPath} from 'Components/conversation/utils/buildCellsUploadPath';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
 import {Config} from 'src/script/Config';
 import {useApplicationContext} from 'src/script/page/rootProvider';
@@ -68,12 +69,12 @@ export const useFilePreview = ({file, cellsRepository, conversationQualifiedId}:
   const handleRetry = async () => {
     try {
       updateFile({conversationId: conversationQualifiedId.id, fileId: file.id, data: {uploadStatus: 'uploading'}});
-      // Temporary solution to handle the local development
-      // TODO: remove this once we have a proper way to handle the domain per env
-      const path =
-        process.env.NODE_ENV === 'development'
-          ? `${conversationQualifiedId.id}@${Config.getConfig().CELLS_WIRE_DOMAIN}`
-          : `${conversationQualifiedId.id}@${conversationQualifiedId.domain}`;
+      const path = buildCellsUploadPath({
+        conversationId: conversationQualifiedId.id,
+        conversationQualifiedId,
+        cellsWireDomain: Config.getConfig().CELLS_WIRE_DOMAIN,
+        isDevelopment: process.env.NODE_ENV === 'development',
+      });
 
       const {uuid, versionId} = await cellsRepository.uploadNodeDraft({
         uuid: file.id,

--- a/apps/webapp/src/script/components/inputBar/inputBar.tsx
+++ b/apps/webapp/src/script/components/inputBar/inputBar.tsx
@@ -347,7 +347,13 @@ export const InputBar = ({
                   disableMessagePreprocessing={disableMessagePreprocessing}
                   replaceEmojis={shouldReplaceEmoji}
                 >
-                  {!!files.length && <FilePreviews files={files} conversationQualifiedId={conversation.qualifiedId} />}
+                  {!!files.length && (
+                    <FilePreviews
+                      files={files}
+                      conversationId={conversation.id}
+                      conversationQualifiedId={conversation.qualifiedId}
+                    />
+                  )}
                   <InputBarControls
                     conversation={conversation}
                     isCellsFeatureEnabled={isCellsEnabled}

--- a/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.test.tsx
@@ -1,0 +1,206 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {act, renderHook} from '@testing-library/react';
+
+import {FileWithPreview, useFileUploadState} from 'Components/conversation/useFilesUploadState/useFilesUploadState';
+import {Config} from 'src/script/Config';
+
+import {useMessageSend} from './useMessageSend';
+
+const conversationId = 'conversation';
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return {promise, resolve, reject};
+};
+
+const createFile = (
+  id: string,
+  uploadStatus: 'success' | 'uploading' = 'success',
+  media: Pick<FileWithPreview, 'audio' | 'video'> = {},
+): FileWithPreview =>
+  Object.assign(new File(['content'], `${id}.png`, {type: 'image/png'}), {
+    id,
+    preview: `blob:${id}`,
+    remoteUuid: `remote-${id}`,
+    remoteVersionId: `version-${id}`,
+    uploadStatus,
+    uploadProgress: uploadStatus === 'success' ? 100 : 40,
+    image: {width: 10, height: 20},
+    ...media,
+  });
+
+const createProps = (overrides: Record<string, unknown> = {}) => ({
+  replyMessageEntity: null,
+  eventRepository: {eventService: {loadEvent: jest.fn()}} as never,
+  messageRepository: {sendTextWithLinkPreview: jest.fn()} as never,
+  conversation: {id: conversationId, mlsVerificationState: () => 'unverified'} as never,
+  conversationRepository: {refreshMLSConversationVerificationState: jest.fn()} as never,
+  cellsRepository: {promoteNodeDraft: jest.fn().mockResolvedValue(undefined)} as never,
+  draftState: {reset: jest.fn()},
+  cancelMessageEditing: jest.fn(),
+  cancelMessageReply: jest.fn(),
+  editedMessage: undefined,
+  replyMessageCallback: jest.fn(),
+  editorRef: {current: null},
+  pastedFile: null,
+  sendPastedFile: jest.fn(),
+  messageContent: {text: 'hello', mentions: []},
+  translate: ((key: string) => key) as never,
+  ...overrides,
+});
+
+describe('useMessageSend', () => {
+  let configSpy: jest.SpyInstance;
+  let notificationContainer: HTMLDivElement;
+
+  beforeEach(() => {
+    notificationContainer = document.createElement('div');
+    notificationContainer.id = 'app-notification';
+    document.body.appendChild(notificationContainer);
+    useFileUploadState.getState().clearAll({conversationId});
+    configSpy = jest.spyOn(Config, 'getConfig').mockReturnValue({
+      FEATURE: {ENABLE_CELLS: true},
+      MAXIMUM_MESSAGE_LENGTH: 1000,
+    } as never);
+  });
+
+  afterEach(() => {
+    configSpy.mockRestore();
+    notificationContainer.remove();
+  });
+
+  it('keeps sending disabled until every selected file is ready', () => {
+    useFileUploadState
+      .getState()
+      .addFiles({conversationId, files: [createFile('ready'), createFile('loading', 'uploading')]});
+
+    const {result} = renderHook(() => useMessageSend(createProps()));
+
+    expect(result.current.isSendingDisabled).toBe(true);
+  });
+
+  it('publishes every ready draft before sending text with preserved attachment metadata', async () => {
+    const sendTextWithLinkPreview = jest.fn();
+    const publication = createDeferred<void>();
+    const promoteNodeDraft = jest.fn().mockReturnValue(publication.promise);
+    const files = [createFile('image')];
+    useFileUploadState.getState().addFiles({conversationId, files});
+    const props = createProps({
+      cellsRepository: {promoteNodeDraft} as never,
+      messageRepository: {sendTextWithLinkPreview} as never,
+    });
+    const {result} = renderHook(() => useMessageSend(props));
+
+    let sendPromise: Promise<void>;
+    act(() => {
+      sendPromise = result.current.sendMessage();
+    });
+    await act(async () => Promise.resolve());
+
+    expect(promoteNodeDraft).toHaveBeenCalledWith({uuid: 'remote-image', versionId: 'version-image'});
+    expect(sendTextWithLinkPreview).not.toHaveBeenCalled();
+    publication.resolve();
+    await act(async () => sendPromise!);
+    await act(async () => Promise.resolve());
+
+    expect(sendTextWithLinkPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        textMessage: 'hello',
+        attachments: [
+          {
+            cellAsset: {
+              uuid: 'image',
+              contentType: 'image/png',
+              initialName: 'image.png',
+              initialSize: files[0].size,
+              image: {width: 10, height: 20},
+              audio: undefined,
+              video: undefined,
+            },
+          },
+        ],
+      }),
+    );
+    expect(useFileUploadState.getState().getFiles({conversationId})).toEqual([]);
+  });
+
+  it('returns publication failures without sending or clearing retryable files', async () => {
+    const sendTextWithLinkPreview = jest.fn();
+    const promoteNodeDraft = jest.fn().mockRejectedValue(new Error('publication failed'));
+    const file = createFile('failed');
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
+    const {result} = renderHook(() =>
+      useMessageSend(
+        createProps({
+          cellsRepository: {promoteNodeDraft} as never,
+          messageRepository: {sendTextWithLinkPreview} as never,
+        }),
+      ),
+    );
+
+    await act(async () => {
+      await expect(result.current.sendMessage()).rejects.toThrow('publication failed');
+    });
+
+    expect(promoteNodeDraft).toHaveBeenCalledWith({uuid: 'remote-failed', versionId: 'version-failed'});
+    expect(sendTextWithLinkPreview).not.toHaveBeenCalled();
+    expect(useFileUploadState.getState().getFiles({conversationId})).toEqual([file]);
+  });
+
+  it('preserves image, audio, and video attachment metadata', async () => {
+    const sendTextWithLinkPreview = jest.fn();
+    const file = createFile('media', 'success', {
+      audio: {durationInMillis: 3},
+      video: {width: 1920, height: 1080},
+    });
+    useFileUploadState.getState().addFiles({conversationId, files: [file]});
+    const {result} = renderHook(() =>
+      useMessageSend(createProps({messageRepository: {sendTextWithLinkPreview} as never})),
+    );
+
+    await act(async () => result.current.sendMessage());
+    await act(async () => Promise.resolve());
+
+    expect(sendTextWithLinkPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            cellAsset: expect.objectContaining({
+              image: {width: 10, height: 20},
+              audio: {durationInMillis: 3},
+              video: {width: 1920, height: 1080},
+            }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('sends text without attachments when no files are selected', async () => {
+    const sendTextWithLinkPreview = jest.fn();
+    const {result} = renderHook(() =>
+      useMessageSend(createProps({messageRepository: {sendTextWithLinkPreview} as never})),
+    );
+
+    await act(async () => result.current.sendMessage());
+    await act(async () => Promise.resolve());
+
+    expect(sendTextWithLinkPreview).toHaveBeenCalledWith(
+      expect.objectContaining({textMessage: 'hello', attachments: []}),
+    );
+  });
+});

--- a/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.ts
+++ b/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.ts
@@ -285,7 +285,8 @@ export const useMessageSend = ({
         translate,
       );
     } else {
-      void sendMessage();
+      // Return the promise so FireAndForgetInvoker can observe publication failures.
+      await sendMessage();
     }
   }, [conversation, conversationRepository, sendMessage, translate]);
 

--- a/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useSendFiles/useSendFiles.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useSendFiles/useSendFiles.test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {act, renderHook} from '@testing-library/react';
+
+import type {FileWithPreview} from 'Components/conversation/useFilesUploadState/useFilesUploadState';
+
+import {useSendFiles} from './useSendFiles';
+
+type Repository = {
+  promoteNodeDraft: jest.Mock<Promise<void>, [{uuid: string; versionId: string}]>;
+};
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return {promise, resolve, reject};
+};
+
+const createFile = (id: string, preview = `blob:${id}`): FileWithPreview =>
+  Object.assign(new File(['content'], `${id}.png`, {type: 'image/png'}), {
+    id,
+    preview,
+    remoteUuid: `remote-${id}`,
+    remoteVersionId: `version-${id}`,
+    uploadStatus: 'success' as const,
+    uploadProgress: 100,
+  });
+
+describe('useSendFiles', () => {
+  it('promotes every draft before completing and revokes previews', async () => {
+    const repository: Repository = {promoteNodeDraft: jest.fn().mockResolvedValue(undefined)};
+    const revoke = jest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    revoke.mockClear();
+    const {result} = renderHook(() =>
+      useSendFiles({
+        files: [createFile('one'), createFile('two')],
+        cellsRepository: repository as never,
+        clearAllFiles: jest.fn(),
+        conversationId: 'conversation',
+        sendFilesErrorMessage: 'send failed',
+      }),
+    );
+
+    await act(async () => result.current.sendFiles());
+
+    expect(repository.promoteNodeDraft).toHaveBeenNthCalledWith(1, {uuid: 'remote-one', versionId: 'version-one'});
+    expect(repository.promoteNodeDraft).toHaveBeenNthCalledWith(2, {uuid: 'remote-two', versionId: 'version-two'});
+    expect(revoke).toHaveBeenCalledWith('blob:one');
+    expect(revoke).toHaveBeenCalledWith('blob:two');
+    revoke.mockRestore();
+  });
+
+  it('starts all publications before completing when one finishes later', async () => {
+    const firstPublication = createDeferred<void>();
+    const secondPublication = createDeferred<void>();
+    const repository: Repository = {
+      promoteNodeDraft: jest
+        .fn()
+        .mockReturnValueOnce(firstPublication.promise)
+        .mockReturnValueOnce(secondPublication.promise),
+    };
+    const files = [createFile('one'), createFile('two')];
+    const {result} = renderHook(() =>
+      useSendFiles({
+        files,
+        cellsRepository: repository as never,
+        clearAllFiles: jest.fn(),
+        conversationId: 'conversation',
+        sendFilesErrorMessage: 'send failed',
+      }),
+    );
+
+    let sending: Promise<void> | undefined;
+    await act(async () => {
+      sending = result.current.sendFiles();
+      await Promise.resolve();
+    });
+
+    expect(repository.promoteNodeDraft).toHaveBeenCalledTimes(2);
+    expect(result.current.isLoading).toBe(true);
+    secondPublication.resolve();
+    firstPublication.resolve();
+    await act(async () => sending);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('does not revoke previews or cancel a promoted draft after another publication fails', async () => {
+    const firstPublication = createDeferred<void>();
+    const secondPublication = createDeferred<void>();
+    const cancelUpload = jest.fn();
+    const repository: Repository & {cancelUpload: jest.Mock} = {
+      promoteNodeDraft: jest
+        .fn()
+        .mockReturnValueOnce(firstPublication.promise)
+        .mockReturnValueOnce(secondPublication.promise),
+      cancelUpload,
+    };
+    const files = [createFile('one'), createFile('two')];
+    const revoke = jest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    revoke.mockClear();
+    const {result} = renderHook(() =>
+      useSendFiles({
+        files,
+        cellsRepository: repository as never,
+        clearAllFiles: jest.fn(),
+        conversationId: 'conversation',
+        sendFilesErrorMessage: 'send failed',
+      }),
+    );
+
+    let sending: Promise<void> | undefined;
+    await act(async () => {
+      sending = result.current.sendFiles();
+      await Promise.resolve();
+    });
+    expect(repository.promoteNodeDraft).toHaveBeenCalledTimes(2);
+
+    firstPublication.resolve();
+    secondPublication.reject(new Error('second publication failed'));
+    await expect(act(async () => sending)).rejects.toThrow();
+
+    expect(revoke).not.toHaveBeenCalled();
+    expect(cancelUpload).not.toHaveBeenCalled();
+    revoke.mockRestore();
+  });
+});

--- a/apps/webapp/src/script/repositories/cells/cellsRepository.test.ts
+++ b/apps/webapp/src/script/repositories/cells/cellsRepository.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {APIClient} from '../../service/apiClientSingleton';
+
+import {CellsRepository} from './cellsRepository';
+
+type UploadCall = {
+  readonly abortController: AbortController;
+  readonly resolve: () => void;
+  readonly reject: (error: unknown) => void;
+};
+
+const createRepository = () => {
+  const calls: UploadCall[] = [];
+  const apiClient = {
+    api: {
+      cells: {
+        uploadNodeDraft: jest.fn(
+          ({abortController}: UploadCall) =>
+            new Promise<void>((resolve, reject) => {
+              calls.push({abortController, resolve, reject});
+            }),
+        ),
+      },
+    },
+  };
+
+  return {repository: new CellsRepository(apiClient as unknown as APIClient), calls};
+};
+
+const upload = (repository: CellsRepository, options?: {uuid?: string; abortController?: AbortController}) =>
+  repository.uploadNodeDraft({
+    uuid: options?.uuid ?? 'upload-id',
+    file: new File(['content'], 'document.txt', {type: 'text/plain'}),
+    path: 'conversation-path',
+    versionId: 'version-id',
+    abortController: options?.abortController,
+  });
+
+describe('CellsRepository upload cancellation', () => {
+  it('cancels legacy uploads through cancelUpload', async () => {
+    const {repository, calls} = createRepository();
+    const uploadTask = upload(repository);
+
+    await Promise.resolve();
+    repository.cancelUpload('upload-id');
+
+    expect(calls[0].abortController.signal.aborted).toBe(true);
+    calls[0].resolve();
+    await uploadTask;
+  });
+
+  it('does not register a manager-owned controller in the legacy cancellation map', async () => {
+    const {repository, calls} = createRepository();
+    const controller = new AbortController();
+    const uploadTask = upload(repository, {abortController: controller});
+
+    await Promise.resolve();
+    repository.cancelUpload('upload-id');
+
+    expect(calls[0].abortController).toBe(controller);
+    expect(controller.signal.aborted).toBe(false);
+    controller.abort();
+    calls[0].resolve();
+    await uploadTask;
+  });
+
+  it('keeps the newest legacy controller when overlapping uploads share an ID', async () => {
+    const {repository, calls} = createRepository();
+    const firstUpload = upload(repository, {uuid: 'shared-id'});
+    const secondUpload = upload(repository, {uuid: 'shared-id'});
+
+    await Promise.resolve();
+    calls[0].resolve();
+    await firstUpload;
+    repository.cancelUpload('shared-id');
+
+    expect(calls[0].abortController.signal.aborted).toBe(false);
+    expect(calls[1].abortController.signal.aborted).toBe(true);
+    calls[1].resolve();
+    await secondUpload;
+  });
+});

--- a/apps/webapp/src/script/repositories/cells/cellsRepository.ts
+++ b/apps/webapp/src/script/repositories/cells/cellsRepository.ts
@@ -67,18 +67,22 @@ export class CellsRepository {
     uuid,
     file,
     path,
+    versionId = createUuid(),
     progressCallback,
+    abortController,
   }: {
     uuid: string;
     file: File;
     path: string;
+    versionId?: string;
     progressCallback?: (progress: number) => void;
+    abortController?: AbortController;
   }): Promise<{uuid: string; versionId: string}> {
     const filePath = `${path || this.basePath}/${file.name}`;
-    const versionId = createUuid();
-
-    const controller = new AbortController();
-    this.uploadControllers.set(uuid, controller);
+    const controller = abortController ?? new AbortController();
+    if (!abortController) {
+      this.uploadControllers.set(uuid, controller);
+    }
 
     try {
       await this.apiClient.api.cells.uploadNodeDraft({
@@ -90,20 +94,16 @@ export class CellsRepository {
         abortController: controller,
       });
 
-      return {
-        uuid,
-        versionId,
-      };
+      return {uuid, versionId};
     } finally {
-      this.uploadControllers.delete(uuid);
+      if (!abortController && this.uploadControllers.get(uuid) === controller) {
+        this.uploadControllers.delete(uuid);
+      }
     }
   }
 
   cancelUpload(uuid: string): void {
-    const controller = this.uploadControllers.get(uuid);
-    if (controller) {
-      controller.abort();
-    }
+    this.uploadControllers.get(uuid)?.abort();
   }
 
   async deleteNodeDraft({uuid, versionId}: {uuid: string; versionId: string}) {

--- a/apps/webapp/src/script/repositories/cells/cellsRepositoryGateway.test.ts
+++ b/apps/webapp/src/script/repositories/cells/cellsRepositoryGateway.test.ts
@@ -1,0 +1,239 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {Task} from 'true-myth';
+
+import {createCellsRepositoryGateway} from './cellsRepositoryGateway';
+import type {DraftIdentity, UploadSource} from './upload/identity';
+import {createCellsUploadManager} from './upload/manager';
+
+const identity: DraftIdentity = {uploadId: 'local-upload', resourceUuid: 'remote-resource', versionId: 'version-1'};
+const source: UploadSource = {
+  blob: new File(['content'], 'document.txt', {type: 'text/plain'}),
+  name: 'document.txt',
+  contentType: 'text/plain',
+  size: 7,
+};
+
+const createRepository = () => ({
+  uploadNodeDraft: jest.fn().mockResolvedValue({uuid: identity.resourceUuid, versionId: identity.versionId}),
+  promoteNodeDraft: jest.fn().mockResolvedValue(undefined),
+  deleteNodeDraft: jest.fn().mockResolvedValue(undefined),
+});
+
+describe('createCellsRepositoryGateway', () => {
+  it('forwards the manager identity, path, abort controller, and progress callback', async () => {
+    const repository = createRepository();
+    const gateway = createCellsRepositoryGateway(repository);
+    const controller = new AbortController();
+    const onProgress = jest.fn();
+
+    const result = await gateway.uploadDraft({
+      uploadId: identity.uploadId,
+      attemptId: 'attempt-1',
+      identity,
+      source,
+      path: 'conversation-path',
+      signal: controller.signal,
+      abortController: controller,
+      onProgress,
+    });
+
+    expect(result).toMatchObject({
+      isOk: true,
+      value: {uploadId: identity.uploadId, resourceUuid: identity.resourceUuid, versionId: identity.versionId},
+    });
+    expect(repository.uploadNodeDraft).toHaveBeenCalledWith({
+      uuid: identity.resourceUuid,
+      file: source.blob,
+      path: 'conversation-path',
+      versionId: identity.versionId,
+      abortController: controller,
+      progressCallback: onProgress,
+    });
+  });
+
+  it('preserves a repository-returned remote identity while retaining the local upload ID', async () => {
+    const repository = createRepository();
+    const remoteIdentity = {uuid: 'remote-resource', versionId: 'remote-version'};
+    repository.uploadNodeDraft.mockResolvedValueOnce(remoteIdentity);
+    const gateway = createCellsRepositoryGateway(repository);
+    const controller = new AbortController();
+
+    const result = await gateway.uploadDraft({
+      uploadId: identity.uploadId,
+      attemptId: 'attempt-1',
+      identity,
+      source,
+      path: 'conversation-path',
+      signal: controller.signal,
+      abortController: controller,
+      onProgress: jest.fn(),
+    });
+
+    expect(result).toMatchObject({
+      isOk: true,
+      value: {uploadId: identity.uploadId, resourceUuid: remoteIdentity.uuid, versionId: remoteIdentity.versionId},
+    });
+  });
+
+  it('converts a generic Blob while preserving upload metadata and content', async () => {
+    const repository = createRepository();
+    const gateway = createCellsRepositoryGateway(repository);
+    const blobSource: UploadSource = {
+      blob: new Blob(['payload'], {type: 'application/octet-stream'}),
+      name: 'archive.bin',
+      contentType: 'application/octet-stream',
+      size: 7,
+    };
+
+    const result = await gateway.uploadDraft({
+      uploadId: identity.uploadId,
+      attemptId: 'attempt-1',
+      identity,
+      source: blobSource,
+      path: 'conversation-path',
+      signal: new AbortController().signal,
+      abortController: new AbortController(),
+      onProgress: jest.fn(),
+    });
+
+    const forwardedFile = repository.uploadNodeDraft.mock.calls[0][0].file as File;
+    expect(result.isOk).toBe(true);
+    expect(forwardedFile).toBeInstanceOf(File);
+    expect(forwardedFile.name).toBe('archive.bin');
+    expect(forwardedFile.type).toBe('application/octet-stream');
+    expect(forwardedFile.size).toBe(7);
+    const content = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result));
+      reader.onerror = () => reject(reader.error);
+      reader.readAsText(forwardedFile);
+    });
+    expect(content).toBe('payload');
+  });
+
+  it('maps upload, publish, and discard failures to operation-specific gateway errors', async () => {
+    const repository = createRepository();
+    repository.uploadNodeDraft.mockRejectedValueOnce(new Error('upload failed'));
+    repository.promoteNodeDraft.mockRejectedValueOnce(new Error('publish failed'));
+    repository.deleteNodeDraft.mockRejectedValueOnce(new Error('discard failed'));
+    const gateway = createCellsRepositoryGateway(repository);
+    const request = {
+      uploadId: identity.uploadId,
+      attemptId: 'attempt-1',
+      identity,
+      source,
+      path: 'conversation-path',
+      signal: new AbortController().signal,
+      abortController: new AbortController(),
+      onProgress: jest.fn(),
+    };
+
+    await expect(gateway.uploadDraft(request)).resolves.toMatchObject({
+      isErr: true,
+      error: {kind: 'gatewayError', operation: 'upload', cause: new Error('upload failed')},
+    });
+    await expect(gateway.publishDraft(identity)).resolves.toMatchObject({
+      isErr: true,
+      error: {kind: 'gatewayError', operation: 'publish', cause: new Error('publish failed')},
+    });
+    await expect(gateway.discardDraft(identity)).resolves.toMatchObject({
+      isErr: true,
+      error: {kind: 'gatewayError', operation: 'discard', cause: new Error('discard failed')},
+    });
+  });
+
+  it('maps a synchronous repository throw to a typed upload gateway error', async () => {
+    const repository = createRepository();
+    const failure = new Error('synchronous upload failure');
+    repository.uploadNodeDraft.mockImplementationOnce(() => {
+      throw failure;
+    });
+    const gateway = createCellsRepositoryGateway(repository);
+
+    await expect(
+      gateway.uploadDraft({
+        uploadId: identity.uploadId,
+        attemptId: 'attempt-1',
+        identity,
+        source,
+        path: 'conversation-path',
+        signal: new AbortController().signal,
+        abortController: new AbortController(),
+        onProgress: jest.fn(),
+      }),
+    ).resolves.toMatchObject({
+      isErr: true,
+      error: {kind: 'gatewayError', operation: 'upload', cause: failure},
+    });
+  });
+
+  it('maps an aborted repository request to a typed upload gateway error', async () => {
+    const repository = createRepository();
+    const controller = new AbortController();
+    const abortError = new DOMException('The upload was aborted', 'AbortError');
+    controller.abort();
+    repository.uploadNodeDraft.mockRejectedValueOnce(abortError);
+    const gateway = createCellsRepositoryGateway(repository);
+
+    await expect(
+      gateway.uploadDraft({
+        uploadId: identity.uploadId,
+        attemptId: 'attempt-1',
+        identity,
+        source,
+        path: 'conversation-path',
+        signal: controller.signal,
+        abortController: controller,
+        onProgress: jest.fn(),
+      }),
+    ).resolves.toMatchObject({
+      isErr: true,
+      error: {kind: 'gatewayError', operation: 'upload', cause: abortError},
+    });
+  });
+
+  it('lets manager cancellation abort the controller forwarded to the repository', async () => {
+    let resolveUpload!: () => void;
+    const repository = createRepository();
+    repository.uploadNodeDraft.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveUpload = () => resolve(undefined);
+        }),
+    );
+    const manager = createCellsUploadManager({
+      gateway: createCellsRepositoryGateway(repository),
+      createResourceUuid: () => identity.resourceUuid,
+      createVersionUuid: () => identity.versionId,
+      createAttemptId: () => 'attempt-1',
+      createAbortController: () => new AbortController(),
+    });
+
+    manager.register(identity.uploadId, source, 'conversation-path');
+    const start = manager.start(identity.uploadId);
+    await Promise.resolve();
+    const controller = repository.uploadNodeDraft.mock.calls[0][0].abortController;
+
+    await manager.cancel(identity.uploadId);
+    expect(controller?.signal.aborted).toBe(true);
+    resolveUpload();
+    await start;
+  });
+
+  it('returns successful publish and discard tasks', async () => {
+    const repository = createRepository();
+    const gateway = createCellsRepositoryGateway(repository);
+
+    expect(await gateway.publishDraft(identity)).toMatchObject({isOk: true, value: undefined});
+    expect(await gateway.discardDraft(identity)).toMatchObject({isOk: true, value: undefined});
+  });
+});

--- a/apps/webapp/src/script/repositories/cells/cellsRepositoryGateway.ts
+++ b/apps/webapp/src/script/repositories/cells/cellsRepositoryGateway.ts
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Task, task} from 'true-myth';
+
+import type {CellsRepository} from './cellsRepository';
+import type {CellsUploadGateway, CellsUploadGatewayError} from './upload/gateway';
+
+type CellsRepositoryUploadGateway = Pick<CellsRepository, 'uploadNodeDraft' | 'promoteNodeDraft' | 'deleteNodeDraft'>;
+type TaskExecutor<T> = () => PromiseLike<T>;
+
+const execute = <T, TOperation extends CellsUploadGatewayError['operation']>(
+  operation: TOperation,
+  executor: TaskExecutor<T>,
+): Task<T, CellsUploadGatewayError<TOperation>> =>
+  task.tryOrElse(
+    reason => ({kind: 'gatewayError', operation, cause: reason}),
+    () => Promise.resolve().then(executor),
+  );
+
+/** Adapts the app-side Cells repository to the lifecycle manager contract. */
+export const createCellsRepositoryGateway = (cellsRepository: CellsRepositoryUploadGateway): CellsUploadGateway => ({
+  uploadDraft: request =>
+    execute('upload', () =>
+      cellsRepository
+        .uploadNodeDraft({
+          uuid: request.identity.resourceUuid,
+          file:
+            request.source.blob instanceof File
+              ? request.source.blob
+              : new File([request.source.blob], request.source.name, {type: request.source.contentType}),
+          path: request.path,
+          versionId: request.identity.versionId,
+          abortController: request.abortController,
+          progressCallback: request.onProgress,
+        })
+        .then(result => ({
+          uploadId: request.identity.uploadId,
+          resourceUuid: result.uuid,
+          versionId: result.versionId,
+        })),
+    ),
+  publishDraft: identity =>
+    execute('publish', () =>
+      cellsRepository
+        .promoteNodeDraft({uuid: identity.resourceUuid, versionId: identity.versionId})
+        .then(() => undefined),
+    ),
+  discardDraft: identity =>
+    execute('discard', () =>
+      cellsRepository
+        .deleteNodeDraft({uuid: identity.resourceUuid, versionId: identity.versionId})
+        .then(() => undefined),
+    ),
+});

--- a/apps/webapp/src/script/repositories/cells/upload/gateway.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/gateway.ts
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {Task} from 'true-myth';
+
+import type {DraftIdentity, UploadSource} from './identity';
+
+export type CellsUploadGatewayOperation = 'upload' | 'publish' | 'discard';
+export type CellsUploadGatewayError<TOperation extends CellsUploadGatewayOperation = CellsUploadGatewayOperation> = {
+  readonly kind: 'gatewayError';
+  readonly operation: TOperation;
+  readonly cause: unknown;
+};
+
+export type UploadDraftRequest = {
+  readonly uploadId: string;
+  readonly attemptId: string;
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+  readonly path: string;
+  readonly signal: AbortSignal;
+  readonly onProgress: (progress: number) => void;
+};
+
+export interface CellsUploadGateway {
+  readonly uploadDraft: (request: UploadDraftRequest) => Task<void, CellsUploadGatewayError<'upload'>>;
+  readonly publishDraft: (identity: DraftIdentity) => Task<void, CellsUploadGatewayError<'publish'>>;
+  readonly discardDraft: (identity: DraftIdentity) => Task<void, CellsUploadGatewayError<'discard'>>;
+}

--- a/apps/webapp/src/script/repositories/cells/upload/gateway.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/gateway.ts
@@ -35,11 +35,12 @@ export type UploadDraftRequest = {
   readonly source: UploadSource;
   readonly path: string;
   readonly signal: AbortSignal;
+  readonly abortController: AbortController;
   readonly onProgress: (progress: number) => void;
 };
 
 export interface CellsUploadGateway {
-  readonly uploadDraft: (request: UploadDraftRequest) => Task<void, CellsUploadGatewayError<'upload'>>;
+  readonly uploadDraft: (request: UploadDraftRequest) => Task<DraftIdentity, CellsUploadGatewayError<'upload'>>;
   readonly publishDraft: (identity: DraftIdentity) => Task<void, CellsUploadGatewayError<'publish'>>;
   readonly discardDraft: (identity: DraftIdentity) => Task<void, CellsUploadGatewayError<'discard'>>;
 }

--- a/apps/webapp/src/script/repositories/cells/upload/identity.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/identity.ts
@@ -1,0 +1,34 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export interface UploadSource {
+  readonly blob: Blob;
+  readonly name: string;
+  readonly contentType: string;
+  readonly size: number;
+}
+
+export interface UploadIdentity {
+  readonly uploadId: string;
+}
+
+export interface DraftIdentity extends UploadIdentity {
+  readonly resourceUuid: string;
+  readonly versionId: string;
+}

--- a/apps/webapp/src/script/repositories/cells/upload/index.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/index.ts
@@ -17,6 +17,9 @@
  *
  */
 
+export * from './gateway';
 export * from './identity';
 export * from './lifecycle';
+export * from './manager';
+export * from './process';
 export * from './transition';

--- a/apps/webapp/src/script/repositories/cells/upload/index.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './identity';
+export * from './lifecycle';
+export * from './transition';

--- a/apps/webapp/src/script/repositories/cells/upload/lifecycle.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/lifecycle.ts
@@ -123,7 +123,11 @@ export type PublishFailureError = {readonly kind: 'publishFailed'; readonly caus
 export type DiscardFailureError = {readonly kind: 'discardFailed'; readonly cause: unknown};
 
 export type UploadLifecycleError =
-  | {readonly kind: 'invalidTransition'; readonly from: UploadState['kind']; readonly action: UploadActionType}
+  | {
+      readonly kind: 'invalidTransition';
+      readonly from: UploadState['kind'];
+      readonly action: UploadActionType | 'release';
+    }
   | UploadFailureError
   | PublishFailureError
   | DiscardFailureError;

--- a/apps/webapp/src/script/repositories/cells/upload/lifecycle.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/lifecycle.ts
@@ -1,0 +1,145 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {DraftIdentity, UploadIdentity, UploadSource} from './identity';
+
+export interface QueuedState {
+  readonly kind: 'queued';
+  readonly identity: UploadIdentity;
+  readonly source: UploadSource;
+}
+
+export interface UploadingState {
+  readonly kind: 'uploading';
+  readonly identity: UploadIdentity;
+  readonly source: UploadSource;
+  readonly progress: number;
+}
+
+export interface DraftReadyState {
+  readonly kind: 'draftReady';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface UploadFailedState {
+  readonly kind: 'uploadFailed';
+  readonly identity: UploadIdentity;
+  readonly source: UploadSource;
+  readonly error: UploadLifecycleError;
+}
+
+export interface PublishingState {
+  readonly kind: 'publishing';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface PublishedState {
+  readonly kind: 'published';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface PublishFailedState {
+  readonly kind: 'publishFailed';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+  readonly error: UploadLifecycleError;
+}
+
+export interface DiscardingState {
+  readonly kind: 'discarding';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface DiscardedState {
+  readonly kind: 'discarded';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface DiscardFailedState {
+  readonly kind: 'discardFailed';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+  readonly error: UploadLifecycleError;
+}
+
+export interface CancelledState {
+  readonly kind: 'cancelled';
+  readonly identity: UploadIdentity;
+  readonly source: UploadSource;
+}
+
+export type UploadState =
+  | QueuedState
+  | UploadingState
+  | DraftReadyState
+  | UploadFailedState
+  | PublishingState
+  | PublishedState
+  | PublishFailedState
+  | DiscardingState
+  | DiscardedState
+  | DiscardFailedState
+  | CancelledState;
+
+export type UploadActionType =
+  | 'startUpload'
+  | 'progress'
+  | 'uploadSucceeded'
+  | 'uploadFailed'
+  | 'publish'
+  | 'publishSucceeded'
+  | 'publishFailed'
+  | 'discard'
+  | 'discardSucceeded'
+  | 'discardFailed'
+  | 'retryUpload'
+  | 'retryPublish'
+  | 'retryDiscard'
+  | 'cancel';
+
+export type UploadFailureError = {readonly kind: 'uploadFailed'; readonly cause: unknown};
+export type PublishFailureError = {readonly kind: 'publishFailed'; readonly cause: unknown};
+export type DiscardFailureError = {readonly kind: 'discardFailed'; readonly cause: unknown};
+
+export type UploadLifecycleError =
+  | {readonly kind: 'invalidTransition'; readonly from: UploadState['kind']; readonly action: UploadActionType}
+  | UploadFailureError
+  | PublishFailureError
+  | DiscardFailureError;
+
+export type UploadAction =
+  | {readonly type: 'startUpload'}
+  | {readonly type: 'progress'; readonly progress: number}
+  | {readonly type: 'uploadSucceeded'; readonly resourceUuid: string; readonly versionId: string}
+  | {readonly type: 'uploadFailed'; readonly error: UploadFailureError}
+  | {readonly type: 'publish'}
+  | {readonly type: 'publishSucceeded'}
+  | {readonly type: 'publishFailed'; readonly error: PublishFailureError}
+  | {readonly type: 'discard'}
+  | {readonly type: 'discardSucceeded'}
+  | {readonly type: 'discardFailed'; readonly error: DiscardFailureError}
+  | {readonly type: 'retryUpload'}
+  | {readonly type: 'retryPublish'}
+  | {readonly type: 'retryDiscard'}
+  | {readonly type: 'cancel'};

--- a/apps/webapp/src/script/repositories/cells/upload/manager.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/manager.test.ts
@@ -1,0 +1,188 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {noop} from 'noop-esm';
+import {Task} from 'true-myth';
+
+import type {CellsUploadGateway, CellsUploadGatewayError, UploadDraftRequest} from './gateway';
+import {createCellsUploadManager} from './manager';
+import type {UploadSource} from './identity';
+
+const source: UploadSource = {blob: new Blob(['data']), name: 'file.txt', contentType: 'text/plain', size: 4};
+const path = 'wire-cells-web/conversation-1';
+
+const required = <T>(value: T | undefined): T => {
+  expect(value).toBeDefined();
+  return value as T;
+};
+
+const deferred = () => {
+  let resolve!: (value: void) => void;
+  let reject!: (error: CellsUploadGatewayError<'upload'>) => void;
+  const task = new Task<void, CellsUploadGatewayError<'upload'>>((resolveTask, rejectTask) => {
+    resolve = resolveTask;
+    reject = rejectTask;
+  });
+  return {task, resolve, reject};
+};
+
+const deferredManager = () => {
+  const requests: UploadDraftRequest[] = [];
+  const tasks: ReturnType<typeof deferred>[] = [];
+  const gateway: CellsUploadGateway = {
+    uploadDraft: request => {
+      requests.push(request);
+      const result = deferred();
+      tasks.push(result);
+      return result.task;
+    },
+    publishDraft: () => Task.resolve<void, never>(undefined),
+    discardDraft: () => Task.resolve<void, never>(undefined),
+  };
+  const instance = createCellsUploadManager({
+    gateway,
+    createResourceUuid: () => 'resource-1',
+    createVersionUuid: () => 'version-1',
+    createAttemptId: () => 'attempt-1',
+    createAbortController: () => new AbortController(),
+  });
+  return {instance, requests, tasks};
+};
+
+describe('createCellsUploadManager', () => {
+  const manager = () => {
+    const requests: UploadDraftRequest[] = [];
+    const gateway: CellsUploadGateway = {
+      uploadDraft: request => {
+        requests.push(request);
+        return Task.resolve<void, never>(undefined);
+      },
+      publishDraft: () => Task.resolve<void, never>(undefined),
+      discardDraft: () => Task.resolve<void, never>(undefined),
+    };
+    const instance = createCellsUploadManager({
+      gateway,
+      createResourceUuid: () => 'resource-1',
+      createVersionUuid: () => 'version-1',
+      createAttemptId: () => 'attempt-1',
+      createAbortController: () => new AbortController(),
+    });
+    return {instance, requests};
+  };
+
+  it('registers by caller-owned upload ID and rejects duplicate IDs', () => {
+    const fixture = manager();
+    expect(fixture.instance.register('upload-1', source, path).isOk).toBe(true);
+    expect(fixture.instance.register('upload-1', source, path)).toMatchObject({
+      isErr: true,
+      error: {kind: 'duplicateUpload', uploadId: 'upload-1'},
+    });
+    expect(fixture.instance.snapshot('upload-1')).toMatchObject({isOk: true, value: {kind: 'queued'}});
+  });
+
+  it('returns typed unknown-upload errors for every manager operation', async () => {
+    const fixture = manager();
+    expect(fixture.instance.snapshot('missing')).toMatchObject({
+      isErr: true,
+      error: {kind: 'unknownUpload', uploadId: 'missing'},
+    });
+    expect(fixture.instance.subscribe('missing', noop)).toMatchObject({
+      isErr: true,
+      error: {kind: 'unknownUpload'},
+    });
+    const start = await fixture.instance.start('missing');
+    const cancel = await fixture.instance.cancel('missing');
+    const retryUpload = await fixture.instance.retryUpload('missing');
+    const publish = await fixture.instance.publish('missing');
+    const retryPublish = await fixture.instance.retryPublish('missing');
+    const discard = await fixture.instance.discard('missing');
+    const retryDiscard = await fixture.instance.retryDiscard('missing');
+    expect(start).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(cancel).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(retryUpload).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(publish).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(retryPublish).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(discard).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(retryDiscard).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(fixture.instance.release('missing')).toMatchObject({isErr: true, error: {kind: 'unknownUpload'}});
+  });
+
+  it('ignores an old process success after cancel, release, and re-register', async () => {
+    const fixture = deferredManager();
+    fixture.instance.register('upload-1', source, path);
+    const oldStart = fixture.instance.start('upload-1');
+    const oldTask = required(fixture.tasks[0]);
+    await fixture.instance.cancel('upload-1');
+    expect(fixture.instance.release('upload-1').isOk).toBe(true);
+
+    fixture.instance.register('upload-1', source, path);
+    const events: string[] = [];
+    fixture.instance.subscribe('upload-1', snapshot => events.push(snapshot.kind));
+    const newStart = fixture.instance.start('upload-1');
+    const beforeOldSettlement = fixture.instance.snapshot('upload-1');
+    oldTask.resolve(undefined);
+    await oldStart;
+    expect(fixture.instance.snapshot('upload-1')).toEqual(beforeOldSettlement);
+    expect(events).toEqual(['queued', 'uploading']);
+    required(fixture.tasks[1]).resolve(undefined);
+    await newStart;
+    expect(fixture.instance.snapshot('upload-1')).toMatchObject({isOk: true, value: {kind: 'draftReady'}});
+  });
+
+  it('ignores an old process failure after cancel, release, and re-register', async () => {
+    const fixture = deferredManager();
+    fixture.instance.register('upload-1', source, path);
+    const oldStart = fixture.instance.start('upload-1');
+    const oldTask = required(fixture.tasks[0]);
+    await fixture.instance.cancel('upload-1');
+    expect(fixture.instance.release('upload-1').isOk).toBe(true);
+
+    fixture.instance.register('upload-1', source, path);
+    const events: string[] = [];
+    fixture.instance.subscribe('upload-1', snapshot => events.push(snapshot.kind));
+    const newStart = fixture.instance.start('upload-1');
+    const beforeOldSettlement = fixture.instance.snapshot('upload-1');
+    oldTask.reject({kind: 'gatewayError', operation: 'upload', cause: 'stale'});
+    await oldStart;
+    expect(fixture.instance.snapshot('upload-1')).toEqual(beforeOldSettlement);
+    expect(events).toEqual(['queued', 'uploading']);
+    required(fixture.tasks[1]).resolve(undefined);
+    await newStart;
+    expect(fixture.instance.snapshot('upload-1')).toMatchObject({isOk: true, value: {kind: 'draftReady'}});
+  });
+
+  it('releases terminal uploads and removes the registry entry', async () => {
+    const fixture = manager();
+    fixture.instance.register('upload-1', source, path);
+    await fixture.instance.start('upload-1');
+    expect(fixture.requests[0].path).toBe(path);
+    await fixture.instance.publish('upload-1');
+    expect(fixture.instance.release('upload-1').isOk).toBe(true);
+    expect(fixture.instance.snapshot('upload-1')).toMatchObject({isErr: true, error: {kind: 'unknownUpload'}});
+  });
+
+  it('rejects release while non-terminal', () => {
+    const fixture = manager();
+    fixture.instance.register('upload-1', source, path);
+    expect(fixture.instance.release('upload-1')).toMatchObject({
+      isErr: true,
+      error: {kind: 'invalidTransition', action: 'release'},
+    });
+  });
+});

--- a/apps/webapp/src/script/repositories/cells/upload/manager.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/manager.test.ts
@@ -22,7 +22,7 @@ import {Task} from 'true-myth';
 
 import type {CellsUploadGateway, CellsUploadGatewayError, UploadDraftRequest} from './gateway';
 import {createCellsUploadManager} from './manager';
-import type {UploadSource} from './identity';
+import type {DraftIdentity, UploadSource} from './identity';
 
 const source: UploadSource = {blob: new Blob(['data']), name: 'file.txt', contentType: 'text/plain', size: 4};
 const path = 'wire-cells-web/conversation-1';
@@ -33,10 +33,10 @@ const required = <T>(value: T | undefined): T => {
 };
 
 const deferred = () => {
-  let resolve!: (value: void) => void;
+  let resolve!: (value?: DraftIdentity) => void;
   let reject!: (error: CellsUploadGatewayError<'upload'>) => void;
-  const task = new Task<void, CellsUploadGatewayError<'upload'>>((resolveTask, rejectTask) => {
-    resolve = resolveTask;
+  const task = new Task<DraftIdentity, CellsUploadGatewayError<'upload'>>((resolveTask, rejectTask) => {
+    resolve = value => resolveTask(value ?? {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'});
     reject = rejectTask;
   });
   return {task, resolve, reject};
@@ -71,7 +71,11 @@ describe('createCellsUploadManager', () => {
     const gateway: CellsUploadGateway = {
       uploadDraft: request => {
         requests.push(request);
-        return Task.resolve<void, never>(undefined);
+        return Task.resolve<DraftIdentity, never>({
+          uploadId: request.uploadId,
+          resourceUuid: request.identity.resourceUuid,
+          versionId: request.identity.versionId,
+        });
       },
       publishDraft: () => Task.resolve<void, never>(undefined),
       discardDraft: () => Task.resolve<void, never>(undefined),

--- a/apps/webapp/src/script/repositories/cells/upload/manager.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/manager.ts
@@ -1,0 +1,109 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe, Result, maybe} from 'true-myth';
+
+import type {UploadSource} from './identity';
+import type {UploadState} from './lifecycle';
+import {
+  createCellsUploadProcess,
+  type CellsUploadProcess,
+  type CellsUploadProcessDependencies,
+  type UploadProcessError,
+  type UploadSnapshotListener,
+} from './process';
+
+export type CellsUploadManagerError =
+  | UploadProcessError
+  | {readonly kind: 'unknownUpload'; readonly uploadId: string}
+  | {readonly kind: 'duplicateUpload'; readonly uploadId: string};
+
+export type CellsUploadManager = {
+  readonly register: (uploadId: string, source: UploadSource, path: string) => Result<void, CellsUploadManagerError>;
+  readonly snapshot: (uploadId: string) => Result<UploadState, CellsUploadManagerError>;
+  readonly subscribe: (
+    uploadId: string,
+    listener: UploadSnapshotListener,
+  ) => Result<() => void, CellsUploadManagerError>;
+  readonly start: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly cancel: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly retryUpload: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly publish: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly retryPublish: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly discard: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly retryDiscard: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly release: (uploadId: string) => Result<void, CellsUploadManagerError>;
+};
+
+export const createCellsUploadManager = (dependencies: CellsUploadProcessDependencies): CellsUploadManager => {
+  const processes = new Map<string, CellsUploadProcess>();
+  const unknown = <T>(uploadId: string): Result<T, CellsUploadManagerError> =>
+    Result.err({kind: 'unknownUpload', uploadId});
+  const processFor = (uploadId: string): Result<CellsUploadProcess, CellsUploadManagerError> => {
+    const process = Maybe.of(processes.get(uploadId));
+    return maybe.isJust(process) ? Result.ok(process.value) : unknown(uploadId);
+  };
+  const command = (
+    uploadId: string,
+    name: 'start' | 'cancel' | 'retryUpload' | 'publish' | 'retryPublish' | 'discard' | 'retryDiscard',
+  ) => {
+    const process = processFor(uploadId);
+    return process.isErr ? Promise.resolve(Result.err(process.error)) : process.value[name]();
+  };
+
+  const register = (uploadId: string, source: UploadSource, path: string): Result<void, CellsUploadManagerError> => {
+    if (processes.has(uploadId)) {
+      return Result.err({kind: 'duplicateUpload', uploadId});
+    }
+    processes.set(uploadId, createCellsUploadProcess(uploadId, source, path, dependencies));
+    return Result.ok(undefined);
+  };
+
+  const release = (uploadId: string): Result<void, CellsUploadManagerError> => {
+    const process = processFor(uploadId);
+    if (process.isErr) {
+      return Result.err(process.error);
+    }
+    const result = process.value.release();
+    if (result.isOk) {
+      processes.delete(uploadId);
+    }
+    return result;
+  };
+
+  return {
+    register,
+    snapshot: uploadId => {
+      const process = processFor(uploadId);
+      return process.isErr ? Result.err(process.error) : process.value.snapshot();
+    },
+    subscribe: (uploadId, listener) => {
+      const process = processFor(uploadId);
+      return process.isErr ? Result.err(process.error) : process.value.subscribe(listener);
+    },
+    start: uploadId => command(uploadId, 'start'),
+    cancel: uploadId => command(uploadId, 'cancel'),
+    retryUpload: uploadId => command(uploadId, 'retryUpload'),
+    publish: uploadId => command(uploadId, 'publish'),
+    retryPublish: uploadId => command(uploadId, 'retryPublish'),
+    discard: uploadId => command(uploadId, 'discard'),
+    retryDiscard: uploadId => command(uploadId, 'retryDiscard'),
+    release,
+  };
+};

--- a/apps/webapp/src/script/repositories/cells/upload/process.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.test.ts
@@ -187,7 +187,9 @@ describe('createCellsUploadProcess', () => {
     required(fixture.process.subscribe(snapshot => snapshots.push(snapshot.kind)));
     firstRequest.onProgress(0.9);
     firstRequest.onProgress(1);
-    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toMatchObject({
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
       kind: 'uploading',
       progress: 0,
     });
@@ -207,7 +209,9 @@ describe('createCellsUploadProcess', () => {
     const secondRequest = required(fixture.uploads[1]);
     expect(secondRequest.attemptId).toBe(firstRequest.attemptId);
     firstRequest.onProgress(0.9);
-    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toMatchObject({
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
       kind: 'uploading',
       progress: 0,
     });
@@ -226,7 +230,9 @@ describe('createCellsUploadProcess', () => {
         cause: {kind: 'gatewayError', operation: 'publish', cause: 'mismatched-operation'},
       },
     });
-    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toMatchObject({
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
       kind: 'uploadFailed',
       error: {
         kind: 'uploadFailed',
@@ -243,7 +249,9 @@ describe('createCellsUploadProcess', () => {
     request.onProgress(0.9);
     required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'late'});
     await unwrap(start);
-    expect(fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source})).toMatchObject({
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
       kind: 'cancelled',
     });
   });
@@ -284,7 +292,9 @@ describe('createCellsUploadProcess', () => {
     await publishFixture.process.publish();
     publishFixture.setFailure();
     await unwrap(publishFixture.process.retryPublish());
-    expect(publishFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source})).toEqual({
+    expect(
+      publishFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toEqual({
       kind: 'published',
       identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
       source,
@@ -297,7 +307,9 @@ describe('createCellsUploadProcess', () => {
     await discardFixture.process.discard();
     discardFixture.setFailure();
     await unwrap(discardFixture.process.retryDiscard());
-    expect(discardFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source})).toEqual({
+    expect(
+      discardFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toEqual({
       kind: 'discarded',
       identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
       source,

--- a/apps/webapp/src/script/repositories/cells/upload/process.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.test.ts
@@ -1,0 +1,350 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Task} from 'true-myth';
+import type {Result} from 'true-myth';
+
+import type {CellsUploadGateway, CellsUploadGatewayError, UploadDraftRequest} from './gateway';
+import type {UploadSource} from './identity';
+import {createCellsUploadProcess, type CellsUploadProcessDependencies} from './process';
+
+const source: UploadSource = {blob: new Blob(['data']), name: 'file.txt', contentType: 'text/plain', size: 4};
+const path = 'wire-cells-web/conversation-1';
+
+const required = <T>(value: T | undefined): T => {
+  expect(value).toBeDefined();
+  return value as T;
+};
+
+const unwrapResult = <T, E>(result: Result<T, E>): T => {
+  expect(result.isOk).toBe(true);
+  return result.unwrapOr(undefined as never);
+};
+
+const deferred = <T, E>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: E) => void;
+  const value = new Task<T, E>((resolveTask, rejectTask) => {
+    resolve = resolveTask;
+    reject = rejectTask;
+  });
+  return {value, resolve, reject};
+};
+
+const setup = (failure?: 'publish' | 'discard' | 'mismatch', duplicateAttemptIds = false) => {
+  const uploads: UploadDraftRequest[] = [];
+  const uploadTasks: ReturnType<typeof deferred<void, CellsUploadGatewayError<'upload'>>>[] = [];
+  const aborts: AbortController[] = [];
+  const published = [] as string[];
+  const discarded = [] as string[];
+  let failureMode = failure;
+  const gateway: CellsUploadGateway = {
+    uploadDraft: request => {
+      uploads.push(request);
+      if (failureMode === 'mismatch') {
+        return Task.reject<void, CellsUploadGatewayError<'publish'>>({
+          kind: 'gatewayError',
+          operation: 'publish',
+          cause: 'mismatched-operation',
+        }) as unknown as Task<void, CellsUploadGatewayError<'upload'>>;
+      }
+      const task = deferred<void, CellsUploadGatewayError<'upload'>>();
+      uploadTasks.push(task);
+      return task.value;
+    },
+    publishDraft: identity => {
+      published.push(identity.versionId);
+      return failureMode === 'publish'
+        ? Task.reject<void, CellsUploadGatewayError<'publish'>>({
+            kind: 'gatewayError',
+            operation: 'publish',
+            cause: 'offline',
+          })
+        : Task.resolve<void, never>(undefined);
+    },
+    discardDraft: identity => {
+      discarded.push(identity.versionId);
+      return failureMode === 'discard'
+        ? Task.reject<void, CellsUploadGatewayError<'discard'>>({
+            kind: 'gatewayError',
+            operation: 'discard',
+            cause: 'offline',
+          })
+        : Task.resolve<void, never>(undefined);
+    },
+  };
+  let version = 0;
+  let attempt = 0;
+  const dependencies: CellsUploadProcessDependencies = {
+    gateway,
+    createResourceUuid: () => 'resource-1',
+    createVersionUuid: () => `version-${++version}`,
+    createAttemptId: () => (duplicateAttemptIds ? 'attempt-1' : `attempt-${++attempt}`),
+    createAbortController: () => {
+      const controller = new AbortController();
+      aborts.push(controller);
+      return controller;
+    },
+  };
+  return {
+    process: createCellsUploadProcess('upload-1', source, path, dependencies),
+    uploads,
+    uploadTasks,
+    aborts,
+    published,
+    discarded,
+    setFailure: (mode?: 'publish' | 'discard') => {
+      failureMode = mode;
+    },
+  };
+};
+
+const unwrap = async <T, E>(promise: PromiseLike<{isOk: boolean; value?: T; error?: E}>) => {
+  const result = await promise;
+  expect(result.isOk).toBe(true);
+  return result;
+};
+
+describe('createCellsUploadProcess', () => {
+  it('uploads successfully and emits ordered snapshots', async () => {
+    const fixture = setup();
+    const snapshots: string[] = [];
+    const subscription = fixture.process.subscribe(snapshot => snapshots.push(snapshot.kind));
+    expect(subscription.isOk).toBe(true);
+    const start = fixture.process.start();
+    required(fixture.uploads[0]).onProgress(0.25);
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+    expect(snapshots).toEqual(['queued', 'uploading', 'uploading', 'draftReady']);
+  });
+
+  it('reports typed upload failure and aborts only the active attempt', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'offline'});
+    const result = await start;
+    expect(result.isErr).toBe(true);
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({kind: 'uploadFailed'});
+    expect(required(fixture.aborts[0]).signal.aborted).toBe(false);
+  });
+
+  it('cancels queued work without creating a controller and is idempotent', async () => {
+    const fixture = setup();
+    await unwrap(fixture.process.cancel());
+    expect(fixture.aborts).toHaveLength(0);
+    await unwrap(fixture.process.cancel());
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({kind: 'cancelled'});
+  });
+
+  it('aborts an active upload and suppresses its late result', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    await unwrap(fixture.process.cancel());
+    required(fixture.uploads[0]).onProgress(0.9);
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+    expect(required(fixture.aborts[0]).signal.aborted).toBe(true);
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({kind: 'cancelled'});
+  });
+
+  it('suppresses stale progress callbacks after a retry starts', async () => {
+    const fixture = setup();
+    const first = fixture.process.start();
+    const firstRequest = required(fixture.uploads[0]);
+    expect(firstRequest.path).toBe(path);
+    firstRequest.onProgress(0.25);
+    required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'offline'});
+    await first;
+
+    const retry = fixture.process.retryUpload();
+    const secondRequest = required(fixture.uploads[1]);
+    expect(secondRequest.path).toBe(path);
+    expect(secondRequest.identity).toMatchObject({resourceUuid: 'resource-1', versionId: 'version-2'});
+    expect(secondRequest.attemptId).toBe('attempt-2');
+    const snapshots: string[] = [];
+    required(fixture.process.subscribe(snapshot => snapshots.push(snapshot.kind)));
+    firstRequest.onProgress(0.9);
+    firstRequest.onProgress(1);
+    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toMatchObject({
+      kind: 'uploading',
+      progress: 0,
+    });
+    required(fixture.uploadTasks[1]).resolve(undefined);
+    await unwrap(retry);
+    expect(snapshots).toEqual(['uploading', 'draftReady']);
+  });
+
+  it('isolates retries when the injected attempt IDs are duplicated', async () => {
+    const fixture = setup(undefined, true);
+    const first = fixture.process.start();
+    const firstRequest = required(fixture.uploads[0]);
+    required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'offline'});
+    await first;
+
+    const retry = fixture.process.retryUpload();
+    const secondRequest = required(fixture.uploads[1]);
+    expect(secondRequest.attemptId).toBe(firstRequest.attemptId);
+    firstRequest.onProgress(0.9);
+    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toMatchObject({
+      kind: 'uploading',
+      progress: 0,
+    });
+    required(fixture.uploadTasks[1]).resolve(undefined);
+    await unwrap(retry);
+  });
+
+  it('normalizes a mismatched gateway operation at the process boundary', async () => {
+    const fixture = setup('mismatch');
+    const result = await fixture.process.start();
+    expect(result).toMatchObject({
+      isErr: true,
+      error: {
+        kind: 'gatewayError',
+        operation: 'upload',
+        cause: {kind: 'gatewayError', operation: 'publish', cause: 'mismatched-operation'},
+      },
+    });
+    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toMatchObject({
+      kind: 'uploadFailed',
+      error: {
+        kind: 'uploadFailed',
+        cause: {kind: 'gatewayError', operation: 'upload'},
+      },
+    });
+  });
+
+  it('suppresses a late failure after cancellation', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    const request = required(fixture.uploads[0]);
+    await unwrap(fixture.process.cancel());
+    request.onProgress(0.9);
+    required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'late'});
+    await unwrap(start);
+    expect(fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source})).toMatchObject({
+      kind: 'cancelled',
+    });
+  });
+
+  it('reports publish and discard failures with recoverable clean states', async () => {
+    const publishFailure = setup('publish');
+    const publishStart = publishFailure.process.start();
+    required(publishFailure.uploadTasks[0]).resolve(undefined);
+    await publishStart;
+    expect((await publishFailure.process.publish()).isErr).toBe(true);
+    expect(
+      publishFailure.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toEqual({
+      kind: 'publishFailed',
+      identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+      source,
+      error: {kind: 'publishFailed', cause: {kind: 'gatewayError', operation: 'publish', cause: 'offline'}},
+    });
+
+    const discardFailure = setup('discard');
+    const discardStart = discardFailure.process.start();
+    required(discardFailure.uploadTasks[0]).resolve(undefined);
+    await discardStart;
+    expect((await discardFailure.process.discard()).isErr).toBe(true);
+    expect(
+      discardFailure.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
+      kind: 'discardFailed',
+      error: {kind: 'discardFailed', cause: {kind: 'gatewayError', operation: 'discard', cause: 'offline'}},
+    });
+  });
+
+  it('retries publish and discard successfully after their failures', async () => {
+    const publishFixture = setup('publish');
+    const publishStart = publishFixture.process.start();
+    required(publishFixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(publishStart);
+    await publishFixture.process.publish();
+    publishFixture.setFailure();
+    await unwrap(publishFixture.process.retryPublish());
+    expect(publishFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source})).toEqual({
+      kind: 'published',
+      identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+      source,
+    });
+
+    const discardFixture = setup('discard');
+    const discardStart = discardFixture.process.start();
+    required(discardFixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(discardStart);
+    await discardFixture.process.discard();
+    discardFixture.setFailure();
+    await unwrap(discardFixture.process.retryDiscard());
+    expect(discardFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source})).toEqual({
+      kind: 'discarded',
+      identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+      source,
+    });
+  });
+
+  it('publishes and discards through the gateway', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+    await unwrap(fixture.process.publish());
+    expect(fixture.published).toEqual(['version-1']);
+
+    const second = setup();
+    const secondStart = second.process.start();
+    required(second.uploadTasks[0]).resolve(undefined);
+    await unwrap(secondStart);
+    await unwrap(second.process.discard());
+    expect(second.discarded).toEqual(['version-1']);
+  });
+
+  it('notifies subscribers synchronously in registration order and supports unsubscribe', async () => {
+    const fixture = setup();
+    const events: string[] = [];
+    const first = fixture.process.subscribe(() => events.push('first'));
+    const second = fixture.process.subscribe(() => events.push('second'));
+    expect(events).toEqual(['first', 'second']);
+    unwrapResult(first)();
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await start;
+    expect(events).toEqual(['first', 'second', 'second', 'second']);
+    const before = events.length;
+    unwrapResult(fixture.process.subscribe(() => events.push('third')))();
+    expect(events.length).toBe(before + 1);
+    expect(second.isOk).toBe(true);
+  });
+
+  it('releases terminal process state and rejects later snapshots', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await start;
+    await fixture.process.publish();
+    expect(fixture.process.release().isOk).toBe(true);
+    expect(fixture.process.snapshot().isErr).toBe(true);
+    expect(fixture.process.start().then(result => result.isErr)).resolves.toBe(true);
+  });
+});

--- a/apps/webapp/src/script/repositories/cells/upload/process.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.test.ts
@@ -21,7 +21,7 @@ import {Task} from 'true-myth';
 import type {Result} from 'true-myth';
 
 import type {CellsUploadGateway, CellsUploadGatewayError, UploadDraftRequest} from './gateway';
-import type {UploadSource} from './identity';
+import type {DraftIdentity, UploadSource} from './identity';
 import {createCellsUploadProcess, type CellsUploadProcessDependencies} from './process';
 
 const source: UploadSource = {blob: new Blob(['data']), name: 'file.txt', contentType: 'text/plain', size: 4};
@@ -37,19 +37,23 @@ const unwrapResult = <T, E>(result: Result<T, E>): T => {
   return result.unwrapOr(undefined as never);
 };
 
-const deferred = <T, E>() => {
-  let resolve!: (value: T) => void;
+const deferred = <T, E>(defaultValue?: T) => {
+  let resolve!: (value?: T) => void;
   let reject!: (error: E) => void;
   const value = new Task<T, E>((resolveTask, rejectTask) => {
-    resolve = resolveTask;
+    resolve = nextValue => resolveTask(nextValue ?? (defaultValue as T));
     reject = rejectTask;
   });
   return {value, resolve, reject};
 };
 
-const setup = (failure?: 'publish' | 'discard' | 'mismatch', duplicateAttemptIds = false) => {
+const setup = (
+  failure?: 'publish' | 'discard' | 'mismatch',
+  duplicateAttemptIds = false,
+  remoteIdentity: DraftIdentity = {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+) => {
   const uploads: UploadDraftRequest[] = [];
-  const uploadTasks: ReturnType<typeof deferred<void, CellsUploadGatewayError<'upload'>>>[] = [];
+  const uploadTasks: ReturnType<typeof deferred<DraftIdentity, CellsUploadGatewayError<'upload'>>>[] = [];
   const aborts: AbortController[] = [];
   const published = [] as string[];
   const discarded = [] as string[];
@@ -58,13 +62,13 @@ const setup = (failure?: 'publish' | 'discard' | 'mismatch', duplicateAttemptIds
     uploadDraft: request => {
       uploads.push(request);
       if (failureMode === 'mismatch') {
-        return Task.reject<void, CellsUploadGatewayError<'publish'>>({
+        return Task.reject<DraftIdentity, CellsUploadGatewayError<'upload'>>({
           kind: 'gatewayError',
-          operation: 'publish',
+          operation: 'publish' as CellsUploadGatewayError<'upload'>['operation'],
           cause: 'mismatched-operation',
-        }) as unknown as Task<void, CellsUploadGatewayError<'upload'>>;
+        });
       }
-      const task = deferred<void, CellsUploadGatewayError<'upload'>>();
+      const task = deferred<DraftIdentity, CellsUploadGatewayError<'upload'>>(remoteIdentity);
       uploadTasks.push(task);
       return task.value;
     },
@@ -132,6 +136,26 @@ describe('createCellsUploadProcess', () => {
     required(fixture.uploadTasks[0]).resolve(undefined);
     await unwrap(start);
     expect(snapshots).toEqual(['queued', 'uploading', 'uploading', 'draftReady']);
+  });
+
+  it('uses the repository-returned remote identity after upload', async () => {
+    const remoteIdentity: DraftIdentity = {
+      uploadId: 'upload-1',
+      resourceUuid: 'remote-resource',
+      versionId: 'remote-version',
+    };
+    const fixture = setup(undefined, false, remoteIdentity);
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+
+    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toEqual({
+      kind: 'draftReady',
+      identity: remoteIdentity,
+      source,
+    });
+    await unwrap(fixture.process.publish());
+    expect(fixture.published).toEqual(['remote-version']);
   });
 
   it('reports typed upload failure and aborts only the active attempt', async () => {

--- a/apps/webapp/src/script/repositories/cells/upload/process.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.ts
@@ -1,0 +1,354 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe, Result, maybe, result as resultModule, task} from 'true-myth';
+
+import type {CellsUploadGateway, CellsUploadGatewayError} from './gateway';
+import type {DraftIdentity, UploadSource} from './identity';
+import type {UploadAction, UploadLifecycleError, UploadState} from './lifecycle';
+import {transition} from './transition';
+
+export type UploadProcessError = UploadLifecycleError | CellsUploadGatewayError | {readonly kind: 'released'};
+export type UploadSnapshotListener = (snapshot: UploadState) => void;
+export type AbortControllerFactory = () => AbortController;
+export type IdFactory = () => string;
+
+export type CellsUploadProcessDependencies = {
+  readonly gateway: CellsUploadGateway;
+  readonly createResourceUuid: IdFactory;
+  readonly createVersionUuid: IdFactory;
+  readonly createAttemptId: IdFactory;
+  readonly createAbortController: AbortControllerFactory;
+};
+
+export type CellsUploadProcess = {
+  readonly snapshot: () => Result<UploadState, UploadProcessError>;
+  readonly subscribe: (listener: UploadSnapshotListener) => Result<() => void, UploadProcessError>;
+  readonly start: () => Promise<Result<void, UploadProcessError>>;
+  readonly cancel: () => Promise<Result<void, UploadProcessError>>;
+  readonly retryUpload: () => Promise<Result<void, UploadProcessError>>;
+  readonly publish: () => Promise<Result<void, UploadProcessError>>;
+  readonly retryPublish: () => Promise<Result<void, UploadProcessError>>;
+  readonly discard: () => Promise<Result<void, UploadProcessError>>;
+  readonly retryDiscard: () => Promise<Result<void, UploadProcessError>>;
+  readonly release: () => Result<void, UploadProcessError>;
+};
+
+type Attempt = {
+  readonly id: string;
+  readonly controller: AbortController;
+  readonly identity: DraftIdentity;
+};
+
+const isSameState = (left: UploadState, right: UploadState): boolean => {
+  if (left === right || left.kind !== right.kind) {
+    return left === right;
+  }
+  const leftRecord = left as unknown as Record<string, unknown>;
+  const rightRecord = right as unknown as Record<string, unknown>;
+  const keys = new Set([...Object.keys(leftRecord), ...Object.keys(rightRecord)]);
+  return [...keys].every(key => leftRecord[key] === rightRecord[key]);
+};
+
+export const createCellsUploadProcess = (
+  uploadId: string,
+  source: UploadSource,
+  path: string,
+  dependencies: CellsUploadProcessDependencies,
+): CellsUploadProcess => {
+  let state: Maybe<UploadState> = Maybe.just({kind: 'queued', identity: {uploadId}, source});
+  let activeSource: Maybe<UploadSource> = Maybe.just(source);
+  let resourceUuid: Maybe<string> = Maybe.nothing();
+  let currentAttempt: Maybe<Attempt> = Maybe.nothing();
+  let operationId = 0;
+  let released = false;
+  const subscribers = new Set<UploadSnapshotListener>();
+
+  const releasedResult = <T>(): Result<T, UploadProcessError> => Result.err({kind: 'released'});
+  const snapshot = (): Result<UploadState, UploadProcessError> =>
+    maybe.isJust(state) ? Result.ok(state.value) : releasedResult();
+
+  const notify = (previous: UploadState, next: UploadState): void => {
+    if (isSameState(previous, next)) {
+      return;
+    }
+    state = Maybe.just(next);
+    subscribers.forEach(listener => listener(next));
+  };
+
+  const apply = (action: UploadAction): Result<UploadState, UploadLifecycleError> => {
+    if (maybe.isNothing(state)) {
+      return Result.err({kind: 'invalidTransition', from: 'cancelled', action: action.type});
+    }
+    const result = transition(state.value, action);
+    if (resultModule.isErr(result)) {
+      return result;
+    }
+    notify(state.value, result.value);
+    return result;
+  };
+
+  const isGatewayError = (
+    reason: unknown,
+    operation: CellsUploadGatewayError['operation'],
+  ): reason is CellsUploadGatewayError =>
+    typeof reason === 'object' &&
+    reason !== null &&
+    (reason as {kind?: unknown; operation?: unknown}).kind === 'gatewayError' &&
+    (reason as {kind?: unknown; operation?: unknown}).operation === operation;
+
+  const safeGateway = <T>(
+    operation: CellsUploadGatewayError['operation'],
+    call: () => PromiseLike<Result<T, CellsUploadGatewayError>>,
+  ) =>
+    task.tryOrElse(
+      reason =>
+        isGatewayError(reason, operation) ? reason : {kind: 'gatewayError' as const, operation, cause: reason},
+      async () => {
+        const result = await call();
+        return resultModule.isErr(result) ? Promise.reject(result.error) : result.value;
+      },
+    );
+
+  const isCurrentAttempt = (attempt: Attempt): boolean => {
+    const activeAttempt = currentAttempt;
+    const currentState = state;
+    return (
+      maybe.isJust(activeAttempt) &&
+      activeAttempt.value === attempt &&
+      maybe.isJust(currentState) &&
+      currentState.value.kind === 'uploading'
+    );
+  };
+
+  const runUpload = async (): Promise<Result<void, UploadProcessError>> => {
+    const currentState = state;
+    const currentResourceUuid = resourceUuid;
+    const currentSource = activeSource;
+    if (
+      maybe.isNothing(currentState) ||
+      currentState.value.kind !== 'uploading' ||
+      maybe.isNothing(currentResourceUuid) ||
+      maybe.isNothing(currentSource)
+    ) {
+      return Result.err({
+        kind: 'invalidTransition',
+        from: maybe.isJust(currentState) ? currentState.value.kind : 'cancelled',
+        action: 'startUpload',
+      });
+    }
+    const attempt: Attempt = {
+      id: dependencies.createAttemptId(),
+      controller: dependencies.createAbortController(),
+      identity: {uploadId, resourceUuid: currentResourceUuid.value, versionId: dependencies.createVersionUuid()},
+    };
+    currentAttempt = Maybe.just(attempt);
+    const gatewayResult = await safeGateway('upload', () =>
+      dependencies.gateway.uploadDraft({
+        uploadId,
+        attemptId: attempt.id,
+        identity: attempt.identity,
+        source: currentSource.value,
+        path,
+        signal: attempt.controller.signal,
+        onProgress: progress => {
+          if (isCurrentAttempt(attempt)) {
+            apply({type: 'progress', progress});
+          }
+        },
+      }),
+    );
+
+    if (!isCurrentAttempt(attempt)) {
+      return Result.ok(undefined);
+    }
+    currentAttempt = Maybe.nothing();
+    if (resultModule.isErr(gatewayResult)) {
+      apply({type: 'uploadFailed', error: {kind: 'uploadFailed', cause: gatewayResult.error}});
+      return Result.err(gatewayResult.error);
+    }
+    apply({
+      type: 'uploadSucceeded',
+      resourceUuid: attempt.identity.resourceUuid,
+      versionId: attempt.identity.versionId,
+    });
+    return Result.ok(undefined);
+  };
+
+  const start = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    if (maybe.isNothing(resourceUuid)) {
+      resourceUuid = Maybe.just(dependencies.createResourceUuid());
+    }
+    const result = apply({type: 'startUpload'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    return runUpload();
+  };
+
+  const cancel = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    if (maybe.isJust(state) && state.value.kind === 'cancelled') {
+      return Result.ok(undefined);
+    }
+    const result = apply({type: 'cancel'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    const attempt = currentAttempt;
+    currentAttempt = Maybe.nothing();
+    if (maybe.isJust(attempt)) {
+      attempt.value.controller.abort();
+    }
+    return Result.ok(undefined);
+  };
+
+  const retryUpload = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'retryUpload'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    return start();
+  };
+
+  const runDraftOperation = async (
+    operation: 'publish' | 'discard',
+    identity: DraftIdentity,
+    completion: UploadAction,
+  ): Promise<Result<void, UploadProcessError>> => {
+    const operationToken = ++operationId;
+    const gatewayResult = await safeGateway(operation, () =>
+      operation === 'publish'
+        ? dependencies.gateway.publishDraft(identity)
+        : dependencies.gateway.discardDraft(identity),
+    );
+    if (
+      released ||
+      operationToken !== operationId ||
+      maybe.isNothing(state) ||
+      state.value.kind !== `${operation}ing`
+    ) {
+      return Result.ok(undefined);
+    }
+    if (resultModule.isErr(gatewayResult)) {
+      apply(
+        operation === 'publish'
+          ? {type: 'publishFailed', error: {kind: 'publishFailed', cause: gatewayResult.error}}
+          : {type: 'discardFailed', error: {kind: 'discardFailed', cause: gatewayResult.error}},
+      );
+      return Result.err(gatewayResult.error);
+    }
+    apply(completion);
+    return Result.ok(undefined);
+  };
+
+  const publish = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'publish'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    if (result.value.kind !== 'publishing') {
+      return Result.err({kind: 'invalidTransition', from: result.value.kind, action: 'publish'});
+    }
+    return runDraftOperation('publish', result.value.identity, {type: 'publishSucceeded'});
+  };
+
+  const retryPublish = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'retryPublish'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    return publish();
+  };
+
+  const discard = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'discard'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    if (result.value.kind !== 'discarding') {
+      return Result.err({kind: 'invalidTransition', from: result.value.kind, action: 'discard'});
+    }
+    return runDraftOperation('discard', result.value.identity, {type: 'discardSucceeded'});
+  };
+
+  const retryDiscard = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'retryDiscard'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    return discard();
+  };
+
+  const subscribe = (listener: UploadSnapshotListener): Result<() => void, UploadProcessError> => {
+    if (maybe.isNothing(state)) {
+      return releasedResult();
+    }
+    subscribers.add(listener);
+    listener(state.value);
+    return Result.ok(() => subscribers.delete(listener));
+  };
+
+  const release = (): Result<void, UploadProcessError> => {
+    if (released) {
+      return releasedResult();
+    }
+    if (maybe.isNothing(state) || !['published', 'discarded', 'cancelled'].includes(state.value.kind)) {
+      return Result.err({
+        kind: 'invalidTransition',
+        from: maybe.isJust(state) ? state.value.kind : 'cancelled',
+        action: 'release',
+      });
+    }
+    const attempt = currentAttempt;
+    currentAttempt = Maybe.nothing();
+    if (maybe.isJust(attempt)) {
+      attempt.value.controller.abort();
+    }
+    operationId += 1;
+    subscribers.clear();
+    state = Maybe.nothing();
+    activeSource = Maybe.nothing();
+    resourceUuid = Maybe.nothing();
+    released = true;
+    return Result.ok(undefined);
+  };
+
+  return {snapshot, subscribe, start, cancel, retryUpload, publish, retryPublish, discard, retryDiscard, release};
+};

--- a/apps/webapp/src/script/repositories/cells/upload/process.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.ts
@@ -167,6 +167,7 @@ export const createCellsUploadProcess = (
         source: currentSource.value,
         path,
         signal: attempt.controller.signal,
+        abortController: attempt.controller,
         onProgress: progress => {
           if (isCurrentAttempt(attempt)) {
             apply({type: 'progress', progress});
@@ -183,10 +184,11 @@ export const createCellsUploadProcess = (
       apply({type: 'uploadFailed', error: {kind: 'uploadFailed', cause: gatewayResult.error}});
       return Result.err(gatewayResult.error);
     }
+    resourceUuid = Maybe.just(gatewayResult.value.resourceUuid);
     apply({
       type: 'uploadSucceeded',
-      resourceUuid: attempt.identity.resourceUuid,
-      versionId: attempt.identity.versionId,
+      resourceUuid: gatewayResult.value.resourceUuid,
+      versionId: gatewayResult.value.versionId,
     });
     return Result.ok(undefined);
   };

--- a/apps/webapp/src/script/repositories/cells/upload/transition.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/transition.test.ts
@@ -1,0 +1,188 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {result as resultModule} from 'true-myth';
+
+import type {UploadAction, UploadLifecycleError, UploadState} from './lifecycle';
+import {normalizeProgress, transition} from './transition';
+
+const source = {blob: new Blob(['content']), name: 'file.txt', contentType: 'text/plain', size: 7};
+const queued: UploadState = {kind: 'queued', identity: {uploadId: 'upload-1'}, source};
+const uploading: UploadState = {...queued, kind: 'uploading', progress: 0};
+const draftReady: UploadState = {
+  kind: 'draftReady',
+  identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+  source,
+};
+const publishing: UploadState = {...draftReady, kind: 'publishing'};
+const publishFailed: UploadState = {
+  ...publishing,
+  kind: 'publishFailed',
+  error: {kind: 'publishFailed', cause: 'offline'},
+};
+const discarding: UploadState = {...draftReady, kind: 'discarding'};
+const discardFailed: UploadState = {
+  ...discarding,
+  kind: 'discardFailed',
+  error: {kind: 'discardFailed', cause: 'offline'},
+};
+
+const expectSuccess = (state: UploadState, action: UploadAction): UploadState => {
+  const result = transition(state, action);
+  expect(result.isOk).toBe(true);
+  return resultModule.isOk(result) ? result.value : state;
+};
+
+const expectFailure = (state: UploadState, action: UploadAction): UploadLifecycleError => {
+  const result = transition(state, action);
+  expect(resultModule.isErr(result)).toBe(true);
+  return resultModule.isErr(result)
+    ? result.error
+    : ({kind: 'invalidTransition', from: state.kind, action: action.type} as UploadLifecycleError);
+};
+
+describe('normalizeProgress', () => {
+  it.each([
+    {progress: -0.1, expected: 0},
+    {progress: 0, expected: 0},
+    {progress: 0.25, expected: 0.25},
+    {progress: 1, expected: 1},
+    {progress: 1.5, expected: 1},
+    {progress: Number.NaN, expected: 0},
+  ])('normalizes $progress to the inclusive 0..1 range', ({progress, expected}) => {
+    expect(normalizeProgress(progress)).toBe(expected);
+  });
+});
+
+describe('transition', () => {
+  it.each([
+    {state: queued, action: {type: 'startUpload'} as const, expected: 'uploading'},
+    {
+      state: uploading,
+      action: {type: 'uploadSucceeded', resourceUuid: 'resource-1', versionId: 'version-1'} as const,
+      expected: 'draftReady',
+    },
+    {
+      state: uploading,
+      action: {type: 'uploadFailed', error: {kind: 'uploadFailed', cause: 'offline'}} as const,
+      expected: 'uploadFailed',
+    },
+    {state: draftReady, action: {type: 'publish'} as const, expected: 'publishing'},
+    {state: publishing, action: {type: 'publishSucceeded'} as const, expected: 'published'},
+    {
+      state: publishing,
+      action: {type: 'publishFailed', error: {kind: 'publishFailed', cause: 'offline'}} as const,
+      expected: 'publishFailed',
+    },
+    {state: draftReady, action: {type: 'discard'} as const, expected: 'discarding'},
+    {state: discarding, action: {type: 'discardSucceeded'} as const, expected: 'discarded'},
+    {
+      state: discarding,
+      action: {type: 'discardFailed', error: {kind: 'discardFailed', cause: 'offline'}} as const,
+      expected: 'discardFailed',
+    },
+  ])('allows $state.kind + $action.type -> $expected', ({state, action, expected}) => {
+    expect(expectSuccess(state, action).kind).toBe(expected);
+  });
+
+  it('normalizes progress while uploading and ignores it outside active upload', () => {
+    expect(expectSuccess(uploading, {type: 'progress', progress: 0.5})).toMatchObject({
+      kind: 'uploading',
+      progress: 0.5,
+    });
+    const result = transition(draftReady, {type: 'progress', progress: 0.8});
+    expect(resultModule.isOk(result)).toBe(true);
+    expect(resultModule.isOk(result) && result.value).toBe(draftReady);
+  });
+
+  it('preserves upload and draft identities across transitions', () => {
+    const ready = expectSuccess(uploading, {
+      type: 'uploadSucceeded',
+      resourceUuid: 'resource-2',
+      versionId: 'version-2',
+    });
+    expect(ready).toMatchObject({identity: {uploadId: 'upload-1', resourceUuid: 'resource-2', versionId: 'version-2'}});
+  });
+
+  it('removes active progress when upload fails', () => {
+    expect(expectSuccess(uploading, {type: 'uploadFailed', error: {kind: 'uploadFailed', cause: 'offline'}})).toEqual({
+      kind: 'uploadFailed',
+      identity: queued.identity,
+      source,
+      error: {kind: 'uploadFailed', cause: 'offline'},
+    });
+  });
+
+  it.each([
+    {state: queued, action: {type: 'publish'} as const},
+    {state: uploading, action: {type: 'publish'} as const},
+    {state: publishing, action: {type: 'publish'} as const},
+    {state: publishing, action: {type: 'discard'} as const},
+    {state: publishFailed, action: {type: 'publish'} as const},
+    {state: discardFailed, action: {type: 'discard'} as const},
+    {state: draftReady, action: {type: 'cancel'} as const},
+    {state: publishFailed, action: {type: 'cancel'} as const},
+    {state: discardFailed, action: {type: 'cancel'} as const},
+    {state: {...draftReady, kind: 'published'} as UploadState, action: {type: 'publish'} as const},
+    {state: {...draftReady, kind: 'discarded'} as UploadState, action: {type: 'discard'} as const},
+  ])('returns a typed error for invalid $state.kind + $action.type', ({state, action}) => {
+    expect(expectFailure(state, action)).toMatchObject({
+      kind: 'invalidTransition',
+      from: state.kind,
+      action: action.type,
+    });
+  });
+
+  it('supports recovery from upload, publish, and discard failures without stale fields', () => {
+    expect(
+      expectSuccess(expectSuccess(uploading, {type: 'uploadFailed', error: {kind: 'uploadFailed', cause: 'offline'}}), {
+        type: 'retryUpload',
+      }),
+    ).toEqual({kind: 'queued', identity: queued.identity, source});
+    expect(expectSuccess(publishFailed, {type: 'retryPublish'})).toEqual({
+      kind: 'draftReady',
+      identity: draftReady.identity,
+      source,
+    });
+    expect(expectSuccess(discardFailed, {type: 'retryDiscard'})).toEqual({
+      kind: 'draftReady',
+      identity: draftReady.identity,
+      source,
+    });
+  });
+
+  it.each([
+    {state: queued, action: {type: 'cancel'} as const},
+    {state: uploading, action: {type: 'cancel'} as const},
+  ])('allows cancellation from $state.kind without stale fields', ({state, action}) => {
+    expect(expectSuccess(state, action)).toEqual({kind: 'cancelled', identity: state.identity, source});
+  });
+
+  it('makes repeated cancellation idempotent', () => {
+    const cancelled = expectSuccess(queued, {type: 'cancel'});
+    const result = transition(cancelled, {type: 'cancel'});
+    expect(resultModule.isOk(result)).toBe(true);
+    expect(resultModule.isOk(result) && result.value).toBe(cancelled);
+  });
+
+  it('rejects repeated publish and discard after terminal outcomes', () => {
+    const published = {...draftReady, kind: 'published'} as UploadState;
+    const discarded = {...draftReady, kind: 'discarded'} as UploadState;
+    expect(expectFailure(published, {type: 'publish'}).kind).toBe('invalidTransition');
+    expect(expectFailure(discarded, {type: 'discard'}).kind).toBe('invalidTransition');
+  });
+
+  it('returns a Result instead of throwing for invalid actions', () => {
+    const result = transition(publishedState(), {type: 'startUpload'});
+    expect(result.isErr).toBe(true);
+  });
+});
+
+const publishedState = (): UploadState => ({...draftReady, kind: 'published'}) as UploadState;

--- a/apps/webapp/src/script/repositories/cells/upload/transition.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/transition.ts
@@ -1,0 +1,203 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Result} from 'true-myth';
+
+import type {UploadAction, UploadLifecycleError, UploadState} from './lifecycle';
+
+export const normalizeProgress = (progress: number): number => {
+  if (Number.isNaN(progress)) {
+    return 0;
+  }
+
+  return Math.min(1, Math.max(0, progress));
+};
+
+const invalidTransition = (state: UploadState, action: UploadAction): Result<UploadState, UploadLifecycleError> =>
+  Result.err({kind: 'invalidTransition', from: state.kind, action: action.type});
+
+const transitionFromQueued = (state: Extract<UploadState, {kind: 'queued'}>, action: UploadAction) => {
+  if (action.type === 'startUpload') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'uploading',
+      identity: state.identity,
+      source: state.source,
+      progress: 0,
+    });
+  }
+
+  if (action.type === 'cancel') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'cancelled',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromUploading = (state: Extract<UploadState, {kind: 'uploading'}>, action: UploadAction) => {
+  if (action.type === 'progress') {
+    return Result.ok<UploadState, UploadLifecycleError>({...state, progress: normalizeProgress(action.progress)});
+  }
+
+  if (action.type === 'uploadSucceeded') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'draftReady',
+      identity: {...state.identity, resourceUuid: action.resourceUuid, versionId: action.versionId},
+      source: state.source,
+    });
+  }
+
+  if (action.type === 'uploadFailed') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'uploadFailed',
+      identity: state.identity,
+      source: state.source,
+      error: action.error,
+    });
+  }
+
+  if (action.type === 'cancel') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'cancelled',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromDraftReady = (state: Extract<UploadState, {kind: 'draftReady'}>, action: UploadAction) => {
+  if (action.type === 'publish') {
+    return Result.ok<UploadState, UploadLifecycleError>({...state, kind: 'publishing'});
+  }
+
+  if (action.type === 'discard') {
+    return Result.ok<UploadState, UploadLifecycleError>({...state, kind: 'discarding'});
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromUploadFailed = (state: Extract<UploadState, {kind: 'uploadFailed'}>, action: UploadAction) => {
+  if (action.type === 'retryUpload') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'queued',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromPublishing = (state: Extract<UploadState, {kind: 'publishing'}>, action: UploadAction) => {
+  if (action.type === 'publishSucceeded') {
+    return Result.ok<UploadState, UploadLifecycleError>({...state, kind: 'published'});
+  }
+
+  if (action.type === 'publishFailed') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'publishFailed',
+      identity: state.identity,
+      source: state.source,
+      error: action.error,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromPublishFailed = (state: Extract<UploadState, {kind: 'publishFailed'}>, action: UploadAction) => {
+  if (action.type === 'retryPublish') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'draftReady',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromDiscarding = (state: Extract<UploadState, {kind: 'discarding'}>, action: UploadAction) => {
+  if (action.type === 'discardSucceeded') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'discarded',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  if (action.type === 'discardFailed') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'discardFailed',
+      identity: state.identity,
+      source: state.source,
+      error: action.error,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromDiscardFailed = (state: Extract<UploadState, {kind: 'discardFailed'}>, action: UploadAction) => {
+  if (action.type === 'retryDiscard') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'draftReady',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+export const transition = (state: UploadState, action: UploadAction): Result<UploadState, UploadLifecycleError> => {
+  if (action.type === 'progress' && state.kind !== 'uploading') {
+    return Result.ok(state);
+  }
+
+  switch (state.kind) {
+    case 'queued':
+      return transitionFromQueued(state, action);
+    case 'uploading':
+      return transitionFromUploading(state, action);
+    case 'draftReady':
+      return transitionFromDraftReady(state, action);
+    case 'uploadFailed':
+      return transitionFromUploadFailed(state, action);
+    case 'publishing':
+      return transitionFromPublishing(state, action);
+    case 'published':
+    case 'discarded':
+      return invalidTransition(state, action);
+    case 'publishFailed':
+      return transitionFromPublishFailed(state, action);
+    case 'discarding':
+      return transitionFromDiscarding(state, action);
+    case 'discardFailed':
+      return transitionFromDiscardFailed(state, action);
+    case 'cancelled':
+      return action.type === 'cancel' ? Result.ok(state) : invalidTransition(state, action);
+  }
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28356" title="WPB-28356" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28356</a>  [web] create logic library for handling upload (non-ui)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem

The upload manager currently only has the gateway contract. Its tests use fakes, so it cannot talk to a real `CellsRepository` yet. Moving the conversation UI at the same time would make this PR much bigger and mix the repository integration with the UI change

## Solution

Added the production gateway adapter for upload, progress, abort, publish, and discard. The manager owns the attempt IDs and cancellation while the current conversation flow stays unchanged, including the existing cancellation path

This gives the next PR one real boundary to connect to the UI instead of making the UI deal with the Cells transport. This PR is stacked on #22341

https://wearezeta.atlassian.net/browse/WPB-28356