### PR TITLE
Respect the regional locale when formatting message timestamps [WPB-28427]

### DIFF
--- a/apps/webapp/src/script/localization/Localizer.test.ts
+++ b/apps/webapp/src/script/localization/Localizer.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {resolveApplicationLocale} from './Localizer';
+
+describe('resolveApplicationLocale', (): void => {
+  it.each([
+    {browserRegionalLocale: 'en-GB', expectedApplicationLanguage: 'en', expectedRegionalDateLocale: 'en-GB'},
+    {browserRegionalLocale: 'en-US', expectedApplicationLanguage: 'en', expectedRegionalDateLocale: 'en-US'},
+    {browserRegionalLocale: 'de-DE', expectedApplicationLanguage: 'de', expectedRegionalDateLocale: 'de-DE'},
+  ])(
+    'keeps the application language and regional locale separate for $browserRegionalLocale',
+    ({browserRegionalLocale, expectedApplicationLanguage, expectedRegionalDateLocale}): void => {
+      const actualLocaleSettings = resolveApplicationLocale({
+        queryParameter: undefined,
+        storedLocale: undefined,
+        browserRegionalLocale,
+      });
+
+      expect(actualLocaleSettings.applicationTranslationLanguage).toBe(expectedApplicationLanguage);
+      expect(actualLocaleSettings.regionalDateLocale).toBe(expectedRegionalDateLocale);
+    },
+  );
+});

--- a/apps/webapp/src/script/localization/Localizer.ts
+++ b/apps/webapp/src/script/localization/Localizer.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {isNonEmptyString} from '@sindresorhus/is';
+
 import cs from 'I18n/cs-CZ.json';
 import da from 'I18n/da-DK.json';
 import de from 'I18n/de-DE.json';
@@ -43,7 +45,7 @@ import uk from 'I18n/uk-UA.json';
 import {StorageKey} from 'Repositories/storage/storageKey';
 import {DEFAULT_LOCALE, setLocale, setStrings} from 'Util/localizerUtil';
 import {loadValue, storeValue} from 'Util/storageUtil';
-import {setDateLocale, LocaleType} from 'Util/timeUtil';
+import {setDateLocale, setRegionalDateLocale} from 'Util/timeUtil';
 import {getParameter} from 'Util/urlUtil';
 
 import {URLParameter} from '../auth/urlParameter';
