### PR TITLE
feat: land Cells upload module on main [WPB-28356]

### DIFF
--- a/apps/webapp/src/script/repositories/cells/cellsRepository.test.ts
+++ b/apps/webapp/src/script/repositories/cells/cellsRepository.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {APIClient} from '../../service/apiClientSingleton';
+
+import {CellsRepository} from './cellsRepository';
+
+type UploadCall = {
+  readonly abortController: AbortController;
+  readonly resolve: () => void;
+  readonly reject: (error: unknown) => void;
+};
+
+const createRepository = () => {
+  const calls: UploadCall[] = [];
+  const apiClient = {
+    api: {
+      cells: {
+        uploadNodeDraft: jest.fn(
+          ({abortController}: UploadCall) =>
+            new Promise<void>((resolve, reject) => {
+              calls.push({abortController, resolve, reject});
+            }),
+        ),
+      },
+    },
+  };
+
+  return {repository: new CellsRepository(apiClient as unknown as APIClient), calls};
+};
+
+const upload = (repository: CellsRepository, options?: {uuid?: string; abortController?: AbortController}) =>
+  repository.uploadNodeDraft({
+    uuid: options?.uuid ?? 'upload-id',
+    file: new File(['content'], 'document.txt', {type: 'text/plain'}),
+    path: 'conversation-path',
+    versionId: 'version-id',
+    abortController: options?.abortController,
+  });
+
+describe('CellsRepository upload cancellation', () => {
+  it('cancels legacy uploads through cancelUpload', async () => {
+    const {repository, calls} = createRepository();
+    const uploadTask = upload(repository);
+
+    await Promise.resolve();
+    repository.cancelUpload('upload-id');
+
+    expect(calls[0].abortController.signal.aborted).toBe(true);
+    calls[0].resolve();
+    await uploadTask;
+  });
+
+  it('does not register a manager-owned controller in the legacy cancellation map', async () => {
+    const {repository, calls} = createRepository();
+    const controller = new AbortController();
+    const uploadTask = upload(repository, {abortController: controller});
+
+    await Promise.resolve();
+    repository.cancelUpload('upload-id');
+
+    expect(calls[0].abortController).toBe(controller);
+    expect(controller.signal.aborted).toBe(false);
+    controller.abort();
+    calls[0].resolve();
+    await uploadTask;
+  });
+
+  it('keeps the newest legacy controller when overlapping uploads share an ID', async () => {
+    const {repository, calls} = createRepository();
+    const firstUpload = upload(repository, {uuid: 'shared-id'});
+    const secondUpload = upload(repository, {uuid: 'shared-id'});
+
+    await Promise.resolve();
+    calls[0].resolve();
+    await firstUpload;
+    repository.cancelUpload('shared-id');
+
+    expect(calls[0].abortController.signal.aborted).toBe(false);
+    expect(calls[1].abortController.signal.aborted).toBe(true);
+    calls[1].resolve();
+    await secondUpload;
+  });
+});

--- a/apps/webapp/src/script/repositories/cells/cellsRepository.ts
+++ b/apps/webapp/src/script/repositories/cells/cellsRepository.ts
@@ -67,18 +67,22 @@ export class CellsRepository {
     uuid,
     file,
     path,
+    versionId = createUuid(),
     progressCallback,
+    abortController,
   }: {
     uuid: string;
     file: File;
     path: string;
+    versionId?: string;
     progressCallback?: (progress: number) => void;
+    abortController?: AbortController;
   }): Promise<{uuid: string; versionId: string}> {
     const filePath = `${path || this.basePath}/${file.name}`;
-    const versionId = createUuid();
-
-    const controller = new AbortController();
-    this.uploadControllers.set(uuid, controller);
+    const controller = abortController ?? new AbortController();
+    if (!abortController) {
+      this.uploadControllers.set(uuid, controller);
+    }
 
     try {
       await this.apiClient.api.cells.uploadNodeDraft({
@@ -90,20 +94,16 @@ export class CellsRepository {
         abortController: controller,
       });
 
-      return {
-        uuid,
-        versionId,
-      };
+      return {uuid, versionId};
     } finally {
-      this.uploadControllers.delete(uuid);
+      if (!abortController && this.uploadControllers.get(uuid) === controller) {
+        this.uploadControllers.delete(uuid);
+      }
     }
   }
 
   cancelUpload(uuid: string): void {
-    const controller = this.uploadControllers.get(uuid);
-    if (controller) {
-      controller.abort();
-    }
+    this.uploadControllers.get(uuid)?.abort();
   }
 
   async deleteNodeDraft({uuid, versionId}: {uuid: string; versionId: string}) {

--- a/apps/webapp/src/script/repositories/cells/cellsRepositoryGateway.test.ts
+++ b/apps/webapp/src/script/repositories/cells/cellsRepositoryGateway.test.ts
@@ -1,0 +1,239 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {Task} from 'true-myth';
+
+import {createCellsRepositoryGateway} from './cellsRepositoryGateway';
+import type {DraftIdentity, UploadSource} from './upload/identity';
+import {createCellsUploadManager} from './upload/manager';
+
+const identity: DraftIdentity = {uploadId: 'local-upload', resourceUuid: 'remote-resource', versionId: 'version-1'};
+const source: UploadSource = {
+  blob: new File(['content'], 'document.txt', {type: 'text/plain'}),
+  name: 'document.txt',
+  contentType: 'text/plain',
+  size: 7,
+};
+
+const createRepository = () => ({
+  uploadNodeDraft: jest.fn().mockResolvedValue({uuid: identity.resourceUuid, versionId: identity.versionId}),
+  promoteNodeDraft: jest.fn().mockResolvedValue(undefined),
+  deleteNodeDraft: jest.fn().mockResolvedValue(undefined),
+});
+
+describe('createCellsRepositoryGateway', () => {
+  it('forwards the manager identity, path, abort controller, and progress callback', async () => {
+    const repository = createRepository();
+    const gateway = createCellsRepositoryGateway(repository);
+    const controller = new AbortController();
+    const onProgress = jest.fn();
+
+    const result = await gateway.uploadDraft({
+      uploadId: identity.uploadId,
+      attemptId: 'attempt-1',
+      identity,
+      source,
+      path: 'conversation-path',
+      signal: controller.signal,
+      abortController: controller,
+      onProgress,
+    });
+
+    expect(result).toMatchObject({
+      isOk: true,
+      value: {uploadId: identity.uploadId, resourceUuid: identity.resourceUuid, versionId: identity.versionId},
+    });
+    expect(repository.uploadNodeDraft).toHaveBeenCalledWith({
+      uuid: identity.resourceUuid,
+      file: source.blob,
+      path: 'conversation-path',
+      versionId: identity.versionId,
+      abortController: controller,
+      progressCallback: onProgress,
+    });
+  });
+
+  it('preserves a repository-returned remote identity while retaining the local upload ID', async () => {
+    const repository = createRepository();
+    const remoteIdentity = {uuid: 'remote-resource', versionId: 'remote-version'};
+    repository.uploadNodeDraft.mockResolvedValueOnce(remoteIdentity);
+    const gateway = createCellsRepositoryGateway(repository);
+    const controller = new AbortController();
+
+    const result = await gateway.uploadDraft({
+      uploadId: identity.uploadId,
+      attemptId: 'attempt-1',
+      identity,
+      source,
+      path: 'conversation-path',
+      signal: controller.signal,
+      abortController: controller,
+      onProgress: jest.fn(),
+    });
+
+    expect(result).toMatchObject({
+      isOk: true,
+      value: {uploadId: identity.uploadId, resourceUuid: remoteIdentity.uuid, versionId: remoteIdentity.versionId},
+    });
+  });
+
+  it('converts a generic Blob while preserving upload metadata and content', async () => {
+    const repository = createRepository();
+    const gateway = createCellsRepositoryGateway(repository);
+    const blobSource: UploadSource = {
+      blob: new Blob(['payload'], {type: 'application/octet-stream'}),
+      name: 'archive.bin',
+      contentType: 'application/octet-stream',
+      size: 7,
+    };
+
+    const result = await gateway.uploadDraft({
+      uploadId: identity.uploadId,
+      attemptId: 'attempt-1',
+      identity,
+      source: blobSource,
+      path: 'conversation-path',
+      signal: new AbortController().signal,
+      abortController: new AbortController(),
+      onProgress: jest.fn(),
+    });
+
+    const forwardedFile = repository.uploadNodeDraft.mock.calls[0][0].file as File;
+    expect(result.isOk).toBe(true);
+    expect(forwardedFile).toBeInstanceOf(File);
+    expect(forwardedFile.name).toBe('archive.bin');
+    expect(forwardedFile.type).toBe('application/octet-stream');
+    expect(forwardedFile.size).toBe(7);
+    const content = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result));
+      reader.onerror = () => reject(reader.error);
+      reader.readAsText(forwardedFile);
+    });
+    expect(content).toBe('payload');
+  });
+
+  it('maps upload, publish, and discard failures to operation-specific gateway errors', async () => {
+    const repository = createRepository();
+    repository.uploadNodeDraft.mockRejectedValueOnce(new Error('upload failed'));
+    repository.promoteNodeDraft.mockRejectedValueOnce(new Error('publish failed'));
+    repository.deleteNodeDraft.mockRejectedValueOnce(new Error('discard failed'));
+    const gateway = createCellsRepositoryGateway(repository);
+    const request = {
+      uploadId: identity.uploadId,
+      attemptId: 'attempt-1',
+      identity,
+      source,
+      path: 'conversation-path',
+      signal: new AbortController().signal,
+      abortController: new AbortController(),
+      onProgress: jest.fn(),
+    };
+
+    await expect(gateway.uploadDraft(request)).resolves.toMatchObject({
+      isErr: true,
+      error: {kind: 'gatewayError', operation: 'upload', cause: new Error('upload failed')},
+    });
+    await expect(gateway.publishDraft(identity)).resolves.toMatchObject({
+      isErr: true,
+      error: {kind: 'gatewayError', operation: 'publish', cause: new Error('publish failed')},
+    });
+    await expect(gateway.discardDraft(identity)).resolves.toMatchObject({
+      isErr: true,
+      error: {kind: 'gatewayError', operation: 'discard', cause: new Error('discard failed')},
+    });
+  });
+
+  it('maps a synchronous repository throw to a typed upload gateway error', async () => {
+    const repository = createRepository();
+    const failure = new Error('synchronous upload failure');
+    repository.uploadNodeDraft.mockImplementationOnce(() => {
+      throw failure;
+    });
+    const gateway = createCellsRepositoryGateway(repository);
+
+    await expect(
+      gateway.uploadDraft({
+        uploadId: identity.uploadId,
+        attemptId: 'attempt-1',
+        identity,
+        source,
+        path: 'conversation-path',
+        signal: new AbortController().signal,
+        abortController: new AbortController(),
+        onProgress: jest.fn(),
+      }),
+    ).resolves.toMatchObject({
+      isErr: true,
+      error: {kind: 'gatewayError', operation: 'upload', cause: failure},
+    });
+  });
+
+  it('maps an aborted repository request to a typed upload gateway error', async () => {
+    const repository = createRepository();
+    const controller = new AbortController();
+    const abortError = new DOMException('The upload was aborted', 'AbortError');
+    controller.abort();
+    repository.uploadNodeDraft.mockRejectedValueOnce(abortError);
+    const gateway = createCellsRepositoryGateway(repository);
+
+    await expect(
+      gateway.uploadDraft({
+        uploadId: identity.uploadId,
+        attemptId: 'attempt-1',
+        identity,
+        source,
+        path: 'conversation-path',
+        signal: controller.signal,
+        abortController: controller,
+        onProgress: jest.fn(),
+      }),
+    ).resolves.toMatchObject({
+      isErr: true,
+      error: {kind: 'gatewayError', operation: 'upload', cause: abortError},
+    });
+  });
+
+  it('lets manager cancellation abort the controller forwarded to the repository', async () => {
+    let resolveUpload!: () => void;
+    const repository = createRepository();
+    repository.uploadNodeDraft.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveUpload = () => resolve(undefined);
+        }),
+    );
+    const manager = createCellsUploadManager({
+      gateway: createCellsRepositoryGateway(repository),
+      createResourceUuid: () => identity.resourceUuid,
+      createVersionUuid: () => identity.versionId,
+      createAttemptId: () => 'attempt-1',
+      createAbortController: () => new AbortController(),
+    });
+
+    manager.register(identity.uploadId, source, 'conversation-path');
+    const start = manager.start(identity.uploadId);
+    await Promise.resolve();
+    const controller = repository.uploadNodeDraft.mock.calls[0][0].abortController;
+
+    await manager.cancel(identity.uploadId);
+    expect(controller?.signal.aborted).toBe(true);
+    resolveUpload();
+    await start;
+  });
+
+  it('returns successful publish and discard tasks', async () => {
+    const repository = createRepository();
+    const gateway = createCellsRepositoryGateway(repository);
+
+    expect(await gateway.publishDraft(identity)).toMatchObject({isOk: true, value: undefined});
+    expect(await gateway.discardDraft(identity)).toMatchObject({isOk: true, value: undefined});
+  });
+});

