### PR TITLE
Increase Elastic Beanstalk deployment timeout [WPB-26469]

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -259,7 +259,7 @@ jobs:
           deployment-package-path: edge-artifact/ebs.zip
           wait-for-deployment: true
           wait-for-environment-recovery: true
-          deployment-timeout: 150
+          deployment-timeout: 300
           use-existing-application-version-if-available: true
 
       - name: Summarize Edge deployment
@@ -406,7 +406,7 @@ jobs:
           deployment-package-path: dev-artifact/ebs.zip
           wait-for-deployment: true
           wait-for-environment-recovery: true
-          deployment-timeout: 150
+          deployment-timeout: 300
           use-existing-application-version-if-available: true
 
       - name: Verify Hosted Dev runtime


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Increase the Elastic Beanstalk deployment timeout for Edge and Hosted Dev from 150 to 300 seconds. The Edge deployment [timed out](https://github.com/wireapp/wire-webapp/actions/runs/33838952921) while both instances were still updating. The artifact build, AWS authentication, upload and Hosted Dev deployment all succeeded.

This gives Elastic Beanstalk deployments more time to complete without changing the existing deployment or environment-recovery checks.