### PR TITLE
Disallow TypeScript non-null and definite assignment assertions [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/auth/module/action/authAction.ts
+++ b/apps/webapp/src/script/auth/module/action/authAction.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {isString} from '@sindresorhus/is';
+import {isString, isUndefined} from '@sindresorhus/is';
 import type {DomainData} from '@wireapp/api-client/lib/account/domainData';
 import type {LoginData, RegisterData} from '@wireapp/api-client/lib/auth/';
 import {VerificationActionType} from '@wireapp/api-client/lib/auth/verificationActionType';
@@ -104,7 +104,11 @@ export class AuthAction {
         await dispatch(selfAction.fetchSelf());
         let entropyData: Uint8Array | undefined = undefined;
         if (getEntropy !== undefined) {
-          const existingClient = await core.service!.client.loadClient();
+          const coreServices = core.service;
+          if (isUndefined(coreServices)) {
+            throw new Error('Core services are not initialized.');
+          }
+          const existingClient = await coreServices.client.loadClient();
           entropyData = existingClient ? undefined : await getEntropy();
         }
         await onAfterLogin(dispatch, getState, global);

--- a/apps/webapp/src/script/auth/page/login/singleSignOnForm.test.tsx
+++ b/apps/webapp/src/script/auth/page/login/singleSignOnForm.test.tsx
@@ -22,6 +22,8 @@ import {fireEvent, waitFor} from '@testing-library/react';
 import {TypeUtil} from '@wireapp/commons';
 import {noop} from 'noop-esm';
 
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
+
 import {SingleSignOnForm} from './singleSignOnForm';
 
 import {Config, Configuration} from '../../../Config';
@@ -130,7 +132,7 @@ describe('SingleSignOnForm', () => {
 
     expect(submitButton.disabled).toBe(false);
 
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.submit(requireValueForTest(container.querySelector('form')));
 
     const errorMessage = getByTestId(errorId);
     expect(errorMessage.dataset.uieValue).toBe(ValidationError.FIELD.SSO_EMAIL_CODE.PATTERN_MISMATCH);
@@ -158,7 +160,7 @@ describe('SingleSignOnForm', () => {
 
     expect(submitButton.disabled).toBe(false);
 
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.submit(requireValueForTest(container.querySelector('form')));
 
     const errorMessage = getByTestId(errorId);
     expect(errorMessage.dataset.uieValue).toBe(ValidationError.FIELD.SSO_CODE.PATTERN_MISMATCH);
@@ -195,7 +197,7 @@ describe('SingleSignOnForm', () => {
 
     expect(submitButton.disabled).toBe(false);
 
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.submit(requireValueForTest(container.querySelector('form')));
 
     await waitFor(() => {
       expect(actionRoot.authAction.doGetDomainInfo).toHaveBeenCalledTimes(1);
@@ -236,7 +238,7 @@ describe('SingleSignOnForm', () => {
 
     expect(submitButton.disabled).toBe(false);
 
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.submit(requireValueForTest(container.querySelector('form')));
 
     await waitFor(() => {
       expect(actionRoot.authAction.doGetDomainInfo).toHaveBeenCalledTimes(1);

--- a/apps/webapp/src/script/auth/page/setEmail.test.tsx
+++ b/apps/webapp/src/script/auth/page/setEmail.test.tsx
@@ -27,6 +27,7 @@ import {ValidationError} from '../module/action/validationError';
 import {initialRootState} from '../module/reducer';
 import {mockStoreFactory} from '../util/test/mockStoreFactory';
 import {mountComponent} from '../util/test/testUtil';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 
 const emailInputId = 'enter-email';
 const verifyButtonId = 'do-verify-email';
@@ -53,7 +54,7 @@ describe('SetEmail', () => {
     const emailInput = getByTestId(emailInputId);
 
     fireEvent.change(emailInput, {target: {value: 'e'}});
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.submit(requireValueForTest(container.querySelector('form')));
 
     await waitFor(() => {
       const errorMessage = getByTestId(errorMessageId);

--- a/apps/webapp/src/script/auth/page/setPassword.test.tsx
+++ b/apps/webapp/src/script/auth/page/setPassword.test.tsx
@@ -25,6 +25,7 @@ import {ValidationError} from '../module/action/validationError';
 import {initialRootState} from '../module/reducer';
 import {mockStoreFactory} from '../util/test/mockStoreFactory';
 import {mountComponent} from '../util/test/testUtil';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 
 const passwordInputId = 'enter-password';
 const setPasswordButtonId = 'do-set-password';
@@ -49,7 +50,7 @@ describe('SetPassword', () => {
     const passwordInput = getByTestId(passwordInputId);
 
     fireEvent.change(passwordInput, {target: {value: 'e'}});
-    fireEvent.submit(container.querySelector('form')!);
+    fireEvent.submit(requireValueForTest(container.querySelector('form')));
 
     await waitFor(() => {
       const errorMessage = getByTestId(errorMessageId);

--- a/apps/webapp/src/script/components/Modals/CreateConversation/ConversationType/ConversationTypeContainer.tsx
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/ConversationType/ConversationTypeContainer.tsx
@@ -19,6 +19,7 @@
 
 import {useEffect} from 'react';
 
+import {isUndefined} from '@sindresorhus/is';
 import {container} from 'tsyringe';
 
 import {TeamState} from 'Repositories/team/TeamState';
@@ -48,7 +49,11 @@ export const ConversationTypeContainer = () => {
     setIsConfirmDiscardModalOpen,
   } = useCreateConversationModal();
 
-  const isInTeam = teamState.isInTeam(self!);
+  if (isUndefined(self)) {
+    throw new Error('The self user must be initialized before rendering conversation type options');
+  }
+
+  const isInTeam = teamState.isInTeam(self);
 
   // Set default conversation type based on user's team membership
   useEffect(() => {

--- a/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/ParticipantsSelection.tsx
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/ParticipantsSelection.tsx
@@ -19,6 +19,7 @@
 
 import {useMemo, useState} from 'react';
 
+import {isUndefined} from '@sindresorhus/is';
 import {container} from 'tsyringe';
 
 import {FadingScrollbar} from 'Components/fadingScrollbar';
@@ -68,6 +69,10 @@ export const ParticipantsSelection = () => {
 
   const filteredContacts = contacts.filter(user => user.isAvailable());
 
+  if (isUndefined(selfUser)) {
+    return null;
+  }
+
   return (
     <>
       <div css={participantsSelectionSearchCss}>
@@ -82,7 +87,7 @@ export const ParticipantsSelection = () => {
       <div className="modal__body" css={participantsSelectionListCss}>
         <FadingScrollbar>
           <UserSearchableList
-            selfUser={selfUser!}
+            selfUser={selfUser}
             users={filteredContacts}
             filter={participantsInput}
             selected={selectedContacts}

--- a/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
+++ b/apps/webapp/src/script/components/Modals/GroupCreation/GroupCreationModal.tsx
@@ -19,6 +19,7 @@
 
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
+import {isUndefined} from '@sindresorhus/is';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data/conversationReceiptModeUpdateData';
 import {CONVERSATION_PROTOCOL, mapToConversationProtocol} from '@wireapp/api-client/lib/team';
 import {isNonFederatingBackendsError} from '@wireapp/core/lib/errors';
@@ -109,7 +110,10 @@ const GroupCreationModal = ({
     });
   }, [defaultProtocol, translate]);
 
-  const initialProtocol = protocolOptions.find(protocol => protocol.value === defaultProtocol)!;
+  const initialProtocol = protocolOptions.find(protocol => protocol.value === defaultProtocol);
+  if (isUndefined(initialProtocol)) {
+    throw new Error(`No protocol option exists for ${defaultProtocol}`);
+  }
 
   // Read receipts are temorarily disabled for MLS groups and channels until it is supported
   const areReadReceiptsEnabled = defaultProtocol !== CONVERSATION_PROTOCOL.MLS;
@@ -165,7 +169,11 @@ const GroupCreationModal = ({
   }, [isTeam]);
 
   useEffect(() => {
-    setSelectedProtocol(protocolOptions.find(protocol => protocol.value === selectedProtocol.value)!);
+    const nextProtocol = protocolOptions.find(protocol => protocol.value === selectedProtocol.value);
+    if (isUndefined(nextProtocol)) {
+      throw new Error(`No protocol option exists for ${selectedProtocol.value}`);
+    }
+    setSelectedProtocol(nextProtocol);
   }, [protocolOptions, selectedProtocol.value]);
 
   const stateIsPreferences = groupCreationState === GroupCreationModalState.PREFERENCES;

--- a/apps/webapp/src/script/components/Modals/ModalComponent/ModalComponent.test.tsx
+++ b/apps/webapp/src/script/components/Modals/ModalComponent/ModalComponent.test.tsx
@@ -20,6 +20,7 @@
 import {act, fireEvent, render} from '@testing-library/react';
 
 import {withTheme} from 'src/script/auth/util/test/testUtil';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 
 import {ModalComponent} from './ModalComponent';
 
@@ -143,7 +144,7 @@ describe('ModalComponent', () => {
     const iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
 
-    const iframeDocument = iframe.contentDocument!;
+    const iframeDocument = requireValueForTest(iframe.contentDocument);
     const iframeContainer = iframeDocument.createElement('div');
     iframeDocument.body.appendChild(iframeContainer);
 
@@ -157,7 +158,7 @@ describe('ModalComponent', () => {
     const iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
 
-    const iframeDocument = iframe.contentDocument!;
+    const iframeDocument = requireValueForTest(iframe.contentDocument);
     const iframeContainer = iframeDocument.createElement('div');
     iframeDocument.body.appendChild(iframeContainer);
 
@@ -170,7 +171,7 @@ describe('ModalComponent', () => {
     const iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
 
-    const iframeDocument = iframe.contentDocument!;
+    const iframeDocument = requireValueForTest(iframe.contentDocument);
     const iframeContainer = iframeDocument.createElement('div');
     iframeDocument.body.appendChild(iframeContainer);
 

--- a/apps/webapp/src/script/components/Modals/QualityFeedbackModal/QualityFeedbackModal.test.tsx
+++ b/apps/webapp/src/script/components/Modals/QualityFeedbackModal/QualityFeedbackModal.test.tsx
@@ -85,10 +85,9 @@ describe('QualityFeedbackModal', () => {
       callingRepository = injectedCallingRepository;
       const conversation = createConversation();
       const selfParticipant = createSelfParticipant();
-      const selfUserId = callingRepository['selfUser']?.qualifiedId!;
 
       call = new Call(
-        selfUserId,
+        user.qualifiedId,
         conversation,
         CONV_TYPE.CONFERENCE,
         selfParticipant,

--- a/apps/webapp/src/script/components/calling/CallingCell/CallingCell.test.tsx
+++ b/apps/webapp/src/script/components/calling/CallingCell/CallingCell.test.tsx
@@ -33,6 +33,7 @@ import {TeamState} from 'Repositories/team/TeamState';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
+  requireValueForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 import {CallActions} from 'src/script/view_model/CallingViewModel';
 import {createUuid} from 'Util/uuid';
@@ -164,12 +165,13 @@ describe('ConversationListCallingCell', () => {
     const callDuration = container.querySelector('[data-uie-name="call-duration"]');
 
     expect(callDuration).not.toBeNull();
-    expect(callDuration!.textContent).toBe('00:00');
+    const callDurationElement = requireValueForTest(callDuration);
+    expect(callDurationElement.textContent).toBe('00:00');
     act(() => {
       jest.advanceTimersByTime(10000);
     });
 
-    expect(callDuration!.textContent).toBe('00:10');
+    expect(callDurationElement.textContent).toBe('00:10');
     jest.useRealTimers();
   });
 });

--- a/apps/webapp/src/script/components/calling/CallingCell/usePressSpaceToUnmute/usePressSpaceToUnmute.ts
+++ b/apps/webapp/src/script/components/calling/CallingCell/usePressSpaceToUnmute/usePressSpaceToUnmute.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {amplify} from 'amplify';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
@@ -50,7 +51,10 @@ export const usePressSpaceToUnmute = ({
 
   const {detachedWindow, viewMode} = callState;
 
-  const activeWindow = viewMode() === CallingViewMode.DETACHED_WINDOW ? detachedWindow()! : window;
+  const activeWindow = viewMode() === CallingViewMode.DETACHED_WINDOW ? detachedWindow() : window;
+  if (isNullOrUndefined(activeWindow)) {
+    throw new Error('The detached calling window is not available');
+  }
 
   const micOnNotification = useAppNotification({
     message: notificationMessage,

--- a/apps/webapp/src/script/components/calling/CallingOverlayContainer.tsx
+++ b/apps/webapp/src/script/components/calling/CallingOverlayContainer.tsx
@@ -17,8 +17,9 @@
  *
  */
 
-import {Fragment, useEffect} from 'react';
+import {Fragment, useEffect, type ReactNode} from 'react';
 
+import {isNullOrUndefined, isUndefined} from '@sindresorhus/is';
 import {container} from 'tsyringe';
 
 import {FireAndForgetInvoker} from '@wireapp/core';
@@ -48,22 +49,35 @@ interface CallingContainerProps {
   readonly toggleScreenshare: (call: Call, desktopScreenShareMenu: DesktopScreenShareMenu) => void;
 }
 
-const CallingContainer = ({
+interface CallingContainerWithJoinedCallProps extends CallingContainerProps {
+  readonly callState: CallState;
+  readonly joinedCall: Call;
+}
+
+function CallingContainer(props: CallingContainerProps): ReactNode {
+  const callState = isUndefined(props.callState) ? container.resolve(CallState) : props.callState;
+  const {joinedCall} = useKoSubscribableChildren(callState, ['joinedCall']);
+
+  if (isUndefined(joinedCall)) {
+    return null;
+  }
+
+  return <CallingContainerWithJoinedCall {...props} callState={callState} joinedCall={joinedCall} />;
+}
+
+function CallingContainerWithJoinedCall({
   propertiesRepository,
   callingRepository,
   fireAndForgetInvoker,
-  callState = container.resolve(CallState),
+  callState,
+  joinedCall,
   toggleScreenshare,
-}: CallingContainerProps) => {
+}: CallingContainerWithJoinedCallProps): ReactNode {
   const mediaDevicesHandler = container.resolve(MediaDevicesHandler);
-  const {activeCallViewTab, joinedCall, hasAvailableScreensToShare, desktopScreenShareMenu, viewMode} =
-    useKoSubscribableChildren(callState, [
-      'activeCallViewTab',
-      'joinedCall',
-      'hasAvailableScreensToShare',
-      'desktopScreenShareMenu',
-      'viewMode',
-    ]);
+  const {activeCallViewTab, hasAvailableScreensToShare, desktopScreenShareMenu, viewMode} = useKoSubscribableChildren(
+    callState,
+    ['activeCallViewTab', 'hasAvailableScreensToShare', 'desktopScreenShareMenu', 'viewMode'],
+  );
 
   const isFullScreenOrDetached = [CallingViewMode.DETACHED_WINDOW, CallingViewMode.FULL_SCREEN].includes(viewMode);
 
@@ -71,7 +85,7 @@ const CallingContainer = ({
     maximizedParticipant,
     state: currentCallState,
     muteState,
-  } = useKoSubscribableChildren(joinedCall!, ['maximizedParticipant', 'state', 'muteState']);
+  } = useKoSubscribableChildren(joinedCall, ['maximizedParticipant', 'state', 'muteState']);
 
   const isMuted = muteState !== MuteState.NOT_MUTED;
 
@@ -83,7 +97,7 @@ const CallingContainer = ({
     }
   }, [callingRepository, currentCallState, fireAndForgetInvoker]);
 
-  const videoGrid = useVideoGrid(joinedCall!);
+  const videoGrid = useVideoGrid(joinedCall);
 
   const changePage = (newPage: number, call: Call) => callingRepository.changeCallPage(call, newPage);
 
@@ -149,9 +163,9 @@ const CallingContainer = ({
 
   const toggleMute = (call: Call, muteState: boolean) => callingRepository.muteCall(call, muteState);
 
-  const conversation = joinedCall?.conversation;
+  const conversation = joinedCall.conversation;
 
-  if (!joinedCall || !conversation || conversation.isSelfUserRemoved()) {
+  if (isNullOrUndefined(conversation) || conversation.isSelfUserRemoved()) {
     return null;
   }
 
@@ -199,6 +213,6 @@ const CallingContainer = ({
       {isScreenshareActive && <ChooseScreen choose={callingRepository.onChooseScreen} />}
     </Fragment>
   );
-};
+}
 
 export {CallingContainer};

--- a/apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx
+++ b/apps/webapp/src/script/components/calling/FullscreenVideoCall.tsx
@@ -19,6 +19,7 @@
 
 import {ChangeEvent, useEffect, useRef, useState} from 'react';
 
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {DefaultConversationRoleName} from '@wireapp/api-client/lib/conversation/';
 import cx from 'classnames';
 import {container} from 'tsyringe';
@@ -209,9 +210,11 @@ const FullscreenVideoCall = ({
     }
   };
 
-  const callNotification = useAppNotification({
-    activeWindow: viewMode === CallingViewMode.DETACHED_WINDOW ? detachedWindow! : window,
-  });
+  const activeWindow = viewMode === CallingViewMode.DETACHED_WINDOW ? detachedWindow : window;
+  if (isNullOrUndefined(activeWindow)) {
+    throw new Error('The detached calling window is not available');
+  }
+  const callNotification = useAppNotification({activeWindow});
 
   useEffect(() => {
     const handRaisedHandler = (event: Event) => {

--- a/apps/webapp/src/script/components/calling/GroupVideoGrid.test.tsx
+++ b/apps/webapp/src/script/components/calling/GroupVideoGrid.test.tsx
@@ -29,6 +29,7 @@ import {backgroundEffectsStore} from 'Repositories/media/useBackgroundEffectsSto
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
+  requireValueForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 import {translate} from 'Util/localizerUtil';
 
@@ -206,7 +207,7 @@ describe('GroupVideoGrid', () => {
     };
 
     const {container} = render(<GroupVideoGrid {...props} />, {wrapper: rootProviderWrapper});
-    const video = container.querySelector('[data-uie-name="self-video-thumbnail"]')!;
+    const video = requireValueForTest(container.querySelector('[data-uie-name="self-video-thumbnail"]'));
 
     expect(container.querySelector('[data-uie-name="background-effect-initializing"]')).toBeInTheDocument();
 

--- a/apps/webapp/src/script/components/calling/GroupVideoGrid.tsx
+++ b/apps/webapp/src/script/components/calling/GroupVideoGrid.tsx
@@ -20,6 +20,7 @@
 import {CSSProperties, ReactNode, useEffect, useState} from 'react';
 
 import {css} from '@emotion/react';
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {Loading, QUERY} from '@wireapp/react-ui-kit';
@@ -67,6 +68,112 @@ const COLUMNS = {
 
 const PARTICIPANTS_DESKTOP_EDGE_CASE = 3;
 const MIN_PARTICIPANTS_FOR_MAXIMIZED_VIEW = 2;
+
+interface GroupVideoThumbnailProps {
+  readonly thumbnail: Participant;
+  readonly minimized: boolean;
+  readonly maximizedParticipant: Participant | null;
+  readonly selfParticipant: Participant;
+}
+
+function GroupVideoThumbnail({
+  thumbnail: thumbnailParticipant,
+  minimized,
+  maximizedParticipant,
+  selfParticipant,
+}: GroupVideoThumbnailProps): ReactNode {
+  const thumbnail = useKoSubscribableChildren(thumbnailParticipant, [
+    'hasActiveVideo',
+    'sharesScreen',
+    'videoStream',
+    'processedVideoStream',
+  ]);
+  const {showLoadingOverlay, onVideoCanPlay} = useShowLoadingOverlay(
+    true,
+    thumbnail.hasActiveVideo,
+    thumbnail.processedVideoStream,
+  );
+  const {isMuted: selfIsMuted, handRaisedAt: selfHandRaisedAt} = useKoSubscribableChildren(selfParticipant, [
+    'isMuted',
+    'handRaisedAt',
+  ]);
+
+  return (
+    <>
+      {!isNullOrUndefined(thumbnail.videoStream) && maximizedParticipant === null && (
+        <GroupVideoThumbnailWrapper minimized={minimized}>
+          <Video
+            className="group-video__thumbnail-video"
+            autoPlay
+            playsInline
+            /* This is needed to keep playing the video when detached to a new window,
+               only muted video can be played automatically without user interacting with the window first,
+               see https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide.
+            */
+            muted
+            data-uie-name="self-video-thumbnail"
+            onCanPlay={onVideoCanPlay}
+            css={{
+              transform: thumbnail.hasActiveVideo && !thumbnail.sharesScreen ? 'rotateY(180deg)' : 'initial',
+            }}
+            srcObject={thumbnail.processedVideoStream?.stream ?? thumbnail.videoStream}
+          />
+          {showLoadingOverlay && (
+            <div
+              aria-busy={showLoadingOverlay}
+              css={groupVideoBackgroundInitializingOverlay}
+              data-uie-name="background-effect-initializing"
+            >
+              <Loading size={32} />
+            </div>
+          )}
+          {selfIsMuted && !minimized && (
+            <span className="group-video-grid__element__label__icon" data-uie-name="status-call-audio-muted">
+              <Icon.MicOffIcon data-uie-name="mic-icon-off" />
+            </span>
+          )}
+          {!isNullOrUndefined(selfHandRaisedAt) && !minimized && (
+            <span className="group-video-grid__element__label__hand_icon small" data-uie-name="status-call-audio-muted">
+              ✋
+            </span>
+          )}
+        </GroupVideoThumbnailWrapper>
+      )}
+      {!thumbnail.hasActiveVideo && (
+        <GroupVideoThumbnailWrapper minimized={minimized}>
+          <div
+            css={{
+              alignItems: 'center',
+              display: 'flex',
+              height: '100%',
+              justifyContent: 'center',
+              width: '100%',
+            }}
+          >
+            {selfIsMuted && !minimized && (
+              <span className="group-video-grid__element__label__icon" data-uie-name="status-call-audio-muted">
+                <Icon.MicOffIcon data-uie-name="mic-icon-off" />
+              </span>
+            )}
+            {!isNullOrUndefined(selfHandRaisedAt) && !minimized && (
+              <span
+                className="group-video-grid__element__label__hand_icon small"
+                data-uie-name="status-call-audio-muted"
+              >
+                ✋
+              </span>
+            )}
+            <Avatar
+              avatarSize={minimized ? AVATAR_SIZE.SMALL : AVATAR_SIZE.MEDIUM}
+              participant={selfParticipant.user}
+              hideAvailabilityStatus
+            />
+          </div>
+        </GroupVideoThumbnailWrapper>
+      )}
+    </>
+  );
+}
 
 interface CalculateRowsAndColumsParams {
   totalCount: number;
@@ -144,18 +251,6 @@ const GroupVideoGrid = ({
   const isMedium = useActiveWindowMatchMedia(HEIGHT_QUERIES.MEDIUM);
   const isTall = useActiveWindowMatchMedia(HEIGHT_QUERIES.TALL);
 
-  const thumbnail = useKoSubscribableChildren(grid.thumbnail!, [
-    'hasActiveVideo',
-    'sharesScreen',
-    'videoStream',
-    'processedVideoStream',
-  ]);
-  const {showLoadingOverlay, onVideoCanPlay} = useShowLoadingOverlay(
-    true,
-    thumbnail.hasActiveVideo,
-    thumbnail.processedVideoStream,
-  );
-
   const [rowsAndColumns, setRowsAndColumns] = useState<RowsAndColumns>(
     calculateRowsAndColumns({
       totalCount: grid?.grid.length,
@@ -229,11 +324,6 @@ const GroupVideoGrid = ({
     }
   }, [call, grid.thumbnail, isTablet, isDesktop, isMobile, isShort, isMedium, isTall]);
 
-  const {isMuted: selfIsMuted, handRaisedAt: selfHandRaisedAt} = useKoSubscribableChildren(selfParticipant, [
-    'isMuted',
-    'handRaisedAt',
-  ]);
-
   return (
     <div className="group-video">
       <div
@@ -281,76 +371,13 @@ const GroupVideoGrid = ({
           />
         ))}
       </div>
-      {thumbnail.videoStream != null && maximizedParticipant === null && (
-        <GroupVideoThumbnailWrapper minimized={minimized}>
-          <Video
-            className="group-video__thumbnail-video"
-            autoPlay
-            playsInline
-            /* This is needed to keep playing the video when detached to a new window,
-               only muted video can be played automatically without user interacting with the window first,
-               see https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide.
-            */
-            muted
-            data-uie-name="self-video-thumbnail"
-            onCanPlay={onVideoCanPlay}
-            css={{
-              transform: thumbnail.hasActiveVideo && !thumbnail.sharesScreen ? 'rotateY(180deg)' : 'initial',
-            }}
-            srcObject={thumbnail.processedVideoStream?.stream ?? thumbnail.videoStream}
-          />
-          {showLoadingOverlay && (
-            <div
-              aria-busy={showLoadingOverlay}
-              css={groupVideoBackgroundInitializingOverlay}
-              data-uie-name="background-effect-initializing"
-            >
-              <Loading size={32} />
-            </div>
-          )}
-          {selfIsMuted && !minimized && (
-            <span className="group-video-grid__element__label__icon" data-uie-name="status-call-audio-muted">
-              <Icon.MicOffIcon data-uie-name="mic-icon-off" />
-            </span>
-          )}
-          {selfHandRaisedAt != null && !minimized && (
-            <span className="group-video-grid__element__label__hand_icon small" data-uie-name="status-call-audio-muted">
-              ✋
-            </span>
-          )}
-        </GroupVideoThumbnailWrapper>
-      )}
-      {grid.thumbnail && !thumbnail.hasActiveVideo && (
-        <GroupVideoThumbnailWrapper minimized={minimized}>
-          <div
-            css={{
-              alignItems: 'center',
-              display: 'flex',
-              height: '100%',
-              justifyContent: 'center',
-              width: '100%',
-            }}
-          >
-            {selfIsMuted && !minimized && (
-              <span className="group-video-grid__element__label__icon" data-uie-name="status-call-audio-muted">
-                <Icon.MicOffIcon data-uie-name="mic-icon-off" />
-              </span>
-            )}
-            {selfHandRaisedAt != null && !minimized && (
-              <span
-                className="group-video-grid__element__label__hand_icon small"
-                data-uie-name="status-call-audio-muted"
-              >
-                ✋
-              </span>
-            )}
-            <Avatar
-              avatarSize={minimized ? AVATAR_SIZE.SMALL : AVATAR_SIZE.MEDIUM}
-              participant={selfParticipant.user}
-              hideAvailabilityStatus
-            />
-          </div>
-        </GroupVideoThumbnailWrapper>
+      {!isNullOrUndefined(grid.thumbnail) && (
+        <GroupVideoThumbnail
+          thumbnail={grid.thumbnail}
+          minimized={minimized}
+          maximizedParticipant={maximizedParticipant}
+          selfParticipant={selfParticipant}
+        />
       )}
     </div>
   );

--- a/apps/webapp/src/script/components/calling/GroupVideoGridTile.test.tsx
+++ b/apps/webapp/src/script/components/calling/GroupVideoGridTile.test.tsx
@@ -27,6 +27,7 @@ import {backgroundEffectsStore} from 'Repositories/media/useBackgroundEffectsSto
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
+  requireValueForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 import {createUuid} from 'Util/uuid';
 
@@ -114,7 +115,7 @@ describe('GroupVideoGridTile', () => {
 
     const {container} = renderComponent({participant});
 
-    fireEvent.canPlay(container.querySelector('video')!);
+    fireEvent.canPlay(requireValueForTest(container.querySelector('video')));
 
     expect(container.querySelector(loadingOverlaySelector)).not.toBeInTheDocument();
   });

--- a/apps/webapp/src/script/components/calling/chooseScreen.test.tsx
+++ b/apps/webapp/src/script/components/calling/chooseScreen.test.tsx
@@ -24,6 +24,7 @@ import {CallState} from 'Repositories/calling/CallState';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
+  requireValueForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 import {captureModalFocusContext} from 'Util/modalFocusUtil';
 
@@ -127,7 +128,7 @@ describe('ChooseScreen', () => {
     const cancelButton = container.querySelector('[data-uie-name="do-choose-screen-cancel"]');
     expect(cancelButton).not.toBeNull();
 
-    fireEvent.click(cancelButton!);
+    fireEvent.click(requireValueForTest(cancelButton));
     expect(callState.selectableScreens()).toEqual([]);
     expect(callState.selectableWindows()).toEqual([]);
   });
@@ -211,7 +212,7 @@ describe('ChooseScreen', () => {
     const outside = document.createElement('button');
     document.body.appendChild(outside);
 
-    fireEvent.focusOut(dialog!, {relatedTarget: outside});
+    fireEvent.focusOut(requireValueForTest(dialog), {relatedTarget: outside});
 
     expect(document.activeElement).toBe(first);
 
@@ -228,7 +229,7 @@ describe('ChooseScreen', () => {
   it('calls focus restoration callback on cancel button click', () => {
     const {container, focusContext} = setup();
 
-    const cancelButton = container.querySelector('[data-uie-name="do-choose-screen-cancel"]')!;
+    const cancelButton = requireValueForTest(container.querySelector('[data-uie-name="do-choose-screen-cancel"]'));
     fireEvent.click(cancelButton);
 
     expect(focusContext.restoreMock).toHaveBeenCalled();
@@ -237,7 +238,7 @@ describe('ChooseScreen', () => {
   it('calls choose and restores focus when selecting a screen/window', () => {
     const {container, props, focusContext} = setup();
 
-    const firstScreen = container.querySelector('[data-uie-name="item-screen"]')!;
+    const firstScreen = requireValueForTest(container.querySelector('[data-uie-name="item-screen"]'));
     fireEvent.click(firstScreen);
 
     expect(props.choose).toHaveBeenCalledWith('screen:first');

--- a/apps/webapp/src/script/components/calling/deviceToggleButton.test.tsx
+++ b/apps/webapp/src/script/components/calling/deviceToggleButton.test.tsx
@@ -19,6 +19,8 @@
 
 import {render, fireEvent} from '@testing-library/react';
 
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
+
 import {DeviceToggleButton} from './DeviceToggleButton';
 
 describe('deviceToggleButton', () => {
@@ -51,7 +53,7 @@ describe('deviceToggleButton', () => {
     const deviceToggleButton = container.querySelector('button[data-uie-name="device-toggle-button-indicator-dot"]');
     expect(deviceToggleButton).not.toBeNull();
 
-    fireEvent.click(deviceToggleButton!);
+    fireEvent.click(requireValueForTest(deviceToggleButton));
     expect(props.onChooseDevice).toHaveBeenCalled();
   });
 });

--- a/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/cellsGlobalView/useSearchCellsNodes/useSearchCellsNodes.test.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {act, renderHook} from '@testing-library/react';
 import {RestNode, RestNodeCollection} from 'cells-sdk-ts';
 
@@ -66,15 +67,8 @@ function buildLoggerMock(): LoggerMock {
   return {debug: jest.fn()};
 }
 
-function createControllablePromise<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-
-  return {promise, resolve, reject};
+function createControllablePromise<T>(): PromiseWithResolvers<T> {
+  return Promise.withResolvers<T>();
 }
 
 function buildRestNodeStub(name: string, uuid = name): RestNode {
@@ -314,14 +308,19 @@ describe('useSearchCellsNodes', () => {
 
     const {fireAndForgetInvoker, result} = renderSearchHook({cellsRepository, logger});
 
-    let currentSearchPromise!: Promise<void>;
+    let currentSearchPromise: Promise<void> | undefined;
     act(() => {
       currentSearchPromise = result.current.handleReload();
     });
 
+    if (isUndefined(currentSearchPromise)) {
+      throw new Error('The current search promise was not created');
+    }
+    const currentSearchRequestPromise = currentSearchPromise;
+
     await act(async () => {
       currentSearch.resolve({Nodes: [buildRestNodeStub('current-file.pdf')]});
-      await currentSearchPromise;
+      await currentSearchRequestPromise;
       await flushMicrotasks();
     });
 
@@ -340,14 +339,19 @@ describe('useSearchCellsNodes', () => {
     };
     const {fireAndForgetInvoker, result} = renderSearchHook({cellsRepository});
 
-    let currentSearchPromise!: Promise<void>;
+    let currentSearchPromise: Promise<void> | undefined;
     act(() => {
       currentSearchPromise = result.current.handleReload();
     });
 
+    if (isUndefined(currentSearchPromise)) {
+      throw new Error('The current search promise was not created');
+    }
+    const currentSearchRequestPromise = currentSearchPromise;
+
     await act(async () => {
       currentSearch.resolve({Nodes: [buildRestNodeStub('current-file.pdf')]});
-      await currentSearchPromise;
+      await currentSearchRequestPromise;
       staleSearch.reject(new Error('stale request failed'));
       await fireAndForgetInvoker.waitUntilAllSettled();
     });

--- a/apps/webapp/src/script/components/conversation/conversation.tsx
+++ b/apps/webapp/src/script/components/conversation/conversation.tsx
@@ -17,8 +17,9 @@
  *
  */
 
-import {UIEvent, useCallback, useEffect, useMemo, useState} from 'react';
+import {UIEvent, useCallback, useEffect, useMemo, useState, type ReactElement} from 'react';
 
+import {isUndefined} from '@sindresorhus/is';
 import {CONVERSATION_CELLS_STATE} from '@wireapp/api-client/lib/conversation';
 import {container} from 'tsyringe';
 
@@ -105,15 +106,31 @@ interface ConversationProps {
   reloadApp: () => void;
 }
 
+interface ConversationContentProps extends ConversationProps {
+  readonly activeConversation: ConversationEntity;
+}
+
 const CONFIG = Config.getConfig();
 
-export const Conversation = ({
+export function Conversation(props: ConversationProps): ReactElement | null {
+  const conversationState = container.resolve(ConversationState);
+  const {activeConversation} = useKoSubscribableChildren(conversationState, ['activeConversation']);
+
+  if (isUndefined(activeConversation)) {
+    return null;
+  }
+
+  return <ConversationContent {...props} activeConversation={activeConversation} />;
+}
+
+function ConversationContent({
   teamState,
   selfUser,
   openRightSidebar,
   isRightSidebarOpen = false,
   reloadApp,
-}: ConversationProps) => {
+  activeConversation,
+}: ConversationContentProps): ReactElement {
   const messageListLogger = getLogger('ConversationList');
 
   const isVirtualizedMessagesListEnabled = CONFIG.FEATURE.ENABLE_VIRTUALIZED_MESSAGES_LIST;
@@ -142,27 +159,22 @@ export const Conversation = ({
   const [isGiphyModalOpen, setIsGiphyModalOpen] = useState<boolean>(false);
   const [isSharedDriveSearchViewOpen, setIsSharedDriveSearchViewOpen] = useState<boolean>(false);
 
-  const conversationState = container.resolve(ConversationState);
   const callState = container.resolve(CallState);
-  const {activeConversation} = useKoSubscribableChildren(conversationState, ['activeConversation']);
   const {classifiedDomains} = useKoSubscribableChildren(teamState, [
     'classifiedDomains',
     'isFileSharingSendingEnabled',
   ]);
 
-  const {is1to1, isRequest, isReadOnlyConversation, isSelfUserRemoved} = useKoSubscribableChildren(
-    activeConversation!,
-    [
-      'is1to1',
-      'isRequest',
-      'readOnlyState',
-      'participating_user_ets',
-      'connection',
-      'isReadOnlyConversation',
-      'isSelfUserRemoved',
-      'selfUser',
-    ],
-  );
+  const {is1to1, isRequest, isReadOnlyConversation, isSelfUserRemoved} = useKoSubscribableChildren(activeConversation, [
+    'is1to1',
+    'isRequest',
+    'readOnlyState',
+    'participating_user_ets',
+    'connection',
+    'isReadOnlyConversation',
+    'isSelfUserRemoved',
+    'selfUser',
+  ]);
 
   const inTeam = teamState.isInTeam(selfUser);
 
@@ -354,7 +366,12 @@ export const Conversation = ({
   };
 
   const handleEmailClick = (event: Event, messageDetails: MessageDetails) => {
-    safeMailOpen(messageDetails.href!);
+    if (isUndefined(messageDetails.href)) {
+      event.preventDefault();
+
+      return false;
+    }
+    safeMailOpen(messageDetails.href);
     event.preventDefault();
     return false;
   };
@@ -392,7 +409,12 @@ export const Conversation = ({
   };
 
   const handleMarkdownLinkClick = (event: MouseEvent | KeyboardEvent, messageDetails: MessageDetails) => {
-    const href = messageDetails.href!;
+    if (isUndefined(messageDetails.href)) {
+      event.preventDefault();
+
+      return false;
+    }
+    const href = messageDetails.href;
 
     const parsed = parseAccountDeepLink(href, CONFIG.URL.ACCOUNT_BASE);
 
@@ -823,4 +845,4 @@ export const Conversation = ({
       </ConversationFileDropzone>
     </CellsSelfUserDriveRoleProvider>
   );
-};
+}

--- a/apps/webapp/src/script/components/conversation/conversationCells/useConversationSearch/useConversationSearchFiles.test.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/useConversationSearch/useConversationSearchFiles.test.ts
@@ -74,12 +74,8 @@ function createFakeUserRepository(): FakeUserRepository {
   return {getUsersById: jest.fn().mockResolvedValue([])};
 }
 
-function createDeferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>(resolvePromise => {
-    resolve = resolvePromise;
-  });
-  return {promise, resolve};
+function createDeferred<T>(): PromiseWithResolvers<T> {
+  return Promise.withResolvers<T>();
 }
 
 function renderSearchHook({

--- a/apps/webapp/src/script/components/conversation/conversationCells/useGetAllCellsNodes/useGetAllCellsNodes.test.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/useGetAllCellsNodes/useGetAllCellsNodes.test.ts
@@ -48,12 +48,8 @@ function createFakeUserRepository(): FakeUserRepository {
   return {getUsersById: jest.fn().mockResolvedValue([])};
 }
 
-function createDeferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>(resolvePromise => {
-    resolve = resolvePromise;
-  });
-  return {promise, resolve};
+function createDeferred<T>(): PromiseWithResolvers<T> {
+  return Promise.withResolvers<T>();
 }
 
 function renderGetAllNodesHook({

--- a/apps/webapp/src/script/components/conversation/conversationCells/useRefreshCellsState/useRefreshCellsState.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/useRefreshCellsState/useRefreshCellsState.ts
@@ -19,6 +19,7 @@
 
 import {useCallback, useEffect, useRef, useState} from 'react';
 
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {CONVERSATION_CELLS_STATE} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
@@ -61,8 +62,9 @@ export const useRefreshCellsState = ({
       return undefined;
     }
 
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
+    const previousInterval = intervalRef.current;
+    if (!isNullOrUndefined(previousInterval)) {
+      clearInterval(previousInterval);
       intervalRef.current = null;
     }
 
@@ -78,7 +80,11 @@ export const useRefreshCellsState = ({
 
     intervalRef.current = setInterval(() => {
       if (fetchCountRef.current >= MAX_REFRESH_COUNT) {
-        clearInterval(intervalRef.current!);
+        const currentInterval = intervalRef.current;
+        if (isNullOrUndefined(currentInterval)) {
+          return;
+        }
+        clearInterval(currentInterval);
         intervalRef.current = null;
         setIsRefreshing(false);
         return;
@@ -87,8 +93,9 @@ export const useRefreshCellsState = ({
     }, REFRESH_INTERVAL_MS);
 
     return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
+      const currentInterval = intervalRef.current;
+      if (!isNullOrUndefined(currentInterval)) {
+        clearInterval(currentInterval);
         intervalRef.current = null;
       }
     };

--- a/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
+++ b/apps/webapp/src/script/components/conversation/useFilesUploadDropzone/useFilesUploadDropzone.test.tsx
@@ -1,3 +1,4 @@
+import {isUndefined} from '@sindresorhus/is';
 import {act, renderHook, waitFor} from '@testing-library/react';
 
 import {useFileUploadState} from '../useFilesUploadState/useFilesUploadState';
@@ -34,10 +35,9 @@ describe('useFilesUploadDropzone', () => {
   });
 
   it('waits for media metadata before starting an upload', async () => {
-    let resolveMetadata!: (metadata: {image: {width: number; height: number}}) => void;
-    const metadataPromise = new Promise<{image: {width: number; height: number}}>(resolve => {
-      resolveMetadata = resolve;
-    });
+    const {promise: metadataPromise, resolve: resolveMetadata} = Promise.withResolvers<{
+      image: {width: number; height: number};
+    }>();
     const cellsRepository = createRepository();
     cellsRepository.uploadNodeDraft.mockResolvedValue({uuid: 'remote-id', versionId: 'version-id'});
     const buildFileMetadata = jest.fn(() => metadataPromise);
@@ -57,17 +57,22 @@ describe('useFilesUploadDropzone', () => {
     );
     const file = new File(['content'], 'image.png', {type: 'image/png'});
 
-    let upload!: Promise<void>;
+    let upload: Promise<void> | undefined;
     await act(async () => {
       upload = result.current.handlePastedFile(file);
       await Promise.resolve();
     });
 
+    if (isUndefined(upload)) {
+      throw new Error('The upload promise was not created');
+    }
+    const completedUploadPromise = upload;
+
     expect(buildFileMetadata).toHaveBeenCalledWith(expect.objectContaining({name: 'image.png'}));
     expect(cellsRepository.uploadNodeDraft).not.toHaveBeenCalled();
 
     resolveMetadata({image: {width: 640, height: 480}});
-    await act(async () => await upload);
+    await act(async () => await completedUploadPromise);
 
     expect(cellsRepository.uploadNodeDraft).toHaveBeenCalledTimes(1);
     expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
@@ -103,10 +108,14 @@ describe('useFilesUploadDropzone', () => {
     );
     const file = new File(['content'], 'document.txt', {type: 'text/plain'});
 
-    let upload!: Promise<void>;
+    let upload: Promise<void> | undefined;
     await act(async () => {
       upload = result.current.handlePastedFile(file);
     });
+    if (isUndefined(upload)) {
+      throw new Error('The upload promise was not created');
+    }
+    const completedUploadPromise = upload;
     await waitFor(() =>
       expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})).toHaveLength(1),
     );
@@ -123,7 +132,7 @@ describe('useFilesUploadDropzone', () => {
     });
 
     resolveUpload({uuid: 'remote-id', versionId: 'version-id'});
-    await act(async () => await upload);
+    await act(async () => await completedUploadPromise);
     expect(useFileUploadState.getState().getFiles({conversationId: conversation.id})[0]).toMatchObject({
       remoteUuid: 'remote-id',
       remoteVersionId: 'version-id',

--- a/apps/webapp/src/script/components/conversationListCell/conversationListCell.tsx
+++ b/apps/webapp/src/script/components/conversationListCell/conversationListCell.tsx
@@ -26,6 +26,7 @@ import React, {
 } from 'react';
 
 import {CSSObject} from '@emotion/react';
+import {isUndefined} from '@sindresorhus/is';
 import {CONVERSATION_ACCESS} from '@wireapp/api-client/lib/conversation/';
 import cx from 'classnames';
 
@@ -120,6 +121,7 @@ export const ConversationListCell = ({
 
   const {isChannelsEnabled} = useChannelsFeatureFlag();
   const isActive = isSelected(conversation);
+  const firstUserEntity = conversation.firstUserEntity();
 
   const conversationRef = useRef<HTMLDivElement>(null);
   const contextMenuRef = useRef<HTMLButtonElement>(null);
@@ -273,8 +275,8 @@ export const ConversationListCell = ({
         </div>
 
         <div className="conversation-list-cell-center">
-          {is1to1 ? (
-            <UserInfo user={conversation.firstUserEntity()!} isActive={isActive}>
+          {is1to1 && !isUndefined(firstUserEntity) ? (
+            <UserInfo user={firstUserEntity} isActive={isActive}>
               {isConversationWithBlockedUser && <UserBlockedBadge />}
             </UserInfo>
           ) : (

--- a/apps/webapp/src/script/components/inputBar/inputBar.tsx
+++ b/apps/webapp/src/script/components/inputBar/inputBar.tsx
@@ -17,8 +17,9 @@
  *
  */
 
-import {useCallback, useRef, useState} from 'react';
+import {useCallback, useRef, useState, type ReactElement} from 'react';
 
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {amplify} from 'amplify';
 import cx from 'classnames';
 import {LexicalEditor, $createTextNode, $insertNodes} from 'lexical';
@@ -33,6 +34,7 @@ import {useFileUploadState} from 'Components/conversation/useFilesUploadState/us
 import {EmojiPicker} from 'Components/emojiPicker/emojiPicker';
 import {useUserPropertyValue} from 'Hooks/useUserProperty';
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {ConnectionEntity} from 'Repositories/connection/connectionEntity';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {MessageRepository} from 'Repositories/conversation/MessageRepository';
 import {Conversation} from 'Repositories/entity/Conversation';
@@ -99,7 +101,35 @@ interface InputBarProps {
   onCellAssetUpload: () => void;
 }
 
-export const InputBar = ({
+interface InputBarContentProps extends InputBarProps {
+  readonly isIncomingRequest: boolean;
+  readonly isOutgoingRequest: boolean;
+}
+
+interface InputBarWithConnectionProps extends InputBarProps {
+  readonly connection: ConnectionEntity;
+}
+
+export function InputBar(props: InputBarProps): ReactElement {
+  const {connection} = useKoSubscribableChildren(props.conversation, ['connection']);
+
+  if (isNullOrUndefined(connection)) {
+    return <InputBarContent {...props} isIncomingRequest={false} isOutgoingRequest={false} />;
+  }
+
+  return <InputBarWithConnection {...props} connection={connection} />;
+}
+
+function InputBarWithConnection({connection, ...props}: InputBarWithConnectionProps): ReactElement {
+  const {isOutgoingRequest, isIncomingRequest} = useKoSubscribableChildren(connection, [
+    'isOutgoingRequest',
+    'isIncomingRequest',
+  ]);
+
+  return <InputBarContent {...props} isIncomingRequest={isIncomingRequest} isOutgoingRequest={isOutgoingRequest} />;
+}
+
+function InputBarContent({
   conversation,
   conversationRepository,
   cellsRepository,
@@ -119,26 +149,18 @@ export const InputBar = ({
   uploadPastedFiles,
   onCellImageUpload,
   onCellAssetUpload,
-}: InputBarProps) => {
+  isOutgoingRequest,
+  isIncomingRequest,
+}: InputBarContentProps): ReactElement {
   const {fireAndForgetInvoker, isFeatureToggleEnabled, translate} = useApplicationContext();
   const {classifiedDomains, isSelfDeletingMessagesEnabled, isFileSharingSendingEnabled} = useKoSubscribableChildren(
     teamState,
     ['classifiedDomains', 'isSelfDeletingMessagesEnabled', 'isFileSharingSendingEnabled'],
   );
-  const {connection, localMessageTimer, messageTimer, hasGlobalMessageTimer, isSelfUserRemoved, is1to1} =
-    useKoSubscribableChildren(conversation, [
-      'connection',
-      'localMessageTimer',
-      'messageTimer',
-      'hasGlobalMessageTimer',
-      'isSelfUserRemoved',
-      'is1to1',
-      'cellsState',
-    ]);
-  const {isOutgoingRequest, isIncomingRequest} = useKoSubscribableChildren(connection!, [
-    'isOutgoingRequest',
-    'isIncomingRequest',
-  ]);
+  const {localMessageTimer, messageTimer, hasGlobalMessageTimer, isSelfUserRemoved, is1to1} = useKoSubscribableChildren(
+    conversation,
+    ['localMessageTimer', 'messageTimer', 'hasGlobalMessageTimer', 'isSelfUserRemoved', 'is1to1', 'cellsState'],
+  );
 
   const {getFiles} = useFileUploadState();
   const files = getFiles({conversationId: conversation.id});
@@ -404,4 +426,4 @@ export const InputBar = ({
       ) : null}
     </div>
   );
-};
+}

--- a/apps/webapp/src/script/components/inputBar/inputBarControls/assetUploadButton/assetUploadButton.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/inputBarControls/assetUploadButton/assetUploadButton.test.tsx
@@ -23,6 +23,7 @@ import {translateForTest} from 'Util/test/translateForTest';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
+  requireValueForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 
 import {AssetUploadButton} from './assetUploadButton';
@@ -51,7 +52,7 @@ describe('AssetUploadButton', () => {
     const {container} = render(<AssetUploadButton onSelectFiles={onSelectFiles} />, {wrapper: rootProviderWrapper});
 
     const form = container.querySelector('form');
-    jest.spyOn(form!, 'reset');
+    jest.spyOn(requireValueForTest(form), 'reset');
 
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
 
@@ -61,6 +62,6 @@ describe('AssetUploadButton', () => {
 
     expect(onSelectFiles).toHaveBeenCalledWith([pngFile]);
     expect(fileInput.files?.[0].name).toEqual(pngFile.name);
-    expect(form!.reset).toHaveBeenCalled();
+    expect(requireValueForTest(form).reset).toHaveBeenCalled();
   });
 });

--- a/apps/webapp/src/script/components/inputBar/inputBarControls/imageUploadButton/imageUploadButton.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/inputBarControls/imageUploadButton/imageUploadButton.test.tsx
@@ -23,6 +23,7 @@ import {translateForTest} from 'Util/test/translateForTest';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
+  requireValueForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 
 import {ImageUploadButton} from './imageUploadButton';
@@ -59,7 +60,7 @@ describe('ImageUploadButton', () => {
     );
 
     const form = container.querySelector('form');
-    jest.spyOn(form!, 'reset');
+    jest.spyOn(requireValueForTest(form), 'reset');
 
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
 
@@ -69,6 +70,6 @@ describe('ImageUploadButton', () => {
 
     expect(onSelectImages).toHaveBeenCalledWith([pngFile]);
     expect(fileInput.files?.[0].name).toEqual(pngFile.name);
-    expect(form!.reset).toHaveBeenCalled();
+    expect(requireValueForTest(form).reset).toHaveBeenCalled();
   });
 });

--- a/apps/webapp/src/script/components/inputBar/inputBarEditor/richTextEditor/richTextEditor.tsx
+++ b/apps/webapp/src/script/components/inputBar/inputBarEditor/richTextEditor/richTextEditor.tsx
@@ -29,6 +29,7 @@ import {ListPlugin} from '@lexical/react/LexicalListPlugin';
 import {MarkdownShortcutPlugin} from '@lexical/react/LexicalMarkdownShortcutPlugin';
 import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {LexicalEditor, EditorState} from 'lexical';
 import {noop} from 'noop-esm';
 
@@ -146,7 +147,10 @@ export const RichTextEditor = ({
           <EditorRefPlugin
             editorRef={editor => {
               editorRef.current = editor;
-              onSetup(editor!);
+              if (isNullOrUndefined(editor)) {
+                return;
+              }
+              onSetup(editor);
             }}
           />
           <DraftStatePlugin loadDraftState={loadDraftState} />

--- a/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useMessageSend.test.tsx
@@ -14,18 +14,13 @@ import {FileWithPreview, useFileUploadState} from 'Components/conversation/useFi
 import {Config} from 'src/script/Config';
 
 import {useMessageSend} from './useMessageSend';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 
 const conversationId = 'conversation';
 
-const createDeferred = <T,>() => {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return {promise, resolve, reject};
-};
+function createDeferred<T>(): PromiseWithResolvers<T> {
+  return Promise.withResolvers<T>();
+}
 
 const createFile = (
   id: string,
@@ -114,7 +109,7 @@ describe('useMessageSend', () => {
     expect(promoteNodeDraft).toHaveBeenCalledWith({uuid: 'remote-image', versionId: 'version-image'});
     expect(sendTextWithLinkPreview).not.toHaveBeenCalled();
     publication.resolve();
-    await act(async () => sendPromise!);
+    await act(async () => requireValueForTest(sendPromise));
     await act(async () => Promise.resolve());
 
     expect(sendTextWithLinkPreview).toHaveBeenCalledWith(

--- a/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useSendFiles/useSendFiles.test.tsx
+++ b/apps/webapp/src/script/components/inputBar/useMessageHandling/useMessageSend/useSendFiles/useSendFiles.test.tsx
@@ -18,15 +18,9 @@ type Repository = {
   promoteNodeDraft: jest.Mock<Promise<void>, [{uuid: string; versionId: string}]>;
 };
 
-const createDeferred = <T,>() => {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return {promise, resolve, reject};
-};
+function createDeferred<T>(): PromiseWithResolvers<T> {
+  return Promise.withResolvers<T>();
+}
 
 const createFile = (id: string, preview = `blob:${id}`): FileWithPreview =>
   Object.assign(new File(['content'], `${id}.png`, {type: 'image/png'}), {

--- a/apps/webapp/src/script/components/meeting/meetNowModal/meetNowModal.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetNowModal/meetNowModal.test.tsx
@@ -53,14 +53,9 @@ import {useMeetNowModal} from './useMeetNowModal';
 const qualifiedConversation = {id: 'conversation-id', domain: 'example.com'};
 const qualifiedMeetingId = {id: 'meeting-id', domain: 'example.com'};
 
-const createDeferred = <T,>() => {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>(resolvePromise => {
-    resolve = resolvePromise;
-  });
-
-  return {promise, resolve};
-};
+function createDeferred<T>(): PromiseWithResolvers<T> {
+  return Promise.withResolvers<T>();
+}
 
 const createDeferredMeetNowMeeting = () => {
   const deferred = createDeferred<CreateMeetingSuccess>();

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingList.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingList.test.tsx
@@ -32,6 +32,7 @@ import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
+  requireValueForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 import {MainViewModel} from 'src/script/view_model/MainViewModel';
 import {translateForTest} from 'Util/test/translateForTest';
@@ -271,7 +272,7 @@ describe('MeetingList', () => {
     const meetingItem = screen.getByText('Visible meeting').closest('[aria-describedby]');
     const describedBy = meetingItem?.getAttribute('aria-describedby');
     expect(describedBy).toBeTruthy();
-    expect(document.getElementById(describedBy!)).toHaveTextContent(/meetings\.list\.today/);
+    expect(document.getElementById(requireValueForTest(describedBy))).toHaveTextContent(/meetings\.list\.today/);
   });
 
   it('does not treat the page tail as last-in-day while more occurrences remain on the same day', () => {

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingParticipants/meetingParticipants.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/meetingParticipants/meetingParticipants.test.tsx
@@ -32,6 +32,7 @@ import en from 'I18n/en-US.json';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
+  requireValueForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 import {MeetingParticipants} from './meetingParticipants';
 
@@ -77,7 +78,7 @@ describe('MeetingParticipants', () => {
       expect(avatar).toBeInTheDocument();
       const tooltipWrapper = avatar.closest('[data-testid="tooltip-wrapper"]');
       expect(tooltipWrapper).toBeInTheDocument();
-      fireEvent.mouseEnter(tooltipWrapper!);
+      fireEvent.mouseEnter(requireValueForTest(tooltipWrapper));
       expect(document.querySelector('[data-testid="tooltip-content"]')).toHaveTextContent(
         `${specialCharacterName} (Organizer)`,
       );
@@ -129,7 +130,7 @@ describe('MeetingParticipants', () => {
       expect(screen.queryByText('Self Organizer')).not.toBeInTheDocument();
       const tooltipWrapper = avatar.closest('[data-testid="tooltip-wrapper"]');
       expect(tooltipWrapper).toBeInTheDocument();
-      fireEvent.mouseEnter(tooltipWrapper!);
+      fireEvent.mouseEnter(requireValueForTest(tooltipWrapper));
       expect(screen.getByText('Self Organizer (Organizer)')).toBeInTheDocument();
       rendered.unmount();
     } finally {

--- a/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingModal.test.tsx
+++ b/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingModal.test.tsx
@@ -47,14 +47,9 @@ const testWallClock = createDeterministicWallClock({
   initialCurrentTimestampInMilliseconds: Date.parse('2026-08-12T10:00:00Z'),
 });
 
-const createDeferred = <T,>() => {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>(resolvePromise => {
-    resolve = resolvePromise;
-  });
-
-  return {promise, resolve};
-};
+function createDeferred<T>(): PromiseWithResolvers<T> {
+  return Promise.withResolvers<T>();
+}
 
 const createMeetingStore = (scheduleMeeting: MeetingStoreState['scheduleMeeting']) =>
   createStore<MeetingStoreState>(() => ({

--- a/apps/webapp/src/script/components/meeting/selectors/getMeetingInstancePage.ts
+++ b/apps/webapp/src/script/components/meeting/selectors/getMeetingInstancePage.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
+
 import type {MeetingInstance} from 'Components/meeting/types/meetingInstance';
 import type {MeetingSeries} from 'Components/meeting/types/meetingSeries';
 
@@ -54,7 +56,11 @@ const insertChronologically = (candidates: MeetingInstance[], meetingInstance: M
   while (lowerBound < upperBound) {
     const middleIndex = Math.floor((lowerBound + upperBound) / BINARY_SEARCH_DIVISOR);
 
-    if (compareMeetingInstances(candidates[middleIndex]!, meetingInstance) <= 0) {
+    const candidate = candidates[middleIndex];
+    if (isUndefined(candidate)) {
+      throw new Error(`Missing meeting instance at index ${middleIndex}`);
+    }
+    if (compareMeetingInstances(candidate, meetingInstance) <= 0) {
       lowerBound = middleIndex + 1;
     } else {
       upperBound = middleIndex;
@@ -69,7 +75,10 @@ export const getNextMeetingInstancePage = (cursor: MeetingInstancePageCursor, li
   const meetingInstances: MeetingInstance[] = [];
 
   while (meetingInstances.length < limit && candidates.length > 0) {
-    const meetingInstance = candidates.shift()!;
+    const meetingInstance = candidates.shift();
+    if (isUndefined(meetingInstance)) {
+      throw new Error('Meeting instance candidates became empty unexpectedly');
+    }
     meetingInstances.push(meetingInstance);
 
     const nextMeetingInstance = getNextMeetingInstance(meetingInstance);

--- a/apps/webapp/src/script/components/meeting/shared/submit/submitDeleteMeeting.test.ts
+++ b/apps/webapp/src/script/components/meeting/shared/submit/submitDeleteMeeting.test.ts
@@ -190,10 +190,7 @@ describe('submitDeleteMeeting', () => {
   });
 
   it('shows feedback when a second submit for the same meeting is already in flight', async () => {
-    let releaseDelete!: () => void;
-    const deleteGate = new Promise<void>(resolve => {
-      releaseDelete = resolve;
-    });
+    const {promise: deleteGate, resolve: releaseDelete} = Promise.withResolvers<void>();
     const deleteMeetingForAll = jest.fn().mockReturnValue(
       task.tryOrElse(
         () => meetingSubmitErrors.deleteFailed,

--- a/apps/webapp/src/script/components/messagesList/message/contentMessage/asset/fileAsset/fileAsset.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/contentMessage/asset/fileAsset/fileAsset.tsx
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
@@ -59,8 +60,12 @@ const FileAsset = ({
   const {isFileSharingReceivingEnabled} = useKoSubscribableChildren(teamState, ['isFileSharingReceivingEnabled']);
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isFocusable);
 
-  const fileName = trimFileExtension(asset.file_name);
-  const fileExtension = getFileExtension(asset.file_name!);
+  const assetFileName = asset.file_name;
+  if (isUndefined(assetFileName)) {
+    throw new Error('File asset has no file name');
+  }
+  const fileName = trimFileExtension(assetFileName);
+  const fileExtension = getFileExtension(assetFileName);
   const formattedFileSize = formatBytes(asset.file_size);
 
   // This is a hack since we don't have a FileAsset available before it's

--- a/apps/webapp/src/script/components/messagesList/message/contentMessage/asset/imageAsset/imageAsset.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/contentMessage/asset/imageAsset/imageAsset.test.tsx
@@ -28,6 +28,7 @@ import {User} from 'Repositories/entity/User';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
+  requireValueForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 import {translateForTest} from 'Util/test/translateForTest';
 
@@ -153,7 +154,7 @@ describe('image-asset', () => {
     });
 
     const wrapper = screen.getByTestId('image-asset-img').closest('div');
-    fireEvent.click(wrapper!);
+    fireEvent.click(requireValueForTest(wrapper));
     expect(onClickMock).toHaveBeenCalledWith(message, expect.any(Object));
   });
 

--- a/apps/webapp/src/script/components/messagesList/message/contentMessage/asset/locationAsset.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/contentMessage/asset/locationAsset.test.tsx
@@ -23,6 +23,7 @@ import type {Location} from 'Repositories/entity/message/location';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
+  requireValueForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 
 import {LocationAsset} from './locationAsset';
@@ -45,6 +46,6 @@ describe('LocationAsset', () => {
 
   it('sets the correct location name', () => {
     const {queryByText} = render(<LocationAsset asset={location as Location} />, {wrapper: rootProviderWrapper});
-    expect(queryByText(location.name!)).not.toBeNull();
+    expect(queryByText(requireValueForTest(location.name))).not.toBeNull();
   });
 });

--- a/apps/webapp/src/script/components/messagesList/message/contentMessage/asset/messageButton/messageButton.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/contentMessage/asset/messageButton/messageButton.test.tsx
@@ -23,6 +23,7 @@ import ko from 'knockout';
 import {CompositeMessage} from 'Repositories/entity/message/compositeMessage';
 
 import {MessageButton} from './messageButton';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 
 import {withTheme} from '../../../../../../auth/util/test/testUtil';
 
@@ -69,6 +70,6 @@ describe('MessageButton', () => {
     const selectedButton = container.querySelector(`button[data-uie-uid="${messageId}"]`);
     expect(selectedButton).not.toBeNull();
 
-    expect(selectedButton!.getAttribute('data-uie-selected')).toBe('true');
+    expect(requireValueForTest(selectedButton).getAttribute('data-uie-selected')).toBe('true');
   });
 });

--- a/apps/webapp/src/script/components/messagesList/message/contentMessage/asset/multipartAssets/multipartAssets.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/contentMessage/asset/multipartAssets/multipartAssets.tsx
@@ -19,6 +19,7 @@
 
 import {useEffect} from 'react';
 
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {container} from 'tsyringe';
 
 import {ICellAsset} from '@wireapp/protocol-messaging';
@@ -94,8 +95,11 @@ const MultipartAsset = ({
   senderName,
   timestamp,
 }: MultipartAssetProps): JSX.Element => {
+  if (isNullOrUndefined(initialName)) {
+    throw new Error('Multipart asset has no file name');
+  }
   const {fireAndForgetInvoker, translate} = useApplicationContext();
-  const extension = getFileExtension(initialName!);
+  const extension = getFileExtension(initialName);
   const size = formatBytes(Number(initialSize));
 
   const {elementRef, hasBeenInView} = useInView<HTMLLIElement>();
@@ -114,7 +118,7 @@ const MultipartAsset = ({
       retryPreviewUntilSuccess: isSingleAsset && !isImage && !isVideo,
     });
 
-  const name = path !== undefined && path !== '' ? getName(path) : getName(initialName!);
+  const name = !isNullOrUndefined(path) && path !== '' ? getName(path) : getName(initialName);
   const canPreviewImage = isPreviewableImage({mimeType: contentType, extension}) || imagePreviewUrl !== undefined;
   const imageSrc = imagePreviewUrl ?? src;
   const hasFilePreview = hasPreview ?? false;

--- a/apps/webapp/src/script/components/messagesList/message/contentMessage/asset/multipartAssets/useGetMultipartAsset/useGetMultipartAsset.test.ts
+++ b/apps/webapp/src/script/components/messagesList/message/contentMessage/asset/multipartAssets/useGetMultipartAsset/useGetMultipartAsset.test.ts
@@ -468,6 +468,14 @@ describe('useGetMultipartAsset', () => {
         expect(mockCellsRepository.getNode).toHaveBeenCalledTimes(1);
       });
 
+      await act(async () => {
+        await fireAndForgetInvoker.waitUntilAllSettled();
+      });
+
+      await waitFor(() => {
+        expect(result.current.hasPreview).toBe(true);
+      });
+
       // Wait for retry
       await act(async () => {
         jest.advanceTimersByTime(100);

--- a/apps/webapp/src/script/components/panel/enrichedFields.test.tsx
+++ b/apps/webapp/src/script/components/panel/enrichedFields.test.tsx
@@ -26,6 +26,7 @@ import {translateForTest} from 'Util/test/translateForTest';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
+  requireValueForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 import {createUuid} from 'Util/uuid';
 
@@ -61,7 +62,7 @@ describe('EnrichedFields', () => {
 
     await waitFor(() => getAllByTestId('item-enriched-key'));
 
-    expect(getAllByTestId('item-enriched-key')).toHaveLength(richInfo.fields!.length);
+    expect(getAllByTestId('item-enriched-key')).toHaveLength(requireValueForTest(richInfo.fields).length);
   });
 
   it('displays the email if set on user', async () => {

--- a/apps/webapp/src/script/components/userList/userList.tsx
+++ b/apps/webapp/src/script/components/userList/userList.tsx
@@ -19,6 +19,7 @@
 
 import {ChangeEvent, useCallback, useId, useMemo, useState} from 'react';
 
+import {isUndefined} from '@sindresorhus/is';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
@@ -112,9 +113,6 @@ export const UserList = ({
   const highlightedUserIds = highlightedUsers.map(user => user.id);
   const {is_verified: isSelfVerified} = useKoSubscribableChildren(selfUser, ['is_verified']);
 
-  // subscribe to roles changes in order to react to them
-  useKoSubscribableChildren(conversation!, ['roles']);
-
   const isCompactMode = mode === UserlistMode.COMPACT;
   const cssClasses = isCompactMode ? 'search-list-sm' : 'search-list-lg';
 
@@ -183,7 +181,7 @@ export const UserList = ({
   const membersHeaderId = useId();
   let content;
 
-  const showRoles = !!conversation;
+  const showRoles = !isUndefined(conversation);
   if (showRoles) {
     let members: User[] = [];
     let admins: User[] = [];
@@ -328,6 +326,7 @@ export const UserList = ({
 
   return (
     <>
+      {!isUndefined(conversation) && <ConversationRolesSubscription conversation={conversation} />}
       {content}
 
       {hasMoreUsers && (
@@ -340,3 +339,9 @@ export const UserList = ({
     </>
   );
 };
+
+function ConversationRolesSubscription({conversation}: {conversation: Conversation}): null {
+  useKoSubscribableChildren(conversation, ['roles']);
+
+  return null;
+}

--- a/apps/webapp/src/script/e2eIdentity/e2eIdentityEnrollment.test.ts
+++ b/apps/webapp/src/script/e2eIdentity/e2eIdentityEnrollment.test.ts
@@ -30,6 +30,7 @@ import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {UserState} from 'Repositories/user/userState';
 import {Core} from 'src/script/service/coreSingleton';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import * as util from 'Util/util';
 
 import {E2EIHandler} from './e2eIdentityEnrollment';
@@ -98,6 +99,9 @@ describe('E2EIHandler', () => {
   const selfClientId = 'clientId';
 
   const coreMock = container.resolve(Core);
+  function getE2EIServiceForTest(): NonNullable<NonNullable<typeof coreMock.service>['e2eIdentity']> {
+    return requireValueForTest(requireValueForTest(coreMock.service).e2eIdentity);
+  }
   const setWindowSearch = (search: string): void => {
     const searchPrefix = search ? `?${search}` : '';
     window.history.replaceState({}, '', `/${searchPrefix}`);
@@ -144,8 +148,8 @@ describe('E2EIHandler', () => {
   });
 
   it('does nothing if there is not enrollment in progress and device is alreaady enrolled', async () => {
-    jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(false);
-    jest.spyOn(coreMock.service!.e2eIdentity!, 'isFreshMLSSelfClient').mockResolvedValue(false);
+    jest.spyOn(getE2EIServiceForTest(), 'isEnrollmentInProgress').mockResolvedValue(false);
+    jest.spyOn(getE2EIServiceForTest(), 'isFreshMLSSelfClient').mockResolvedValue(false);
     const enrollPromise = E2EIHandler.getInstance().initialize(params);
 
     expect(modalMock).not.toHaveBeenCalled();
@@ -154,7 +158,7 @@ describe('E2EIHandler', () => {
   });
 
   it('trigger an enrollment when instantiated with a fresh new MLS device', async () => {
-    jest.spyOn(coreMock.service!.e2eIdentity!, 'isFreshMLSSelfClient').mockResolvedValue(true);
+    jest.spyOn(getE2EIServiceForTest(), 'isFreshMLSSelfClient').mockResolvedValue(true);
     const enrollPromise = E2EIHandler.getInstance().initialize(params);
     await waitFor(() => {
       expect(modalMock).toHaveBeenCalledWith(
@@ -184,7 +188,7 @@ describe('E2EIHandler', () => {
   });
 
   it('continues in progress enrollment', async () => {
-    jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(true);
+    jest.spyOn(getE2EIServiceForTest(), 'isEnrollmentInProgress').mockResolvedValue(true);
 
     // mock window search params (code, session_state, state)
     const searchParams = new URLSearchParams();
@@ -220,7 +224,7 @@ describe('E2EIHandler', () => {
   });
 
   it('starts from scratch if returned to app without auth params', async () => {
-    jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(true);
+    jest.spyOn(getE2EIServiceForTest(), 'isEnrollmentInProgress').mockResolvedValue(true);
 
     // mock window search params (code, session_state, state)
     setWindowSearch('');
@@ -255,8 +259,8 @@ describe('E2EIHandler', () => {
   });
 
   it('shows the error modal without the snooze option after enrollment failed and the client is fresh', async () => {
-    jest.spyOn(coreMock.service!.e2eIdentity!, 'isFreshMLSSelfClient').mockResolvedValue(true);
-    jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(true);
+    jest.spyOn(getE2EIServiceForTest(), 'isFreshMLSSelfClient').mockResolvedValue(true);
+    jest.spyOn(getE2EIServiceForTest(), 'isEnrollmentInProgress').mockResolvedValue(true);
     jest.spyOn(coreMock, 'enrollE2EI').mockRejectedValue(new Error('OIDC Error'));
 
     const handler = E2EIHandler.getInstance();
@@ -294,8 +298,8 @@ describe('E2EIHandler', () => {
   });
 
   it('shows the error modal with the snooze option after enrollment failed and the client is an e2ei client already', async () => {
-    jest.spyOn(coreMock.service!.e2eIdentity!, 'isFreshMLSSelfClient').mockResolvedValue(false);
-    jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(true);
+    jest.spyOn(getE2EIServiceForTest(), 'isFreshMLSSelfClient').mockResolvedValue(false);
+    jest.spyOn(getE2EIServiceForTest(), 'isEnrollmentInProgress').mockResolvedValue(true);
     jest.spyOn(coreMock, 'enrollE2EI').mockRejectedValue(new Error('OIDC Error'));
 
     const handler = E2EIHandler.getInstance();
@@ -338,10 +342,10 @@ describe('E2EIHandler', () => {
     const enrollmentStore = getEnrollmentStore({id: 'userId', domain: 'domain'}, 'clientId');
     enrollmentStore.store.e2eiActivatedAt(Date.now());
 
-    jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(false);
-    jest.spyOn(coreMock.service!.e2eIdentity!, 'isFreshMLSSelfClient').mockResolvedValue(false);
+    jest.spyOn(getE2EIServiceForTest(), 'isEnrollmentInProgress').mockResolvedValue(false);
+    jest.spyOn(getE2EIServiceForTest(), 'isFreshMLSSelfClient').mockResolvedValue(false);
     jest
-      .spyOn(coreMock.service!.conversation!, 'getMLSSelfConversation')
+      .spyOn(requireValueForTest(requireValueForTest(coreMock.service).conversation), 'getMLSSelfConversation')
       .mockResolvedValue({group_id: 'groupId'} as any);
 
     const taskMock = jest.spyOn(LowPrecisionTaskScheduler, 'addTask');
@@ -355,8 +359,8 @@ describe('E2EIHandler', () => {
 
   describe('startTimers()', () => {
     it('should reset the timer after user interaction with modal', async () => {
-      jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(false);
-      jest.spyOn(coreMock.service!.e2eIdentity!, 'isFreshMLSSelfClient').mockResolvedValue(false);
+      jest.spyOn(getE2EIServiceForTest(), 'isEnrollmentInProgress').mockResolvedValue(false);
+      jest.spyOn(getE2EIServiceForTest(), 'isFreshMLSSelfClient').mockResolvedValue(false);
       jest
         .spyOn(e2eIdentityVerification, 'getActiveWireIdentity')
         .mockResolvedValue(
@@ -388,8 +392,8 @@ describe('E2EIHandler', () => {
 
     describe('should start enrollment for existing devices', () => {
       it('with a basic credential type', async () => {
-        jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(false);
-        jest.spyOn(coreMock.service!.e2eIdentity!, 'isFreshMLSSelfClient').mockResolvedValue(false);
+        jest.spyOn(getE2EIServiceForTest(), 'isEnrollmentInProgress').mockResolvedValue(false);
+        jest.spyOn(getE2EIServiceForTest(), 'isFreshMLSSelfClient').mockResolvedValue(false);
         jest
           .spyOn(e2eIdentityVerification, 'getActiveWireIdentity')
           .mockResolvedValue(
@@ -408,8 +412,8 @@ describe('E2EIHandler', () => {
       });
 
       it('without existing WireIdentity', async () => {
-        jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(false);
-        jest.spyOn(coreMock.service!.e2eIdentity!, 'isFreshMLSSelfClient').mockResolvedValue(false);
+        jest.spyOn(getE2EIServiceForTest(), 'isEnrollmentInProgress').mockResolvedValue(false);
+        jest.spyOn(getE2EIServiceForTest(), 'isFreshMLSSelfClient').mockResolvedValue(false);
         jest.spyOn(e2eIdentityVerification, 'getActiveWireIdentity').mockResolvedValue(undefined);
 
         const instance = await E2EIHandler.getInstance().initialize(params);
@@ -424,8 +428,8 @@ describe('E2EIHandler', () => {
       });
 
       it('with pristine WireIdentity', async () => {
-        jest.spyOn(coreMock.service!.e2eIdentity!, 'isEnrollmentInProgress').mockResolvedValue(false);
-        jest.spyOn(coreMock.service!.e2eIdentity!, 'isFreshMLSSelfClient').mockResolvedValue(false);
+        jest.spyOn(getE2EIServiceForTest(), 'isEnrollmentInProgress').mockResolvedValue(false);
+        jest.spyOn(getE2EIServiceForTest(), 'isFreshMLSSelfClient').mockResolvedValue(false);
         jest
           .spyOn(e2eIdentityVerification, 'getActiveWireIdentity')
           .mockResolvedValue(generateWireIdentity(selfClientId, CredentialType.X509));

--- a/apps/webapp/src/script/e2eIdentity/e2eIdentityEnrollment.ts
+++ b/apps/webapp/src/script/e2eIdentity/e2eIdentityEnrollment.ts
@@ -329,9 +329,13 @@ export class E2EIHandler extends TypedEventEmitter<Events> {
 
           return conversations.found
             .filter(conversation => isNonEmptyString(conversation.group_id))
-            .map(({group_id}) => ({
-              group_id: group_id!,
-            }));
+            .map(({group_id}) => {
+              if (!isNonEmptyString(group_id)) {
+                throw new Error('An MLS conversation is missing its group id');
+              }
+
+              return {group_id};
+            });
         },
       });
 

--- a/apps/webapp/src/script/mls/MLSConversations.test.ts
+++ b/apps/webapp/src/script/mls/MLSConversations.test.ts
@@ -34,6 +34,7 @@ import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {UserState} from 'Repositories/user/userState';
 import {Core} from 'src/script/service/coreSingleton';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import {TestFactory} from 'test/helper/TestFactory';
 import {translateForTest} from 'Util/test/translateForTest';
 
@@ -46,6 +47,14 @@ import {
   initialiseSelfAndTeamConversations,
   readLocalMLSState,
 } from './MLSConversations';
+
+function getConversationServiceForTest(core: Account): NonNullable<NonNullable<Account['service']>['conversation']> {
+  return requireValueForTest(requireValueForTest(core.service).conversation);
+}
+
+function getMlsServiceForTest(core: Account): NonNullable<NonNullable<Account['service']>['mls']> {
+  return requireValueForTest(requireValueForTest(core.service).mls);
+}
 
 function createMLSConversation(type?: CONVERSATION_TYPE, epoch = 0): MLSConversation {
   const conversation = new Conversation(randomUUID(), '', CONVERSATION_PROTOCOL.MLS, translateForTest);
@@ -83,7 +92,7 @@ describe('MLSConversations', () => {
 
       const conversationRepository = await testFactory.exposeConversationActors();
       const repositoryCore = conversationRepository['core'];
-      jest.spyOn(repositoryCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
+      jest.spyOn(getConversationServiceForTest(repositoryCore), 'mlsGroupExistsLocally').mockResolvedValue(false);
       jest
         .spyOn(
           (conversationRepository as unknown as {conversationService: {getSafeConversationById: jest.Mock}})
@@ -92,7 +101,7 @@ describe('MLSConversations', () => {
         )
         .mockReturnValue(task.fromResult(result.ok({epoch: 1})));
       mockSafeEpoch(repositoryCore);
-      const joinSpy = jest.spyOn(repositoryCore.service!.conversation, 'joinByExternalCommit');
+      const joinSpy = jest.spyOn(getConversationServiceForTest(repositoryCore), 'joinByExternalCommit');
 
       await initMLSGroupConversations(mlsConversations, conversationRepository, {core: repositoryCore});
 
@@ -108,9 +117,9 @@ describe('MLSConversations', () => {
       const conversationRepository = await testFactory.exposeConversationActors();
       const repositoryCore = conversationRepository['core'];
 
-      jest.spyOn(repositoryCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
+      jest.spyOn(getConversationServiceForTest(repositoryCore), 'mlsGroupExistsLocally').mockResolvedValue(false);
       mockSafeEpoch(repositoryCore);
-      const joinSpy = jest.spyOn(repositoryCore.service!.conversation, 'joinByExternalCommit');
+      const joinSpy = jest.spyOn(getConversationServiceForTest(repositoryCore), 'joinByExternalCommit');
 
       await initMLSGroupConversations([mlsConversation], conversationRepository, {core: repositoryCore});
 
@@ -123,7 +132,7 @@ describe('MLSConversations', () => {
 
       const conversationRepository = await testFactory.exposeConversationActors();
       const repositoryCore = conversationRepository['core'];
-      jest.spyOn(repositoryCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
+      jest.spyOn(getConversationServiceForTest(repositoryCore), 'mlsGroupExistsLocally').mockResolvedValue(false);
       jest
         .spyOn(
           (conversationRepository as unknown as {conversationService: {getSafeConversationById: jest.Mock}})
@@ -132,7 +141,7 @@ describe('MLSConversations', () => {
         )
         .mockReturnValue(task.fromResult(result.ok({epoch: 1})));
       mockSafeEpoch(repositoryCore);
-      const joinSpy = jest.spyOn(repositoryCore.service!.conversation, 'joinByExternalCommit');
+      const joinSpy = jest.spyOn(getConversationServiceForTest(repositoryCore), 'joinByExternalCommit');
 
       await initMLSGroupConversations([meetingConversation], conversationRepository, {core: repositoryCore});
 
@@ -146,15 +155,15 @@ describe('MLSConversations', () => {
 
     const mlsConversations = createMLSConversations(nbMLSConversations, CONVERSATION_TYPE.REGULAR);
 
-    jest.spyOn(core.service!.conversation!, 'mlsGroupExistsLocally').mockResolvedValue(true);
+    jest.spyOn(getConversationServiceForTest(core), 'mlsGroupExistsLocally').mockResolvedValue(true);
     mockSafeEpoch(core);
-    jest.spyOn(core.service!.mls!, 'scheduleKeyMaterialRenewal');
+    jest.spyOn(getMlsServiceForTest(core), 'scheduleKeyMaterialRenewal');
 
     const conversationRepository = await testFactory.exposeConversationActors();
     await initMLSGroupConversations(mlsConversations, conversationRepository, {core});
 
     for (const conversation of mlsConversations) {
-      expect(core.service!.mls!.scheduleKeyMaterialRenewal).toHaveBeenCalledWith(conversation.groupId);
+      expect(getMlsServiceForTest(core).scheduleKeyMaterialRenewal).toHaveBeenCalledWith(conversation.groupId);
     }
   });
 
@@ -166,8 +175,8 @@ describe('MLSConversations', () => {
       const selfConversation = createMLSConversation(CONVERSATION_TYPE.SELF);
 
       const teamConversation = createMLSConversation(CONVERSATION_TYPE.GLOBAL_TEAM);
-      jest.spyOn(core.service!.conversation!, 'mlsGroupExistsLocally').mockResolvedValue(true);
-      jest.spyOn(core.service!.mls!, 'scheduleKeyMaterialRenewal');
+      jest.spyOn(getConversationServiceForTest(core), 'mlsGroupExistsLocally').mockResolvedValue(true);
+      jest.spyOn(getMlsServiceForTest(core), 'scheduleKeyMaterialRenewal');
 
       const mlsConversations = createMLSConversations(nbMLSConversations);
       const conversations = [teamConversation, ...mlsConversations, selfConversation];
@@ -183,7 +192,7 @@ describe('MLSConversations', () => {
         core,
       );
 
-      expect(core.service!.mls!.registerConversation).toHaveBeenCalledTimes(2);
+      expect(getMlsServiceForTest(core).registerConversation).toHaveBeenCalledTimes(2);
     });
 
     it('does not register self and team conversation that have epoch > 0', async () => {
@@ -203,7 +212,7 @@ describe('MLSConversations', () => {
 
       const conversationRepository = await testFactory.exposeConversationActors();
       const repositoryCore = conversationRepository['core'];
-      jest.spyOn(repositoryCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(true);
+      jest.spyOn(getConversationServiceForTest(repositoryCore), 'mlsGroupExistsLocally').mockResolvedValue(true);
       mockSafeEpoch(core);
 
       await initialiseSelfAndTeamConversations(
@@ -214,7 +223,7 @@ describe('MLSConversations', () => {
         core,
       );
 
-      expect(core.service!.mls!.registerConversation).toHaveBeenCalledTimes(0);
+      expect(getMlsServiceForTest(core).registerConversation).toHaveBeenCalledTimes(0);
     });
 
     it('joins self and team conversation with external commit that have epoch > 0', async () => {
@@ -235,8 +244,8 @@ describe('MLSConversations', () => {
       const repositoryCore = conversationRepository['core'];
       mockSafeEpoch(repositoryCore);
       // MLS group is not yet established locally
-      jest.spyOn(repositoryCore.service!.mls!, 'isConversationEstablished').mockResolvedValue(false);
-      jest.spyOn(repositoryCore.service!.conversation!, 'mlsGroupExistsLocally').mockResolvedValue(false);
+      jest.spyOn(getMlsServiceForTest(repositoryCore), 'isConversationEstablished').mockResolvedValue(false);
+      jest.spyOn(getConversationServiceForTest(repositoryCore), 'mlsGroupExistsLocally').mockResolvedValue(false);
       jest
         .spyOn(
           (conversationRepository as unknown as {conversationService: {getSafeConversationById: jest.Mock}})
@@ -245,7 +254,7 @@ describe('MLSConversations', () => {
         )
         .mockReturnValue(task.fromResult(result.ok({epoch: 1})));
 
-      const joinSpy = jest.spyOn(repositoryCore.service!.conversation!, 'joinByExternalCommit');
+      const joinSpy = jest.spyOn(getConversationServiceForTest(repositoryCore), 'joinByExternalCommit');
       await initialiseSelfAndTeamConversations(
         conversations,
         conversationRepository,
@@ -254,7 +263,7 @@ describe('MLSConversations', () => {
         repositoryCore,
       );
 
-      expect(repositoryCore.service!.mls!.registerConversation).toHaveBeenCalledTimes(0);
+      expect(getMlsServiceForTest(repositoryCore).registerConversation).toHaveBeenCalledTimes(0);
       expect(joinSpy).toHaveBeenCalledTimes(2);
     });
 
@@ -273,7 +282,7 @@ describe('MLSConversations', () => {
       const mlsConversations = createMLSConversations(nbMLSConversations);
       const conversations = [teamConversation, ...mlsConversations, selfConversation];
 
-      jest.spyOn(core.service!.mls!, 'isConversationEstablished').mockResolvedValue(true);
+      jest.spyOn(getMlsServiceForTest(core), 'isConversationEstablished').mockResolvedValue(true);
 
       const conversationRepository = await testFactory.exposeConversationActors();
       mockSafeEpoch(core);
@@ -286,8 +295,8 @@ describe('MLSConversations', () => {
         core,
       );
 
-      expect(core.service!.mls!.registerConversation).not.toHaveBeenCalled();
-      expect(core.service!.conversation!.joinByExternalCommit).not.toHaveBeenCalled();
+      expect(getMlsServiceForTest(core).registerConversation).not.toHaveBeenCalled();
+      expect(getConversationServiceForTest(core).joinByExternalCommit).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/webapp/src/script/mls/MLSMigration/migrationFinaliser/joinConversationsAfterMigrationFinalisation/joinConversationsAfterMigrationFinalisation.test.ts
+++ b/apps/webapp/src/script/mls/MLSMigration/migrationFinaliser/joinConversationsAfterMigrationFinalisation/joinConversationsAfterMigrationFinalisation.test.ts
@@ -25,12 +25,19 @@ import {container} from 'tsyringe';
 import {ConversationDatabaseData, ConversationMapper} from 'Repositories/conversation/ConversationMapper';
 import {User} from 'Repositories/entity/User';
 import {Core} from 'src/script/service/coreSingleton';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import {TestFactory} from 'test/helper/TestFactory';
 import {translate} from 'Util/localizerUtil';
 import {createUuid} from 'Util/uuid';
 
 import {joinConversationsAfterMigrationFinalisation} from '.';
 import {translateForTest} from 'Util/test/translateForTest';
+
+function getConversationServiceForTest(core: Core): NonNullable<NonNullable<Core['service']>['conversation']> {
+  const service = requireValueForTest(core.service);
+
+  return requireValueForTest(service.conversation);
+}
 
 const createMockedDBConversationEntry = (
   id: string,
@@ -135,7 +142,7 @@ describe('joinConversationsAfterMigrationFinalisation', () => {
     const mockCore = container.resolve(Core);
     mockSafeEpoch(mockCore);
 
-    jest.spyOn(mockCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
+    jest.spyOn(getConversationServiceForTest(mockCore), 'mlsGroupExistsLocally').mockResolvedValue(false);
 
     const conversationId = 'conversation1';
     const mockDomain = 'anta.wire.link';
@@ -181,7 +188,7 @@ describe('joinConversationsAfterMigrationFinalisation', () => {
     const mockCore = container.resolve(Core);
     mockSafeEpoch(mockCore);
 
-    jest.spyOn(mockCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
+    jest.spyOn(getConversationServiceForTest(mockCore), 'mlsGroupExistsLocally').mockResolvedValue(false);
 
     const conversationId = 'conversation1';
     const mockDomain = 'anta.wire.link';
@@ -218,7 +225,7 @@ describe('joinConversationsAfterMigrationFinalisation', () => {
     const mockCore = container.resolve(Core);
     mockSafeEpoch(mockCore);
 
-    jest.spyOn(mockCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
+    jest.spyOn(getConversationServiceForTest(mockCore), 'mlsGroupExistsLocally').mockResolvedValue(false);
 
     const conversationId = 'conversation1';
     const mockDomain = 'anta.wire.link';
@@ -255,7 +262,7 @@ describe('joinConversationsAfterMigrationFinalisation', () => {
     const mockCore = container.resolve(Core);
     mockSafeEpoch(mockCore);
 
-    jest.spyOn(mockCore.service!.conversation, 'mlsGroupExistsLocally').mockResolvedValue(false);
+    jest.spyOn(getConversationServiceForTest(mockCore), 'mlsGroupExistsLocally').mockResolvedValue(false);
 
     const conversationId = 'conversation1';
     const mockDomain = 'anta.wire.link';

--- a/apps/webapp/src/script/mls/MLSMigration/migrationInitialiser/joinUnestablishedMixedConversations/joinUnestablishedMixedConversations.test.ts
+++ b/apps/webapp/src/script/mls/MLSMigration/migrationInitialiser/joinUnestablishedMixedConversations/joinUnestablishedMixedConversations.test.ts
@@ -25,11 +25,18 @@ import {MixedConversation} from 'Repositories/conversation/ConversationSelectors
 import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {Core} from 'src/script/service/coreSingleton';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import {TestFactory} from 'test/helper/TestFactory';
 import {createUuid} from 'Util/uuid';
 
 import {joinUnestablishedMixedConversations} from '.';
 import {translateForTest} from 'Util/test/translateForTest';
+
+function getConversationServiceForTest(core: Core): NonNullable<NonNullable<Core['service']>['conversation']> {
+  const service = requireValueForTest(core.service);
+
+  return requireValueForTest(service.conversation);
+}
 
 const createMixedConversation = (mockGroupId: string, epoch = 5): MixedConversation => {
   const conversation = new Conversation(createUuid(), '', CONVERSATION_PROTOCOL.MIXED, translateForTest);
@@ -58,7 +65,7 @@ describe('joinUnestablishedMixedConversations', () => {
     // Use the exact same core instance the repository was constructed with to avoid mismatched spies
     const repositoryCore = (mockedConversationRepository as any).core as Core; // core is a private ctor arg
 
-    jest.spyOn(repositoryCore.service!.conversation!, 'mlsGroupExistsLocally').mockImplementation(groupId => {
+    jest.spyOn(getConversationServiceForTest(repositoryCore), 'mlsGroupExistsLocally').mockImplementation(groupId => {
       return Promise.resolve(!groupId.includes('unestablished'));
     });
 
@@ -67,7 +74,7 @@ describe('joinUnestablishedMixedConversations', () => {
       .mockResolvedValue(task.fromResult(result.ok(1)));
 
     // Spy on joinByExternalCommit of the repository's core instance
-    const joinSpy = jest.spyOn(repositoryCore.service!.conversation!, 'joinByExternalCommit');
+    const joinSpy = jest.spyOn(getConversationServiceForTest(repositoryCore), 'joinByExternalCommit');
     jest
       .spyOn(
         (mockedConversationRepository as unknown as {conversationService: {getSafeConversationById: jest.Mock}})
@@ -99,7 +106,7 @@ describe('joinUnestablishedMixedConversations', () => {
     const selfUser = new User(createUuid(), 'domain', translateForTest);
     const mockedConversationRepository = await testFactory.exposeConversationActors();
     const repositoryCore = (mockedConversationRepository as any).core as Core;
-    jest.spyOn(repositoryCore.service!.conversation!, 'mlsGroupExistsLocally').mockImplementation(groupId => {
+    jest.spyOn(getConversationServiceForTest(repositoryCore), 'mlsGroupExistsLocally').mockImplementation(groupId => {
       return Promise.resolve(!groupId.includes('unestablished'));
     });
     jest.spyOn(mockedConversationRepository, 'tryEstablishingMLSGroup');

--- a/apps/webapp/src/script/page/components/featureConfigChange/featureConfigChangeHandler/features/e2eIdentity.ts
+++ b/apps/webapp/src/script/page/components/featureConfigChange/featureConfigChangeHandler/features/e2eIdentity.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {FEATURE_STATUS, FEATURE_KEY, FeatureList} from '@wireapp/api-client/lib/team';
 
 import {E2EIHandler} from 'src/script/e2eIdentity';
@@ -58,8 +59,12 @@ export const configureE2EI = (config: FeatureList): undefined | Promise<E2EIHand
   if (!e2eiConfig) {
     return undefined;
   }
+  const discoveryUrl = e2eiConfig.config.acmeDiscoveryUrl;
+  if (isUndefined(discoveryUrl)) {
+    throw new Error('E2EI configuration is missing the ACME discovery URL');
+  }
   return E2EIHandler.getInstance().initialize({
-    discoveryUrl: e2eiConfig.config.acmeDiscoveryUrl!,
+    discoveryUrl,
     gracePeriodInSeconds: e2eiConfig.config.verificationExpiration,
   });
 };

--- a/apps/webapp/src/script/page/leftSidebar/panels/startUi/servicesTab.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/startUi/servicesTab.tsx
@@ -19,6 +19,7 @@
 
 import {useState, useEffect} from 'react';
 
+import {isUndefined} from '@sindresorhus/is';
 import {useDebouncedCallback} from 'use-debounce';
 
 import {Button, ButtonVariant} from '@wireapp/react-ui-kit';
@@ -50,7 +51,12 @@ export const ServicesTab = ({
   const [services, setServices] = useState<ServiceEntity[]>(integrationRepository.services());
   const manageServicesUrl = getManageServicesUrl('client_landing');
 
-  const openManageServices = () => safeWindowOpen(manageServicesUrl!);
+  const openManageServices = () => {
+    if (isUndefined(manageServicesUrl)) {
+      throw new Error('The manage services URL is not configured');
+    }
+    safeWindowOpen(manageServicesUrl);
+  };
 
   const debouncedSearch = useDebouncedCallback(async () => {
     const results = await integrationRepository.searchForServices(searchQuery);

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/devicesPreferences/components/e2eiCertificateDetails/e2eiCertificateDetails.test.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/devicesPreferences/components/e2eiCertificateDetails/e2eiCertificateDetails.test.tsx
@@ -30,6 +30,7 @@ import {E2EIHandler, MLSStatuses, WireIdentity} from 'src/script/e2eIdentity';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
+  requireValueForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 import {Core} from 'src/script/service/coreSingleton';
 import {generateAPIConversation} from 'test/helper/ConversationGenerator';
@@ -67,7 +68,7 @@ describe('E2EICertificateDetails', () => {
   const rootProviderWrapper = createRootProviderWrapperForTest(rootContextValue);
 
   beforeAll(async () => {
-    jest.spyOn(core.service?.conversation!, 'getMLSSelfConversation').mockResolvedValue(
+    jest.spyOn(requireValueForTest(core.service?.conversation), 'getMLSSelfConversation').mockResolvedValue(
       generateAPIConversation({
         id: {id: 'id', domain: 'domain'},
         type: CONVERSATION_TYPE.ONE_TO_ONE,

--- a/apps/webapp/src/script/page/rightSidebar/conversationDetails/components/conversationDetailsOptions/conversationDetailsOptions.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/conversationDetails/components/conversationDetailsOptions/conversationDetailsOptions.tsx
@@ -17,6 +17,9 @@
  *
  */
 
+import {type ReactElement} from 'react';
+
+import {isUndefined} from '@sindresorhus/is';
 import {CONVERSATION_CELLS_STATE} from '@wireapp/api-client/lib/conversation';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data/';
 import {amplify} from 'amplify';
@@ -66,7 +69,41 @@ interface ConversationDetailsOptionsProps {
   isChannelPublic?: boolean;
 }
 
-const ConversationDetailsOptions = ({
+interface ConversationDetailsOptionsContentProps extends ConversationDetailsOptionsProps {
+  readonly firstParticipant?: User;
+  readonly isParticipantBlocked?: boolean;
+}
+
+interface ConversationDetailsOptionsWithParticipantProps extends ConversationDetailsOptionsProps {
+  readonly firstParticipant: User;
+}
+
+function ConversationDetailsOptions(props: ConversationDetailsOptionsProps): ReactElement {
+  const {firstUserEntity: firstParticipant} = useKoSubscribableChildren(props.activeConversation, ['firstUserEntity']);
+
+  if (isUndefined(firstParticipant)) {
+    return <ConversationDetailsOptionsContent {...props} />;
+  }
+
+  return <ConversationDetailsOptionsWithParticipant {...props} firstParticipant={firstParticipant} />;
+}
+
+function ConversationDetailsOptionsWithParticipant({
+  firstParticipant,
+  ...props
+}: ConversationDetailsOptionsWithParticipantProps): ReactElement {
+  const {isBlocked: isParticipantBlocked} = useKoSubscribableChildren(firstParticipant, ['isBlocked']);
+
+  return (
+    <ConversationDetailsOptionsContent
+      {...props}
+      firstParticipant={firstParticipant}
+      isParticipantBlocked={isParticipantBlocked}
+    />
+  );
+}
+
+function ConversationDetailsOptionsContent({
   actionsViewModel,
   activeConversation,
   conversationRepository,
@@ -80,41 +117,32 @@ const ConversationDetailsOptions = ({
   teamState,
   updateConversationReceiptMode,
   isChannelPublic,
-}: ConversationDetailsOptionsProps) => {
+  firstParticipant,
+  isParticipantBlocked,
+}: ConversationDetailsOptionsContentProps): ReactElement {
   const {isFeatureToggleEnabled, translate} = useApplicationContext();
-  const {
-    isMutable,
-    receiptMode,
-    is1to1,
-    isRequest,
-    isSelfUserRemoved,
-    firstUserEntity: firstParticipant,
-    isChannel,
-    isGroupOrChannel,
-    cellsState,
-  } = useKoSubscribableChildren(activeConversation, [
-    'isMutable',
-    'receiptMode',
-    'is1to1',
-    'isRequest',
-    'isSelfUserRemoved',
-    'firstUserEntity',
-    'isChannel',
-    'isGroupOrChannel',
-    'cellsState',
-  ]);
+  const {isMutable, receiptMode, is1to1, isRequest, isSelfUserRemoved, isChannel, isGroupOrChannel, cellsState} =
+    useKoSubscribableChildren(activeConversation, [
+      'isMutable',
+      'receiptMode',
+      'is1to1',
+      'isRequest',
+      'isSelfUserRemoved',
+      'isChannel',
+      'isGroupOrChannel',
+      'cellsState',
+    ]);
   const {isSelfDeletingMessagesEnabled, isTeam} = useKoSubscribableChildren(teamState, [
     'isSelfDeletingMessagesEnabled',
     'isTeam',
   ]);
   const {isChannelsHistorySharingEnabled, isChannelsEnabled} = useChannelsFeatureFlag();
   const {isActivatedAccount, teamRole} = useKoSubscribableChildren(selfUser, ['isActivatedAccount', 'teamRole']);
-  const {isBlocked: isParticipantBlocked} = useKoSubscribableChildren(firstParticipant!, ['isBlocked']);
 
   const teamId = activeConversation.teamId;
 
   const isSingleUserMode = is1to1 || isRequest;
-  const isServiceMode = isSingleUserMode && firstParticipant!.isService;
+  const isServiceMode = isSingleUserMode && !isUndefined(firstParticipant) && firstParticipant.isService;
 
   const conversationActions = getConversationActions({
     conversationEntity: activeConversation,
@@ -162,7 +190,12 @@ const ConversationDetailsOptions = ({
 
   const openConversationHistoryPanel = () => togglePanel(PanelState.CONVERSATION_HISTORY, activeConversation);
 
-  const openParticipantDevices = () => togglePanel(PanelState.PARTICIPANT_DEVICES, firstParticipant!, false, 'left');
+  const openParticipantDevices = () => {
+    if (isUndefined(firstParticipant)) {
+      throw new Error('Cannot open participant devices without a participant');
+    }
+    togglePanel(PanelState.PARTICIPANT_DEVICES, firstParticipant, false, 'left');
+  };
 
   const getSharedDriveStatusTranslationKey = () => {
     if (!isViewerPermissionFeatureEnabled) {
@@ -346,6 +379,6 @@ const ConversationDetailsOptions = ({
       </ul>
     </div>
   );
-};
+}
 
 export {ConversationDetailsOptions};

--- a/apps/webapp/src/script/page/rightSidebar/conversationDetails/conversationDetails.test.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/conversationDetails/conversationDetails.test.tsx
@@ -18,11 +18,14 @@
  */
 
 import {act, fireEvent, render} from '@testing-library/react';
+import {type ReactElement} from 'react';
+import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
 import {CONVERSATION_CELLS_STATE, CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 import {UserType} from '@wireapp/api-client/lib/user';
 
 import {CellsRepository} from 'Repositories/cells/cellsRepository';
+import {ConnectionEntity} from 'Repositories/connection/connectionEntity';
 import {ConnectionRepository} from 'Repositories/connection/connectionRepository';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {ConversationMapper} from 'Repositories/conversation/ConversationMapper';
@@ -57,7 +60,17 @@ import {PanelState} from '../rightSidebar';
 
 jest.mock('Components/panel/enrichedFields', () => ({
   useEnrichedFields: (): never[] => [],
-  EnrichedFields: () => <div />,
+  EnrichedFields: function EnrichedFields({
+    showAvailability = false,
+  }: {
+    showAvailability?: boolean;
+  }): ReactElement | null {
+    if (!showAvailability) {
+      return null;
+    }
+
+    return <div data-uie-name="item-enriched-value" />;
+  },
   __esModule: true,
 }));
 jest.mock('Components/panel/userDetails', () => ({
@@ -295,5 +308,57 @@ describe('ConversationDetails', () => {
         expect(actionItem).not.toBeNull();
       });
     });
+  });
+
+  it('updates the block action when the participant blocking state changes', () => {
+    const conversation = new Conversation('', '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
+    conversation.type(CONVERSATION_TYPE.ONE_TO_ONE);
+
+    const participant = new User('other-user', '', translateForTest);
+    const connection = new ConnectionEntity();
+    connection.status(ConnectionStatus.ACCEPTED);
+    participant.connection(connection);
+    conversation.participating_user_ets([participant]);
+
+    const defaultProps = getDefaultParams();
+    const {queryByTestId} = render(<ConversationDetails {...defaultProps} activeConversation={conversation} />, {
+      wrapper: rootProviderWrapper,
+    });
+
+    expect(queryByTestId('do-block')).not.toBeNull();
+    expect(queryByTestId('do-unblock')).toBeNull();
+
+    act(() => {
+      connection.status(ConnectionStatus.BLOCKED);
+    });
+
+    expect(queryByTestId('do-block')).toBeNull();
+    expect(queryByTestId('do-unblock')).not.toBeNull();
+  });
+
+  it('updates participant availability when the participant becomes a temporary guest', () => {
+    const conversation = new Conversation('', '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
+    conversation.type(CONVERSATION_TYPE.ONE_TO_ONE);
+
+    const participant = new User('other-user', '', translateForTest);
+    participant.teamId = 'team-id';
+    conversation.participating_user_ets([participant]);
+
+    const defaultProps = getDefaultParams();
+    const team = new TeamEntity();
+    team.id = 'team-id';
+    defaultProps.teamState.team(team);
+
+    const {queryByTestId} = render(<ConversationDetails {...defaultProps} activeConversation={conversation} />, {
+      wrapper: rootProviderWrapper,
+    });
+
+    expect(queryByTestId('item-enriched-value')).not.toBeNull();
+
+    act(() => {
+      participant.isTemporaryGuest(true);
+    });
+
+    expect(queryByTestId('item-enriched-value')).toBeNull();
   });
 });

--- a/apps/webapp/src/script/page/rightSidebar/conversationDetails/conversationDetails.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/conversationDetails/conversationDetails.tsx
@@ -17,8 +17,9 @@
  *
  */
 
-import {forwardRef, useEffect, useMemo, useState} from 'react';
+import {forwardRef, useEffect, useMemo, useState, type ReactElement} from 'react';
 
+import {isUndefined} from '@sindresorhus/is';
 import {CONVERSATION_ACCESS, CONVERSATION_CELLS_STATE} from '@wireapp/api-client/lib/conversation';
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data/';
 import {UserType} from '@wireapp/api-client/lib/user';
@@ -73,6 +74,48 @@ interface ConversationDetailsProps {
   teamState: TeamState;
   selfUser: User;
   isFederated?: boolean;
+}
+
+interface ConversationDetailsParticipantProps {
+  readonly activeConversation: Conversation;
+  readonly classifiedDomains: string[] | undefined;
+  readonly isFederated: boolean;
+  readonly isTeam: boolean;
+  readonly isVerified: boolean;
+  readonly participant: User;
+  readonly teamRepository: TeamRepository;
+  readonly teamState: TeamState;
+}
+
+function ConversationDetailsParticipant({
+  activeConversation,
+  classifiedDomains,
+  isFederated,
+  isTeam,
+  isVerified,
+  participant,
+  teamRepository,
+  teamState,
+}: ConversationDetailsParticipantProps): ReactElement {
+  const {isTemporaryGuest} = useKoSubscribableChildren(participant, ['isTemporaryGuest']);
+
+  return (
+    <>
+      <UserDetails
+        groupId={activeConversation.groupId}
+        participant={participant}
+        isVerified={isVerified}
+        badge={teamRepository.getRoleBadge(participant.id)}
+        classifiedDomains={classifiedDomains}
+      />
+
+      <EnrichedFields
+        user={participant}
+        showDomain={isFederated}
+        showAvailability={isTeam && !isTemporaryGuest && teamState.isInTeam(participant)}
+      />
+    </>
+  );
 }
 
 const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>(
@@ -132,8 +175,6 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
       'isGroupOrChannel',
       'cellsState',
     ]);
-
-    const {isTemporaryGuest} = useKoSubscribableChildren(firstParticipant!, ['isTemporaryGuest']);
 
     const {isTeam, classifiedDomains, team, isSelfDeletingMessagesEnforced, getEnforcedSelfDeletingMessagesTimeout} =
       useKoSubscribableChildren(teamState, [
@@ -246,15 +287,15 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
       conversationRepository.updateConversationReceiptMode(activeConversation, {receipt_mode: receiptMode});
 
     const isSingleUserMode = is1to1 || isRequest;
-    const isServiceMode = isSingleUserMode && firstParticipant!.isService;
+    const isServiceMode = isSingleUserMode && !isUndefined(firstParticipant) && firstParticipant.isService;
 
     useEffect(() => {
       void conversationRepository.refreshUnavailableParticipants(activeConversation);
     }, [activeConversation, conversationRepository]);
 
     useEffect(() => {
-      if (team.id && isSingleUserMode) {
-        void teamRepository.updateTeamMembersByIds(team.id, [firstParticipant!.id], true);
+      if (team.id && isSingleUserMode && !isUndefined(firstParticipant)) {
+        void teamRepository.updateTeamMembersByIds(team.id, [firstParticipant.id], true);
       }
     }, [firstParticipant, isSingleUserMode, team, teamRepository]);
 
@@ -295,21 +336,16 @@ const ConversationDetails = forwardRef<HTMLDivElement, ConversationDetailsProps>
           {isSingleUserMode && isServiceMode && selectedService && <ServiceDetails service={selectedService} />}
 
           {isSingleUserMode && !isServiceMode && firstParticipant && (
-            <>
-              <UserDetails
-                groupId={activeConversation.groupId}
-                participant={firstParticipant}
-                isVerified={isVerified}
-                badge={teamRepository.getRoleBadge(firstParticipant.id)}
-                classifiedDomains={classifiedDomains}
-              />
-
-              <EnrichedFields
-                user={firstParticipant}
-                showDomain={isFederated}
-                showAvailability={isTeam && !isTemporaryGuest && teamState.isInTeam(firstParticipant)}
-              />
-            </>
+            <ConversationDetailsParticipant
+              activeConversation={activeConversation}
+              classifiedDomains={classifiedDomains}
+              isFederated={isFederated}
+              isTeam={isTeam}
+              isVerified={isVerified}
+              participant={firstParticipant}
+              teamRepository={teamRepository}
+              teamState={teamState}
+            />
           )}
 
           {!isSingleUserMode && (

--- a/apps/webapp/src/script/page/testSupport/rootContextTestSupport.tsx
+++ b/apps/webapp/src/script/page/testSupport/rootContextTestSupport.tsx
@@ -21,6 +21,7 @@ import {ReactNode} from 'react';
 
 import {createWallClock} from '@enormora/wall-clock/wall-clock';
 import type {WallClock} from '@enormora/wall-clock/wall-clock';
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {noop} from 'noop-esm';
 
 import {FireAndForgetInvoker} from '@wireapp/core';
@@ -43,6 +44,14 @@ type CreateRootContextValueForTestParameters = {
 type RootProviderWrapperProperties = {
   readonly children: ReactNode;
 };
+
+export function requireValueForTest<Value>(value: Value | null | undefined): Value {
+  if (isNullOrUndefined(value)) {
+    throw new Error('Expected test value to be available');
+  }
+
+  return value;
+}
 
 function isFeatureToggleDisabledForTest(): boolean {
   return false;

--- a/apps/webapp/src/script/repositories/assets/assetRepository.test.ts
+++ b/apps/webapp/src/script/repositories/assets/assetRepository.test.ts
@@ -18,6 +18,7 @@
  */
 
 import {AssetUploadData} from '@wireapp/api-client/lib/asset/';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import {container} from 'tsyringe';
 
 import {createUuid} from 'Util/uuid';
@@ -50,7 +51,7 @@ describe('AssetRepository', () => {
   });
 
   it('keeps track of current uploads and removes it once finished', async () => {
-    spyOn(core.service!.asset, 'uploadAsset').and.callFake(() => {
+    spyOn(requireValueForTest(core.service).asset, 'uploadAsset').and.callFake(() => {
       expect(assetRepository.getNumberOfOngoingUploads()).toBe(1);
       return Promise.resolve({
         cancel: null,
@@ -66,7 +67,7 @@ describe('AssetRepository', () => {
   });
 
   it('removes cancelled uploads and cancels upload', () => {
-    spyOn(core.service!.asset, 'uploadAsset').and.callFake(() => {
+    spyOn(requireValueForTest(core.service).asset, 'uploadAsset').and.callFake(() => {
       expect(assetRepository.getNumberOfOngoingUploads()).toBe(1);
       return Promise.resolve({
         cancel: null,
@@ -85,7 +86,7 @@ describe('AssetRepository', () => {
   });
 
   it('updates the upload progress while the file is being uploaded', async () => {
-    spyOn(core.service!.asset, 'uploadAsset').and.callFake((_asset, _options, callback) => {
+    spyOn(requireValueForTest(core.service).asset, 'uploadAsset').and.callFake((_asset, _options, callback) => {
       const uploadProgress = assetRepository.getUploadProgress(messageId);
 
       callback(0.1);
@@ -115,7 +116,7 @@ describe('AssetRepository', () => {
       filetype: 'filetype',
     };
     options.auditData = assetAuditData;
-    const uploadAssetSpy = spyOn(core.service!.asset, 'uploadAsset').and.callFake(() => {
+    const uploadAssetSpy = spyOn(requireValueForTest(core.service).asset, 'uploadAsset').and.callFake(() => {
       return Promise.resolve({
         cancel: null,
         response: Promise.resolve({
@@ -138,7 +139,7 @@ describe('AssetRepository', () => {
     };
     options.auditData = assetAuditData;
 
-    const uploadAssetSpy = spyOn(core.service!.asset, 'uploadAsset').and.callFake(() => {
+    const uploadAssetSpy = spyOn(requireValueForTest(core.service).asset, 'uploadAsset').and.callFake(() => {
       return Promise.resolve({
         cancel: null,
         response: Promise.resolve({
@@ -166,14 +167,14 @@ describe('AssetRepository', () => {
       cancelDownload: null as (() => void) | null,
     };
 
-    spyOn(core.service!.asset, 'downloadAsset').and.returnValue({
+    spyOn(requireValueForTest(core.service).asset, 'downloadAsset').and.returnValue({
       cancel: jest.fn(),
       response: Promise.resolve({buffer: mockBuffer, mimeType: mockMimeType}),
     });
 
     const result = await assetRepository.load(mockAsset as any);
 
-    expect(core.service!.asset.downloadAsset).toHaveBeenCalledWith(
+    expect(requireValueForTest(core.service).asset.downloadAsset).toHaveBeenCalledWith(
       mockAsset.urlData,
       otrKey,
       sha256,
@@ -196,14 +197,17 @@ describe('AssetRepository', () => {
       cancelDownload: null as (() => void) | null,
     };
 
-    spyOn(core.service!.asset, 'downloadRawAsset').and.returnValue({
+    spyOn(requireValueForTest(core.service).asset, 'downloadRawAsset').and.returnValue({
       cancel: jest.fn(),
       response: Promise.resolve({buffer: mockBuffer, mimeType: mockMimeType}),
     });
 
     const result = await assetRepository.load(mockAsset as any);
 
-    expect(core.service!.asset.downloadRawAsset).toHaveBeenCalledWith(mockAsset.urlData, jasmine.any(Function));
+    expect(requireValueForTest(core.service).asset.downloadRawAsset).toHaveBeenCalledWith(
+      mockAsset.urlData,
+      jasmine.any(Function),
+    );
     expect(result).toBeInstanceOf(Blob);
     expect(result?.type).toBe(mockMimeType);
   });
@@ -218,7 +222,7 @@ describe('AssetRepository', () => {
       cancelDownload: null as (() => void) | null,
     };
 
-    spyOn(core.service!.asset, 'downloadAsset').and.returnValue({
+    spyOn(requireValueForTest(core.service).asset, 'downloadAsset').and.returnValue({
       cancel: jest.fn(),
       response: Promise.reject(new Error('Asset not found: 404')),
     });

--- a/apps/webapp/src/script/repositories/assets/assetRepository.ts
+++ b/apps/webapp/src/script/repositories/assets/assetRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {AssetAuditData, AssetOptions, AssetRetentionPolicy} from '@wireapp/api-client/lib/asset/';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import ko from 'knockout';
@@ -73,7 +74,12 @@ export class AssetRepository {
   }
 
   get assetCoreService() {
-    return this.core.service!.asset;
+    const coreServices = this.core.service;
+    if (isUndefined(coreServices)) {
+      throw new Error('Core services are not initialized');
+    }
+
+    return coreServices.asset;
   }
 
   public addToProcessQueue(message: GenericMessage, conversationId: string) {
@@ -130,11 +136,12 @@ export class AssetRepository {
     };
 
     if (!isEncryptedAsset) {
-      return this.core.service!.asset.downloadRawAsset(asset.urlData, progressCallback);
+      return this.assetCoreService.downloadRawAsset(asset.urlData, progressCallback);
     }
     const otrKey = asset.otrKey instanceof Uint8Array ? asset.otrKey : Uint8Array.from(Object.values(asset.otrKey));
     const sha256 = asset.sha256 instanceof Uint8Array ? asset.sha256 : Uint8Array.from(Object.values(asset.sha256));
-    return this.core.service!.asset.downloadAsset(asset.urlData, otrKey, sha256, progressCallback);
+
+    return this.assetCoreService.downloadAsset(asset.urlData, otrKey, sha256, progressCallback);
   }
 
   public async download(asset: AssetRemoteData, fileName: string) {

--- a/apps/webapp/src/script/repositories/backup/backupService.ts
+++ b/apps/webapp/src/script/repositories/backup/backupService.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import Dexie from 'dexie';
 import DexieBatch from 'dexie-batch';
 import {container} from 'tsyringe';
@@ -59,11 +60,12 @@ export class BackupService {
   }
 
   getTables() {
-    return [
-      this.storageService.db!.conversations,
-      this.storageService.db!.events,
-      this.storageService.db!.users,
-    ] as const;
+    const database = this.storageService.db;
+    if (isUndefined(database)) {
+      throw new Error('The backup database is not initialized');
+    }
+
+    return [database.conversations, database.events, database.users] as const;
   }
 
   async runDbSchemaUpdates(archiveVersion: number): Promise<void> {
@@ -110,8 +112,12 @@ export class BackupService {
   }
 
   async getConversationCreationEvents() {
-    const events = await this.storageService
-      .db!.events.where('type')
+    const database = this.storageService.db;
+    if (isUndefined(database)) {
+      throw new Error('The backup database is not initialized');
+    }
+    const events = await database.events
+      .where('type')
       .anyOf([CONVERSATION.ONE2ONE_CREATION, CONVERSATION.GROUP_CREATION])
       .toArray();
     return events;

--- a/apps/webapp/src/script/repositories/calling/Call.ts
+++ b/apps/webapp/src/script/repositories/calling/Call.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import ko from 'knockout';
 
@@ -101,7 +102,15 @@ export class Call {
     this.handRaisedParticipants = ko.pureComputed(() =>
       this.participants()
         .filter(participant => Boolean(participant.handRaisedAt()))
-        .toSorted((p1, p2) => p1.handRaisedAt()! - p2.handRaisedAt()!),
+        .toSorted((p1, p2) => {
+          const firstHandRaisedAt = p1.handRaisedAt();
+          const secondHandRaisedAt = p2.handRaisedAt();
+          if (isNullOrUndefined(firstHandRaisedAt) || isNullOrUndefined(secondHandRaisedAt)) {
+            throw new Error('A hand-raised participant is missing its timestamp');
+          }
+
+          return firstHandRaisedAt - secondHandRaisedAt;
+        }),
     );
     this.canvasMixer = new CanvasMediaStreamMixer();
     this.maximizedParticipant = ko.observable(null);

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.test.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.test.ts
@@ -78,6 +78,7 @@ import {ConversationState} from 'Repositories/conversation/ConversationState';
 import {Translate} from 'Util/localizerUtil';
 import type {QualifiedId} from '@wireapp/api-client/lib/user';
 import {BackgroundEffectSelection} from 'Repositories/media/VideoBackgroundEffects';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 
 type AudioFlowStat = {
   bytesReceived?: number;
@@ -137,6 +138,12 @@ function createCallingRepositoryForTest({
 const translateWithPrefixForTest: Translate = (translationKey, _substitutions, _dangerousSubstitutions, _skipEscape) =>
   `translated:${translationKey}`;
 
+function getSubconversationServiceForTest(): NonNullable<NonNullable<Core['service']>['subconversation']> {
+  const service = requireValueForTest(container.resolve(Core).service);
+
+  return requireValueForTest(service.subconversation);
+}
+
 describe('CallingRepository', () => {
   const testFactory = new TestFactory();
   let callingRepository: CallingRepository;
@@ -172,8 +179,8 @@ describe('CallingRepository', () => {
       const conversation = createConversation();
       const selfParticipant = createSelfParticipant();
       const senderUserId = {domain: 'senderdomain', id: 'senderid'};
-      const selfUserId = callingRepository['selfUser']?.qualifiedId!;
-      const selfClientId = callingRepository['selfClientId']!;
+      const selfUserId = requireValueForTest(callingRepository['selfUser']).qualifiedId;
+      const selfClientId = requireValueForTest(callingRepository['selfClientId']);
       const call = new Call(
         selfUserId,
         conversation,
@@ -218,8 +225,8 @@ describe('CallingRepository', () => {
       const conversation = createConversation();
       const selfParticipant = createSelfParticipant();
       const senderUserId = {domain: 'senderdomain', id: 'senderid'};
-      const selfUserId = callingRepository['selfUser']?.qualifiedId!;
-      const selfClientId = callingRepository['selfClientId']!;
+      const selfUserId = requireValueForTest(callingRepository['selfUser']).qualifiedId;
+      const selfClientId = requireValueForTest(callingRepository['selfClientId']);
       const call = new Call(
         selfUserId,
         conversation,
@@ -264,7 +271,7 @@ describe('CallingRepository', () => {
       const conversation = createConversation();
       const selfParticipant = createSelfParticipant();
       const senderUserId = {domain: 'senderdomain', id: 'senderid'};
-      const selfUserId = callingRepository['selfUser']?.qualifiedId!;
+      const selfUserId = requireValueForTest(callingRepository['selfUser']).qualifiedId;
 
       const call = new Call(
         selfUserId,
@@ -311,9 +318,7 @@ describe('CallingRepository', () => {
 
   describe('startCall', () => {
     beforeEach(() => {
-      const subscribeToEpochUpdates = jest.mocked(
-        container.resolve(Core).service!.subconversation.subscribeToEpochUpdates,
-      );
+      const subscribeToEpochUpdates = jest.mocked(getSubconversationServiceForTest().subscribeToEpochUpdates);
       subscribeToEpochUpdates?.mockClear();
     });
 
@@ -414,9 +419,7 @@ describe('CallingRepository', () => {
 
   describe('answerCall', () => {
     beforeEach(() => {
-      const subscribeToEpochUpdates = jest.mocked(
-        container.resolve(Core).service!.subconversation.subscribeToEpochUpdates,
-      );
+      const subscribeToEpochUpdates = jest.mocked(getSubconversationServiceForTest().subscribeToEpochUpdates);
       subscribeToEpochUpdates?.mockClear();
     });
 
@@ -698,7 +701,7 @@ describe('CallingRepository', () => {
       const remoteParticipant = new Participant(user, remoteClientId);
 
       const call = new Call(
-        callingRepository['selfUser']!.qualifiedId,
+        requireValueForTest(callingRepository['selfUser']).qualifiedId,
         conversation,
         CONV_TYPE.CONFERENCE,
         selfParticipant,
@@ -1380,7 +1383,8 @@ describe('init AVS state', () => {
 
 const createLinkInsideDetachedWindow = (detachedWindow: Window, target = '_blank') => {
   detachedWindow.document.body.innerHTML = `<a href="https://wire.com" target="${target}">Wire</a>`;
-  return detachedWindow.document.querySelector('a')!;
+
+  return requireValueForTest(detachedWindow.document.querySelector('a'));
 };
 
 describe('setupDetachedWindowExternalLinksClick', () => {

--- a/apps/webapp/src/script/repositories/calling/CallingRepository.ts
+++ b/apps/webapp/src/script/repositories/calling/CallingRepository.ts
@@ -667,7 +667,11 @@ export class CallingRepository {
     }
     const {conversation} = call;
 
-    const allClients = await this.core.service!.conversation.fetchAllParticipantsClients(conversation.qualifiedId);
+    const coreServices = this.core.service;
+    if (isUndefined(coreServices)) {
+      throw new Error('Core services are not initialized');
+    }
+    const allClients = await coreServices.conversation.fetchAllParticipantsClients(conversation.qualifiedId);
 
     if (!this.isMLSConference(conversation)) {
       const qualifiedClients = flattenUserMap(allClients);
@@ -982,7 +986,11 @@ export class CallingRepository {
     switch (content.type) {
       case CALL_MESSAGE_TYPE.CONFKEY: {
         if (source !== EventRepository.SOURCE.STREAM) {
-          const allClients = await this.core.service!.conversation.fetchAllParticipantsClients(conversationId);
+          const coreServices = this.core.service;
+          if (isUndefined(coreServices)) {
+            throw new Error('Core services are not initialized');
+          }
+          const allClients = await coreServices.conversation.fetchAllParticipantsClients(conversationId);
 
           // We warn the message repository that a mismatch has happened outside of its lifecycle (eventually triggering a conversation degradation)
           const shouldContinue = await this.messageRepository.updateMissingClients(
@@ -2365,13 +2373,21 @@ export class CallingRepository {
       const response = await axios.post(url, data);
       const {status, data: axiosData} = response;
       const jsonData = JSON.stringify(axiosData);
-      this.wCall?.sftResp(this.wUser!, status, jsonData, jsonData.length, context);
+      const user = this.wUser;
+      if (isUndefined(user)) {
+        return;
+      }
+      this.wCall?.sftResp(user, status, jsonData, jsonData.length, context);
     };
     const avsSftResponseFailedCode = 1000;
     _sendSFTRequest().catch((error: unknown) => {
       this.avsLogHandler(LOG_LEVEL.WARN, `Request to sft server failed with error: ${toError(error).message}`, error);
       avsLogger.warn(`Request to sft server failed with error`, error);
-      this.wCall?.sftResp(this.wUser!, avsSftResponseFailedCode, '', 0, context);
+      const user = this.wUser;
+      if (isUndefined(user)) {
+        return;
+      }
+      this.wCall?.sftResp(user, avsSftResponseFailedCode, '', 0, context);
     });
 
     return 0;

--- a/apps/webapp/src/script/repositories/cells/cellsRepositoryGateway.test.ts
+++ b/apps/webapp/src/script/repositories/cells/cellsRepositoryGateway.test.ts
@@ -202,14 +202,9 @@ describe('createCellsRepositoryGateway', () => {
   });
 
   it('lets manager cancellation abort the controller forwarded to the repository', async () => {
-    let resolveUpload!: () => void;
+    const {promise: uploadPromise, resolve: resolveUpload} = Promise.withResolvers<void>();
     const repository = createRepository();
-    repository.uploadNodeDraft.mockImplementation(
-      () =>
-        new Promise(resolve => {
-          resolveUpload = () => resolve(undefined);
-        }),
-    );
+    repository.uploadNodeDraft.mockImplementation(() => uploadPromise);
     const manager = createCellsUploadManager({
       gateway: createCellsRepositoryGateway(repository),
       createResourceUuid: () => identity.resourceUuid,

--- a/apps/webapp/src/script/repositories/cells/upload/manager.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/manager.test.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {noop} from 'noop-esm';
 import {Task} from 'true-myth';
 
@@ -32,23 +33,34 @@ const required = <T>(value: T | undefined): T => {
   return value as T;
 };
 
-const deferred = () => {
-  let resolve!: (value?: DraftIdentity) => void;
-  let reject!: (error: CellsUploadGatewayError<'upload'>) => void;
+type DeferredUploadTask = {
+  readonly task: Task<DraftIdentity, CellsUploadGatewayError<'upload'>>;
+  readonly resolve: (value?: DraftIdentity) => void;
+  readonly reject: (error: CellsUploadGatewayError<'upload'>) => void;
+};
+
+function createDeferredUploadTask(): DeferredUploadTask {
+  let resolve: ((value?: DraftIdentity) => void) | undefined;
+  let reject: ((error: CellsUploadGatewayError<'upload'>) => void) | undefined;
   const task = new Task<DraftIdentity, CellsUploadGatewayError<'upload'>>((resolveTask, rejectTask) => {
     resolve = value => resolveTask(value ?? {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'});
     reject = rejectTask;
   });
+
+  if (isUndefined(resolve) || isUndefined(reject)) {
+    throw new Error('Deferred upload task callbacks were not created');
+  }
+
   return {task, resolve, reject};
-};
+}
 
 const deferredManager = () => {
   const requests: UploadDraftRequest[] = [];
-  const tasks: ReturnType<typeof deferred>[] = [];
+  const tasks: DeferredUploadTask[] = [];
   const gateway: CellsUploadGateway = {
     uploadDraft: request => {
       requests.push(request);
-      const result = deferred();
+      const result = createDeferredUploadTask();
       tasks.push(result);
       return result.task;
     },

--- a/apps/webapp/src/script/repositories/cells/upload/process.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.test.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {Task} from 'true-myth';
 import type {Result} from 'true-myth';
 
@@ -37,15 +38,34 @@ const unwrapResult = <T, E>(result: Result<T, E>): T => {
   return result.unwrapOr(undefined as never);
 };
 
-const deferred = <T, E>(defaultValue?: T) => {
-  let resolve!: (value?: T) => void;
-  let reject!: (error: E) => void;
-  const value = new Task<T, E>((resolveTask, rejectTask) => {
-    resolve = nextValue => resolveTask(nextValue ?? (defaultValue as T));
+type DeferredTask<Value, Failure> = {
+  readonly value: Task<Value, Failure>;
+  readonly resolve: (value?: Value) => void;
+  readonly reject: (error: Failure) => void;
+};
+
+function createDeferredTask<Value, Failure>(defaultValue: Value): DeferredTask<Value, Failure> {
+  let resolve: ((value?: Value) => void) | undefined;
+  let reject: ((error: Failure) => void) | undefined;
+  const value = new Task<Value, Failure>((resolveTask, rejectTask) => {
+    resolve = nextValue => {
+      if (isUndefined(nextValue)) {
+        resolveTask(defaultValue);
+
+        return;
+      }
+
+      resolveTask(nextValue);
+    };
     reject = rejectTask;
   });
+
+  if (isUndefined(resolve) || isUndefined(reject)) {
+    throw new Error('Deferred task callbacks were not created');
+  }
+
   return {value, resolve, reject};
-};
+}
 
 const setup = (
   failure?: 'publish' | 'discard' | 'mismatch',
@@ -53,7 +73,7 @@ const setup = (
   remoteIdentity: DraftIdentity = {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
 ) => {
   const uploads: UploadDraftRequest[] = [];
-  const uploadTasks: ReturnType<typeof deferred<DraftIdentity, CellsUploadGatewayError<'upload'>>>[] = [];
+  const uploadTasks: DeferredTask<DraftIdentity, CellsUploadGatewayError<'upload'>>[] = [];
   const aborts: AbortController[] = [];
   const published = [] as string[];
   const discarded = [] as string[];
@@ -68,7 +88,7 @@ const setup = (
           cause: 'mismatched-operation',
         });
       }
-      const task = deferred<DraftIdentity, CellsUploadGatewayError<'upload'>>(remoteIdentity);
+      const task = createDeferredTask<DraftIdentity, CellsUploadGatewayError<'upload'>>(remoteIdentity);
       uploadTasks.push(task);
       return task.value;
     },

--- a/apps/webapp/src/script/repositories/client/ClientRepository.ts
+++ b/apps/webapp/src/script/repositories/client/ClientRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {ClientType, PublicClient, RegisteredClient} from '@wireapp/api-client/lib/client/';
 import {UserClientAddEvent, UserClientRemoveEvent, USER_EVENT} from '@wireapp/api-client/lib/event';
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
@@ -101,7 +102,12 @@ export class ClientRepository {
    * @returns Resolves when the temporary client was deleted on the backend
    */
   private deleteLocalTemporaryClient() {
-    return this.core.service!.client.deleteLocalClient();
+    const coreServices = this.core.service;
+    if (isUndefined(coreServices)) {
+      throw new Error('Core services are not initialized');
+    }
+
+    return coreServices.client.deleteLocalClient();
   }
 
   /**
@@ -301,7 +307,11 @@ export class ClientRepository {
    */
   async deleteClient(clientId: string, password?: string): Promise<ClientEntity[]> {
     const selfUser = this.selfUser();
-    await this.core.service!.client.deleteClient(clientId, password);
+    const coreServices = this.core.service;
+    if (isUndefined(coreServices)) {
+      throw new Error('Core services are not initialized');
+    }
+    await coreServices.client.deleteClient(clientId, password);
     selfUser.removeClient(clientId);
     amplify.publish(WebAppEvents.USER.CLIENT_REMOVED, selfUser.qualifiedId, clientId);
     return selfUser.devices();

--- a/apps/webapp/src/script/repositories/connection/connectionRepository.test.ts
+++ b/apps/webapp/src/script/repositories/connection/connectionRepository.test.ts
@@ -33,6 +33,7 @@ import {UserRepository} from 'Repositories/user/userRepository';
 import {generateUser} from 'test/helper/UserGenerator';
 import type {Translate} from 'Util/localizerUtil';
 import {translateForTest} from 'Util/test/translateForTest';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import {createUuid} from 'Util/uuid';
 
 import {ConnectionEntity} from './connectionEntity';
@@ -75,7 +76,7 @@ describe('ConnectionRepository', () => {
 
     it('sets the connection status to cancelled', () => {
       const user = createConnection();
-      connectionRepository.addConnectionEntity(user.connection()!);
+      connectionRepository.addConnectionEntity(requireValueForTest(user.connection()));
       jest.spyOn(connectionService, 'putConnections').mockResolvedValue({} as any);
       return connectionRepository.cancelRequest(user).then(() => {
         expect(connectionService.putConnections).toHaveBeenCalled();
@@ -84,7 +85,7 @@ describe('ConnectionRepository', () => {
 
     it('switches the conversation if requested', () => {
       const user = createConnection();
-      connectionRepository.addConnectionEntity(user.connection()!);
+      connectionRepository.addConnectionEntity(requireValueForTest(user.connection()));
       const amplifySpy = jasmine.createSpy('conversation_show');
       amplify.subscribe(WebAppEvents.CONVERSATION.SHOW, amplifySpy);
 
@@ -99,7 +100,7 @@ describe('ConnectionRepository', () => {
     it('deletes connection request if the other user does not exist on backend anymore', async () => {
       const user = createConnection();
 
-      connectionRepository.addConnectionEntity(user.connection()!);
+      connectionRepository.addConnectionEntity(requireValueForTest(user.connection()));
 
       jest.spyOn(userRepository, 'refreshUser').mockImplementationOnce(async (uid: QualifiedId) => {
         user.isDeleted = true;
@@ -121,8 +122,10 @@ describe('ConnectionRepository', () => {
 
     it('should return the expected connection for the given conversation id', () => {
       const userA = createConnection();
-      connectionRepository.addConnectionEntity(userA.connection()!);
-      const connectionEntity = connectionRepository.getConnectionByConversationId(userA.connection()!.conversationId);
+      connectionRepository.addConnectionEntity(requireValueForTest(userA.connection()));
+      const connectionEntity = connectionRepository.getConnectionByConversationId(
+        requireValueForTest(userA.connection()).conversationId,
+      );
 
       expect(connectionEntity).toBe(userA.connection());
 

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.safeWrappers.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.safeWrappers.test.ts
@@ -23,6 +23,18 @@ import {AddUsersFailureReasons} from '@wireapp/core/lib/conversation';
 import {generateConversation as _generateConversation} from 'test/helper/ConversationGenerator';
 import {TestFactory} from 'test/helper/TestFactory';
 import {generateUser} from 'test/helper/UserGenerator';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
+import {Core} from 'src/script/service/coreSingleton';
+
+import {ConversationRepository} from './ConversationRepository';
+
+function getConversationServiceForTest(
+  conversationRepository: ConversationRepository,
+): NonNullable<NonNullable<Core['service']>['conversation']> {
+  const service = requireValueForTest(conversationRepository['core'].service);
+
+  return requireValueForTest(service.conversation);
+}
 
 describe('ConversationRepository safe* wrappers', () => {
   const testFactory = new TestFactory();
@@ -34,7 +46,7 @@ describe('ConversationRepository safe* wrappers', () => {
   describe('safeGetConversationById', () => {
     it('resolves to Ok when getConversationById succeeds', async () => {
       const conversation = _generateConversation();
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       jest.spyOn(conversationRepository, 'getConversationById').mockResolvedValue(conversation);
 
       const settled = await conversationRepository.safeGetConversationById(conversation.qualifiedId);
@@ -46,7 +58,7 @@ describe('ConversationRepository safe* wrappers', () => {
     it('resolves to Err when getConversationById throws', async () => {
       const conversationId: QualifiedId = {id: 'missing', domain: 'wire.com'};
       const error = new Error('not found');
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       jest.spyOn(conversationRepository, 'getConversationById').mockRejectedValue(error);
 
       const settled = await conversationRepository.safeGetConversationById(conversationId);
@@ -61,9 +73,9 @@ describe('ConversationRepository safe* wrappers', () => {
       const conversation = _generateConversation();
       const selfUser = generateUser();
       const failedToAdd = [{users: [], backends: [], reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}];
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       jest.spyOn(conversationRepository['userState'], 'self').mockReturnValue(selfUser);
-      conversationRepository['core'].service!.conversation.establishMLSGroupConversation = jest
+      getConversationServiceForTest(conversationRepository).establishMLSGroupConversation = jest
         .fn()
         .mockResolvedValue({failedToAdd});
 
@@ -81,9 +93,9 @@ describe('ConversationRepository safe* wrappers', () => {
       const conversation = _generateConversation();
       const selfUser = generateUser();
       const error = new Error('MLS commit failed');
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       jest.spyOn(conversationRepository['userState'], 'self').mockReturnValue(selfUser);
-      conversationRepository['core'].service!.conversation.establishMLSGroupConversation = jest
+      getConversationServiceForTest(conversationRepository).establishMLSGroupConversation = jest
         .fn()
         .mockRejectedValue(error);
 
@@ -104,8 +116,8 @@ describe('ConversationRepository safe* wrappers', () => {
       conversation.groupId = 'group-id';
       const user = generateUser();
       const failedToAdd = [{users: [], backends: [], reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}];
-      const conversationRepository = testFactory.conversation_repository!;
-      conversationRepository['core'].service!.conversation.addUsersToMLSConversation = jest
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      getConversationServiceForTest(conversationRepository).addUsersToMLSConversation = jest
         .fn()
         .mockResolvedValue({failedToAdd});
 
@@ -113,7 +125,7 @@ describe('ConversationRepository safe* wrappers', () => {
 
       expect(settled.isOk).toBe(true);
       expect(settled.match({Ok: value => value.failedToAdd, Err: () => null})).toEqual(failedToAdd);
-      expect(conversationRepository['core'].service!.conversation.addUsersToMLSConversation).toHaveBeenCalledWith({
+      expect(getConversationServiceForTest(conversationRepository).addUsersToMLSConversation).toHaveBeenCalledWith({
         conversationId: conversation.qualifiedId,
         groupId: conversation.groupId,
         qualifiedUsers: [user.qualifiedId],
@@ -123,14 +135,14 @@ describe('ConversationRepository safe* wrappers', () => {
     it('resolves to Ok with empty failedToAdd when no users are provided', async () => {
       const conversation = _generateConversation();
       conversation.groupId = 'group-id';
-      const conversationRepository = testFactory.conversation_repository!;
-      conversationRepository['core'].service!.conversation.addUsersToMLSConversation = jest.fn();
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      getConversationServiceForTest(conversationRepository).addUsersToMLSConversation = jest.fn();
 
       const settled = await conversationRepository.safeAddUsers(conversation, []);
 
       expect(settled.isOk).toBe(true);
       expect(settled.match({Ok: value => value.failedToAdd, Err: () => null})).toEqual([]);
-      expect(conversationRepository['core'].service!.conversation.addUsersToMLSConversation).not.toHaveBeenCalled();
+      expect(getConversationServiceForTest(conversationRepository).addUsersToMLSConversation).not.toHaveBeenCalled();
     });
 
     it('resolves to Err when adding users throws', async () => {
@@ -138,8 +150,8 @@ describe('ConversationRepository safe* wrappers', () => {
       conversation.groupId = 'group-id';
       const user = generateUser();
       const error = new Error('MLS commit failed');
-      const conversationRepository = testFactory.conversation_repository!;
-      conversationRepository['core'].service!.conversation.addUsersToMLSConversation = jest
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      getConversationServiceForTest(conversationRepository).addUsersToMLSConversation = jest
         .fn()
         .mockRejectedValue(error);
 
@@ -153,7 +165,7 @@ describe('ConversationRepository safe* wrappers', () => {
       const conversation = _generateConversation();
       conversation.groupId = undefined;
       const user = generateUser();
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
 
       const settled = await conversationRepository.safeAddUsers(conversation, [user]);
 

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
@@ -96,6 +96,7 @@ import {matchQualifiedIds} from 'Util/qualifiedId';
 import type {Translate} from 'Util/localizerUtil';
 import {translateForTest} from 'Util/test/translateForTest';
 import {escapeRegex} from 'Util/sanitizationUtil';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import {createUuid} from 'Util/uuid';
 
 import {ConversationDatabaseData, ConversationMapper} from './ConversationMapper';
@@ -119,6 +120,22 @@ import {TestFactory} from '../../../../test/helper/TestFactory';
 import {createMockHttpServer, MockHttpServer} from '../../../../test/helper/mockHttpServer';
 import {generateUser} from '../../../../test/helper/UserGenerator';
 import {Core} from '../../service/coreSingleton';
+
+function getCoreConversationServiceForTest(): NonNullable<NonNullable<Core['service']>['conversation']> {
+  const service = requireValueForTest(container.resolve(Core).service);
+
+  return requireValueForTest(service.conversation);
+}
+
+function getMlsServiceForTest(core: Core = container.resolve(Core)): NonNullable<NonNullable<Core['service']>['mls']> {
+  const service = requireValueForTest(core.service);
+
+  return requireValueForTest(service.mls);
+}
+
+function getConversationServiceFromCoreForTest(core: Core): NonNullable<NonNullable<Core['service']>['conversation']> {
+  return requireValueForTest(requireValueForTest(core.service).conversation);
+}
 
 function buildConversationRepository(translate: Translate) {
   const teamState = new TeamState();
@@ -229,7 +246,7 @@ describe('ConversationRepository', () => {
   });
 
   beforeEach(async () => {
-    const conversationRepository = testFactory.conversation_repository!;
+    const conversationRepository = requireValueForTest(testFactory.conversation_repository);
 
     jest.spyOn(conversationRepository['conversationService'], 'saveConversationStateInDb').mockResolvedValue({} as any);
     await conversationRepository['saveConversation'](selfConversation);
@@ -241,7 +258,7 @@ describe('ConversationRepository', () => {
   });
 
   afterEach(() => {
-    const conversationRepository = testFactory.conversation_repository!;
+    const conversationRepository = requireValueForTest(testFactory.conversation_repository);
     conversationRepository['conversationState'].conversations.removeAll();
   });
 
@@ -288,7 +305,7 @@ describe('ConversationRepository', () => {
 
   describe('saveConversation', () => {
     it('preserves existing participants when new conversation lacks them', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const user = generateUser();
       const existing = _generateConversation({type: CONVERSATION_TYPE.ONE_TO_ONE, users: [user]});
       await conversationRepository['saveConversation'](existing);
@@ -296,13 +313,15 @@ describe('ConversationRepository', () => {
       const shell = _generateConversation({id: existing.qualifiedId, type: CONVERSATION_TYPE.ONE_TO_ONE, users: []});
       await conversationRepository['saveConversation'](shell);
 
-      const stored = conversationRepository['conversationState'].findConversation(existing.qualifiedId)!;
+      const stored = requireValueForTest(
+        conversationRepository['conversationState'].findConversation(existing.qualifiedId),
+      );
       expect(stored.participating_user_ids()).toHaveLength(1);
       expect(stored.participating_user_ids()[0]).toEqual(user.qualifiedId);
     });
 
     it('updates observable-backed properties when merging into an existing conversation', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const existing = _generateConversation({name: 'Old title'});
       await conversationRepository['saveConversation'](existing);
 
@@ -313,14 +332,16 @@ describe('ConversationRepository', () => {
       });
       await conversationRepository['saveConversation'](updated);
 
-      const stored = conversationRepository['conversationState'].findConversation(existing.qualifiedId)!;
+      const stored = requireValueForTest(
+        conversationRepository['conversationState'].findConversation(existing.qualifiedId),
+      );
       expect(stored.name()).toBe('New title');
       expect(stored.groupConversationType()).toBe(GROUP_CONVERSATION_TYPE.MEETING);
       expect(stored.display_name()).toBe('New title');
     });
 
     it('preserves guest status when merging into an existing conversation', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const existing = _generateConversation({name: 'Old title'});
       existing.isGuest(true);
       await conversationRepository['saveConversation'](existing);
@@ -332,7 +353,9 @@ describe('ConversationRepository', () => {
       });
       await conversationRepository['saveConversation'](updated);
 
-      const stored = conversationRepository['conversationState'].findConversation(existing.qualifiedId)!;
+      const stored = requireValueForTest(
+        conversationRepository['conversationState'].findConversation(existing.qualifiedId),
+      );
       expect(stored.name()).toBe('New title');
       expect(stored.isGuest()).toBe(true);
     });
@@ -340,7 +363,7 @@ describe('ConversationRepository', () => {
 
   describe('saveMeetingConversationFromBackend', () => {
     it('updates the name of an already-loaded meeting conversation', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const qualifiedId = {id: createUuid(), domain: 'test.wire.link'};
       const existing = _generateConversation({
         id: qualifiedId,
@@ -363,13 +386,13 @@ describe('ConversationRepository', () => {
       );
 
       expect(result.isOk).toBe(true);
-      const stored = conversationRepository['conversationState'].findConversation(qualifiedId)!;
+      const stored = requireValueForTest(conversationRepository['conversationState'].findConversation(qualifiedId));
       expect(stored.name()).toBe('Updated meeting title');
       expect(stored.display_name()).toBe('Updated meeting title');
     });
 
     it('preserves guest status when updating the meeting title', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const qualifiedId = {id: createUuid(), domain: 'test.wire.link'};
       const existing = _generateConversation({
         id: qualifiedId,
@@ -393,13 +416,13 @@ describe('ConversationRepository', () => {
       );
 
       expect(result.isOk).toBe(true);
-      const stored = conversationRepository['conversationState'].findConversation(qualifiedId)!;
+      const stored = requireValueForTest(conversationRepository['conversationState'].findConversation(qualifiedId));
       expect(stored.name()).toBe('Updated meeting title');
       expect(stored.isGuest()).toBe(true);
     });
 
     it('preserves loaded messages and local state when updating the meeting title', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const qualifiedId = {id: createUuid(), domain: 'test.wire.link'};
       const message = new ContentMessage(createUuid(), translateForTest);
       message.id = createUuid();
@@ -432,7 +455,7 @@ describe('ConversationRepository', () => {
       );
 
       expect(result.isOk).toBe(true);
-      const stored = conversationRepository['conversationState'].findConversation(qualifiedId)!;
+      const stored = requireValueForTest(conversationRepository['conversationState'].findConversation(qualifiedId));
       expect(stored.name()).toBe('Updated meeting title');
       expect(stored.display_name()).toBe('Updated meeting title');
       expect(stored.messages_unordered()).toHaveLength(1);
@@ -445,7 +468,7 @@ describe('ConversationRepository', () => {
     });
 
     it('preserves existing title and add permission when the update payload omits those fields', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const qualifiedId = {id: createUuid(), domain: 'test.wire.link'};
       const existing = _generateConversation({
         id: qualifiedId,
@@ -473,7 +496,7 @@ describe('ConversationRepository', () => {
       );
 
       expect(result.isOk).toBe(true);
-      const stored = conversationRepository['conversationState'].findConversation(qualifiedId)!;
+      const stored = requireValueForTest(conversationRepository['conversationState'].findConversation(qualifiedId));
       expect(stored.name()).toBe('Existing meeting title');
       expect(stored.conversationModerator()).toBe(ADD_PERMISSION.EVERYONE);
     });
@@ -572,7 +595,7 @@ describe('ConversationRepository', () => {
 
   describe('init1to1Conversation', () => {
     it('just returns a conversation if id of the other user cannot be found', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
 
       const conversation = _generateConversation({
         type: CONVERSATION_TYPE.ONE_TO_ONE,
@@ -584,8 +607,8 @@ describe('ConversationRepository', () => {
     });
 
     it('returns a conversation if we fail when fetching other users supported protocols', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain, translateForTest);
@@ -610,8 +633,8 @@ describe('ConversationRepository', () => {
     });
 
     it('returns a proteus conversation even if both users support mls but the user was deleted on backend', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const otherUserId = {id: 'f718410c-3833-479d-bd80-af03f38416', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain, translateForTest);
@@ -645,7 +668,7 @@ describe('ConversationRepository', () => {
     });
 
     it('returns a selected proteus 1:1 conversation with a team member even if there are multiple conversations with the same user', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
 
       const teamId = 'teamId';
       const domain = 'test-domain';
@@ -685,8 +708,8 @@ describe('ConversationRepository', () => {
     });
 
     it('just returns a proteus conversation with a bot/service', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const otherUserId = {id: 'f718410c-1733-479d-bd80-af03f38416', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain, translateForTest);
@@ -743,7 +766,7 @@ describe('ConversationRepository', () => {
 
     beforeAll(() => {
       jest
-        .spyOn(testFactory.conversation_repository!, 'saveConversation')
+        .spyOn(requireValueForTest(testFactory.conversation_repository), 'saveConversation')
         .mockImplementation((conversation: Conversation) => {
           testFactory.conversation_repository['conversationState'].conversations.push(conversation);
           return Promise.resolve(conversation);
@@ -751,8 +774,8 @@ describe('ConversationRepository', () => {
     });
 
     it('finds an existing 1:1 conversation within a team', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const team1to1Conversation: Partial<ConversationDatabaseData> = {
         access: [CONVERSATION_ACCESS.INVITE],
@@ -813,8 +836,8 @@ describe('ConversationRepository', () => {
     });
 
     it('returns proteus 1:1 conversation if one of the users does not support mls', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain, translateForTest);
@@ -855,8 +878,8 @@ describe('ConversationRepository', () => {
     });
 
     it('returns proteus 1:1 conversation and marks it as readonly if the other user does not support proteus', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain, translateForTest);
@@ -896,8 +919,8 @@ describe('ConversationRepository', () => {
     });
 
     it('returns established mls 1:1 conversation if both users support mls', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain, translateForTest);
@@ -932,8 +955,8 @@ describe('ConversationRepository', () => {
     });
 
     it('replaces proteus 1:1 with mls 1:1', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const mockedGroupId = 'groupId';
 
@@ -999,7 +1022,7 @@ describe('ConversationRepository', () => {
       }) as BackendMLSConversation;
 
       jest
-        .spyOn(container.resolve(Core).service!.conversation, 'establishMLS1to1Conversation')
+        .spyOn(getCoreConversationServiceForTest(), 'establishMLS1to1Conversation')
         .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
 
       jest.spyOn(conversationRepository['eventService'], 'moveEventsToConversation');
@@ -1030,7 +1053,7 @@ describe('ConversationRepository', () => {
       expect(conversationRepository['conversationService'].blacklistConversation).toHaveBeenCalledWith(
         proteus1to1Conversation.qualifiedId,
       );
-      expect(container.resolve(Core).service!.conversation.establishMLS1to1Conversation).toHaveBeenCalled();
+      expect(getCoreConversationServiceForTest().establishMLS1to1Conversation).toHaveBeenCalled();
       expect(conversationRepository['eventRepository'].injectEvent).toHaveBeenCalled();
       expect(conversationRepository['conversationState'].conversations()).not.toEqual(
         expect.arrayContaining([proteus1to1Conversation]),
@@ -1038,8 +1061,8 @@ describe('ConversationRepository', () => {
     });
 
     it("establishes MLS 1:1 conversation if it's not yet established", async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
       const mockedGroupId = 'groupId';
 
       const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
@@ -1083,7 +1106,7 @@ describe('ConversationRepository', () => {
       }) as BackendMLSConversation;
 
       jest
-        .spyOn(container.resolve(Core).service!.conversation, 'establishMLS1to1Conversation')
+        .spyOn(getCoreConversationServiceForTest(), 'establishMLS1to1Conversation')
         .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
 
       Object.defineProperty(container.resolve(Core), 'clientId', {
@@ -1095,7 +1118,7 @@ describe('ConversationRepository', () => {
 
       const conversationEntity = await conversationRepository.resolve1To1Conversation(otherUser.qualifiedId);
 
-      expect(container.resolve(Core).service!.conversation.establishMLS1to1Conversation).toHaveBeenCalledWith(
+      expect(getCoreConversationServiceForTest().establishMLS1to1Conversation).toHaveBeenCalledWith(
         mockedGroupId,
         {client: mockSelfClientId, user: selfUserId},
         otherUserId,
@@ -1104,8 +1127,8 @@ describe('ConversationRepository', () => {
     });
 
     it('establishes MLS 1:1 conversation between team members', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
       const teamId = 'team-id';
       const mockedGroupId = 'groupId';
 
@@ -1153,7 +1176,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
         .mockResolvedValueOnce({conversation: establishedMls1to1ConversationResponse});
       jest
-        .spyOn(container.resolve(Core).service!.conversation, 'establishMLS1to1Conversation')
+        .spyOn(getCoreConversationServiceForTest(), 'establishMLS1to1Conversation')
         .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
 
       selfUser.supportedProtocols([CONVERSATION_PROTOCOL.PROTEUS, CONVERSATION_PROTOCOL.MLS]);
@@ -1161,12 +1184,12 @@ describe('ConversationRepository', () => {
 
       await conversationRepository.resolve1To1Conversation(otherUser.qualifiedId);
 
-      expect(container.resolve(Core).service!.conversation.establishMLS1to1Conversation).toHaveBeenCalled();
+      expect(getCoreConversationServiceForTest().establishMLS1to1Conversation).toHaveBeenCalled();
     });
 
     it("establishes MLS 1:1 conversation if it's a team-owned 1:1 conversation only if it was already established on backend", async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
       const teamId = 'team-id';
       const mockedGroupId = 'groupId';
 
@@ -1202,7 +1225,7 @@ describe('ConversationRepository', () => {
         .spyOn(conversationRepository['conversationService'], 'getMLS1to1Conversation')
         .mockResolvedValueOnce({conversation: establishedMls1to1ConversationResponse});
       jest
-        .spyOn(container.resolve(Core).service!.conversation, 'establishMLS1to1Conversation')
+        .spyOn(getCoreConversationServiceForTest(), 'establishMLS1to1Conversation')
         .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
 
       const [mls1to1Conversation] = conversationRepository.mapConversations([establishedMls1to1ConversationResponse]);
@@ -1216,12 +1239,12 @@ describe('ConversationRepository', () => {
       const conversationEntity = await conversationRepository.resolve1To1Conversation(otherUser.qualifiedId);
 
       expect(conversationEntity?.serialize()).toEqual(mls1to1Conversation.serialize());
-      expect(container.resolve(Core).service!.conversation.establishMLS1to1Conversation).toHaveBeenCalled();
+      expect(getCoreConversationServiceForTest().establishMLS1to1Conversation).toHaveBeenCalled();
     });
 
     it('returns established mls 1:1 conversation if conversation exists locally even when proteus is choosen.', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain, translateForTest);
@@ -1260,8 +1283,8 @@ describe('ConversationRepository', () => {
     });
 
     it('marks mls 1:1 conversation as read-only if the other user does not support mls and mls 1:1 was never established', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain, translateForTest);
@@ -1303,8 +1326,8 @@ describe('ConversationRepository', () => {
     });
 
     it('marks mls 1:1 conversation as read-only if both users support mls but the other user has no keys available', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const otherUserId = {id: 'a718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain, translateForTest);
@@ -1326,7 +1349,7 @@ describe('ConversationRepository', () => {
       const noKeysError = new ClientMLSError(ClientMLSErrorLabel.NO_KEY_PACKAGES_AVAILABLE);
 
       jest
-        .spyOn(container.resolve(Core).service!.conversation, 'establishMLS1to1Conversation')
+        .spyOn(getCoreConversationServiceForTest(), 'establishMLS1to1Conversation')
         .mockRejectedValueOnce(noKeysError);
 
       const [mls1to1Conversation] = conversationRepository.mapConversations([mls1to1ConversationResponse]);
@@ -1352,8 +1375,8 @@ describe('ConversationRepository', () => {
     });
 
     it('deos not mark mls 1:1 conversation as read-only if the other user does not support mls but mls 1:1 was already established', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain, translateForTest);
@@ -1393,8 +1416,8 @@ describe('ConversationRepository', () => {
     });
 
     it('re-evaluates 1:1 conversation with user after their supported protocols are updated', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
       const mockedGroupId = 'groupId';
 
       const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
@@ -1448,7 +1471,7 @@ describe('ConversationRepository', () => {
       }) as BackendMLSConversation;
 
       jest
-        .spyOn(container.resolve(Core).service!.conversation, 'establishMLS1to1Conversation')
+        .spyOn(getCoreConversationServiceForTest(), 'establishMLS1to1Conversation')
         .mockResolvedValueOnce(establishedMls1to1ConversationResponse);
 
       Object.defineProperty(container.resolve(Core), 'clientId', {
@@ -1471,8 +1494,8 @@ describe('ConversationRepository', () => {
     });
 
     it('does not re-evaluates 1:1 conversation with user after their supported protocols are updated if conversation did not exist before', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain, translateForTest);
@@ -1544,8 +1567,8 @@ describe('ConversationRepository', () => {
 
   describe('mapConnections', () => {
     it("maps a connection to connection request placeholder for 1:1 conversation when there's an outgoing connection request", async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const userRepository = testFactory.user_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const userRepository = requireValueForTest(testFactory.user_repository);
 
       const otherUserId = {id: 'f718410c-3833-479d-bd80-a5df03f38414', domain: 'test-domain'};
       const otherUser = new User(otherUserId.id, otherUserId.domain, translateForTest);
@@ -1690,9 +1713,9 @@ describe('ConversationRepository', () => {
     });
 
     it('clears all the messages from database and local state and re-applies creation message', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
-      const messageRepository = testFactory.message_repository!;
-      const eventRepository = testFactory.event_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
+      const messageRepository = requireValueForTest(testFactory.message_repository);
+      const eventRepository = requireValueForTest(testFactory.event_repository);
 
       const conversationEntity = _generateConversation({type: CONVERSATION_TYPE.REGULAR});
       const selfUser = generateUser();
@@ -1754,7 +1777,7 @@ describe('ConversationRepository', () => {
       spyOn(testFactory.conversation_repository as any, 'fetchConversationById').and.callThrough();
       spyOn(testFactory.user_repository, 'getUserSupportedProtocols').and.returnValue([CONVERSATION_PROTOCOL.PROTEUS]);
       spyOn(testFactory.self_repository, 'getSelfSupportedProtocols').and.returnValue([CONVERSATION_PROTOCOL.PROTEUS]);
-      conversationService = testFactory.conversation_repository!['conversationService'];
+      conversationService = requireValueForTest(testFactory.conversation_repository)['conversationService'];
       spyOn(conversationService, 'getConversationById').and.returnValue(Promise.resolve(conversation_payload));
       spyOn(testFactory.user_repository, 'getUsersById').and.returnValue(Promise.resolve([]));
     });
@@ -1762,7 +1785,7 @@ describe('ConversationRepository', () => {
     it('should map a connection to an existing conversation', () => {
       conversation_et.type(CONVERSATION_TYPE.ONE_TO_ONE);
 
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const user = new User('id', 'domain', translateForTest);
       user.connection(connectionEntity);
       connectionEntity.userId = user.qualifiedId;
@@ -1778,7 +1801,7 @@ describe('ConversationRepository', () => {
     });
 
     it('should map a connection to a new conversation', () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const user = new User('id1', 'domain1', translateForTest);
       user.connection(connectionEntity);
       connectionEntity.userId = user.qualifiedId;
@@ -1796,7 +1819,7 @@ describe('ConversationRepository', () => {
     });
 
     it('should map a cancelled connection to an existing conversation and filter it', () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const user = new User('id', 'domain', translateForTest);
       user.connection(connectionEntity);
       connectionEntity.userId = user.qualifiedId;
@@ -1893,7 +1916,7 @@ describe('ConversationRepository', () => {
     });
 
     it('does not show an undefined conversation when archiving the only active conversation', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const conversation = _generateConversation();
       const selfUser = generateUser();
 
@@ -1922,7 +1945,7 @@ describe('ConversationRepository', () => {
 
     describe('conversation.mls-welcome', () => {
       it('should initialise mls 1:1 conversation after receiving a welcome', async () => {
-        const conversationRepository = testFactory.conversation_repository!;
+        const conversationRepository = requireValueForTest(testFactory.conversation_repository);
         const mockedGroupId = 'AAEAAKA0LuGtiU7NjqqlZIE2dQUAZWxuYS53aXJlLmxpbms=';
 
         const conversation = _generateConversation({
@@ -1942,17 +1965,17 @@ describe('ConversationRepository', () => {
 
         const welcomeEvent: ConversationMLSWelcomeEvent = {
           conversation: conversation.id,
-          data: conversation.groupId!,
+          data: requireValueForTest(conversation.groupId),
           from: 'd5a39ffb-6ce3-4cc8-9048-0e15d031b4c5',
           time: '2015-04-27T11:42:31.475Z',
           type: CONVERSATION_EVENT.MLS_WELCOME_MESSAGE,
         };
 
-        const coreConversationService = container.resolve(Core).service!.conversation!;
+        const coreConversationService = getCoreConversationServiceForTest();
 
         jest.spyOn(coreConversationService, 'isMLSGroupEstablishedLocally').mockResolvedValueOnce(false);
         const selfSupportedProtocolsSpy = jest
-          .spyOn(testFactory.self_repository!, 'getSelfSupportedProtocols')
+          .spyOn(requireValueForTest(testFactory.self_repository), 'getSelfSupportedProtocols')
           .mockResolvedValue([CONVERSATION_PROTOCOL.PROTEUS, CONVERSATION_PROTOCOL.MLS]);
 
         const establishedMls1to1ConversationResponse = generateAPIConversation({
@@ -2316,7 +2339,7 @@ describe('ConversationRepository', () => {
       });
 
       it('injects a group creation message when create-meeting has participants', async () => {
-        const conversationRepository = testFactory.conversation_repository!;
+        const conversationRepository = requireValueForTest(testFactory.conversation_repository);
         const injectEventSpy = jest
           .spyOn(conversationRepository['eventRepository'], 'injectEvent')
           .mockResolvedValue(undefined);
@@ -2427,7 +2450,7 @@ describe('ConversationRepository', () => {
       });
 
       const saveMeetingConversation = async () => {
-        const conversationRepository = testFactory.conversation_repository!;
+        const conversationRepository = requireValueForTest(testFactory.conversation_repository);
         const meetingConversation = _generateConversation({
           protocol: CONVERSATION_PROTOCOL.MLS,
           overwites: {group_conv_type: GROUP_CONVERSATION_TYPE.MEETING},
@@ -2440,7 +2463,7 @@ describe('ConversationRepository', () => {
       let wipeMeetingConversationSpy: jest.SpyInstance;
 
       beforeEach(() => {
-        const conversationRepository = testFactory.conversation_repository!;
+        const conversationRepository = requireValueForTest(testFactory.conversation_repository);
         deleteFromDbSpy = jest
           .spyOn(conversationRepository['conversationService'], 'deleteConversationFromDb')
           .mockResolvedValue('');
@@ -2455,7 +2478,7 @@ describe('ConversationRepository', () => {
       });
 
       it('deletes a local meeting conversation without a delete notification', async () => {
-        const conversationRepository = testFactory.conversation_repository!;
+        const conversationRepository = requireValueForTest(testFactory.conversation_repository);
         const meetingConversation = await saveMeetingConversation();
         const publishSpy = jest.spyOn(amplify, 'publish');
 
@@ -2485,7 +2508,7 @@ describe('ConversationRepository', () => {
           params: {type: CONVERSATION_TYPE.ONE_TO_ONE},
         },
       ])('ignores conversation.delete-meeting for a $name', async ({params}) => {
-        const conversationRepository = testFactory.conversation_repository!;
+        const conversationRepository = requireValueForTest(testFactory.conversation_repository);
         const conversation = _generateConversation(params);
         await conversationRepository['saveConversation'](conversation);
 
@@ -2497,7 +2520,7 @@ describe('ConversationRepository', () => {
       });
 
       it('does not throw when the conversation is unknown', async () => {
-        const conversationRepository = testFactory.conversation_repository!;
+        const conversationRepository = requireValueForTest(testFactory.conversation_repository);
         const getConversationByIdSpy = jest
           .spyOn(conversationRepository, 'getConversationById')
           .mockRejectedValue(
@@ -2521,7 +2544,7 @@ describe('ConversationRepository', () => {
       });
 
       it('still deletes a conversation.delete event and notifies', async () => {
-        const conversationRepository = testFactory.conversation_repository!;
+        const conversationRepository = requireValueForTest(testFactory.conversation_repository);
         const conversation = _generateConversation();
         await conversationRepository['saveConversation'](conversation);
         const publishSpy = jest.spyOn(amplify, 'publish');
@@ -2542,7 +2565,7 @@ describe('ConversationRepository', () => {
       });
 
       it('leaves an active call and clears calling state for a deleted meeting conversation', async () => {
-        const conversationRepository = testFactory.conversation_repository!;
+        const conversationRepository = requireValueForTest(testFactory.conversation_repository);
         const meetingConversation = await saveMeetingConversation();
         const callState = container.resolve(CallState);
         const call = new Call(
@@ -2574,7 +2597,7 @@ describe('ConversationRepository', () => {
       });
 
       it('succeeds when there is no call for the meeting conversation', async () => {
-        const conversationRepository = testFactory.conversation_repository!;
+        const conversationRepository = requireValueForTest(testFactory.conversation_repository);
         const meetingConversation = await saveMeetingConversation();
         const leaveCallSpy = jest.spyOn(conversationRepository['callingRepository'], 'leaveCall');
 
@@ -2602,9 +2625,7 @@ describe('ConversationRepository', () => {
         spyOn(testFactory.conversation_repository as any, 'onMemberJoin').and.callThrough();
         spyOn(testFactory.conversation_repository, 'updateParticipatingUserEntities').and.callThrough();
         spyOn(testFactory.user_repository, 'getUsersById').and.returnValue(Promise.resolve([]));
-        spyOn(container.resolve(Core).service!.conversation, 'mlsGroupExistsLocally').and.returnValue(
-          Promise.resolve(true),
-        );
+        spyOn(getCoreConversationServiceForTest(), 'mlsGroupExistsLocally').and.returnValue(Promise.resolve(true));
 
         conversation_et = _generateConversation();
 
@@ -2660,9 +2681,9 @@ describe('ConversationRepository', () => {
             configurable: true,
           });
 
-          jest.spyOn(container.resolve(Core).service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+          jest.spyOn(getMlsServiceForTest(), 'conversationExists').mockResolvedValueOnce(true);
 
-          const conversationRepo = testFactory.conversation_repository!;
+          const conversationRepo = requireValueForTest(testFactory.conversation_repository);
           jest.spyOn(conversationRepo['conversationService'], 'mlsGroupExistsLocally').mockResolvedValue(false);
 
           return testFactory.conversation_repository['handleConversationEvent'](memberJoinEvent).then(() => {
@@ -2685,9 +2706,9 @@ describe('ConversationRepository', () => {
 
             Object.defineProperty(container.resolve(Core), 'clientId', {value: mockSelfClientId});
 
-            jest.spyOn(container.resolve(Core).service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+            jest.spyOn(getMlsServiceForTest(), 'conversationExists').mockResolvedValueOnce(true);
 
-            const conversationRepo = testFactory.conversation_repository!;
+            const conversationRepo = requireValueForTest(testFactory.conversation_repository);
             jest.spyOn(conversationRepo['conversationService'], 'mlsGroupExistsLocally').mockResolvedValue(false);
 
             return testFactory.conversation_repository['handleConversationEvent'](memberJoinEvent).then(() => {
@@ -2715,7 +2736,7 @@ describe('ConversationRepository', () => {
           type: CONVERSATION_EVENT.MEMBER_JOIN,
         } as ConversationMemberJoinEvent;
 
-        const conversationRepo = testFactory.conversation_repository!;
+        const conversationRepo = requireValueForTest(testFactory.conversation_repository);
         conversationRepo['conversationState'].conversations.push(conversation);
 
         // conversation has a corresponding pending connection
@@ -2723,9 +2744,9 @@ describe('ConversationRepository', () => {
         connectionEntity.conversationId = conversation.qualifiedId;
         connectionEntity.userId = {domain: '', id: ''};
         connectionEntity.status(ConnectionStatus.PENDING);
-        testFactory.connection_repository!.addConnectionEntity(connectionEntity);
+        requireValueForTest(testFactory.connection_repository).addConnectionEntity(connectionEntity);
 
-        spyOn(conversationRepo!['userState'], 'self').and.returnValue(selfUser);
+        spyOn(conversationRepo['userState'], 'self').and.returnValue(selfUser);
 
         return conversationRepo['handleConversationEvent'](memberJoinEvent).then(() => {
           expect(conversationRepo['onMemberJoin']).toHaveBeenCalled();
@@ -2754,8 +2775,8 @@ describe('ConversationRepository', () => {
           type: CONVERSATION_EVENT.MEMBER_JOIN,
         } as ConversationMemberJoinEvent;
 
-        const conversationRepo = testFactory.conversation_repository!;
-        const userRepo = testFactory.user_repository!;
+        const conversationRepo = requireValueForTest(testFactory.conversation_repository);
+        const userRepo = requireValueForTest(testFactory.user_repository);
         conversationRepo['conversationState'].conversations.push(conversation);
 
         jest.spyOn(conversationRepo, 'resolve1To1Conversation').mockResolvedValueOnce(conversation);
@@ -2770,9 +2791,9 @@ describe('ConversationRepository', () => {
         connectionEntity.conversationId = conversation.qualifiedId;
         connectionEntity.userId = otherUser.qualifiedId;
         connectionEntity.status(ConnectionStatus.SENT);
-        testFactory.connection_repository!.addConnectionEntity(connectionEntity);
+        requireValueForTest(testFactory.connection_repository).addConnectionEntity(connectionEntity);
 
-        spyOn(conversationRepo!['userState'], 'self').and.returnValue(selfUser);
+        spyOn(conversationRepo['userState'], 'self').and.returnValue(selfUser);
 
         return conversationRepo['handleConversationEvent'](memberJoinEvent).then(() => {
           expect(conversationRepo['onMemberJoin']).toHaveBeenCalled();
@@ -3299,16 +3320,16 @@ describe('ConversationRepository', () => {
     it('marks inaccessible conversations as past member', async () => {
       const inaccessibleGroup = _generateConversation();
       const activeGroup = _generateConversation();
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
 
-      jest.spyOn(testFactory.conversation_service!, 'getConversationByIds').mockResolvedValue({
+      jest.spyOn(requireValueForTest(testFactory.conversation_service), 'getConversationByIds').mockResolvedValue({
         not_found: [inaccessibleGroup],
       });
       await conversationRepository['saveConversation'](inaccessibleGroup);
       await conversationRepository['saveConversation'](activeGroup);
 
       const currentNbConversations = conversationRepository['conversationState'].conversations().length;
-      await testFactory.conversation_repository!.syncDeletedConversations();
+      await requireValueForTest(testFactory.conversation_repository).syncDeletedConversations();
 
       expect(conversationRepository['conversationState'].conversations()).toHaveLength(currentNbConversations);
       expect(inaccessibleGroup.status()).toBe(ConversationStatus.PAST_MEMBER);
@@ -3339,11 +3360,11 @@ describe('ConversationRepository', () => {
 
   describe('loadConversations', () => {
     beforeEach(() => {
-      testFactory.conversation_repository!['conversationState'].conversations.removeAll();
+      requireValueForTest(testFactory.conversation_repository)['conversationState'].conversations.removeAll();
     });
 
     it('loads all conversations from backend when there is no local conversations', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const conversationService = conversationRepository['conversationService'];
       const remoteConversations = {
         found: [
@@ -3380,7 +3401,7 @@ describe('ConversationRepository', () => {
     });
 
     it("does not load proteus 1:1 conversation if there's mls 1:1 conversation with the same user", async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const conversationService = conversationRepository['conversationService'];
       const userId = {id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b', domain: 'staging.zinfra.io'};
 
@@ -3425,7 +3446,7 @@ describe('ConversationRepository', () => {
     });
 
     it("still loads proteus 1:1 conversation if there's mls 1:1 conversation with the same user but conversation exists locally", async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const conversationService = conversationRepository['conversationService'];
       const userId = {id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b', domain: 'staging.zinfra.io'};
 
@@ -3470,7 +3491,7 @@ describe('ConversationRepository', () => {
     });
 
     it('does not load connection request (type 3) conversations if their users were deleted on backend', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const conversationService = conversationRepository['conversationService'];
       const userId = {id: '05d0f240-bfe9-40d7-b6cb-602dac89fa1b', domain: 'staging.zinfra.io'};
 
@@ -3508,7 +3529,7 @@ describe('ConversationRepository', () => {
     });
 
     it('keeps track of missing conversations', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const conversationService = conversationRepository['conversationService'];
       const conversationState = conversationRepository['conversationState'];
       const remoteConversations = {
@@ -3551,11 +3572,11 @@ describe('ConversationRepository', () => {
   });
   describe('loadMissingConversations', () => {
     beforeEach(() => {
-      testFactory.conversation_repository!['conversationState'].conversations.removeAll();
+      requireValueForTest(testFactory.conversation_repository)['conversationState'].conversations.removeAll();
     });
 
     it('make sure missing conversations are properly updated', async () => {
-      const conversationRepository = testFactory.conversation_repository!;
+      const conversationRepository = requireValueForTest(testFactory.conversation_repository);
       const conversationService = conversationRepository['conversationService'];
       const conversationState = conversationRepository['conversationState'];
 
@@ -3607,7 +3628,7 @@ describe('ConversationRepository', () => {
       conversation.participating_user_ets.push(unavailableUsers[0], unavailableUsers[1], unavailableUsers[2]);
 
       const conversationRepo = await testFactory.exposeConversationActors();
-      spyOn(testFactory.user_repository!, 'refreshUsers').and.callFake(() => {
+      spyOn(requireValueForTest(testFactory.user_repository), 'refreshUsers').and.callFake(() => {
         unavailableUsers.map(user => {
           user.id = createUuid();
           user.name(faker.person.fullName());
@@ -3616,7 +3637,7 @@ describe('ConversationRepository', () => {
 
       await conversationRepo.refreshUnavailableParticipants(conversation);
 
-      expect(testFactory.user_repository!.refreshUsers).toHaveBeenCalled();
+      expect(requireValueForTest(testFactory.user_repository).refreshUsers).toHaveBeenCalled();
       expect(unavailableUsers[0].name).toBeTruthy();
       expect(unavailableUsers[1].name).toBeTruthy();
       expect(unavailableUsers[2].name).toBeTruthy();
@@ -3642,9 +3663,12 @@ describe('ConversationRepository', () => {
       conversation2.participating_user_ets.push(unavailableUsers2[0], unavailableUsers2[1], unavailableUsers2[2]);
 
       const conversationRepo = await testFactory.exposeConversationActors();
-      testFactory.conversation_repository!['conversationState'].conversations([conversation1, conversation2]);
+      requireValueForTest(testFactory.conversation_repository)['conversationState'].conversations([
+        conversation1,
+        conversation2,
+      ]);
 
-      spyOn(testFactory.user_repository!, 'refreshUsers').and.callFake(() => {
+      spyOn(requireValueForTest(testFactory.user_repository), 'refreshUsers').and.callFake(() => {
         unavailableUsers1.map(user => {
           user.id = createUuid();
           user.name(faker.person.fullName());
@@ -3657,7 +3681,7 @@ describe('ConversationRepository', () => {
 
       await conversationRepo['refreshAllConversationsUnavailableParticipants']();
 
-      expect(testFactory.user_repository!.refreshUsers).toHaveBeenCalled();
+      expect(requireValueForTest(testFactory.user_repository).refreshUsers).toHaveBeenCalled();
       expect(unavailableUsers1[0].name).toBeTruthy();
       expect(unavailableUsers1[1].name).toBeTruthy();
       expect(unavailableUsers1[2].name).toBeTruthy();
@@ -3878,7 +3902,7 @@ describe('ConversationRepository', () => {
 
       const usersToAdd = [generateUser(), generateUser()];
 
-      const coreConversationService = container.resolve(Core).service!.conversation;
+      const coreConversationService = getCoreConversationServiceForTest();
       spyOn(coreConversationService, 'addUsersToProteusConversation');
 
       await conversationRepository.addUsers(conversation, usersToAdd);
@@ -3898,7 +3922,7 @@ describe('ConversationRepository', () => {
 
       const usersToAdd = [generateUser(), generateUser()];
 
-      const coreConversationService = container.resolve(Core).service!.conversation;
+      const coreConversationService = getCoreConversationServiceForTest();
       jest.spyOn(coreConversationService, 'addUsersToMLSConversation');
       jest.spyOn(coreConversationService, 'addUsersToProteusConversation').mockResolvedValueOnce({});
 
@@ -3921,7 +3945,7 @@ describe('ConversationRepository', () => {
 
       const usersToAdd = [generateUser(), generateUser()];
 
-      const coreConversationService = container.resolve(Core).service!.conversation;
+      const coreConversationService = getCoreConversationServiceForTest();
       spyOn(coreConversationService, 'addUsersToMLSConversation');
 
       await conversationRepository.addUsers(conversation, usersToAdd);
@@ -3949,7 +3973,7 @@ describe('ConversationRepository', () => {
 
         conversation.participating_user_ets([user1, user2]);
 
-        const coreConversationService = container.resolve(Core).service!.conversation;
+        const coreConversationService = getCoreConversationServiceForTest();
 
         jest.spyOn(conversationRepository['eventRepository'], 'injectEvent').mockImplementation(jest.fn());
 
@@ -3975,7 +3999,7 @@ describe('ConversationRepository', () => {
 
       conversation.participating_user_ets([user1, user2]);
 
-      const coreConversationService = container.resolve(Core).service!.conversation;
+      const coreConversationService = getCoreConversationServiceForTest();
 
       jest
         .spyOn(coreConversationService, 'removeUsersFromMLSConversation')
@@ -4040,7 +4064,10 @@ describe('leaveConversation', () => {
 
       conversation.participating_user_ets([generateUser(), generateUser()]);
 
-      const removeUserFromConversationSpy = jest.spyOn(core.service!.conversation, 'removeUserFromConversation');
+      const removeUserFromConversationSpy = jest.spyOn(
+        getConversationServiceFromCoreForTest(core),
+        'removeUserFromConversation',
+      );
 
       const injectEventsSpy = jest.spyOn(eventRepository, 'injectEvents');
 
@@ -4129,8 +4156,9 @@ describe('onMLSResetMessage', () => {
       },
     };
 
-    spyOn(core.service!.conversation, 'wipeMLSConversation').and.returnValue(Promise.resolve(undefined));
-    spyOn(core.service!.conversation, 'mlsGroupExistsLocally').and.returnValue(Promise.resolve(false));
+    const coreConversationService = getConversationServiceFromCoreForTest(core);
+    spyOn(coreConversationService, 'wipeMLSConversation').and.returnValue(Promise.resolve(undefined));
+    spyOn(coreConversationService, 'mlsGroupExistsLocally').and.returnValue(Promise.resolve(false));
     const updatePropertiesSpy = jest.spyOn(ConversationMapper, 'updateProperties');
     const saveConversationStateInDbSpy = jest.spyOn(conversationService, 'saveConversationStateInDb');
 
@@ -4164,9 +4192,10 @@ describe('onMLSResetMessage', () => {
       },
     };
 
-    spyOn(core.service!.conversation, 'wipeMLSConversation').and.returnValue(Promise.resolve(undefined));
-    spyOn(core.service!.conversation, 'mlsGroupExistsLocally').and.returnValue(Promise.resolve(true));
-    spyOn(core.service!.mls!, 'getEpoch').and.returnValue(Promise.resolve(5));
+    const coreConversationService = getConversationServiceFromCoreForTest(core);
+    spyOn(coreConversationService, 'wipeMLSConversation').and.returnValue(Promise.resolve(undefined));
+    spyOn(coreConversationService, 'mlsGroupExistsLocally').and.returnValue(Promise.resolve(true));
+    spyOn(getMlsServiceForTest(core), 'getEpoch').and.returnValue(Promise.resolve(5));
 
     const updatePropertiesSpy = jest.spyOn(ConversationMapper, 'updateProperties');
     const saveConversationStateInDbSpy = jest.spyOn(conversationService, 'saveConversationStateInDb');

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -213,6 +213,15 @@ export class ConversationRepository {
   private mlsConversationVerificationStateHandler?: MLSConversationVerificationStateHandler;
   private initiatingMlsConversationQualifiedIds: QualifiedId[] = [];
 
+  private get coreServices() {
+    const coreServices = this.core.service;
+    if (isUndefined(coreServices)) {
+      throw new Error('Core services are not initialized');
+    }
+
+    return coreServices;
+  }
+
   static get CONFIG() {
     return {
       CONFIRMATION_THRESHOLD: TIME_IN_MILLIS.WEEK,
@@ -487,9 +496,13 @@ export class ConversationRepository {
     };
 
     if (this.teamState.team().id) {
+      const teamId = this.teamState.team().id;
+      if (isUndefined(teamId)) {
+        throw new Error('Cannot create a team conversation without a team id');
+      }
       payload.team = {
         managed: false,
-        teamid: this.teamState.team().id!,
+        teamid: teamId,
       };
 
       if (accessState) {
@@ -517,13 +530,13 @@ export class ConversationRepository {
         throw new Error('Cannot create conversation before self user is available');
       }
       if (isMLSConversation) {
-        response = await this.core.service!.conversation.createMLSConversation(
+        response = await this.coreServices.conversation.createMLSConversation(
           payload,
           selfUser.qualifiedId,
           this.core.clientId,
         );
       } else {
-        const {conversation, failedToAdd} = await this.core.service!.conversation.createProteusConversation(payload);
+        const {conversation, failedToAdd} = await this.coreServices.conversation.createProteusConversation(payload);
         response = {conversation, failedToAdd};
       }
 
@@ -2410,7 +2423,7 @@ export class ConversationRepository {
           throw new Error('Cannot establish meeting conversation before self user is available');
         }
 
-        const {failedToAdd = []} = await this.core.service!.conversation.establishMLSGroupConversation(
+        const {failedToAdd = []} = await this.coreServices.conversation.establishMLSGroupConversation(
           groupId,
           userIdsToAdd,
           selfUser.qualifiedId,
@@ -2721,7 +2734,7 @@ export class ConversationRepository {
     try {
       if (isProteusConversation(conversation) || isMixedConversation(conversation)) {
         const {failedToAdd, event: memberJoinEvent} =
-          await this.core.service!.conversation.addUsersToProteusConversation({
+          await this.coreServices.conversation.addUsersToProteusConversation({
             conversationId,
             qualifiedUsers,
           });
@@ -2741,7 +2754,7 @@ export class ConversationRepository {
       }
 
       if (isMLSCapableConversation(conversation)) {
-        const {failedToAdd} = await this.core.service!.conversation.addUsersToMLSConversation({
+        const {failedToAdd} = await this.coreServices.conversation.addUsersToMLSConversation({
           conversationId: conversation.qualifiedId,
           groupId: conversation.groupId,
           qualifiedUsers,
@@ -3003,7 +3016,7 @@ export class ConversationRepository {
    */
   private async removeMembersFromMLSConversation(conversationEntity: MLSConversation, userIds: QualifiedId[]) {
     const {groupId, qualifiedId} = conversationEntity;
-    await this.core.service!.conversation.removeUsersFromMLSConversation({
+    await this.coreServices.conversation.removeUsersFromMLSConversation({
       conversationId: qualifiedId,
       groupId,
       qualifiedUserIds: userIds,
@@ -3020,10 +3033,7 @@ export class ConversationRepository {
   private async removeMembersFromConversation(conversation: Conversation, userIds: QualifiedId[]) {
     return await Promise.all(
       userIds.map(async userId => {
-        const event = await this.core.service!.conversation.removeUserFromConversation(
-          conversation.qualifiedId,
-          userId,
-        );
+        const event = await this.coreServices.conversation.removeUserFromConversation(conversation.qualifiedId, userId);
         const roles = conversation.roles();
         delete roles[userId.id];
         conversation.roles(roles);

--- a/apps/webapp/src/script/repositories/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationVerificationStateHandler/MLS/MLSStateHandler.test.ts
@@ -23,6 +23,7 @@ import {asyncNoop, noop} from 'noop-esm';
 
 import {Conversation} from 'Repositories/entity/Conversation';
 import * as e2eIdentity from 'src/script/e2eIdentity';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import {Core} from 'src/script/service/coreSingleton';
 import {createUuid} from 'Util/uuid';
 import {waitFor} from 'Util/waitFor';
@@ -45,6 +46,18 @@ jest.mock('src/script/e2eIdentity', () => ({
 }));
 
 describe('MLSConversationVerificationStateHandler', () => {
+  function getCoreServiceForTest(): NonNullable<Core['service']> {
+    return requireValueForTest(core.service);
+  }
+
+  function getMlsServiceForTest(): NonNullable<NonNullable<Core['service']>['mls']> {
+    return requireValueForTest(getCoreServiceForTest().mls);
+  }
+
+  function getE2EIServiceForTest(): NonNullable<NonNullable<Core['service']>['e2eIdentity']> {
+    return requireValueForTest(getCoreServiceForTest().e2eIdentity);
+  }
+
   const getActiveWireIdentityMock = e2eIdentity.getActiveWireIdentity as jest.MockedFunction<
     typeof e2eIdentity.getActiveWireIdentity
   >;
@@ -104,7 +117,7 @@ describe('MLSConversationVerificationStateHandler', () => {
   });
 
   it('should do nothing if MLS service is not available', () => {
-    core.service!.mls = undefined;
+    getCoreServiceForTest().mls = undefined;
 
     const t = () => new MLSConversationVerificationStateHandler('domain', noop, asyncNoop, conversationState, core);
 
@@ -112,7 +125,7 @@ describe('MLSConversationVerificationStateHandler', () => {
   });
 
   it('should do nothing if e2eIdentity service is not available', () => {
-    core.service!.e2eIdentity = undefined;
+    getCoreServiceForTest().e2eIdentity = undefined;
 
     new MLSConversationVerificationStateHandler('domain', noop, asyncNoop, conversationState, core);
 
@@ -134,11 +147,12 @@ describe('MLSConversationVerificationStateHandler', () => {
       const onSelfClientCertificateRevoked = jest.fn().mockResolvedValue(undefined);
 
       getActiveWireIdentityMock.mockResolvedValue(createRevokedWireIdentity());
-      jest.spyOn(core.service!.e2eIdentity!, 'on').mockImplementation((event, listener) => {
+      jest.spyOn(getE2EIServiceForTest(), 'on').mockImplementation((event, listener) => {
         if (event === 'crlChanged') {
           triggerCrlChanged = listener;
         }
-        return core.service!.e2eIdentity!;
+
+        return getE2EIServiceForTest();
       });
 
       new MLSConversationVerificationStateHandler(
@@ -161,11 +175,12 @@ describe('MLSConversationVerificationStateHandler', () => {
       const onSelfClientCertificateRevoked = jest.fn().mockResolvedValue(undefined);
 
       getActiveWireIdentityMock.mockResolvedValue(createRevokedWireIdentity());
-      jest.spyOn(core.service!.e2eIdentity!, 'on').mockImplementation((event, listener) => {
+      jest.spyOn(getE2EIServiceForTest(), 'on').mockImplementation((event, listener) => {
         if (event === 'crlChanged') {
           triggerCrlChanged = listener;
         }
-        return core.service!.e2eIdentity!;
+
+        return getE2EIServiceForTest();
       });
 
       new MLSConversationVerificationStateHandler(
@@ -187,10 +202,10 @@ describe('MLSConversationVerificationStateHandler', () => {
     it('should reset to unverified if mls group does not exist anymore', async () => {
       let triggerEpochChange: Function = noop;
       conversation.mlsVerificationState(ConversationVerificationState.VERIFIED);
-      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(false);
+      jest.spyOn(getMlsServiceForTest(), 'conversationExists').mockResolvedValueOnce(false);
 
       jest
-        .spyOn(core.service!.mls!, 'on')
+        .spyOn(getMlsServiceForTest(), 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
       new MLSConversationVerificationStateHandler('domain', noop, asyncNoop, conversationState, core);
@@ -203,11 +218,11 @@ describe('MLSConversationVerificationStateHandler', () => {
     it('should degrade conversation', async () => {
       let triggerEpochChange: Function = noop;
       conversation.mlsVerificationState(ConversationVerificationState.VERIFIED);
-      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+      jest.spyOn(getMlsServiceForTest(), 'conversationExists').mockResolvedValueOnce(true);
 
       getConversationVerificationStateMock.mockResolvedValue(E2eiConversationState.NotVerified);
       jest
-        .spyOn(core.service!.mls!, 'on')
+        .spyOn(getMlsServiceForTest(), 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
       new MLSConversationVerificationStateHandler('domain', noop, asyncNoop, conversationState, core);
@@ -221,11 +236,11 @@ describe('MLSConversationVerificationStateHandler', () => {
       let triggerEpochChange: Function = noop;
       conversation.mlsVerificationState(ConversationVerificationState.UNVERIFIED);
 
-      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+      jest.spyOn(getMlsServiceForTest(), 'conversationExists').mockResolvedValueOnce(true);
 
       getConversationVerificationStateMock.mockResolvedValue(E2eiConversationState.NotVerified);
       jest
-        .spyOn(core.service!.mls!, 'on')
+        .spyOn(getMlsServiceForTest(), 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
       new MLSConversationVerificationStateHandler('domain', noop, asyncNoop, conversationState, core);
@@ -239,11 +254,11 @@ describe('MLSConversationVerificationStateHandler', () => {
       let triggerEpochChange: Function = noop;
       conversation.mlsVerificationState(ConversationVerificationState.DEGRADED);
 
-      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+      jest.spyOn(getMlsServiceForTest(), 'conversationExists').mockResolvedValueOnce(true);
 
       getConversationVerificationStateMock.mockResolvedValue(E2eiConversationState.Verified);
       jest
-        .spyOn(core.service!.mls!, 'on')
+        .spyOn(getMlsServiceForTest(), 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
       new MLSConversationVerificationStateHandler('domain', noop, asyncNoop, conversationState, core);
@@ -256,14 +271,14 @@ describe('MLSConversationVerificationStateHandler', () => {
     it('should wait for conversation to be known', async () => {
       let triggerEpochChange: Function = noop;
 
-      jest.spyOn(core.service!.mls!, 'conversationExists').mockResolvedValueOnce(true);
+      jest.spyOn(getMlsServiceForTest(), 'conversationExists').mockResolvedValueOnce(true);
 
       const newConversation = new Conversation(createUuid(), '', CONVERSATION_PROTOCOL.MLS, translateForTest);
       newConversation.groupId = 'AAEAAAOygT3TL0wljoaNabgK4yIAZWxuYS53aXJlLmxpbms=';
 
       getConversationVerificationStateMock.mockResolvedValue(E2eiConversationState.Verified);
       jest
-        .spyOn(core.service!.mls!, 'on')
+        .spyOn(getMlsServiceForTest(), 'on')
         .mockImplementation((_event, listener) => (triggerEpochChange = listener) as any);
 
       new MLSConversationVerificationStateHandler('domain', noop, asyncNoop, conversationState, core);

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -50,6 +50,7 @@ import {TeamState} from 'Repositories/team/TeamState';
 import {UserRepository} from 'Repositories/user/userRepository';
 import {UserState} from 'Repositories/user/userState';
 import {ConversationError} from 'src/script/error/conversationError';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import {generateQualifiedId} from 'test/helper/UserGenerator';
 import type {Translate} from 'Util/localizerUtil';
 import {translateForTest} from 'Util/test/translateForTest';
@@ -91,6 +92,12 @@ type MessageRepositoryPrivateMethodsForTest = {
   updateMessageAsFailed: () => Promise<void>;
   updateMessageAsSent: () => Promise<void>;
 };
+
+function getConversationServiceForTest(core: Account): NonNullable<NonNullable<Account['service']>['conversation']> {
+  const service = requireValueForTest(core.service);
+
+  return requireValueForTest(service.conversation);
+}
 
 async function buildMessageRepository(
   translate: Translate,
@@ -163,12 +170,12 @@ describe('MessageRepository', () => {
   describe('sendPing', () => {
     it('sends a ping', async () => {
       const [messageRepository, {core, eventRepository}] = await buildMessageRepository(translateForTest);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
       const conversation = generateConversation();
 
       await messageRepository.sendPing(conversation);
-      expect(core.service!.conversation.send).toHaveBeenCalledWith({
+      expect(getConversationServiceForTest(core).send).toHaveBeenCalledWith({
         ...commonSendResponse,
         conversationId: conversation.qualifiedId,
         nativePush: true,
@@ -212,7 +219,7 @@ describe('MessageRepository', () => {
   describe('sendMessageEdit', () => {
     it('sends an edit message if original message exists', async () => {
       const [messageRepository, {core, eventRepository}] = await buildMessageRepository(translateForTest);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
 
       const originalMessage = new ContentMessage(createUuid(), translateForTest);
@@ -221,7 +228,7 @@ describe('MessageRepository', () => {
       conversation.addMessage(originalMessage);
 
       await messageRepository.sendMessageEdit(conversation, 'new text', originalMessage, []);
-      expect(core.service!.conversation.send).toHaveBeenCalledWith({
+      expect(getConversationServiceForTest(core).send).toHaveBeenCalledWith({
         ...commonSendResponse,
         conversationId: conversation.qualifiedId,
         nativePush: true,
@@ -240,7 +247,7 @@ describe('MessageRepository', () => {
       const {Multipart} = await import('Repositories/entity/message/multipart');
 
       const [messageRepository, {core, eventRepository}] = await buildMessageRepository(translateForTest);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
 
       const originalMessage = new ContentMessage(createUuid(), translateForTest);
@@ -253,7 +260,7 @@ describe('MessageRepository', () => {
 
       await messageRepository.sendMessageEdit(conversation, 'new text', originalMessage, []);
 
-      expect(core.service!.conversation.send).toHaveBeenCalledWith({
+      expect(getConversationServiceForTest(core).send).toHaveBeenCalledWith({
         ...commonSendResponse,
         conversationId: conversation.qualifiedId,
         nativePush: true,
@@ -275,7 +282,7 @@ describe('MessageRepository', () => {
       const {Multipart} = await import('Repositories/entity/message/multipart');
 
       const [messageRepository, {core, eventRepository}] = await buildMessageRepository(translateForTest);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
 
       const cellId1 = 'cell-uuid-1';
@@ -294,7 +301,7 @@ describe('MessageRepository', () => {
 
       await messageRepository.sendMessageEdit(conversation, 'edited text', originalMessage, []);
 
-      const sendCall = (core.service!.conversation.send as jest.Mock).mock.calls[0][0];
+      const sendCall = (getConversationServiceForTest(core).send as jest.Mock).mock.calls[0][0];
       expect(sendCall.payload.edited.multipart.text).toEqual(expect.objectContaining({content: 'edited text'}));
       expect(sendCall.payload.edited.multipart.attachments).toHaveLength(2);
       expect(sendCall.payload.edited.multipart.attachments).toEqual(
@@ -313,7 +320,7 @@ describe('MessageRepository', () => {
       const {Multipart} = await import('Repositories/entity/message/multipart');
 
       const [messageRepository, {core, eventRepository}] = await buildMessageRepository(translateForTest);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
 
       const originalMessage = new ContentMessage(createUuid(), translateForTest);
@@ -325,7 +332,7 @@ describe('MessageRepository', () => {
 
       await messageRepository.sendMessageEdit(conversation, 'edited text', originalMessage, []);
 
-      expect(core.service!.conversation.send).toHaveBeenCalledWith({
+      expect(getConversationServiceForTest(core).send).toHaveBeenCalledWith({
         ...commonSendResponse,
         conversationId: conversation.qualifiedId,
         nativePush: true,
@@ -346,7 +353,7 @@ describe('MessageRepository', () => {
       const {Multipart} = await import('Repositories/entity/message/multipart');
 
       const [messageRepository, {core, eventRepository}] = await buildMessageRepository(translateForTest);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
 
       const cellId = 'valid-cell-id';
@@ -366,7 +373,7 @@ describe('MessageRepository', () => {
 
       await messageRepository.sendMessageEdit(conversation, 'edited text', originalMessage, []);
 
-      const sendCall = (core.service!.conversation.send as jest.Mock).mock.calls[0][0];
+      const sendCall = (getConversationServiceForTest(core).send as jest.Mock).mock.calls[0][0];
       const resultAttachments = sendCall.payload.edited.multipart.attachments;
 
       // Should have 2 valid attachments (null and undefined filtered out)
@@ -389,7 +396,7 @@ describe('MessageRepository', () => {
     it('when the message is sent, then should send without targeted parameters and update local state of button', async () => {
       // given
       const [messageRepository, {core, eventRepository}] = await buildMessageRepository(translateForTest);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
 
       // Spy on the internal method that sendButtonAction actually calls
@@ -459,7 +466,7 @@ describe('MessageRepository', () => {
     it('when no changes are returned, then no update should be called', async () => {
       // given
       const [messageRepository, {core, eventRepository}] = await buildMessageRepository(translateForTest);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
 
       // Spy on the internal method that sendButtonAction actually calls
@@ -510,11 +517,11 @@ describe('MessageRepository', () => {
       const [messageRepository, {eventRepository, core, propertiesRepository}] =
         await buildMessageRepository(translateForTest);
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       spyOn(eventRepository, 'injectEvent').and.returnValue(Promise.resolve());
       const conversation = generateConversation();
       await messageRepository.sendTextWithLinkPreview({conversation, textMessage: 'hello there', mentions: []});
-      expect(core.service!.conversation.send).toHaveBeenCalledWith({
+      expect(getConversationServiceForTest(core).send).toHaveBeenCalledWith({
         ...commonSendResponse,
         conversationId: conversation.qualifiedId,
         nativePush: true,
@@ -660,7 +667,7 @@ describe('MessageRepository', () => {
         await buildMessageRepository(translateForTest);
       clientState.currentClient = new ClientEntity(true, '', 'test-client-id');
       spyOn(propertiesRepository, 'getPreference').and.returnValue(false);
-      jest.spyOn(core.service!.conversation, 'send').mockRejectedValue(new Error('backend send failed'));
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockRejectedValue(new Error('backend send failed'));
       jest.spyOn(eventRepository, 'injectEvent').mockResolvedValue(undefined);
       const messageRepositoryPrivateMethods = messageRepository as unknown as MessageRepositoryPrivateMethodsForTest;
       jest.spyOn(messageRepositoryPrivateMethods, 'updateMessageAsFailed').mockResolvedValue(undefined);
@@ -745,14 +752,14 @@ describe('MessageRepository', () => {
       msgToDelete.user(sender);
       conversation.addMessage(msgToDelete);
       const [messageRepository, {core}] = await buildMessageRepository(translateForTest);
-      spyOn(core.service!.conversation, 'send').and.returnValue(
+      spyOn(getConversationServiceForTest(core), 'send').and.returnValue(
         Promise.resolve({state: MessageSendingState.OUTGOING_SENT, sentAt: new Date().toISOString()}),
       );
 
       await expect(messageRepository.deleteMessageForEveryone(conversation, msgToDelete)).rejects.toMatchObject({
         type: ConversationError.TYPE.WRONG_USER,
       });
-      expect(core.service!.conversation.send).not.toHaveBeenCalled();
+      expect(getConversationServiceForTest(core).send).not.toHaveBeenCalled();
     });
 
     it('should send delete and deletes message for own messages', async () => {
@@ -764,11 +771,11 @@ describe('MessageRepository', () => {
       conversation.addMessage(messageToDelete);
 
       const [messageRepository, {core, eventRepository}] = await buildMessageRepository(translateForTest);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       spyOn(eventRepository.eventService, 'deleteEvent').and.returnValue(Promise.resolve());
 
       await messageRepository.deleteMessageForEveryone(conversation, messageToDelete);
-      expect(core.service!.conversation.send).toHaveBeenCalledWith(
+      expect(getConversationServiceForTest(core).send).toHaveBeenCalledWith(
         expect.objectContaining({
           payload: expect.objectContaining({deleted: {messageId: messageToDelete.id}}),
           userIds: {'': {selfid: [], user1: []}},
@@ -786,7 +793,7 @@ describe('MessageRepository', () => {
       conversation.addMessage(messageToDelete);
 
       const [messageRepository, {core, eventRepository}] = await buildMessageRepository(translateForTest);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       spyOn(eventRepository.eventService, 'deleteEvent').and.returnValue(Promise.resolve());
       spyOn(messageRepository, 'deleteMessageById');
 
@@ -799,7 +806,7 @@ describe('MessageRepository', () => {
   describe('resetSession', () => {
     it('resets the session with another device', async () => {
       const [messageRepository, {cryptographyRepository, core}] = await buildMessageRepository(translateForTest);
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       jest.spyOn(cryptographyRepository, 'getRemoteFingerprint').mockResolvedValue('first');
       spyOn(cryptographyRepository, 'deleteSession');
       const conversation = generateConversation();
@@ -808,7 +815,7 @@ describe('MessageRepository', () => {
       const clientId = 'client1';
       await messageRepository.resetSession(userId, clientId, conversation);
       expect(cryptographyRepository.deleteSession).toHaveBeenCalledWith(userId, clientId);
-      expect(core.service!.conversation.send).toHaveBeenCalled();
+      expect(getConversationServiceForTest(core).send).toHaveBeenCalled();
     });
 
     it('unverifies device if fingerprint has changed', async () => {
@@ -823,7 +830,7 @@ describe('MessageRepository', () => {
 
       jest.spyOn(userRepository, 'findUserById').mockReturnValue(user);
 
-      jest.spyOn(core.service!.conversation, 'send').mockResolvedValue(successPayload);
+      jest.spyOn(getConversationServiceForTest(core), 'send').mockResolvedValue(successPayload);
       jest
         .spyOn(cryptographyRepository, 'getRemoteFingerprint')
         .mockResolvedValueOnce('first')
@@ -837,7 +844,7 @@ describe('MessageRepository', () => {
       await messageRepository.resetSession(userId, clientId, conversation);
       expect(device.meta.isVerified()).toBe(false);
       expect(cryptographyRepository.deleteSession).toHaveBeenCalledWith(userId, clientId);
-      expect(core.service!.conversation.send).toHaveBeenCalled();
+      expect(getConversationServiceForTest(core).send).toHaveBeenCalled();
     });
   });
 

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -178,6 +178,15 @@ export class MessageRepository {
   private isBlockingNotificationHandling: boolean;
   private onClientMismatch?: ClientMismatchHandlerFn;
 
+  private get coreServices() {
+    const coreServices = this.core.service;
+    if (isUndefined(coreServices)) {
+      throw new Error('Core services are not initialized');
+    }
+
+    return coreServices;
+  }
+
   constructor(
     private readonly conversationRepositoryProvider: () => ConversationRepository,
     private readonly cryptography_repository: CryptographyRepository,
@@ -205,7 +214,7 @@ export class MessageRepository {
   }
 
   private get conversationService() {
-    return this.core.service!.conversation;
+    return this.coreServices.conversation;
   }
 
   private initSubscriptions(): void {
@@ -588,7 +597,7 @@ export class MessageRepository {
         {
           ...textPayload,
           linkPreview: linkPreview.image
-            ? await this.core.service!.linkPreview.uploadLinkPreviewImage(
+            ? await this.coreServices.linkPreview.uploadLinkPreviewImage(
                 linkPreview as LinkPreviewContent,
                 conversationId,
                 isAuditLogEnabled,
@@ -1030,10 +1039,14 @@ export class MessageRepository {
         }
 
         const currentTimestamp = this.serverTimeHandler.toServerTimestamp();
+        const selfUser = this.userState.self();
+        if (isUndefined(selfUser)) {
+          throw new Error('No self user found, cannot send message optimistically');
+        }
         const optimisticEvent = EventBuilder.buildMessageAdd({
           conversationEntity: conversation,
           currentTimestamp,
-          senderId: this.userState.self()!.id,
+          senderId: selfUser.id,
           clientId,
         });
         this.trackContributed(conversation, payload);
@@ -1313,7 +1326,15 @@ export class MessageRepository {
       if (!message.user().isMe && !message.ephemeral_expires()) {
         throw new ConversationError(ConversationError.TYPE.WRONG_USER, ConversationError.MESSAGE.WRONG_USER);
       }
-      const userIds = options.targetedUsers || conversation.allUserEntities().map(user => user!.qualifiedId);
+      const userIds =
+        options.targetedUsers ??
+        conversation.allUserEntities().map(user => {
+          if (isUndefined(user)) {
+            throw new Error('Conversation member list contains an empty user');
+          }
+
+          return user.qualifiedId;
+        });
       const payload = MessageBuilder.buildDeleteMessage({
         messageId: message.id,
       });

--- a/apps/webapp/src/script/repositories/cryptography/CryptographyMapper.ts
+++ b/apps/webapp/src/script/repositories/cryptography/CryptographyMapper.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {
   ConversationOtrMessageAddEvent,
   ConversationMLSMessageAddEvent,
@@ -567,7 +568,11 @@ export class CryptographyMapper {
       }
       const cipherTextArray = base64ToArray(eventData.data);
       const cipherText = cipherTextArray;
-      const externalMessageBuffer = await this.core.service!.asset.decryptAsset({
+      const coreServices = this.core.service;
+      if (isUndefined(coreServices)) {
+        throw new Error('Core services are not initialized');
+      }
+      const externalMessageBuffer = await coreServices.asset.decryptAsset({
         cipherText,
         keyBytes: otrKey,
         sha256,

--- a/apps/webapp/src/script/repositories/cryptography/CryptographyRepository.ts
+++ b/apps/webapp/src/script/repositories/cryptography/CryptographyRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import type {PreKey as BackendPreKey} from '@wireapp/api-client/lib/auth/';
 import type {QualifiedId} from '@wireapp/api-client/lib/user/';
 import {container} from 'tsyringe';
@@ -48,10 +49,12 @@ export class CryptographyRepository {
   }
 
   get proteusService() {
-    if (!this.core.service) {
+    const coreServices = this.core.service;
+    if (isUndefined(coreServices)) {
       throw new Error('Core is not initiated');
     }
-    return this.core.service!.proteus;
+
+    return coreServices.proteus;
   }
 
   /**

--- a/apps/webapp/src/script/repositories/entity/message/asset.ts
+++ b/apps/webapp/src/script/repositories/entity/message/asset.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
+
 import {AssetType} from 'Repositories/assets/assetType';
 
 import type {FileAsset} from './fileAsset';
@@ -71,9 +73,10 @@ export class Asset {
   }
 
   isAudio(): boolean {
-    const is_audio_asset = this.type === AssetType.FILE && this.file_type?.startsWith('audio');
-    if (is_audio_asset) {
-      const can_play = document.createElement('audio').canPlayType(this.file_type!);
+    const fileType = this.file_type;
+    const is_audio_asset = this.type === AssetType.FILE && !isUndefined(fileType) && fileType.startsWith('audio');
+    if (is_audio_asset && !isUndefined(fileType)) {
+      const can_play = document.createElement('audio').canPlayType(fileType);
       if (can_play !== '') {
         return true;
       }

--- a/apps/webapp/src/script/repositories/event/EventRepository.test.ts
+++ b/apps/webapp/src/script/repositories/event/EventRepository.test.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {BackendEvent, CONVERSATION_EVENT, MEETING_EVENT, USER_EVENT} from '@wireapp/api-client/lib/event/';
 import {ConnectionState} from '@wireapp/core';
 import {WebAppEvents} from '@wireapp/webapp-events';
@@ -32,8 +33,13 @@ import {EventSource} from './EventSource';
 import {NOTIFICATION_HANDLING_STATE} from './NotificationHandlingState';
 
 import {TestFactory} from '../../../../test/helper/TestFactory';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 
 const testFactory = new TestFactory();
+
+function getEventRepositoryForTest(): EventRepository {
+  return requireValueForTest(testFactory.event_repository);
+}
 
 describe('EventRepository', () => {
   beforeAll(() => testFactory.exposeClientActors());
@@ -44,40 +50,31 @@ describe('EventRepository', () => {
 
   describe('handleEvent', () => {
     beforeEach(() => {
-      testFactory.event_repository!.notificationHandlingState(NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
-      spyOn<any>(testFactory.event_repository!, 'distributeEvent');
+      getEventRepositoryForTest().notificationHandlingState(NOTIFICATION_HANDLING_STATE.WEB_SOCKET);
+      spyOn<any>(getEventRepositoryForTest(), 'distributeEvent');
     });
 
     it('should not save but distribute "user.*" events', () => {
-      return testFactory
-        .event_repository!['handleEvent'](
-          {event: {type: USER_EVENT.UPDATE, user: {id: ''}}},
-          EventSource.NOTIFICATION_STREAM,
-        )
+      return getEventRepositoryForTest()
+        ['handleEvent']({event: {type: USER_EVENT.UPDATE, user: {id: ''}}}, EventSource.NOTIFICATION_STREAM)
         .then(() => {
-          expect(testFactory.event_repository!['distributeEvent']).toHaveBeenCalled();
+          expect(getEventRepositoryForTest()['distributeEvent']).toHaveBeenCalled();
         });
     });
 
     it('should not save but distribute "call.*" events', () => {
-      return testFactory
-        .event_repository!['handleEvent'](
-          {event: {type: ClientEvent.CALL.E_CALL} as any},
-          EventSource.NOTIFICATION_STREAM,
-        )
+      return getEventRepositoryForTest()
+        ['handleEvent']({event: {type: ClientEvent.CALL.E_CALL} as any}, EventSource.NOTIFICATION_STREAM)
         .then(() => {
-          expect(testFactory.event_repository!['distributeEvent']).toHaveBeenCalled();
+          expect(getEventRepositoryForTest()['distributeEvent']).toHaveBeenCalled();
         });
     });
 
     it('should not save but distribute "conversation.create" events', () => {
-      return testFactory
-        .event_repository!['handleEvent'](
-          {event: {type: CONVERSATION_EVENT.CREATE} as any},
-          EventSource.NOTIFICATION_STREAM,
-        )
+      return getEventRepositoryForTest()
+        ['handleEvent']({event: {type: CONVERSATION_EVENT.CREATE} as any}, EventSource.NOTIFICATION_STREAM)
         .then(() => {
-          expect(testFactory.event_repository!['distributeEvent']).toHaveBeenCalled();
+          expect(getEventRepositoryForTest()['distributeEvent']).toHaveBeenCalled();
         });
     });
 
@@ -91,9 +88,11 @@ describe('EventRepository', () => {
         type: 'conversation.rename',
       } as BackendEvent;
 
-      return testFactory.event_repository!['handleEvent']({event}, EventSource.NOTIFICATION_STREAM).then(() => {
-        expect(testFactory.event_repository!['distributeEvent']).toHaveBeenCalled();
-      });
+      return getEventRepositoryForTest()
+        ['handleEvent']({event}, EventSource.NOTIFICATION_STREAM)
+        .then(() => {
+          expect(getEventRepositoryForTest()['distributeEvent']).toHaveBeenCalled();
+        });
     });
 
     it('accepts "conversation.member-join" events', () => {
@@ -106,9 +105,11 @@ describe('EventRepository', () => {
         type: 'conversation.member-join',
       } as BackendEvent;
 
-      return testFactory.event_repository!['handleEvent']({event}, EventSource.NOTIFICATION_STREAM).then(() => {
-        expect(testFactory.event_repository!['distributeEvent']).toHaveBeenCalled();
-      });
+      return getEventRepositoryForTest()
+        ['handleEvent']({event}, EventSource.NOTIFICATION_STREAM)
+        .then(() => {
+          expect(getEventRepositoryForTest()['distributeEvent']).toHaveBeenCalled();
+        });
     });
 
     it('accepts "conversation.member-leave" events', () => {
@@ -121,9 +122,11 @@ describe('EventRepository', () => {
         type: 'conversation.member-leave',
       } as BackendEvent;
 
-      return testFactory.event_repository!['handleEvent']({event}, EventSource.NOTIFICATION_STREAM).then(() => {
-        expect(testFactory.event_repository!['distributeEvent']).toHaveBeenCalled();
-      });
+      return getEventRepositoryForTest()
+        ['handleEvent']({event}, EventSource.NOTIFICATION_STREAM)
+        .then(() => {
+          expect(getEventRepositoryForTest()['distributeEvent']).toHaveBeenCalled();
+        });
     });
 
     it('accepts "conversation.voice-channel-deactivate" (missed call) events', async () => {
@@ -157,9 +160,11 @@ describe('EventRepository', () => {
         type: 'conversation.unable-to-decrypt',
       } as ClientConversationEvent;
 
-      return testFactory.event_repository!.injectEvent(event).then(() => {
-        expect(testFactory.event_repository!['distributeEvent']).toHaveBeenCalled();
-      });
+      return getEventRepositoryForTest()
+        .injectEvent(event)
+        .then(() => {
+          expect(getEventRepositoryForTest()['distributeEvent']).toHaveBeenCalled();
+        });
     });
   });
 
@@ -542,17 +547,22 @@ describe('EventRepository', () => {
       // Calls connectWebSocket, captures the onConnectionStateChanged callback,
       // transitions to LIVE, and clears mock call counts ready for assertions.
       const setup = async () => {
-        let stateCallback!: (state: ConnectionState) => void;
+        let stateCallback: ((state: ConnectionState) => void) | undefined;
         mockAccount.listen.mockImplementation(({onConnectionStateChanged}: any) => {
           stateCallback = onConnectionStateChanged;
           return Promise.resolve(jest.fn());
         });
         jest.spyOn(Runtime, 'isElectron').mockReturnValue(false);
         await eventRepository.connectWebSocket(mockAccount, false, jest.fn());
-        stateCallback(ConnectionState.LIVE);
+        if (isUndefined(stateCallback)) {
+          throw new Error('The connection state callback was not created');
+        }
+        const connectionStateCallback = stateCallback;
+        connectionStateCallback(ConnectionState.LIVE);
         mockAccount.listen.mockClear();
         mockAccount.isWebsocketHealthy.mockClear();
-        return stateCallback;
+
+        return connectionStateCallback;
       };
 
       describe('reconnect decision by socket state (CLOSED vs CONNECTING/OPEN)', () => {
@@ -639,12 +649,8 @@ describe('EventRepository', () => {
       describe('no reconnect storm on concurrent focus/visibility/heartbeat triggers', () => {
         it('drops concurrent health checks when healthCheckInProgress', async () => {
           await setup();
-          let resolveHealth!: (check: boolean) => void;
-          mockAccount.isWebsocketHealthy.mockReturnValue(
-            new Promise<boolean>(resolve => {
-              resolveHealth = resolve;
-            }),
-          );
+          const {promise: healthCheckPromise, resolve: resolveHealth} = Promise.withResolvers<boolean>();
+          mockAccount.isWebsocketHealthy.mockReturnValue(healthCheckPromise);
 
           // Fire three visibility events before the first health check resolves
           triggerVisibility();
@@ -661,13 +667,9 @@ describe('EventRepository', () => {
 
         it('drops health check when connectionInProgress is true', async () => {
           await setup();
-          let resolveConnect!: (fn: jest.Mock) => void;
+          const {promise: connectionPromise, resolve: resolveConnect} = Promise.withResolvers<jest.Mock>();
           // Make the next listen call hang so connectionInProgress stays true
-          mockAccount.listen.mockReturnValueOnce(
-            new Promise<jest.Mock>(resolve => {
-              resolveConnect = resolve;
-            }),
-          );
+          mockAccount.listen.mockReturnValueOnce(connectionPromise);
 
           // online → handleOnline → connect() sets connectionInProgress = true synchronously
           const onlineHandler = (window.addEventListener as jest.Mock).mock.calls.find(
@@ -685,10 +687,10 @@ describe('EventRepository', () => {
         });
 
         it('deduplicates concurrent visibility and heartbeat triggers', async () => {
-          let heartbeatCb!: () => void;
+          let heartbeatCallback: (() => void) | undefined;
           // Capture the heartbeat callback before connectWebSocket registers it
           (window.setInterval as jest.Mock).mockImplementationOnce((cb: TimerHandler) => {
-            heartbeatCb = cb as () => void;
+            heartbeatCallback = cb as () => void;
             return 999 as any;
           });
 
@@ -697,16 +699,12 @@ describe('EventRepository', () => {
           mockAccount.listen.mockClear();
           mockAccount.isWebsocketHealthy.mockClear();
 
-          let resolveHealth!: (v: boolean) => void;
-          mockAccount.isWebsocketHealthy.mockReturnValue(
-            new Promise<boolean>(resolve => {
-              resolveHealth = resolve;
-            }),
-          );
+          const {promise: healthCheckPromise, resolve: resolveHealth} = Promise.withResolvers<boolean>();
+          mockAccount.isWebsocketHealthy.mockReturnValue(healthCheckPromise);
 
           // Fire all three concurrently: visibility, heartbeat, visibility again
           triggerVisibility();
-          heartbeatCb?.();
+          heartbeatCallback?.();
           triggerVisibility();
 
           resolveHealth(false);

--- a/apps/webapp/src/script/repositories/media/CanvasMediaStreamMixer.ts
+++ b/apps/webapp/src/script/repositories/media/CanvasMediaStreamMixer.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {isNullOrUndefined} from '@sindresorhus/is';
+
 // Canvas configuration
 const DEFAULT_CANVAS_WIDTH = 1920;
 const DEFAULT_CANVAS_HEIGHT = 1080;
@@ -58,21 +60,29 @@ export class CanvasMediaStreamMixer {
     this.canvas.style.display = 'none';
     document.body.appendChild(this.canvas);
 
-    this.context = this.canvas.getContext('2d', {
+    const context = this.canvas.getContext('2d', {
       alpha: false,
       desynchronized: true,
       willReadFrequently: false,
-    })!;
+    });
+    if (isNullOrUndefined(context)) {
+      throw new Error('Unable to create the canvas drawing context');
+    }
+    this.context = context;
 
     this.context.imageSmoothingEnabled = true;
     this.context.imageSmoothingQuality = 'high';
 
     // Create temp canvas for better performance
     this.tempCanvas = document.createElement('canvas');
-    this.tempContext = this.tempCanvas.getContext('2d', {
+    const tempContext = this.tempCanvas.getContext('2d', {
       alpha: false,
       desynchronized: true,
-    })!;
+    });
+    if (isNullOrUndefined(tempContext)) {
+      throw new Error('Unable to create the temporary canvas drawing context');
+    }
+    this.tempContext = tempContext;
   }
 
   async startMixing(screenShare: MediaStream, camera: MediaStream): Promise<MediaStream> {

--- a/apps/webapp/src/script/repositories/media/MediaDevicesHandler.test.ts
+++ b/apps/webapp/src/script/repositories/media/MediaDevicesHandler.test.ts
@@ -19,6 +19,7 @@
 
 import {MediaDeviceType} from './MediaDeviceType';
 import {MediaDevicesHandler} from './MediaDevicesHandler';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import {mediaDevicesStore} from 'Repositories/media/useMediaDevicesStore';
 
 /* yarn test:app --specs media/MediaDevicesHandler --nolegacy */
@@ -252,7 +253,7 @@ describe('MediaDevicesHandler', () => {
 
       const newCameras = [{deviceId: 'newcamera', kind: MediaDeviceType.VIDEO_INPUT}];
       enumerateDevicesSpy.and.returnValue(Promise.resolve(newCameras));
-      navigator.mediaDevices!.ondevicechange?.(Event.prototype);
+      requireValueForTest(navigator.mediaDevices).ondevicechange?.(Event.prototype);
 
       expect(enumerateDevicesSpy).toHaveBeenCalledTimes(3);
       setTimeout(() => {

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/helper/restartQueue.test.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/helper/restartQueue.test.ts
@@ -25,21 +25,15 @@ describe('createRestartQueue', () => {
   it('runs restarts sequentially', async () => {
     const calls: string[] = [];
 
-    let resolveFirst!: () => void;
+    const {promise: firstRestartGate, resolve: resolveFirst} = Promise.withResolvers<void>();
 
     const restart = jest
       .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>(resolve => {
-            calls.push('first-start');
-
-            resolveFirst = () => {
-              calls.push('first-end');
-              resolve();
-            };
-          }),
-      )
+      .mockImplementationOnce(async () => {
+        calls.push('first-start');
+        await firstRestartGate;
+        calls.push('first-end');
+      })
       .mockImplementationOnce(async () => {
         calls.push('second-start');
         calls.push('second-end');

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/filter.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/filter.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {isNullOrUndefined} from '@sindresorhus/is';
+
 import {getSafeLogger} from 'Repositories/media/backgroundEffects/helper/logger';
 
 type QuadBuffers = {
@@ -393,8 +395,13 @@ export class VideoFilter {
 
       if (blur > 0) {
         // If blur was applied, currentTexture is this.texture2
-        inputForColorAdjust = this.texture2!;
-        outputFbo = this.fbo1!; // Write to texture1
+        const blurredTexture = this.texture2;
+        const colorAdjustFramebuffer = this.fbo1;
+        if (isNullOrUndefined(blurredTexture) || isNullOrUndefined(colorAdjustFramebuffer)) {
+          throw new Error('Blur output is not initialized for color adjustment');
+        }
+        inputForColorAdjust = blurredTexture;
+        outputFbo = colorAdjustFramebuffer; // Write to texture1
         finalPassOutputToTexture1 = true;
       } else {
         // No blur, currentTexture is the original sourceTexture
@@ -402,7 +409,11 @@ export class VideoFilter {
         // We need to draw to an FBO. If FBOs are available, use fbo1.
         // If sourceTexture is the only input and no blur, and we need color adjust,
         // this implies we are drawing from sourceTexture to fbo1/texture1.
-        outputFbo = this.fbo1!;
+        const colorAdjustFramebuffer = this.fbo1;
+        if (isNullOrUndefined(colorAdjustFramebuffer)) {
+          throw new Error('Color adjustment framebuffer is not initialized');
+        }
+        outputFbo = colorAdjustFramebuffer;
         finalPassOutputToTexture1 = true;
       }
 

--- a/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/segmenter.test.ts
+++ b/apps/webapp/src/script/repositories/media/backgroundEffects/pipe/segmenter.test.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import type {WorkerProcessVideoTrackOptions} from 'Repositories/media/backgroundEffects/pipe/options';
 import {defaultWorkerOpts} from 'Repositories/media/backgroundEffects/pipe/options';
 import {
@@ -84,6 +85,14 @@ jest.mock('Repositories/media/backgroundEffects/helper/metrics', () => ({
   buildMetrics: jest.fn(() => ({})),
 }));
 
+async function writeVideoFrameToSink(writerSink: UnderlyingSink<VideoFrame>, frame: VideoFrame): Promise<void> {
+  if (isUndefined(writerSink.write)) {
+    throw new Error('The video frame writer was not created');
+  }
+
+  await writerSink.write(frame, {} as WritableStreamDefaultController);
+}
+
 describe('segmenter tests', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -138,11 +147,12 @@ describe('segmenter tests', () => {
 
       (ImageSegmenter.createFromOptions as jest.Mock).mockResolvedValueOnce(firstSegmenter);
 
-      let writerSink!: UnderlyingSink<VideoFrame>;
+      const {promise: writerSinkPromise, resolve: resolveWriterSink} =
+        Promise.withResolvers<UnderlyingSink<VideoFrame>>();
 
       const readable = {
         pipeTo: jest.fn(writer => {
-          writerSink = writer.sink;
+          resolveWriterSink(writer.sink);
           return Promise.resolve();
         }),
       } as unknown as ReadableStream;
@@ -177,7 +187,8 @@ describe('segmenter tests', () => {
         close: jest.fn(),
       } as unknown as VideoFrame;
 
-      await writerSink.write!(frame, {} as WritableStreamDefaultController);
+      const writerSink = await writerSinkPromise;
+      await writeVideoFrameToSink(writerSink, frame);
 
       expect(firstSegmenter.setOptions).toHaveBeenCalledWith({
         baseOptions: {
@@ -280,16 +291,12 @@ describe('segmenter tests', () => {
         segmentForVideo: jest.fn(),
       };
 
-      let resolveSecondCreate!: () => void;
+      const {promise: secondSegmenterPromise, resolve: resolveSecondSegmenter} =
+        Promise.withResolvers<typeof secondSegmenter>();
 
       (ImageSegmenter.createFromOptions as jest.Mock)
         .mockResolvedValueOnce(firstSegmenter)
-        .mockImplementationOnce(
-          () =>
-            new Promise(resolve => {
-              resolveSecondCreate = () => resolve(secondSegmenter);
-            }),
-        )
+        .mockImplementationOnce(() => secondSegmenterPromise)
         .mockResolvedValueOnce(thirdSegmenter);
 
       const canvas = {
@@ -351,7 +358,7 @@ describe('segmenter tests', () => {
       expect(ImageSegmenter.createFromOptions).toHaveBeenCalledTimes(2);
 
       // Finish first queued restart.
-      resolveSecondCreate();
+      resolveSecondSegmenter(secondSegmenter);
 
       await Promise.resolve();
       await Promise.resolve();
@@ -373,11 +380,12 @@ describe('segmenter tests', () => {
 
       (ImageSegmenter.createFromOptions as jest.Mock).mockResolvedValueOnce(segmenter);
 
-      let writerSink!: UnderlyingSink<VideoFrame>;
+      const {promise: writerSinkPromise, resolve: resolveWriterSink} =
+        Promise.withResolvers<UnderlyingSink<VideoFrame>>();
 
       const readable = {
         pipeTo: jest.fn(writer => {
-          writerSink = writer.sink;
+          resolveWriterSink(writer.sink);
           return Promise.resolve();
         }),
       } as unknown as ReadableStream;
@@ -411,7 +419,8 @@ describe('segmenter tests', () => {
         close: jest.fn(),
       } as unknown as VideoFrame;
 
-      await writerSink.write!(frame, {} as WritableStreamDefaultController);
+      const writerSink = await writerSinkPromise;
+      await writeVideoFrameToSink(writerSink, frame);
 
       const {WebGLRenderer} = await import('./renderer');
 
@@ -460,11 +469,12 @@ describe('segmenter tests', () => {
 
       (ImageSegmenter.createFromOptions as jest.Mock).mockResolvedValueOnce(segmenter);
 
-      let writerSink!: UnderlyingSink<VideoFrame>;
+      const {promise: writerSinkPromise, resolve: resolveWriterSink} =
+        Promise.withResolvers<UnderlyingSink<VideoFrame>>();
 
       const readable = {
         pipeTo: jest.fn(writer => {
-          writerSink = writer.sink;
+          resolveWriterSink(writer.sink);
           return Promise.resolve();
         }),
       } as unknown as ReadableStream;
@@ -494,7 +504,8 @@ describe('segmenter tests', () => {
         close: jest.fn(),
       } as unknown as VideoFrame;
 
-      await writerSink.write!(frame, {} as WritableStreamDefaultController);
+      const writerSink = await writerSinkPromise;
+      await writeVideoFrameToSink(writerSink, frame);
 
       const {WebGLRenderer} = await import('./renderer');
 
@@ -544,10 +555,11 @@ describe('segmenter tests', () => {
 
         (ImageSegmenter.createFromOptions as jest.Mock).mockResolvedValueOnce(segmenter);
 
-        let writerSink!: UnderlyingSink<VideoFrame>;
+        const {promise: writerSinkPromise, resolve: resolveWriterSink} =
+          Promise.withResolvers<UnderlyingSink<VideoFrame>>();
         const readable = {
           pipeTo: jest.fn((writer: {sink: UnderlyingSink<VideoFrame>}) => {
-            writerSink = writer.sink;
+            resolveWriterSink(writer.sink);
             return Promise.resolve();
           }),
         } as unknown as ReadableStream;
@@ -578,8 +590,9 @@ describe('segmenter tests', () => {
             close: jest.fn(),
           }) as unknown as VideoFrame;
 
-        await writerSink.write!(createFrame(1), {} as WritableStreamDefaultController);
-        await writerSink.write!(createFrame(2), {} as WritableStreamDefaultController);
+        const writerSink = await writerSinkPromise;
+        await writeVideoFrameToSink(writerSink, createFrame(1));
+        await writeVideoFrameToSink(writerSink, createFrame(2));
 
         const {WebGLRenderer} = await import('./renderer');
         const renderer = (WebGLRenderer as unknown as jest.Mock).mock.results[0].value;
@@ -609,11 +622,12 @@ describe('segmenter tests', () => {
 
       (ImageSegmenter.createFromOptions as jest.Mock).mockResolvedValueOnce(segmenter);
 
-      let writerSink!: UnderlyingSink<VideoFrame>;
+      const {promise: writerSinkPromise, resolve: resolveWriterSink} =
+        Promise.withResolvers<UnderlyingSink<VideoFrame>>();
 
       const readable = {
         pipeTo: jest.fn(writer => {
-          writerSink = writer.sink;
+          resolveWriterSink(writer.sink);
           return Promise.resolve();
         }),
       } as unknown as ReadableStream;
@@ -648,7 +662,8 @@ describe('segmenter tests', () => {
         close: jest.fn(),
       } as unknown as VideoFrame;
 
-      await writerSink.write!(frame, {} as WritableStreamDefaultController);
+      const writerSink = await writerSinkPromise;
+      await writeVideoFrameToSink(writerSink, frame);
 
       const {WebGLRenderer} = await import('./renderer');
 

--- a/apps/webapp/src/script/repositories/media/useMediaDevicesStore.ts
+++ b/apps/webapp/src/script/repositories/media/useMediaDevicesStore.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {useStore} from 'zustand';
 import {immer} from 'zustand/middleware/immer';
 import {createStore} from 'zustand/vanilla';
@@ -182,44 +183,52 @@ export const mediaDevicesStore = createStore<MediaDevicesState>()(
         if (payload.audio?.input?.devices !== undefined) {
           state.audio.input.devices = filterInvalidDevices(payload.audio.input.devices);
         }
-        if (payload.audio?.input?.selectedId !== undefined) {
-          state.audio.input.selectedId = payload.audio.input.selectedId!;
+        const audioInputSelectedId = payload.audio?.input?.selectedId;
+        if (!isUndefined(audioInputSelectedId)) {
+          state.audio.input.selectedId = audioInputSelectedId;
         }
-        if (payload.audio?.input?.supported !== undefined) {
-          state.audio.input.supported = payload.audio.input.supported!;
+        const audioInputSupported = payload.audio?.input?.supported;
+        if (!isUndefined(audioInputSupported)) {
+          state.audio.input.supported = audioInputSupported;
         }
 
         // audio.output
         if (payload.audio?.output?.devices !== undefined) {
           state.audio.output.devices = filterInvalidDevices(payload.audio.output.devices);
         }
-        if (payload.audio?.output?.selectedId !== undefined) {
-          state.audio.output.selectedId = payload.audio.output.selectedId!;
+        const audioOutputSelectedId = payload.audio?.output?.selectedId;
+        if (!isUndefined(audioOutputSelectedId)) {
+          state.audio.output.selectedId = audioOutputSelectedId;
         }
-        if (payload.audio?.output?.supported !== undefined) {
-          state.audio.output.supported = payload.audio.output.supported!;
+        const audioOutputSupported = payload.audio?.output?.supported;
+        if (!isUndefined(audioOutputSupported)) {
+          state.audio.output.supported = audioOutputSupported;
         }
 
         // video.input
         if (payload.video?.input?.devices !== undefined) {
           state.video.input.devices = filterInvalidDevices(payload.video.input.devices);
         }
-        if (payload.video?.input?.selectedId !== undefined) {
-          state.video.input.selectedId = payload.video.input.selectedId!;
+        const videoInputSelectedId = payload.video?.input?.selectedId;
+        if (!isUndefined(videoInputSelectedId)) {
+          state.video.input.selectedId = videoInputSelectedId;
         }
-        if (payload.video?.input?.supported !== undefined) {
-          state.video.input.supported = payload.video.input.supported!;
+        const videoInputSupported = payload.video?.input?.supported;
+        if (!isUndefined(videoInputSupported)) {
+          state.video.input.supported = videoInputSupported;
         }
 
         // screen.input
         if (payload.screen?.input?.devices !== undefined) {
           state.screen.input.devices = payload.screen.input.devices;
         }
-        if (payload.screen?.input?.selectedId !== undefined) {
-          state.screen.input.selectedId = payload.screen.input.selectedId!;
+        const screenInputSelectedId = payload.screen?.input?.selectedId;
+        if (!isUndefined(screenInputSelectedId)) {
+          state.screen.input.selectedId = screenInputSelectedId;
         }
-        if (payload.screen?.input?.supported !== undefined) {
-          state.screen.input.supported = payload.screen.input.supported!;
+        const screenInputSupported = payload.screen?.input?.supported;
+        if (!isUndefined(screenInputSupported)) {
+          state.screen.input.supported = screenInputSupported;
         }
       }),
 

--- a/apps/webapp/src/script/repositories/self/SelfRepository.test.ts
+++ b/apps/webapp/src/script/repositories/self/SelfRepository.test.ts
@@ -25,6 +25,7 @@ import {container} from 'tsyringe';
 
 import {ClientEntity} from 'Repositories/client';
 import {TestFactory} from 'test/helper/TestFactory';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import {TIME_IN_MILLIS} from 'Util/timeUtil';
 
 import {SelfRepository} from './SelfRepository';
@@ -61,7 +62,7 @@ describe('SelfRepository', () => {
     ])('Updates the list of supported protocols', async (initialProtocols, evaluatedProtocols) => {
       const selfRepository = await testFactory.exposeSelfActors();
 
-      const selfUser = selfRepository['userState'].self()!;
+      const selfUser = requireValueForTest(selfRepository['userState'].self());
 
       selfUser.supportedProtocols(initialProtocols);
 
@@ -86,7 +87,7 @@ describe('SelfRepository', () => {
     it("Does not update supported protocols if they didn't change", async () => {
       const selfRepository = await testFactory.exposeSelfActors();
 
-      const selfUser = selfRepository['userState'].self()!;
+      const selfUser = requireValueForTest(selfRepository['userState'].self());
 
       const initialProtocols = [CONVERSATION_PROTOCOL.PROTEUS];
       selfUser.supportedProtocols(initialProtocols);
@@ -113,7 +114,7 @@ describe('SelfRepository', () => {
       const selfRepository = await testFactory.exposeSelfActors();
       const core = container.resolve(Core);
 
-      const selfUser = selfRepository['userState'].self()!;
+      const selfUser = requireValueForTest(selfRepository['userState'].self());
 
       const initialProtocols = [CONVERSATION_PROTOCOL.PROTEUS];
       selfUser.supportedProtocols(initialProtocols);
@@ -146,7 +147,7 @@ describe('SelfRepository', () => {
     it('deletes the self user client and refreshes self supported protocols', async () => {
       const selfRepository = await testFactory.exposeSelfActors();
 
-      const selfUser = selfRepository['userState'].self()!;
+      const selfUser = requireValueForTest(selfRepository['userState'].self());
 
       selfRepository['clientRepository'].init(selfUser);
 
@@ -158,7 +159,7 @@ describe('SelfRepository', () => {
 
       const clientToDelete = initialClients[0];
 
-      jest.spyOn(container.resolve(Core).service?.client!, 'deleteClient');
+      jest.spyOn(requireValueForTest(container.resolve(Core).service?.client), 'deleteClient');
       jest.spyOn(selfRepository, 'refreshSelfSupportedProtocols').mockImplementationOnce(jest.fn());
 
       const expectedClients = [...initialClients].filter(client => client.id !== clientToDelete.id);
@@ -174,7 +175,7 @@ describe('SelfRepository', () => {
     it('refreshes self supported protocols and updates backend with the new list', async () => {
       const selfRepository = await testFactory.exposeSelfActors();
 
-      const selfUser = selfRepository['userState'].self()!;
+      const selfUser = requireValueForTest(selfRepository['userState'].self());
 
       const initialProtocols = [CONVERSATION_PROTOCOL.PROTEUS];
       selfUser.supportedProtocols(initialProtocols);
@@ -200,7 +201,7 @@ describe('SelfRepository', () => {
     it('does not update backend with supported protocols when not changed', async () => {
       const selfRepository = await testFactory.exposeSelfActors();
 
-      const selfUser = selfRepository['userState'].self()!;
+      const selfUser = requireValueForTest(selfRepository['userState'].self());
 
       const initialProtocols = [CONVERSATION_PROTOCOL.PROTEUS, CONVERSATION_PROTOCOL.MLS];
       selfUser.supportedProtocols(initialProtocols);

--- a/apps/webapp/src/script/repositories/tracking/eventTrackingRepository.ts
+++ b/apps/webapp/src/script/repositories/tracking/eventTrackingRepository.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {HttpClient, LongRunningRetryDetails} from '@wireapp/api-client/lib/http';
 import {WebSocketClient} from '@wireapp/api-client/lib/tcp';
 import {amplify} from 'amplify';
@@ -391,7 +392,11 @@ export class EventTrackingRepository {
       if (this.teamState.teamSize() >= TEAM_SIZE_THRESHOLD_VALUE) {
         const selfRole = this.teamState.selfRole();
         segmentation[Segmentation.COMMON.TEAM_USER_TYPE] = selfRole ? selfRole.toString() : '';
-        segmentation[Segmentation.COMMON.TEAM_TEAM_ID] = this.teamState.team().id!;
+        const teamId = this.teamState.team().id;
+        if (isUndefined(teamId)) {
+          throw new Error('Team tracking data is missing the team id');
+        }
+        segmentation[Segmentation.COMMON.TEAM_TEAM_ID] = teamId;
         segmentation[Segmentation.COMMON.TEAM_TEAM_SIZE] = this.teamState.teamSize();
       }
     } else {

--- a/apps/webapp/src/script/repositories/user/userRepository.test.ts
+++ b/apps/webapp/src/script/repositories/user/userRepository.test.ts
@@ -44,6 +44,7 @@ import {TeamState} from 'Repositories/team/TeamState';
 import type {UserRecord} from 'Repositories/storage';
 import type {Translate} from 'Util/localizerUtil';
 import {matchQualifiedIds} from 'Util/qualifiedId';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 import {translateForTest} from 'Util/test/translateForTest';
 import {createUuid} from 'Util/uuid';
 
@@ -245,7 +246,7 @@ describe('UserRepository', () => {
         jest.spyOn(userService, 'loadUserFromDb').mockResolvedValue(departedUser);
         const backendUsersSpy = jest.spyOn(userService, 'getUsers');
 
-        const users = await userRepository.getUsersByIdsFromDb([departedUser.qualified_id!]);
+        const users = await userRepository.getUsersByIdsFromDb([requireValueForTest(departedUser.qualified_id)]);
 
         expect(users).toHaveLength(1);
         expect(users[0].name()).toBe('Former Member');
@@ -342,7 +343,7 @@ describe('UserRepository', () => {
         await userRepository.loadUsers(new User('self', '', translateForTest), connections, [], []);
 
         expect(userState.users()).toHaveLength(users.length + 1);
-        expect(fetchUserSpy).toHaveBeenCalledWith(users.map(user => user.qualified_id!));
+        expect(fetchUserSpy).toHaveBeenCalledWith(users.map(user => requireValueForTest(user.qualified_id)));
       });
 
       it('assigns connections with users', async () => {
@@ -361,7 +362,7 @@ describe('UserRepository', () => {
       });
 
       it('loads users that are partially stored in the DB and maps availability', async () => {
-        const userIds = localUsers.map(user => user.qualified_id!);
+        const userIds = localUsers.map(user => requireValueForTest(user.qualified_id));
         const connections = createConnections(localUsers);
         const partialUsers = [
           {

--- a/apps/webapp/src/script/ui/contextMenu.test.tsx
+++ b/apps/webapp/src/script/ui/contextMenu.test.tsx
@@ -21,6 +21,7 @@ import '@testing-library/jest-dom';
 import {act, screen, waitFor} from '@testing-library/react';
 
 import {showContextMenu} from './contextMenu';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
 
 import * as ActiveWindowMod from '../hooks/useActiveWindow';
 
@@ -102,7 +103,7 @@ describe('ContextMenu positioning', () => {
       offset: 10,
     });
 
-    const menu = queryMenu()!;
+    const menu = requireValueForTest(queryMenu());
     expect(menu.style.left).toBe(px(120)); // 140 - 20
     expect(menu.style.top).toBe(px(130)); // 120 + 10
     expect(menu.style.position).toBe('fixed');
@@ -119,7 +120,7 @@ describe('ContextMenu positioning', () => {
       identifier: 'message-options-menu',
     });
 
-    const menu = queryMenu()!;
+    const menu = requireValueForTest(queryMenu());
     expect(menu.style.left).toBe(px(300));
     expect(menu.style.top).toBe(px(400));
   });
@@ -137,7 +138,7 @@ describe('ContextMenu positioning', () => {
       identifier: 'message-options-menu',
     });
 
-    const menu = queryMenu()!;
+    const menu = requireValueForTest(queryMenu());
     expect(menu.style.left).toBe(px(230)); // 290 - 60
     expect(menu.style.top).toBe(px(155)); // 195 - 40
 
@@ -179,7 +180,7 @@ describe('ContextMenu positioning', () => {
       identifier: 'message-options-menu',
     });
 
-    const button = screen.getByRole('menuitem').querySelector('button')!;
+    const button = requireValueForTest(screen.getByRole('menuitem').querySelector('button'));
     expect(button).toHaveAttribute('aria-disabled', 'true');
 
     await act(async () => {

--- a/apps/webapp/src/script/ui/contextMenu.tsx
+++ b/apps/webapp/src/script/ui/contextMenu.tsx
@@ -20,6 +20,7 @@
 import {ComponentType, CSSProperties, ReactNode, SVGProps, useEffect, useMemo, useRef, useState} from 'react';
 
 import {CSSObject} from '@emotion/react';
+import {isUndefined} from '@sindresorhus/is';
 import cx from 'classnames';
 import {createRoot, Root} from 'react-dom/client';
 
@@ -108,7 +109,7 @@ const getPositionFromPlacement = (
   }
 };
 
-const getButtonId = (label: string): string => `btn-${label?.split(' ').join('-').toLowerCase()}`;
+const getButtonId = (label: string | undefined): string => `btn-${label?.split(' ').join('-').toLowerCase()}`;
 
 const contextMenuClassName = 'ctx-menu';
 const msgMenuIdentifier = 'message-options-menu';
@@ -170,8 +171,11 @@ const ContextMenu = ({
 
       // context menu options such as 10 seconds etc begings with digit which is an invalid querySelector
       // param append btn- to avoid such errors
+      if (isUndefined(labelWithoutQuotes)) {
+        return;
+      }
       const selectedButton = activeWindow.document.querySelector(
-        `#${CSS.escape(getButtonId(labelWithoutQuotes!))}`,
+        `#${CSS.escape(getButtonId(labelWithoutQuotes))}`,
       ) as HTMLButtonElement;
       selectedButton?.focus();
     }
@@ -195,13 +199,13 @@ const ContextMenu = ({
       }
 
       if (isOneOfKeys(event, [KEY.ARROW_UP, KEY.ARROW_DOWN])) {
-        if (!entries.includes(selected!)) {
+        if (isUndefined(selected) || !entries.includes(selected)) {
           const index = isKey(event, KEY.ARROW_DOWN) ? 0 : entries.length - 1;
           setSelected(entries[index]);
           return;
         }
         const direction = isKey(event, KEY.ARROW_DOWN) ? 1 : -1;
-        const nextIndex = (entries.indexOf(selected!) + direction + entries.length) % entries.length;
+        const nextIndex = (entries.indexOf(selected) + direction + entries.length) % entries.length;
         setSelected(entries[nextIndex]);
       }
       if (isEnterKey(event) || isSpaceKey(event)) {
@@ -274,7 +278,7 @@ const ContextMenu = ({
                   aria-haspopup="true"
                 >
                   <button
-                    id={getButtonId(entry.label!)}
+                    id={getButtonId(entry.label)}
                     className={`${contextMenuClassName}__button`}
                     type="button"
                     data-uie-name={entry.identifier || defaultIdentifier}

--- a/apps/webapp/src/script/util/connectionQualityHandler/connectionQualityHandler.test.ts
+++ b/apps/webapp/src/script/util/connectionQualityHandler/connectionQualityHandler.test.ts
@@ -18,6 +18,11 @@
  */
 
 import {getConnectionQualityHander} from './';
+import {requireValueForTest} from 'src/script/page/testSupport/rootContextTestSupport';
+
+function getAvailableConnectionQualityHandlerForTest(): NonNullable<ReturnType<typeof getConnectionQualityHander>> {
+  return requireValueForTest(getConnectionQualityHander());
+}
 
 describe('connectionQualityListener', () => {
   let originalNavigator: any;
@@ -44,33 +49,33 @@ describe('connectionQualityListener', () => {
   });
 
   it('should initialize the handler if navigator.connection is supported', () => {
-    const handler = getConnectionQualityHander();
+    const handler = getAvailableConnectionQualityHandlerForTest();
     expect(handler).not.toBeNull();
-    expect(typeof handler!.refresh).toBe('function');
-    expect(typeof handler!.subscribe).toBe('function');
+    expect(typeof handler.refresh).toBe('function');
+    expect(typeof handler.subscribe).toBe('function');
   });
 
   it.each(['slow-2g', '2g', '3g'])('should detect slow connections correctly', (quality: string) => {
     mockConnection.effectiveType = quality;
-    const handler = getConnectionQualityHander();
+    const handler = getAvailableConnectionQualityHandlerForTest();
     const callback = jest.fn();
-    handler!.refresh(callback);
+    handler.refresh(callback);
     expect(callback).toHaveBeenCalledWith(true);
   });
 
   it('should detect stable correctly', () => {
     mockConnection.effectiveType = '4g';
-    const handler = getConnectionQualityHander();
+    const handler = getAvailableConnectionQualityHandlerForTest();
     const callback = jest.fn();
-    handler!.refresh(callback);
+    handler.refresh(callback);
     expect(callback).toHaveBeenCalledWith(false);
   });
 
   it('should call the callback on connection change', () => {
-    const handler = getConnectionQualityHander();
+    const handler = getAvailableConnectionQualityHandlerForTest();
     const callback = jest.fn();
 
-    handler!.subscribe(callback);
+    handler.subscribe(callback);
     expect(callback).toHaveBeenCalled();
 
     const changeEvent = new Event('change');
@@ -84,9 +89,9 @@ describe('connectionQualityListener', () => {
   });
 
   it('should unsubscribe properly', () => {
-    const handler = getConnectionQualityHander();
+    const handler = getAvailableConnectionQualityHandlerForTest();
     const callback = jest.fn();
-    const unsubscribe = handler!.subscribe(callback);
+    const unsubscribe = handler.subscribe(callback);
 
     unsubscribe();
 
@@ -95,10 +100,10 @@ describe('connectionQualityListener', () => {
 
   it('should refresh the connection quality periodically', () => {
     jest.useFakeTimers();
-    const handler = getConnectionQualityHander();
+    const handler = getAvailableConnectionQualityHandlerForTest();
     const callback = jest.fn();
 
-    handler!.subscribe(callback);
+    handler.subscribe(callback);
 
     jest.advanceTimersByTime(60000);
     expect(callback).toHaveBeenCalledTimes(2); // Initial call + 1 refresh

--- a/apps/webapp/src/script/util/debugUtil.ts
+++ b/apps/webapp/src/script/util/debugUtil.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {isNonEmptyString, isObject} from '@sindresorhus/is';
+import {isNonEmptyString, isObject, isUndefined} from '@sindresorhus/is';
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection';
 import {MemberLeaveReason} from '@wireapp/api-client/lib/conversation/data/';
 import {
@@ -165,7 +165,11 @@ export class DebugUtil {
       const startTime = performance.now();
 
       for (const notification of notificationResponse.notifications) {
-        const events = this.core.service!.notification.handleNotification(
+        const coreServices = this.core.service;
+        if (isUndefined(coreServices)) {
+          throw new Error('Core services are not initialized');
+        }
+        const events = coreServices.notification.handleNotification(
           notification,
           NotificationSource.NOTIFICATION_STREAM,
         );
@@ -388,7 +392,11 @@ export class DebugUtil {
 
   /** Used by QA test automation. */
   async breakSession(userId: QualifiedId, clientId: string): Promise<void> {
-    const proteusService = this.core.service!.proteus;
+    const coreServices = this.core.service;
+    if (isUndefined(coreServices)) {
+      throw new Error('Core services are not initialized');
+    }
+    const proteusService = coreServices.proteus;
     const sessionId = proteusService.constructSessionId(userId, clientId);
     await proteusService['cryptoClient'].debugBreakSession(sessionId);
   }
@@ -467,7 +475,10 @@ export class DebugUtil {
       .__lexicalEditor as LexicalEditor;
 
     lexicalEditor.update(() => {
-      const root = $getRoot().getLastChild()!;
+      const root = $getRoot().getLastChild();
+      if (isUndefined(root)) {
+        throw new Error('The editor has no root child');
+      }
       const textNode = $createTextNode(text);
       // the "as any" can be removed when this issue is fixed https://github.com/facebook/lexical/issues/5502
       (root as any).append(textNode);

--- a/apps/webapp/src/script/util/emojiUtil.ts
+++ b/apps/webapp/src/script/util/emojiUtil.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {isNonEmptyString} from '@sindresorhus/is';
+import {isNonEmptyString, isUndefined} from '@sindresorhus/is';
 import emojies from 'emoji-picker-react/src/data/emojis.json';
 import {groupBy} from 'underscore';
 
@@ -83,8 +83,9 @@ const removeSkinToneModifiers = (emojiUnicode: string): string => {
   return unicodeWithoutSkinModifier.join('-');
 };
 export const getEmojiTitleFromEmojiUnicode = (emojiUnicode: string): string => {
-  if (emojiDictionary.has(emojiUnicode)) {
-    return emojiDictionary.get(emojiUnicode)!;
+  const emojiTitle = emojiDictionary.get(emojiUnicode);
+  if (!isUndefined(emojiTitle)) {
+    return emojiTitle;
   }
 
   const unicodeWithoutSkinModifier = removeSkinToneModifiers(emojiUnicode);

--- a/apps/webapp/src/script/util/messageRenderer.ts
+++ b/apps/webapp/src/script/util/messageRenderer.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import MarkdownIt from 'markdown-it';
 import {escape} from 'underscore';
@@ -79,14 +80,20 @@ markdownit.linkify.add('wire:', {
   },
 });
 
-const originalFenceRule = markdownit.renderer.rules.fence!;
+const originalFenceRule = markdownit.renderer.rules.fence;
+if (isUndefined(originalFenceRule)) {
+  throw new Error('Markdown renderer fence rule is not configured');
+}
 
 markdownit.renderer.rules.heading_open = (tokens, idx) => {
   const headingLevel = tokens[idx].tag.slice(1);
   return `<div class="md-heading md-heading--${headingLevel}">`;
 };
 markdownit.renderer.rules.heading_close = () => '</div>';
-const originalNormalizeLink = markdownit.normalizeLink!;
+const originalNormalizeLink = markdownit.normalizeLink;
+if (isUndefined(originalNormalizeLink)) {
+  throw new Error('Markdown link normalizer is not configured');
+}
 
 const isValidUrl = (url: string): boolean => {
   // only allow urls to wire://, https://, http:// and mailto:

--- a/apps/webapp/test/e2e_tests/backend/apiManager.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/apiManager.e2e.ts
@@ -18,6 +18,7 @@
  */
 
 import {FEATURE_KEY} from '@wireapp/api-client/lib/team/feature';
+import {isUndefined} from '@sindresorhus/is';
 import {AxiosResponse} from 'axios';
 
 import {AuthRepositoryE2E} from './authRepository.e2e';
@@ -193,7 +194,16 @@ export class ApiManagerE2E {
 
   private extractCookieFromRegisterResponse(registerResponse: AxiosResponse): string {
     try {
-      return registerResponse.headers['set-cookie']!.find((cookieStr: string) => cookieStr.startsWith('zuid='))!;
+      const cookies = registerResponse.headers['set-cookie'];
+      if (isUndefined(cookies)) {
+        throw new Error('Response did not contain cookies');
+      }
+      const zuidCookie = cookies.find((cookieString: string) => cookieString.startsWith('zuid='));
+      if (isUndefined(zuidCookie)) {
+        throw new Error('Response did not contain a zuid cookie');
+      }
+
+      return zuidCookie;
     } catch (error: unknown) {
       throw new Error(
         `Error extracting zuid cookie from register response: ${error instanceof Error ? error.message : error}`,

--- a/apps/webapp/test/e2e_tests/data/user.ts
+++ b/apps/webapp/test/e2e_tests/data/user.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {isNonEmptyString} from '@sindresorhus/is';
+
 import {
   generateWireEmail,
   generateFirstName,
@@ -41,6 +43,14 @@ export interface User {
     id: string;
   };
   locale?: 'en-US' | 'de-DE';
+}
+
+export function getRequiredUserId(user: User): string {
+  if (!isNonEmptyString(user.id)) {
+    throw new Error(`User ${user.username} does not have an id`);
+  }
+
+  return user.id;
 }
 
 export const getUser = (user: Partial<User> = {}): User => {

--- a/apps/webapp/test/e2e_tests/pageManager/index.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/index.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {Page} from '@playwright/test';
 
 import {MarketingConsentModal} from './webapp/modals/marketingConsent.modal';
@@ -148,7 +149,12 @@ export class PageManager {
     if (!this.cache.has(key)) {
       this.cache.set(key, factory());
     }
-    return this.cache.get(key)!;
+    const cachedPage = this.cache.get(key);
+    if (isUndefined(cachedPage)) {
+      throw new Error(`Page manager cache did not contain ${key}`);
+    }
+
+    return cachedPage;
   }
 
   // ───────────── WEBAPP ─────────────

--- a/apps/webapp/test/e2e_tests/specs/CrossPlatform/crossPlatform.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/CrossPlatform/crossPlatform.spec.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {User} from 'test/e2e_tests/data/user';
+import {getRequiredUserId, User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
 import {connectWithUser} from 'test/e2e_tests/utils/userActions';
@@ -50,7 +50,7 @@ test.describe('Cross Platform', () => {
           'Test Service Device',
           false,
         );
-        const conversationId = await api.conversation.getConversationWithUser(userA.token, userB.id!);
+        const conversationId = await api.conversation.getConversationWithUser(userA.token, getRequiredUserId(userB));
         if (conversationId === undefined) throw new Error("Couldn't find conversation of userA with userB");
         await api.testService.sendLocation(instanceId, conversationId, {
           locationName: 'Test Location',

--- a/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Delete/delete.spec.ts
@@ -19,7 +19,7 @@
 
 import {Locator, Page} from 'playwright/test';
 import {ApiManagerE2E} from 'test/e2e_tests/backend/apiManager.e2e';
-import {User} from 'test/e2e_tests/data/user';
+import {getRequiredUserId, User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
@@ -297,7 +297,7 @@ test.describe('Delete', () => {
           false,
         );
 
-        const conversationId = await api.conversation.getConversationWithUser(userA.token, userB.id!, {
+        const conversationId = await api.conversation.getConversationWithUser(userA.token, getRequiredUserId(userB), {
           protocol: 'mls',
         });
         if (conversationId === undefined) throw new Error("Couldn't find MLS conversation of userB with userA");

--- a/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Federation/federation.spec.ts
@@ -1,4 +1,5 @@
 import {Page} from 'playwright/test';
+import {isNonEmptyString} from '@sindresorhus/is';
 import {ApiManagerE2E} from 'test/e2e_tests/backend/apiManager.e2e';
 import {User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
@@ -7,16 +8,29 @@ import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} f
 import {getImageFilePath} from 'test/e2e_tests/utils/sendImage.util';
 import {createAndSaveBackup, createGroup, sendConnectionRequest} from 'test/e2e_tests/utils/userActions';
 
-test.describe('Federation', () => {
-  const federationBaseUrl = process.env.FEDERATION_WEBAPP_URL!;
-  const federationApiManager = new ApiManagerE2E({
-    backendUrl: process.env.FEDERATION_BACKEND_URL!,
-    basicAuth: process.env.FEDERATION_BASIC_AUTH!,
-  });
+function getRequiredEnvironmentVariable(variableName: string): string {
+  const variableValue = process.env[variableName];
+  if (!isNonEmptyString(variableValue)) {
+    throw new Error(`Missing required environment variable: ${variableName}`);
+  }
 
+  return variableValue;
+}
+
+test.describe('Federation', () => {
+  let federationBaseUrl: string;
+  let federationApiManager: ApiManagerE2E;
   let normalUser: User;
   let federatedUser: User;
   const groupName = 'Federated group';
+
+  test.beforeAll(() => {
+    federationBaseUrl = getRequiredEnvironmentVariable('FEDERATION_WEBAPP_URL');
+    federationApiManager = new ApiManagerE2E({
+      backendUrl: getRequiredEnvironmentVariable('FEDERATION_BACKEND_URL'),
+      basicAuth: getRequiredEnvironmentVariable('FEDERATION_BASIC_AUTH'),
+    });
+  });
 
   test.beforeEach(async ({api}) => {
     normalUser = (await createTeam(api, 'Normal Team', {features: {conferenceCalling: true, mls: true}})).owner;

--- a/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reactions/reactions.spec.ts
@@ -18,7 +18,7 @@
  */
 
 import {Page} from 'playwright/test';
-import {User} from 'test/e2e_tests/data/user';
+import {getRequiredUserId, User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
@@ -117,7 +117,9 @@ test.describe('Reactions', () => {
         'Test Service Device',
         false,
       );
-      const conversationId = await api.conversation.getConversationWithUser(userB.token, userA.id!, {protocol: 'mls'});
+      const conversationId = await api.conversation.getConversationWithUser(userB.token, getRequiredUserId(userA), {
+        protocol: 'mls',
+      });
       if (conversationId === undefined) throw new Error("Couldn't find MLS conversation of user B with user A");
       await api.testService.sendLocation(instanceId, conversationId, {
         locationName: 'Test Location',

--- a/apps/webapp/test/e2e_tests/specs/ReadReceipts/readReceipts.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/ReadReceipts/readReceipts.spec.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {User} from 'test/e2e_tests/data/user';
+import {getRequiredUserId, User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
@@ -101,7 +101,7 @@ test.describe('Read Receipts', () => {
             'Test Service Device',
             false,
           );
-          const conversationId = await api.conversation.getConversationWithUser(userB.token, userA.id!);
+          const conversationId = await api.conversation.getConversationWithUser(userB.token, getRequiredUserId(userA));
           if (conversationId === undefined) throw new Error("Couldn't find conversation of userA with userB");
           await api.testService.sendLocation(instanceId, conversationId, {
             locationName: 'Test Location',

--- a/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Reply/reply.spec.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {User} from 'test/e2e_tests/data/user';
+import {getRequiredUserId, User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
@@ -256,7 +256,7 @@ test.describe('Reply', () => {
         'Test Service Device',
         false,
       );
-      const conversationId = await api.conversation.getConversationWithUser(userA.token, userB.id!);
+      const conversationId = await api.conversation.getConversationWithUser(userA.token, getRequiredUserId(userB));
       if (conversationId === undefined) throw new Error("Couldn't find conversation of userA with userB");
       await api.testService.sendLocation(instanceId, conversationId, {
         locationName: 'Test Location',

--- a/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/Status/status.spec.ts
@@ -19,7 +19,7 @@
 
 import {Page} from 'playwright/test';
 import {ApiManagerE2E} from 'test/e2e_tests/backend/apiManager.e2e';
-import {User} from 'test/e2e_tests/data/user';
+import {getRequiredUserId, User} from 'test/e2e_tests/data/user';
 import {PageManager} from 'test/e2e_tests/pageManager';
 import {test, expect, withLogin, Team} from 'test/e2e_tests/test.fixtures';
 import {getAudioFilePath, getTextFilePath, getVideoFilePath, shareAssetHelper} from 'test/e2e_tests/utils/asset.util';
@@ -106,7 +106,7 @@ test.describe('Status', () => {
       sendAction: async ({api, conversation}) => {
         let conversationId;
         if (conversation === '1on1') {
-          conversationId = await api.conversation.getConversationWithUser(userA.token, userB.id!, {
+          conversationId = await api.conversation.getConversationWithUser(userA.token, getRequiredUserId(userB), {
             protocol: 'mls',
           });
         } else {

--- a/apps/webapp/test/integration/ConversationLabelRepositorySync.test.ts
+++ b/apps/webapp/test/integration/ConversationLabelRepositorySync.test.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isNullOrUndefined} from '@sindresorhus/is';
 import ko from 'knockout';
 import {asyncNoop} from 'noop-esm';
 import {ConversationLabelRepository, LabelType} from 'Repositories/conversation/ConversationLabelRepository';
@@ -113,7 +114,10 @@ describe('ConversationLabelRepository Integration - Synchronization Fix', () => 
     // Verify that localStorage was updated with the newer data
     const storedData = localStorage.getItem(ConversationLabelRepository.LocalStorageKey);
     expect(storedData).toBeTruthy();
-    const parsedData = JSON.parse(storedData!);
+    if (isNullOrUndefined(storedData)) {
+      throw new Error('Expected localStorage data to be available');
+    }
+    const parsedData = JSON.parse(storedData);
     expect(parsedData.labels[0].name).toBe('Local Folder');
   });
 
@@ -162,7 +166,10 @@ describe('ConversationLabelRepository Integration - Synchronization Fix', () => 
     // Verify that localStorage was updated with the newer data
     const storedData = localStorage.getItem(ConversationLabelRepository.LocalStorageKey);
     expect(storedData).toBeTruthy();
-    const parsedData = JSON.parse(storedData!);
+    if (isNullOrUndefined(storedData)) {
+      throw new Error('Expected localStorage data to be available');
+    }
+    const parsedData = JSON.parse(storedData);
     expect(parsedData.labels[0].name).toBe('Backend Folder');
   });
 
@@ -197,7 +204,10 @@ describe('ConversationLabelRepository Integration - Synchronization Fix', () => 
     // Verify that localStorage was populated
     const storedData = localStorage.getItem(ConversationLabelRepository.LocalStorageKey);
     expect(storedData).toBeTruthy();
-    const parsedData = JSON.parse(storedData!);
+    if (isNullOrUndefined(storedData)) {
+      throw new Error('Expected localStorage data to be available');
+    }
+    const parsedData = JSON.parse(storedData);
     expect(parsedData.labels).toHaveLength(1);
   });
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -269,6 +269,19 @@ const emptyArrowFunctionRestrictions = [
   },
 ];
 
+const definiteAssignmentAssertionRestrictions = [
+  {
+    selector: 'PropertyDefinition[definite=true]',
+    message:
+      'Definite assignment assertions are not allowed. Initialize the value explicitly or model its absence in the type.',
+  },
+  {
+    selector: 'VariableDeclarator[definite=true]',
+    message:
+      'Definite assignment assertions are not allowed. Initialize the value explicitly or model its absence in the type.',
+  },
+];
+
 const restrictedSyntaxRule = [
   'error',
   {
@@ -285,9 +298,14 @@ const restrictedSyntaxRule = [
     message: 'Use named imports from @sindresorhus/is instead of a namespace import.',
   },
   ...emptyArrowFunctionRestrictions,
+  ...definiteAssignmentAssertionRestrictions,
 ];
 
-const emptyArrowFunctionRule = ['error', ...emptyArrowFunctionRestrictions];
+const testRestrictedSyntaxRule = [
+  'error',
+  ...emptyArrowFunctionRestrictions,
+  ...definiteAssignmentAssertionRestrictions,
+];
 
 const jestMockRestrictionRule = [
   'warn',
@@ -399,7 +417,7 @@ const productionConfigs = [
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/no-var-requires': 'off',
-      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'error',
       '@typescript-eslint/no-floating-promises': 'warn',
       '@typescript-eslint/no-unused-vars': [
         'warn',
@@ -711,6 +729,12 @@ const config = [
         },
       },
     },
+    plugins: {
+      '@typescript-eslint': typescriptPlugin,
+    },
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'error',
+    },
   },
   {
     files: testTsxFilePatterns,
@@ -724,6 +748,12 @@ const config = [
           jsx: true,
         },
       },
+    },
+    plugins: {
+      '@typescript-eslint': typescriptPlugin,
+    },
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'error',
     },
   },
   {
@@ -751,7 +781,7 @@ const config = [
       ...testJsxFilePatterns,
     ],
     rules: {
-      'no-restricted-syntax': emptyArrowFunctionRule,
+      'no-restricted-syntax': testRestrictedSyntaxRule,
     },
   },
   {

--- a/libraries/api-client/src/http/httpClient.test.ts
+++ b/libraries/api-client/src/http/httpClient.test.ts
@@ -18,6 +18,7 @@
  */
 
 import assert from 'assert';
+import {isNullOrUndefined} from '@sindresorhus/is';
 import nock from 'nock';
 import {AxiosHeaders, AxiosResponse} from 'axios';
 
@@ -91,7 +92,12 @@ describe('HttpClient', () => {
 
       const client = new HttpClient(testConfig, mockedAccessTokenStore as AccessTokenStore);
       client.refreshAccessToken = () => {
-        return Promise.resolve(mockedAccessTokenStore.accessTokenData!);
+        const accessTokenData = mockedAccessTokenStore.accessTokenData;
+        if (isNullOrUndefined(accessTokenData)) {
+          throw new Error('Expected test access token data to be available');
+        }
+
+        return Promise.resolve(accessTokenData);
       };
 
       await client._sendRequest({config: {method: 'GET', baseURL: testConfig.urls.rest, url: AuthAPI.URL.ACCESS}});

--- a/libraries/api-client/src/obfuscation/obfuscationUtil.test.ts
+++ b/libraries/api-client/src/obfuscation/obfuscationUtil.test.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {Cookie as ToughCookie} from 'tough-cookie';
 
 import {ObfuscationUtil} from './obfuscationUtil';
@@ -48,13 +49,19 @@ describe('ObfuscationUtil', () => {
 
   it('obfuscates a cookie', () => {
     expect(cookie).toBeDefined();
-    const obfuscatedCookie = ObfuscationUtil.obfuscateCookie(cookie!);
-    expect(cookie!.value).not.toBe(obfuscatedCookie.value);
+    if (isNullOrUndefined(cookie)) {
+      throw new Error('Expected test cookie to be available');
+    }
+    const obfuscatedCookie = ObfuscationUtil.obfuscateCookie(cookie);
+    expect(cookie.value).not.toBe(obfuscatedCookie.value);
   });
 
   it(`doesn't obfuscate a cookie when disabled`, () => {
     expect(cookie).toBeDefined();
-    const obfuscatedCookie = ObfuscationUtil.obfuscateCookie(cookie!, false);
-    expect(cookie!.value).toBe(obfuscatedCookie.value);
+    if (isNullOrUndefined(cookie)) {
+      throw new Error('Expected test cookie to be available');
+    }
+    const obfuscatedCookie = ObfuscationUtil.obfuscateCookie(cookie, false);
+    expect(cookie.value).toBe(obfuscatedCookie.value);
   });
 });

--- a/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
+++ b/libraries/api-client/src/tcp/reconnectingWebsocket.test.ts
@@ -53,6 +53,15 @@ type MockReconnectingWebsocketWrapper = {
   send: jest.Mock;
 };
 
+function getSocketForTest(reconnectingWebsocket: ReconnectingWebsocket): NonNullable<ReconnectingWebsocket['socket']> {
+  const socket = reconnectingWebsocket['socket'];
+  if (isNullOrUndefined(socket)) {
+    throw new Error('Expected websocket socket to be initialized');
+  }
+
+  return socket;
+}
+
 function createMockReconnectingWebsocketWrapper(readyState: WEBSOCKET_STATE): MockReconnectingWebsocketWrapper {
   const socket: MockReconnectingWebsocketWrapper = {
     binaryType: 'blob',
@@ -767,7 +776,7 @@ describe('ReconnectingWebsocket', () => {
       reconnectCalls++;
       expect(onReconnect).toHaveBeenCalledTimes(reconnectCalls);
       if (reconnectCalls === 1) {
-        RWS['socket']!.reconnect();
+        getSocketForTest(RWS).reconnect();
       } else {
         RWS.disconnect();
       }
@@ -1425,7 +1434,7 @@ describe('ReconnectingWebsocket', () => {
       const testMessage = 'test';
 
       RWS.setOnOpen(() => {
-        const sendSpy = jest.spyOn(RWS['socket']!, 'send');
+        const sendSpy = jest.spyOn(getSocketForTest(RWS), 'send');
         RWS.send(testMessage);
 
         expect(sendSpy).toHaveBeenCalledWith(testMessage);
@@ -1478,7 +1487,7 @@ describe('ReconnectingWebsocket', () => {
       });
 
       RWS.setOnOpen(() => {
-        const reconnectSpy = jest.spyOn(RWS['socket']!, 'reconnect');
+        const reconnectSpy = jest.spyOn(getSocketForTest(RWS), 'reconnect');
         RWS['hasUnansweredPing'] = true;
         setTimeout(() => {
           RWS['sendPing']();
@@ -1518,7 +1527,7 @@ describe('ReconnectingWebsocket', () => {
       const RWS = createRWS(onReconnect);
 
       RWS.setOnOpen(() => {
-        expect(RWS['socket']!.binaryType).toBe('arraybuffer');
+        expect(getSocketForTest(RWS).binaryType).toBe('arraybuffer');
         RWS.disconnect();
         done();
       });

--- a/libraries/bazinga64/jest.config.js
+++ b/libraries/bazinga64/jest.config.js
@@ -25,6 +25,7 @@ module.exports = {
     '^.+\\.(ts|tsx)$': '@swc/jest',
     '^.+\\.(js|jsx)$': '@swc/jest',
   },
+  transformIgnorePatterns: ['/node_modules/(?!(@sindresorhus/is)/)'],
   coverageDirectory: '../../coverage/libraries/bazinga64',
   testMatch: [
     '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',

--- a/libraries/bazinga64/src/Converter.ts
+++ b/libraries/bazinga64/src/Converter.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
+
 import {UnsupportedInputError} from './UnsupportedInputError';
 
 export class Converter {
@@ -66,7 +68,11 @@ export class Converter {
 
     for (const key in objectSource) {
       if (objectSource.hasOwnProperty(key)) {
-        arrayBufferView[parseInt(key, 10)] = objectSource[key]!;
+        const value = objectSource[key];
+        if (isUndefined(value)) {
+          throw new Error(`Missing value for byte index ${key}`);
+        }
+        arrayBufferView[parseInt(key, 10)] = value;
       }
     }
 
@@ -78,7 +84,11 @@ export class Converter {
     const arrayBufferView = new Uint8Array(arrayBuffer);
 
     for (let i = 0; i < arrayBufferView.length; i++) {
-      arrayBufferView[i] = array[i]!;
+      const value = array[i];
+      if (isUndefined(value)) {
+        throw new Error(`Missing value for byte index ${i}`);
+      }
+      arrayBufferView[i] = value;
     }
 
     return arrayBufferView;

--- a/libraries/commons/src/LogFactory.ts
+++ b/libraries/commons/src/LogFactory.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {isNonEmptyString} from '@sindresorhus/is';
+import {isNonEmptyString, isUndefined} from '@sindresorhus/is';
 import ansiRegex from 'ansi-regex';
 import * as fs from 'fs-extra';
 import logdown from 'logdown';
@@ -67,7 +67,11 @@ export class LogFactory {
   }
 
   static addTimestamp(logTransport: logdown.TransportOptions): void {
-    const formattedDate = new Date().toISOString().split('.')[0]!.replace('T', ' ');
+    const formattedDatePart = new Date().toISOString().split('.')[0];
+    if (isUndefined(formattedDatePart)) {
+      throw new Error('The current date did not contain a time separator');
+    }
+    const formattedDate = formattedDatePart.replace('T', ' ');
     logTransport.args.unshift(`[${formattedDate}]`);
   }
 

--- a/libraries/commons/src/util/AccentColor.ts
+++ b/libraries/commons/src/util/AccentColor.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
+
 import * as RandomUtil from './RandomUtil';
 
 export enum AccentColorID {
@@ -88,7 +90,14 @@ export const ACCENT_COLORS: AccentColor[] = [
 ];
 
 export const getById = (id: number): AccentColor | undefined => ACCENT_COLORS.find(color => color.id === id);
-export const getRandom = (): AccentColor => RandomUtil.randomArrayElement(ACCENT_COLORS);
+export const getRandom = (): AccentColor => {
+  const randomAccentColor = RandomUtil.randomArrayElement(ACCENT_COLORS);
+  if (isUndefined(randomAccentColor)) {
+    throw new Error('Accent colors must contain at least one color');
+  }
+
+  return randomAccentColor;
+};
 
 /**
  * Use with caution:

--- a/libraries/commons/src/util/DateUtil.ts
+++ b/libraries/commons/src/util/DateUtil.ts
@@ -21,6 +21,8 @@
  * Converts a date object into two strings of format `YYYY-MM-DD` and `HH:mm:ss`.
  * @param date The date to format
  */
+import {isUndefined} from '@sindresorhus/is';
+
 export function isoFormat(date: Date): {date: string; time: string} {
   const isoString = date.toISOString();
 
@@ -30,5 +32,9 @@ export function isoFormat(date: Date): {date: string; time: string} {
     throw new Error('Invalid ISO date string');
   }
   const [, formattedDate, formattedTime] = match;
-  return {date: formattedDate!, time: formattedTime!};
+  if (isUndefined(formattedDate) || isUndefined(formattedTime)) {
+    throw new Error('Invalid ISO date string components');
+  }
+
+  return {date: formattedDate, time: formattedTime};
 }

--- a/libraries/commons/src/util/RandomUtil.ts
+++ b/libraries/commons/src/util/RandomUtil.ts
@@ -17,8 +17,12 @@
  *
  */
 
-export function randomArrayElement<T>(array: T[]): T {
-  return array[randomInt(array.length - 1)]!;
+import {isUndefined} from '@sindresorhus/is';
+
+export function randomArrayElement<T>(array: T[]): T | undefined {
+  const randomElement = array[randomInt(array.length - 1)];
+
+  return isUndefined(randomElement) ? undefined : randomElement;
 }
 
 export function randomInt(max: number): number {

--- a/libraries/copy-config/jest.config.js
+++ b/libraries/copy-config/jest.config.js
@@ -25,6 +25,7 @@ module.exports = {
     '^.+\\.(ts|tsx)$': '@swc/jest',
     '^.+\\.(js|jsx)$': '@swc/jest',
   },
+  transformIgnorePatterns: ['/node_modules/(?!(@sindresorhus/is)/)'],
   coverageDirectory: '../../coverage/libraries/copy-config',
   testMatch: [
     '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',

--- a/libraries/copy-config/src/utils.ts
+++ b/libraries/copy-config/src/utils.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import axios from 'axios';
 import copy from 'copy';
 import {ensureDir, remove, readFile, writeFile, createWriteStream} from 'fs-extra';
@@ -71,7 +72,11 @@ export async function extractAsync(zipFile: string, destination: string): Promis
 
   await jszip.loadAsync(data, {createFolders: true});
   jszip.forEach((filePath, entry) => entries.push([filePath, entry]));
-  const stripEntry = entries[0]![0];
+  const firstEntry = entries[0];
+  if (isUndefined(firstEntry)) {
+    throw new Error('The archive contains no entries');
+  }
+  const stripEntry = firstEntry[0];
 
   await Promise.all(
     entries.map(async ([filePath, entry]) => {

--- a/libraries/core/src/account.test.ts
+++ b/libraries/core/src/account.test.ts
@@ -18,6 +18,7 @@
  */
 
 import {AuthAPI} from '@wireapp/api-client/lib/auth';
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {
   ClientAPI,
   ClientCapability,
@@ -62,6 +63,14 @@ import {Account} from './account';
 import {ConnectionState} from './connectionState/connectionState';
 import type {MLSService} from './messagingProtocols/mls';
 import {NotificationSource} from './notification';
+
+function getAccountServiceForTest(account: Account): NonNullable<Account['service']> {
+  if (isNullOrUndefined(account.service)) {
+    throw new Error('Expected account services to be initialized');
+  }
+
+  return account.service;
+}
 
 const BASE_URL = 'mock-backend.wire.com';
 const MOCK_BACKEND = {
@@ -239,7 +248,7 @@ describe('Account', () => {
 
       await account['initServices']({clientType: ClientType.TEMPORARY, userId: ''});
 
-      expect(account.service!.conversation).toBeDefined();
+      expect(getAccountServiceForTest(account).conversation).toBeDefined();
 
       const message = GenericMessage.create({
         messageId: '2d7cb6d8-118f-11e8-b642-0ed5f89f718b',
@@ -335,10 +344,10 @@ describe('Account', () => {
       });
       account['currentClient'] = currentClient;
       jest
-        .spyOn(dependencies.account.service!.notification, 'handleNotification')
+        .spyOn(getAccountServiceForTest(dependencies.account).notification, 'handleNotification')
         .mockImplementation(notif => notif.payload as any);
       jest
-        .spyOn(dependencies.account.service!.notification['database'], 'getLastNotificationId')
+        .spyOn(getAccountServiceForTest(dependencies.account).notification['database'], 'getLastNotificationId')
         .mockResolvedValue('0');
 
       await account.useAPIVersion(MINIMUM_API_VERSION, MINIMUM_API_VERSION);
@@ -376,7 +385,7 @@ describe('Account', () => {
               onEvent.mockReset();
               await server.connected;
               jest
-                .spyOn(dependencies.account.service!.notification as any, 'handleNotification')
+                .spyOn(getAccountServiceForTest(dependencies.account).notification as any, 'handleNotification')
                 .mockReturnValue([{event: {testData: 1}}]);
               server.send(
                 JSON.stringify({
@@ -529,7 +538,9 @@ describe('Account', () => {
                     {domain: 'zinfra.io', type: 'federation.delete'},
                     NotificationSource.WEBSOCKET,
                   );
-                  expect(dependencies.account.service!.notification.handleNotification).toHaveBeenCalledTimes(2);
+                  expect(
+                    getAccountServiceForTest(dependencies.account).notification.handleNotification,
+                  ).toHaveBeenCalledTimes(2);
                   resolve();
               }
             },
@@ -542,7 +553,7 @@ describe('Account', () => {
       it('emits CLOSED without unlocking websocket when legacy notification catch-up fails after websocket open', async () => {
         const catchUpError = new Error('Legacy catch-up failed');
         jest
-          .spyOn(dependencies.account.service!.notification, 'legacyProcessNotificationStream')
+          .spyOn(getAccountServiceForTest(dependencies.account).notification, 'legacyProcessNotificationStream')
           .mockRejectedValue(catchUpError);
         const unlock = jest.spyOn(dependencies.apiClient.transport.ws, 'unlock');
         const onConnectionStateChanged = jest.fn<void, [ConnectionState]>();

--- a/libraries/core/src/account.ts
+++ b/libraries/core/src/account.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {isNonEmptyString} from '@sindresorhus/is';
+import {isNonEmptyString, isUndefined} from '@sindresorhus/is';
 import {
   RegisterData,
   AUTH_COOKIE_KEY,
@@ -463,7 +463,11 @@ export class Account extends TypedEventEmitter<Events> {
       onNewPrekeys: async (prekeys: PreKey[]) => {
         this.logger.debug(`Received '${prekeys.length}' new PreKeys.`);
 
-        await this.apiClient.api.client.putClient(context.clientId!, {prekeys});
+        const clientId = context.clientId;
+        if (isUndefined(clientId)) {
+          throw new Error('Client id is not set in the account context.');
+        }
+        await this.apiClient.api.client.putClient(clientId, {prekeys});
         this.logger.debug(`Successfully uploaded '${prekeys.length}' PreKeys.`);
       },
     };
@@ -909,7 +913,11 @@ export class Account extends TypedEventEmitter<Events> {
             conversation,
           } = event as Events.ConversationMessageTimerUpdateEvent;
           const expireAfterMillis = Number(message_timer);
-          this.service!.conversation.messageTimer.setConversationLevelTimer(conversation, expireAfterMillis);
+          const accountServices = this.service;
+          if (isUndefined(accountServices)) {
+            throw new Error('Services are not set.');
+          }
+          accountServices.conversation.messageTimer.setConversationLevelTimer(conversation, expireAfterMillis);
           break;
         }
       }
@@ -945,7 +953,11 @@ export class Account extends TypedEventEmitter<Events> {
               onNotificationStreamProgress(notificationTime);
             }
 
-            const messages = this.service!.notification.handleNotification(notification, source);
+            const accountServices = this.service;
+            if (isUndefined(accountServices)) {
+              throw new Error('Services are not set.');
+            }
+            const messages = accountServices.notification.handleNotification(notification, source);
 
             for await (const message of messages) {
               await handleEvent(message, source);
@@ -1077,7 +1089,11 @@ export class Account extends TypedEventEmitter<Events> {
         `[WebSocketLifecycle] layer=account event=live-transition-start${getWebSocketLifecycleContext(connectionContext)}`,
       );
       await this.rehydrateMlsPendingProposalsTasksOnLiveTransition();
-      await this.service!.conversation.runDeferredEpochRecovery();
+      const accountServices = this.service;
+      if (isUndefined(accountServices)) {
+        throw new Error('Services are not set.');
+      }
+      await accountServices.conversation.runDeferredEpochRecovery();
       resumeProposalProcessing();
       resumeMessageSending();
       resumeRejoiningMLSConversations();
@@ -1102,7 +1118,11 @@ export class Account extends TypedEventEmitter<Events> {
   ): Promise<void> => {
     try {
       this.logger.info('Sending consumable notification for decryption');
-      const payloads = this.service!.notification.handleNotification(notification.data.event, source);
+      const accountServices = this.service;
+      if (isUndefined(accountServices)) {
+        throw new Error('Services are not set.');
+      }
+      const payloads = accountServices.notification.handleNotification(notification.data.event, source);
 
       const firstEventPayload = notification.data.event.payload[0];
       const notificationTime =
@@ -1147,9 +1167,14 @@ export class Account extends TypedEventEmitter<Events> {
   ) => {
     return async (notificationId: string) => {
       if (this.hasMLSDevice) {
-        void queueConversationRejoin('all-conversations', () =>
-          this.service!.conversation.handleConversationsEpochMismatch(),
-        );
+        void queueConversationRejoin('all-conversations', () => {
+          const accountServices = this.service;
+          if (isUndefined(accountServices)) {
+            throw new Error('Services are not set.');
+          }
+
+          return accountServices.conversation.handleConversationsEpochMismatch();
+        });
       }
 
       return onMissedNotifications(notificationId);
@@ -1185,7 +1210,11 @@ export class Account extends TypedEventEmitter<Events> {
       pauseRejoiningMLSConversations();
       onConnectionStateChanged(ConnectionState.PROCESSING_NOTIFICATIONS);
 
-      const results = await this.service!.notification.legacyProcessNotificationStream(
+      const accountServices = this.service;
+      if (isUndefined(accountServices)) {
+        throw new Error('Services are not set.');
+      }
+      const results = await accountServices.notification.legacyProcessNotificationStream(
         async (notification, source) => {
           await handleLegacyNotification(notification, source);
         },

--- a/libraries/core/src/client/clientService.ts
+++ b/libraries/core/src/client/clientService.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {LoginData} from '@wireapp/api-client/lib/auth';
 import {
   ClientCapability,
@@ -158,10 +159,12 @@ export class ClientService {
   public async synchronizeClients(currentClient: string): Promise<MetaClient[]> {
     const registeredClients = await this.backend.getClients();
     const filteredClients = registeredClients.filter(client => client.id !== currentClient);
-    return this.database.createClientList(
-      {id: this.apiClient.context!.userId, domain: this.apiClient.context!.domain ?? ''},
-      filteredClients,
-    );
+    const context = this.apiClient.context;
+    if (isUndefined(context)) {
+      throw new Error('Context is not set.');
+    }
+
+    return this.database.createClientList({id: context.userId, domain: context.domain ?? ''}, filteredClients);
   }
 
   // TODO: Split functionality into "create" and "register" client

--- a/libraries/core/src/conversation/conversationService/conversationService.ts
+++ b/libraries/core/src/conversation/conversationService/conversationService.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {isEmptySet} from '@sindresorhus/is';
+import {isEmptySet, isUndefined} from '@sindresorhus/is';
 import {
   Conversation,
   DefaultConversationRoleName,
@@ -86,6 +86,14 @@ type DeferredEpochRecoveryEntry = {
   subconvId?: SUBCONVERSATION_ID;
   trigger?: MlsEpochRecoveryTrigger;
 };
+
+function requireMlsRecoveryOrchestrator(orchestrator: MlsRecoveryOrchestrator | undefined): MlsRecoveryOrchestrator {
+  if (isUndefined(orchestrator)) {
+    throw new Error('MLS recovery orchestrator is not initialized');
+  }
+
+  return orchestrator;
+}
 
 type Events = {
   MLSConversationRecovered: {conversationId: QualifiedId};
@@ -389,7 +397,8 @@ export class ConversationService extends TypedEventEmitter<Events> {
     if (this._mlsService === undefined) {
       throw new Error('MLSService is required to establish MLS group conversation');
     }
-    return this.MLSRecoveryOrchestrator!.execute({
+
+    return requireMlsRecoveryOrchestrator(this.MLSRecoveryOrchestrator).execute({
       context: {
         operationName: OperationName.establishGroup,
         qualifiedConversationId: conversationQualifiedId,
@@ -452,7 +461,8 @@ export class ConversationService extends TypedEventEmitter<Events> {
     if (this._mlsService === undefined) {
       throw new Error('MLSService is required to send MLS messages');
     }
-    return this.MLSRecoveryOrchestrator!.execute({
+
+    return requireMlsRecoveryOrchestrator(this.MLSRecoveryOrchestrator).execute({
       context: {operationName: OperationName.send, qualifiedConversationId: conversationId, groupId},
       callBack: () => this.performSendMLSMessageAPI(params),
     });
@@ -511,7 +521,8 @@ export class ConversationService extends TypedEventEmitter<Events> {
     if (this._mlsService === undefined) {
       throw new Error('MLSService is required to add users to MLS conversation');
     }
-    return this.MLSRecoveryOrchestrator!.execute({
+
+    return requireMlsRecoveryOrchestrator(this.MLSRecoveryOrchestrator).execute({
       context: {operationName: OperationName.addUsers, qualifiedConversationId: conversationId, groupId},
       callBack: () =>
         this.performAddUsersToMLSConversationAPI({
@@ -578,7 +589,8 @@ export class ConversationService extends TypedEventEmitter<Events> {
     if (this._mlsService === undefined) {
       throw new Error('MLSService is required to remove users from MLS conversation');
     }
-    return this.MLSRecoveryOrchestrator!.execute({
+
+    return requireMlsRecoveryOrchestrator(this.MLSRecoveryOrchestrator).execute({
       context: {operationName: OperationName.removeUsers, qualifiedConversationId: conversationId, groupId},
       callBack: () => this.performRemoveUsersFromMLSConversationAPI({groupId, conversationId, qualifiedUserIds}),
     });
@@ -615,7 +627,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     if (this._mlsService === undefined) {
       throw new Error('MLSService is required to join MLS conversation');
     }
-    await this.MLSRecoveryOrchestrator!.execute({
+    await requireMlsRecoveryOrchestrator(this.MLSRecoveryOrchestrator).execute({
       context: {operationName: OperationName.joinExternalCommit, qualifiedConversationId: conversationId},
       callBack: () => this.performJoinByExternalCommitAPI(conversationId),
     });
@@ -666,7 +678,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     }
 
     try {
-      await this.MLSRecoveryOrchestrator!.execute({
+      await requireMlsRecoveryOrchestrator(this.MLSRecoveryOrchestrator).execute({
         context: {
           operationName: OperationName.keyMaterialUpdate,
           qualifiedConversationId: conversation.qualified_id,
@@ -1122,7 +1134,8 @@ export class ConversationService extends TypedEventEmitter<Events> {
       if (this._mlsService === undefined) {
         throw new Error('MLSService is required to handle MLS message-add event');
       }
-      return await this.MLSRecoveryOrchestrator!.execute<HandledEventPayload | null>({
+
+      return await requireMlsRecoveryOrchestrator(this.MLSRecoveryOrchestrator).execute<HandledEventPayload | null>({
         context: {
           operationName: OperationName.handleMessageAdd,
           qualifiedConversationId,
@@ -1234,7 +1247,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     if (this._mlsService === undefined) {
       throw new Error('MLSService is required to handle MLS welcome message event');
     }
-    await this.MLSRecoveryOrchestrator!.execute({
+    await requireMlsRecoveryOrchestrator(this.MLSRecoveryOrchestrator).execute({
       context: {
         operationName: OperationName.handleWelcome,
         qualifiedConversationId: event.qualified_conversation,

--- a/libraries/core/src/conversation/message/messageBuilder.ts
+++ b/libraries/core/src/conversation/message/messageBuilder.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {v4 as uuidv4} from 'uuid';
 
@@ -452,9 +453,14 @@ function buildAsset(payloadBundle: ImageAssetMessageOutgoing['content']): Asset 
 }
 
 export function wrapInEphemeral(originalGenericMessage: GenericMessage, expireAfterMillis: number): GenericMessage {
+  const contentType = originalGenericMessage.content;
+  if (isUndefined(contentType)) {
+    throw new Error('Cannot wrap a generic message without content');
+  }
+
   const ephemeralMessage = Ephemeral.create({
     expireAfterMillis,
-    [originalGenericMessage.content!]: originalGenericMessage[originalGenericMessage.content!],
+    [contentType]: originalGenericMessage[contentType],
   });
 
   const genericMessage = GenericMessage.create({

--- a/libraries/core/src/conversation/message/messageService.ts
+++ b/libraries/core/src/conversation/message/messageService.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {MessageSendingStatus, QualifiedOTRRecipients, QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId, QualifiedUserPreKeyBundleMap} from '@wireapp/api-client/lib/user';
 import {uuidToBytes} from '@wireapp/commons/lib/util/StringUtil';
@@ -80,7 +81,11 @@ export class MessageService {
       if (this.isClientMismatchError(error) === false) {
         throw error;
       }
-      const mismatch = error.response!.data as MessageSendingStatus;
+      const response = error.response;
+      if (isUndefined(response)) {
+        throw new Error('Client mismatch error did not include a response');
+      }
+      const mismatch = response.data as MessageSendingStatus;
       const shouldStopSending =
         options.onClientMismatch !== undefined && (await options.onClientMismatch(mismatch)) === false;
       if (shouldStopSending) {

--- a/libraries/core/src/cryptography/genericMessageMapper.ts
+++ b/libraries/core/src/cryptography/genericMessageMapper.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {ConversationOtrMessageAddEvent} from '@wireapp/api-client/lib/event';
 
 import {LogFactory} from '@wireapp/commons';
@@ -95,9 +96,13 @@ export class GenericMessageMapper {
         };
       }
       case GenericMessageType.BUTTON_ACTION: {
+        const buttonAction = genericMessage.buttonAction;
+        if (isUndefined(buttonAction)) {
+          throw new Error('Button action message has no button action content');
+        }
         return {
           ...baseMessage,
-          content: genericMessage.buttonAction!,
+          content: buttonAction,
           type: PayloadBundleType.BUTTON_ACTION,
         };
       }

--- a/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/authorization.ts
+++ b/libraries/core/src/messagingProtocols/mls/e2eIdentityService/steps/authorization.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
+
 import {toBufferSource} from '../../../../util/bufferUtils';
 import {AcmeService} from '../connection';
 import {E2eiEnrollment, NewAcmeAuthz, Nonce} from '../e2eiService.types';
@@ -59,9 +61,12 @@ export const getAuthorizationChallenges = async ({
   if (dpopChallenge === undefined || oidcChallenge === undefined) {
     throw new Error('missing dpop or oidc challenge');
   }
+  if (isUndefined(oidcChallenge.keyauth)) {
+    throw new Error('missing oidc key authorization');
+  }
   // manual copy of the wasm data because of a problem while cloning it
   const authorization = {
-    keyauth: oidcChallenge.keyauth!,
+    keyauth: oidcChallenge.keyauth,
     dpopChallenge: {
       delegate: toBufferSource(dpopChallenge.challenge.delegate),
       target: dpopChallenge.challenge.target,

--- a/libraries/core/src/messagingProtocols/mls/eventHandler/events/welcomeMessage/welcomeMessage.test.ts
+++ b/libraries/core/src/messagingProtocols/mls/eventHandler/events/welcomeMessage/welcomeMessage.test.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {ConversationMLSWelcomeEvent, CONVERSATION_EVENT} from '@wireapp/api-client/lib/event';
 
 import {Welcome} from '@wireapp/core-crypto';
@@ -70,7 +71,10 @@ describe('MLS welcomeMessage eventHandler', () => {
     it('returns a eventHandlerResult', async () => {
       const eventHandlerResult = await handleMLSWelcomeMessage(mockParams);
       expect(eventHandlerResult).toBeDefined();
-      expect(eventHandlerResult!.event).toEqual({data: Uint8Array.from([1, 2, 3]), type: 'conversation.mls-welcome'});
+      if (isNullOrUndefined(eventHandlerResult)) {
+        throw new Error('Expected an event handler result');
+      }
+      expect(eventHandlerResult.event).toEqual({data: Uint8Array.from([1, 2, 3]), type: 'conversation.mls-welcome'});
     });
 
     it('emits new epoch event after processing a welcome message', async () => {

--- a/libraries/core/src/messagingProtocols/mls/mlsService/commitBundleUtil.test.ts
+++ b/libraries/core/src/messagingProtocols/mls/mlsService/commitBundleUtil.test.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isNullOrUndefined} from '@sindresorhus/is';
 import {mls} from '@wireapp/protocol-messaging/web/mls';
 import {Encoder} from 'bazinga64';
 
@@ -37,9 +38,12 @@ describe('toProtobufCommitBundle', () => {
     };
     const result = toProtobufCommitBundle(payload);
     const {commit, welcome, groupInfoBundle} = mls.CommitBundle.decode(result);
+    if (isNullOrUndefined(payload.welcome)) {
+      throw new Error('Expected test welcome to be available');
+    }
 
     expect(Encoder.toBase64(commit)).toEqual(Encoder.toBase64(payload.commit));
-    expect(Encoder.toBase64(welcome)).toEqual(Encoder.toBase64(payload.welcome?.copyBytes()!));
+    expect(Encoder.toBase64(welcome)).toEqual(Encoder.toBase64(payload.welcome.copyBytes()));
     expect(Encoder.toBase64(groupInfoBundle.groupInfo)).toEqual(
       Encoder.toBase64(payload.groupInfo.payload.copyBytes()),
     );

--- a/libraries/core/src/messagingProtocols/proteus/proteusService/cryptoClient/cryptoboxWrapper.ts
+++ b/libraries/core/src/messagingProtocols/proteus/proteusService/cryptoClient/cryptoboxWrapper.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {PreKey} from '@wireapp/api-client/lib/auth';
 
 import {Cryptobox} from '@wireapp/cryptobox';
@@ -80,10 +81,14 @@ export class CryptoboxWrapper implements CryptoClient {
         return {id: -1, key: ''};
       })
       .filter(serializedPreKey => serializedPreKey.key.length > 0);
+    const lastResortPreKey = this.cryptobox.lastResortPreKey;
+    if (isUndefined(lastResortPreKey)) {
+      throw new Error('The last resort prekey was not created');
+    }
 
     return {
       prekeys,
-      lastPrekey: this.cryptobox.serialize_prekey(this.cryptobox.lastResortPreKey!),
+      lastPrekey: this.cryptobox.serialize_prekey(lastResortPreKey),
     };
   }
 

--- a/libraries/license-collector/src/LicenseCollector.ts
+++ b/libraries/license-collector/src/LicenseCollector.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import * as fs from 'fs-extra';
 import logdown from 'logdown';
 import pkginfo from 'npm-registry-package-info';
@@ -112,11 +113,15 @@ export class LicenseCollector {
       const id = crypto.randomBytes(CLONE_DIR_ID_BYTE_LENGTH).toString('hex');
       const cloneDir = path.join(this.TMP_DIR, id);
       const name = gitUrlRegex.exec(url) ?? ['', url];
-      repository.name = name[1]!;
+      const repositoryName = name[1];
+      if (isUndefined(repositoryName)) {
+        throw new Error(`Unable to determine repository name from ${url}`);
+      }
+      repository.name = repositoryName;
 
       repository.dir = cloneDir;
 
-      this.logger.info(`${name[1]}: Cloning "${url}" into "${cloneDir}" ...`);
+      this.logger.info(`${repositoryName}: Cloning "${url}" into "${cloneDir}" ...`);
 
       const {stderr: stderrClone} = await execAsync(`git clone --depth 1 "${url}" "${cloneDir}"`);
 
@@ -216,7 +221,10 @@ export class LicenseCollector {
     this.logger.info(`Extracted ${packages.length} licenses.`);
 
     for (const packageName of packages) {
-      const currentPackage = result.data[packageName]!;
+      const currentPackage = result.data[packageName];
+      if (isUndefined(currentPackage)) {
+        throw new Error(`Missing package data for ${packageName}`);
+      }
 
       const link = currentPackage.homepage ?? currentPackage.repository?.url ?? 'none';
 

--- a/libraries/priority-queue/src/PriorityQueue.ts
+++ b/libraries/priority-queue/src/PriorityQueue.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {isObject} from '@sindresorhus/is';
+import {isObject, isUndefined} from '@sindresorhus/is';
 
 import {Config} from './Config';
 import {Item} from './Item';
@@ -83,11 +83,21 @@ export class PriorityQueue {
   }
 
   public get first(): Item {
-    return this.queue[0]!;
+    const firstItem = this.queue[0];
+    if (isUndefined(firstItem)) {
+      throw new Error('Cannot read the first item from an empty priority queue');
+    }
+
+    return firstItem;
   }
 
   public get last(): Item {
-    return this.queue[this.queue.length - 1]!;
+    const lastItem = this.queue[this.queue.length - 1];
+    if (isUndefined(lastItem)) {
+      throw new Error('Cannot read the last item from an empty priority queue');
+    }
+
+    return lastItem;
   }
 
   public get size(): number {

--- a/libraries/react-ui-kit/src/inputs/timePickerField/timePickerUtils.test.ts
+++ b/libraries/react-ui-kit/src/inputs/timePickerField/timePickerUtils.test.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
+
 import {buildTimeOptions, filterTimeOptionsAfter, getTimeOptionTotalMinutes} from './timePickerUtils';
 
 describe('timePickerUtils', () => {
@@ -28,6 +30,10 @@ describe('timePickerUtils', () => {
 
     expect(filteredOptions.some(option => option.label === '4:15 PM')).toBe(false);
     expect(filteredOptions.some(option => option.label === '4:30 PM')).toBe(true);
-    expect(getTimeOptionTotalMinutes(filteredOptions[0]!)).toBeGreaterThan(16 * 60 + 27);
+    const firstFilteredOption = filteredOptions[0];
+    if (isUndefined(firstFilteredOption)) {
+      throw new Error('Expected filtered time options to be non-empty');
+    }
+    expect(getTimeOptionTotalMinutes(firstFilteredOption)).toBeGreaterThan(16 * 60 + 27);
   });
 });

--- a/libraries/store-engine/src/engine/MemoryEngine.ts
+++ b/libraries/store-engine/src/engine/MemoryEngine.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {isNullOrUndefined} from '@sindresorhus/is';
+import {isNullOrUndefined, isUndefined} from '@sindresorhus/is';
 
 import {CRUDEngine} from './CRUDEngine';
 import {RecordAlreadyExistsError, RecordNotFoundError, RecordTypeError} from './error';
@@ -30,11 +30,21 @@ export class MemoryEngine implements CRUDEngine {
   private autoIncrementedPrimaryKey: number = 1;
 
   private get store(): Record<string, Record<string, any>> {
-    return this.stores[this.storeName]!;
+    const store = this.stores[this.storeName];
+    if (isUndefined(store)) {
+      throw new Error(`Store ${this.storeName} is not initialized`);
+    }
+
+    return store;
   }
 
   private getTable(tableName: string): Record<PropertyKey, any> {
-    return this.store[tableName]! as Record<PropertyKey, any>;
+    const table = this.store[tableName];
+    if (isUndefined(table)) {
+      throw new Error(`Table ${tableName} is not initialized`);
+    }
+
+    return table;
   }
 
   create<EntityType, PrimaryKey = string>(

--- a/libraries/store-engine/src/store/TransientStore.ts
+++ b/libraries/store-engine/src/store/TransientStore.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {isNullOrUndefined} from '@sindresorhus/is';
+import {isNullOrUndefined, isUndefined} from '@sindresorhus/is';
 
 import {EventEmitter} from 'events';
 
@@ -87,9 +87,11 @@ export class TransientStore extends EventEmitter {
 
     const bundles = await Promise.all(readBundles);
 
-    for (const index in bundles) {
-      const bundle = bundles[index]!;
-      const cacheKey = cacheKeys[index]!;
+    for (const [index, bundle] of bundles.entries()) {
+      const cacheKey = cacheKeys[index];
+      if (isUndefined(cacheKey)) {
+        throw new Error(`Missing cache key for bundle at index ${index}`);
+      }
       await this.startTimer(cacheKey);
       this.bundles[cacheKey] = bundle;
     }
@@ -144,9 +146,13 @@ export class TransientStore extends EventEmitter {
   }
 
   private async expireBundle(cacheKey: string): Promise<ExpiredBundle> {
+    const bundle = this.bundles[cacheKey];
+    if (isUndefined(bundle)) {
+      throw new Error(`Cannot expire missing transient bundle ${cacheKey}`);
+    }
     const expiredBundle: ExpiredBundle = {
       cacheKey: cacheKey,
-      payload: this.bundles[cacheKey]!.payload,
+      payload: bundle.payload,
       primaryKey: this.constructPrimaryKey(cacheKey),
     };
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

This pull request enables TypeScript safety policies for non-null and definite assignment assertions.

It:

- enables `@typescript-eslint/no-non-null-assertion` for TypeScript and TSX production and test sources;
- adds existing `no-restricted-syntax` restrictions for `PropertyDefinition[definite=true]` and `VariableDeclarator[definite=true]`;
- migrates existing assertion usages to explicit initialization, control flow, runtime checks, and lifecycle handling;
- applies both policies to production and test TypeScript and TSX sources.

The policies reject expression-level assertions such as:

    const value = possiblyUndefined!;

and declaration-level assertions such as:

    let value!: string;

    class Example {
      private dependency!: Dependency;
    }

Both assertion forms bypass TypeScript analysis and can hide invalid assumptions about initialization, external values, collection lookups, browser APIs, and object lifecycles.