--- a/apps/webapp/src/script/repositories/cells/cellsRepositoryGateway.ts
+++ b/apps/webapp/src/script/repositories/cells/cellsRepositoryGateway.ts
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Task, task} from 'true-myth';
+
+import type {CellsRepository} from './cellsRepository';
+import type {CellsUploadGateway, CellsUploadGatewayError} from './upload/gateway';
+
+type CellsRepositoryUploadGateway = Pick<CellsRepository, 'uploadNodeDraft' | 'promoteNodeDraft' | 'deleteNodeDraft'>;
+type TaskExecutor<T> = () => PromiseLike<T>;
+
+const execute = <T, TOperation extends CellsUploadGatewayError['operation']>(
+  operation: TOperation,
+  executor: TaskExecutor<T>,
+): Task<T, CellsUploadGatewayError<TOperation>> =>
+  task.tryOrElse(
+    reason => ({kind: 'gatewayError', operation, cause: reason}),
+    () => Promise.resolve().then(executor),
+  );
+
+/** Adapts the app-side Cells repository to the lifecycle manager contract. */
+export const createCellsRepositoryGateway = (cellsRepository: CellsRepositoryUploadGateway): CellsUploadGateway => ({
+  uploadDraft: request =>
+    execute('upload', () =>
+      cellsRepository
+        .uploadNodeDraft({
+          uuid: request.identity.resourceUuid,
+          file:
+            request.source.blob instanceof File
+              ? request.source.blob
+              : new File([request.source.blob], request.source.name, {type: request.source.contentType}),
+          path: request.path,
+          versionId: request.identity.versionId,
+          abortController: request.abortController,
+          progressCallback: request.onProgress,
+        })
+        .then(result => ({
+          uploadId: request.identity.uploadId,
+          resourceUuid: result.uuid,
+          versionId: result.versionId,
+        })),
+    ),
+  publishDraft: identity =>
+    execute('publish', () =>
+      cellsRepository
+        .promoteNodeDraft({uuid: identity.resourceUuid, versionId: identity.versionId})
+        .then(() => undefined),
+    ),
+  discardDraft: identity =>
+    execute('discard', () =>
+      cellsRepository
+        .deleteNodeDraft({uuid: identity.resourceUuid, versionId: identity.versionId})
+        .then(() => undefined),
+    ),
+});

--- a/apps/webapp/src/script/repositories/cells/upload/gateway.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/gateway.ts
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {Task} from 'true-myth';
+
+import type {DraftIdentity, UploadSource} from './identity';
+
+export type CellsUploadGatewayOperation = 'upload' | 'publish' | 'discard';
+export type CellsUploadGatewayError<TOperation extends CellsUploadGatewayOperation = CellsUploadGatewayOperation> = {
+  readonly kind: 'gatewayError';
+  readonly operation: TOperation;
+  readonly cause: unknown;
+};
+
+export type UploadDraftRequest = {
+  readonly uploadId: string;
+  readonly attemptId: string;
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+  readonly path: string;
+  readonly signal: AbortSignal;
+  readonly abortController: AbortController;
+  readonly onProgress: (progress: number) => void;
+};
+
+export interface CellsUploadGateway {
+  readonly uploadDraft: (request: UploadDraftRequest) => Task<DraftIdentity, CellsUploadGatewayError<'upload'>>;
+  readonly publishDraft: (identity: DraftIdentity) => Task<void, CellsUploadGatewayError<'publish'>>;
+  readonly discardDraft: (identity: DraftIdentity) => Task<void, CellsUploadGatewayError<'discard'>>;
+}

--- a/apps/webapp/src/script/repositories/cells/upload/identity.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/identity.ts
@@ -1,0 +1,34 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export interface UploadSource {
+  readonly blob: Blob;
+  readonly name: string;
+  readonly contentType: string;
+  readonly size: number;
+}
+
+export interface UploadIdentity {
+  readonly uploadId: string;
+}
+
+export interface DraftIdentity extends UploadIdentity {
+  readonly resourceUuid: string;
+  readonly versionId: string;
+}

--- a/apps/webapp/src/script/repositories/cells/upload/index.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './gateway';
+export * from './identity';
+export * from './lifecycle';
+export * from './manager';
+export * from './process';
+export * from './transition';