@@ -76,18 +78,65 @@ const strings = {
 
 setStrings(strings);
 
-export function setAppLocale() {
-  const queryParam = getParameter(URLParameter.LOCALE);
-  const currentBrowserLocale = navigator.language.slice(0, 2) as LocaleType;
+type ApplicationTranslationLanguage = keyof typeof strings;
 
-  if (queryParam) {
+export type ApplicationLocaleResolutionInput = {
+  queryParameter: unknown;
+  storedLocale: unknown;
+  browserRegionalLocale: string;
+};
+
+export type ApplicationLocaleSettings = {
+  applicationTranslationLanguage: ApplicationTranslationLanguage;
+  regionalDateLocale: string;
+};
+
+function isApplicationTranslationLanguage(value: string): value is ApplicationTranslationLanguage {
+  return Object.hasOwn(strings, value);
+}
+
+export function resolveApplicationLocale(input: ApplicationLocaleResolutionInput): ApplicationLocaleSettings {
+  const browserLanguage = input.browserRegionalLocale.split('-')[0];
+  let selectedLanguage: string = DEFAULT_LOCALE;
+
+  if (isNonEmptyString(input.queryParameter)) {
+    selectedLanguage = input.queryParameter;
+  } else if (isNonEmptyString(input.storedLocale)) {
+    selectedLanguage = input.storedLocale;
+  } else if (isNonEmptyString(browserLanguage)) {
+    selectedLanguage = browserLanguage;
+  }
+
+  let applicationTranslationLanguage: ApplicationTranslationLanguage = DEFAULT_LOCALE;
+  if (isApplicationTranslationLanguage(selectedLanguage)) {
+    applicationTranslationLanguage = selectedLanguage;
+  }
+
+  return {
+    applicationTranslationLanguage,
+    regionalDateLocale: input.browserRegionalLocale,
+  };
+}
+
+export function setAppLocale(): void {
+  const queryParam = getParameter(URLParameter.LOCALE);
+  const currentBrowserRegionalLocale = navigator.language;
+
+  if (isNonEmptyString(queryParam)) {
     storeValue(StorageKey.LOCALIZATION.LOCALE, queryParam);
   }
 
-  const storedLocale = loadValue<LocaleType>(StorageKey.LOCALIZATION.LOCALE);
-  const locale: LocaleType = storedLocale || currentBrowserLocale || (DEFAULT_LOCALE as LocaleType);
-  setLocale(locale);
-  setDateLocale(locale);
+  const storedLocale = loadValue<unknown>(StorageKey.LOCALIZATION.LOCALE);
+  const resolvedLocaleSettings = resolveApplicationLocale({
+    queryParameter: queryParam,
+    storedLocale,
+    browserRegionalLocale: currentBrowserRegionalLocale,
+  });
+  const {applicationTranslationLanguage, regionalDateLocale} = resolvedLocaleSettings;
 
-  document.getElementsByTagName('html')[0].setAttribute('lang', locale);
+  setLocale(applicationTranslationLanguage);
+  setDateLocale(applicationTranslationLanguage);
+  setRegionalDateLocale(regionalDateLocale);
+
+  document.getElementsByTagName('html')[0].setAttribute('lang', applicationTranslationLanguage);
 }

--- a/apps/webapp/src/script/util/timeUtil.test.ts
+++ b/apps/webapp/src/script/util/timeUtil.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {formatDateNumeral, formatDayMonthNumeral, formatLocale, setDateLocale, setRegionalDateLocale} from './timeUtil';
+
+const fixedLocalCalendarDate = new Date(2026, 6, 27, 12, 0, 0, 0);
+
+describe('regional numeric date formatting', (): void => {
+  beforeEach((): void => {
+    setDateLocale('en');
+    setRegionalDateLocale('en-US');
+  });
+
+  afterEach((): void => {
+    setDateLocale('en');
+    setRegionalDateLocale('en-US');
+  });
+
+  it.each([
+    {regionalLocale: 'en-US', expectedDate: '07/27/2026', expectedDayMonth: '07/27'},
+    {regionalLocale: 'en-GB', expectedDate: '27/07/2026', expectedDayMonth: '27/07'},
+    {regionalLocale: 'de-DE', expectedDate: '27.07.2026', expectedDayMonth: '27.07.'},
+  ])('uses the date order for $regionalLocale', ({regionalLocale, expectedDate, expectedDayMonth}): void => {
+    setRegionalDateLocale(regionalLocale);
+
+    const actualDate = formatDateNumeral(fixedLocalCalendarDate);
+    const actualDayMonth = formatDayMonthNumeral(fixedLocalCalendarDate);
+
+    expect(actualDate).toBe(expectedDate);
+    expect(actualDayMonth).toBe(expectedDayMonth);
+  });
+
+  it('keeps date-fns language formatting separate from regional numeric formatting', (): void => {
+    setDateLocale('de');
+    setRegionalDateLocale('en-GB');
+
+    const actualMonthName = formatLocale(fixedLocalCalendarDate, 'MMMM');
+    const actualDate = formatDateNumeral(fixedLocalCalendarDate);
+
+    expect(actualMonthName).toBe('Juli');
+    expect(actualDate).toBe('27/07/2026');
+  });
+});

--- a/apps/webapp/src/script/util/timeUtil.ts
+++ b/apps/webapp/src/script/util/timeUtil.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {
   differenceInDays,
   differenceInHours,
@@ -83,14 +84,88 @@ export enum TIME_IN_MILLIS {
   WEEK = DAY * 7,
   YEAR = DAY * 365,
 }
-const locales = {cs, da, de, el, es, et, fi, fr, hr, hu, it, lt, nl, pl, pt, ro, ru, sk, sl, tr, uk};
-const defaultLocale = enUS;
-let locale = defaultLocale;
-export type LocaleType = keyof typeof locales;
-export const setDateLocale = (newLocale: LocaleType) => (locale = locales[newLocale] ?? defaultLocale);
+const dateFnsLocales = {
+  cs,
+  da,
+  de,
+  el,
+  en: enUS,
+  es,
+  et,
+  fi,
+  fr,
+  hr,
+  hu,
+  it,
+  lt,
+  nl,
+  pl,
+  pt,
+  ro,
+  ru,
+  sk,
+  sl,
+  tr,
+  uk,
+};
+const defaultDateFnsLocale = enUS;
+let dateFnsLocale = defaultDateFnsLocale;
+export type LocaleType = keyof typeof dateFnsLocales;
+
+const DEFAULT_REGIONAL_DATE_LOCALE = 'en-US';
+let regionalDateLocale = DEFAULT_REGIONAL_DATE_LOCALE;
+
+const numeralDateFormatOptions: Intl.DateTimeFormatOptions = {
+  day: '2-digit',
+  month: '2-digit',
+  year: 'numeric',
+};
+const dayMonthNumeralFormatOptions: Intl.DateTimeFormatOptions = {
+  day: '2-digit',
+  month: '2-digit',
+};
+
+function findDateFnsLocale(localeName: string): typeof enUS {
+  const matchingLocale = Object.entries(dateFnsLocales).find(
+    ([supportedLocaleName]): boolean => supportedLocaleName === localeName,
+  );
+
+  if (isUndefined(matchingLocale)) {
+    return defaultDateFnsLocale;
+  }
+
+  return matchingLocale[1];
+}
+
+function resolveRegionalDateLocale(localeName: string): string {
+  try {
+    const supportedLocales = Intl.DateTimeFormat.supportedLocalesOf(localeName);
+    const firstSupportedLocale = supportedLocales[0];
+
+    if (isUndefined(firstSupportedLocale)) {
+      return DEFAULT_REGIONAL_DATE_LOCALE;
+    }
+
+    return firstSupportedLocale;
+  } catch {
+    return DEFAULT_REGIONAL_DATE_LOCALE;
+  }
+}
+
+export function setDateLocale(newLocale: string): void {
+  dateFnsLocale = findDateFnsLocale(newLocale);
+}
+
+export function setRegionalDateLocale(newLocale: string): void {
+  regionalDateLocale = resolveRegionalDateLocale(newLocale);
+}
 
 export const formatLocale = (date: FnDate | string | number, formatString: string) =>
-  format(new Date(date), formatString, {locale});
+  format(new Date(date), formatString, {locale: dateFnsLocale});
+
+function formatRegionalDate(date: FnDate | string | number, options: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat(regionalDateLocale, options).format(new Date(date));
+}
 
 /**
  * Format the time as `12:00 AM`.
@@ -106,17 +181,18 @@ export const formatDateShort = (date: FnDate | string | number) => formatLocale(
 export const formatDayMonth = (date: FnDate | string | number) =>
   formatDateShort(date)
     .replace(/[0-9]{4}/g, '')
-    .replace(locale === de ? /^\s*|\s*$/g : /^\W|\W$|\W\W/, '');
+    .replace(dateFnsLocale === de ? /^\s*|\s*$/g : /^\W|\W$|\W\W/, '');
 
 /**
- * Format the date as `05/29/2020`.
- * This is equivalent to momentjs' `L` formatting
+ * Format the date numerically according to the browser's regional locale.
  */
-export const formatDateNumeral = (date: FnDate | string | number) => formatLocale(date, 'P');
-export const formatDayMonthNumeral = (date: FnDate | string | number) =>
-  formatDateNumeral(date)
-    .replace(/[0-9]{4}/g, '')
-    .replace(locale === de ? /^\s*|\s*$/g : /^\W|\W$|\W\W/, '');
+export function formatDateNumeral(date: FnDate | string | number): string {
+  return formatRegionalDate(date, numeralDateFormatOptions);
+}
+
+export function formatDayMonthNumeral(date: FnDate | string | number): string {
+  return formatRegionalDate(date, dayMonthNumeralFormatOptions);
+}
 
 const durationUnits = (translate: Translate) => [
   {
@@ -290,7 +366,7 @@ export const isYoungerThanMinute = (date: FnDate): boolean => differenceInMinute
 export const isYoungerThan1Hour = (date: FnDate) => differenceInHours(new Date(), date) < 1;
 export const isYoungerThan7Days = (date: FnDate) => differenceInDays(new Date(), date) < 7;
 
-export const fromNowLocale = (date: FnDate) => formatDistanceToNow(date, {addSuffix: true, locale});
+export const fromNowLocale = (date: FnDate) => formatDistanceToNow(date, {addSuffix: true, locale: dateFnsLocale});
 
 export {isToday, fromUnixTime, isYesterday, isSameDay, isSameMonth, isThisYear, differenceInHours, differenceInMinutes};
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28427" title="WPB-28427" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28427</a>  [Web] Message timestamp tooltip ignores the regional date format
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Message timestamp tooltips do not respect the user's regional locale.

The application reduces the browser locale to its language component before configuring date formatting. As a result, regional English locales such as `en-GB` fall back to the US date format and display dates such as `07/27/2026` instead of `27/07/2026`.

---

<img width="220" height="106" alt="image" src="https://github.com/user-attachments/assets/bb547302-9e23-4959-9d38-34352e0f1c4f" />
