### PR TITLE
feat: show precise Shared Drive upload progress [WPB-28302]

### DIFF
--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.test.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.test.ts
@@ -27,6 +27,7 @@ const state = (kind: string) => ({
   kind,
   identity: {uploadId: 'upload-1'},
   source,
+  ...(kind === 'uploading' ? {progress: 0, hasProgress: false} : {}),
 });
 
 describe('toSharedDriveUploadStatus', () => {
@@ -37,14 +38,32 @@ describe('toSharedDriveUploadStatus', () => {
       fileName: 'report.pdf',
       fileSize: 4,
       kind: 'uploading',
+      progress: 0,
+      hasProgress: false,
+      isTransferActive: kind === 'uploading',
       canCancel: true,
     });
   });
 
-  it.each(['draftReady', 'publishing'])('maps %s to uploading but marks it not cancellable', kind => {
+  it.each(['draftReady', 'publishing'])('maps %s to uploading but marks it not cancellable and indeterminate', kind => {
     expect(toSharedDriveUploadStatus(state(kind) as never, conversationQualifiedId)).toEqual(
-      expect.objectContaining({kind: 'uploading', canCancel: false}),
+      expect.objectContaining({
+        kind: 'uploading',
+        progress: 0,
+        hasProgress: false,
+        isTransferActive: false,
+        canCancel: false,
+      }),
     );
+  });
+
+  it('preserves determinate progress for an active upload', () => {
+    expect(
+      toSharedDriveUploadStatus(
+        {...state('uploading'), progress: 0.45, hasProgress: true} as never,
+        conversationQualifiedId,
+      ),
+    ).toEqual(expect.objectContaining({kind: 'uploading', progress: 0.45, hasProgress: true, isTransferActive: true}));
   });
 
   it('maps published to uploaded', () => {

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.ts
@@ -27,6 +27,9 @@ export type SharedDriveUploadStatus = {
   readonly fileName: string;
   readonly fileSize: number;
   readonly kind: SharedDriveUploadStatusKind;
+  readonly progress: number;
+  readonly hasProgress: boolean;
+  readonly isTransferActive: boolean;
   readonly canCancel: boolean;
 };
 
@@ -64,6 +67,9 @@ export const toSharedDriveUploadStatus = (
     fileName: state.source.name,
     fileSize: state.source.size,
     kind,
+    progress: state.kind === 'uploading' ? state.progress : 0,
+    hasProgress: state.kind === 'uploading' && state.hasProgress,
+    isTransferActive: state.kind === 'uploading',
     canCancel: state.kind === 'queued' || state.kind === 'uploading',
   };
 };

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
@@ -21,6 +21,8 @@ import type {CSSObject} from '@emotion/react';
 
 import type {SharedDriveUploadStatusKind} from './sharedDriveUploadStatus';
 
+const PROGRESS_PERCENTAGE_MAX = 100;
+
 export const sharedDriveUploadStatusPopupStyles: CSSObject = {
   position: 'absolute',
   right: 16,
@@ -157,14 +159,18 @@ export const sharedDriveUploadStatusPopupRowIconStyles: CSSObject = {
   flex: '0 0 auto',
 };
 
-export const sharedDriveUploadStatusPopupProgressStyles: CSSObject = {
+const sharedDriveUploadStatusPopupProgressBaseStyles: CSSObject = {
   position: 'absolute',
   bottom: 0,
   left: 3,
-  width: 'min(209px, calc(50% + 3px))',
   height: 3,
   overflow: 'hidden',
   backgroundColor: '#0667c8',
+};
+
+export const sharedDriveUploadStatusPopupProgressStyles: CSSObject = {
+  ...sharedDriveUploadStatusPopupProgressBaseStyles,
+  width: 'min(209px, calc(50% + 3px))',
   animation: 'shared-drive-upload-progress 1.5s ease-in-out infinite',
   '@keyframes shared-drive-upload-progress': {
     '0%': {transform: 'translateX(-100%)'},
@@ -174,3 +180,8 @@ export const sharedDriveUploadStatusPopupProgressStyles: CSSObject = {
     animation: 'none',
   },
 };
+
+export const sharedDriveUploadStatusPopupDeterminateProgressStyles = (progress: number): CSSObject => ({
+  ...sharedDriveUploadStatusPopupProgressBaseStyles,
+  width: `${progress * PROGRESS_PERCENTAGE_MAX}%`,
+});

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.test.tsx
@@ -30,6 +30,9 @@ const upload: SharedDriveUploadStatus = {
   fileName: 'report.pdf',
   fileSize: 4,
   kind: 'uploading',
+  progress: 0,
+  hasProgress: false,
+  isTransferActive: true,
   canCancel: true,
 };
 
@@ -37,7 +40,7 @@ const renderPopup = (kind: SharedDriveUploadStatus['kind'], isExpanded = false) 
   render(
     <ThemeProvider>
       <SharedDriveUploadStatusPopup
-        upload={{...upload, kind, canCancel: kind === 'uploading'}}
+        upload={{...upload, kind, isTransferActive: kind === 'uploading', canCancel: kind === 'uploading'}}
         title={`${kind} report.pdf`}
         statusLabel={
           kind === 'failed' ? 'Couldn’t upload file' : `${kind === 'uploading' ? 'Uploading' : 'Uploaded'} 4 KB`
@@ -61,6 +64,58 @@ describe('SharedDriveUploadStatusPopup', () => {
     expect(getByText('uploading report.pdf')).toBeInTheDocument();
     expect(getByText('to Shared Drive')).toBeInTheDocument();
     expect(getByTestId('shared-drive-upload-progress')).toBeInTheDocument();
+    const progress = getByRole('progressbar', {name: 'report.pdf'});
+    expect(progress).not.toHaveAttribute('aria-valuenow');
+    expect(progress).not.toHaveAttribute('aria-valuemin');
+    expect(progress).not.toHaveAttribute('aria-valuemax');
+  });
+
+  it('shows determinate progress with semantic values when progress is reported', () => {
+    render(
+      <ThemeProvider>
+        <SharedDriveUploadStatusPopup
+          upload={{...upload, progress: 0.45, hasProgress: true}}
+          title="Uploading report.pdf"
+          statusLabel="Uploading 4 B"
+          destination="to Shared Drive"
+          isExpanded={false}
+          toggleLabel="Expand upload details"
+          cancelLabel="Cancel"
+          isCancelling={false}
+          onToggle={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      </ThemeProvider>,
+    );
+
+    const progress = screen.getByRole('progressbar');
+    expect(progress).toHaveAttribute('aria-valuemin', '0');
+    expect(progress).toHaveAttribute('aria-valuemax', '100');
+    expect(progress).toHaveAttribute('aria-valuenow', '45');
+    expect(progress).toHaveStyle({width: '45%'});
+    expect(screen.getByTestId('shared-drive-upload-progress')).toBeInTheDocument();
+  });
+
+  it('does not show active progress for a queued upload', () => {
+    render(
+      <ThemeProvider>
+        <SharedDriveUploadStatusPopup
+          upload={{...upload, isTransferActive: false}}
+          title="Uploading report.pdf"
+          statusLabel="Uploading 4 B"
+          destination="to Shared Drive"
+          isExpanded={false}
+          toggleLabel="Expand upload details"
+          cancelLabel="Cancel"
+          isCancelling={false}
+          onToggle={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('shared-drive-upload-progress')).not.toBeInTheDocument();
   });
 
   it.each([

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
@@ -28,6 +28,7 @@ import type {SharedDriveUploadStatus} from './sharedDriveUploadStatus';
 import {
   sharedDriveUploadStatusPopupCancelStyles,
   sharedDriveUploadStatusPopupContentStyles,
+  sharedDriveUploadStatusPopupDeterminateProgressStyles,
   sharedDriveUploadStatusPopupDestinationStyles,
   sharedDriveUploadStatusPopupProgressStyles,
   sharedDriveUploadStatusPopupRowFileNameStyles,
@@ -41,6 +42,8 @@ import {
   sharedDriveUploadStatusPopupToggleIconStyles,
   sharedDriveUploadStatusPopupToggleStyles,
 } from './sharedDriveUploadStatusPopup.styles';
+
+const PROGRESS_PERCENTAGE_MAX = 100;
 
 interface SharedDriveUploadStatusPopupProps {
   readonly upload: SharedDriveUploadStatus;
@@ -162,9 +165,27 @@ export const SharedDriveUploadStatusPopup = ({
           </button>
         )}
       </div>
-      {upload.kind === 'uploading' && (
-        <div css={sharedDriveUploadStatusPopupProgressStyles} data-uie-name="shared-drive-upload-progress" />
-      )}
+      {upload.isTransferActive &&
+        (upload.hasProgress ? (
+          <div
+            role="progressbar"
+            aria-label={upload.fileName}
+            aria-valuemin={0}
+            aria-valuemax={PROGRESS_PERCENTAGE_MAX}
+            aria-valuenow={upload.progress * PROGRESS_PERCENTAGE_MAX}
+            css={sharedDriveUploadStatusPopupDeterminateProgressStyles(upload.progress)}
+            data-testid="shared-drive-upload-progress"
+            data-uie-name="shared-drive-upload-progress"
+          />
+        ) : (
+          <div
+            role="progressbar"
+            aria-label={upload.fileName}
+            css={sharedDriveUploadStatusPopupProgressStyles}
+            data-testid="shared-drive-upload-progress"
+            data-uie-name="shared-drive-upload-progress"
+          />
+        ))}
     </div>
   );
 };

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.test.tsx
@@ -37,6 +37,7 @@ const uploadState: UploadState = {
   identity: {uploadId: 'upload-1'},
   source: uploadSource,
   progress: 0,
+  hasProgress: false,
 };
 const uploadedState: UploadState = {
   kind: 'published',

--- a/apps/webapp/src/script/repositories/cells/upload/lifecycle.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/lifecycle.ts
@@ -29,7 +29,10 @@ export interface UploadingState {
   readonly kind: 'uploading';
   readonly identity: UploadIdentity;
   readonly source: UploadSource;
+  /** Last normalized progress reported by the current upload attempt. */
   readonly progress: number;
+  /** Whether the gateway has reported at least one progress event for this attempt. */
+  readonly hasProgress: boolean;
 }
 
 export interface DraftReadyState {

--- a/apps/webapp/src/script/repositories/cells/upload/process.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.test.ts
@@ -22,6 +22,7 @@ import type {Result} from 'true-myth';
 
 import type {CellsUploadGateway, CellsUploadGatewayError, UploadDraftRequest} from './gateway';
 import type {DraftIdentity, UploadSource} from './identity';
+import type {UploadState} from './lifecycle';
 import {createCellsUploadProcess, type CellsUploadProcessDependencies} from './process';
 
 const source: UploadSource = {blob: new Blob(['data']), name: 'file.txt', contentType: 'text/plain', size: 4};
@@ -126,16 +127,47 @@ const unwrap = async <T, E>(promise: PromiseLike<{isOk: boolean; value?: T; erro
 };
 
 describe('createCellsUploadProcess', () => {
-  it('uploads successfully and emits ordered snapshots', async () => {
+  it('uploads successfully and reports initial, intermediate, and complete progress in order', async () => {
     const fixture = setup();
-    const snapshots: string[] = [];
-    const subscription = fixture.process.subscribe(snapshot => snapshots.push(snapshot.kind));
+    const snapshots: UploadState[] = [];
+    const subscription = fixture.process.subscribe(snapshot => snapshots.push(snapshot));
     expect(subscription.isOk).toBe(true);
     const start = fixture.process.start();
+    expect(fixture.process.snapshot()).toMatchObject({value: {kind: 'uploading', progress: 0, hasProgress: false}});
+    required(fixture.uploads[0]).onProgress(0);
     required(fixture.uploads[0]).onProgress(0.25);
+    required(fixture.uploads[0]).onProgress(1);
     required(fixture.uploadTasks[0]).resolve(undefined);
     await unwrap(start);
-    expect(snapshots).toEqual(['queued', 'uploading', 'uploading', 'draftReady']);
+    expect(snapshots.map(snapshot => snapshot.kind)).toEqual([
+      'queued',
+      'uploading',
+      'uploading',
+      'uploading',
+      'uploading',
+      'draftReady',
+    ]);
+    expect(snapshots[1]).toMatchObject({progress: 0, hasProgress: false});
+    expect(snapshots[2]).toMatchObject({progress: 0, hasProgress: true});
+    expect(snapshots[3]).toMatchObject({progress: 0.25, hasProgress: true});
+    expect(snapshots[4]).toMatchObject({progress: 1, hasProgress: true});
+  });
+
+  it('clamps invalid progress and ignores an out-of-order update', async () => {
+    const fixture = setup();
+    const start = fixture.process.start();
+    const request = required(fixture.uploads[0]);
+
+    request.onProgress(-1);
+    expect(fixture.process.snapshot()).toMatchObject({value: {progress: 0, hasProgress: true}});
+    request.onProgress(0.8);
+    request.onProgress(0.4);
+    expect(fixture.process.snapshot()).toMatchObject({value: {progress: 0.8, hasProgress: true}});
+    request.onProgress(2);
+    expect(fixture.process.snapshot()).toMatchObject({value: {progress: 1, hasProgress: true}});
+
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
   });
 
   it('uses the repository-returned remote identity after upload', async () => {

--- a/apps/webapp/src/script/repositories/cells/upload/transition.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/transition.test.ts
@@ -15,7 +15,7 @@ import {normalizeProgress, transition} from './transition';
 
 const source = {blob: new Blob(['content']), name: 'file.txt', contentType: 'text/plain', size: 7};
 const queued: UploadState = {kind: 'queued', identity: {uploadId: 'upload-1'}, source};
-const uploading: UploadState = {...queued, kind: 'uploading', progress: 0};
+const uploading: UploadState = {...queued, kind: 'uploading', progress: 0, hasProgress: false};
 const draftReady: UploadState = {
   kind: 'draftReady',
   identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
@@ -92,14 +92,43 @@ describe('transition', () => {
     expect(expectSuccess(state, action).kind).toBe(expected);
   });
 
-  it('normalizes progress while uploading and ignores it outside active upload', () => {
+  it('starts without determinate progress until the gateway reports it', () => {
+    expect(expectSuccess(queued, {type: 'startUpload'})).toMatchObject({
+      kind: 'uploading',
+      progress: 0,
+      hasProgress: false,
+    });
+  });
+
+  it('normalizes and marks progress while uploading and ignores it outside active upload', () => {
     expect(expectSuccess(uploading, {type: 'progress', progress: 0.5})).toMatchObject({
       kind: 'uploading',
       progress: 0.5,
+      hasProgress: true,
     });
     const result = transition(draftReady, {type: 'progress', progress: 0.8});
     expect(resultModule.isOk(result)).toBe(true);
     expect(resultModule.isOk(result) && result.value).toBe(draftReady);
+  });
+
+  it.each([
+    {reported: -0.5, expected: 0},
+    {reported: 1.5, expected: 1},
+    {reported: Number.NaN, expected: 0},
+  ])('clamps invalid progress $reported to $expected', ({reported, expected}) => {
+    expect(expectSuccess(uploading, {type: 'progress', progress: reported})).toMatchObject({
+      progress: expected,
+      hasProgress: true,
+    });
+  });
+
+  it('does not move progress backwards within an attempt', () => {
+    const intermediate = expectSuccess(uploading, {type: 'progress', progress: 0.75});
+
+    expect(expectSuccess(intermediate, {type: 'progress', progress: 0.25})).toMatchObject({
+      progress: 0.75,
+      hasProgress: true,
+    });
   });
 
   it('preserves upload and draft identities across transitions', () => {

--- a/apps/webapp/src/script/repositories/cells/upload/transition.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/transition.ts
@@ -39,6 +39,7 @@ const transitionFromQueued = (state: Extract<UploadState, {kind: 'queued'}>, act
       identity: state.identity,
       source: state.source,
       progress: 0,
+      hasProgress: false,
     });
   }
 
@@ -55,7 +56,12 @@ const transitionFromQueued = (state: Extract<UploadState, {kind: 'queued'}>, act
 
 const transitionFromUploading = (state: Extract<UploadState, {kind: 'uploading'}>, action: UploadAction) => {
   if (action.type === 'progress') {
-    return Result.ok<UploadState, UploadLifecycleError>({...state, progress: normalizeProgress(action.progress)});
+    const progress = normalizeProgress(action.progress);
+    return Result.ok<UploadState, UploadLifecycleError>({
+      ...state,
+      progress: Math.max(state.progress, progress),
+      hasProgress: true,
+    });
   }
 
   if (action.type === 'uploadSucceeded') {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28302" title="WPB-28302" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28302</a>   [web] Add direct upload progress popup for Shared Drive (ui only)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem
Indeterminate upload status does not show whether a large Shared Drive upload is advancing or stalled.

## Solution
Use lifecycle-owned Cells progress to render accessible determinate progress while preserving an indeterminate fallback when no progress has been reported. Clamp invalid values and prevent progress from moving backward within an upload attempt.

https://wearezeta.atlassian.net/browse/WPB-28302