### PR TITLE
Render message translations with React [WPB-27666]

### DIFF
--- a/apps/webapp/src/script/components/messagesList/message/contentMessage/warnings/completeFailureToSend/completeFailureToSend.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/contentMessage/warnings/completeFailureToSend/completeFailureToSend.test.tsx
@@ -1,0 +1,231 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render} from '@testing-library/react';
+import {isNull} from '@sindresorhus/is';
+
+import en from 'I18n/en-US.json';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {setStrings, translate} from 'Util/localizerUtil';
+
+import {CompleteFailureToSendWarning} from './completeFailureToSend';
+
+const legacyRootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureToggleName) {
+      return featureToggleName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
+
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
+
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
+}
+
+function getWarningTextContainer(container: HTMLElement): HTMLElement {
+  const warningTextContainer = container.querySelector<HTMLElement>('p > span');
+
+  if (isNull(warningTextContainer)) {
+    throw new Error('Expected the complete send failure warning text to be rendered');
+  }
+
+  return warningTextContainer;
+}
+
+describe('CompleteFailureToSendWarning', () => {
+  it(
+    'preserves legacy rendering when React translation rendering is disabled',
+    withTranslationStrings(en, () => {
+      const {container, getByTestId, getByText} = render(
+        withThemeAndRootContext(
+          <CompleteFailureToSendWarning
+            isMessageFocused={false}
+            onRetry={jest.fn()}
+            unreachableDomain="example.test"
+          />,
+          legacyRootProviderWrapper,
+        ),
+      );
+      const warningTextContainer = getWarningTextContainer(container);
+
+      expect(warningTextContainer).toHaveTextContent(
+        'Message could not be sent as the back-end of example.test could not be reached.',
+      );
+      expect(warningTextContainer.querySelectorAll('strong')).toHaveLength(1);
+      expect(getByTestId('go-offline-backend')).not.toBeNull();
+      expect(getByText('Retry')).not.toBeNull();
+    }),
+  );
+
+  it(
+    'renders the translated warning with React formatting when enabled',
+    withTranslationStrings(en, () => {
+      const {container, getByTestId} = render(
+        withThemeAndRootContext(
+          <CompleteFailureToSendWarning
+            isMessageFocused={false}
+            onRetry={jest.fn()}
+            unreachableDomain="example.test"
+          />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+      const warningTextContainer = getWarningTextContainer(container);
+
+      expect(warningTextContainer).toHaveTextContent(
+        'Message could not be sent as the back-end of example.test could not be reached.',
+      );
+      expect(warningTextContainer.querySelectorAll('strong')).toHaveLength(1);
+      expect(getByTestId('go-offline-backend')).not.toBeNull();
+    }),
+  );
+
+  it(
+    'renders an HTML-looking runtime domain as text',
+    withTranslationStrings(en, () => {
+      const {container} = render(
+        withThemeAndRootContext(
+          <CompleteFailureToSendWarning isMessageFocused={false} onRetry={jest.fn()} unreachableDomain="R&D <Test>" />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+      const warningTextContainer = getWarningTextContainer(container);
+
+      expect(warningTextContainer).toHaveTextContent(
+        'Message could not be sent as the back-end of R&D <Test> could not be reached.',
+      );
+      expect(warningTextContainer.querySelector('test')).toBeNull();
+      expect(warningTextContainer.querySelectorAll('strong')).toHaveLength(1);
+    }),
+  );
+
+  it(
+    'keeps a translation-looking runtime domain literal',
+    withTranslationStrings(en, () => {
+      const {container} = render(
+        withThemeAndRootContext(
+          <CompleteFailureToSendWarning
+            isMessageFocused={false}
+            onRetry={jest.fn()}
+            unreachableDomain="[bold]example[/bold]"
+          />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+      const warningTextContainer = getWarningTextContainer(container);
+
+      expect(warningTextContainer).toHaveTextContent(
+        'Message could not be sent as the back-end of [bold]example[/bold] could not be reached.',
+      );
+      expect(warningTextContainer.querySelectorAll('strong')).toHaveLength(1);
+    }),
+  );
+
+  it(
+    'renders a runtime domain outside translation-authored formatting',
+    withTranslationStrings(
+      {
+        ...en,
+        messageCouldNotBeSentBackEndOffline: 'Backend {domain} is unavailable.',
+      },
+      () => {
+        const {container} = render(
+          withThemeAndRootContext(
+            <CompleteFailureToSendWarning
+              isMessageFocused={false}
+              onRetry={jest.fn()}
+              unreachableDomain="example.test"
+            />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+        const warningTextContainer = getWarningTextContainer(container);
+
+        expect(warningTextContainer).toHaveTextContent('Backend example.test is unavailable.');
+        expect(warningTextContainer.querySelectorAll('strong')).toHaveLength(0);
+      },
+    ),
+  );
+
+  it(
+    'keeps unsupported translation markup as text',
+    withTranslationStrings(
+      {
+        ...en,
+        messageCouldNotBeSentBackEndOffline:
+          '<img src="example">Message could not be sent as the back-end of [bold]{domain}[/bold] could not be reached.',
+      },
+      () => {
+        const {container} = render(
+          withThemeAndRootContext(
+            <CompleteFailureToSendWarning
+              isMessageFocused={false}
+              onRetry={jest.fn()}
+              unreachableDomain="example.test"
+            />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+        const warningTextContainer = getWarningTextContainer(container);
+
+        expect(warningTextContainer).toHaveTextContent(
+          '<img src="example">Message could not be sent as the back-end of example.test could not be reached.',
+        );
+        expect(warningTextContainer.querySelector('img')).toBeNull();
+        expect(warningTextContainer.querySelectorAll('strong')).toHaveLength(1);
+      },
+    ),
+  );
+
+  it(
+    'renders the connectivity warning without an offline backend link',
+    withTranslationStrings(en, () => {
+      const {container, queryByTestId} = render(
+        withThemeAndRootContext(
+          <CompleteFailureToSendWarning isMessageFocused={false} onRetry={jest.fn()} />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+
+      expect(container).toHaveTextContent('Message could not be sent due to connectivity issues.');
+      expect(queryByTestId('go-offline-backend')).toBeNull();
+    }),
+  );
+});

--- a/apps/webapp/src/script/components/messagesList/message/contentMessage/warnings/completeFailureToSend/completeFailureToSend.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/contentMessage/warnings/completeFailureToSend/completeFailureToSend.tsx
@@ -17,11 +17,19 @@
  *
  */
 
+import type {FunctionComponent, ReactNode} from 'react';
+
+import {isNonEmptyString} from '@sindresorhus/is';
+
 import {Button, ButtonVariant, Link, LinkVariant} from '@wireapp/react-ui-kit';
 
 import {useMessageFocusedTabIndex} from 'Components/messagesList/message/util';
 import {Config} from 'src/script/Config';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {ReactTranslationValueReplacement} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 
 import {backendErrorLink, button, warning, wrapper} from '../warnings.styles';
 
@@ -31,35 +39,94 @@ type Props = {
   unreachableDomain?: string;
 };
 
-const config = Config.getConfig();
+type RenderCompleteFailureToSendWarningOptions = {
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly messageFocusedTabIndex: number;
+  readonly translate: Translate;
+  readonly unreachableDomain?: string;
+};
 
-export const CompleteFailureToSendWarning = ({isMessageFocused, onRetry, unreachableDomain}: Props) => {
-  const {translate} = useApplicationContext();
+const config = Config.getConfig();
+const unreachableDomainMarker = createReactTranslationMarker('complete-failure-to-send-domain');
+
+function renderCompleteFailureToSendWarning(options: RenderCompleteFailureToSendWarningOptions): ReactNode {
+  const {isReactTranslationRenderingEnabled, messageFocusedTabIndex, translate, unreachableDomain} = options;
+
+  if (isNonEmptyString(unreachableDomain) === false) {
+    return <p css={warning}>{translate('messageCouldNotBeSentConnectivityIssues')}</p>;
+  }
+
+  let warningContent: ReactNode;
+  if (isReactTranslationRenderingEnabled) {
+    const translatedText = translate('messageCouldNotBeSentBackEndOffline', {
+      domain: unreachableDomainMarker.substitution,
+    });
+    const valueReplacements: ReactTranslationValueReplacement[] = [
+      {marker: unreachableDomainMarker, runtimeText: unreachableDomain},
+    ];
+
+    warningContent = (
+      <span css={warning}>
+        {renderReactTranslation({
+          translatedText,
+          componentReplacements: [
+            {
+              start: '<strong>',
+              end: '</strong>',
+              render(children) {
+                return <strong>{children}</strong>;
+              },
+            },
+          ],
+          valueReplacements,
+        })}
+      </span>
+    );
+  } else {
+    warningContent = (
+      <span
+        css={warning}
+        dangerouslySetInnerHTML={{
+          __html: translate('messageCouldNotBeSentBackEndOffline', {domain: unreachableDomain}),
+        }}
+      />
+    );
+  }
+
+  return (
+    <p>
+      {warningContent}{' '}
+      <Link
+        tabIndex={messageFocusedTabIndex}
+        targetBlank
+        variant={LinkVariant.PRIMARY}
+        href={config.URL.SUPPORT.OFFLINE_BACKEND}
+        data-uie-name="go-offline-backend"
+        css={backendErrorLink}
+      >
+        {translate('offlineBackendLearnMore')}
+      </Link>
+    </p>
+  );
+}
+
+export const CompleteFailureToSendWarning: FunctionComponent<Props> = ({
+  isMessageFocused,
+  onRetry,
+  unreachableDomain,
+}) => {
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
+
   return (
     <div css={wrapper}>
-      {unreachableDomain !== undefined && unreachableDomain !== '' ? (
-        <p>
-          <span
-            css={warning}
-            dangerouslySetInnerHTML={{
-              __html: translate('messageCouldNotBeSentBackEndOffline', {domain: unreachableDomain}),
-            }}
-          />{' '}
-          <Link
-            tabIndex={messageFocusedTabIndex}
-            targetBlank
-            variant={LinkVariant.PRIMARY}
-            href={config.URL.SUPPORT.OFFLINE_BACKEND}
-            data-uie-name="go-offline-backend"
-            css={backendErrorLink}
-          >
-            {translate('offlineBackendLearnMore')}
-          </Link>
-        </p>
-      ) : (
-        <p css={warning}>{translate('messageCouldNotBeSentConnectivityIssues')}</p>
-      )}
+      {renderCompleteFailureToSendWarning({
+        isReactTranslationRenderingEnabled,
+        messageFocusedTabIndex,
+        translate,
+        unreachableDomain,
+      })}
       <div css={{display: 'flex'}}>
         <Button
           css={button}

--- a/apps/webapp/src/script/components/messagesList/message/decryptErrorMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/decryptErrorMessage.test.tsx
@@ -19,11 +19,15 @@
 
 import {act} from 'react';
 import {render, fireEvent} from '@testing-library/react';
+import {isNull} from '@sindresorhus/is';
 import {ProteusErrors} from '@wireapp/core/lib/messagingProtocols/proteus';
 
+import en from 'I18n/en-US.json';
 import {DecryptErrorMessage as DecryptErrorMessageEntity} from 'Repositories/entity/message/decryptErrorMessage';
 import {User} from 'Repositories/entity/User';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {translateForTest} from 'Util/test/translateForTest';
+import {setStrings, translate} from 'Util/localizerUtil';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
@@ -34,14 +38,249 @@ import {DecryptErrorMessage} from './decryptErrorMessage';
 const rootProviderWrapper = createRootProviderWrapperForTest(
   createRootContextValueForTest({translate: translateForTest}),
 );
+const legacyTranslationRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate}),
+);
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName) {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
 
-function createError(code: number) {
+type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
+
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
+
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
+}
+
+function createError(code: number, userName = 'Alice'): DecryptErrorMessageEntity {
   const error = new DecryptErrorMessageEntity('client', code, translateForTest);
-  error.user(new User('', '', translateForTest));
+  const user = new User('', '', translateForTest);
+  user.name(userName);
+  error.user(user);
+
   return error;
 }
 
+function getDecryptErrorCaption(container: HTMLElement): HTMLElement {
+  const decryptErrorCaption = container.querySelector<HTMLElement>('.message-header-label > p');
+
+  if (isNull(decryptErrorCaption)) {
+    throw new Error('Expected the decrypt error caption to be rendered');
+  }
+
+  return decryptErrorCaption;
+}
+
 describe('DecryptErrorMessage', () => {
+  it(
+    'preserves the legacy highlighted caption when React translation rendering is disabled',
+    withTranslationStrings(en, () => {
+      const props = {
+        message: createError(ProteusErrors.InvalidMessage),
+        onClickResetSession: jest.fn(),
+      };
+
+      const {container} = render(<DecryptErrorMessage {...props} />, {wrapper: legacyTranslationRootProviderWrapper});
+      const decryptErrorCaption = getDecryptErrorCaption(container);
+
+      expect(decryptErrorCaption).toHaveTextContent('A message from Alice was not received.');
+      expect(decryptErrorCaption.querySelectorAll('.label-bold-xs')).toHaveLength(1);
+      expect(decryptErrorCaption.querySelector('.label-bold-xs')).toHaveTextContent('Alice');
+    }),
+  );
+
+  it(
+    'renders conversationUnableToDecrypt1 with React highlighting when enabled',
+    withTranslationStrings(en, () => {
+      const props = {
+        message: createError(ProteusErrors.InvalidMessage),
+        onClickResetSession: jest.fn(),
+      };
+
+      const {container} = render(<DecryptErrorMessage {...props} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+      const decryptErrorCaption = getDecryptErrorCaption(container);
+
+      expect(decryptErrorCaption).toHaveTextContent('A message from Alice was not received.');
+      expect(decryptErrorCaption.querySelectorAll('.label-bold-xs')).toHaveLength(1);
+      expect(decryptErrorCaption.querySelector('.label-bold-xs')).toHaveTextContent('Alice');
+    }),
+  );
+
+  it(
+    'renders conversationUnableToDecrypt2 with React highlighting when enabled',
+    withTranslationStrings(en, () => {
+      const props = {
+        message: createError(ProteusErrors.RemoteIdentityChanged),
+        onClickResetSession: jest.fn(),
+      };
+
+      const {container} = render(<DecryptErrorMessage {...props} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+      const decryptErrorCaption = getDecryptErrorCaption(container);
+
+      expect(decryptErrorCaption).toHaveTextContent('Alice´s device identity changed. Undelivered message.');
+      expect(decryptErrorCaption.querySelectorAll('.label-bold-xs')).toHaveLength(1);
+      expect(decryptErrorCaption.querySelector('.label-bold-xs')).toHaveTextContent('Alice');
+    }),
+  );
+
+  it(
+    'renders a translation without highlight markup correctly',
+    withTranslationStrings(
+      {
+        ...en,
+        conversationUnableToDecrypt1: 'A message from {user} was not received.',
+      },
+      () => {
+        const props = {
+          message: createError(ProteusErrors.InvalidMessage),
+          onClickResetSession: jest.fn(),
+        };
+
+        const {container} = render(<DecryptErrorMessage {...props} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        const decryptErrorCaption = getDecryptErrorCaption(container);
+
+        expect(decryptErrorCaption).toHaveTextContent('A message from Alice was not received.');
+        expect(decryptErrorCaption.querySelectorAll('.label-bold-xs')).toHaveLength(0);
+      },
+    ),
+  );
+
+  it(
+    'renders an HTML-looking runtime user name as text',
+    withTranslationStrings(en, () => {
+      const props = {
+        message: createError(ProteusErrors.InvalidMessage, 'R&D <Test>'),
+        onClickResetSession: jest.fn(),
+      };
+
+      const {container} = render(<DecryptErrorMessage {...props} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+      const decryptErrorCaption = getDecryptErrorCaption(container);
+
+      expect(decryptErrorCaption).toHaveTextContent('A message from R&D <Test> was not received.');
+      expect(decryptErrorCaption.querySelector('test')).toBeNull();
+      expect(decryptErrorCaption.querySelectorAll('.label-bold-xs')).toHaveLength(1);
+      expect(decryptErrorCaption.querySelector('.label-bold-xs')).toHaveTextContent('R&D <Test>');
+    }),
+  );
+
+  it(
+    'keeps a translation-looking runtime user name literal inside highlighting',
+    withTranslationStrings(en, () => {
+      const props = {
+        message: createError(ProteusErrors.InvalidMessage, '[highlight]Alice[/highlight]'),
+        onClickResetSession: jest.fn(),
+      };
+
+      const {container} = render(<DecryptErrorMessage {...props} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+      const decryptErrorCaption = getDecryptErrorCaption(container);
+
+      expect(decryptErrorCaption).toHaveTextContent('A message from [highlight]Alice[/highlight] was not received.');
+      expect(decryptErrorCaption.querySelectorAll('.label-bold-xs')).toHaveLength(1);
+      expect(decryptErrorCaption.querySelector('.label-bold-xs')).toHaveTextContent('[highlight]Alice[/highlight]');
+      expect(decryptErrorCaption.querySelector('.label-bold-xs .label-bold-xs')).toBeNull();
+    }),
+  );
+
+  it(
+    'renders the user name outside translation-authored highlighting',
+    withTranslationStrings(
+      {
+        ...en,
+        conversationUnableToDecrypt1: 'A message from {user} was not received.',
+      },
+      () => {
+        const props = {
+          message: createError(ProteusErrors.InvalidMessage),
+          onClickResetSession: jest.fn(),
+        };
+
+        const {container} = render(<DecryptErrorMessage {...props} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        const decryptErrorCaption = getDecryptErrorCaption(container);
+
+        expect(decryptErrorCaption).toHaveTextContent('A message from Alice was not received.');
+        expect(decryptErrorCaption.querySelectorAll('.label-bold-xs')).toHaveLength(0);
+      },
+    ),
+  );
+
+  it(
+    'keeps a translation-looking runtime user name literal outside highlighting',
+    withTranslationStrings(
+      {
+        ...en,
+        conversationUnableToDecrypt1: 'A message from {user} was not received.',
+      },
+      () => {
+        const props = {
+          message: createError(ProteusErrors.InvalidMessage, '[highlight]Alice[/highlight]'),
+          onClickResetSession: jest.fn(),
+        };
+
+        const {container} = render(<DecryptErrorMessage {...props} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        const decryptErrorCaption = getDecryptErrorCaption(container);
+
+        expect(decryptErrorCaption).toHaveTextContent('A message from [highlight]Alice[/highlight] was not received.');
+        expect(decryptErrorCaption.querySelectorAll('.label-bold-xs')).toHaveLength(0);
+      },
+    ),
+  );
+
+  it(
+    'keeps unsupported translation markup as text',
+    withTranslationStrings(
+      {
+        ...en,
+        conversationUnableToDecrypt1:
+          '<img src="example">A message from [highlight]{user}[/highlight] was not received.',
+      },
+      () => {
+        const props = {
+          message: createError(ProteusErrors.InvalidMessage),
+          onClickResetSession: jest.fn(),
+        };
+
+        const {container} = render(<DecryptErrorMessage {...props} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        const decryptErrorCaption = getDecryptErrorCaption(container);
+
+        expect(decryptErrorCaption).toHaveTextContent('<img src="example">A message from Alice was not received.');
+        expect(decryptErrorCaption.querySelector('img')).toBeNull();
+        expect(decryptErrorCaption.querySelectorAll('.label-bold-xs')).toHaveLength(1);
+      },
+    ),
+  );
+
   it('shows "reset session" action when error is recoverable', async () => {
     const props = {
       message: createError(ProteusErrors.InvalidMessage),

--- a/apps/webapp/src/script/components/messagesList/message/decryptErrorMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/decryptErrorMessage.tsx
@@ -18,45 +18,108 @@
  */
 
 import {useState} from 'react';
+import type {FunctionComponent, ReactNode} from 'react';
 
 import * as Icon from 'Components/icon';
 import {DecryptErrorMessage as DecryptErrorMessageEntity} from 'Repositories/entity/message/decryptErrorMessage';
 import {Config} from 'src/script/Config';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {MotionDuration} from 'src/script/motion/MotionDuration';
 import {useApplicationContext} from 'src/script/page/rootProvider';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 import {splitFingerprint} from 'Util/stringUtil';
 
 import {messageBodyWrapper} from './contentMessage/contentMessage.styles';
 
 import {FormattedId} from '../../../page/mainContent/panels/preferences/devicesPreferences/components/formattedId';
 
-interface DecryptErrorMessageProps {
+type DecryptErrorMessageProps = {
   message: DecryptErrorMessageEntity;
   onClickResetSession: (message: DecryptErrorMessageEntity) => void;
+};
+
+type TranslateDecryptErrorCaptionOptions = {
+  readonly translate: Translate;
+  readonly userSubstitution: string;
+  readonly isIdentityChanged: boolean;
+};
+
+type RenderDecryptErrorCaptionOptions = {
+  readonly isIdentityChanged: boolean;
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly translate: Translate;
+  readonly userName: string;
+};
+
+const decryptErrorUserMarker = createReactTranslationMarker('decrypt-error-user');
+const decryptErrorHighlightSubstitutions = {
+  '/highlight': '</span>',
+  highlight: '<span class="label-bold-xs">',
+};
+
+function translateDecryptErrorCaption(options: TranslateDecryptErrorCaptionOptions): string {
+  const {isIdentityChanged, translate, userSubstitution} = options;
+  let translationKey: 'conversationUnableToDecrypt1' | 'conversationUnableToDecrypt2';
+
+  if (isIdentityChanged) {
+    translationKey = 'conversationUnableToDecrypt2';
+  } else {
+    translationKey = 'conversationUnableToDecrypt1';
+  }
+
+  return translate(translationKey, {user: userSubstitution}, decryptErrorHighlightSubstitutions);
 }
 
-const DecryptErrorMessage = ({message, onClickResetSession}: DecryptErrorMessageProps) => {
+function renderDecryptErrorCaption(options: RenderDecryptErrorCaptionOptions): ReactNode {
+  const {isIdentityChanged, isReactTranslationRenderingEnabled, translate, userName} = options;
+
+  if (isReactTranslationRenderingEnabled) {
+    const translatedText = translateDecryptErrorCaption({
+      isIdentityChanged,
+      translate,
+      userSubstitution: decryptErrorUserMarker.substitution,
+    });
+
+    return renderReactTranslation({
+      translatedText,
+      componentReplacements: [
+        {
+          start: '<span class="label-bold-xs">',
+          end: '</span>',
+          render(children) {
+            return <span className="label-bold-xs">{children}</span>;
+          },
+        },
+      ],
+      valueReplacements: [{marker: decryptErrorUserMarker, runtimeText: userName}],
+    });
+  }
+
+  const legacyCaption = translateDecryptErrorCaption({
+    isIdentityChanged,
+    translate,
+    userSubstitution: userName,
+  });
+
+  return <span dangerouslySetInnerHTML={{__html: legacyCaption}} />;
+}
+
+const DecryptErrorMessage: FunctionComponent<DecryptErrorMessageProps> = function DecryptErrorMessage({
+  message,
+  onClickResetSession,
+}): ReactNode {
   const [isResettingSession, setIsResettingSession] = useState(false);
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
 
   const link = Config.getConfig().URL.SUPPORT.DECRYPT_ERROR;
-  const caption = message.isIdentityChanged
-    ? translate(
-        'conversationUnableToDecrypt2',
-        {user: message.user().name()},
-        {
-          '/highlight': '</span>',
-          highlight: '<span class="label-bold-xs">',
-        },
-      )
-    : translate(
-        'conversationUnableToDecrypt1',
-        {user: message.user().name()},
-        {
-          '/highlight': '</span>',
-          highlight: '<span class="label-bold-xs">',
-        },
-      );
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
+  const decryptErrorCaption = renderDecryptErrorCaption({
+    isIdentityChanged: message.isIdentityChanged,
+    isReactTranslationRenderingEnabled,
+    translate,
+    userName: message.user().name(),
+  });
 
   return (
     <div data-uie-name="element-message-decrypt-error">
@@ -67,7 +130,7 @@ const DecryptErrorMessage = ({message, onClickResetSession}: DecryptErrorMessage
 
         <div className="message-header-label">
           <p>
-            <span dangerouslySetInnerHTML={{__html: caption}} />
+            {decryptErrorCaption}
             <span>&nbsp;</span>
             <a
               className="accent-text"

--- a/apps/webapp/src/script/components/messagesList/message/federationStopMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/federationStopMessage.test.tsx
@@ -18,6 +18,7 @@
  */
 
 import {render} from '@testing-library/react';
+import {isNull} from '@sindresorhus/is';
 
 import en from 'I18n/en-US.json';
 import {FederationStopMessage as FederationStopMessageEntity} from 'Repositories/entity/message/federationStopMessage';
@@ -31,8 +32,6 @@ import {setStrings, translate} from 'Util/localizerUtil';
 
 import {FederationStopMessage} from './federationStopMessage';
 
-setStrings({en});
-
 const legacyRootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
 const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
   createRootContextValueForTest({
@@ -44,8 +43,12 @@ const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperFo
 );
 
 type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
 
-function withTranslationStrings(strings: typeof en, testFunction: TranslationTestFunction): TranslationTestFunction {
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
   return async function runTranslationTest(): Promise<void> {
     setStrings({en: strings});
 
@@ -63,86 +66,101 @@ function createFederationStopMessage(domains: string[]): FederationStopMessageEn
 
 function getTranslationTextContainer(container: HTMLElement): HTMLElement {
   const translationTextContainer = container.querySelector<HTMLElement>('.message-header-label > span');
-  if (translationTextContainer === null) {
+  if (isNull(translationTextContainer)) {
     throw new Error('Expected the federation translation text container to be rendered');
   }
   return translationTextContainer;
 }
 
 describe('FederationStopMessage', () => {
-  it('preserves legacy rendering when React translation rendering is disabled', () => {
-    const {container} = render(
-      withThemeAndRootContext(
-        <FederationStopMessage message={createFederationStopMessage(['example.test'])} isMessageFocused={false} />,
-        legacyRootProviderWrapper,
-      ),
-    );
-    const translationTextContainer = getTranslationTextContainer(container);
+  it(
+    'preserves legacy rendering when React translation rendering is disabled',
+    withTranslationStrings(en, () => {
+      const {container} = render(
+        withThemeAndRootContext(
+          <FederationStopMessage message={createFederationStopMessage(['example.test'])} isMessageFocused={false} />,
+          legacyRootProviderWrapper,
+        ),
+      );
+      const translationTextContainer = getTranslationTextContainer(container);
 
-    expect(translationTextContainer).toHaveTextContent('Your backend stopped federating with example.test.');
-    expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
-  });
+      expect(translationTextContainer).toHaveTextContent('Your backend stopped federating with example.test.');
+      expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
+    }),
+  );
 
-  it('renders the one-domain translation with React formatting when enabled', () => {
-    const {container} = render(
-      withThemeAndRootContext(
-        <FederationStopMessage message={createFederationStopMessage(['example.test'])} isMessageFocused={false} />,
-        reactTranslationRenderingRootProviderWrapper,
-      ),
-    );
-    const translationTextContainer = getTranslationTextContainer(container);
+  it(
+    'renders the one-domain translation with React formatting when enabled',
+    withTranslationStrings(en, () => {
+      const {container} = render(
+        withThemeAndRootContext(
+          <FederationStopMessage message={createFederationStopMessage(['example.test'])} isMessageFocused={false} />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+      const translationTextContainer = getTranslationTextContainer(container);
 
-    expect(translationTextContainer).toHaveTextContent('Your backend stopped federating with example.test.');
-    expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
-  });
+      expect(translationTextContainer).toHaveTextContent('Your backend stopped federating with example.test.');
+      expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
+    }),
+  );
 
-  it('renders the two-domain translation with React formatting when enabled', () => {
-    const {container} = render(
-      withThemeAndRootContext(
-        <FederationStopMessage
-          message={createFederationStopMessage(['example-one.test', 'example-two.test'])}
-          isMessageFocused={false}
-        />,
-        reactTranslationRenderingRootProviderWrapper,
-      ),
-    );
-    const translationTextContainer = getTranslationTextContainer(container);
+  it(
+    'renders the two-domain translation with React formatting when enabled',
+    withTranslationStrings(en, () => {
+      const {container} = render(
+        withThemeAndRootContext(
+          <FederationStopMessage
+            message={createFederationStopMessage(['example-one.test', 'example-two.test'])}
+            isMessageFocused={false}
+          />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+      const translationTextContainer = getTranslationTextContainer(container);
 
-    expect(translationTextContainer).toHaveTextContent(
-      'The backends example-one.test and example-two.test stopped federating.',
-    );
-    expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
-  });
+      expect(translationTextContainer).toHaveTextContent(
+        'The backends example-one.test and example-two.test stopped federating.',
+      );
+      expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
+    }),
+  );
 
-  it('renders HTML-looking runtime domains as text', () => {
-    const {container} = render(
-      withThemeAndRootContext(
-        <FederationStopMessage message={createFederationStopMessage(['R&D <Test>'])} isMessageFocused={false} />,
-        reactTranslationRenderingRootProviderWrapper,
-      ),
-    );
-    const translationTextContainer = getTranslationTextContainer(container);
+  it(
+    'renders HTML-looking runtime domains as text',
+    withTranslationStrings(en, () => {
+      const {container} = render(
+        withThemeAndRootContext(
+          <FederationStopMessage message={createFederationStopMessage(['R&D <Test>'])} isMessageFocused={false} />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+      const translationTextContainer = getTranslationTextContainer(container);
 
-    expect(translationTextContainer).toHaveTextContent('Your backend stopped federating with R&D <Test>.');
-    expect(translationTextContainer.querySelector('test')).toBeNull();
-    expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
-  });
+      expect(translationTextContainer).toHaveTextContent('Your backend stopped federating with R&D <Test>.');
+      expect(translationTextContainer.querySelector('test')).toBeNull();
+      expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
+    }),
+  );
 
-  it('keeps translation-looking runtime domains literal', () => {
-    const {container} = render(
-      withThemeAndRootContext(
-        <FederationStopMessage
-          message={createFederationStopMessage(['[bold]example[/bold]'])}
-          isMessageFocused={false}
-        />,
-        reactTranslationRenderingRootProviderWrapper,
-      ),
-    );
-    const translationTextContainer = getTranslationTextContainer(container);
+  it(
+    'keeps translation-looking runtime domains literal',
+    withTranslationStrings(en, () => {
+      const {container} = render(
+        withThemeAndRootContext(
+          <FederationStopMessage
+            message={createFederationStopMessage(['[bold]example[/bold]'])}
+            isMessageFocused={false}
+          />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+      const translationTextContainer = getTranslationTextContainer(container);
 
-    expect(translationTextContainer).toHaveTextContent('Your backend stopped federating with [bold]example[/bold].');
-    expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
-  });
+      expect(translationTextContainer).toHaveTextContent('Your backend stopped federating with [bold]example[/bold].');
+      expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
+    }),
+  );
 
   it(
     'renders a runtime domain outside translation-authored formatting',
@@ -172,7 +190,8 @@ describe('FederationStopMessage', () => {
     withTranslationStrings(
       {
         ...en,
-        federationDelete: '<img src="example">[bold]Your backend[/bold] stopped federating with [bold]{backendUrl}.[/bold]',
+        federationDelete:
+          '<img src="example">[bold]Your backend[/bold] stopped federating with [bold]{backendUrl}.[/bold]',
       },
       () => {
         const {container} = render(

--- a/apps/webapp/src/script/components/messagesList/message/federationStopMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/federationStopMessage.test.tsx
@@ -1,0 +1,194 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render} from '@testing-library/react';
+
+import en from 'I18n/en-US.json';
+import {FederationStopMessage as FederationStopMessageEntity} from 'Repositories/entity/message/federationStopMessage';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {setStrings, translate} from 'Util/localizerUtil';
+
+import {FederationStopMessage} from './federationStopMessage';
+
+setStrings({en});
+
+const legacyRootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureToggleName) {
+      return featureToggleName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+
+function withTranslationStrings(strings: typeof en, testFunction: TranslationTestFunction): TranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
+
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
+}
+
+function createFederationStopMessage(domains: string[]): FederationStopMessageEntity {
+  return new FederationStopMessageEntity(domains, 0, translate);
+}
+
+function getTranslationTextContainer(container: HTMLElement): HTMLElement {
+  const translationTextContainer = container.querySelector<HTMLElement>('.message-header-label > span');
+  if (translationTextContainer === null) {
+    throw new Error('Expected the federation translation text container to be rendered');
+  }
+  return translationTextContainer;
+}
+
+describe('FederationStopMessage', () => {
+  it('preserves legacy rendering when React translation rendering is disabled', () => {
+    const {container} = render(
+      withThemeAndRootContext(
+        <FederationStopMessage message={createFederationStopMessage(['example.test'])} isMessageFocused={false} />,
+        legacyRootProviderWrapper,
+      ),
+    );
+    const translationTextContainer = getTranslationTextContainer(container);
+
+    expect(translationTextContainer).toHaveTextContent('Your backend stopped federating with example.test.');
+    expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
+  });
+
+  it('renders the one-domain translation with React formatting when enabled', () => {
+    const {container} = render(
+      withThemeAndRootContext(
+        <FederationStopMessage message={createFederationStopMessage(['example.test'])} isMessageFocused={false} />,
+        reactTranslationRenderingRootProviderWrapper,
+      ),
+    );
+    const translationTextContainer = getTranslationTextContainer(container);
+
+    expect(translationTextContainer).toHaveTextContent('Your backend stopped federating with example.test.');
+    expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
+  });
+
+  it('renders the two-domain translation with React formatting when enabled', () => {
+    const {container} = render(
+      withThemeAndRootContext(
+        <FederationStopMessage
+          message={createFederationStopMessage(['example-one.test', 'example-two.test'])}
+          isMessageFocused={false}
+        />,
+        reactTranslationRenderingRootProviderWrapper,
+      ),
+    );
+    const translationTextContainer = getTranslationTextContainer(container);
+
+    expect(translationTextContainer).toHaveTextContent(
+      'The backends example-one.test and example-two.test stopped federating.',
+    );
+    expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
+  });
+
+  it('renders HTML-looking runtime domains as text', () => {
+    const {container} = render(
+      withThemeAndRootContext(
+        <FederationStopMessage message={createFederationStopMessage(['R&D <Test>'])} isMessageFocused={false} />,
+        reactTranslationRenderingRootProviderWrapper,
+      ),
+    );
+    const translationTextContainer = getTranslationTextContainer(container);
+
+    expect(translationTextContainer).toHaveTextContent('Your backend stopped federating with R&D <Test>.');
+    expect(translationTextContainer.querySelector('test')).toBeNull();
+    expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
+  });
+
+  it('keeps translation-looking runtime domains literal', () => {
+    const {container} = render(
+      withThemeAndRootContext(
+        <FederationStopMessage
+          message={createFederationStopMessage(['[bold]example[/bold]'])}
+          isMessageFocused={false}
+        />,
+        reactTranslationRenderingRootProviderWrapper,
+      ),
+    );
+    const translationTextContainer = getTranslationTextContainer(container);
+
+    expect(translationTextContainer).toHaveTextContent('Your backend stopped federating with [bold]example[/bold].');
+    expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
+  });
+
+  it(
+    'renders a runtime domain outside translation-authored formatting',
+    withTranslationStrings(
+      {
+        ...en,
+        federationDelete: '{backendUrl} stopped federating with [bold]Wire[/bold].',
+      },
+      () => {
+        const {container} = render(
+          withThemeAndRootContext(
+            <FederationStopMessage message={createFederationStopMessage(['example.test'])} isMessageFocused={false} />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+        const translationTextContainer = getTranslationTextContainer(container);
+
+        expect(translationTextContainer).toHaveTextContent('example.test stopped federating with Wire.');
+        expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(1);
+        expect(translationTextContainer.querySelector('strong')).toHaveTextContent('Wire');
+      },
+    ),
+  );
+
+  it(
+    'keeps unsupported translation markup as text',
+    withTranslationStrings(
+      {
+        ...en,
+        federationDelete: '<img src="example">[bold]Your backend[/bold] stopped federating with [bold]{backendUrl}.[/bold]',
+      },
+      () => {
+        const {container} = render(
+          withThemeAndRootContext(
+            <FederationStopMessage message={createFederationStopMessage(['example.test'])} isMessageFocused={false} />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+        const translationTextContainer = getTranslationTextContainer(container);
+
+        expect(translationTextContainer).toHaveTextContent(
+          '<img src="example">Your backend stopped federating with example.test.',
+        );
+        expect(translationTextContainer.querySelector('img')).toBeNull();
+        expect(translationTextContainer.querySelectorAll('strong')).toHaveLength(2);
+      },
+    ),
+  );
+});

--- a/apps/webapp/src/script/components/messagesList/message/federationStopMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/federationStopMessage.tsx
@@ -17,13 +17,21 @@
  *
  */
 
+import type {FunctionComponent, ReactNode} from 'react';
+
+import {isNonEmptyArray} from '@sindresorhus/is';
+
 import {Link, LinkVariant} from '@wireapp/react-ui-kit';
 
 import * as Icon from 'Components/icon';
 import {FederationStopMessage as FederationStopMessageEntity} from 'Repositories/entity/message/federationStopMessage';
 import {Config} from 'src/script/Config';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {ReactTranslationValueReplacement} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 
 import {MessageTime} from './messageTime';
 import {useMessageFocusedTabIndex} from './util';
@@ -33,13 +41,87 @@ interface FederationStopMessageProps {
   isMessageFocused: boolean;
 }
 
-const config = Config.getConfig();
+type RenderFederationStopMessageOptions = {
+  readonly domains: string[];
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly translate: Translate;
+};
 
-const FederationStopMessage = ({message, isMessageFocused}: FederationStopMessageProps) => {
-  const {translate} = useApplicationContext();
+const config = Config.getConfig();
+const backendUrlMarker = createReactTranslationMarker('federation-stop-backend-url');
+const backendUrlOneMarker = createReactTranslationMarker('federation-stop-backend-url-one');
+const backendUrlTwoMarker = createReactTranslationMarker('federation-stop-backend-url-two');
+
+function renderFederationStopMessage(options: RenderFederationStopMessageOptions): ReactNode {
+  const {domains, isReactTranslationRenderingEnabled, translate} = options;
+
+  if (isReactTranslationRenderingEnabled === true) {
+    if (isNonEmptyArray(domains) === false) {
+      return <span />;
+    }
+
+    let translatedText: string;
+    let valueReplacements: ReactTranslationValueReplacement[];
+    if (domains.length === 1) {
+      translatedText = translate('federationDelete', {backendUrl: backendUrlMarker.substitution});
+      valueReplacements = [{marker: backendUrlMarker, runtimeText: domains[0]}];
+    } else {
+      translatedText = translate('federationConnectionRemove', {
+        backendUrlOne: backendUrlOneMarker.substitution,
+        backendUrlTwo: backendUrlTwoMarker.substitution,
+      });
+      valueReplacements = [
+        {marker: backendUrlOneMarker, runtimeText: domains[0]},
+        {marker: backendUrlTwoMarker, runtimeText: domains[1]},
+      ];
+    }
+
+    return (
+      <span>
+        {renderReactTranslation({
+          translatedText,
+          componentReplacements: [
+            {
+              start: '<strong>',
+              end: '</strong>',
+              render(children) {
+                return <strong>{children}</strong>;
+              },
+            },
+          ],
+          valueReplacements,
+        })}
+      </span>
+    );
+  }
+
+  let legacyTranslation: string;
+  if (domains.length === 1) {
+    legacyTranslation = translate('federationDelete', {backendUrl: domains[0]});
+  } else {
+    legacyTranslation = translate('federationConnectionRemove', {backendUrlOne: domains[0], backendUrlTwo: domains[1]});
+  }
+
+  return (
+    <span
+      dangerouslySetInnerHTML={{
+        __html: legacyTranslation,
+      }}
+    />
+  );
+}
+
+const FederationStopMessage: FunctionComponent<FederationStopMessageProps> = ({message, isMessageFocused}) => {
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
   const {timestamp} = useKoSubscribableChildren(message, ['timestamp']);
   const {id, domains} = message;
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
+  const federationStopMessage = renderFederationStopMessage({
+    domains,
+    isReactTranslationRenderingEnabled,
+    translate,
+  });
 
   return (
     <div className="message-header">
@@ -53,14 +135,7 @@ const FederationStopMessage = ({message, isMessageFocused}: FederationStopMessag
         data-uie-name="element-message-failed-to-add-users"
         data-uie-value={`domains-${domains.join('_')}`}
       >
-        <span
-          dangerouslySetInnerHTML={{
-            __html:
-              domains.length === 1
-                ? translate('federationDelete', {backendUrl: domains[0]})
-                : translate('federationConnectionRemove', {backendUrlOne: domains[0], backendUrlTwo: domains[1]}),
-          }}
-        />
+        {federationStopMessage}
         <Link
           css={{fontSize: 'var(--font-size-small)', marginLeft: 2}}
           tabIndex={messageFocusedTabIndex}

--- a/apps/webapp/src/script/components/messagesList/message/federationStopMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/federationStopMessage.tsx
@@ -55,7 +55,7 @@ const backendUrlTwoMarker = createReactTranslationMarker('federation-stop-backen
 function renderFederationStopMessage(options: RenderFederationStopMessageOptions): ReactNode {
   const {domains, isReactTranslationRenderingEnabled, translate} = options;
 
-  if (isReactTranslationRenderingEnabled === true) {
+  if (isReactTranslationRenderingEnabled) {
     if (isNonEmptyArray(domains) === false) {
       return <span />;
     }

--- a/apps/webapp/src/script/util/localizerUtil/reactLocalizerUtil.test.tsx
+++ b/apps/webapp/src/script/util/localizerUtil/reactLocalizerUtil.test.tsx
@@ -19,7 +19,7 @@
 
 import {render} from '@testing-library/react';
 
-import {replaceReactComponents} from './reactLocalizerUtil';
+import {createReactTranslationMarker, renderReactTranslation, replaceReactComponents} from './reactLocalizerUtil';
 
 describe('replaceReactComponents', () => {
   it('return the string untouched if no replacements are given', () => {
@@ -160,5 +160,77 @@ describe('replaceReactComponents', () => {
 
     expect(result).toHaveLength(7);
     expect(getByTestId('parent').textContent).toEqual('Hello Jake, Paul and Marco!');
+  });
+
+  it('renders runtime values as text inside and outside translated components', () => {
+    const senderNameMarker = createReactTranslationMarker('sender-name');
+    const senderName = 'R&D <Test>';
+    const translatedText = `<strong>${senderNameMarker.substitution}</strong> started the conversation with ${senderNameMarker.substitution}`;
+    const result = renderReactTranslation({
+      translatedText,
+      componentReplacements: [
+        {
+          start: '<strong>',
+          end: '</strong>',
+          render(children) {
+            return <strong>{children}</strong>;
+          },
+        },
+      ],
+      valueReplacements: [{marker: senderNameMarker, runtimeText: senderName}],
+    });
+
+    const {container} = render(<p>{result}</p>);
+    const actualText = container.querySelector('p')?.textContent;
+    const expectedText = 'R&D <Test> started the conversation with R&D <Test>';
+
+    expect(actualText).toBe(expectedText);
+    expect(container.querySelectorAll('strong')).toHaveLength(1);
+    expect(container.querySelector('test')).toBeNull();
+  });
+
+  it('keeps translation-looking runtime values literal', () => {
+    const senderNameMarker = createReactTranslationMarker('sender-name');
+    const senderName = '[bold]Admin[/bold]';
+    const result = renderReactTranslation({
+      translatedText: `<strong>${senderNameMarker.substitution}</strong> started the conversation`,
+      componentReplacements: [
+        {
+          start: '<strong>',
+          end: '</strong>',
+          render(children) {
+            return <strong>{children}</strong>;
+          },
+        },
+      ],
+      valueReplacements: [{marker: senderNameMarker, runtimeText: senderName}],
+    });
+
+    const {container} = render(<p>{result}</p>);
+
+    expect(container.querySelector('p')?.textContent).toBe('[bold]Admin[/bold] started the conversation');
+    expect(container.querySelectorAll('strong')).toHaveLength(1);
+  });
+
+  it('keeps unsupported translation markup as text', () => {
+    const result = renderReactTranslation({
+      translatedText: '<img src="example"><strong>Started</strong>',
+      componentReplacements: [
+        {
+          start: '<strong>',
+          end: '</strong>',
+          render(children) {
+            return <strong>{children}</strong>;
+          },
+        },
+      ],
+      valueReplacements: [],
+    });
+
+    const {container} = render(<p>{result}</p>);
+
+    expect(container.querySelector('p')?.textContent).toBe('<img src="example">Started');
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('strong')).toHaveTextContent('Started');
   });
 });

--- a/apps/webapp/src/script/util/localizerUtil/reactLocalizerUtil.tsx
+++ b/apps/webapp/src/script/util/localizerUtil/reactLocalizerUtil.tsx
@@ -32,8 +32,73 @@ interface StringReplacement {
 
 type Replacement = ComponentReplacement | StringReplacement;
 
+export type ReactTranslationMarker = {
+  readonly start: string;
+  readonly end: string;
+  readonly substitution: string;
+};
+
+export type ReactTranslationComponentReplacement = {
+  readonly start: string;
+  readonly end: string;
+  render(children: React.ReactNode[]): React.ReactNode;
+};
+
+export type ReactTranslationValueReplacement = {
+  readonly marker: ReactTranslationMarker;
+  readonly runtimeText: string;
+};
+
+type RenderReactTranslationOptions = {
+  readonly translatedText: string;
+  readonly componentReplacements: readonly ReactTranslationComponentReplacement[];
+  readonly valueReplacements: readonly ReactTranslationValueReplacement[];
+};
+
 function sanitizeRegexp(text: string) {
   return text.replaceAll('[', '\\[').replaceAll(']', '\\]');
+}
+
+export function createReactTranslationMarker(markerName: string): ReactTranslationMarker {
+  const markerIdentifier = markerName.replaceAll(/[^a-zA-Z0-9]/g, '_');
+  const markerStart = `__wire_react_translation_${markerIdentifier}_start__`;
+  const markerEnd = `__wire_react_translation_${markerIdentifier}_end__`;
+
+  return {
+    start: markerStart,
+    end: markerEnd,
+    substitution: `${markerStart}value${markerEnd}`,
+  };
+}
+
+export function renderReactTranslation(options: RenderReactTranslationOptions): React.ReactNode[] {
+  const {translatedText, componentReplacements, valueReplacements} = options;
+
+  const renderedValueReplacements = valueReplacements.map(valueReplacement => {
+    return {
+      start: valueReplacement.marker.start,
+      end: valueReplacement.marker.end,
+      render() {
+        return valueReplacement.runtimeText;
+      },
+    };
+  });
+
+  function renderRuntimeValues(text: string): React.ReactNode[] {
+    return replaceReactComponents(text, renderedValueReplacements);
+  }
+
+  const renderedComponentReplacements = componentReplacements.map(componentReplacement => {
+    return {
+      start: componentReplacement.start,
+      end: componentReplacement.end,
+      render(text: string) {
+        return componentReplacement.render(renderRuntimeValues(text));
+      },
+    };
+  });
+
+  return replaceReactComponents(translatedText, [...renderedComponentReplacements, ...renderedValueReplacements]);
 }
 
 /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27666" title="WPB-27666" target="_blank"><img alt="Security" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/13902?size=medium" />WPB-27666</a>  [Web] Text rendering
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This pull request continues the localized rich-text rendering migration started in #22411.

It migrates three additional message-level rendering paths to React-based translation rendering behind the existing startup feature toggle:

```text
react-translation-rendering
```
