### PR TITLE
Fix user list role reactivity [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/userList/userList.test.tsx
+++ b/apps/webapp/src/script/components/userList/userList.test.tsx
@@ -19,10 +19,13 @@
 
 import React from 'react';
 
-import {fireEvent, render} from '@testing-library/react';
+import {DefaultConversationRoleName} from '@wireapp/api-client/lib/conversation/';
+import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
+import {act, fireEvent, render, waitFor} from '@testing-library/react';
 
 import {UserList} from 'Components/userList/userList';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
+import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {translateForTest} from 'Util/test/translateForTest';
 import {
@@ -39,14 +42,15 @@ const rootProviderWrapper = createRootProviderWrapperForTest(
   createRootContextValueForTest({translate: translateForTest}),
 );
 
-beforeAll(() => {
-  testFactory.exposeConversationActors().then(factory => {
-    conversationRepository = factory;
-    return conversationRepository;
-  });
+beforeAll(async () => {
+  conversationRepository = await testFactory.exposeConversationActors();
 });
 
 describe('UserList', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('lists all selected users', () => {
     const user = new User('test-id', '', translateForTest);
     user.isMe = true;
@@ -94,5 +98,37 @@ describe('UserList', () => {
     expect(contactsList).toHaveLength(4);
     fireEvent.click(contactsList[0]);
     expect(mockOnSelectUser).toHaveBeenCalledWith(users[0]);
+  });
+
+  it('moves a user to the admins list when their conversation role changes', async () => {
+    const selfUser = new User('self-id', '', translateForTest);
+    selfUser.isMe = true;
+
+    const user = new User('member-id', '', translateForTest);
+    const conversation = new Conversation('conversation-id', '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
+    const userListProperties = {
+      conversation,
+      conversationRepository,
+      selfUser,
+      users: [user],
+    };
+
+    const {getByTestId, queryByTestId} = render(withTheme(<UserList {...userListProperties} />), {
+      wrapper: rootProviderWrapper,
+    });
+    const membersList = getByTestId('list-members');
+    expect(membersList).toContainElement(getByTestId('item-user'));
+
+    act(() => {
+      conversation.roles({
+        [user.id]: DefaultConversationRoleName.WIRE_ADMIN,
+      });
+    });
+
+    await waitFor(() => {
+      const adminsList = getByTestId('list-admins');
+      expect(adminsList).toContainElement(getByTestId('item-user'));
+      expect(queryByTestId('list-members')).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/webapp/src/script/components/userList/userList.tsx
+++ b/apps/webapp/src/script/components/userList/userList.tsx
@@ -17,9 +17,10 @@
  *
  */
 
-import {ChangeEvent, useCallback, useId, useMemo, useState} from 'react';
+import {ChangeEvent, Fragment, useCallback, useId, useMemo, useState} from 'react';
+import type {ReactNode} from 'react';
 
-import {isUndefined} from '@sindresorhus/is';
+import {isEmptyArray, isNonEmptyArray, isUndefined} from '@sindresorhus/is';
 import cx from 'classnames';
 import {container} from 'tsyringe';
 
@@ -177,77 +178,23 @@ export const UserList = ({
     ],
   );
 
-  const adminsHeaderId = useId();
-  const membersHeaderId = useId();
   let content;
 
   const showRoles = !isUndefined(conversation);
   if (showRoles) {
-    let members: User[] = [];
-    let admins: User[] = [];
-    let adminCount = 0;
-    let memberCount = 0;
-
-    filteredUsers.forEach((userEntity: User) => {
-      if (userEntity.isService) {
-        return;
-      }
-      if (conversationRepository?.conversationRoleRepository.isUserGroupAdmin(conversation, userEntity) === true) {
-        admins.push(userEntity);
-      } else {
-        members.push(userEntity);
-      }
-    });
-    adminCount = admins.length;
-    memberCount = members.length;
-
-    if (truncate && admins.length + members.length > maxVisibleUsers) {
-      admins = admins.slice(0, reducedUserCount);
-      members = members.slice(0, reducedUserCount - admins.length);
-    }
-
     content = (
-      <>
-        {(admins.length > 0 || showEmptyAdmin) && (
-          <>
-            <h3 id={adminsHeaderId} className="user-list__header" data-uie-name="label-conversation-admins">
-              {translate('searchListAdmins', {count: adminCount})}
-            </h3>
-
-            {admins.length > 0 && (
-              <ul
-                className={cx('search-list', cssClasses)}
-                data-uie-name="list-admins"
-                aria-labelledby={adminsHeaderId}
-              >
-                {admins.slice(0, maxShownUsers).map(user => renderListItem(user))}
-              </ul>
-            )}
-
-            {!(admins.length > 0) && (
-              <div className="user-list__no-admin" data-uie-name="status-no-admins">
-                {translate('searchListNoAdmins')}
-              </div>
-            )}
-          </>
-        )}
-
-        {members.length > 0 && maxShownUsers > admins.length && (
-          <>
-            <h3 id={membersHeaderId} className="user-list__header" data-uie-name="label-conversation-members">
-              {translate('searchListMembers', {count: memberCount})}
-            </h3>
-
-            <ul
-              className={cx('search-list', cssClasses)}
-              data-uie-name="list-members"
-              aria-labelledby={membersHeaderId}
-            >
-              {members.slice(0, maxShownUsers - admins.length).map(user => renderListItem(user))}
-            </ul>
-          </>
-        )}
-      </>
+      <ConversationUserList
+        conversation={conversation}
+        conversationRepository={conversationRepository}
+        filteredUsers={filteredUsers}
+        maxShownUsers={maxShownUsers}
+        maxVisibleUsers={maxVisibleUsers}
+        mode={mode}
+        reducedUserCount={reducedUserCount}
+        renderListItem={renderListItem}
+        showEmptyAdmin={showEmptyAdmin}
+        truncate={truncate}
+      />
     );
   } else {
     const truncatedUsers = truncate ? filteredUsers.slice(0, reducedUserCount) : filteredUsers;
@@ -268,9 +215,9 @@ export const UserList = ({
     const unselectedUsers = truncatedUsers.slice(0, maxShownUsers).filter(user => !isSelected(user));
 
     content = (
-      <>
+      <Fragment>
         {isSelectable && hasSelectedUsers && (
-          <>
+          <Fragment>
             <button
               onClick={() => toggleFolder(UserListSections.SELECTED_CONTACTS)}
               css={collapseButton}
@@ -295,7 +242,7 @@ export const UserList = ({
                   return renderListItem(user, isLastItem);
                 })}
             </ul>
-          </>
+          </Fragment>
         )}
 
         {isSelectable && (
@@ -320,13 +267,12 @@ export const UserList = ({
               return renderListItem(user, isLastItem);
             })}
         </ul>
-      </>
+      </Fragment>
     );
   }
 
   return (
-    <>
-      {!isUndefined(conversation) && <ConversationRolesSubscription conversation={conversation} />}
+    <Fragment>
       {content}
 
       {hasMoreUsers && (
@@ -336,12 +282,102 @@ export const UserList = ({
           style={{height: 10, transform: 'translateY(-60px)', width: 10}}
         />
       )}
-    </>
+    </Fragment>
   );
 };
 
-function ConversationRolesSubscription({conversation}: {conversation: Conversation}): null {
+interface ConversationUserListProps {
+  conversation: Conversation;
+  conversationRepository?: ConversationRepository;
+  filteredUsers: User[];
+  maxShownUsers: number;
+  maxVisibleUsers: number;
+  mode: UserlistMode;
+  reducedUserCount: number;
+  renderListItem: (user: User) => ReactNode;
+  showEmptyAdmin: boolean;
+  truncate: boolean;
+}
+
+function ConversationUserList({
+  conversation,
+  conversationRepository,
+  filteredUsers,
+  maxShownUsers,
+  maxVisibleUsers,
+  mode,
+  reducedUserCount,
+  renderListItem,
+  showEmptyAdmin,
+  truncate,
+}: ConversationUserListProps): ReactNode {
+  const {translate} = useApplicationContext();
+  const adminsHeaderId = useId();
+  const membersHeaderId = useId();
   useKoSubscribableChildren(conversation, ['roles']);
 
-  return null;
+  const isCompactMode = mode === UserlistMode.COMPACT;
+  const cssClasses = isCompactMode ? 'search-list-sm' : 'search-list-lg';
+
+  let members: User[] = [];
+  let admins: User[] = [];
+  let adminCount = 0;
+  let memberCount = 0;
+
+  filteredUsers.forEach((userEntity: User) => {
+    if (userEntity.isService) {
+      return;
+    }
+    if (conversationRepository?.conversationRoleRepository.isUserGroupAdmin(conversation, userEntity) === true) {
+      admins.push(userEntity);
+    } else {
+      members.push(userEntity);
+    }
+  });
+  adminCount = admins.length;
+  memberCount = members.length;
+
+  if (truncate && admins.length + members.length > maxVisibleUsers) {
+    admins = admins.slice(0, reducedUserCount);
+    members = members.slice(0, reducedUserCount - admins.length);
+  }
+
+  const hasAdmins = isNonEmptyArray(admins);
+  const hasMembers = isNonEmptyArray(members);
+
+  return (
+    <Fragment>
+      {(hasAdmins || showEmptyAdmin) && (
+        <Fragment>
+          <h3 id={adminsHeaderId} className="user-list__header" data-uie-name="label-conversation-admins">
+            {translate('searchListAdmins', {count: adminCount})}
+          </h3>
+
+          {hasAdmins && (
+            <ul className={cx('search-list', cssClasses)} data-uie-name="list-admins" aria-labelledby={adminsHeaderId}>
+              {admins.slice(0, maxShownUsers).map(user => renderListItem(user))}
+            </ul>
+          )}
+
+          {isEmptyArray(admins) && (
+            <div className="user-list__no-admin" data-uie-name="status-no-admins">
+              {translate('searchListNoAdmins')}
+            </div>
+          )}
+        </Fragment>
+      )}
+
+      {hasMembers && maxShownUsers > admins.length && (
+        <Fragment>
+          <h3 id={membersHeaderId} className="user-list__header" data-uie-name="label-conversation-members">
+            {translate('searchListMembers', {count: memberCount})}
+          </h3>
+
+          <ul className={cx('search-list', cssClasses)} data-uie-name="list-members" aria-labelledby={membersHeaderId}>
+            {members.slice(0, maxShownUsers - admins.length).map(user => renderListItem(user))}
+          </ul>
+        </Fragment>
+      )}
+    </Fragment>
+  );
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Restore reactive updates of the conversation member list when `conversation.roles` changes.

The previous non-null assertion migration in https://github.com/wireapp/wire-webapp/pull/22358 moved the Knockout subscription into a child component that returned `null`. Role changes therefore rerendered only that child, while the `UserList` component did not recompute which users are admins or members.

This caused the channels management Playwright flow to keep showing a promoted user as a regular member.

The fix keeps the role subscription where the admin/member classification is rendered, without reintroducing a non-null assertion or conditional hook usage.
