### PR TITLE
fix: text overflow for admin permission help text during conversation creation(WPB-28435)

### DIFF
--- a/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/CreateConversationSteps.styles.ts
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/CreateConversationSteps/CreateConversationSteps.styles.ts
@@ -20,12 +20,19 @@
 import {CSSObject} from '@emotion/react';
 
 export const createConversationStepWrapperCss: CSSObject = {
-  height: '456px',
+  height: '480px',
+  minHeight: 0,
+  overflow: 'hidden',
 };
 
 export const createConversationStepRightContainerCss: CSSObject = {
-  margin: '1rem 1.5rem',
+  boxSizing: 'border-box',
   flex: 1,
+  maxHeight: '100%',
+  minHeight: 0,
+  overflowX: 'hidden',
+  overflowY: 'auto',
+  padding: '1rem 1.5rem',
 };
 
 export const participantsSelectionSearchCss = {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28435" title="WPB-28435" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28435</a>  The DE version for permissions during a group creation is broken
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

The DE version for permissions during a group creation is broken

<img width="1512" height="982" alt="Screenshot 2026-09-03 at 10 36 34" src="https://github.com/user-attachments/assets/a92eb400-9edf-4c2c-9002-2fa1517bf2fa" />

<img width="1512" height="982" alt="Screenshot 2026-09-03 at 16 59 16" src="https://github.com/user-attachments/assets/87ed8a27-3a2c-446c-8ae9-6ef03dd7d149" />

