### PR TITLE
fix: align shared drive drop file type checks with conversation file upload(WPB-28291)

### DIFF
--- a/apps/webapp/src/script/components/conversation/conversationCells/useSharedDriveFileDrop.test.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/useSharedDriveFileDrop.test.ts
@@ -90,12 +90,64 @@ describe('useSharedDriveFileDrop', () => {
     );
   });
 
-  it('starts upload for a dropped file that is allowed by the restrictive upload extension config', async () => {
+  it.each([
+    ['document.pdf', 'application/pdf'],
+    ['archive.zip', 'application/zip'],
+    ['report.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+  ])('starts upload for a dropped %s file allowed by the upload extension config', async (fileName, fileType) => {
+    jest.spyOn(Config, 'getConfig').mockReturnValue({
+      ...defaultConfiguration,
+      FEATURE: {
+        ...defaultConfiguration.FEATURE,
+        ALLOWED_FILE_UPLOAD_EXTENSIONS: ['.pdf', '.zip', '.docx'],
+      },
+    });
     const fireAndForgetInvoker = createFireAndForgetInvoker();
     const sharedDriveUploadController = createSharedDriveUploadController();
     const showFileDropzoneError = jest.fn();
     const onRefresh = jest.fn();
-    const file = new File(['content'], 'document.pdf', {type: 'application/pdf'});
+    const file = new File(['content'], fileName, {type: fileType});
+    const {result} = renderHook(() =>
+      useSharedDriveFileDrop({
+        conversationQualifiedId,
+        fireAndForgetInvoker,
+        isInRecycleBin: false,
+        isUploadFilesEnabled: true,
+        onRefresh,
+        sharedDriveUploadController,
+        showFileDropzoneError,
+        translate: translateForTest,
+        uploadPath,
+      }),
+    );
+
+    act(() => result.current([file]));
+
+    expect(showFileDropzoneError).not.toHaveBeenCalled();
+    expect(fireAndForgetInvoker.fireAndForget).toHaveBeenCalledTimes(1);
+    const uploadAction = jest.mocked(fireAndForgetInvoker.fireAndForget).mock.calls[0][0];
+    await uploadAction();
+    expect(sharedDriveUploadController.upload).toHaveBeenCalledWith(
+      [file],
+      uploadPath,
+      onRefresh,
+      conversationQualifiedId,
+    );
+  });
+
+  it('starts upload for any dropped file when the upload extension config allows all files', async () => {
+    jest.spyOn(Config, 'getConfig').mockReturnValue({
+      ...defaultConfiguration,
+      FEATURE: {
+        ...defaultConfiguration.FEATURE,
+        ALLOWED_FILE_UPLOAD_EXTENSIONS: ['*'],
+      },
+    });
+    const fireAndForgetInvoker = createFireAndForgetInvoker();
+    const sharedDriveUploadController = createSharedDriveUploadController();
+    const showFileDropzoneError = jest.fn();
+    const onRefresh = jest.fn();
+    const file = new File(['content'], 'installer.exe', {type: 'application/octet-stream'});
     const {result} = renderHook(() =>
       useSharedDriveFileDrop({
         conversationQualifiedId,

--- a/apps/webapp/src/script/components/conversation/conversationCells/useSharedDriveFileDrop.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/useSharedDriveFileDrop.ts
@@ -22,7 +22,7 @@ import {useCallback} from 'react';
 import type {FireAndForgetInvoker} from '@wireapp/core';
 
 import {Config} from 'src/script/Config';
-import {isAllowedFile} from 'Util/fileTypeUtil';
+import {allowsAllFiles, hasAllowedExtension} from 'Util/fileTypeUtil';
 import type {Translate} from 'Util/localizerUtil';
 
 import {getSharedDriveDropRejectionFeedback, handleSharedDriveDroppedFiles} from './sharedDriveDrop';
@@ -62,7 +62,7 @@ export const useSharedDriveFileDrop = ({
       handleSharedDriveDroppedFiles(files, {
         conversationQualifiedId,
         fireAndForgetInvoker,
-        isAcceptedFile: file => isAllowedFile(file.name, file.type),
+        isAcceptedFile: file => allowsAllFiles() || hasAllowedExtension(file.name),
         isInRecycleBin,
         isUploadFilesEnabled,
         maxFileSize: CONFIG.MAXIMUM_ASSET_FILE_SIZE_CELLS,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28291" title="WPB-28291" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28291</a>  [web] Add drag and drop support for single file upload in root
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Aligns Shared Drive drag/drop file acceptance with conversation file upload rules.
- Uses `allowsAllFiles() || hasAllowedExtension(file.name)` for dropped files.
- Adds tests for restrictive extension configs across `.pdf`, `.zip`, and `.docx`.
- Adds coverage for wildcard `*` configs allowing any dropped file.