--- a/apps/webapp/src/script/repositories/cells/upload/lifecycle.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/lifecycle.ts
@@ -1,0 +1,149 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {DraftIdentity, UploadIdentity, UploadSource} from './identity';
+
+export interface QueuedState {
+  readonly kind: 'queued';
+  readonly identity: UploadIdentity;
+  readonly source: UploadSource;
+}
+
+export interface UploadingState {
+  readonly kind: 'uploading';
+  readonly identity: UploadIdentity;
+  readonly source: UploadSource;
+  readonly progress: number;
+}
+
+export interface DraftReadyState {
+  readonly kind: 'draftReady';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface UploadFailedState {
+  readonly kind: 'uploadFailed';
+  readonly identity: UploadIdentity;
+  readonly source: UploadSource;
+  readonly error: UploadLifecycleError;
+}
+
+export interface PublishingState {
+  readonly kind: 'publishing';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface PublishedState {
+  readonly kind: 'published';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface PublishFailedState {
+  readonly kind: 'publishFailed';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+  readonly error: UploadLifecycleError;
+}
+
+export interface DiscardingState {
+  readonly kind: 'discarding';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface DiscardedState {
+  readonly kind: 'discarded';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+}
+
+export interface DiscardFailedState {
+  readonly kind: 'discardFailed';
+  readonly identity: DraftIdentity;
+  readonly source: UploadSource;
+  readonly error: UploadLifecycleError;
+}
+
+export interface CancelledState {
+  readonly kind: 'cancelled';
+  readonly identity: UploadIdentity;
+  readonly source: UploadSource;
+}
+
+export type UploadState =
+  | QueuedState
+  | UploadingState
+  | DraftReadyState
+  | UploadFailedState
+  | PublishingState
+  | PublishedState
+  | PublishFailedState
+  | DiscardingState
+  | DiscardedState
+  | DiscardFailedState
+  | CancelledState;
+
+export type UploadActionType =
+  | 'startUpload'
+  | 'progress'
+  | 'uploadSucceeded'
+  | 'uploadFailed'
+  | 'publish'
+  | 'publishSucceeded'
+  | 'publishFailed'
+  | 'discard'
+  | 'discardSucceeded'
+  | 'discardFailed'
+  | 'retryUpload'
+  | 'retryPublish'
+  | 'retryDiscard'
+  | 'cancel';
+
+export type UploadFailureError = {readonly kind: 'uploadFailed'; readonly cause: unknown};
+export type PublishFailureError = {readonly kind: 'publishFailed'; readonly cause: unknown};
+export type DiscardFailureError = {readonly kind: 'discardFailed'; readonly cause: unknown};
+
+export type UploadLifecycleError =
+  | {
+      readonly kind: 'invalidTransition';
+      readonly from: UploadState['kind'];
+      readonly action: UploadActionType | 'release';
+    }
+  | UploadFailureError
+  | PublishFailureError
+  | DiscardFailureError;
+
+export type UploadAction =
+  | {readonly type: 'startUpload'}
+  | {readonly type: 'progress'; readonly progress: number}
+  | {readonly type: 'uploadSucceeded'; readonly resourceUuid: string; readonly versionId: string}
+  | {readonly type: 'uploadFailed'; readonly error: UploadFailureError}
+  | {readonly type: 'publish'}
+  | {readonly type: 'publishSucceeded'}
+  | {readonly type: 'publishFailed'; readonly error: PublishFailureError}
+  | {readonly type: 'discard'}
+  | {readonly type: 'discardSucceeded'}
+  | {readonly type: 'discardFailed'; readonly error: DiscardFailureError}
+  | {readonly type: 'retryUpload'}
+  | {readonly type: 'retryPublish'}
+  | {readonly type: 'retryDiscard'}
+  | {readonly type: 'cancel'};

--- a/apps/webapp/src/script/repositories/cells/upload/manager.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/manager.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {noop} from 'noop-esm';
+import {Task} from 'true-myth';
+
+import type {CellsUploadGateway, CellsUploadGatewayError, UploadDraftRequest} from './gateway';
+import {createCellsUploadManager} from './manager';
+import type {DraftIdentity, UploadSource} from './identity';
+
+const source: UploadSource = {blob: new Blob(['data']), name: 'file.txt', contentType: 'text/plain', size: 4};
+const path = 'wire-cells-web/conversation-1';
+
+const required = <T>(value: T | undefined): T => {
+  expect(value).toBeDefined();
+  return value as T;
+};
+
+const deferred = () => {
+  let resolve!: (value?: DraftIdentity) => void;
+  let reject!: (error: CellsUploadGatewayError<'upload'>) => void;
+  const task = new Task<DraftIdentity, CellsUploadGatewayError<'upload'>>((resolveTask, rejectTask) => {
+    resolve = value => resolveTask(value ?? {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'});
+    reject = rejectTask;
+  });
+  return {task, resolve, reject};
+};
+
+const deferredManager = () => {
+  const requests: UploadDraftRequest[] = [];
+  const tasks: ReturnType<typeof deferred>[] = [];
+  const gateway: CellsUploadGateway = {
+    uploadDraft: request => {
+      requests.push(request);
+      const result = deferred();
+      tasks.push(result);
+      return result.task;
+    },
+    publishDraft: () => Task.resolve<void, never>(undefined),
+    discardDraft: () => Task.resolve<void, never>(undefined),
+  };
+  const instance = createCellsUploadManager({
+    gateway,
+    createResourceUuid: () => 'resource-1',
+    createVersionUuid: () => 'version-1',
+    createAttemptId: () => 'attempt-1',
+    createAbortController: () => new AbortController(),
+  });
+  return {instance, requests, tasks};
+};
+
+describe('createCellsUploadManager', () => {
+  const manager = () => {
+    const requests: UploadDraftRequest[] = [];
+    const gateway: CellsUploadGateway = {
+      uploadDraft: request => {
+        requests.push(request);
+        return Task.resolve<DraftIdentity, never>({
+          uploadId: request.uploadId,
+          resourceUuid: request.identity.resourceUuid,
+          versionId: request.identity.versionId,
+        });
+      },
+      publishDraft: () => Task.resolve<void, never>(undefined),
+      discardDraft: () => Task.resolve<void, never>(undefined),
+    };
+    const instance = createCellsUploadManager({
+      gateway,
+      createResourceUuid: () => 'resource-1',
+      createVersionUuid: () => 'version-1',
+      createAttemptId: () => 'attempt-1',
+      createAbortController: () => new AbortController(),
+    });
+    return {instance, requests};
+  };
+
+  it('registers by caller-owned upload ID and rejects duplicate IDs', () => {
+    const fixture = manager();
+    expect(fixture.instance.register('upload-1', source, path).isOk).toBe(true);
+    expect(fixture.instance.register('upload-1', source, path)).toMatchObject({
+      isErr: true,
+      error: {kind: 'duplicateUpload', uploadId: 'upload-1'},
+    });
+    expect(fixture.instance.snapshot('upload-1')).toMatchObject({isOk: true, value: {kind: 'queued'}});
+  });
+
+  it('returns typed unknown-upload errors for every manager operation', async () => {
+    const fixture = manager();
+    expect(fixture.instance.snapshot('missing')).toMatchObject({
+      isErr: true,
+      error: {kind: 'unknownUpload', uploadId: 'missing'},
+    });
+    expect(fixture.instance.subscribe('missing', noop)).toMatchObject({
+      isErr: true,
+      error: {kind: 'unknownUpload'},
+    });
+    const start = await fixture.instance.start('missing');
+    const cancel = await fixture.instance.cancel('missing');
+    const retryUpload = await fixture.instance.retryUpload('missing');
+    const publish = await fixture.instance.publish('missing');
+    const retryPublish = await fixture.instance.retryPublish('missing');
+    const discard = await fixture.instance.discard('missing');
+    const retryDiscard = await fixture.instance.retryDiscard('missing');
+    expect(start).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(cancel).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(retryUpload).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(publish).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(retryPublish).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(discard).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(retryDiscard).toMatchObject({isErr: true, error: {kind: 'unknownUpload', uploadId: 'missing'}});
+    expect(fixture.instance.release('missing')).toMatchObject({isErr: true, error: {kind: 'unknownUpload'}});
+  });
+
+  it('ignores an old process success after cancel, release, and re-register', async () => {
+    const fixture = deferredManager();
+    fixture.instance.register('upload-1', source, path);
+    const oldStart = fixture.instance.start('upload-1');
+    const oldTask = required(fixture.tasks[0]);
+    await fixture.instance.cancel('upload-1');
+    expect(fixture.instance.release('upload-1').isOk).toBe(true);
+
+    fixture.instance.register('upload-1', source, path);
+    const events: string[] = [];
+    fixture.instance.subscribe('upload-1', snapshot => events.push(snapshot.kind));
+    const newStart = fixture.instance.start('upload-1');
+    const beforeOldSettlement = fixture.instance.snapshot('upload-1');
+    oldTask.resolve(undefined);
+    await oldStart;
+    expect(fixture.instance.snapshot('upload-1')).toEqual(beforeOldSettlement);
+    expect(events).toEqual(['queued', 'uploading']);
+    required(fixture.tasks[1]).resolve(undefined);
+    await newStart;
+    expect(fixture.instance.snapshot('upload-1')).toMatchObject({isOk: true, value: {kind: 'draftReady'}});
+  });
+
+  it('ignores an old process failure after cancel, release, and re-register', async () => {
+    const fixture = deferredManager();
+    fixture.instance.register('upload-1', source, path);
+    const oldStart = fixture.instance.start('upload-1');
+    const oldTask = required(fixture.tasks[0]);
+    await fixture.instance.cancel('upload-1');
+    expect(fixture.instance.release('upload-1').isOk).toBe(true);
+
+    fixture.instance.register('upload-1', source, path);
+    const events: string[] = [];
+    fixture.instance.subscribe('upload-1', snapshot => events.push(snapshot.kind));
+    const newStart = fixture.instance.start('upload-1');
+    const beforeOldSettlement = fixture.instance.snapshot('upload-1');
+    oldTask.reject({kind: 'gatewayError', operation: 'upload', cause: 'stale'});
+    await oldStart;
+    expect(fixture.instance.snapshot('upload-1')).toEqual(beforeOldSettlement);
+    expect(events).toEqual(['queued', 'uploading']);
+    required(fixture.tasks[1]).resolve(undefined);
+    await newStart;
+    expect(fixture.instance.snapshot('upload-1')).toMatchObject({isOk: true, value: {kind: 'draftReady'}});
+  });
+
+  it('releases terminal uploads and removes the registry entry', async () => {
+    const fixture = manager();
+    fixture.instance.register('upload-1', source, path);
+    await fixture.instance.start('upload-1');
+    expect(fixture.requests[0].path).toBe(path);
+    await fixture.instance.publish('upload-1');
+    expect(fixture.instance.release('upload-1').isOk).toBe(true);
+    expect(fixture.instance.snapshot('upload-1')).toMatchObject({isErr: true, error: {kind: 'unknownUpload'}});
+  });
+
+  it('rejects release while non-terminal', () => {
+    const fixture = manager();
+    fixture.instance.register('upload-1', source, path);
+    expect(fixture.instance.release('upload-1')).toMatchObject({
+      isErr: true,
+      error: {kind: 'invalidTransition', action: 'release'},
+    });
+  });
+});

--- a/apps/webapp/src/script/repositories/cells/upload/manager.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/manager.ts
@@ -1,0 +1,109 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe, Result, maybe} from 'true-myth';
+
+import type {UploadSource} from './identity';
+import type {UploadState} from './lifecycle';
+import {
+  createCellsUploadProcess,
+  type CellsUploadProcess,
+  type CellsUploadProcessDependencies,
+  type UploadProcessError,
+  type UploadSnapshotListener,
+} from './process';
+
+export type CellsUploadManagerError =
+  | UploadProcessError
+  | {readonly kind: 'unknownUpload'; readonly uploadId: string}
+  | {readonly kind: 'duplicateUpload'; readonly uploadId: string};
+
+export type CellsUploadManager = {
+  readonly register: (uploadId: string, source: UploadSource, path: string) => Result<void, CellsUploadManagerError>;
+  readonly snapshot: (uploadId: string) => Result<UploadState, CellsUploadManagerError>;
+  readonly subscribe: (
+    uploadId: string,
+    listener: UploadSnapshotListener,
+  ) => Result<() => void, CellsUploadManagerError>;
+  readonly start: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly cancel: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly retryUpload: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly publish: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly retryPublish: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly discard: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly retryDiscard: (uploadId: string) => Promise<Result<void, CellsUploadManagerError>>;
+  readonly release: (uploadId: string) => Result<void, CellsUploadManagerError>;
+};
+
+export const createCellsUploadManager = (dependencies: CellsUploadProcessDependencies): CellsUploadManager => {
+  const processes = new Map<string, CellsUploadProcess>();
+  const unknown = <T>(uploadId: string): Result<T, CellsUploadManagerError> =>
+    Result.err({kind: 'unknownUpload', uploadId});
+  const processFor = (uploadId: string): Result<CellsUploadProcess, CellsUploadManagerError> => {
+    const process = Maybe.of(processes.get(uploadId));
+    return maybe.isJust(process) ? Result.ok(process.value) : unknown(uploadId);
+  };
+  const command = (
+    uploadId: string,
+    name: 'start' | 'cancel' | 'retryUpload' | 'publish' | 'retryPublish' | 'discard' | 'retryDiscard',
+  ) => {
+    const process = processFor(uploadId);
+    return process.isErr ? Promise.resolve(Result.err(process.error)) : process.value[name]();
+  };
+
+  const register = (uploadId: string, source: UploadSource, path: string): Result<void, CellsUploadManagerError> => {
+    if (processes.has(uploadId)) {
+      return Result.err({kind: 'duplicateUpload', uploadId});
+    }
+    processes.set(uploadId, createCellsUploadProcess(uploadId, source, path, dependencies));
+    return Result.ok(undefined);
+  };
+
+  const release = (uploadId: string): Result<void, CellsUploadManagerError> => {
+    const process = processFor(uploadId);
+    if (process.isErr) {
+      return Result.err(process.error);
+    }
+    const result = process.value.release();
+    if (result.isOk) {
+      processes.delete(uploadId);
+    }
+    return result;
+  };
+
+  return {
+    register,
+    snapshot: uploadId => {
+      const process = processFor(uploadId);
+      return process.isErr ? Result.err(process.error) : process.value.snapshot();
+    },
+    subscribe: (uploadId, listener) => {
+      const process = processFor(uploadId);
+      return process.isErr ? Result.err(process.error) : process.value.subscribe(listener);
+    },
+    start: uploadId => command(uploadId, 'start'),
+    cancel: uploadId => command(uploadId, 'cancel'),
+    retryUpload: uploadId => command(uploadId, 'retryUpload'),
+    publish: uploadId => command(uploadId, 'publish'),
+    retryPublish: uploadId => command(uploadId, 'retryPublish'),
+    discard: uploadId => command(uploadId, 'discard'),
+    retryDiscard: uploadId => command(uploadId, 'retryDiscard'),
+    release,
+  };
+};

--- a/apps/webapp/src/script/repositories/cells/upload/process.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.test.ts
@@ -1,0 +1,386 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Task} from 'true-myth';
+import type {Result} from 'true-myth';
+
+import type {CellsUploadGateway, CellsUploadGatewayError, UploadDraftRequest} from './gateway';
+import type {DraftIdentity, UploadSource} from './identity';
+import {createCellsUploadProcess, type CellsUploadProcessDependencies} from './process';
+
+const source: UploadSource = {blob: new Blob(['data']), name: 'file.txt', contentType: 'text/plain', size: 4};
+const path = 'wire-cells-web/conversation-1';
+
+const required = <T>(value: T | undefined): T => {
+  expect(value).toBeDefined();
+  return value as T;
+};
+
+const unwrapResult = <T, E>(result: Result<T, E>): T => {
+  expect(result.isOk).toBe(true);
+  return result.unwrapOr(undefined as never);
+};
+
+const deferred = <T, E>(defaultValue?: T) => {
+  let resolve!: (value?: T) => void;
+  let reject!: (error: E) => void;
+  const value = new Task<T, E>((resolveTask, rejectTask) => {
+    resolve = nextValue => resolveTask(nextValue ?? (defaultValue as T));
+    reject = rejectTask;
+  });
+  return {value, resolve, reject};
+};
+
+const setup = (
+  failure?: 'publish' | 'discard' | 'mismatch',
+  duplicateAttemptIds = false,
+  remoteIdentity: DraftIdentity = {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+) => {
+  const uploads: UploadDraftRequest[] = [];
+  const uploadTasks: ReturnType<typeof deferred<DraftIdentity, CellsUploadGatewayError<'upload'>>>[] = [];
+  const aborts: AbortController[] = [];
+  const published = [] as string[];
+  const discarded = [] as string[];
+  let failureMode = failure;
+  const gateway: CellsUploadGateway = {
+    uploadDraft: request => {
+      uploads.push(request);
+      if (failureMode === 'mismatch') {
+        return Task.reject<DraftIdentity, CellsUploadGatewayError<'upload'>>({
+          kind: 'gatewayError',
+          operation: 'publish' as CellsUploadGatewayError<'upload'>['operation'],
+          cause: 'mismatched-operation',
+        });
+      }
+      const task = deferred<DraftIdentity, CellsUploadGatewayError<'upload'>>(remoteIdentity);
+      uploadTasks.push(task);
+      return task.value;
+    },
+    publishDraft: identity => {
+      published.push(identity.versionId);
+      return failureMode === 'publish'
+        ? Task.reject<void, CellsUploadGatewayError<'publish'>>({
+            kind: 'gatewayError',
+            operation: 'publish',
+            cause: 'offline',
+          })
+        : Task.resolve<void, never>(undefined);
+    },
+    discardDraft: identity => {
+      discarded.push(identity.versionId);
+      return failureMode === 'discard'
+        ? Task.reject<void, CellsUploadGatewayError<'discard'>>({
+            kind: 'gatewayError',
+            operation: 'discard',
+            cause: 'offline',
+          })
+        : Task.resolve<void, never>(undefined);
+    },
+  };
+  let version = 0;
+  let attempt = 0;
+  const dependencies: CellsUploadProcessDependencies = {
+    gateway,
+    createResourceUuid: () => 'resource-1',
+    createVersionUuid: () => `version-${++version}`,
+    createAttemptId: () => (duplicateAttemptIds ? 'attempt-1' : `attempt-${++attempt}`),
+    createAbortController: () => {
+      const controller = new AbortController();
+      aborts.push(controller);
+      return controller;
+    },
+  };
+  return {
+    process: createCellsUploadProcess('upload-1', source, path, dependencies),
+    uploads,
+    uploadTasks,
+    aborts,
+    published,
+    discarded,
+    setFailure: (mode?: 'publish' | 'discard') => {
+      failureMode = mode;
+    },
+  };
+};
+
+const unwrap = async <T, E>(promise: PromiseLike<{isOk: boolean; value?: T; error?: E}>) => {
+  const result = await promise;
+  expect(result.isOk).toBe(true);
+  return result;
+};
+
+describe('createCellsUploadProcess', () => {
+  it('uploads successfully and emits ordered snapshots', async () => {
+    const fixture = setup();
+    const snapshots: string[] = [];
+    const subscription = fixture.process.subscribe(snapshot => snapshots.push(snapshot.kind));
+    expect(subscription.isOk).toBe(true);
+    const start = fixture.process.start();
+    required(fixture.uploads[0]).onProgress(0.25);
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+    expect(snapshots).toEqual(['queued', 'uploading', 'uploading', 'draftReady']);
+  });
+
+  it('uses the repository-returned remote identity after upload', async () => {
+    const remoteIdentity: DraftIdentity = {
+      uploadId: 'upload-1',
+      resourceUuid: 'remote-resource',
+      versionId: 'remote-version',
+    };
+    const fixture = setup(undefined, false, remoteIdentity);
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+
+    expect(fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source})).toEqual({
+      kind: 'draftReady',
+      identity: remoteIdentity,
+      source,
+    });
+    await unwrap(fixture.process.publish());
+    expect(fixture.published).toEqual(['remote-version']);
+  });
+
+  it('reports typed upload failure and aborts only the active attempt', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'offline'});
+    const result = await start;
+    expect(result.isErr).toBe(true);
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({kind: 'uploadFailed'});
+    expect(required(fixture.aborts[0]).signal.aborted).toBe(false);
+  });
+
+  it('cancels queued work without creating a controller and is idempotent', async () => {
+    const fixture = setup();
+    await unwrap(fixture.process.cancel());
+    expect(fixture.aborts).toHaveLength(0);
+    await unwrap(fixture.process.cancel());
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({kind: 'cancelled'});
+  });
+
+  it('aborts an active upload and suppresses its late result', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    await unwrap(fixture.process.cancel());
+    required(fixture.uploads[0]).onProgress(0.9);
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+    expect(required(fixture.aborts[0]).signal.aborted).toBe(true);
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({kind: 'cancelled'});
+  });
+
+  it('suppresses stale progress callbacks after a retry starts', async () => {
+    const fixture = setup();
+    const first = fixture.process.start();
+    const firstRequest = required(fixture.uploads[0]);
+    expect(firstRequest.path).toBe(path);
+    firstRequest.onProgress(0.25);
+    required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'offline'});
+    await first;
+
+    const retry = fixture.process.retryUpload();
+    const secondRequest = required(fixture.uploads[1]);
+    expect(secondRequest.path).toBe(path);
+    expect(secondRequest.identity).toMatchObject({resourceUuid: 'resource-1', versionId: 'version-2'});
+    expect(secondRequest.attemptId).toBe('attempt-2');
+    const snapshots: string[] = [];
+    required(fixture.process.subscribe(snapshot => snapshots.push(snapshot.kind)));
+    firstRequest.onProgress(0.9);
+    firstRequest.onProgress(1);
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
+      kind: 'uploading',
+      progress: 0,
+    });
+    required(fixture.uploadTasks[1]).resolve(undefined);
+    await unwrap(retry);
+    expect(snapshots).toEqual(['uploading', 'draftReady']);
+  });
+
+  it('isolates retries when the injected attempt IDs are duplicated', async () => {
+    const fixture = setup(undefined, true);
+    const first = fixture.process.start();
+    const firstRequest = required(fixture.uploads[0]);
+    required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'offline'});
+    await first;
+
+    const retry = fixture.process.retryUpload();
+    const secondRequest = required(fixture.uploads[1]);
+    expect(secondRequest.attemptId).toBe(firstRequest.attemptId);
+    firstRequest.onProgress(0.9);
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
+      kind: 'uploading',
+      progress: 0,
+    });
+    required(fixture.uploadTasks[1]).resolve(undefined);
+    await unwrap(retry);
+  });
+
+  it('normalizes a mismatched gateway operation at the process boundary', async () => {
+    const fixture = setup('mismatch');
+    const result = await fixture.process.start();
+    expect(result).toMatchObject({
+      isErr: true,
+      error: {
+        kind: 'gatewayError',
+        operation: 'upload',
+        cause: {kind: 'gatewayError', operation: 'publish', cause: 'mismatched-operation'},
+      },
+    });
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'cancelled', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
+      kind: 'uploadFailed',
+      error: {
+        kind: 'uploadFailed',
+        cause: {kind: 'gatewayError', operation: 'upload'},
+      },
+    });
+  });
+
+  it('suppresses a late failure after cancellation', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    const request = required(fixture.uploads[0]);
+    await unwrap(fixture.process.cancel());
+    request.onProgress(0.9);
+    required(fixture.uploadTasks[0]).reject({kind: 'gatewayError', operation: 'upload', cause: 'late'});
+    await unwrap(start);
+    expect(
+      fixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
+      kind: 'cancelled',
+    });
+  });
+
+  it('reports publish and discard failures with recoverable clean states', async () => {
+    const publishFailure = setup('publish');
+    const publishStart = publishFailure.process.start();
+    required(publishFailure.uploadTasks[0]).resolve(undefined);
+    await publishStart;
+    expect((await publishFailure.process.publish()).isErr).toBe(true);
+    expect(
+      publishFailure.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toEqual({
+      kind: 'publishFailed',
+      identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+      source,
+      error: {kind: 'publishFailed', cause: {kind: 'gatewayError', operation: 'publish', cause: 'offline'}},
+    });
+
+    const discardFailure = setup('discard');
+    const discardStart = discardFailure.process.start();
+    required(discardFailure.uploadTasks[0]).resolve(undefined);
+    await discardStart;
+    expect((await discardFailure.process.discard()).isErr).toBe(true);
+    expect(
+      discardFailure.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toMatchObject({
+      kind: 'discardFailed',
+      error: {kind: 'discardFailed', cause: {kind: 'gatewayError', operation: 'discard', cause: 'offline'}},
+    });
+  });
+
+  it('retries publish and discard successfully after their failures', async () => {
+    const publishFixture = setup('publish');
+    const publishStart = publishFixture.process.start();
+    required(publishFixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(publishStart);
+    await publishFixture.process.publish();
+    publishFixture.setFailure();
+    await unwrap(publishFixture.process.retryPublish());
+    expect(
+      publishFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toEqual({
+      kind: 'published',
+      identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+      source,
+    });
+
+    const discardFixture = setup('discard');
+    const discardStart = discardFixture.process.start();
+    required(discardFixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(discardStart);
+    await discardFixture.process.discard();
+    discardFixture.setFailure();
+    await unwrap(discardFixture.process.retryDiscard());
+    expect(
+      discardFixture.process.snapshot().unwrapOr({kind: 'queued', identity: {uploadId: 'missing'}, source}),
+    ).toEqual({
+      kind: 'discarded',
+      identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+      source,
+    });
+  });
+
+  it('publishes and discards through the gateway', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+    await unwrap(fixture.process.publish());
+    expect(fixture.published).toEqual(['version-1']);
+
+    const second = setup();
+    const secondStart = second.process.start();
+    required(second.uploadTasks[0]).resolve(undefined);
+    await unwrap(secondStart);
+    await unwrap(second.process.discard());
+    expect(second.discarded).toEqual(['version-1']);
+  });
+
+  it('notifies subscribers synchronously in registration order and supports unsubscribe', async () => {
+    const fixture = setup();
+    const events: string[] = [];
+    const first = fixture.process.subscribe(() => events.push('first'));
+    const second = fixture.process.subscribe(() => events.push('second'));
+    expect(events).toEqual(['first', 'second']);
+    unwrapResult(first)();
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await start;
+    expect(events).toEqual(['first', 'second', 'second', 'second']);
+    const before = events.length;
+    unwrapResult(fixture.process.subscribe(() => events.push('third')))();
+    expect(events.length).toBe(before + 1);
+    expect(second.isOk).toBe(true);
+  });
+
+  it('releases terminal process state and rejects later snapshots', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await start;
+    await fixture.process.publish();
+    expect(fixture.process.release().isOk).toBe(true);
+    expect(fixture.process.snapshot().isErr).toBe(true);
+    expect(fixture.process.start().then(result => result.isErr)).resolves.toBe(true);
+  });
+});

--- a/apps/webapp/src/script/repositories/cells/upload/process.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.ts
@@ -1,0 +1,356 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Maybe, Result, maybe, result as resultModule, task} from 'true-myth';
+
+import type {CellsUploadGateway, CellsUploadGatewayError} from './gateway';
+import type {DraftIdentity, UploadSource} from './identity';
+import type {UploadAction, UploadLifecycleError, UploadState} from './lifecycle';
+import {transition} from './transition';
+
+export type UploadProcessError = UploadLifecycleError | CellsUploadGatewayError | {readonly kind: 'released'};
+export type UploadSnapshotListener = (snapshot: UploadState) => void;
+export type AbortControllerFactory = () => AbortController;
+export type IdFactory = () => string;
+
+export type CellsUploadProcessDependencies = {
+  readonly gateway: CellsUploadGateway;
+  readonly createResourceUuid: IdFactory;
+  readonly createVersionUuid: IdFactory;
+  readonly createAttemptId: IdFactory;
+  readonly createAbortController: AbortControllerFactory;
+};
+
+export type CellsUploadProcess = {
+  readonly snapshot: () => Result<UploadState, UploadProcessError>;
+  readonly subscribe: (listener: UploadSnapshotListener) => Result<() => void, UploadProcessError>;
+  readonly start: () => Promise<Result<void, UploadProcessError>>;
+  readonly cancel: () => Promise<Result<void, UploadProcessError>>;
+  readonly retryUpload: () => Promise<Result<void, UploadProcessError>>;
+  readonly publish: () => Promise<Result<void, UploadProcessError>>;
+  readonly retryPublish: () => Promise<Result<void, UploadProcessError>>;
+  readonly discard: () => Promise<Result<void, UploadProcessError>>;
+  readonly retryDiscard: () => Promise<Result<void, UploadProcessError>>;
+  readonly release: () => Result<void, UploadProcessError>;
+};
+
+type Attempt = {
+  readonly id: string;
+  readonly controller: AbortController;
+  readonly identity: DraftIdentity;
+};
+
+const isSameState = (left: UploadState, right: UploadState): boolean => {
+  if (left === right || left.kind !== right.kind) {
+    return left === right;
+  }
+  const leftRecord = left as unknown as Record<string, unknown>;
+  const rightRecord = right as unknown as Record<string, unknown>;
+  const keys = new Set([...Object.keys(leftRecord), ...Object.keys(rightRecord)]);
+  return [...keys].every(key => leftRecord[key] === rightRecord[key]);
+};
+
+export const createCellsUploadProcess = (
+  uploadId: string,
+  source: UploadSource,
+  path: string,
+  dependencies: CellsUploadProcessDependencies,
+): CellsUploadProcess => {
+  let state: Maybe<UploadState> = Maybe.just({kind: 'queued', identity: {uploadId}, source});
+  let activeSource: Maybe<UploadSource> = Maybe.just(source);
+  let resourceUuid: Maybe<string> = Maybe.nothing();
+  let currentAttempt: Maybe<Attempt> = Maybe.nothing();
+  let operationId = 0;
+  let released = false;
+  const subscribers = new Set<UploadSnapshotListener>();
+
+  const releasedResult = <T>(): Result<T, UploadProcessError> => Result.err({kind: 'released'});
+  const snapshot = (): Result<UploadState, UploadProcessError> =>
+    maybe.isJust(state) ? Result.ok(state.value) : releasedResult();
+
+  const notify = (previous: UploadState, next: UploadState): void => {
+    if (isSameState(previous, next)) {
+      return;
+    }
+    state = Maybe.just(next);
+    subscribers.forEach(listener => listener(next));
+  };
+
+  const apply = (action: UploadAction): Result<UploadState, UploadLifecycleError> => {
+    if (maybe.isNothing(state)) {
+      return Result.err({kind: 'invalidTransition', from: 'cancelled', action: action.type});
+    }
+    const result = transition(state.value, action);
+    if (resultModule.isErr(result)) {
+      return result;
+    }
+    notify(state.value, result.value);
+    return result;
+  };
+
+  const isGatewayError = (
+    reason: unknown,
+    operation: CellsUploadGatewayError['operation'],
+  ): reason is CellsUploadGatewayError =>
+    typeof reason === 'object' &&
+    reason !== null &&
+    (reason as {kind?: unknown; operation?: unknown}).kind === 'gatewayError' &&
+    (reason as {kind?: unknown; operation?: unknown}).operation === operation;
+
+  const safeGateway = <T>(
+    operation: CellsUploadGatewayError['operation'],
+    call: () => PromiseLike<Result<T, CellsUploadGatewayError>>,
+  ) =>
+    task.tryOrElse(
+      reason =>
+        isGatewayError(reason, operation) ? reason : {kind: 'gatewayError' as const, operation, cause: reason},
+      async () => {
+        const result = await call();
+        return resultModule.isErr(result) ? Promise.reject(result.error) : result.value;
+      },
+    );
+
+  const isCurrentAttempt = (attempt: Attempt): boolean => {
+    const activeAttempt = currentAttempt;
+    const currentState = state;
+    return (
+      maybe.isJust(activeAttempt) &&
+      activeAttempt.value === attempt &&
+      maybe.isJust(currentState) &&
+      currentState.value.kind === 'uploading'
+    );
+  };
+
+  const runUpload = async (): Promise<Result<void, UploadProcessError>> => {
+    const currentState = state;
+    const currentResourceUuid = resourceUuid;
+    const currentSource = activeSource;
+    if (
+      maybe.isNothing(currentState) ||
+      currentState.value.kind !== 'uploading' ||
+      maybe.isNothing(currentResourceUuid) ||
+      maybe.isNothing(currentSource)
+    ) {
+      return Result.err({
+        kind: 'invalidTransition',
+        from: maybe.isJust(currentState) ? currentState.value.kind : 'cancelled',
+        action: 'startUpload',
+      });
+    }
+    const attempt: Attempt = {
+      id: dependencies.createAttemptId(),
+      controller: dependencies.createAbortController(),
+      identity: {uploadId, resourceUuid: currentResourceUuid.value, versionId: dependencies.createVersionUuid()},
+    };
+    currentAttempt = Maybe.just(attempt);
+    const gatewayResult = await safeGateway('upload', () =>
+      dependencies.gateway.uploadDraft({
+        uploadId,
+        attemptId: attempt.id,
+        identity: attempt.identity,
+        source: currentSource.value,
+        path,
+        signal: attempt.controller.signal,
+        abortController: attempt.controller,
+        onProgress: progress => {
+          if (isCurrentAttempt(attempt)) {
+            apply({type: 'progress', progress});
+          }
+        },
+      }),
+    );
+
+    if (!isCurrentAttempt(attempt)) {
+      return Result.ok(undefined);
+    }
+    currentAttempt = Maybe.nothing();
+    if (resultModule.isErr(gatewayResult)) {
+      apply({type: 'uploadFailed', error: {kind: 'uploadFailed', cause: gatewayResult.error}});
+      return Result.err(gatewayResult.error);
+    }
+    resourceUuid = Maybe.just(gatewayResult.value.resourceUuid);
+    apply({
+      type: 'uploadSucceeded',
+      resourceUuid: gatewayResult.value.resourceUuid,
+      versionId: gatewayResult.value.versionId,
+    });
+    return Result.ok(undefined);
+  };
+
+  const start = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    if (maybe.isNothing(resourceUuid)) {
+      resourceUuid = Maybe.just(dependencies.createResourceUuid());
+    }
+    const result = apply({type: 'startUpload'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    return runUpload();
+  };
+
+  const cancel = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    if (maybe.isJust(state) && state.value.kind === 'cancelled') {
+      return Result.ok(undefined);
+    }
+    const result = apply({type: 'cancel'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    const attempt = currentAttempt;
+    currentAttempt = Maybe.nothing();
+    if (maybe.isJust(attempt)) {
+      attempt.value.controller.abort();
+    }
+    return Result.ok(undefined);
+  };
+
+  const retryUpload = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'retryUpload'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    return start();
+  };
+
+  const runDraftOperation = async (
+    operation: 'publish' | 'discard',
+    identity: DraftIdentity,
+    completion: UploadAction,
+  ): Promise<Result<void, UploadProcessError>> => {
+    const operationToken = ++operationId;
+    const gatewayResult = await safeGateway(operation, () =>
+      operation === 'publish'
+        ? dependencies.gateway.publishDraft(identity)
+        : dependencies.gateway.discardDraft(identity),
+    );
+    if (
+      released ||
+      operationToken !== operationId ||
+      maybe.isNothing(state) ||
+      state.value.kind !== `${operation}ing`
+    ) {
+      return Result.ok(undefined);
+    }
+    if (resultModule.isErr(gatewayResult)) {
+      apply(
+        operation === 'publish'
+          ? {type: 'publishFailed', error: {kind: 'publishFailed', cause: gatewayResult.error}}
+          : {type: 'discardFailed', error: {kind: 'discardFailed', cause: gatewayResult.error}},
+      );
+      return Result.err(gatewayResult.error);
+    }
+    apply(completion);
+    return Result.ok(undefined);
+  };
+
+  const publish = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'publish'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    if (result.value.kind !== 'publishing') {
+      return Result.err({kind: 'invalidTransition', from: result.value.kind, action: 'publish'});
+    }
+    return runDraftOperation('publish', result.value.identity, {type: 'publishSucceeded'});
+  };
+
+  const retryPublish = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'retryPublish'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    return publish();
+  };
+
+  const discard = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'discard'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    if (result.value.kind !== 'discarding') {
+      return Result.err({kind: 'invalidTransition', from: result.value.kind, action: 'discard'});
+    }
+    return runDraftOperation('discard', result.value.identity, {type: 'discardSucceeded'});
+  };
+
+  const retryDiscard = async (): Promise<Result<void, UploadProcessError>> => {
+    if (released) {
+      return releasedResult();
+    }
+    const result = apply({type: 'retryDiscard'});
+    if (resultModule.isErr(result)) {
+      return Result.err(result.error);
+    }
+    return discard();
+  };
+
+  const subscribe = (listener: UploadSnapshotListener): Result<() => void, UploadProcessError> => {
+    if (maybe.isNothing(state)) {
+      return releasedResult();
+    }
+    subscribers.add(listener);
+    listener(state.value);
+    return Result.ok(() => subscribers.delete(listener));
+  };
+
+  const release = (): Result<void, UploadProcessError> => {
+    if (released) {
+      return releasedResult();
+    }
+    if (maybe.isNothing(state) || !['published', 'discarded', 'cancelled'].includes(state.value.kind)) {
+      return Result.err({
+        kind: 'invalidTransition',
+        from: maybe.isJust(state) ? state.value.kind : 'cancelled',
+        action: 'release',
+      });
+    }
+    const attempt = currentAttempt;
+    currentAttempt = Maybe.nothing();
+    if (maybe.isJust(attempt)) {
+      attempt.value.controller.abort();
+    }
+    operationId += 1;
+    subscribers.clear();
+    state = Maybe.nothing();
+    activeSource = Maybe.nothing();
+    resourceUuid = Maybe.nothing();
+    released = true;
+    return Result.ok(undefined);
+  };
+
+  return {snapshot, subscribe, start, cancel, retryUpload, publish, retryPublish, discard, retryDiscard, release};
+};

