### PR TITLE
fix overlapping of CallingCell.tsx and meetingNotificationHost.tsx [WPB-27879]

### DIFF
--- a/apps/webapp/src/script/components/calling/CallingCell/CallingCell.styles.ts
+++ b/apps/webapp/src/script/components/calling/CallingCell/CallingCell.styles.ts
@@ -19,11 +19,16 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const callingContainer: CSSObject = {
+import {meetingNotificationHostCollapsedOffset} from 'Components/meeting/meetingNotificationHost/meetingNotificationHost.styles';
+
+const callingContainerBottomPadding = 20;
+
+export const callingContainer = (hasNotifications: boolean): CSSObject => ({
   position: 'relative',
   display: 'flex',
   flexDirection: 'column',
   flexShrink: '0',
-  padding: '10px 12px 20px',
+  padding: `10px 12px ${callingContainerBottomPadding + (hasNotifications ? meetingNotificationHostCollapsedOffset : 0)}px`,
+  transition: 'padding-bottom var(--animation-timing-fast) ease-in-out',
   animation: 'show-call-ui var(--animation-timing-fast) ease-in-out 0s 1',
-};
+});

--- a/apps/webapp/src/script/components/calling/CallingCell/CallingCell.tsx
+++ b/apps/webapp/src/script/components/calling/CallingCell/CallingCell.tsx
@@ -33,6 +33,7 @@ import {GroupVideoGrid} from 'Components/calling/GroupVideoGrid';
 import {useCallAlertState} from 'Components/calling/useCallAlertState';
 import {ConversationClassifiedBar} from 'Components/classifiedBar/classifiedBar';
 import * as Icon from 'Components/icon';
+import {useMeetingNotificationStore} from 'Components/meeting/meetingNotificationStore/meetingNotificationStore';
 import {useConversationCall} from 'Hooks/useConversationCall';
 import {useNoInternetCallGuard} from 'Hooks/useNoInternetCallGuard/useNoInternetCallGuard';
 import type {Call} from 'Repositories/calling/Call';
@@ -71,6 +72,7 @@ interface AnsweringControlsProps {
   classifiedDomains?: string[];
   isTemporaryUser?: boolean;
   setMaximizedParticipant?: (participant: Participant | null) => void;
+  isNotificationHostVisible?: boolean;
 }
 
 export type CallingCellProps = VideoCallProps & AnsweringControlsProps;
