### PR TITLE
fix(cells): stop infinite upload retries offline [WPB-28305]

### DIFF
--- a/libraries/api-client/src/cells/cellsApi.test.ts
+++ b/libraries/api-client/src/cells/cellsApi.test.ts
@@ -147,7 +147,7 @@ describe('CellsAPI', () => {
           Inputs: [{Type: 'LEAF', Locator: {Path: TEST_FILE_PATH, Uuid: MOCKED_UUID}, VersionId: MOCKED_UUID}],
           FindAvailablePath: true,
         },
-        {abortController: undefined},
+        {signal: undefined, 'axios-retry': {retries: 3}},
       );
 
       expect(mockStorage.putObject).toHaveBeenCalledWith({
@@ -273,7 +273,7 @@ describe('CellsAPI', () => {
           Inputs: [{Type: 'LEAF', Locator: {Path: '', Uuid: MOCKED_UUID}, VersionId: MOCKED_UUID}],
           FindAvailablePath: true,
         },
-        {abortControllerntroller: undefined},
+        {signal: undefined, 'axios-retry': {retries: 3}},
       );
 
       expect(mockStorage.putObject).toHaveBeenCalledWith({
@@ -314,7 +314,7 @@ describe('CellsAPI', () => {
           Inputs: [{Type: 'LEAF', Locator: {Path: TEST_FILE_PATH, Uuid: MOCKED_UUID}, VersionId: MOCKED_UUID}],
           FindAvailablePath: true,
         },
-        {signal: abortController.signal},
+        {signal: abortController.signal, 'axios-retry': {retries: 3}},
       );
       expect(result).toBe(response);
     });
@@ -402,6 +402,27 @@ describe('CellsAPI', () => {
         progressCallback: undefined,
         abortController: undefined,
       });
+    });
+  });
+
+  describe('checkNodeCreation', () => {
+    it('disables infinite network retries while checking a destination', async () => {
+      mockNodeServiceApi.createCheck.mockResolvedValueOnce(createMockResponse({Results: [{Exists: false}]}));
+
+      await cellsAPI.checkNodeCreation({
+        path: TEST_FILE_PATH,
+        uuid: MOCKED_UUID,
+        versionId: MOCKED_UUID,
+        type: 'LEAF',
+      });
+
+      expect(mockNodeServiceApi.createCheck).toHaveBeenCalledWith(
+        {
+          Inputs: [{Type: 'LEAF', Locator: {Path: TEST_FILE_PATH, Uuid: MOCKED_UUID}, VersionId: MOCKED_UUID}],
+          FindAvailablePath: false,
+        },
+        {'axios-retry': {retries: 3}},
+      );
     });
   });
 
@@ -985,7 +1006,12 @@ describe('CellsAPI', () => {
 
       const result = await cellsAPI.promoteNodeDraft({uuid, versionId});
 
-      expect(mockNodeServiceApi.promoteVersion).toHaveBeenCalledWith(uuid, versionId, {Publish: true});
+      expect(mockNodeServiceApi.promoteVersion).toHaveBeenCalledWith(
+        uuid,
+        versionId,
+        {Publish: true},
+        {'axios-retry': {retries: 3}},
+      );
       expect(result).toEqual(mockResponse);
     });
 
@@ -1023,7 +1049,7 @@ describe('CellsAPI', () => {
 
       const result = await cellsAPI.deleteNodeDraft({uuid, versionId});
 
-      expect(mockNodeServiceApi.deleteVersion).toHaveBeenCalledWith(uuid, versionId);
+      expect(mockNodeServiceApi.deleteVersion).toHaveBeenCalledWith(uuid, versionId, {'axios-retry': {retries: 3}});
       expect(result).toEqual(mockResponse);
     });
 

--- a/libraries/api-client/src/cells/cellsApi.ts
+++ b/libraries/api-client/src/cells/cellsApi.ts
@@ -56,6 +56,13 @@ const USER_META_TAGS_NAMESPACE = 'usermeta-tags';
 const USER_META_OWNER_UUID_NAMESPACE = 'usermeta-owner-uuid';
 const MIME_NAMESPACE = 'mime';
 
+const uploadNetworkRetryConfig = {
+  // Uploads have their own retry action, so keep automatic retries bounded while allowing transient recovery.
+  'axios-retry': {
+    retries: 3,
+  },
+} as const;
+
 // Each selected tag is sent as its own metadata filter with the `Should` operation so the
 // backend applies OR semantics across tags (a node matching any selected tag is returned).
 // Matches the iOS client shape in WireMessaging RestAPI.swift.
@@ -187,7 +194,7 @@ export class CellsAPI {
         Inputs: [{Type: 'LEAF', Locator: {Path: filePath, Uuid: uuid}, VersionId: versionId}],
         FindAvailablePath: true,
       },
-      {signal: abortController?.signal},
+      {signal: abortController?.signal, ...uploadNetworkRetryConfig},
     );
 
     const firstCreateCheckResult = result.data.Results?.[0];
@@ -264,10 +271,13 @@ export class CellsAPI {
       throw new Error(CONFIGURATION_ERROR);
     }
 
-    const result = await this.client.createCheck({
-      Inputs: [{Type: type, Locator: {Path: path.normalize('NFC'), Uuid: uuid}, VersionId: versionId}],
-      FindAvailablePath: false,
-    });
+    const result = await this.client.createCheck(
+      {
+        Inputs: [{Type: type, Locator: {Path: path.normalize('NFC'), Uuid: uuid}, VersionId: versionId}],
+        FindAvailablePath: false,
+      },
+      uploadNetworkRetryConfig,
+    );
 
     return result.data;
   }
@@ -277,7 +287,7 @@ export class CellsAPI {
       throw new Error(CONFIGURATION_ERROR);
     }
 
-    const result = await this.client.promoteVersion(uuid, versionId, {Publish: true});
+    const result = await this.client.promoteVersion(uuid, versionId, {Publish: true}, uploadNetworkRetryConfig);
 
     return result.data;
   }
@@ -287,7 +297,7 @@ export class CellsAPI {
       throw new Error(CONFIGURATION_ERROR);
     }
 
-    const result = await this.client.deleteVersion(uuid, versionId);
+    const result = await this.client.deleteVersion(uuid, versionId, uploadNetworkRetryConfig);
 
     return result.data;
   }

--- a/libraries/api-client/src/cells/cellsApi.ts
+++ b/libraries/api-client/src/cells/cellsApi.ts
@@ -242,7 +242,7 @@ export class CellsAPI {
         Inputs: [{Type: 'LEAF', Locator: {Path: filePath, Uuid: uuid}, VersionId: versionId}],
         FindAvailablePath: true,
       },
-      {signal: abortController?.signal},
+      {signal: abortController?.signal, ...uploadNetworkRetryConfig},
     );
 
     const firstCreateCheckResult = result.data.Results?.[0];


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28305" title="WPB-28305" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28305</a>  [Web] Add retry support for failed direct Shared Drive uploads
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Problem
Cells upload requests inherit the global infinite axios retry policy. When the client is offline, precheck, publish, or discard requests keep retrying and the upload never reaches its failed state.

## Solution
Bound automatic retries for the Cells upload lifecycle to 3 retries per request. The existing exponential backoff remains enabled, while failed uploads still reach the existing failed state and remain available for explicit manual retry.