--- a/apps/webapp/src/script/repositories/cells/upload/transition.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/transition.test.ts
@@ -1,0 +1,188 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {result as resultModule} from 'true-myth';
+
+import type {UploadAction, UploadLifecycleError, UploadState} from './lifecycle';
+import {normalizeProgress, transition} from './transition';
+
+const source = {blob: new Blob(['content']), name: 'file.txt', contentType: 'text/plain', size: 7};
+const queued: UploadState = {kind: 'queued', identity: {uploadId: 'upload-1'}, source};
+const uploading: UploadState = {...queued, kind: 'uploading', progress: 0};
+const draftReady: UploadState = {
+  kind: 'draftReady',
+  identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+  source,
+};
+const publishing: UploadState = {...draftReady, kind: 'publishing'};
+const publishFailed: UploadState = {
+  ...publishing,
+  kind: 'publishFailed',
+  error: {kind: 'publishFailed', cause: 'offline'},
+};
+const discarding: UploadState = {...draftReady, kind: 'discarding'};
+const discardFailed: UploadState = {
+  ...discarding,
+  kind: 'discardFailed',
+  error: {kind: 'discardFailed', cause: 'offline'},
+};
+
+const expectSuccess = (state: UploadState, action: UploadAction): UploadState => {
+  const result = transition(state, action);
+  expect(result.isOk).toBe(true);
+  return resultModule.isOk(result) ? result.value : state;
+};
+
+const expectFailure = (state: UploadState, action: UploadAction): UploadLifecycleError => {
+  const result = transition(state, action);
+  expect(resultModule.isErr(result)).toBe(true);
+  return resultModule.isErr(result)
+    ? result.error
+    : ({kind: 'invalidTransition', from: state.kind, action: action.type} as UploadLifecycleError);
+};
+
+describe('normalizeProgress', () => {
+  it.each([
+    {progress: -0.1, expected: 0},
+    {progress: 0, expected: 0},
+    {progress: 0.25, expected: 0.25},
+    {progress: 1, expected: 1},
+    {progress: 1.5, expected: 1},
+    {progress: Number.NaN, expected: 0},
+  ])('normalizes $progress to the inclusive 0..1 range', ({progress, expected}) => {
+    expect(normalizeProgress(progress)).toBe(expected);
+  });
+});
+
+describe('transition', () => {
+  it.each([
+    {state: queued, action: {type: 'startUpload'} as const, expected: 'uploading'},
+    {
+      state: uploading,
+      action: {type: 'uploadSucceeded', resourceUuid: 'resource-1', versionId: 'version-1'} as const,
+      expected: 'draftReady',
+    },
+    {
+      state: uploading,
+      action: {type: 'uploadFailed', error: {kind: 'uploadFailed', cause: 'offline'}} as const,
+      expected: 'uploadFailed',
+    },
+    {state: draftReady, action: {type: 'publish'} as const, expected: 'publishing'},
+    {state: publishing, action: {type: 'publishSucceeded'} as const, expected: 'published'},
+    {
+      state: publishing,
+      action: {type: 'publishFailed', error: {kind: 'publishFailed', cause: 'offline'}} as const,
+      expected: 'publishFailed',
+    },
+    {state: draftReady, action: {type: 'discard'} as const, expected: 'discarding'},
+    {state: discarding, action: {type: 'discardSucceeded'} as const, expected: 'discarded'},
+    {
+      state: discarding,
+      action: {type: 'discardFailed', error: {kind: 'discardFailed', cause: 'offline'}} as const,
+      expected: 'discardFailed',
+    },
+  ])('allows $state.kind + $action.type -> $expected', ({state, action, expected}) => {
+    expect(expectSuccess(state, action).kind).toBe(expected);
+  });
+
+  it('normalizes progress while uploading and ignores it outside active upload', () => {
+    expect(expectSuccess(uploading, {type: 'progress', progress: 0.5})).toMatchObject({
+      kind: 'uploading',
+      progress: 0.5,
+    });
+    const result = transition(draftReady, {type: 'progress', progress: 0.8});
+    expect(resultModule.isOk(result)).toBe(true);
+    expect(resultModule.isOk(result) && result.value).toBe(draftReady);
+  });
+
+  it('preserves upload and draft identities across transitions', () => {
+    const ready = expectSuccess(uploading, {
+      type: 'uploadSucceeded',
+      resourceUuid: 'resource-2',
+      versionId: 'version-2',
+    });
+    expect(ready).toMatchObject({identity: {uploadId: 'upload-1', resourceUuid: 'resource-2', versionId: 'version-2'}});
+  });
+
+  it('removes active progress when upload fails', () => {
+    expect(expectSuccess(uploading, {type: 'uploadFailed', error: {kind: 'uploadFailed', cause: 'offline'}})).toEqual({
+      kind: 'uploadFailed',
+      identity: queued.identity,
+      source,
+      error: {kind: 'uploadFailed', cause: 'offline'},
+    });
+  });
+
+  it.each([
+    {state: queued, action: {type: 'publish'} as const},
+    {state: uploading, action: {type: 'publish'} as const},
+    {state: publishing, action: {type: 'publish'} as const},
+    {state: publishing, action: {type: 'discard'} as const},
+    {state: publishFailed, action: {type: 'publish'} as const},
+    {state: discardFailed, action: {type: 'discard'} as const},
+    {state: draftReady, action: {type: 'cancel'} as const},
+    {state: publishFailed, action: {type: 'cancel'} as const},
+    {state: discardFailed, action: {type: 'cancel'} as const},
+    {state: {...draftReady, kind: 'published'} as UploadState, action: {type: 'publish'} as const},
+    {state: {...draftReady, kind: 'discarded'} as UploadState, action: {type: 'discard'} as const},
+  ])('returns a typed error for invalid $state.kind + $action.type', ({state, action}) => {
+    expect(expectFailure(state, action)).toMatchObject({
+      kind: 'invalidTransition',
+      from: state.kind,
+      action: action.type,
+    });
+  });
+
+  it('supports recovery from upload, publish, and discard failures without stale fields', () => {
+    expect(
+      expectSuccess(expectSuccess(uploading, {type: 'uploadFailed', error: {kind: 'uploadFailed', cause: 'offline'}}), {
+        type: 'retryUpload',
+      }),
+    ).toEqual({kind: 'queued', identity: queued.identity, source});
+    expect(expectSuccess(publishFailed, {type: 'retryPublish'})).toEqual({
+      kind: 'draftReady',
+      identity: draftReady.identity,
+      source,
+    });
+    expect(expectSuccess(discardFailed, {type: 'retryDiscard'})).toEqual({
+      kind: 'draftReady',
+      identity: draftReady.identity,
+      source,
+    });
+  });
+
+  it.each([
+    {state: queued, action: {type: 'cancel'} as const},
+    {state: uploading, action: {type: 'cancel'} as const},
+  ])('allows cancellation from $state.kind without stale fields', ({state, action}) => {
+    expect(expectSuccess(state, action)).toEqual({kind: 'cancelled', identity: state.identity, source});
+  });
+
+  it('makes repeated cancellation idempotent', () => {
+    const cancelled = expectSuccess(queued, {type: 'cancel'});
+    const result = transition(cancelled, {type: 'cancel'});
+    expect(resultModule.isOk(result)).toBe(true);
+    expect(resultModule.isOk(result) && result.value).toBe(cancelled);
+  });
+
+  it('rejects repeated publish and discard after terminal outcomes', () => {
+    const published = {...draftReady, kind: 'published'} as UploadState;
+    const discarded = {...draftReady, kind: 'discarded'} as UploadState;
+    expect(expectFailure(published, {type: 'publish'}).kind).toBe('invalidTransition');
+    expect(expectFailure(discarded, {type: 'discard'}).kind).toBe('invalidTransition');
+  });
+
+  it('returns a Result instead of throwing for invalid actions', () => {
+    const result = transition(publishedState(), {type: 'startUpload'});
+    expect(result.isErr).toBe(true);
+  });
+});
+
+const publishedState = (): UploadState => ({...draftReady, kind: 'published'}) as UploadState;

