### PR TITLE
feat: allow cancelling active Shared Drive uploads [WPB-28302]

### DIFF
--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.test.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.test.ts
@@ -30,14 +30,21 @@ const state = (kind: string) => ({
 });
 
 describe('toSharedDriveUploadStatus', () => {
-  it.each(['queued', 'uploading', 'draftReady', 'publishing'])('maps %s to uploading', kind => {
+  it.each(['queued', 'uploading'])('maps %s to uploading and marks it cancellable', kind => {
     expect(toSharedDriveUploadStatus(state(kind) as never, conversationQualifiedId)).toEqual({
       uploadId: 'upload-1',
       conversationQualifiedId,
       fileName: 'report.pdf',
       fileSize: 4,
       kind: 'uploading',
+      canCancel: true,
     });
+  });
+
+  it.each(['draftReady', 'publishing'])('maps %s to uploading but marks it not cancellable', kind => {
+    expect(toSharedDriveUploadStatus(state(kind) as never, conversationQualifiedId)).toEqual(
+      expect.objectContaining({kind: 'uploading', canCancel: false}),
+    );
   });
 
   it('maps published to uploaded', () => {
@@ -46,6 +53,7 @@ describe('toSharedDriveUploadStatus', () => {
 
   it.each(['uploadFailed', 'publishFailed', 'discardFailed'])('maps %s to failed', kind => {
     expect(toSharedDriveUploadStatus(state(kind) as never, conversationQualifiedId)?.kind).toBe('failed');
+    expect(toSharedDriveUploadStatus(state(kind) as never, conversationQualifiedId)?.canCancel).toBe(false);
   });
 
   it.each(['cancelled', 'discarding', 'discarded'])('does not expose %s', kind => {

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.ts
@@ -27,6 +27,7 @@ export type SharedDriveUploadStatus = {
   readonly fileName: string;
   readonly fileSize: number;
   readonly kind: SharedDriveUploadStatusKind;
+  readonly canCancel: boolean;
 };
 
 const getSharedDriveUploadStatusKind = (state: UploadState): SharedDriveUploadStatusKind | null => {
@@ -63,5 +64,6 @@ export const toSharedDriveUploadStatus = (
     fileName: state.source.name,
     fileSize: state.source.size,
     kind,
+    canCancel: state.kind === 'queued' || state.kind === 'uploading',
   };
 };

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
@@ -21,6 +21,9 @@ import type {CSSObject} from '@emotion/react';
 
 import type {SharedDriveUploadStatusKind} from './sharedDriveUploadStatus';
 
+const SHARED_DRIVE_UPLOAD_PROGRESS_EXPANDED_TOP = 51;
+const SHARED_DRIVE_UPLOAD_PROGRESS_COLLAPSED_LEFT = 3;
+
 export const sharedDriveUploadStatusPopupStyles: CSSObject = {
   position: 'absolute',
   right: 16,
@@ -40,13 +43,6 @@ export const sharedDriveUploadStatusPopupStyles: CSSObject = {
 };
 
 export const sharedDriveUploadStatusPopupContentStyles: CSSObject = {
-  display: 'flex',
-  minWidth: 0,
-  flexDirection: 'column',
-  gap: 5,
-};
-
-export const sharedDriveUploadStatusPopupHeaderRowStyles: CSSObject = {
   display: 'flex',
   minWidth: 0,
   minHeight: 36,
@@ -194,8 +190,11 @@ export const sharedDriveUploadStatusPopupRowIconStyles: CSSObject = {
   flex: '0 0 auto',
 };
 
-export const sharedDriveUploadStatusPopupProgressStyles: CSSObject = {
-  alignSelf: 'flex-start',
+export const sharedDriveUploadStatusPopupProgressStyles = (isExpanded: boolean): CSSObject => ({
+  position: 'absolute',
+  top: isExpanded ? SHARED_DRIVE_UPLOAD_PROGRESS_EXPANDED_TOP : undefined,
+  bottom: isExpanded ? undefined : 0,
+  left: isExpanded ? 0 : SHARED_DRIVE_UPLOAD_PROGRESS_COLLAPSED_LEFT,
   width: 'min(209px, calc(50% + 3px))',
   height: 3,
   overflow: 'hidden',
@@ -208,4 +207,4 @@ export const sharedDriveUploadStatusPopupProgressStyles: CSSObject = {
   '@media (prefers-reduced-motion: reduce)': {
     animation: 'none',
   },
-};
+});

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
@@ -109,8 +109,24 @@ export const sharedDriveUploadStatusPopupRowStyles: CSSObject = {
 export const sharedDriveUploadStatusPopupRowTextStyles: CSSObject = {
   display: 'flex',
   minWidth: 0,
+  flex: 1,
   flexDirection: 'column',
   gap: 2,
+};
+
+export const sharedDriveUploadStatusPopupCancelStyles: CSSObject = {
+  flex: '0 0 auto',
+  padding: 0,
+  border: 0,
+  background: 'transparent',
+  color: 'var(--accent-color)',
+  fontSize: 12,
+  lineHeight: '14px',
+  cursor: 'pointer',
+  '&:disabled': {
+    cursor: 'default',
+    opacity: 0.5,
+  },
 };
 
 export const sharedDriveUploadStatusPopupRowFileNameStyles: CSSObject = {

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
@@ -73,6 +73,32 @@ export const sharedDriveUploadStatusPopupDestinationStyles: CSSObject = {
   whiteSpace: 'nowrap',
 };
 
+export const sharedDriveUploadStatusPopupHeaderActionsStyles: CSSObject = {
+  display: 'flex',
+  flex: '0 0 auto',
+  alignItems: 'center',
+  gap: 8,
+};
+
+export const sharedDriveUploadStatusPopupHeaderCancelStyles: CSSObject = {
+  minWidth: 74,
+  height: 32,
+  padding: '4px 12px',
+  border: '1px solid #dce0e3',
+  borderRadius: 12,
+  background: 'var(--app-bg, #fff)',
+  color: 'inherit',
+  fontSize: 14,
+  fontWeight: 700,
+  letterSpacing: '0.35px',
+  lineHeight: '22px',
+  cursor: 'pointer',
+  '&:disabled': {
+    cursor: 'default',
+    opacity: 0.5,
+  },
+};
+
 export const sharedDriveUploadStatusPopupToggleStyles: CSSObject = {
   display: 'flex',
   width: 24,
@@ -114,14 +140,18 @@ export const sharedDriveUploadStatusPopupRowTextStyles: CSSObject = {
   gap: 2,
 };
 
-export const sharedDriveUploadStatusPopupCancelStyles: CSSObject = {
+export const sharedDriveUploadStatusPopupRowCancelStyles: CSSObject = {
+  display: 'flex',
   flex: '0 0 auto',
+  width: 24,
+  height: 24,
+  alignItems: 'center',
+  justifyContent: 'center',
   padding: 0,
   border: 0,
+  borderRadius: 12,
   background: 'transparent',
-  color: 'var(--accent-color)',
-  fontSize: 12,
-  lineHeight: '14px',
+  color: 'inherit',
   cursor: 'pointer',
   '&:disabled': {
     cursor: 'default',

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
@@ -42,6 +42,13 @@ export const sharedDriveUploadStatusPopupStyles: CSSObject = {
 export const sharedDriveUploadStatusPopupContentStyles: CSSObject = {
   display: 'flex',
   minWidth: 0,
+  flexDirection: 'column',
+  gap: 5,
+};
+
+export const sharedDriveUploadStatusPopupHeaderRowStyles: CSSObject = {
+  display: 'flex',
+  minWidth: 0,
   minHeight: 36,
   alignItems: 'center',
   justifyContent: 'space-between',
@@ -188,9 +195,7 @@ export const sharedDriveUploadStatusPopupRowIconStyles: CSSObject = {
 };
 
 export const sharedDriveUploadStatusPopupProgressStyles: CSSObject = {
-  position: 'absolute',
-  bottom: 0,
-  left: 3,
+  alignSelf: 'flex-start',
   width: 'min(209px, calc(50% + 3px))',
   height: 3,
   overflow: 'hidden',

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.test.tsx
@@ -23,6 +23,7 @@ import {ThemeProvider} from '@wireapp/react-ui-kit';
 
 import type {SharedDriveUploadStatus} from './sharedDriveUploadStatus';
 import {SharedDriveUploadStatusPopup} from './sharedDriveUploadStatusPopup';
+import {sharedDriveUploadStatusPopupProgressStyles} from './sharedDriveUploadStatusPopup.styles';
 
 const upload: SharedDriveUploadStatus = {
   uploadId: 'upload-1',
@@ -54,6 +55,21 @@ const renderPopup = (kind: SharedDriveUploadStatus['kind'], isExpanded = false) 
   );
 
 describe('SharedDriveUploadStatusPopup', () => {
+  it('positions progress at the bottom when closed and below the header when expanded', () => {
+    expect(sharedDriveUploadStatusPopupProgressStyles(false)).toMatchObject({
+      position: 'absolute',
+      bottom: 0,
+      left: 3,
+      top: undefined,
+    });
+    expect(sharedDriveUploadStatusPopupProgressStyles(true)).toMatchObject({
+      position: 'absolute',
+      top: 51,
+      left: 0,
+      bottom: undefined,
+    });
+  });
+
   it('shows the filename and destination while uploading with indeterminate progress', () => {
     const {getByRole, getByText, getByTestId} = renderPopup('uploading');
 

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.test.tsx
@@ -89,10 +89,12 @@ describe('SharedDriveUploadStatusPopup', () => {
     expect(queryByTestId('shared-drive-upload-progress')).not.toBeInTheDocument();
   });
 
-  it('starts collapsed and exposes an accessible toggle for the file details', () => {
+  it('starts collapsed and exposes accessible cancel and toggle actions in the header', () => {
     renderPopup('uploading');
 
-    const toggle = screen.getByRole('button', {name: 'Expand upload details'});
+    const header = screen.getByTestId('shared-drive-upload-status-header');
+    const toggle = within(header).getByRole('button', {name: 'Expand upload details'});
+    expect(within(header).getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
     expect(toggle).toHaveAttribute('aria-controls', 'shared-drive-upload-status-upload-1');
     expect(screen.getByRole('status').querySelector('button')).not.toBeInTheDocument();
@@ -141,7 +143,34 @@ describe('SharedDriveUploadStatusPopup', () => {
     expect(onToggle).toHaveBeenCalledTimes(2);
   });
 
-  it('shows a cancel action for an active upload and prevents duplicate interaction while cancelling', async () => {
+  it('invokes cancellation from the header', async () => {
+    const user = userEvent.setup();
+    const onCancel = jest.fn();
+    render(
+      <ThemeProvider>
+        <SharedDriveUploadStatusPopup
+          upload={upload}
+          title="Uploading report.pdf"
+          statusLabel="Uploading"
+          destination="to Shared Drive"
+          isExpanded={false}
+          toggleLabel="Expand upload details"
+          cancelLabel="Cancel"
+          isCancelling={false}
+          onToggle={jest.fn()}
+          onCancel={onCancel}
+        />
+      </ThemeProvider>,
+    );
+
+    await user.click(
+      within(screen.getByTestId('shared-drive-upload-status-header')).getByRole('button', {name: 'Cancel'}),
+    );
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes cancellation from the expanded row icon action', async () => {
     const user = userEvent.setup();
     const onCancel = jest.fn();
     render(
@@ -154,17 +183,42 @@ describe('SharedDriveUploadStatusPopup', () => {
           isExpanded
           toggleLabel="Collapse upload details"
           cancelLabel="Cancel"
-          isCancelling
+          isCancelling={false}
           onToggle={jest.fn()}
           onCancel={onCancel}
         />
       </ThemeProvider>,
     );
 
-    const cancel = screen.getByRole('button', {name: 'Cancel'});
-    expect(cancel).toBeDisabled();
-    await user.click(cancel);
-    expect(onCancel).not.toHaveBeenCalled();
+    const row = screen.getByTestId('shared-drive-upload-status-row');
+    const rowCancel = within(row).getByRole('button', {name: 'Cancel'});
+    expect(rowCancel).toHaveAttribute('data-uie-name', 'shared-drive-upload-cancel');
+    expect(rowCancel.querySelector('svg')).toHaveAttribute('aria-hidden', 'true');
+    await user.click(rowCancel);
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables every cancel action while cancellation is pending', () => {
+    render(
+      <ThemeProvider>
+        <SharedDriveUploadStatusPopup
+          upload={upload}
+          title="Uploading report.pdf"
+          statusLabel="Uploading"
+          destination="to Shared Drive"
+          isExpanded
+          toggleLabel="Collapse upload details"
+          cancelLabel="Cancel"
+          isCancelling
+          onToggle={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getAllByRole('button', {name: 'Cancel'})).toHaveLength(2);
+    screen.getAllByRole('button', {name: 'Cancel'}).forEach(cancel => expect(cancel).toBeDisabled());
   });
 
   it.each(['uploaded', 'failed'] as const)('does not show cancel for %s status', kind => {

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.test.tsx
@@ -30,13 +30,14 @@ const upload: SharedDriveUploadStatus = {
   fileName: 'report.pdf',
   fileSize: 4,
   kind: 'uploading',
+  canCancel: true,
 };
 
 const renderPopup = (kind: SharedDriveUploadStatus['kind'], isExpanded = false) =>
   render(
     <ThemeProvider>
       <SharedDriveUploadStatusPopup
-        upload={{...upload, kind}}
+        upload={{...upload, kind, canCancel: kind === 'uploading'}}
         title={`${kind} report.pdf`}
         statusLabel={
           kind === 'failed' ? 'Couldn’t upload file' : `${kind === 'uploading' ? 'Uploading' : 'Uploaded'} 4 KB`
@@ -44,7 +45,10 @@ const renderPopup = (kind: SharedDriveUploadStatus['kind'], isExpanded = false) 
         destination="to Shared Drive"
         isExpanded={isExpanded}
         toggleLabel={isExpanded ? 'Collapse upload details' : 'Expand upload details'}
+        cancelLabel="Cancel"
+        isCancelling={false}
         onToggle={jest.fn()}
+        onCancel={jest.fn()}
       />
     </ThemeProvider>,
   );
@@ -123,7 +127,10 @@ describe('SharedDriveUploadStatusPopup', () => {
         destination="to Shared Drive"
         isExpanded={false}
         toggleLabel="Expand upload details"
+        cancelLabel="Cancel"
+        isCancelling={false}
         onToggle={onToggle}
+        onCancel={jest.fn()}
       />,
     );
 
@@ -134,10 +141,35 @@ describe('SharedDriveUploadStatusPopup', () => {
     expect(onToggle).toHaveBeenCalledTimes(2);
   });
 
-  it('shows failed status without retry, cancel, or open actions', () => {
-    const {getByText, queryByRole} = renderPopup('failed');
+  it('shows a cancel action for an active upload and prevents duplicate interaction while cancelling', async () => {
+    const user = userEvent.setup();
+    const onCancel = jest.fn();
+    render(
+      <ThemeProvider>
+        <SharedDriveUploadStatusPopup
+          upload={upload}
+          title="Uploading report.pdf"
+          statusLabel="Uploading"
+          destination="to Shared Drive"
+          isExpanded
+          toggleLabel="Collapse upload details"
+          cancelLabel="Cancel"
+          isCancelling
+          onToggle={jest.fn()}
+          onCancel={onCancel}
+        />
+      </ThemeProvider>,
+    );
 
-    expect(getByText('failed report.pdf')).toBeInTheDocument();
-    expect(queryByRole('button', {name: /retry|cancel|open/i})).not.toBeInTheDocument();
+    const cancel = screen.getByRole('button', {name: 'Cancel'});
+    expect(cancel).toBeDisabled();
+    await user.click(cancel);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it.each(['uploaded', 'failed'] as const)('does not show cancel for %s status', kind => {
+    const {queryByRole} = renderPopup(kind);
+
+    expect(queryByRole('button', {name: 'Cancel'})).not.toBeInTheDocument();
   });
 });

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
@@ -26,6 +26,7 @@ import {getFileExtension} from 'Util/util';
 
 import type {SharedDriveUploadStatus} from './sharedDriveUploadStatus';
 import {
+  sharedDriveUploadStatusPopupCancelStyles,
   sharedDriveUploadStatusPopupContentStyles,
   sharedDriveUploadStatusPopupDestinationStyles,
   sharedDriveUploadStatusPopupProgressStyles,
@@ -48,7 +49,10 @@ interface SharedDriveUploadStatusPopupProps {
   readonly destination: string;
   readonly isExpanded: boolean;
   readonly toggleLabel: string;
+  readonly cancelLabel: string;
+  readonly isCancelling: boolean;
   readonly onToggle: () => void;
+  readonly onCancel: () => void;
 }
 
 const statusIcon = (upload: SharedDriveUploadStatus): ReactNode => {
@@ -92,7 +96,10 @@ export const SharedDriveUploadStatusPopup = ({
   destination,
   isExpanded,
   toggleLabel,
+  cancelLabel,
+  isCancelling,
   onToggle,
+  onCancel,
 }: SharedDriveUploadStatusPopupProps) => {
   const statusRowId = `shared-drive-upload-status-${upload.uploadId}`;
 
@@ -143,6 +150,17 @@ export const SharedDriveUploadStatusPopup = ({
             {statusLabel}
           </span>
         </div>
+        {upload.canCancel && (
+          <button
+            type="button"
+            css={sharedDriveUploadStatusPopupCancelStyles}
+            disabled={isCancelling}
+            data-uie-name="shared-drive-upload-cancel"
+            onClick={onCancel}
+          >
+            {cancelLabel}
+          </button>
+        )}
       </div>
       {upload.kind === 'uploading' && (
         <div css={sharedDriveUploadStatusPopupProgressStyles} data-uie-name="shared-drive-upload-progress" />

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
@@ -19,17 +19,19 @@
 
 import type {ReactNode} from 'react';
 
-import {AlertIcon, ChevronIcon, UploadIcon} from '@wireapp/react-ui-kit';
+import {AlertIcon, ChevronIcon, CloseIcon, UploadIcon} from '@wireapp/react-ui-kit';
 
 import {FileTypeIcon} from 'Components/conversation/common/fileTypeIcon/fileTypeIcon';
 import {getFileExtension} from 'Util/util';
 
 import type {SharedDriveUploadStatus} from './sharedDriveUploadStatus';
 import {
-  sharedDriveUploadStatusPopupCancelStyles,
   sharedDriveUploadStatusPopupContentStyles,
   sharedDriveUploadStatusPopupDestinationStyles,
+  sharedDriveUploadStatusPopupHeaderActionsStyles,
+  sharedDriveUploadStatusPopupHeaderCancelStyles,
   sharedDriveUploadStatusPopupProgressStyles,
+  sharedDriveUploadStatusPopupRowCancelStyles,
   sharedDriveUploadStatusPopupRowFileNameStyles,
   sharedDriveUploadStatusPopupRowIconStyles,
   sharedDriveUploadStatusPopupRowStatusStyles,
@@ -118,22 +120,35 @@ export const SharedDriveUploadStatusPopup = ({
             {destination}
           </span>
         </div>
-        <button
-          type="button"
-          css={sharedDriveUploadStatusPopupToggleStyles}
-          aria-label={toggleLabel}
-          aria-expanded={isExpanded}
-          aria-controls={statusRowId}
-          data-uie-name="shared-drive-upload-status-toggle"
-          onClick={onToggle}
-        >
-          <ChevronIcon
-            direction={isExpanded ? 'down' : 'up'}
-            css={sharedDriveUploadStatusPopupToggleIconStyles}
-            color="currentColor"
-            aria-hidden="true"
-          />
-        </button>
+        <div css={sharedDriveUploadStatusPopupHeaderActionsStyles}>
+          {upload.canCancel && (
+            <button
+              type="button"
+              css={sharedDriveUploadStatusPopupHeaderCancelStyles}
+              disabled={isCancelling}
+              data-uie-name="shared-drive-upload-header-cancel"
+              onClick={onCancel}
+            >
+              {cancelLabel}
+            </button>
+          )}
+          <button
+            type="button"
+            css={sharedDriveUploadStatusPopupToggleStyles}
+            aria-label={toggleLabel}
+            aria-expanded={isExpanded}
+            aria-controls={statusRowId}
+            data-uie-name="shared-drive-upload-status-toggle"
+            onClick={onToggle}
+          >
+            <ChevronIcon
+              direction={isExpanded ? 'down' : 'up'}
+              css={sharedDriveUploadStatusPopupToggleIconStyles}
+              color="currentColor"
+              aria-hidden="true"
+            />
+          </button>
+        </div>
       </div>
       <div
         id={statusRowId}
@@ -153,12 +168,13 @@ export const SharedDriveUploadStatusPopup = ({
         {upload.canCancel && (
           <button
             type="button"
-            css={sharedDriveUploadStatusPopupCancelStyles}
+            css={sharedDriveUploadStatusPopupRowCancelStyles}
+            aria-label={cancelLabel}
             disabled={isCancelling}
             data-uie-name="shared-drive-upload-cancel"
             onClick={onCancel}
           >
-            {cancelLabel}
+            <CloseIcon color="currentColor" aria-hidden="true" />
           </button>
         )}
       </div>

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
@@ -30,6 +30,7 @@ import {
   sharedDriveUploadStatusPopupDestinationStyles,
   sharedDriveUploadStatusPopupHeaderActionsStyles,
   sharedDriveUploadStatusPopupHeaderCancelStyles,
+  sharedDriveUploadStatusPopupHeaderRowStyles,
   sharedDriveUploadStatusPopupProgressStyles,
   sharedDriveUploadStatusPopupRowCancelStyles,
   sharedDriveUploadStatusPopupRowFileNameStyles,
@@ -112,43 +113,48 @@ export const SharedDriveUploadStatusPopup = ({
         data-uie-name="shared-drive-upload-status-header"
         data-testid="shared-drive-upload-status-header"
       >
-        <div css={sharedDriveUploadStatusPopupTextStyles} role="status" aria-live="polite">
-          <strong css={sharedDriveUploadStatusPopupTitleStyles} title={title}>
-            {title}
-          </strong>
-          <span css={sharedDriveUploadStatusPopupDestinationStyles} title={destination}>
-            {destination}
-          </span>
-        </div>
-        <div css={sharedDriveUploadStatusPopupHeaderActionsStyles}>
-          {upload.canCancel && (
+        <div css={sharedDriveUploadStatusPopupHeaderRowStyles}>
+          <div css={sharedDriveUploadStatusPopupTextStyles} role="status" aria-live="polite">
+            <strong css={sharedDriveUploadStatusPopupTitleStyles} title={title}>
+              {title}
+            </strong>
+            <span css={sharedDriveUploadStatusPopupDestinationStyles} title={destination}>
+              {destination}
+            </span>
+          </div>
+          <div css={sharedDriveUploadStatusPopupHeaderActionsStyles}>
+            {upload.canCancel && (
+              <button
+                type="button"
+                css={sharedDriveUploadStatusPopupHeaderCancelStyles}
+                disabled={isCancelling}
+                data-uie-name="shared-drive-upload-header-cancel"
+                onClick={onCancel}
+              >
+                {cancelLabel}
+              </button>
+            )}
             <button
               type="button"
-              css={sharedDriveUploadStatusPopupHeaderCancelStyles}
-              disabled={isCancelling}
-              data-uie-name="shared-drive-upload-header-cancel"
-              onClick={onCancel}
+              css={sharedDriveUploadStatusPopupToggleStyles}
+              aria-label={toggleLabel}
+              aria-expanded={isExpanded}
+              aria-controls={statusRowId}
+              data-uie-name="shared-drive-upload-status-toggle"
+              onClick={onToggle}
             >
-              {cancelLabel}
+              <ChevronIcon
+                direction={isExpanded ? 'down' : 'up'}
+                css={sharedDriveUploadStatusPopupToggleIconStyles}
+                color="currentColor"
+                aria-hidden="true"
+              />
             </button>
-          )}
-          <button
-            type="button"
-            css={sharedDriveUploadStatusPopupToggleStyles}
-            aria-label={toggleLabel}
-            aria-expanded={isExpanded}
-            aria-controls={statusRowId}
-            data-uie-name="shared-drive-upload-status-toggle"
-            onClick={onToggle}
-          >
-            <ChevronIcon
-              direction={isExpanded ? 'down' : 'up'}
-              css={sharedDriveUploadStatusPopupToggleIconStyles}
-              color="currentColor"
-              aria-hidden="true"
-            />
-          </button>
+          </div>
         </div>
+        {upload.kind === 'uploading' && (
+          <div css={sharedDriveUploadStatusPopupProgressStyles} data-uie-name="shared-drive-upload-progress" />
+        )}
       </div>
       <div
         id={statusRowId}
@@ -178,9 +184,6 @@ export const SharedDriveUploadStatusPopup = ({
           </button>
         )}
       </div>
-      {upload.kind === 'uploading' && (
-        <div css={sharedDriveUploadStatusPopupProgressStyles} data-uie-name="shared-drive-upload-progress" />
-      )}
     </div>
   );
 };

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
@@ -30,7 +30,6 @@ import {
   sharedDriveUploadStatusPopupDestinationStyles,
   sharedDriveUploadStatusPopupHeaderActionsStyles,
   sharedDriveUploadStatusPopupHeaderCancelStyles,
-  sharedDriveUploadStatusPopupHeaderRowStyles,
   sharedDriveUploadStatusPopupProgressStyles,
   sharedDriveUploadStatusPopupRowCancelStyles,
   sharedDriveUploadStatusPopupRowFileNameStyles,
@@ -113,48 +112,43 @@ export const SharedDriveUploadStatusPopup = ({
         data-uie-name="shared-drive-upload-status-header"
         data-testid="shared-drive-upload-status-header"
       >
-        <div css={sharedDriveUploadStatusPopupHeaderRowStyles}>
-          <div css={sharedDriveUploadStatusPopupTextStyles} role="status" aria-live="polite">
-            <strong css={sharedDriveUploadStatusPopupTitleStyles} title={title}>
-              {title}
-            </strong>
-            <span css={sharedDriveUploadStatusPopupDestinationStyles} title={destination}>
-              {destination}
-            </span>
-          </div>
-          <div css={sharedDriveUploadStatusPopupHeaderActionsStyles}>
-            {upload.canCancel && (
-              <button
-                type="button"
-                css={sharedDriveUploadStatusPopupHeaderCancelStyles}
-                disabled={isCancelling}
-                data-uie-name="shared-drive-upload-header-cancel"
-                onClick={onCancel}
-              >
-                {cancelLabel}
-              </button>
-            )}
+        <div css={sharedDriveUploadStatusPopupTextStyles} role="status" aria-live="polite">
+          <strong css={sharedDriveUploadStatusPopupTitleStyles} title={title}>
+            {title}
+          </strong>
+          <span css={sharedDriveUploadStatusPopupDestinationStyles} title={destination}>
+            {destination}
+          </span>
+        </div>
+        <div css={sharedDriveUploadStatusPopupHeaderActionsStyles}>
+          {upload.canCancel && (
             <button
               type="button"
-              css={sharedDriveUploadStatusPopupToggleStyles}
-              aria-label={toggleLabel}
-              aria-expanded={isExpanded}
-              aria-controls={statusRowId}
-              data-uie-name="shared-drive-upload-status-toggle"
-              onClick={onToggle}
+              css={sharedDriveUploadStatusPopupHeaderCancelStyles}
+              disabled={isCancelling}
+              data-uie-name="shared-drive-upload-header-cancel"
+              onClick={onCancel}
             >
-              <ChevronIcon
-                direction={isExpanded ? 'down' : 'up'}
-                css={sharedDriveUploadStatusPopupToggleIconStyles}
-                color="currentColor"
-                aria-hidden="true"
-              />
+              {cancelLabel}
             </button>
-          </div>
+          )}
+          <button
+            type="button"
+            css={sharedDriveUploadStatusPopupToggleStyles}
+            aria-label={toggleLabel}
+            aria-expanded={isExpanded}
+            aria-controls={statusRowId}
+            data-uie-name="shared-drive-upload-status-toggle"
+            onClick={onToggle}
+          >
+            <ChevronIcon
+              direction={isExpanded ? 'down' : 'up'}
+              css={sharedDriveUploadStatusPopupToggleIconStyles}
+              color="currentColor"
+              aria-hidden="true"
+            />
+          </button>
         </div>
-        {upload.kind === 'uploading' && (
-          <div css={sharedDriveUploadStatusPopupProgressStyles} data-uie-name="shared-drive-upload-progress" />
-        )}
       </div>
       <div
         id={statusRowId}
@@ -184,6 +178,12 @@ export const SharedDriveUploadStatusPopup = ({
           </button>
         )}
       </div>
+      {upload.kind === 'uploading' && (
+        <div
+          css={sharedDriveUploadStatusPopupProgressStyles(isExpanded)}
+          data-uie-name="shared-drive-upload-progress"
+        />
+      )}
     </div>
   );
 };

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.test.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {act, render, screen} from '@testing-library/react';
+import {act, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {UploadState} from 'Repositories/cells/upload';
 import type {SharedDriveUploadController} from './sharedDriveUploadController';
@@ -52,13 +52,14 @@ const failedState: UploadState = {
 type TestController = SharedDriveUploadController & {
   snapshots: jest.MockedFunction<SharedDriveUploadController['snapshots']>;
   subscribe: jest.MockedFunction<SharedDriveUploadController['subscribe']>;
+  cancel: jest.MockedFunction<SharedDriveUploadController['cancel']>;
 };
 
 const createController = (state: UploadState = uploadState): TestController => ({
   snapshots: jest.fn(scope => (scope === conversationQualifiedId ? [state] : [])),
   subscribe: jest.fn((_listener: () => void) => jest.fn()),
   upload: jest.fn(),
-  cancel: jest.fn(),
+  cancel: jest.fn(async (_uploadId: string): Promise<void> => undefined),
   retryUpload: jest.fn(),
   retryPublish: jest.fn(),
   discard: jest.fn(),
@@ -140,6 +141,66 @@ describe('SharedDriveUploadStatusPopupHost', () => {
 
     expect(view.getByRole('status')).toBeInTheDocument();
     expect(controller.snapshots).toHaveBeenCalledWith(conversationQualifiedId);
+  });
+
+  it('cancels the displayed upload and removes its status', async () => {
+    const user = userEvent.setup();
+    const controller = createController();
+    let state: UploadState = uploadState;
+    let notify: () => void = jest.fn();
+    controller.snapshots.mockImplementation(scope => (scope === conversationQualifiedId ? [state] : []));
+    controller.subscribe.mockImplementation(listener => {
+      notify = listener;
+      return jest.fn();
+    });
+    controller.cancel.mockImplementation(async uploadId => {
+      expect(uploadId).toBe('upload-1');
+      state = {...uploadState, kind: 'cancelled'};
+      act(() => notify());
+    });
+
+    const view = renderHost(controller, conversationQualifiedId);
+    await user.click(view.getByRole('button', {name: 'cells.uploadStatus.expand'}));
+    await user.click(view.getByRole('button', {name: 'conversationAssetUploadCancel'}));
+
+    expect(controller.cancel).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(view.queryByRole('status')).not.toBeInTheDocument());
+  });
+
+  it('re-enables cancellation when the command completes without changing the upload state', async () => {
+    const user = userEvent.setup();
+    const controller = createController();
+
+    const view = renderHost(controller, conversationQualifiedId);
+    await user.click(view.getByRole('button', {name: 'cells.uploadStatus.expand'}));
+    const cancel = view.getByRole('button', {name: 'conversationAssetUploadCancel'});
+    await user.click(cancel);
+
+    expect(controller.cancel).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(cancel).toBeEnabled());
+    expect(view.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('blocks a second cancellation while the first command is pending', async () => {
+    const user = userEvent.setup();
+    const controller = createController();
+    let resolveCancellation: () => void = jest.fn();
+    const cancellation = new Promise<void>(resolve => {
+      resolveCancellation = resolve;
+    });
+    controller.cancel.mockReturnValue(cancellation);
+
+    const view = renderHost(controller, conversationQualifiedId);
+    await user.click(view.getByRole('button', {name: 'cells.uploadStatus.expand'}));
+    const cancel = view.getByRole('button', {name: 'conversationAssetUploadCancel'});
+    await user.click(cancel);
+    await user.click(cancel);
+
+    expect(controller.cancel).toHaveBeenCalledTimes(1);
+    expect(cancel).toBeDisabled();
+
+    await act(async () => resolveCancellation());
+    await waitFor(() => expect(cancel).toBeEnabled());
   });
 
   it('formats the source size in the expanded status copy', async () => {

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.test.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {act, render, screen, waitFor} from '@testing-library/react';
+import {act, render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {UploadState} from 'Repositories/cells/upload';
 import type {SharedDriveUploadController} from './sharedDriveUploadController';
@@ -160,8 +160,10 @@ describe('SharedDriveUploadStatusPopupHost', () => {
     });
 
     const view = renderHost(controller, conversationQualifiedId);
-    await user.click(view.getByRole('button', {name: 'cells.uploadStatus.expand'}));
-    await user.click(view.getByRole('button', {name: 'conversationAssetUploadCancel'}));
+    const cancel = within(view.getByTestId('shared-drive-upload-status-header')).getByRole('button', {
+      name: 'conversationAssetUploadCancel',
+    });
+    await user.click(cancel);
 
     expect(controller.cancel).toHaveBeenCalledTimes(1);
     await waitFor(() => expect(view.queryByRole('status')).not.toBeInTheDocument());
@@ -172,8 +174,9 @@ describe('SharedDriveUploadStatusPopupHost', () => {
     const controller = createController();
 
     const view = renderHost(controller, conversationQualifiedId);
-    await user.click(view.getByRole('button', {name: 'cells.uploadStatus.expand'}));
-    const cancel = view.getByRole('button', {name: 'conversationAssetUploadCancel'});
+    const cancel = within(view.getByTestId('shared-drive-upload-status-header')).getByRole('button', {
+      name: 'conversationAssetUploadCancel',
+    });
     await user.click(cancel);
 
     expect(controller.cancel).toHaveBeenCalledTimes(1);
@@ -191,8 +194,9 @@ describe('SharedDriveUploadStatusPopupHost', () => {
     controller.cancel.mockReturnValue(cancellation);
 
     const view = renderHost(controller, conversationQualifiedId);
-    await user.click(view.getByRole('button', {name: 'cells.uploadStatus.expand'}));
-    const cancel = view.getByRole('button', {name: 'conversationAssetUploadCancel'});
+    const cancel = within(view.getByTestId('shared-drive-upload-status-header')).getByRole('button', {
+      name: 'conversationAssetUploadCancel',
+    });
     await user.click(cancel);
     await user.click(cancel);
 

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.test.tsx
@@ -19,6 +19,7 @@
 
 import {act, render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {noop} from 'noop-esm';
 import type {UploadState} from 'Repositories/cells/upload';
 import type {SharedDriveUploadController} from './sharedDriveUploadController';
 import {SharedDriveUploadStatusPopupHost} from './sharedDriveUploadStatusPopupHost';
@@ -143,21 +144,10 @@ describe('SharedDriveUploadStatusPopupHost', () => {
     expect(controller.snapshots).toHaveBeenCalledWith(conversationQualifiedId);
   });
 
-  it('cancels the displayed upload and removes its status', async () => {
+  it('dismisses the popup immediately while cancellation is pending', async () => {
     const user = userEvent.setup();
     const controller = createController();
-    let state: UploadState = uploadState;
-    let notify: () => void = jest.fn();
-    controller.snapshots.mockImplementation(scope => (scope === conversationQualifiedId ? [state] : []));
-    controller.subscribe.mockImplementation(listener => {
-      notify = listener;
-      return jest.fn();
-    });
-    controller.cancel.mockImplementation(async uploadId => {
-      expect(uploadId).toBe('upload-1');
-      state = {...uploadState, kind: 'cancelled'};
-      act(() => notify());
-    });
+    controller.cancel.mockReturnValue(new Promise<void>(noop));
 
     const view = renderHost(controller, conversationQualifiedId);
     const cancel = within(view.getByTestId('shared-drive-upload-status-header')).getByRole('button', {
@@ -165,46 +155,24 @@ describe('SharedDriveUploadStatusPopupHost', () => {
     });
     await user.click(cancel);
 
-    expect(controller.cancel).toHaveBeenCalledTimes(1);
+    expect(controller.cancel).toHaveBeenCalledWith('upload-1');
+    expect(view.queryByRole('status')).not.toBeInTheDocument();
+    expect(view.queryByTestId('shared-drive-upload-status-popup')).not.toBeInTheDocument();
+  });
+
+  it('keeps the popup dismissed when cancellation fails', async () => {
+    const user = userEvent.setup();
+    const controller = createController();
+    controller.cancel.mockRejectedValue(new Error('cancellation failed'));
+
+    const view = renderHost(controller, conversationQualifiedId);
+    const cancel = within(view.getByTestId('shared-drive-upload-status-header')).getByRole('button', {
+      name: 'conversationAssetUploadCancel',
+    });
+    await user.click(cancel);
+
+    expect(controller.cancel).toHaveBeenCalledWith('upload-1');
     await waitFor(() => expect(view.queryByRole('status')).not.toBeInTheDocument());
-  });
-
-  it('re-enables cancellation when the command completes without changing the upload state', async () => {
-    const user = userEvent.setup();
-    const controller = createController();
-
-    const view = renderHost(controller, conversationQualifiedId);
-    const cancel = within(view.getByTestId('shared-drive-upload-status-header')).getByRole('button', {
-      name: 'conversationAssetUploadCancel',
-    });
-    await user.click(cancel);
-
-    expect(controller.cancel).toHaveBeenCalledTimes(1);
-    await waitFor(() => expect(cancel).toBeEnabled());
-    expect(view.getByRole('status')).toBeInTheDocument();
-  });
-
-  it('blocks a second cancellation while the first command is pending', async () => {
-    const user = userEvent.setup();
-    const controller = createController();
-    let resolveCancellation: () => void = jest.fn();
-    const cancellation = new Promise<void>(resolve => {
-      resolveCancellation = resolve;
-    });
-    controller.cancel.mockReturnValue(cancellation);
-
-    const view = renderHost(controller, conversationQualifiedId);
-    const cancel = within(view.getByTestId('shared-drive-upload-status-header')).getByRole('button', {
-      name: 'conversationAssetUploadCancel',
-    });
-    await user.click(cancel);
-    await user.click(cancel);
-
-    expect(controller.cancel).toHaveBeenCalledTimes(1);
-    expect(cancel).toBeDisabled();
-
-    await act(async () => resolveCancellation());
-    await waitFor(() => expect(cancel).toBeEnabled());
   });
 
   it('formats the source size in the expanded status copy', async () => {

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
@@ -28,6 +28,11 @@ import type {SharedDriveUploadController} from './sharedDriveUploadController';
 import {toSharedDriveUploadStatus, type SharedDriveUploadStatus} from './sharedDriveUploadStatus';
 import {SharedDriveUploadStatusPopup} from './sharedDriveUploadStatusPopup';
 
+type DismissedUpload = {
+  readonly conversationQualifiedId: string;
+  readonly uploadId: string;
+};
+
 interface SharedDriveUploadStatusPopupHostProps {
   readonly controller: SharedDriveUploadController;
   readonly conversationQualifiedId: string;
@@ -64,7 +69,13 @@ export const SharedDriveUploadStatusPopupHost = ({
   }));
   const [isExpanded, setIsExpanded] = useState(false);
   const [cancellingUploadId, setCancellingUploadId] = useState<Maybe<string>>(Maybe.nothing());
+  const [dismissedUpload, setDismissedUpload] = useState<Maybe<DismissedUpload>>(Maybe.nothing());
   const upload = status.conversationQualifiedId === conversationQualifiedId ? status.upload : readStatus();
+  const isUploadDismissed =
+    maybe.isJust(dismissedUpload) &&
+    dismissedUpload.value.conversationQualifiedId === conversationQualifiedId &&
+    upload !== null &&
+    dismissedUpload.value.uploadId === upload.uploadId;
 
   const cancelUpload = useCallback(
     (uploadId: string): void => {
@@ -72,6 +83,7 @@ export const SharedDriveUploadStatusPopupHost = ({
         return;
       }
 
+      setDismissedUpload(Maybe.just({conversationQualifiedId, uploadId}));
       setCancellingUploadId(Maybe.just(uploadId));
       const finishCancellation = () =>
         setCancellingUploadId(current =>
@@ -79,7 +91,7 @@ export const SharedDriveUploadStatusPopupHost = ({
         );
       void controller.cancel(uploadId).then(finishCancellation, finishCancellation);
     },
-    [cancellingUploadId, controller],
+    [cancellingUploadId, controller, conversationQualifiedId],
   );
 
   useEffect(() => {
@@ -88,7 +100,7 @@ export const SharedDriveUploadStatusPopupHost = ({
     return controller.subscribe(updateStatus);
   }, [controller, conversationQualifiedId, readStatus]);
 
-  if (!isEnabled || !isFileTabActive || !upload) {
+  if (!isEnabled || !isFileTabActive || !upload || isUploadDismissed) {
     return null;
   }
 

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
@@ -19,6 +19,8 @@
 
 import {useCallback, useEffect, useState} from 'react';
 
+import {Maybe, maybe} from 'true-myth';
+
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {formatBytes} from 'Util/util';
 
@@ -61,7 +63,24 @@ export const SharedDriveUploadStatusPopupHost = ({
     upload: readStatus(),
   }));
   const [isExpanded, setIsExpanded] = useState(false);
+  const [cancellingUploadId, setCancellingUploadId] = useState<Maybe<string>>(Maybe.nothing());
   const upload = status.conversationQualifiedId === conversationQualifiedId ? status.upload : readStatus();
+
+  const cancelUpload = useCallback(
+    (uploadId: string): void => {
+      if (maybe.isJust(cancellingUploadId)) {
+        return;
+      }
+
+      setCancellingUploadId(Maybe.just(uploadId));
+      const finishCancellation = () =>
+        setCancellingUploadId(current =>
+          maybe.isJust(current) && current.value === uploadId ? Maybe.nothing() : current,
+        );
+      void controller.cancel(uploadId).then(finishCancellation, finishCancellation);
+    },
+    [cancellingUploadId, controller],
+  );
 
   useEffect(() => {
     const updateStatus = () => setStatus({conversationQualifiedId, upload: readStatus()});
@@ -97,7 +116,10 @@ export const SharedDriveUploadStatusPopupHost = ({
       destination={translate('cells.uploadStatus.destination', {destination: translate('cells.sharedDrive.title')})}
       isExpanded={isExpanded}
       toggleLabel={translate(isExpanded ? 'cells.uploadStatus.collapse' : 'cells.uploadStatus.expand')}
+      cancelLabel={translate('conversationAssetUploadCancel')}
+      isCancelling={maybe.isJust(cancellingUploadId) && cancellingUploadId.value === upload.uploadId}
       onToggle={() => setIsExpanded(expanded => !expanded)}
+      onCancel={() => cancelUpload(upload.uploadId)}
     />
   );
 };

--- a/apps/webapp/src/script/repositories/cells/upload/process.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.test.ts
@@ -213,6 +213,17 @@ describe('createCellsUploadProcess', () => {
     ).toMatchObject({kind: 'cancelled'});
   });
 
+  it('does not publish a cancelled upload', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    await unwrap(fixture.process.cancel());
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+
+    expect((await fixture.process.publish()).isErr).toBe(true);
+    expect(fixture.published).toEqual([]);
+  });
+
   it('suppresses stale progress callbacks after a retry starts', async () => {
     const fixture = setup();
     const first = fixture.process.start();


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28302" title="WPB-28302" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28302</a>   [web] Add direct upload progress popup for Shared Drive (ui only)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


## Problem
Users cannot stop an accidental or no-longer-needed active Shared Drive upload. This wastes bandwidth and leaves them without control over the operation.

## Solution
Add a Cancel action for cancellable upload states, prevent duplicate cancellation while the command is pending, and ensure cancellation cannot publish the file.

## Demo

https://github.com/user-attachments/assets/d59957c4-f7fe-4e37-8b1f-6db7f6abc54d




https://wearezeta.atlassian.net/browse/WPB-28302

Also cover https://wearezeta.atlassian.net/browse/WPB-28303