### PR TITLE
Prefer the Desktop regional locale for date formatting [WPB-28427]

### DIFF
--- a/apps/webapp/src/script/localization/Localizer.test.ts
+++ b/apps/webapp/src/script/localization/Localizer.test.ts
@@ -22,37 +22,37 @@ import {resolveApplicationLocale} from './Localizer';
 describe('resolveApplicationLocale', (): void => {
   it.each([
     {
-      browserRegionalLocale: 'en-US',
+      browserLocale: 'en-US',
       desktopRegionalLocale: 'de-DE',
       expectedApplicationLanguage: 'en',
       expectedRegionalDateLocale: 'de-DE',
       queryParameter: undefined,
     },
     {
-      browserRegionalLocale: 'en-GB',
+      browserLocale: 'en-GB',
       desktopRegionalLocale: undefined,
       expectedApplicationLanguage: 'en',
       expectedRegionalDateLocale: 'en-GB',
       queryParameter: undefined,
     },
     {
-      browserRegionalLocale: 'en-US',
+      browserLocale: 'en-US',
       desktopRegionalLocale: 'en-GB',
       expectedApplicationLanguage: 'de',
       expectedRegionalDateLocale: 'en-GB',
       queryParameter: 'de',
     },
     {
-      browserRegionalLocale: 'en-GB',
+      browserLocale: 'en-GB',
       desktopRegionalLocale: '',
       expectedApplicationLanguage: 'en',
       expectedRegionalDateLocale: 'en-GB',
       queryParameter: undefined,
     },
   ])(
-    'resolves application and regional locales independently for $browserRegionalLocale',
+    'resolves application and regional locales independently for $browserLocale',
     ({
-      browserRegionalLocale,
+      browserLocale,
       desktopRegionalLocale,
       expectedApplicationLanguage,
       expectedRegionalDateLocale,
@@ -61,7 +61,7 @@ describe('resolveApplicationLocale', (): void => {
       const actualLocaleSettings = resolveApplicationLocale({
         queryParameter,
         storedLocale: undefined,
-        browserRegionalLocale,
+        browserLocale,
         desktopRegionalLocale,
       });
 

--- a/apps/webapp/src/script/localization/Localizer.test.ts
+++ b/apps/webapp/src/script/localization/Localizer.test.ts
@@ -21,16 +21,48 @@ import {resolveApplicationLocale} from './Localizer';
 
 describe('resolveApplicationLocale', (): void => {
   it.each([
-    {browserRegionalLocale: 'en-GB', expectedApplicationLanguage: 'en', expectedRegionalDateLocale: 'en-GB'},
-    {browserRegionalLocale: 'en-US', expectedApplicationLanguage: 'en', expectedRegionalDateLocale: 'en-US'},
-    {browserRegionalLocale: 'de-DE', expectedApplicationLanguage: 'de', expectedRegionalDateLocale: 'de-DE'},
+    {
+      browserRegionalLocale: 'en-US',
+      desktopRegionalLocale: 'de-DE',
+      expectedApplicationLanguage: 'en',
+      expectedRegionalDateLocale: 'de-DE',
+      queryParameter: undefined,
+    },
+    {
+      browserRegionalLocale: 'en-GB',
+      desktopRegionalLocale: undefined,
+      expectedApplicationLanguage: 'en',
+      expectedRegionalDateLocale: 'en-GB',
+      queryParameter: undefined,
+    },
+    {
+      browserRegionalLocale: 'en-US',
+      desktopRegionalLocale: 'en-GB',
+      expectedApplicationLanguage: 'de',
+      expectedRegionalDateLocale: 'en-GB',
+      queryParameter: 'de',
+    },
+    {
+      browserRegionalLocale: 'en-GB',
+      desktopRegionalLocale: '',
+      expectedApplicationLanguage: 'en',
+      expectedRegionalDateLocale: 'en-GB',
+      queryParameter: undefined,
+    },
   ])(
-    'keeps the application language and regional locale separate for $browserRegionalLocale',
-    ({browserRegionalLocale, expectedApplicationLanguage, expectedRegionalDateLocale}): void => {
+    'resolves application and regional locales independently for $browserRegionalLocale',
+    ({
+      browserRegionalLocale,
+      desktopRegionalLocale,
+      expectedApplicationLanguage,
+      expectedRegionalDateLocale,
+      queryParameter,
+    }): void => {
       const actualLocaleSettings = resolveApplicationLocale({
-        queryParameter: undefined,
+        queryParameter,
         storedLocale: undefined,
         browserRegionalLocale,
+        desktopRegionalLocale,
       });
 
       expect(actualLocaleSettings.applicationTranslationLanguage).toBe(expectedApplicationLanguage);

--- a/apps/webapp/src/script/localization/Localizer.test.ts
+++ b/apps/webapp/src/script/localization/Localizer.test.ts
@@ -36,6 +36,13 @@ describe('resolveApplicationLocale', (): void => {
       queryParameter: undefined,
     },
     {
+      browserLocale: 'de-DE',
+      desktopRegionalLocale: undefined,
+      expectedApplicationLanguage: 'de',
+      expectedRegionalDateLocale: 'de-DE',
+      queryParameter: undefined,
+    },
+    {
       browserLocale: 'en-US',
       desktopRegionalLocale: 'en-GB',
       expectedApplicationLanguage: 'de',

--- a/apps/webapp/src/script/localization/Localizer.ts
+++ b/apps/webapp/src/script/localization/Localizer.ts
@@ -49,6 +49,7 @@ import {setDateLocale, setRegionalDateLocale} from 'Util/timeUtil';
 import {getParameter} from 'Util/urlUtil';
 
 import {URLParameter} from '../auth/urlParameter';
+import {Config} from '../Config';
 
 const strings = {
   cs,
@@ -84,6 +85,7 @@ export type ApplicationLocaleResolutionInput = {
   queryParameter: unknown;
   storedLocale: unknown;
   browserRegionalLocale: string;
+  desktopRegionalLocale?: string;
 };
 
 export type ApplicationLocaleSettings = {
@@ -112,15 +114,20 @@ export function resolveApplicationLocale(input: ApplicationLocaleResolutionInput
     applicationTranslationLanguage = selectedLanguage;
   }
 
+  const regionalDateLocale = isNonEmptyString(input.desktopRegionalLocale)
+    ? input.desktopRegionalLocale
+    : input.browserRegionalLocale;
+
   return {
     applicationTranslationLanguage,
-    regionalDateLocale: input.browserRegionalLocale,
+    regionalDateLocale,
   };
 }
 
 export function setAppLocale(): void {
   const queryParam = getParameter(URLParameter.LOCALE);
   const currentBrowserRegionalLocale = navigator.language;
+  const desktopRegionalLocale = Config.getDesktopConfig()?.regionalLocale;
 
   if (isNonEmptyString(queryParam)) {
     storeValue(StorageKey.LOCALIZATION.LOCALE, queryParam);
@@ -131,6 +138,7 @@ export function setAppLocale(): void {
     queryParameter: queryParam,
     storedLocale,
     browserRegionalLocale: currentBrowserRegionalLocale,
+    desktopRegionalLocale,
   });
   const {applicationTranslationLanguage, regionalDateLocale} = resolvedLocaleSettings;
 

--- a/apps/webapp/src/script/localization/Localizer.ts
+++ b/apps/webapp/src/script/localization/Localizer.ts
@@ -82,10 +82,10 @@ setStrings(strings);
 type ApplicationTranslationLanguage = keyof typeof strings;
 
 export type ApplicationLocaleResolutionInput = {
+  browserLocale: string;
+  desktopRegionalLocale: unknown;
   queryParameter: unknown;
   storedLocale: unknown;
-  browserRegionalLocale: string;
-  desktopRegionalLocale?: string;
 };
 
 export type ApplicationLocaleSettings = {
@@ -98,7 +98,7 @@ function isApplicationTranslationLanguage(value: string): value is ApplicationTr
 }
 
 export function resolveApplicationLocale(input: ApplicationLocaleResolutionInput): ApplicationLocaleSettings {
-  const browserLanguage = input.browserRegionalLocale.split('-')[0];
+  const browserLanguage = input.browserLocale.split('-')[0];
   let selectedLanguage: string = DEFAULT_LOCALE;
 
   if (isNonEmptyString(input.queryParameter)) {
@@ -116,7 +116,7 @@ export function resolveApplicationLocale(input: ApplicationLocaleResolutionInput
 
   const regionalDateLocale = isNonEmptyString(input.desktopRegionalLocale)
     ? input.desktopRegionalLocale
-    : input.browserRegionalLocale;
+    : input.browserLocale;
 
   return {
     applicationTranslationLanguage,
@@ -126,7 +126,7 @@ export function resolveApplicationLocale(input: ApplicationLocaleResolutionInput
 
 export function setAppLocale(): void {
   const queryParam = getParameter(URLParameter.LOCALE);
-  const currentBrowserRegionalLocale = navigator.language;
+  const browserLocale = navigator.language;
   const desktopRegionalLocale = Config.getDesktopConfig()?.regionalLocale;
 
   if (isNonEmptyString(queryParam)) {
@@ -137,7 +137,7 @@ export function setAppLocale(): void {
   const resolvedLocaleSettings = resolveApplicationLocale({
     queryParameter: queryParam,
     storedLocale,
-    browserRegionalLocale: currentBrowserRegionalLocale,
+    browserLocale,
     desktopRegionalLocale,
   });
   const {applicationTranslationLanguage, regionalDateLocale} = resolvedLocaleSettings;

--- a/apps/webapp/src/script/repositories/conversation/linkPreviews/index.ts
+++ b/apps/webapp/src/script/repositories/conversation/linkPreviews/index.ts
@@ -51,12 +51,6 @@ type LinkPreviewContent = {
 declare global {
   interface Window {
     openGraphAsync?: (url: string) => Promise<OpenGraphResult>;
-    desktopAppConfig?: {
-      version: string;
-      supportsCallingPopoutWindow?: boolean;
-      supportsWebViewRefresh?: boolean;
-      managedConfig?: {applockOverride: boolean};
-    };
   }
 }
 const logger = getLogger('LinkPreviewRepository');

--- a/apps/webapp/src/types/window.d.ts
+++ b/apps/webapp/src/types/window.d.ts
@@ -33,6 +33,13 @@ declare global {
     wire: WireModule;
     amplify: amplify.Static;
     showOpenFilePicker: () => Promise<FileSystemFileHandle[]>;
+    desktopAppConfig?: {
+      version: string;
+      regionalLocale?: string;
+      supportsCallingPopoutWindow?: boolean;
+      supportsWebViewRefresh?: boolean;
+      managedConfig?: {applockOverride: boolean};
+    };
     z: any;
   }
 


### PR DESCRIPTION



<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28427" title="WPB-28427" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28427</a>  [Web] Message timestamp tooltip ignores the regional date format
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->



Use the regional locale provided by Wire Desktop when formatting numeric dates.

#22347 fixed browser date formatting by preserving the full browser locale instead of reducing values such as `en-GB` to `en`. However, `navigator.language` does not necessarily represent the operating system's regional settings in Wire Desktop.

The paired Desktop change in https://github.com/wireapp/wire-desktop/pull/9738 exposes Electron's system regional locale through:

`window.desktopAppConfig.regionalLocale`

The WebApp now prefers this value when available and falls back to `navigator.language` for normal browsers and older Desktop versions.