--- a/apps/webapp/src/script/repositories/cells/upload/transition.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/transition.ts
@@ -1,0 +1,203 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Result} from 'true-myth';
+
+import type {UploadAction, UploadLifecycleError, UploadState} from './lifecycle';
+
+export const normalizeProgress = (progress: number): number => {
+  if (Number.isNaN(progress)) {
+    return 0;
+  }
+
+  return Math.min(1, Math.max(0, progress));
+};
+
+const invalidTransition = (state: UploadState, action: UploadAction): Result<UploadState, UploadLifecycleError> =>
+  Result.err({kind: 'invalidTransition', from: state.kind, action: action.type});
+
+const transitionFromQueued = (state: Extract<UploadState, {kind: 'queued'}>, action: UploadAction) => {
+  if (action.type === 'startUpload') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'uploading',
+      identity: state.identity,
+      source: state.source,
+      progress: 0,
+    });
+  }
+
+  if (action.type === 'cancel') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'cancelled',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromUploading = (state: Extract<UploadState, {kind: 'uploading'}>, action: UploadAction) => {
+  if (action.type === 'progress') {
+    return Result.ok<UploadState, UploadLifecycleError>({...state, progress: normalizeProgress(action.progress)});
+  }
+
+  if (action.type === 'uploadSucceeded') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'draftReady',
+      identity: {...state.identity, resourceUuid: action.resourceUuid, versionId: action.versionId},
+      source: state.source,
+    });
+  }
+
+  if (action.type === 'uploadFailed') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'uploadFailed',
+      identity: state.identity,
+      source: state.source,
+      error: action.error,
+    });
+  }
+
+  if (action.type === 'cancel') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'cancelled',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromDraftReady = (state: Extract<UploadState, {kind: 'draftReady'}>, action: UploadAction) => {
+  if (action.type === 'publish') {
+    return Result.ok<UploadState, UploadLifecycleError>({...state, kind: 'publishing'});
+  }
+
+  if (action.type === 'discard') {
+    return Result.ok<UploadState, UploadLifecycleError>({...state, kind: 'discarding'});
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromUploadFailed = (state: Extract<UploadState, {kind: 'uploadFailed'}>, action: UploadAction) => {
+  if (action.type === 'retryUpload') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'queued',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromPublishing = (state: Extract<UploadState, {kind: 'publishing'}>, action: UploadAction) => {
+  if (action.type === 'publishSucceeded') {
+    return Result.ok<UploadState, UploadLifecycleError>({...state, kind: 'published'});
+  }
+
+  if (action.type === 'publishFailed') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'publishFailed',
+      identity: state.identity,
+      source: state.source,
+      error: action.error,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromPublishFailed = (state: Extract<UploadState, {kind: 'publishFailed'}>, action: UploadAction) => {
+  if (action.type === 'retryPublish') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'draftReady',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromDiscarding = (state: Extract<UploadState, {kind: 'discarding'}>, action: UploadAction) => {
+  if (action.type === 'discardSucceeded') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'discarded',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  if (action.type === 'discardFailed') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'discardFailed',
+      identity: state.identity,
+      source: state.source,
+      error: action.error,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+const transitionFromDiscardFailed = (state: Extract<UploadState, {kind: 'discardFailed'}>, action: UploadAction) => {
+  if (action.type === 'retryDiscard') {
+    return Result.ok<UploadState, UploadLifecycleError>({
+      kind: 'draftReady',
+      identity: state.identity,
+      source: state.source,
+    });
+  }
+
+  return invalidTransition(state, action);
+};
+
+export const transition = (state: UploadState, action: UploadAction): Result<UploadState, UploadLifecycleError> => {
+  if (action.type === 'progress' && state.kind !== 'uploading') {
+    return Result.ok(state);
+  }
+
+  switch (state.kind) {
+    case 'queued':
+      return transitionFromQueued(state, action);
+    case 'uploading':
+      return transitionFromUploading(state, action);
+    case 'draftReady':
+      return transitionFromDraftReady(state, action);
+    case 'uploadFailed':
+      return transitionFromUploadFailed(state, action);
+    case 'publishing':
+      return transitionFromPublishing(state, action);
+    case 'published':
+    case 'discarded':
+      return invalidTransition(state, action);
+    case 'publishFailed':
+      return transitionFromPublishFailed(state, action);
+    case 'discarding':
+      return transitionFromDiscarding(state, action);
+    case 'discardFailed':
+      return transitionFromDiscardFailed(state, action);
+    case 'cancelled':
+      return action.type === 'cancel' ? Result.ok(state) : invalidTransition(state, action);
+  }
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28356" title="WPB-28356" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28356</a>  [web] create logic library for handling upload (non-ui)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem

The reviewed Cells upload lifecycle, process manager, and repository gateway were merged into stacked feature branches, so the complete module never reached `main`.

## Solution

Replay the approved changes on current `main` without consumer wiring or behavior changes. This makes the module available for the new Shared Drive direct-upload button while leaving conversation upload unchanged.

https://wearezeta.atlassian.net/browse/WPB-28356