@@ -88,6 +90,7 @@ export const CallingCell = ({
   callingRepository,
   propertiesRepository,
   setMaximizedParticipant,
+  isNotificationHostVisible = true,
   teamState = container.resolve(TeamState),
   callState = container.resolve(CallState),
 }: CallingCellProps) => {
@@ -120,6 +123,7 @@ export const CallingCell = ({
     'display_name',
   ]);
   const {activeCallViewTab, viewMode} = useKoSubscribableChildren(callState, ['activeCallViewTab', 'viewMode']);
+  const hasMeetingNotifications = useMeetingNotificationStore(state => state.notifications.length > 0);
 
   const guardCall = useNoInternetCallGuard({
     description: translate('callNotEstablishedDescription'),
@@ -365,7 +369,7 @@ export const CallingCell = ({
   }
 
   return (
-    <div css={callingContainer}>
+    <div css={callingContainer(isNotificationHostVisible && hasMeetingNotifications)}>
       {isIncoming && (
         <p role="alert" className="visually-hidden">
           {translate('callConversationAcceptOrDecline', {conversationName: resolvedConversationName})}

--- a/apps/webapp/src/script/components/meeting/meetingCallingView/meetingCallingView.styles.ts
+++ b/apps/webapp/src/script/components/meeting/meetingCallingView/meetingCallingView.styles.ts
@@ -19,14 +19,19 @@
 
 import {CSSObject} from '@emotion/react';
 
-export const meetingCallingViewStyles: CSSObject = {
+import {meetingNotificationHostCollapsedOffset} from 'Components/meeting/meetingNotificationHost/meetingNotificationHost.styles';
+
+const meetingCallingViewOffset = 24;
+
+export const meetingCallingViewStyles = (hasNotifications: boolean): CSSObject => ({
   position: 'absolute',
-  bottom: '24px',
-  left: '24px',
+  bottom: `${hasNotifications ? meetingNotificationHostCollapsedOffset : meetingCallingViewOffset}px`,
+  left: `${meetingCallingViewOffset}px`,
   width: 'min(420px, calc(100% - 48px))',
   zIndex: 2,
   pointerEvents: 'auto',
-};
+  transition: 'bottom var(--animation-timing-fast) ease-in-out',
+});
 
 export const meetingsContentWrapperStyles: CSSObject = {
   display: 'flex',

--- a/apps/webapp/src/script/components/meeting/meetingCallingView/meetingCallingView.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingCallingView/meetingCallingView.tsx
@@ -21,6 +21,7 @@ import {container} from 'tsyringe';
 
 import {CallingCell} from 'Components/calling/CallingCell';
 import {meetingCallingViewStyles} from 'Components/meeting/meetingCallingView/meetingCallingView.styles';
+import {useMeetingNotificationStore} from 'Components/meeting/meetingNotificationStore/meetingNotificationStore';
 import {CallState} from 'Repositories/calling/CallState';
 import {TeamState} from 'Repositories/team/TeamState';
 import {useApplicationContext, useMainViewModel} from 'src/script/page/rootProvider';
@@ -35,13 +36,14 @@ export const MeetingCallingView = () => {
   const {activeCalls} = useKoSubscribableChildren(callState, ['activeCalls']);
   const {classifiedDomains} = useKoSubscribableChildren(teamState, ['classifiedDomains']);
   const {callingRepository} = callingViewModel;
+  const hasMeetingNotifications = useMeetingNotificationStore(state => state.notifications.length > 0);
 
   if (activeCalls.length === 0) {
     return null;
   }
 
   return (
-    <div css={meetingCallingViewStyles} data-uie-name="meeting-calling-view">
+    <div css={meetingCallingViewStyles(hasMeetingNotifications)} data-uie-name="meeting-calling-view">
       {activeCalls.map(call => (
         <CallingCell
           key={`${call.conversation.qualifiedId.id}-${call.conversation.qualifiedId.domain}`}
@@ -51,6 +53,7 @@ export const MeetingCallingView = () => {
           callingRepository={callingRepository}
           propertiesRepository={propertiesRepository}
           isFullUi
+          isNotificationHostVisible={false}
           hasAccessToCamera={callingViewModel.hasAccessToCamera()}
         />
       ))}

--- a/apps/webapp/src/script/components/meeting/meetingNotificationHost/meetingNotificationHost.styles.ts
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationHost/meetingNotificationHost.styles.ts
@@ -19,10 +19,13 @@
 
 import type {CSSObject} from '@emotion/react';
 
+/** height of notification host + padding */
+export const meetingNotificationHostCollapsedOffset = 72;
+
 export const meetingNotificationHostStyles: CSSObject = {
   position: 'absolute',
   bottom: 0,
-  zIndex: 'var(--z-index-panel)',
+  zIndex: 'var(--z-index-badge)',
   display: 'flex',
   flexDirection: 'column',
   width: '100%',

--- a/apps/webapp/src/script/components/meeting/meetingNotificationHost/meetingNotificationHost.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationHost/meetingNotificationHost.test.tsx
@@ -173,6 +173,26 @@ describe('MeetingNotificationHost', () => {
     expect(screen.getAllByText('meetings.notifications.title')).toHaveLength(4);
   });
 
+  it('collapses when clicking outside while keeping clicks inside active', () => {
+    useMeetingNotificationStore.getState().addNotification({
+      kind: MeetingNotificationKind.INVITE,
+      qualifiedId,
+      meetingTitle: 'Meeting',
+      qualifiedCreator,
+      meetingStartTime,
+    });
+
+    renderHost();
+    fireEvent.click(screen.getByRole('button', {name: 'meetings.notifications.showAll'}));
+    fireEvent.click(screen.getByRole('listitem'));
+
+    expect(useMeetingNotificationStore.getState().isExpanded).toBe(true);
+
+    fireEvent.click(document.body);
+
+    expect(useMeetingNotificationStore.getState().isExpanded).toBe(false);
+  });
+
   it('dismisses all cards and collapse preserves cards', () => {
     useMeetingNotificationStore.getState().addNotification({
       kind: MeetingNotificationKind.INVITE,

--- a/apps/webapp/src/script/components/meeting/meetingNotificationHost/meetingNotificationHost.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationHost/meetingNotificationHost.test.tsx
@@ -45,7 +45,9 @@ const translateForCountTest: Translate = (_key, substitutions) => {
   return '';
 };
 
-const getHost = () => document.querySelector('[data-uie-name="meeting-notification-host"]');
+const getHost = () => {
+  return document.querySelector('.meeting-notification-host');
+};
 const getList = () => document.getElementById('meeting-notification-list');
 
 const renderHost = (isStandalone = true, translate: Translate = translateForTest) =>

--- a/apps/webapp/src/script/components/meeting/meetingNotificationHost/meetingNotificationHost.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationHost/meetingNotificationHost.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import {useEffect, useRef} from 'react';
+
 import {ChevronIcon} from '@wireapp/react-ui-kit';
 
 import {MeetingNotificationCard} from 'Components/meeting/meetingNotificationCard/meetingNotificationCard';
@@ -43,6 +45,30 @@ export const MeetingNotificationHost = ({isStandalone}: MeetingNotificationHostP
   const {translate} = useApplicationContext();
   const notifications = useMeetingNotificationStore(state => state.notifications);
   const isExpanded = useMeetingNotificationStore(state => state.isExpanded);
+  const hostRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (notifications.length === 0) {
+      return;
+    }
+
+    const collapseWhenClickedOutside = (event: MouseEvent) => {
+      const target = event.target;
+      const isInsideNotificationHost =
+        target instanceof Node &&
+        (hostRef.current?.contains(target) ||
+          (target instanceof Element && target.closest('[data-uie-name="meeting-notification-host"]') !== null));
+
+      if (!(target instanceof Node) || isInsideNotificationHost) {
+        return;
+      }
+
+      useMeetingNotificationStore.getState().setIsExpanded(false);
+    };
+
+    document.addEventListener('click', collapseWhenClickedOutside);
+    return () => document.removeEventListener('click', collapseWhenClickedOutside);
+  }, [notifications.length]);
 
   if (notifications.length === 0) {
     return null;
@@ -50,6 +76,7 @@ export const MeetingNotificationHost = ({isStandalone}: MeetingNotificationHostP
 
   return (
     <div
+      ref={hostRef}
       css={{
         ...meetingNotificationHostStyles,
         ...(isStandalone ? meetingNotificationHostFallbackStyles : {}),

--- a/apps/webapp/src/script/components/meeting/meetingNotificationHost/meetingNotificationHost.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingNotificationHost/meetingNotificationHost.tsx
@@ -57,7 +57,7 @@ export const MeetingNotificationHost = ({isStandalone}: MeetingNotificationHostP
       const isInsideNotificationHost =
         target instanceof Node &&
         (hostRef.current?.contains(target) ||
-          (target instanceof Element && target.closest('[data-uie-name="meeting-notification-host"]') !== null));
+          (target instanceof Element && target.closest('.meeting-notification-host') !== null));
 
       if (!(target instanceof Node) || isInsideNotificationHost) {
         return;
@@ -82,6 +82,7 @@ export const MeetingNotificationHost = ({isStandalone}: MeetingNotificationHostP
         ...(isStandalone ? meetingNotificationHostFallbackStyles : {}),
       }}
       data-uie-name="meeting-notification-host"
+      className="meeting-notification-host"
     >
       <div css={meetingNotificationHostContainerStyles}>
         <div css={meetingNotificationHostHeaderStyles}>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27879" title="WPB-27879" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27879</a>  User cannot access the minimized call view while meeting notifications are displayed - Also affecting the normal calls UI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

https://github.com/user-attachments/assets/e999ba42-9757-4f82-9c4c-90cf58064d24

