### PR TITLE
Render group creation header behind startup toggle [WPB-27666]

### DIFF
--- a/apps/webapp/src/script/components/messagesList/message/memberMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/memberMessage.test.tsx
@@ -379,9 +379,11 @@ describe('MemberMessage', () => {
             ),
           );
           const groupCreationHeader = container.querySelector('.message-group-creation-header-text');
+          const strongElements = groupCreationHeader?.querySelectorAll('strong');
 
           expect(groupCreationHeader).toHaveTextContent('You started the conversation');
-          expect(groupCreationHeader?.querySelector('strong')).toHaveTextContent('You');
+          expect(strongElements).toHaveLength(1);
+          expect(strongElements?.[0]).toHaveTextContent('You');
         },
       );
     });
@@ -445,6 +447,118 @@ describe('MemberMessage', () => {
       expect(groupCreationHeader?.textContent).toBe('[bold]Admin[/bold] started the conversation');
       expect(strongElements).toHaveLength(1);
       expect(strongElements?.[0]).toHaveTextContent('[bold]Admin[/bold]');
+    });
+
+    it('renders the sender name outside formatting when the translation places it outside formatting', async () => {
+      await withTranslationStrings(
+        {
+          ...en,
+          conversationCreatedName: '{name} started the conversation',
+        },
+        () => {
+          const message = createMemberMessage({systemType: SystemMessageType.CONVERSATION_CREATE}, [generateUser()]);
+          message.user().isMe = false;
+          message.user().name('Alice');
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <MemberMessage
+                hasReadReceiptsTurnedOn={baseProps.hasReadReceiptsTurnedOn}
+                isSelfDeletingMessagesOff={baseProps.isSelfDeletingMessagesOff}
+                isSelfTemporaryGuest={baseProps.isSelfTemporaryGuest}
+                message={message}
+                onClickCancelRequest={baseProps.onClickCancelRequest}
+                onClickInvitePeople={baseProps.onClickInvitePeople}
+                onClickParticipants={baseProps.onClickParticipants}
+                shouldShowInvitePeople={baseProps.shouldShowInvitePeople}
+                conversationName={baseProps.conversationName}
+                isCellsConversation={baseProps.isCellsConversation}
+                isSelfGuest={baseProps.isSelfGuest}
+              />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+          const groupCreationHeader = container.querySelector('.message-group-creation-header-text');
+
+          expect(groupCreationHeader?.textContent).toBe('Alice started the conversation');
+          expect(groupCreationHeader?.querySelector('strong')).toBeNull();
+        },
+      );
+    });
+
+    it('follows translated word order and formatting around the sender name', async () => {
+      await withTranslationStrings(
+        {
+          ...en,
+          conversationCreatedName: 'Conversation started by [bold]{name}[/bold]',
+        },
+        () => {
+          const message = createMemberMessage({systemType: SystemMessageType.CONVERSATION_CREATE}, [generateUser()]);
+          message.user().isMe = false;
+          message.user().name('Alice');
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <MemberMessage
+                hasReadReceiptsTurnedOn={baseProps.hasReadReceiptsTurnedOn}
+                isSelfDeletingMessagesOff={baseProps.isSelfDeletingMessagesOff}
+                isSelfTemporaryGuest={baseProps.isSelfTemporaryGuest}
+                message={message}
+                onClickCancelRequest={baseProps.onClickCancelRequest}
+                onClickInvitePeople={baseProps.onClickInvitePeople}
+                onClickParticipants={baseProps.onClickParticipants}
+                shouldShowInvitePeople={baseProps.shouldShowInvitePeople}
+                conversationName={baseProps.conversationName}
+                isCellsConversation={baseProps.isCellsConversation}
+                isSelfGuest={baseProps.isSelfGuest}
+              />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+          const groupCreationHeader = container.querySelector('.message-group-creation-header-text');
+
+          expect(groupCreationHeader?.textContent).toBe('Conversation started by Alice');
+          expect(groupCreationHeader?.querySelectorAll('strong')).toHaveLength(1);
+          expect(groupCreationHeader?.querySelector('strong')).toHaveTextContent('Alice');
+        },
+      );
+    });
+
+    it('keeps a markup-like sender name literal when the translation places it outside formatting', async () => {
+      await withTranslationStrings(
+        {
+          ...en,
+          conversationCreatedName: '{name} started the conversation',
+        },
+        () => {
+          const message = createMemberMessage({systemType: SystemMessageType.CONVERSATION_CREATE}, [generateUser()]);
+          message.user().isMe = false;
+          message.user().name('[bold]Admin[/bold]');
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <MemberMessage
+                hasReadReceiptsTurnedOn={baseProps.hasReadReceiptsTurnedOn}
+                isSelfDeletingMessagesOff={baseProps.isSelfDeletingMessagesOff}
+                isSelfTemporaryGuest={baseProps.isSelfTemporaryGuest}
+                message={message}
+                onClickCancelRequest={baseProps.onClickCancelRequest}
+                onClickInvitePeople={baseProps.onClickInvitePeople}
+                onClickParticipants={baseProps.onClickParticipants}
+                shouldShowInvitePeople={baseProps.shouldShowInvitePeople}
+                conversationName={baseProps.conversationName}
+                isCellsConversation={baseProps.isCellsConversation}
+                isSelfGuest={baseProps.isSelfGuest}
+              />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+          const groupCreationHeader = container.querySelector('.message-group-creation-header-text');
+
+          expect(groupCreationHeader?.textContent).toBe('[bold]Admin[/bold] started the conversation');
+          expect(groupCreationHeader?.querySelector('strong')).toBeNull();
+        },
+      );
     });
 
     it('renders arbitrary image markup as text when the feature toggle is enabled', async () => {

--- a/apps/webapp/src/script/components/messagesList/message/memberMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/memberMessage.test.tsx
@@ -386,6 +386,67 @@ describe('MemberMessage', () => {
       );
     });
 
+    it('renders another sender name as React text when the feature toggle is enabled', () => {
+      const message = createMemberMessage({systemType: SystemMessageType.CONVERSATION_CREATE}, [generateUser()]);
+      message.user().isMe = false;
+      message.user().name('R&D <Test>');
+
+      const {container} = render(
+        withThemeAndRootContext(
+          <MemberMessage
+            hasReadReceiptsTurnedOn={baseProps.hasReadReceiptsTurnedOn}
+            isSelfDeletingMessagesOff={baseProps.isSelfDeletingMessagesOff}
+            isSelfTemporaryGuest={baseProps.isSelfTemporaryGuest}
+            message={message}
+            onClickCancelRequest={baseProps.onClickCancelRequest}
+            onClickInvitePeople={baseProps.onClickInvitePeople}
+            onClickParticipants={baseProps.onClickParticipants}
+            shouldShowInvitePeople={baseProps.shouldShowInvitePeople}
+            conversationName={baseProps.conversationName}
+            isCellsConversation={baseProps.isCellsConversation}
+            isSelfGuest={baseProps.isSelfGuest}
+          />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+      const groupCreationHeader = container.querySelector('.message-group-creation-header-text');
+
+      expect(groupCreationHeader?.textContent).toBe('R&D <Test> started the conversation');
+      expect(groupCreationHeader?.querySelector('strong')).toHaveTextContent('R&D <Test>');
+      expect(container.querySelector('test')).toBeNull();
+    });
+
+    it('keeps markup-like sender names as literal React text when the feature toggle is enabled', () => {
+      const message = createMemberMessage({systemType: SystemMessageType.CONVERSATION_CREATE}, [generateUser()]);
+      message.user().isMe = false;
+      message.user().name('[bold]Admin[/bold]');
+
+      const {container} = render(
+        withThemeAndRootContext(
+          <MemberMessage
+            hasReadReceiptsTurnedOn={baseProps.hasReadReceiptsTurnedOn}
+            isSelfDeletingMessagesOff={baseProps.isSelfDeletingMessagesOff}
+            isSelfTemporaryGuest={baseProps.isSelfTemporaryGuest}
+            message={message}
+            onClickCancelRequest={baseProps.onClickCancelRequest}
+            onClickInvitePeople={baseProps.onClickInvitePeople}
+            onClickParticipants={baseProps.onClickParticipants}
+            shouldShowInvitePeople={baseProps.shouldShowInvitePeople}
+            conversationName={baseProps.conversationName}
+            isCellsConversation={baseProps.isCellsConversation}
+            isSelfGuest={baseProps.isSelfGuest}
+          />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+      const groupCreationHeader = container.querySelector('.message-group-creation-header-text');
+      const strongElements = groupCreationHeader?.querySelectorAll('strong');
+
+      expect(groupCreationHeader?.textContent).toBe('[bold]Admin[/bold] started the conversation');
+      expect(strongElements).toHaveLength(1);
+      expect(strongElements?.[0]).toHaveTextContent('[bold]Admin[/bold]');
+    });
+
     it('renders arbitrary image markup as text when the feature toggle is enabled', async () => {
       await withTranslationStrings(
         {

--- a/apps/webapp/src/script/components/messagesList/message/memberMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/memberMessage.test.tsx
@@ -27,7 +27,8 @@ import {generateUser} from 'test/helper/UserGenerator';
 import en from 'I18n/en-US.json';
 import {MemberMessage as MemberMessageEntity} from 'Repositories/entity/message/memberMessage';
 import {User} from 'Repositories/entity/User';
-import {withTheme} from 'src/script/auth/util/test/testUtil';
+import {withTheme, withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {SystemMessageType} from 'src/script/message/systemMessageType';
 import {
   createRootContextValueForTest,
@@ -48,6 +49,26 @@ jest.mock('Components/avatar', () => ({
 setStrings({en});
 
 const rootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureToggleName) {
+      return featureToggleName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+
+async function withTranslationStrings(strings: typeof en, testFunction: TranslationTestFunction): Promise<void> {
+  setStrings({en: strings});
+
+  try {
+    await testFunction();
+  } finally {
+    setStrings({en});
+  }
+}
 
 function createMemberMessage({systemType, type}: {systemType?: SystemMessageType; type?: string}, users?: User[]) {
   const message = new MemberMessageEntity(translate);
@@ -300,6 +321,145 @@ describe('MemberMessage', () => {
 
       const {container} = render(withTheme(<MemberMessage {...props} />), {wrapper: rootProviderWrapper});
       expect(container.textContent).toContain('You started a conversation with');
+    });
+
+    it('renders the named group creation header with the legacy renderer when the feature toggle is disabled', () => {
+      const message = createMemberMessage({systemType: SystemMessageType.CONVERSATION_CREATE}, [generateUser()]);
+      message.user().isMe = true;
+
+      const {container} = render(
+        withTheme(
+          <MemberMessage
+            hasReadReceiptsTurnedOn={baseProps.hasReadReceiptsTurnedOn}
+            isSelfDeletingMessagesOff={baseProps.isSelfDeletingMessagesOff}
+            isSelfTemporaryGuest={baseProps.isSelfTemporaryGuest}
+            message={message}
+            onClickCancelRequest={baseProps.onClickCancelRequest}
+            onClickInvitePeople={baseProps.onClickInvitePeople}
+            onClickParticipants={baseProps.onClickParticipants}
+            shouldShowInvitePeople={baseProps.shouldShowInvitePeople}
+            conversationName={baseProps.conversationName}
+            isCellsConversation={baseProps.isCellsConversation}
+            isSelfGuest={baseProps.isSelfGuest}
+          />,
+        ),
+        {wrapper: rootProviderWrapper},
+      );
+
+      expect(container.querySelector('.message-group-creation-header-text strong')).toBeInTheDocument();
+      expect(container.textContent).toContain('You started the conversation');
+    });
+
+    it('renders supported bold translation markup as a React element when the feature toggle is enabled', async () => {
+      await withTranslationStrings(
+        {
+          ...en,
+          conversationCreatedNameYou: '[bold]You[/bold] started the conversation',
+        },
+        () => {
+          const message = createMemberMessage({systemType: SystemMessageType.CONVERSATION_CREATE}, [generateUser()]);
+          message.user().isMe = true;
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <MemberMessage
+                hasReadReceiptsTurnedOn={baseProps.hasReadReceiptsTurnedOn}
+                isSelfDeletingMessagesOff={baseProps.isSelfDeletingMessagesOff}
+                isSelfTemporaryGuest={baseProps.isSelfTemporaryGuest}
+                message={message}
+                onClickCancelRequest={baseProps.onClickCancelRequest}
+                onClickInvitePeople={baseProps.onClickInvitePeople}
+                onClickParticipants={baseProps.onClickParticipants}
+                shouldShowInvitePeople={baseProps.shouldShowInvitePeople}
+                conversationName={baseProps.conversationName}
+                isCellsConversation={baseProps.isCellsConversation}
+                isSelfGuest={baseProps.isSelfGuest}
+              />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+          const groupCreationHeader = container.querySelector('.message-group-creation-header-text');
+
+          expect(groupCreationHeader).toHaveTextContent('You started the conversation');
+          expect(groupCreationHeader?.querySelector('strong')).toHaveTextContent('You');
+        },
+      );
+    });
+
+    it('renders arbitrary image markup as text when the feature toggle is enabled', async () => {
+      await withTranslationStrings(
+        {
+          ...en,
+          conversationCreatedNameYou: '<img src="example">[bold]You[/bold] started the conversation',
+        },
+        () => {
+          const message = createMemberMessage({systemType: SystemMessageType.CONVERSATION_CREATE}, [generateUser()]);
+          message.user().isMe = true;
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <MemberMessage
+                hasReadReceiptsTurnedOn={baseProps.hasReadReceiptsTurnedOn}
+                isSelfDeletingMessagesOff={baseProps.isSelfDeletingMessagesOff}
+                isSelfTemporaryGuest={baseProps.isSelfTemporaryGuest}
+                message={message}
+                onClickCancelRequest={baseProps.onClickCancelRequest}
+                onClickInvitePeople={baseProps.onClickInvitePeople}
+                onClickParticipants={baseProps.onClickParticipants}
+                shouldShowInvitePeople={baseProps.shouldShowInvitePeople}
+                conversationName={baseProps.conversationName}
+                isCellsConversation={baseProps.isCellsConversation}
+                isSelfGuest={baseProps.isSelfGuest}
+              />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+          const groupCreationHeader = container.querySelector('.message-group-creation-header-text');
+
+          expect(groupCreationHeader).toHaveTextContent('<img src="example">You started the conversation');
+          expect(groupCreationHeader?.querySelector('strong')).toHaveTextContent('You');
+          expect(container.querySelector('img')).toBeNull();
+        },
+      );
+    });
+
+    it('renders arbitrary meta markup as text when the feature toggle is enabled', async () => {
+      await withTranslationStrings(
+        {
+          ...en,
+          conversationCreatedNameYou: '<meta name="example" content="value">[bold]You[/bold] started the conversation',
+        },
+        () => {
+          const message = createMemberMessage({systemType: SystemMessageType.CONVERSATION_CREATE}, [generateUser()]);
+          message.user().isMe = true;
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <MemberMessage
+                hasReadReceiptsTurnedOn={baseProps.hasReadReceiptsTurnedOn}
+                isSelfDeletingMessagesOff={baseProps.isSelfDeletingMessagesOff}
+                isSelfTemporaryGuest={baseProps.isSelfTemporaryGuest}
+                message={message}
+                onClickCancelRequest={baseProps.onClickCancelRequest}
+                onClickInvitePeople={baseProps.onClickInvitePeople}
+                onClickParticipants={baseProps.onClickParticipants}
+                shouldShowInvitePeople={baseProps.shouldShowInvitePeople}
+                conversationName={baseProps.conversationName}
+                isCellsConversation={baseProps.isCellsConversation}
+                isSelfGuest={baseProps.isSelfGuest}
+              />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+          const groupCreationHeader = container.querySelector('.message-group-creation-header-text');
+
+          expect(groupCreationHeader).toHaveTextContent(
+            '<meta name="example" content="value">You started the conversation',
+          );
+          expect(groupCreationHeader?.querySelector('strong')).toHaveTextContent('You');
+          expect(container.querySelector('meta')).toBeNull();
+        },
+      );
     });
   });
 

--- a/apps/webapp/src/script/components/messagesList/message/memberMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/memberMessage.tsx
@@ -22,7 +22,10 @@ import type {ReactElement} from 'react';
 import {Button, ButtonVariant, CollectionIcon, Link, LinkVariant} from '@wireapp/react-ui-kit';
 
 import * as Icon from 'Components/icon';
-import {MemberMessage as MemberMessageEntity} from 'Repositories/entity/message/memberMessage';
+import {
+  groupCreationHeaderSenderNamePlaceholder,
+  MemberMessage as MemberMessageEntity,
+} from 'Repositories/entity/message/memberMessage';
 import {User} from 'Repositories/entity/User';
 import {Config} from 'src/script/Config';
 import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
@@ -39,21 +42,34 @@ import {MessageTime} from './messageTime';
 
 type RenderGroupCreationHeaderOptions = {
   readonly htmlGroupCreationHeader: string;
+  readonly reactGroupCreationHeader: string;
+  readonly senderName: string;
   readonly isReactTranslationRenderingEnabled: boolean;
 };
 
 function renderGroupCreationHeader(options: RenderGroupCreationHeaderOptions): ReactElement {
-  const {htmlGroupCreationHeader, isReactTranslationRenderingEnabled} = options;
+  const {htmlGroupCreationHeader, reactGroupCreationHeader, senderName, isReactTranslationRenderingEnabled} = options;
 
   if (isReactTranslationRenderingEnabled) {
     return (
       <p className="message-group-creation-header-text">
-        {replaceReactComponents(htmlGroupCreationHeader, [
+        {replaceReactComponents(reactGroupCreationHeader, [
           {
             start: '<strong>',
             end: '</strong>',
             render(text): ReactElement {
-              return <strong>{text}</strong>;
+              return (
+                <strong>
+                  {replaceReactComponents(text, [
+                    {
+                      exactMatch: groupCreationHeaderSenderNamePlaceholder,
+                      render(): string {
+                        return senderName;
+                      },
+                    },
+                  ])}
+                </strong>
+              );
             },
           },
         ])}
@@ -96,10 +112,25 @@ export const MemberMessage = ({
   isSelfGuest,
 }: MemberMessageProps) => {
   const {isFeatureToggleEnabled, translate} = useApplicationContext();
-  const {otherUser, timestamp, user, htmlGroupCreationHeader, showNamedCreation, hasUsers} = useKoSubscribableChildren(
-    message,
-    ['otherUser', 'timestamp', 'user', 'htmlGroupCreationHeader', 'showNamedCreation', 'hasUsers'],
-  );
+  const {
+    otherUser,
+    timestamp,
+    user,
+    senderName,
+    htmlGroupCreationHeader,
+    reactGroupCreationHeader,
+    showNamedCreation,
+    hasUsers,
+  } = useKoSubscribableChildren(message, [
+    'otherUser',
+    'timestamp',
+    'user',
+    'senderName',
+    'htmlGroupCreationHeader',
+    'reactGroupCreationHeader',
+    'showNamedCreation',
+    'hasUsers',
+  ]);
 
   const isGroupCreation = message.isGroupCreation();
   const isMemberRemoval = message.isMemberRemoval();
@@ -135,6 +166,8 @@ export const MemberMessage = ({
         <div className="message-group-creation-header">
           {renderGroupCreationHeader({
             htmlGroupCreationHeader,
+            reactGroupCreationHeader,
+            senderName,
             isReactTranslationRenderingEnabled: isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName),
           })}
           <h2 className="message-group-creation-header-name" data-uie-name="conversation-name">

--- a/apps/webapp/src/script/components/messagesList/message/memberMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/memberMessage.tsx
@@ -17,21 +17,54 @@
  *
  */
 
+import type {ReactElement} from 'react';
+
 import {Button, ButtonVariant, CollectionIcon, Link, LinkVariant} from '@wireapp/react-ui-kit';
 
 import * as Icon from 'Components/icon';
 import {MemberMessage as MemberMessageEntity} from 'Repositories/entity/message/memberMessage';
 import {User} from 'Repositories/entity/User';
 import {Config} from 'src/script/Config';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {SystemMessageType} from 'src/script/message/systemMessageType';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
+import {replaceReactComponents} from 'Util/localizerUtil/reactLocalizerUtil';
 
 import {E2eEncryptionMessage} from './e2eEncryptionMessage/e2eEncryptionMessage';
 import {e2eMessageContentLinkCss} from './e2eEncryptionMessage/e2eEncryptionMessage.styles';
 import {ConnectedMessage} from './memberMessage/connectedMessage';
 import {MessageContent} from './memberMessage/messageContent';
 import {MessageTime} from './messageTime';
+
+type RenderGroupCreationHeaderOptions = {
+  readonly htmlGroupCreationHeader: string;
+  readonly isReactTranslationRenderingEnabled: boolean;
+};
+
+function renderGroupCreationHeader(options: RenderGroupCreationHeaderOptions): ReactElement {
+  const {htmlGroupCreationHeader, isReactTranslationRenderingEnabled} = options;
+
+  if (isReactTranslationRenderingEnabled) {
+    return (
+      <p className="message-group-creation-header-text">
+        {replaceReactComponents(htmlGroupCreationHeader, [
+          {
+            start: '<strong>',
+            end: '</strong>',
+            render(text): ReactElement {
+              return <strong>{text}</strong>;
+            },
+          },
+        ])}
+      </p>
+    );
+  }
+
+  return (
+    <p className="message-group-creation-header-text" dangerouslySetInnerHTML={{__html: htmlGroupCreationHeader}} />
+  );
+}
 
 interface MemberMessageProps {
   classifiedDomains?: string[];
@@ -62,7 +95,7 @@ export const MemberMessage = ({
   isCellsConversation,
   isSelfGuest,
 }: MemberMessageProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
   const {otherUser, timestamp, user, htmlGroupCreationHeader, showNamedCreation, hasUsers} = useKoSubscribableChildren(
     message,
     ['otherUser', 'timestamp', 'user', 'htmlGroupCreationHeader', 'showNamedCreation', 'hasUsers'],
@@ -100,10 +133,10 @@ export const MemberMessage = ({
     <>
       {showNamedCreation && (
         <div className="message-group-creation-header">
-          <p
-            className="message-group-creation-header-text"
-            dangerouslySetInnerHTML={{__html: htmlGroupCreationHeader}}
-          />
+          {renderGroupCreationHeader({
+            htmlGroupCreationHeader,
+            isReactTranslationRenderingEnabled: isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName),
+          })}
           <h2 className="message-group-creation-header-name" data-uie-name="conversation-name">
             {conversationName}
           </h2>

--- a/apps/webapp/src/script/components/messagesList/message/memberMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/memberMessage.tsx
@@ -17,13 +17,14 @@
  *
  */
 
-import type {ReactElement} from 'react';
+import type {ReactElement, ReactNode} from 'react';
 
 import {Button, ButtonVariant, CollectionIcon, Link, LinkVariant} from '@wireapp/react-ui-kit';
 
 import * as Icon from 'Components/icon';
 import {
-  groupCreationHeaderSenderNamePlaceholder,
+  groupCreationHeaderSenderNameMarkerEnd,
+  groupCreationHeaderSenderNameMarkerStart,
   MemberMessage as MemberMessageEntity,
 } from 'Repositories/entity/message/memberMessage';
 import {User} from 'Repositories/entity/User';
@@ -47,6 +48,18 @@ type RenderGroupCreationHeaderOptions = {
   readonly isReactTranslationRenderingEnabled: boolean;
 };
 
+function renderGroupCreationHeaderSenderName(text: string, senderName: string): ReactNode[] {
+  return replaceReactComponents(text, [
+    {
+      start: groupCreationHeaderSenderNameMarkerStart,
+      end: groupCreationHeaderSenderNameMarkerEnd,
+      render(): string {
+        return senderName;
+      },
+    },
+  ]);
+}
+
 function renderGroupCreationHeader(options: RenderGroupCreationHeaderOptions): ReactElement {
   const {htmlGroupCreationHeader, reactGroupCreationHeader, senderName, isReactTranslationRenderingEnabled} = options;
 
@@ -58,18 +71,14 @@ function renderGroupCreationHeader(options: RenderGroupCreationHeaderOptions): R
             start: '<strong>',
             end: '</strong>',
             render(text): ReactElement {
-              return (
-                <strong>
-                  {replaceReactComponents(text, [
-                    {
-                      exactMatch: groupCreationHeaderSenderNamePlaceholder,
-                      render(): string {
-                        return senderName;
-                      },
-                    },
-                  ])}
-                </strong>
-              );
+              return <strong>{renderGroupCreationHeaderSenderName(text, senderName)}</strong>;
+            },
+          },
+          {
+            start: groupCreationHeaderSenderNameMarkerStart,
+            end: groupCreationHeaderSenderNameMarkerEnd,
+            render(): string {
+              return senderName;
             },
           },
         ])}

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggleNames.ts
@@ -22,6 +22,7 @@ export const conversationListCollapseFeatureToggleName = 'conversation-list-coll
 export const viewerPermissionFeatureToggleName = 'viewer-permission';
 export const disableMessagePreprocessingFeatureToggleName = 'disable-message-preprocessing';
 export const sharedDriveDirectUploadFeatureToggleName = 'shared-drive-direct-upload';
+export const reactTranslationRenderingFeatureToggleName = 'react-translation-rendering';
 
 export const startupFeatureToggleNames = [
   applockRefactoredFeatureToggleName,
@@ -29,6 +30,7 @@ export const startupFeatureToggleNames = [
   viewerPermissionFeatureToggleName,
   disableMessagePreprocessingFeatureToggleName,
   sharedDriveDirectUploadFeatureToggleName,
+  reactTranslationRenderingFeatureToggleName,
 ] as const;
 
 export type StartupFeatureToggleName = (typeof startupFeatureToggleNames)[number];

--- a/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
+++ b/apps/webapp/src/script/featureToggles/startupFeatureToggles.test.ts
@@ -26,6 +26,7 @@ import {
   applockRefactoredFeatureToggleName,
   conversationListCollapseFeatureToggleName,
   disableMessagePreprocessingFeatureToggleName,
+  reactTranslationRenderingFeatureToggleName,
   sharedDriveDirectUploadFeatureToggleName,
   startupFeatureToggleNames,
   viewerPermissionFeatureToggleName,
@@ -37,6 +38,7 @@ const featureToggleNamesWithDedicatedExistenceTests = [
   viewerPermissionFeatureToggleName,
   disableMessagePreprocessingFeatureToggleName,
   sharedDriveDirectUploadFeatureToggleName,
+  reactTranslationRenderingFeatureToggleName,
 ] as const;
 
 describe('startupFeatureToggles', function () {
@@ -44,6 +46,7 @@ describe('startupFeatureToggles', function () {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch('?foo=bar');
 
     expect(startupFeatureToggles.isFeatureToggleEnabled(applockRefactoredFeatureToggleName)).toBe(false);
+    expect(startupFeatureToggles.isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName)).toBe(false);
     expect(startupFeatureToggles.enabledFeatureToggleNames).toEqual([]);
   });
 
@@ -129,6 +132,14 @@ describe('startupFeatureToggles', function () {
     expect(startupFeatureToggles.isFeatureToggleEnabled(sharedDriveDirectUploadFeatureToggleName)).toBe(true);
   });
 
+  it('enables the React translation rendering feature toggle when present in the query parameter', () => {
+    const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
+      `?${startupFeatureToggleQueryParameterName}=${reactTranslationRenderingFeatureToggleName}`,
+    );
+
+    expect(startupFeatureToggles.isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName)).toBe(true);
+  });
+
   it('trims whitespace around feature toggle names', () => {
     const startupFeatureToggles = createStartupFeatureTogglesFromLocationSearch(
       `?${startupFeatureToggleQueryParameterName}= ${applockRefactoredFeatureToggleName} `,
@@ -172,6 +183,7 @@ describe('startupFeatureToggles', function () {
       viewerPermissionFeatureToggleName,
       disableMessagePreprocessingFeatureToggleName,
       sharedDriveDirectUploadFeatureToggleName,
+      reactTranslationRenderingFeatureToggleName,
     ]);
   });
 

--- a/apps/webapp/src/script/repositories/entity/message/memberMessage.ts
+++ b/apps/webapp/src/script/repositories/entity/message/memberMessage.ts
@@ -33,6 +33,32 @@ import {SuperType} from '../../../message/superType';
 import {SystemMessageType} from '../../../message/systemMessageType';
 import {User} from '../User';
 
+export const groupCreationHeaderSenderNamePlaceholder = '{senderName}';
+
+type GroupCreationHeaderTranslationOptions = {
+  readonly isNamedCreation: boolean;
+  readonly isTemporaryGuest: boolean;
+  readonly isCurrentUser: boolean;
+  readonly senderName: string;
+  readonly translate: Translate;
+};
+
+function translateGroupCreationHeader(options: GroupCreationHeaderTranslationOptions): string {
+  if (options.isNamedCreation === false) {
+    return '';
+  }
+
+  if (options.isTemporaryGuest) {
+    return options.translate('conversationCreateTemporary');
+  }
+
+  const groupCreationString = options.isCurrentUser
+    ? options.translate('conversationCreatedNameYou')
+    : options.translate('conversationCreatedName', {name: options.senderName});
+
+  return capitalizeFirstChar(groupCreationString);
+}
+
 export class MemberMessage extends SystemMessage {
   public allTeamMembers: User[] | undefined;
   public readonly hasUsers: ko.PureComputed<boolean>;
@@ -44,6 +70,7 @@ export class MemberMessage extends SystemMessage {
   public readonly otherUser: ko.PureComputed<User>;
   public readonly showNamedCreation: ko.PureComputed<boolean>;
   public readonly htmlGroupCreationHeader: ko.PureComputed<string>;
+  public readonly reactGroupCreationHeader: ko.PureComputed<string>;
   public readonly remoteUserEntities: ko.PureComputed<User[]>;
   public showServicesWarning: boolean;
   public memberMessageType: SystemMessageType;
@@ -99,17 +126,22 @@ export class MemberMessage extends SystemMessage {
     });
 
     this.htmlGroupCreationHeader = ko.pureComputed(() => {
-      if (this.showNamedCreation()) {
-        if (this.user().isTemporaryGuest()) {
-          return this.translate('conversationCreateTemporary');
-        }
-
-        const groupCreationString = this.user().isMe
-          ? this.translate('conversationCreatedNameYou')
-          : this.translate('conversationCreatedName', {name: this.senderName()});
-        return capitalizeFirstChar(groupCreationString);
-      }
-      return '';
+      return translateGroupCreationHeader({
+        isNamedCreation: this.showNamedCreation(),
+        isTemporaryGuest: this.user().isTemporaryGuest(),
+        isCurrentUser: this.user().isMe,
+        senderName: this.senderName(),
+        translate: this.translate,
+      });
+    });
+    this.reactGroupCreationHeader = ko.pureComputed(() => {
+      return translateGroupCreationHeader({
+        isNamedCreation: this.showNamedCreation(),
+        isTemporaryGuest: this.user().isTemporaryGuest(),
+        isCurrentUser: this.user().isMe,
+        senderName: groupCreationHeaderSenderNamePlaceholder,
+        translate: this.translate,
+      });
     });
   }
 

--- a/apps/webapp/src/script/repositories/entity/message/memberMessage.ts
+++ b/apps/webapp/src/script/repositories/entity/message/memberMessage.ts
@@ -33,7 +33,10 @@ import {SuperType} from '../../../message/superType';
 import {SystemMessageType} from '../../../message/systemMessageType';
 import {User} from '../User';
 
-export const groupCreationHeaderSenderNamePlaceholder = '{senderName}';
+export const groupCreationHeaderSenderNameMarkerStart = '__wire_group_creation_sender_name_start__';
+export const groupCreationHeaderSenderNameMarkerEnd = '__wire_group_creation_sender_name_end__';
+
+const groupCreationHeaderSenderNameMarker = `${groupCreationHeaderSenderNameMarkerStart}value${groupCreationHeaderSenderNameMarkerEnd}`;
 
 type GroupCreationHeaderTranslationOptions = {
   readonly isNamedCreation: boolean;
@@ -139,7 +142,7 @@ export class MemberMessage extends SystemMessage {
         isNamedCreation: this.showNamedCreation(),
         isTemporaryGuest: this.user().isTemporaryGuest(),
         isCurrentUser: this.user().isMe,
-        senderName: groupCreationHeaderSenderNamePlaceholder,
+        senderName: groupCreationHeaderSenderNameMarker,
         translate: this.translate,
       });
     });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27666" title="WPB-27666" target="_blank"><img alt="Security" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/13902?size=medium" />WPB-27666</a>  [Web] Text rendering
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This pull request introduces the first step of migrating localized rich-text rendering from direct HTML rendering to React-based component rendering.

It adds the temporary startup feature toggle:

```text
react-translation-rendering
```

and uses it for the named group creation header.

Enable the new rendering path with:

```text
?enabled-features=react-translation-rendering
```

### Rendering behavior

With the new path enabled, supported formatting is explicitly mapped to React components.

For example:

```html
<strong>You</strong> started the conversation
```

renders the bold section as a React `<strong>` element.

Other markup that is not explicitly supported by the renderer remains ordinary text.

This keeps the translation format explicit while allowing React to own the rendered component tree.
