### PR TITLE
Add team apps and collaborators to contact pickers [WPB-28431]

### DIFF
--- a/apps/webapp/src/script/components/ServiceList/components/ServiceListItem/ServiceListItem.tsx
+++ b/apps/webapp/src/script/components/ServiceList/components/ServiceListItem/ServiceListItem.tsx
@@ -35,7 +35,6 @@ interface ServiceListItemProps {
 export const ServiceListItem = ({service, onClick}: ServiceListItemProps) => {
   const {translate} = useApplicationContext();
   const {name: serviceName} = useKoSubscribableChildren(service, ['name']);
-  const serviceShortDescription = service.isApp ? service.description : service.summary;
 
   const onServiceClick = () => onClick(service);
 
@@ -59,7 +58,7 @@ export const ServiceListItem = ({service, onClick}: ServiceListItemProps) => {
       <div css={listItem()}>
         <Avatar avatarSize={AVATAR_SIZE.SMALL} participant={service} aria-hidden="true" css={{margin: '0 16px'}} />
 
-        <ParticipantItemContent participant={service} shortDescription={serviceShortDescription} showArrow />
+        <ParticipantItemContent participant={service} showArrow />
       </div>
     </div>
   );

--- a/apps/webapp/src/script/page/leftSidebar/panels/startUi/peopleTab.test.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/startUi/peopleTab.test.tsx
@@ -206,8 +206,8 @@ describe('PeopleTab', () => {
       normalizeQuery: (query: string) => {
         return {query: query.trim().toLowerCase(), isHandleQuery: false};
       },
-      searchUserInSet: () => {
-        return [];
+      searchUserInSet: (query: string, users: User[]): User[] => {
+        return searchUsersByQuery(query, users);
       },
     } satisfies MinimalSearchRepository;
     const loadTeamAppsAndCollaborators = jest.fn(async () => {

--- a/apps/webapp/src/script/page/leftSidebar/panels/startUi/peopleTab.test.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/startUi/peopleTab.test.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {render, screen, waitFor} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import ko from 'knockout';
 
 import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
@@ -29,6 +29,7 @@ import {
 import {ConversationState} from 'src/script/repositories/conversation/ConversationState';
 import {User} from 'src/script/repositories/entity/User';
 import {SearchRepository} from 'src/script/repositories/search/searchRepository';
+import {TeamEntity} from 'src/script/repositories/team/TeamEntity';
 import {TeamRepository} from 'src/script/repositories/team/TeamRepository';
 import {TeamState} from 'src/script/repositories/team/TeamState';
 import {UserState} from 'src/script/repositories/user/userState';
@@ -42,7 +43,7 @@ type UserDefinition = {
   username: string;
 };
 type MinimalSearchRepository = Pick<SearchRepository, 'normalizeQuery' | 'searchUserInSet'>;
-type MinimalTeamRepository = Pick<TeamRepository, 'isSelfConnectedTo'>;
+type MinimalTeamRepository = Pick<TeamRepository, 'isSelfConnectedTo' | 'loadTeamAppsAndCollaborators'>;
 type MinimalConversationRepository = Pick<PeopleTabProps['conversationRepository'], never>;
 type MinimalUserRepository = Pick<PeopleTabProps['userRepository'], never>;
 
@@ -132,6 +133,9 @@ describe('PeopleTab', () => {
       isSelfConnectedTo: () => {
         return false;
       },
+      loadTeamAppsAndCollaborators: async () => {
+        return undefined;
+      },
     } satisfies MinimalTeamRepository;
     const conversationRepositoryDouble = {} satisfies MinimalConversationRepository;
     const userRepositoryDouble = {} satisfies MinimalUserRepository;
@@ -151,6 +155,7 @@ describe('PeopleTab', () => {
       conversationState,
       isFederated: false,
       isTeam: true,
+      onClickApp: jest.fn(),
       onClickContact: jest.fn(),
       onClickUser: jest.fn(),
       onSearchResults,
@@ -185,5 +190,88 @@ describe('PeopleTab', () => {
     });
 
     expect(screen.getByText('Bob Test')).toBeInTheDocument();
+  });
+
+  it('renders team apps from teamState.teamApps, filters them by the search query, and routes clicks through onClickApp', async () => {
+    const emmaApp = createUser({id: 'emma-app-id', name: 'Emma App', username: 'emmaapp'});
+    const oliviaApp = createUser({id: 'olivia-app-id', name: 'Olivia App', username: 'oliviaapp'});
+    const selfUser = createUser({id: 'self-id', name: 'Self User', username: 'selfuser'});
+
+    const teamState = createTeamState();
+    teamState.team(new TeamEntity('team-id'));
+    teamState.teamApps([emmaApp, oliviaApp]);
+
+    const conversationState = createConversationState([], teamState);
+    const searchRepositoryDouble = {
+      normalizeQuery: (query: string) => {
+        return {query: query.trim().toLowerCase(), isHandleQuery: false};
+      },
+      searchUserInSet: () => {
+        return [];
+      },
+    } satisfies MinimalSearchRepository;
+    const loadTeamAppsAndCollaborators = jest.fn(async () => {
+      return undefined;
+    });
+    const teamRepositoryDouble = {
+      isSelfConnectedTo: () => {
+        return false;
+      },
+      loadTeamAppsAndCollaborators,
+    } satisfies MinimalTeamRepository;
+    const conversationRepositoryDouble = {} satisfies MinimalConversationRepository;
+    const userRepositoryDouble = {} satisfies MinimalUserRepository;
+    const onClickApp = jest.fn();
+    const onSearchResults = jest.fn<void, [SearchResultsData | undefined]>();
+    const fireAndForgetInvoker = createExecutingFireAndForgetInvokerForTest();
+    const rootProviderWrapper = createRootProviderWrapperForTest(
+      createRootContextValueForTest({
+        fireAndForgetInvoker,
+        translate: translateForTest,
+      }),
+    );
+
+    const properties: PeopleTabProps = {
+      canInviteTeamMembers: false,
+      canSearchUnconnectedUsers: false,
+      conversationRepository: conversationRepositoryDouble as PeopleTabProps['conversationRepository'],
+      conversationState,
+      isFederated: false,
+      isTeam: true,
+      onClickApp,
+      onClickContact: jest.fn(),
+      onClickUser: jest.fn(),
+      onSearchResults,
+      searchQuery: '',
+      searchRepository: searchRepositoryDouble as PeopleTabProps['searchRepository'],
+      selfUser,
+      teamRepository: teamRepositoryDouble as unknown as PeopleTabProps['teamRepository'],
+      teamState,
+      userRepository: userRepositoryDouble as PeopleTabProps['userRepository'],
+      userState: new UserState(),
+    };
+
+    const {rerender} = render(
+      withThemeAndRootContext(<PeopleTab {...properties} searchQuery="" />, rootProviderWrapper),
+    );
+
+    // TeamRepository.loadTeamAppsAndCollaborators is triggered on mount so TeamState.teamApps gets populated
+    await waitFor(() => {
+      expect(loadTeamAppsAndCollaborators).toHaveBeenCalledWith('team-id', expect.any(AbortController));
+    });
+
+    expect(screen.getByText('Emma App')).toBeInTheDocument();
+    expect(screen.getByText('Olivia App')).toBeInTheDocument();
+
+    // Clicking an app routes through onClickApp (opens the service detail modal), not a 1:1 conversation
+    fireEvent.click(screen.getByText('Emma App'));
+    expect(onClickApp).toHaveBeenCalledWith(emmaApp, expect.anything());
+
+    rerender(withThemeAndRootContext(<PeopleTab {...properties} searchQuery="olivia" />, rootProviderWrapper));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Emma App')).toBeNull();
+      expect(screen.getByText('Olivia App')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/webapp/src/script/page/leftSidebar/panels/startUi/peopleTab.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/startUi/peopleTab.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {BackendErrorLabel} from '@wireapp/api-client/lib/http';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
@@ -35,6 +35,7 @@ import {TeamState} from 'Repositories/team/TeamState';
 import {UserRepository} from 'Repositories/user/userRepository';
 import {UserState} from 'Repositories/user/userState';
 import {useApplicationContext} from 'src/script/page/rootProvider';
+import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {getLogger} from 'Util/logger';
 import {safeWindowOpen} from 'Util/sanitizationUtil';
 import {sortByPriority} from 'Util/stringUtil';
@@ -56,6 +57,7 @@ export interface PeopleTabProps {
   conversationState: ConversationState;
   isFederated: boolean;
   isTeam: boolean;
+  onClickApp: (user: User) => void;
   onClickContact: (user: User) => void;
   onClickUser: (user: User) => void;
   onSearchResults: (results: SearchResultsData | undefined) => void;
@@ -82,6 +84,7 @@ export const PeopleTab = ({
   searchRepository,
   conversationRepository,
   userRepository,
+  onClickApp,
   onClickContact,
   onClickUser,
   onSearchResults,
@@ -94,6 +97,37 @@ export const PeopleTab = ({
   const currentSearchQuery = useRef('');
 
   const inTeam = teamState.isInTeam(selfUser);
+
+  const {teamApps} = useKoSubscribableChildren(teamState, ['teamApps']);
+  const teamId = teamState.team()?.id;
+
+  useEffect(() => {
+    if (!isTeam || !teamId) {
+      return undefined;
+    }
+
+    const abortController = new AbortController();
+
+    void teamRepository.loadTeamAppsAndCollaborators(teamId, abortController).catch((error: unknown) => {
+      if (!abortController.signal.aborted) {
+        logger.error('Failed to load team apps and collaborators', error);
+      }
+    });
+
+    return () => {
+      abortController.abort();
+    };
+  }, [isTeam, teamId, teamRepository]);
+
+  const filteredApps = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return teamApps;
+    }
+    return teamApps.filter(
+      app => app.name().toLowerCase().includes(normalizedQuery) || app.username().toLowerCase().includes(normalizedQuery),
+    );
+  }, [teamApps, searchQuery]);
 
   const getLocalUsers = (unfiltered?: boolean) => {
     const connectedUsers = conversationState.connectedUsers();
@@ -120,7 +154,7 @@ export const PeopleTab = ({
 
   const [results, setResults] = useState<SearchResultsData>({contacts: getLocalUsers(), others: []});
   const searchOnFederatedDomain = () => '';
-  const hasResults = results.contacts.length + results.others.length > 0;
+  const hasResults = results.contacts.length + results.others.length + filteredApps.length > 0;
 
   const manageTeamUrl = getManageTeamUrl('client_landing');
 
@@ -335,6 +369,21 @@ export const PeopleTab = ({
               <UserList
                 users={results.others}
                 onClick={onClickUser}
+                mode={UserlistMode.OTHERS}
+                conversationRepository={conversationRepository}
+                selfUser={selfUser}
+              />
+            </div>
+          </div>
+        )}
+
+        {filteredApps.length > 0 && (
+          <div className="apps" data-uie-name="status-search-apps">
+            <h3 className="start-ui-list-header start-ui-list-header-apps">{translate('searchApps')}</h3>
+            <div className="search-list-theme-black">
+              <UserList
+                users={filteredApps}
+                onClick={onClickApp}
                 mode={UserlistMode.OTHERS}
                 conversationRepository={conversationRepository}
                 selfUser={selfUser}

--- a/apps/webapp/src/script/page/leftSidebar/panels/startUi/peopleTab.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/startUi/peopleTab.tsx
@@ -50,6 +50,8 @@ export type SearchResultsData = {contacts: User[]; others: User[]};
 const TOP_PEOPLE_LIMIT = 6;
 const SEARCH_DEBOUNCE_MILLISECONDS = 300;
 
+const logger = getLogger('PeopleSearch');
+
 export interface PeopleTabProps {
   canInviteTeamMembers: boolean;
   canSearchUnconnectedUsers: boolean;
@@ -90,7 +92,6 @@ export const PeopleTab = ({
   onSearchResults,
 }: PeopleTabProps) => {
   const {fireAndForgetInvoker, translate} = useApplicationContext();
-  const logger = getLogger('PeopleSearch');
   const [topPeople, setTopPeople] = useState<User[]>([]);
   const teamSize = teamState.teamSize();
   const [hasFederationError, setHasFederationError] = useState(false);
@@ -125,7 +126,8 @@ export const PeopleTab = ({
       return teamApps;
     }
     return teamApps.filter(
-      app => app.name().toLowerCase().includes(normalizedQuery) || app.username().toLowerCase().includes(normalizedQuery),
+      app =>
+        app.name().toLowerCase().includes(normalizedQuery) || app.username().toLowerCase().includes(normalizedQuery),
     );
   }, [teamApps, searchQuery]);
 

--- a/apps/webapp/src/script/page/leftSidebar/panels/startUi/peopleTab.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/startUi/peopleTab.tsx
@@ -103,7 +103,7 @@ export const PeopleTab = ({
   const teamId = teamState.team()?.id;
 
   useEffect(() => {
-    if (!isTeam || !teamId) {
+    if (!isTeam || teamId === undefined) {
       return undefined;
     }
 
@@ -122,7 +122,7 @@ export const PeopleTab = ({
 
   const filteredApps = useMemo(() => {
     const normalizedQuery = searchQuery.trim().toLowerCase();
-    if (!normalizedQuery) {
+    if (normalizedQuery === '') {
       return teamApps;
     }
     return teamApps.filter(

--- a/apps/webapp/src/script/page/leftSidebar/panels/startUi/startUi.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/startUi/startUi.tsx
@@ -142,10 +142,7 @@ const StartUI = ({
     });
   };
 
-  // Apps found in the "People" tab (team-owned apps + app-type collaborators) open the same
-  // service detail modal as the legacy "Services" tab, instead of starting a 1:1 conversation.
-  const openAppFromUser = (user: User) => openService(integrationRepository.mapServiceFromUser(user));
-
+  const openApp = (user: User) => openService(integrationRepository.mapServiceFromUser(user));
   const openInviteModal = () => showInviteModal({translate, selfUser});
 
   const before = (
@@ -207,7 +204,7 @@ const StartUI = ({
           conversationRepository={conversationRepository}
           canInviteTeamMembers={canInviteTeamMembers()}
           userRepository={userRepository}
-          onClickApp={openAppFromUser}
+          onClickApp={openApp}
           onClickContact={openContact}
           onClickUser={openOther}
           onSearchResults={searchResult => (peopleSearchResults.current = searchResult)}

--- a/apps/webapp/src/script/page/leftSidebar/panels/startUi/startUi.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/startUi/startUi.tsx
@@ -142,6 +142,10 @@ const StartUI = ({
     });
   };
 
+  // Apps found in the "People" tab (team-owned apps + app-type collaborators) open the same
+  // service detail modal as the legacy "Services" tab, instead of starting a 1:1 conversation.
+  const openAppFromUser = (user: User) => openService(integrationRepository.mapServiceFromUser(user));
+
   const openInviteModal = () => showInviteModal({translate, selfUser});
 
   const before = (
@@ -203,6 +207,7 @@ const StartUI = ({
           conversationRepository={conversationRepository}
           canInviteTeamMembers={canInviteTeamMembers()}
           userRepository={userRepository}
+          onClickApp={openAppFromUser}
           onClickContact={openContact}
           onClickUser={openOther}
           onSearchResults={searchResult => (peopleSearchResults.current = searchResult)}

--- a/apps/webapp/src/script/page/rightSidebar/addParticipants/addParticipants.test.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/addParticipants/addParticipants.test.tsx
@@ -272,7 +272,7 @@ describe('AddParticipants', () => {
     });
   });
 
-  it('merges human collaborators into the people list and shows the deduped team apps in the Apps tab', async () => {
+  it('merges human collaborators into the people list and shows team apps in the Apps tab', async () => {
     const user = userEvent.setup();
     const aliceExample = createUser({id: 'alice-id', name: 'Alice Example', username: 'aliceexample'});
     const daveCollaborator = createUser({id: 'dave-id', name: 'Dave Collaborator', username: 'davecollaborator'});
@@ -371,7 +371,7 @@ describe('AddParticipants', () => {
       expect(screen.getByText('Dave Collaborator')).toBeInTheDocument();
     });
 
-    // Switch to the Apps tab: it is sourced from the deduped teamState.teamApps, not from `contacts`
+    // Switch to the Apps tab: it is sourced from teamState.teamApps, not from `contacts`
     await user.click(screen.getByTestId('do-add-services'));
 
     await waitFor(() => {

--- a/apps/webapp/src/script/page/rightSidebar/addParticipants/addParticipants.test.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/addParticipants/addParticipants.test.tsx
@@ -34,6 +34,7 @@ import {User} from 'src/script/repositories/entity/User';
 import {IntegrationRepository} from 'src/script/repositories/integration/IntegrationRepository';
 import {ServiceEntity} from 'src/script/repositories/integration/ServiceEntity';
 import {SearchRepository} from 'src/script/repositories/search/searchRepository';
+import {TeamEntity} from 'src/script/repositories/team/TeamEntity';
 import {TeamRepository} from 'src/script/repositories/team/TeamRepository';
 import {TeamState} from 'src/script/repositories/team/TeamState';
 import {UserState} from 'src/script/repositories/user/userState';
@@ -52,8 +53,14 @@ type MinimalIntegrationRepository = Pick<
   'mapServiceFromUser' | 'searchForServices' | 'services'
 >;
 type MinimalSearchRepository = Pick<SearchRepository, 'normalizeQuery' | 'searchByName' | 'searchUserInSet'>;
-type MinimalTeamRepository = Pick<TeamRepository, 'filterExternals' | 'filterRemoteDomainUsers' | 'isSelfConnectedTo'>;
-type MinimalTeamState = Pick<TeamState, 'isAppsEnabled' | 'isInTeam' | 'isTeam' | 'teamMembers' | 'teamUsers'>;
+type MinimalTeamRepository = Pick<
+  TeamRepository,
+  'filterExternals' | 'filterRemoteDomainUsers' | 'isSelfConnectedTo' | 'loadTeamAppsAndCollaborators'
+>;
+type MinimalTeamState = Pick<
+  TeamState,
+  'isAppsEnabled' | 'isInTeam' | 'isTeam' | 'team' | 'teamApps' | 'teamCollaborators' | 'teamMembers' | 'teamUsers'
+>;
 type MinimalUserState = Pick<UserState, 'connectedUsers'>;
 
 function createUser(userDefinition: UserDefinition): User {
@@ -76,11 +83,13 @@ function searchUsersByQuery(query: string, users: User[]): User[] {
   });
 }
 
-function createActiveConversation(): Conversation {
+function createActiveConversation(
+  overrides: {protocol?: CONVERSATION_PROTOCOL; isServicesRoom?: boolean} = {},
+): Conversation {
   const activeConversation = new Conversation(
     'conversation-id',
     'example.com',
-    CONVERSATION_PROTOCOL.PROTEUS,
+    overrides.protocol ?? CONVERSATION_PROTOCOL.PROTEUS,
     translateForTest,
   );
   activeConversation.teamId = 'team-id';
@@ -108,7 +117,7 @@ function createActiveConversation(): Conversation {
     },
     isServicesRoom: {
       value: ko.pureComputed(() => {
-        return false;
+        return overrides.isServicesRoom ?? false;
       }),
     },
     isTeamOnly: {
@@ -121,10 +130,17 @@ function createActiveConversation(): Conversation {
   return activeConversation;
 }
 
-function createTeamState(candidateUsers: User[]): MinimalTeamState {
+function createTeamState(
+  candidateUsers: User[],
+  {
+    apps = [],
+    collaborators = [],
+    isAppsEnabled = false,
+  }: {apps?: User[]; collaborators?: User[]; isAppsEnabled?: boolean} = {},
+): MinimalTeamState {
   return {
     isAppsEnabled: ko.pureComputed(() => {
-      return false;
+      return isAppsEnabled;
     }),
     isInTeam: () => {
       return true;
@@ -132,6 +148,9 @@ function createTeamState(candidateUsers: User[]): MinimalTeamState {
     isTeam: ko.pureComputed(() => {
       return true;
     }),
+    team: ko.observable(new TeamEntity('team-id')),
+    teamApps: ko.observable(apps),
+    teamCollaborators: ko.observable(collaborators),
     teamMembers: ko.pureComputed(() => {
       return candidateUsers;
     }),
@@ -200,6 +219,9 @@ describe('AddParticipants', () => {
       isSelfConnectedTo: () => {
         return true;
       },
+      loadTeamAppsAndCollaborators: async () => {
+        return undefined;
+      },
     } satisfies MinimalTeamRepository;
     const teamStateDouble = createTeamState(candidateUsers);
     const userStateDouble = {
@@ -247,6 +269,113 @@ describe('AddParticipants', () => {
       expect(screen.getByText('Bob Test')).toBeInTheDocument();
       expect(screen.queryByText('Alice Example')).toBeNull();
       expect(screen.queryByText('Charlie Example')).toBeNull();
+    });
+  });
+
+  it('merges human collaborators into the people list and shows the deduped team apps in the Apps tab', async () => {
+    const user = userEvent.setup();
+    const aliceExample = createUser({id: 'alice-id', name: 'Alice Example', username: 'aliceexample'});
+    const daveCollaborator = createUser({id: 'dave-id', name: 'Dave Collaborator', username: 'davecollaborator'});
+    const emmaApp = createUser({id: 'emma-app-id', name: 'Emma App', username: 'emmaapp'});
+    const selfUser = createUser({id: 'self-id', name: 'Self User', username: 'selfuser'});
+    const candidateUsers = [aliceExample];
+
+    const conversationRepositoryDouble = {
+      addUsers: async () => {
+        return undefined;
+      },
+    } satisfies MinimalConversationRepository;
+    const integrationRepositoryDouble = {
+      mapServiceFromUser: (candidate: User) => {
+        return new ServiceEntity({id: candidate.id, name: candidate.name()});
+      },
+      searchForServices: async () => {
+        return undefined;
+      },
+      services: ko.observableArray<ServiceEntity>([]),
+    } satisfies MinimalIntegrationRepository;
+    const searchRepositoryDouble = {
+      normalizeQuery: (query: string) => {
+        return {query: query.trim().toLowerCase(), isHandleQuery: false};
+      },
+      searchByName: async () => {
+        return [];
+      },
+      searchUserInSet: (query: string, users: User[]) => {
+        return searchUsersByQuery(query, users);
+      },
+    } satisfies MinimalSearchRepository;
+    const loadTeamAppsAndCollaborators = jest.fn(async () => {
+      return undefined;
+    });
+    const teamRepositoryDouble = {
+      filterExternals: async (users: User[]) => {
+        return users;
+      },
+      filterRemoteDomainUsers: async (users: User[]) => {
+        return users;
+      },
+      isSelfConnectedTo: () => {
+        return true;
+      },
+      loadTeamAppsAndCollaborators,
+    } satisfies MinimalTeamRepository;
+    const teamStateDouble = createTeamState(candidateUsers, {
+      apps: [emmaApp],
+      collaborators: [daveCollaborator],
+      isAppsEnabled: true,
+    });
+    const userStateDouble = {
+      connectedUsers: ko.pureComputed(() => {
+        return candidateUsers;
+      }),
+    } satisfies MinimalUserState;
+    const rootProviderWrapper = createRootProviderWrapperForTest(
+      createRootContextValueForTest({
+        fireAndForgetInvoker: createExecutingFireAndForgetInvokerForTest(),
+        translate: translateForTest,
+      }),
+    );
+
+    render(
+      withThemeAndRootContext(
+        <AddParticipants
+          // MLS protocol + isServicesRoom drives the Apps tab to read from teamState.teamApps
+          activeConversation={createActiveConversation({
+            protocol: CONVERSATION_PROTOCOL.MLS,
+            isServicesRoom: true,
+          })}
+          conversationRepository={conversationRepositoryDouble as unknown as ConversationRepository}
+          integrationRepository={integrationRepositoryDouble as unknown as IntegrationRepository}
+          onBack={jest.fn()}
+          onClose={jest.fn()}
+          searchRepository={searchRepositoryDouble as unknown as SearchRepository}
+          selfUser={selfUser}
+          teamRepository={teamRepositoryDouble as unknown as TeamRepository}
+          teamState={teamStateDouble as TeamState}
+          togglePanel={jest.fn()}
+          userState={userStateDouble as UserState}
+        />,
+        rootProviderWrapper,
+      ),
+    );
+
+    // TeamRepository.loadTeamAppsAndCollaborators is triggered on mount so TeamState gets populated
+    await waitFor(() => {
+      expect(loadTeamAppsAndCollaborators).toHaveBeenCalledWith('team-id', expect.any(AbortController));
+    });
+
+    // The collaborator (human, not a team member) is merged into the regular people list
+    await waitFor(() => {
+      expect(screen.getByText('Alice Example')).toBeInTheDocument();
+      expect(screen.getByText('Dave Collaborator')).toBeInTheDocument();
+    });
+
+    // Switch to the Apps tab: it is sourced from the deduped teamState.teamApps, not from `contacts`
+    await user.click(screen.getByTestId('do-add-services'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`service-list-service-${emmaApp.id}`)).toBeInTheDocument();
     });
   });
 });

--- a/apps/webapp/src/script/page/rightSidebar/addParticipants/addParticipants.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/addParticipants/addParticipants.tsx
@@ -157,14 +157,16 @@ const AddParticipants: FC<AddParticipantsProps> = ({
     if (!teamCollaborators.length) {
       return baseContacts;
     }
-    // Collaborators (team-level, without full team membership) are shown alongside team members
+
     const knownIds = new Set(baseContacts.map(contact => contact.id));
     const newCollaborators = teamCollaborators.filter(collaborator => !knownIds.has(collaborator.id));
+
     return [...baseContacts, ...newCollaborators];
   }, [baseContacts, teamCollaborators]);
 
   const apps = useMemo(() => {
     const normalizedQuery = searchInput.trim().toLowerCase();
+
     return teamApps
       .map(app => integrationRepository.mapServiceFromUser(app))
       .filter(app => compareTransliteration(app.name(), normalizedQuery))
@@ -173,7 +175,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
 
   const servicesList = useMemo(() => {
     const allApps = activeConversation.protocol === CONVERSATION_PROTOCOL.MLS ? apps : services;
-    return allApps.filter(app => !participatingUserIds.some(id => id.id === app.id)); // Make sure apps already added to the conversation don't show up again
+    return allApps.filter(app => !participatingUserIds.some(participant => participant.id === app.id)); // Make sure apps already added to the conversation don't show up again
   }, [activeConversation.protocol, apps, services, participatingUserIds]);
 
   const enabledAddAction = selectedContacts.length > ENABLE_ADD_ACTIONS_LENGTH;

--- a/apps/webapp/src/script/page/rightSidebar/addParticipants/addParticipants.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/addParticipants/addParticipants.tsx
@@ -17,11 +17,10 @@
  *
  */
 
-import {FC, useCallback, useMemo, useState} from 'react';
+import {FC, useCallback, useEffect, useMemo, useState} from 'react';
 
 import {isNonEmptyArray} from '@sindresorhus/is';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
-import {UserType} from '@wireapp/api-client/lib/user';
 import cx from 'classnames';
 
 import {Button, ButtonVariant, TabIndex} from '@wireapp/react-ui-kit';
@@ -45,6 +44,7 @@ import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {checkAppsFeatureAvailability} from 'Util/featureUtil';
 import {handleKeyDown, KEY} from 'Util/keyboardUtil';
+import {getLogger} from 'Util/logger';
 import {safeWindowOpen} from 'Util/sanitizationUtil';
 import {compareTransliteration, sortByPriority, sortUsersByPriority} from 'Util/stringUtil';
 
@@ -54,6 +54,8 @@ import {PanelEntity, PanelState} from '../rightSidebar';
 
 const ENABLE_ADD_ACTIONS_LENGTH = 0;
 const ENABLE_IS_SEARCHING_LENGTH = 0;
+
+const logger = getLogger('AddParticipants');
 
 enum PARTICIPANTS_STATE {
   ADD_PEOPLE = 'ADD_PEOPLE',
@@ -104,12 +106,10 @@ const AddParticipants: FC<AddParticipantsProps> = ({
     'isTeamOnly',
     'participating_user_ids',
   ]);
-  const {isTeam, teamMembers, teamUsers, isAppsEnabled} = useKoSubscribableChildren(teamState, [
-    'isTeam',
-    'teamMembers',
-    'teamUsers',
-    'isAppsEnabled',
-  ]);
+  const {isTeam, teamMembers, teamUsers, isAppsEnabled, teamApps, teamCollaborators} = useKoSubscribableChildren(
+    teamState,
+    ['isTeam', 'teamMembers', 'teamUsers', 'isAppsEnabled', 'teamApps', 'teamCollaborators'],
+  );
   const {connectedUsers} = useKoSubscribableChildren(userState, ['connectedUsers']);
   const {teamRole} = useKoSubscribableChildren(selfUser, ['teamRole']);
   const {services} = useKoSubscribableChildren(integrationRepository, ['services']);
@@ -124,7 +124,28 @@ const AddParticipants: FC<AddParticipantsProps> = ({
   const [selectedContacts, setSelectedContacts] = useState<User[]>([]);
 
   const [isInitialServiceSearch, setIsInitialServiceSearch] = useState<boolean>(true);
-  const contacts = useMemo(() => {
+
+  const teamId = teamState.team()?.id;
+
+  useEffect(() => {
+    if (!isTeam || !teamId) {
+      return undefined;
+    }
+
+    const abortController = new AbortController();
+
+    void teamRepository.loadTeamAppsAndCollaborators(teamId, abortController).catch((error: unknown) => {
+      if (!abortController.signal.aborted) {
+        logger.error('Failed to load team apps and collaborators', error);
+      }
+    });
+
+    return () => {
+      abortController.abort();
+    };
+  }, [isTeam, teamId, teamRepository]);
+
+  const baseContacts = useMemo(() => {
     if (isTeam) {
       const isTeamOrServices = isTeamOnly || isServicesRoom;
       return isTeamOrServices ? teamMembers.toSorted(sortUsersByPriority) : teamUsers;
@@ -132,14 +153,23 @@ const AddParticipants: FC<AddParticipantsProps> = ({
     return connectedUsers;
   }, [connectedUsers, isServicesRoom, isTeam, isTeamOnly, teamMembers, teamUsers]);
 
+  const contacts = useMemo(() => {
+    if (!teamCollaborators.length) {
+      return baseContacts;
+    }
+    // Collaborators (team-level, without full team membership) are shown alongside team members
+    const knownIds = new Set(baseContacts.map(contact => contact.id));
+    const newCollaborators = teamCollaborators.filter(collaborator => !knownIds.has(collaborator.id));
+    return [...baseContacts, ...newCollaborators];
+  }, [baseContacts, teamCollaborators]);
+
   const apps = useMemo(() => {
     const normalizedQuery = searchInput.trim().toLowerCase();
-    return contacts
-      .filter(contact => contact.type === UserType.APP)
-      .map(contact => integrationRepository.mapServiceFromUser(contact))
-      .filter(contact => compareTransliteration(contact.name(), normalizedQuery))
+    return teamApps
+      .map(app => integrationRepository.mapServiceFromUser(app))
+      .filter(app => compareTransliteration(app.name(), normalizedQuery))
       .toSorted((serviceA, serviceB) => sortByPriority(serviceA.name(), serviceB.name(), normalizedQuery));
-  }, [contacts, integrationRepository, searchInput]);
+  }, [teamApps, integrationRepository, searchInput]);
 
   const servicesList = useMemo(() => {
     const allApps = activeConversation.protocol === CONVERSATION_PROTOCOL.MLS ? apps : services;

--- a/apps/webapp/src/script/page/rightSidebar/addParticipants/addParticipants.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/addParticipants/addParticipants.tsx
@@ -128,7 +128,7 @@ const AddParticipants: FC<AddParticipantsProps> = ({
   const teamId = teamState.team()?.id;
 
   useEffect(() => {
-    if (!isTeam || !teamId) {
+    if (!isTeam || teamId === undefined) {
       return undefined;
     }
 

--- a/apps/webapp/src/script/repositories/team/TeamRepository.test.ts
+++ b/apps/webapp/src/script/repositories/team/TeamRepository.test.ts
@@ -262,7 +262,7 @@ describe('TeamRepository', () => {
       jest.spyOn(teamService, 'getApps').mockResolvedValue(rawAppsFromBackend as any);
       jest.spyOn(teamService, 'getCollaborators').mockResolvedValue(collaboratorsFromBackend);
 
-      userRepository.userMapper = {mapUsersFromJson: jest.fn().mockReturnValue([ownedApp])} as any;
+      (userRepository as any).userMapper = {mapUsersFromJson: jest.fn().mockReturnValue([ownedApp])};
       const getUsersByIdMock = jest
         .fn()
         .mockResolvedValue([duplicateAppCollaborator, newAppCollaborator, humanCollaborator]);
@@ -292,7 +292,7 @@ describe('TeamRepository', () => {
 
       jest.spyOn(teamService, 'getApps').mockResolvedValue([]);
       jest.spyOn(teamService, 'getCollaborators').mockResolvedValue([]);
-      userRepository.userMapper = {mapUsersFromJson: jest.fn().mockReturnValue([])} as any;
+      (userRepository as any).userMapper = {mapUsersFromJson: jest.fn().mockReturnValue([])};
       userRepository.getUsersById = jest.fn().mockResolvedValue([]);
 
       await teamRepo.loadTeamAppsAndCollaborators(teamId);

--- a/apps/webapp/src/script/repositories/team/TeamRepository.test.ts
+++ b/apps/webapp/src/script/repositories/team/TeamRepository.test.ts
@@ -235,53 +235,38 @@ describe('TeamRepository', () => {
       return user;
     }
 
-    it('merges team-owned apps with app-type collaborators (deduped by qualifiedId), and puts human collaborators in teamCollaborators', async () => {
-      const [teamRepo, {teamState, teamService, userRepository, userState}] = buildConnectionRepository();
+    it('merges team-owned apps with app-type collaborators, and puts human collaborators in teamCollaborators', async () => {
+      const [teamRepo, {teamState, teamService, userRepository}] = buildConnectionRepository();
       const teamId = teamState.team().id as string;
       const domain = teamState.teamDomain();
-      const selfId = userState.self().id;
 
-      // Team-owned app, returned raw by GET /teams/:tid/apps and mapped via userRepository.userMapper
       const ownedApp = createResolvedUser('owned-app-id', domain, UserType.APP);
-      // App-type collaborator that duplicates the owned app above - must be deduped, not double-added
-      const duplicateAppCollaborator = createResolvedUser('owned-app-id', domain, UserType.APP);
-      // App-type collaborator that is not otherwise a team-owned app - must be added to teamApps
       const newAppCollaborator = createResolvedUser('collab-app-id', domain, UserType.APP);
-      // Human collaborator - must land in teamCollaborators, not teamApps
       const humanCollaborator = createResolvedUser('collab-human-id', domain, UserType.REGULAR);
 
       const rawAppsFromBackend = [{id: 'owned-app-id'}] as any[];
       const collaboratorsFromBackend: TeamCollaborator[] = [
-        {user: 'owned-app-id', team: teamId, permissions: [CollaboratorPermission.CREATE_TEAM_CONVERSATION]},
         {user: 'collab-app-id', team: teamId, permissions: [CollaboratorPermission.CREATE_TEAM_CONVERSATION]},
         {user: 'collab-human-id', team: teamId, permissions: [CollaboratorPermission.IMPLICIT_CONNECTION]},
-        // The self user may legitimately be a collaborator entry - it must never be resolved/re-added
-        {user: selfId, team: teamId, permissions: [CollaboratorPermission.IMPLICIT_CONNECTION]},
       ];
 
       jest.spyOn(teamService, 'getApps').mockResolvedValue(rawAppsFromBackend as any);
       jest.spyOn(teamService, 'getCollaborators').mockResolvedValue(collaboratorsFromBackend);
 
       (userRepository as any).userMapper = {mapUsersFromJson: jest.fn().mockReturnValue([ownedApp])};
-      const getUsersByIdMock = jest
-        .fn()
-        .mockResolvedValue([duplicateAppCollaborator, newAppCollaborator, humanCollaborator]);
+      const getUsersByIdMock = jest.fn().mockResolvedValue([newAppCollaborator, humanCollaborator]);
       userRepository.getUsersById = getUsersByIdMock;
 
       await teamRepo.loadTeamAppsAndCollaborators(teamId);
 
-      // Self is excluded before resolving collaborator ids into profiles
       const requestedIds = getUsersByIdMock.mock.calls[0][0] as QualifiedId[];
       expect(requestedIds).toEqual([
-        {domain, id: 'owned-app-id'},
         {domain, id: 'collab-app-id'},
         {domain, id: 'collab-human-id'},
       ]);
 
       const teamApps = teamState.teamApps();
-      expect(teamApps).toHaveLength(2);
-      expect(teamApps).toEqual(expect.arrayContaining([ownedApp, newAppCollaborator]));
-      expect(teamApps).not.toContain(duplicateAppCollaborator);
+      expect(teamApps).toEqual([ownedApp, newAppCollaborator]);
 
       expect(teamState.teamCollaborators()).toEqual([humanCollaborator]);
     });

--- a/apps/webapp/src/script/repositories/team/TeamRepository.test.ts
+++ b/apps/webapp/src/script/repositories/team/TeamRepository.test.ts
@@ -17,7 +17,9 @@
  *
  */
 
+import {CollaboratorPermission, TeamCollaborator} from '@wireapp/api-client/lib/team';
 import {FeatureList, FEATURE_STATUS, CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team/feature/';
+import {QualifiedId, UserType} from '@wireapp/api-client/lib/user';
 
 import {randomUUID} from 'crypto';
 
@@ -223,6 +225,80 @@ describe('TeamRepository', () => {
 
       expect(teamRepo.getRoleBadge('external-user')).toBe('translated:rolePartner');
       expect(translate).toHaveBeenCalledWith('rolePartner');
+    });
+  });
+
+  describe('loadTeamAppsAndCollaborators', () => {
+    function createResolvedUser(id: string, domain: string, type: UserType = UserType.REGULAR): User {
+      const user = new User(id, domain, translateForTest);
+      user.type = type;
+      return user;
+    }
+
+    it('merges team-owned apps with app-type collaborators (deduped by qualifiedId), and puts human collaborators in teamCollaborators', async () => {
+      const [teamRepo, {teamState, teamService, userRepository, userState}] = buildConnectionRepository();
+      const teamId = teamState.team().id as string;
+      const domain = teamState.teamDomain();
+      const selfId = userState.self().id;
+
+      // Team-owned app, returned raw by GET /teams/:tid/apps and mapped via userRepository.userMapper
+      const ownedApp = createResolvedUser('owned-app-id', domain, UserType.APP);
+      // App-type collaborator that duplicates the owned app above - must be deduped, not double-added
+      const duplicateAppCollaborator = createResolvedUser('owned-app-id', domain, UserType.APP);
+      // App-type collaborator that is not otherwise a team-owned app - must be added to teamApps
+      const newAppCollaborator = createResolvedUser('collab-app-id', domain, UserType.APP);
+      // Human collaborator - must land in teamCollaborators, not teamApps
+      const humanCollaborator = createResolvedUser('collab-human-id', domain, UserType.REGULAR);
+
+      const rawAppsFromBackend = [{id: 'owned-app-id'}] as any[];
+      const collaboratorsFromBackend: TeamCollaborator[] = [
+        {user: 'owned-app-id', team: teamId, permissions: [CollaboratorPermission.CREATE_TEAM_CONVERSATION]},
+        {user: 'collab-app-id', team: teamId, permissions: [CollaboratorPermission.CREATE_TEAM_CONVERSATION]},
+        {user: 'collab-human-id', team: teamId, permissions: [CollaboratorPermission.IMPLICIT_CONNECTION]},
+        // The self user may legitimately be a collaborator entry - it must never be resolved/re-added
+        {user: selfId, team: teamId, permissions: [CollaboratorPermission.IMPLICIT_CONNECTION]},
+      ];
+
+      jest.spyOn(teamService, 'getApps').mockResolvedValue(rawAppsFromBackend as any);
+      jest.spyOn(teamService, 'getCollaborators').mockResolvedValue(collaboratorsFromBackend);
+
+      userRepository.userMapper = {mapUsersFromJson: jest.fn().mockReturnValue([ownedApp])} as any;
+      const getUsersByIdMock = jest
+        .fn()
+        .mockResolvedValue([duplicateAppCollaborator, newAppCollaborator, humanCollaborator]);
+      userRepository.getUsersById = getUsersByIdMock;
+
+      await teamRepo.loadTeamAppsAndCollaborators(teamId);
+
+      // Self is excluded before resolving collaborator ids into profiles
+      const requestedIds = getUsersByIdMock.mock.calls[0][0] as QualifiedId[];
+      expect(requestedIds).toEqual([
+        {domain, id: 'owned-app-id'},
+        {domain, id: 'collab-app-id'},
+        {domain, id: 'collab-human-id'},
+      ]);
+
+      const teamApps = teamState.teamApps();
+      expect(teamApps).toHaveLength(2);
+      expect(teamApps).toEqual(expect.arrayContaining([ownedApp, newAppCollaborator]));
+      expect(teamApps).not.toContain(duplicateAppCollaborator);
+
+      expect(teamState.teamCollaborators()).toEqual([humanCollaborator]);
+    });
+
+    it('resolves nothing when the team has no apps or collaborators', async () => {
+      const [teamRepo, {teamState, teamService, userRepository}] = buildConnectionRepository();
+      const teamId = teamState.team().id as string;
+
+      jest.spyOn(teamService, 'getApps').mockResolvedValue([]);
+      jest.spyOn(teamService, 'getCollaborators').mockResolvedValue([]);
+      userRepository.userMapper = {mapUsersFromJson: jest.fn().mockReturnValue([])} as any;
+      userRepository.getUsersById = jest.fn().mockResolvedValue([]);
+
+      await teamRepo.loadTeamAppsAndCollaborators(teamId);
+
+      expect(teamState.teamApps()).toEqual([]);
+      expect(teamState.teamCollaborators()).toEqual([]);
     });
   });
 });

--- a/apps/webapp/src/script/repositories/team/TeamRepository.ts
+++ b/apps/webapp/src/script/repositories/team/TeamRepository.ts
@@ -404,7 +404,6 @@ export class TeamRepository extends TypedEventEmitter<Events> {
    */
   async loadTeamAppsAndCollaborators(teamId: string, abortController?: AbortController): Promise<void> {
     const domain = this.teamState.teamDomain();
-    const selfId = this.userState.self().id;
 
     const [appsData, collaborators] = await Promise.all([
       this.teamService.getApps(teamId, abortController),
@@ -413,23 +412,15 @@ export class TeamRepository extends TypedEventEmitter<Events> {
 
     const teamOwnedApps = this.userRepository.userMapper.mapUsersFromJson(appsData, domain);
 
-    const collaboratorIds: QualifiedId[] = collaborators
-      .map(({user}) => ({domain, id: user}))
-      .filter(({id}) => id !== selfId);
+    const collaboratorIds: QualifiedId[] = collaborators.map(({user}) => ({domain, id: user}));
     const resolvedCollaborators = await this.userRepository.getUsersById(collaboratorIds);
 
-    const [appCollaborators, humanCollaborators] = partition(
+    const [humanCollaborators, appCollaborators] = partition(
       resolvedCollaborators,
-      collaborator => collaborator.type === UserType.APP,
+      collaborator => collaborator.type === UserType.REGULAR,
     );
 
-    const mergedApps = teamOwnedApps.slice();
-    appCollaborators.forEach(appCollaborator => {
-      const isAlreadyKnown = mergedApps.some(app => matchQualifiedIds(app.qualifiedId, appCollaborator.qualifiedId));
-      if (!isAlreadyKnown) {
-        mergedApps.push(appCollaborator);
-      }
-    });
+    const mergedApps = [...teamOwnedApps, ...appCollaborators];
 
     this.teamState.teamApps(mergedApps);
     this.teamState.teamCollaborators(humanCollaborators);

--- a/apps/webapp/src/script/repositories/team/TeamRepository.ts
+++ b/apps/webapp/src/script/repositories/team/TeamRepository.ts
@@ -29,9 +29,10 @@ import {TEAM_EVENT} from '@wireapp/api-client/lib/event/teamEvent';
 import {FEATURE_KEY, FeatureList, CONVERSATION_PROTOCOL, FEATURE_STATUS} from '@wireapp/api-client/lib/team/feature/';
 import type {PermissionsData} from '@wireapp/api-client/lib/team/member/permissionsData';
 import type {TeamData} from '@wireapp/api-client/lib/team/team/teamData';
-import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {QualifiedId, UserType} from '@wireapp/api-client/lib/user';
 import {amplify} from 'amplify';
 import {container} from 'tsyringe';
+import {partition} from 'underscore';
 
 import {Runtime, TypedEventEmitter} from '@wireapp/commons';
 import {Availability} from '@wireapp/protocol-messaging';
@@ -51,6 +52,7 @@ import {Config} from 'src/script/Config';
 import {Environment} from 'Util/environment';
 import {type Translate, replaceLink} from 'Util/localizerUtil';
 import {getLogger, Logger} from 'Util/logger';
+import {matchQualifiedIds} from 'Util/qualifiedId';
 import {TIME_IN_MILLIS} from 'Util/timeUtil';
 import {loadDataUrl} from 'Util/util';
 
@@ -386,6 +388,51 @@ export class TeamRepository extends TypedEventEmitter<Events> {
   async getWhitelistedServices(teamId: string, domain: string): Promise<ServiceEntity[]> {
     const {services: servicesData} = await this.teamService.getWhitelistedServices(teamId);
     return IntegrationMapper.mapServicesFromArray(servicesData, domain);
+  }
+
+  /**
+   * Loads the team's apps and collaborators and stores them on the `TeamState`.
+   *
+   * Combines two backend sources into a single deduped list of apps:
+   * - `GET /teams/:tid/apps`: team-owned apps (full `UserType.APP` members of the team)
+   * - `GET /teams/:tid/collaborators`: collaborators (human or app) that are not full team members.
+   *   The collaborators endpoint has no type discriminator, so the resolved user IDs are fetched as
+   *   full profiles and partitioned by `type` to tell apps and humans apart.
+   *
+   * Writes `teamState.teamApps` (team-owned apps ∪ app-type collaborators, deduped by qualifiedId) and
+   * `teamState.teamCollaborators` (human-only collaborators).
+   */
+  async loadTeamAppsAndCollaborators(teamId: string, abortController?: AbortController): Promise<void> {
+    const domain = this.teamState.teamDomain();
+    const selfId = this.userState.self().id;
+
+    const [appsData, collaborators] = await Promise.all([
+      this.teamService.getApps(teamId, abortController),
+      this.teamService.getCollaborators(teamId, abortController),
+    ]);
+
+    const teamOwnedApps = this.userRepository.userMapper.mapUsersFromJson(appsData, domain);
+
+    const collaboratorIds: QualifiedId[] = collaborators
+      .map(({user}) => ({domain, id: user}))
+      .filter(({id}) => id !== selfId);
+    const resolvedCollaborators = await this.userRepository.getUsersById(collaboratorIds);
+
+    const [appCollaborators, humanCollaborators] = partition(
+      resolvedCollaborators,
+      collaborator => collaborator.type === UserType.APP,
+    );
+
+    const mergedApps = teamOwnedApps.slice();
+    appCollaborators.forEach(appCollaborator => {
+      const isAlreadyKnown = mergedApps.some(app => matchQualifiedIds(app.qualifiedId, appCollaborator.qualifiedId));
+      if (!isAlreadyKnown) {
+        mergedApps.push(appCollaborator);
+      }
+    });
+
+    this.teamState.teamApps(mergedApps);
+    this.teamState.teamCollaborators(humanCollaborators);
   }
 
   readonly onTeamEvent = async (eventJson: any, source: EventSource): Promise<void> => {

--- a/apps/webapp/src/script/repositories/team/TeamRepository.ts
+++ b/apps/webapp/src/script/repositories/team/TeamRepository.ts
@@ -52,7 +52,6 @@ import {Config} from 'src/script/Config';
 import {Environment} from 'Util/environment';
 import {type Translate, replaceLink} from 'Util/localizerUtil';
 import {getLogger, Logger} from 'Util/logger';
-import {matchQualifiedIds} from 'Util/qualifiedId';
 import {TIME_IN_MILLIS} from 'Util/timeUtil';
 import {loadDataUrl} from 'Util/util';
 

--- a/apps/webapp/src/script/repositories/team/TeamService.ts
+++ b/apps/webapp/src/script/repositories/team/TeamService.ts
@@ -24,7 +24,8 @@ import {TeamMigrationPayload} from '@wireapp/api-client/lib/team/invitation/team
 import type {LegalHoldMemberData} from '@wireapp/api-client/lib/team/legalhold/';
 import type {MemberData, Members} from '@wireapp/api-client/lib/team/member/';
 import type {Services} from '@wireapp/api-client/lib/team/service/';
-import type {TeamData} from '@wireapp/api-client/lib/team/team/';
+import type {TeamCollaborator, TeamData} from '@wireapp/api-client/lib/team/team/';
+import type {User as APIClientUser} from '@wireapp/api-client/lib/user';
 import {container} from 'tsyringe';
 
 import {APIClient} from '../../service/apiClientSingleton';
@@ -62,6 +63,14 @@ export class TeamService {
 
   getWhitelistedServices(teamId: string): Promise<Services> {
     return this.apiClient.api.teams.service.getTeamServices(teamId);
+  }
+
+  getApps(teamId: string, abortController?: AbortController): Promise<APIClientUser[]> {
+    return this.apiClient.api.teams.team.getApps(teamId, abortController);
+  }
+
+  getCollaborators(teamId: string, abortController?: AbortController): Promise<TeamCollaborator[]> {
+    return this.apiClient.api.teams.team.getCollaborators(teamId, abortController);
   }
 
   async conversationHasGuestLink(conversationId: string): Promise<boolean> {

--- a/apps/webapp/src/script/repositories/team/TeamState.test.ts
+++ b/apps/webapp/src/script/repositories/team/TeamState.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {UserType} from '@wireapp/api-client/lib/user';
+
+import {randomUUID} from 'crypto';
+
+import {User} from 'Repositories/entity/User';
+import {UserState} from 'Repositories/user/userState';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {TeamEntity} from './TeamEntity';
+import {TeamState} from './TeamState';
+
+function createTeamMember(id: string, domain: string, teamId: string, type: UserType = UserType.REGULAR): User {
+  const user = new User(id, domain, translateForTest);
+  user.teamId = teamId;
+  user.type = type;
+  return user;
+}
+
+describe('TeamState', () => {
+  describe('teamMembers', () => {
+    it('excludes the self user, users outside the team, and app-type users', () => {
+      const domain = 'example.com';
+      const team = new TeamEntity(randomUUID());
+      const userState = new UserState();
+
+      const selfUser = createTeamMember('self-id', domain, team.id as string);
+      selfUser.isMe = true;
+      userState.self(selfUser);
+
+      const teamState = new TeamState(userState);
+      teamState.team(team);
+
+      const regularMember = createTeamMember('member-id', domain, team.id as string);
+      // Apps resolved into the shared userState.users() cache (e.g. by TeamRepository.loadTeamAppsAndCollaborators)
+      // must never leak into teamMembers/teamUsers - they were never legitimately selectable team members.
+      const appMember = createTeamMember('app-id', domain, team.id as string, UserType.APP);
+      const outsideTeamMember = createTeamMember('outside-id', domain, randomUUID());
+
+      userState.users([selfUser, regularMember, appMember, outsideTeamMember]);
+
+      const teamMembers = teamState.teamMembers();
+
+      expect(teamMembers.map(user => user.id)).toEqual([regularMember.id]);
+    });
+  });
+
+  describe('teamApps and teamCollaborators', () => {
+    it('default to empty arrays and can be written to directly (populated by TeamRepository.loadTeamAppsAndCollaborators)', () => {
+      const userState = new UserState();
+      userState.self(createTeamMember('self-id', 'example.com', randomUUID()));
+      const teamState = new TeamState(userState);
+
+      expect(teamState.teamApps()).toEqual([]);
+      expect(teamState.teamCollaborators()).toEqual([]);
+
+      const app = createTeamMember('app-id', 'example.com', randomUUID(), UserType.APP);
+      const collaborator = createTeamMember('collaborator-id', 'example.com', randomUUID());
+
+      teamState.teamApps([app]);
+      teamState.teamCollaborators([collaborator]);
+
+      expect(teamState.teamApps()).toEqual([app]);
+      expect(teamState.teamCollaborators()).toEqual([collaborator]);
+    });
+  });
+});

--- a/apps/webapp/src/script/repositories/team/TeamState.ts
+++ b/apps/webapp/src/script/repositories/team/TeamState.ts
@@ -58,7 +58,7 @@ export class TeamState {
   readonly teamMembers: ko.PureComputed<User[]>;
   /** all the members of the team + the users the selfUser is connected with */
   readonly teamUsers: ko.PureComputed<User[]>;
-  /** team-owned apps merged with app-type collaborators, deduped by qualifiedId - see TeamRepository.loadTeamAppsAndCollaborators */
+  /** team-owned apps merged with app-type collaborators, see TeamRepository.loadTeamAppsAndCollaborators */
   readonly teamApps: ko.Observable<User[]>;
   /** human (non-app) team collaborators, resolved from GET /teams/:tid/collaborators - see TeamRepository.loadTeamAppsAndCollaborators */
   readonly teamCollaborators: ko.Observable<User[]>;

--- a/apps/webapp/src/script/repositories/team/TeamState.ts
+++ b/apps/webapp/src/script/repositories/team/TeamState.ts
@@ -20,6 +20,7 @@
 import {Backend} from '@wireapp/api-client/lib/env';
 import {Role} from '@wireapp/api-client/lib/team';
 import {FEATURE_STATUS, FeatureList, SELF_DELETING_TIMEOUT} from '@wireapp/api-client/lib/team/feature/';
+import {UserType} from '@wireapp/api-client/lib/user';
 import ko from 'knockout';
 import {container, singleton} from 'tsyringe';
 
@@ -53,10 +54,14 @@ export class TeamState {
   public readonly isSelfDeletingMessagesEnabled: ko.PureComputed<boolean>;
   public readonly isSelfDeletingMessagesEnforced: ko.PureComputed<boolean>;
   public readonly getEnforcedSelfDeletingMessagesTimeout: ko.PureComputed<SELF_DELETING_TIMEOUT>;
-  /** all the members of the team */
+  /** all the members of the team (excludes apps, which are never legitimately selectable team members) */
   readonly teamMembers: ko.PureComputed<User[]>;
   /** all the members of the team + the users the selfUser is connected with */
   readonly teamUsers: ko.PureComputed<User[]>;
+  /** team-owned apps merged with app-type collaborators, deduped by qualifiedId - see TeamRepository.loadTeamAppsAndCollaborators */
+  readonly teamApps: ko.Observable<User[]>;
+  /** human (non-app) team collaborators, resolved from GET /teams/:tid/collaborators - see TeamRepository.loadTeamAppsAndCollaborators */
+  readonly teamCollaborators: ko.Observable<User[]>;
   readonly isTeam: ko.PureComputed<boolean>;
   readonly team = ko.observable(new TeamEntity());
   readonly teamDomain: ko.PureComputed<string>;
@@ -71,11 +76,15 @@ export class TeamState {
     this.isTeam = ko.pureComputed(() => !!this.team()?.id);
     this.isTeamDeleted = ko.observable(false);
 
-    /** Note: this does not include the self user */
-    this.teamMembers = ko.pureComputed(() => this.userState.users().filter(user => !user.isMe && this.isInTeam(user)));
+    /** Note: this does not include the self user, nor apps (type === UserType.APP) */
+    this.teamMembers = ko.pureComputed(() =>
+      this.userState.users().filter(user => !user.isMe && this.isInTeam(user) && user.type !== UserType.APP),
+    );
     this.memberRoles = ko.observable({});
     this.memberInviters = ko.observable({});
     this.teamFeatures = ko.observable();
+    this.teamApps = ko.observable([]);
+    this.teamCollaborators = ko.observable([]);
 
     this.teamDomain = ko.pureComputed(() => userState.self().domain);
     this.teamName = ko.pureComputed(() => (this.isTeam() ? this.team().name() : this.userState.self().name()));

--- a/apps/webapp/src/style/modal/service-modal.less
+++ b/apps/webapp/src/style/modal/service-modal.less
@@ -15,7 +15,7 @@
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    padding: 8px;
+    padding: 8px 16px;
     margin-top: -30px;
   }
 
@@ -43,6 +43,6 @@
   }
 
   &__footer {
-    padding: 16px 0;
+    padding: 16px;
   }
 }

--- a/libraries/api-client/src/team/index.ts
+++ b/libraries/api-client/src/team/index.ts
@@ -20,7 +20,16 @@
 export {NewTeamInvitation, TeamInvitation, TeamInvitationAPI, TeamInvitationChunk} from './invitation/';
 export {LegalHoldAPI} from './legalhold/';
 export {MemberAPI, MemberData, Members, Permissions, PermissionsData, Role} from './member/';
-export {NewTeamData, TeamAPI, TeamChunkData, TeamData, TeamInfo, UpdateTeamData} from './team/';
+export {
+  CollaboratorPermission,
+  NewTeamData,
+  TeamAPI,
+  TeamChunkData,
+  TeamCollaborator,
+  TeamData,
+  TeamInfo,
+  UpdateTeamData,
+} from './team/';
 export {PaymentAPI, PaymentData} from './payment/';
 export {ServiceAPI, Service, ServiceWhitelistData} from './service/';
 export {TeamError, InviteEmailInUseError, InvalidInvitationCodeError, ServiceNotFoundError} from './teamError';

--- a/libraries/api-client/src/team/team/collaborator/teamCollaborator.ts
+++ b/libraries/api-client/src/team/team/collaborator/teamCollaborator.ts
@@ -22,11 +22,6 @@ export enum CollaboratorPermission {
   IMPLICIT_CONNECTION = 'implicit_connection',
 }
 
-/**
- * Note: `permissions` is a plain array, as returned by the backend (`GET /teams/:tid/collaborators`).
- * Do not change this to a `Set` - that is not how the JSON payload deserializes. Convert to a `Set`
- * only at the point of consumption (e.g. in a repository) if O(1) membership checks are needed there.
- */
 export interface TeamCollaborator {
   permissions: CollaboratorPermission[];
   team: string;

--- a/libraries/api-client/src/team/team/collaborator/teamCollaborator.ts
+++ b/libraries/api-client/src/team/team/collaborator/teamCollaborator.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,11 +17,18 @@
  *
  */
 
-export * from './collaborator/teamCollaborator';
-export * from './newTeamData';
-export * from './teamApi';
-export * from './teamChunkData';
-export * from './teamData';
-export * from './teamInfo';
-export * from './updateTeamData';
-export * from './teamSizeData';
+export enum CollaboratorPermission {
+  CREATE_TEAM_CONVERSATION = 'create_team_conversation',
+  IMPLICIT_CONNECTION = 'implicit_connection',
+}
+
+/**
+ * Note: `permissions` is a plain array, as returned by the backend (`GET /teams/:tid/collaborators`).
+ * Do not change this to a `Set` - that is not how the JSON payload deserializes. Convert to a `Set`
+ * only at the point of consumption (e.g. in a repository) if O(1) membership checks are needed there.
+ */
+export interface TeamCollaborator {
+  permissions: CollaboratorPermission[];
+  team: string;
+  user: string;
+}

--- a/libraries/api-client/src/team/team/teamApi.ts
+++ b/libraries/api-client/src/team/team/teamApi.ts
@@ -21,19 +21,21 @@ import Axios, {AxiosRequestConfig} from 'axios';
 
 import {NewAppRequest} from './app/newAppRequest';
 import {NewAppResponse} from './app/newAppResponse';
+import {TeamCollaborator} from './collaborator/teamCollaborator';
 import {LeadData} from './leadData';
 import {TeamSizeData} from './teamSizeData';
 import {UpdateTeamData} from './updateTeamData';
 
 import {NewTeamData, TeamChunkData, TeamData} from '../';
 import {BackendError, HttpClient, RequestCancelable, SyntheticErrorLabel} from '../../http/';
-import {RequestCancellationError} from '../../user';
+import {RequestCancellationError, User} from '../../user';
 
 export class TeamAPI {
   constructor(private readonly client: HttpClient) {}
 
   public static readonly URL = {
     APPS: 'apps',
+    COLLABORATORS: 'collaborators',
     SIZE: 'size',
     TEAMS: '/teams',
     CONSENT: '/consent',
@@ -140,6 +142,35 @@ export class TeamAPI {
     };
 
     const response = await this.client.sendJSON<any>(config);
+    return response.data;
+  }
+
+  /**
+   * Returns the team-owned apps (i.e. apps that are full members of the team, `type: 'app'`).
+   * This does not include apps that are collaborators only - see `getCollaborators`.
+   */
+  public async getApps(teamId: string, abortController?: AbortController): Promise<User[]> {
+    const config: AxiosRequestConfig = {
+      method: 'get',
+      url: `${TeamAPI.URL.TEAMS}/${teamId}/${TeamAPI.URL.APPS}`,
+    };
+
+    const response = await this.client.sendJSON<User[]>(config, false, abortController);
+    return response.data;
+  }
+
+  /**
+   * Returns the team's collaborators (human or app) - i.e. users granted specific permissions on the team
+   * without being full team members. The response contains no discriminator for whether a collaborator is
+   * a human or an app; resolve `user` into a full profile to find out via its `type`.
+   */
+  public async getCollaborators(teamId: string, abortController?: AbortController): Promise<TeamCollaborator[]> {
+    const config: AxiosRequestConfig = {
+      method: 'get',
+      url: `${TeamAPI.URL.TEAMS}/${teamId}/${TeamAPI.URL.COLLABORATORS}`,
+    };
+
+    const response = await this.client.sendJSON<TeamCollaborator[]>(config, false, abortController);
     return response.data;
   }
 

--- a/libraries/api-client/src/team/team/teamApi.ts
+++ b/libraries/api-client/src/team/team/teamApi.ts
@@ -146,8 +146,7 @@ export class TeamAPI {
   }
 
   /**
-   * Returns the team-owned apps (i.e. apps that are full members of the team, `type: 'app'`).
-   * This does not include apps that are collaborators only - see `getCollaborators`.
+   * Returns the team-owned apps.
    */
   public async getApps(teamId: string, abortController?: AbortController): Promise<User[]> {
     const config: AxiosRequestConfig = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28431" title="WPB-28431" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28431</a>  Add apps and collaborators to web app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
With external apps implementation on Team management, Team A can add an app created by Team B using the App id.

Issue is that web app does not recognize these external apps for Team A and will not show the apps in the Apps section to add the app in Groups or channels.

Another fix that is underway on the backend is removing internal apps (owned by Team A) from team members response.

With this implementation External Apps should be visible for Team A once they added the App and a user should be able to add that App into a Group or Channel where Apps are enabled.

Once backend removal of internal apps from team members is merged everything should work as it works for internal apps today.