### PR TITLE
chore(e2e): Add test automation for upgrading team to paid TC-11757 [WPB-28450]

### DIFF
--- a/apps/webapp/test/e2e_tests/backend/inbucketClient.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/inbucketClient.e2e.ts
@@ -18,6 +18,7 @@
  */
 
 import axios, {AxiosInstance} from 'axios';
+import { User } from '../data/user';
 
 export class InbucketClientE2E {
   private readonly axiosInstance: AxiosInstance;
@@ -82,6 +83,28 @@ export class InbucketClientE2E {
       if (response.status === 200) {
         const message = response.data;
         if (message.body.text.includes(`${inviterEmail} has invited you to join a team on Wire.`)) {
+          return true;
+        }
+      }
+      await new Promise(resolve => setTimeout(resolve, delayBetweenAttempts));
+      attempt++;
+    }
+
+    return false;
+  }
+
+  async isPaymentConfirmationEmailReceived(teamOwner: User) {
+    const timeoutLimit = 30000;
+    const delayBetweenAttempts = 500;
+    const maxAttempts = timeoutLimit / delayBetweenAttempts;
+    let attempt = 0;
+    while (attempt < maxAttempts) {
+      const response = await this.getLatestEmail(teamOwner.email);
+      if (response.status === 200) {
+        const message = response.data;
+        const subject = response.data.subject;
+        // const attachment
+        if (message.body.text.includes(`Team ID: ${teamOwner.teamId}`) && subject.includes('Thank you for your order')) {
           return true;
         }
       }

--- a/apps/webapp/test/e2e_tests/backend/inbucketClient.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/inbucketClient.e2e.ts
@@ -18,7 +18,7 @@
  */
 
 import axios, {AxiosInstance} from 'axios';
-import { User } from '../data/user';
+import {User} from '../data/user';
 
 export class InbucketClientE2E {
   private readonly axiosInstance: AxiosInstance;
@@ -104,7 +104,10 @@ export class InbucketClientE2E {
         const message = response.data;
         const subject = response.data.subject;
         // const attachment
-        if (message.body.text.includes(`Team ID: ${teamOwner.teamId}`) && subject.includes('Thank you for your order')) {
+        if (
+          message.body.text.includes(`Team ID: ${teamOwner.teamId}`) &&
+          subject.includes('Thank you for your order')
+        ) {
           return true;
         }
       }

--- a/apps/webapp/test/e2e_tests/backend/inbucketClient.e2e.ts
+++ b/apps/webapp/test/e2e_tests/backend/inbucketClient.e2e.ts
@@ -101,12 +101,27 @@ export class InbucketClientE2E {
     while (attempt < maxAttempts) {
       const response = await this.getLatestEmail(teamOwner.email);
       if (response.status === 200) {
-        const message = response.data;
-        const subject = response.data.subject;
-        // const attachment
+        const message = response.data as {
+          from: string;
+          subject: string;
+          body: {text: string};
+          attachments: {filename: string; 'content-type': string}[];
+        };
+
+        const attachments = (message.attachments as any) ?? [];
+
+        const hasPdfAttachment = attachments.some(
+          (attachment: {filename: string; 'content-type': string}) =>
+            attachment['content-type'] === 'application/pdf' ||
+            attachment.filename?.toLowerCase().startsWith('wire_invoice') ||
+            attachment.filename?.toLowerCase().endsWith('.pdf'),
+        );
+
         if (
           message.body.text.includes(`Team ID: ${teamOwner.teamId}`) &&
-          subject.includes('Thank you for your order')
+          message.subject.includes('Thank you for your order') &&
+          message.from.includes('payments@wire.com') &&
+          hasPdfAttachment
         ) {
           return true;
         }

--- a/apps/webapp/test/e2e_tests/specs/SSOAndSCIM/SSOAndSCIM.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/SSOAndSCIM/SSOAndSCIM.spec.ts
@@ -35,11 +35,9 @@ test.describe('SSO and SCIM', () => {
 
   test.beforeEach(async ({createTeam, api}) => {
     // Creating a team and enabling SSO feature.
-    const team = await createTeam('Test Team');
+    const team = await createTeam('Test Team', {features: {sso: true}});
     userA = team.owner;
 
-    await api.team.upgradeTeam(userA.teamId, userA);
-    await api.brig.enableSSOFeature(userA.teamId);
     await api.waitForFeatureToBeEnabled(FEATURE_KEY.SSO, userA.teamId, userA.token);
 
     // Register a Keycloak user. This user will be used to log in via SSO and SCIM.

--- a/apps/webapp/test/e2e_tests/specs/TeamUpgrade/teamUpgrade.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/TeamUpgrade/teamUpgrade.spec.ts
@@ -19,7 +19,7 @@
 
 import {test, expect} from 'test/e2e_tests/test.fixtures';
 
-test('Team Upgrade', {tag: ['@TC-11757', '@regression']}, async ({createUser, createTeam, api}) => {
+test('I want to upgrade team to paid', {tag: ['@TC-11757', '@regression']}, async ({createUser, createTeam, api}) => {
   const userB = await createUser();
   const {owner: userA} = await createTeam('Critical Team', {users: [userB]});
 

--- a/apps/webapp/test/e2e_tests/specs/TeamUpgrade/teamUpgrade.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/TeamUpgrade/teamUpgrade.spec.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {test, expect} from 'test/e2e_tests/test.fixtures';
+
+test('Team Upgrade', {tag: ['@TC-11757', '@regression']}, async ({createUser, createTeam, api}) => {
+  const userB = await createUser();
+  const {owner: userA} = await createTeam('Critical Team', {users: [userB]});
+
+  await test.step('Upgrade team and verify payment confirmation email is received', async () => {
+      await api.team.upgradeTeam(userA.teamId, userA);
+      expect(await api.inbucket.isPaymentConfirmationEmailReceived(userA)).toBe(true);
+  });
+});

--- a/apps/webapp/test/e2e_tests/specs/TeamUpgrade/teamUpgrade.spec.ts
+++ b/apps/webapp/test/e2e_tests/specs/TeamUpgrade/teamUpgrade.spec.ts
@@ -24,7 +24,7 @@ test('I want to upgrade team to paid', {tag: ['@TC-11757', '@regression']}, asyn
   const {owner: userA} = await createTeam('Critical Team', {users: [userB]});
 
   await test.step('Upgrade team and verify payment confirmation email is received', async () => {
-      await api.team.upgradeTeam(userA.teamId, userA);
-      expect(await api.inbucket.isPaymentConfirmationEmailReceived(userA)).toBe(true);
+    await api.team.upgradeTeam(userA.teamId, userA);
+    expect(await api.inbucket.isPaymentConfirmationEmailReceived(userA)).toBe(true);
   });
 });

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -206,6 +206,7 @@ export const createTeam = async (
       meetings?: boolean;
       mls?: boolean | Parameters<BrigRepositoryE2E['configureMLSFeature']>[1];
       cells?: boolean;
+      sso?: boolean;
     };
   },
 ) => {
@@ -273,6 +274,11 @@ export const createTeam = async (
       await api.brig.unlockCellsFeature(teamId);
       await api.brig.enableCells(teamId);
       await api.waitForFeatureToBeEnabled(FEATURE_KEY.CELLS, teamId, owner.token);
+    }
+
+    if (options.features.sso) {
+      await api.brig.enableSSOFeature(teamId);
+      await api.waitForFeatureToBeEnabled(FEATURE_KEY.SSO, teamId, owner.token);
     }
   }
 

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -234,6 +234,7 @@ export const createTeam = async (
 
   if (options?.features && Object.values(options.features).some(Boolean)) {
     await api.team.upgradeTeam(teamId, owner);
+    await api.inbucket.isPaymentConfirmationEmailReceived(owner);
 
     if (options.features.conferenceCalling) {
       await api.enableConferenceCallingFeature(teamId);

--- a/apps/webapp/test/e2e_tests/test.fixtures.ts
+++ b/apps/webapp/test/e2e_tests/test.fixtures.ts
@@ -235,7 +235,6 @@ export const createTeam = async (
 
   if (options?.features && Object.values(options.features).some(Boolean)) {
     await api.team.upgradeTeam(teamId, owner);
-    await api.inbucket.isPaymentConfirmationEmailReceived(owner);
 
     if (options.features.conferenceCalling) {
       await api.enableConferenceCallingFeature(teamId);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28450" title="WPB-28450" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28450</a>  [Ibis E2E] Ensure that an email with correct TeamID and Invoice is sent to the team owner after subscription
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Upgrading is done via API call and that's not new. What's new is checking that payment confirmation email contains all the expected information. 