### PR TITLE
Render UI translations with React [WPB-27666]

### DIFF
--- a/apps/webapp/src/script/components/messagesList/message/contentMessage/warnings/completeFailureToSend/completeFailureToSend.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/contentMessage/warnings/completeFailureToSend/completeFailureToSend.tsx
@@ -78,6 +78,7 @@ function renderCompleteFailureToSendWarning(options: RenderCompleteFailureToSend
               },
             },
           ],
+          nodeReplacements: [],
           valueReplacements,
         })}
       </span>

--- a/apps/webapp/src/script/components/messagesList/message/decryptErrorMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/decryptErrorMessage.tsx
@@ -92,6 +92,7 @@ function renderDecryptErrorCaption(options: RenderDecryptErrorCaptionOptions): R
           },
         },
       ],
+      nodeReplacements: [],
       valueReplacements: [{marker: decryptErrorUserMarker, runtimeText: userName}],
     });
   }

--- a/apps/webapp/src/script/components/messagesList/message/federationStopMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/federationStopMessage.tsx
@@ -89,6 +89,7 @@ function renderFederationStopMessage(options: RenderFederationStopMessageOptions
               },
             },
           ],
+          nodeReplacements: [],
           valueReplacements,
         })}
       </span>

--- a/apps/webapp/src/script/components/messagesList/message/memberMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/memberMessage.test.tsx
@@ -59,15 +59,21 @@ const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperFo
 );
 
 type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
 
-async function withTranslationStrings(strings: typeof en, testFunction: TranslationTestFunction): Promise<void> {
-  setStrings({en: strings});
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
 
-  try {
-    await testFunction();
-  } finally {
-    setStrings({en});
-  }
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
 }
 
 function createMemberMessage({systemType, type}: {systemType?: SystemMessageType; type?: string}, users?: User[]) {
@@ -350,8 +356,9 @@ describe('MemberMessage', () => {
       expect(container.textContent).toContain('You started the conversation');
     });
 
-    it('renders supported bold translation markup as a React element when the feature toggle is enabled', async () => {
-      await withTranslationStrings(
+    it(
+      'renders supported bold translation markup as a React element when the feature toggle is enabled',
+      withTranslationStrings(
         {
           ...en,
           conversationCreatedNameYou: '[bold]You[/bold] started the conversation',
@@ -385,8 +392,8 @@ describe('MemberMessage', () => {
           expect(strongElements).toHaveLength(1);
           expect(strongElements?.[0]).toHaveTextContent('You');
         },
-      );
-    });
+      ),
+    );
 
     it('renders another sender name as React text when the feature toggle is enabled', () => {
       const message = createMemberMessage({systemType: SystemMessageType.CONVERSATION_CREATE}, [generateUser()]);
@@ -449,8 +456,9 @@ describe('MemberMessage', () => {
       expect(strongElements?.[0]).toHaveTextContent('[bold]Admin[/bold]');
     });
 
-    it('renders the sender name outside formatting when the translation places it outside formatting', async () => {
-      await withTranslationStrings(
+    it(
+      'renders the sender name outside formatting when the translation places it outside formatting',
+      withTranslationStrings(
         {
           ...en,
           conversationCreatedName: '{name} started the conversation',
@@ -483,11 +491,12 @@ describe('MemberMessage', () => {
           expect(groupCreationHeader?.textContent).toBe('Alice started the conversation');
           expect(groupCreationHeader?.querySelector('strong')).toBeNull();
         },
-      );
-    });
+      ),
+    );
 
-    it('follows translated word order and formatting around the sender name', async () => {
-      await withTranslationStrings(
+    it(
+      'follows translated word order and formatting around the sender name',
+      withTranslationStrings(
         {
           ...en,
           conversationCreatedName: 'Conversation started by [bold]{name}[/bold]',
@@ -521,11 +530,12 @@ describe('MemberMessage', () => {
           expect(groupCreationHeader?.querySelectorAll('strong')).toHaveLength(1);
           expect(groupCreationHeader?.querySelector('strong')).toHaveTextContent('Alice');
         },
-      );
-    });
+      ),
+    );
 
-    it('keeps a markup-like sender name literal when the translation places it outside formatting', async () => {
-      await withTranslationStrings(
+    it(
+      'keeps a markup-like sender name literal when the translation places it outside formatting',
+      withTranslationStrings(
         {
           ...en,
           conversationCreatedName: '{name} started the conversation',
@@ -558,11 +568,12 @@ describe('MemberMessage', () => {
           expect(groupCreationHeader?.textContent).toBe('[bold]Admin[/bold] started the conversation');
           expect(groupCreationHeader?.querySelector('strong')).toBeNull();
         },
-      );
-    });
+      ),
+    );
 
-    it('renders arbitrary image markup as text when the feature toggle is enabled', async () => {
-      await withTranslationStrings(
+    it(
+      'renders arbitrary image markup as text when the feature toggle is enabled',
+      withTranslationStrings(
         {
           ...en,
           conversationCreatedNameYou: '<img src="example">[bold]You[/bold] started the conversation',
@@ -595,11 +606,12 @@ describe('MemberMessage', () => {
           expect(groupCreationHeader?.querySelector('strong')).toHaveTextContent('You');
           expect(container.querySelector('img')).toBeNull();
         },
-      );
-    });
+      ),
+    );
 
-    it('renders arbitrary meta markup as text when the feature toggle is enabled', async () => {
-      await withTranslationStrings(
+    it(
+      'renders arbitrary meta markup as text when the feature toggle is enabled',
+      withTranslationStrings(
         {
           ...en,
           conversationCreatedNameYou: '<meta name="example" content="value">[bold]You[/bold] started the conversation',
@@ -634,8 +646,8 @@ describe('MemberMessage', () => {
           expect(groupCreationHeader?.querySelector('strong')).toHaveTextContent('You');
           expect(container.querySelector('meta')).toBeNull();
         },
-      );
-    });
+      ),
+    );
   });
 
   describe('MEMBER_JOIN', () => {

--- a/apps/webapp/src/script/page/appLock/appLock.test.tsx
+++ b/apps/webapp/src/script/page/appLock/appLock.test.tsx
@@ -24,19 +24,47 @@ import ko from 'knockout';
 
 import {WebAppEvents} from '@wireapp/webapp-events';
 
+import en from 'I18n/en-US.json';
 import type {ClientRepository} from 'Repositories/client';
 import {User} from 'Repositories/entity/User/User';
 import {TeamState} from 'Repositories/team/TeamState';
 import {AppLockCrypto, AppLockRepository} from 'Repositories/user/appLockRepository';
 import {AppLockState} from 'Repositories/user/appLockState';
 import {UserState} from 'Repositories/user/userState';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {withTheme, withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {setStrings, translate} from 'Util/localizerUtil';
 import {translateForTest} from 'Util/test/translateForTest';
 import {createUuid} from 'Util/uuid';
 
 import {AppLock, APPLOCK_STATE} from './appLock';
-import {withTheme} from 'src/script/auth/util/test/testUtil';
 
 const clientRepository = {} as unknown as ClientRepository;
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName) {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+
+async function withTranslationStrings(strings: typeof en, testFunction: TranslationTestFunction): Promise<void> {
+  setStrings({en: strings});
+
+  try {
+    await testFunction();
+  } finally {
+    setStrings({en});
+  }
+}
+
 const appLockCrypto: AppLockCrypto = {
   cryptoPwhashMemLimitInteractive: 1,
   cryptoPwhashOpsLimitInteractive: 1,
@@ -83,6 +111,79 @@ const createAppLockRepository = (appLockState?: AppLockState) => {
   return appLockRepository;
 };
 describe('AppLock', () => {
+  it('keeps the legacy setup message rendering when React translation rendering is disabled', async () => {
+    await withTranslationStrings(en, () => {
+      const appLockState = createAppLockState();
+      const appLockRepository = createAppLockRepository(appLockState);
+      appLockState.hasPassphrase(false);
+      appLockState.isActivatedInPreferences(true);
+
+      const props = {
+        appLockRepository,
+        appLockState,
+        clientRepository,
+      };
+
+      const {getByTestId} = render(withTheme(<AppLock {...props} />));
+      const setupMessage = getByTestId('label-applock-set-text');
+
+      expect(setupMessage.querySelectorAll('br')).toHaveLength(2);
+    });
+  });
+
+  it('renders setup line breaks as React nodes when React translation rendering is enabled', async () => {
+    await withTranslationStrings(en, () => {
+      const appLockState = createAppLockState();
+      const appLockRepository = createAppLockRepository(appLockState);
+      appLockState.hasPassphrase(false);
+      appLockState.isActivatedInPreferences(true);
+
+      const props = {
+        appLockRepository,
+        appLockState,
+        clientRepository,
+      };
+
+      const {getByTestId} = render(
+        withThemeAndRootContext(<AppLock {...props} />, reactTranslationRenderingRootProviderWrapper),
+      );
+      const setupMessage = getByTestId('label-applock-set-text');
+
+      expect(setupMessage).toHaveTextContent('Wire will lock itself after 1 minute of inactivity.');
+      expect(setupMessage.querySelectorAll('br')).toHaveLength(2);
+    });
+  });
+
+  it('keeps unsupported setup translation markup as text', async () => {
+    await withTranslationStrings(
+      {
+        ...en,
+        modalAppLockSetupMessage: '<img src="example">Wire will lock itself.[br]Enter your passcode.',
+      },
+      () => {
+        const appLockState = createAppLockState();
+        const appLockRepository = createAppLockRepository(appLockState);
+        appLockState.hasPassphrase(false);
+        appLockState.isActivatedInPreferences(true);
+
+        const props = {
+          appLockRepository,
+          appLockState,
+          clientRepository,
+        };
+
+        const {getByTestId} = render(
+          withThemeAndRootContext(<AppLock {...props} />, reactTranslationRenderingRootProviderWrapper),
+        );
+        const setupMessage = getByTestId('label-applock-set-text');
+
+        expect(setupMessage).toHaveTextContent('<img src="example">Wire will lock itself.Enter your passcode.');
+        expect(setupMessage.querySelector('img')).toBeNull();
+        expect(setupMessage.querySelectorAll('br')).toHaveLength(2);
+      },
+    );
+  });
+
   describe('disabled feature', () => {
     it('does not shows up if applock is disabled', () => {
       const appLockState = createAppLockState(createTeamState({status: FEATURE_STATUS.DISABLED}));

--- a/apps/webapp/src/script/page/appLock/appLock.test.tsx
+++ b/apps/webapp/src/script/page/appLock/appLock.test.tsx
@@ -54,15 +54,21 @@ const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperFo
 );
 
 type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
 
-async function withTranslationStrings(strings: typeof en, testFunction: TranslationTestFunction): Promise<void> {
-  setStrings({en: strings});
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
 
-  try {
-    await testFunction();
-  } finally {
-    setStrings({en});
-  }
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
 }
 
 const appLockCrypto: AppLockCrypto = {
@@ -111,8 +117,9 @@ const createAppLockRepository = (appLockState?: AppLockState) => {
   return appLockRepository;
 };
 describe('AppLock', () => {
-  it('keeps the legacy setup message rendering when React translation rendering is disabled', async () => {
-    await withTranslationStrings(en, () => {
+  it(
+    'keeps the legacy setup message rendering when React translation rendering is disabled',
+    withTranslationStrings(en, () => {
       const appLockState = createAppLockState();
       const appLockRepository = createAppLockRepository(appLockState);
       appLockState.hasPassphrase(false);
@@ -128,11 +135,12 @@ describe('AppLock', () => {
       const setupMessage = getByTestId('label-applock-set-text');
 
       expect(setupMessage.querySelectorAll('br')).toHaveLength(2);
-    });
-  });
+    }),
+  );
 
-  it('renders setup line breaks as React nodes when React translation rendering is enabled', async () => {
-    await withTranslationStrings(en, () => {
+  it(
+    'renders setup line breaks as React nodes when React translation rendering is enabled',
+    withTranslationStrings(en, () => {
       const appLockState = createAppLockState();
       const appLockRepository = createAppLockRepository(appLockState);
       appLockState.hasPassphrase(false);
@@ -151,11 +159,12 @@ describe('AppLock', () => {
 
       expect(setupMessage).toHaveTextContent('Wire will lock itself after 1 minute of inactivity.');
       expect(setupMessage.querySelectorAll('br')).toHaveLength(2);
-    });
-  });
+    }),
+  );
 
-  it('keeps unsupported setup translation markup as text', async () => {
-    await withTranslationStrings(
+  it(
+    'keeps unsupported setup translation markup as text',
+    withTranslationStrings(
       {
         ...en,
         modalAppLockSetupMessage: '<img src="example">Wire will lock itself.[br]Enter your passcode.',
@@ -181,8 +190,8 @@ describe('AppLock', () => {
         expect(setupMessage.querySelector('img')).toBeNull();
         expect(setupMessage.querySelectorAll('br')).toHaveLength(2);
       },
-    );
-  });
+    ),
+  );
 
   describe('disabled feature', () => {
     it('does not shows up if applock is disabled', () => {

--- a/apps/webapp/src/script/page/appLock/appLock.tsx
+++ b/apps/webapp/src/script/page/appLock/appLock.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {useCallback, useEffect, useRef, useState, Fragment, FormEvent} from 'react';
+import {useCallback, useEffect, useRef, useState, Fragment, FormEvent, ReactNode} from 'react';
 
 import {amplify} from 'amplify';
 import cx from 'classnames';
@@ -35,8 +35,12 @@ import {AppLockRepository} from 'Repositories/user/appLockRepository';
 import {AppLockState} from 'Repositories/user/appLockState';
 import {SIGN_OUT_REASON} from 'src/script/auth/signOutReason';
 import {Config} from 'src/script/Config';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {ReactTranslationValueReplacement} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 
 import {applockStyles} from './appLock.styles';
 
@@ -58,6 +62,110 @@ const passwordRegexLower = /(?=.*[a-z])/;
 const passwordRegexSpecial = /(?=.*[!@#$%^&*(),.?":{}|<>])/;
 const passwordRegexUpper = /(?=.*[A-Z])/;
 
+type RenderAppLockTranslationOptions = {
+  readonly translatedText: string;
+  readonly valueReplacements: readonly ReactTranslationValueReplacement[];
+};
+
+type RenderAppLockSetupMessageOptions = {
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly translate: Translate;
+};
+
+type RenderAppLockSetupChangeMessageOptions = RenderAppLockSetupMessageOptions & {
+  readonly brandName: string;
+};
+
+const appLockBrandNameMarker = createReactTranslationMarker('app-lock-brand-name');
+const appLockLineBreakMarker = createReactTranslationMarker('app-lock-line-break');
+
+function renderAppLockTranslation(options: RenderAppLockTranslationOptions): ReactNode[] {
+  const {translatedText, valueReplacements} = options;
+
+  return renderReactTranslation({
+    translatedText,
+    componentReplacements: [],
+    nodeReplacements: [
+      {
+        marker: appLockLineBreakMarker,
+        render() {
+          return (
+            <Fragment>
+              <br />
+              <br />
+            </Fragment>
+          );
+        },
+      },
+    ],
+    valueReplacements,
+  });
+}
+
+function renderAppLockSetupMessage(options: RenderAppLockSetupMessageOptions): ReactNode {
+  const {isReactTranslationRenderingEnabled, translate} = options;
+
+  if (isReactTranslationRenderingEnabled) {
+    const lineBreakSubstitution = appLockLineBreakMarker.substitution;
+    const translatedText = translate(
+      'modalAppLockSetupMessage',
+      {br: lineBreakSubstitution},
+      {br: lineBreakSubstitution},
+    );
+
+    return (
+      <p className="modal__text" data-uie-name="label-applock-set-text">
+        {renderAppLockTranslation({translatedText, valueReplacements: []})}
+      </p>
+    );
+  }
+
+  return (
+    <p
+      className="modal__text"
+      dangerouslySetInnerHTML={{__html: translate('modalAppLockSetupMessage', undefined, {br: '<br><br>'})}}
+      data-uie-name="label-applock-set-text"
+    />
+  );
+}
+
+function renderAppLockSetupChangeMessage(options: RenderAppLockSetupChangeMessageOptions): ReactNode {
+  const {brandName, isReactTranslationRenderingEnabled, translate} = options;
+
+  if (isReactTranslationRenderingEnabled) {
+    const brandNameSubstitution = appLockBrandNameMarker.substitution;
+    const lineBreakSubstitution = appLockLineBreakMarker.substitution;
+    const translatedText = translate(
+      'modalAppLockSetupChangeMessage',
+      {brandName: brandNameSubstitution, br: lineBreakSubstitution},
+      {br: lineBreakSubstitution},
+    );
+
+    return (
+      <div className="modal__text" data-uie-name="label-applock-set-text">
+        {renderAppLockTranslation({
+          translatedText,
+          valueReplacements: [{marker: appLockBrandNameMarker, runtimeText: brandName}],
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="modal__text"
+      dangerouslySetInnerHTML={{
+        __html: translate(
+          'modalAppLockSetupChangeMessage',
+          {brandName: Config.getConfig().BRAND_NAME},
+          {br: '<br><br>'},
+        ),
+      }}
+      data-uie-name="label-applock-set-text"
+    />
+  );
+}
+
 interface AppLockProps {
   appLockRepository: AppLockRepository;
   appLockState?: AppLockState;
@@ -71,7 +179,7 @@ const AppLock = ({
   appLockState = container.resolve(AppLockState),
   appLockRepository,
 }: AppLockProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
   const [localAppLockState, setLocalAppLockState] = useState<APPLOCK_STATE>(APPLOCK_STATE.NONE);
   const [unlockError, setUnlockError] = useState('');
   const [isVisible, setIsVisible] = useState(false);
@@ -86,6 +194,8 @@ const AppLock = ({
   ]);
 
   const isTemporaryClient = clientState.currentClient?.isTemporary();
+  const brandName = Config.getConfig().BRAND_NAME;
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
 
   // We log the user out if there is a style change on the app element
   // i.e. if there is an attempt to remove the blur effect
@@ -292,11 +402,7 @@ const AppLock = ({
       <div className="modal__body" data-uie-name="applock-modal-body" data-uie-value={localAppLockState}>
         {localAppLockState === APPLOCK_STATE.SETUP && (
           <form onSubmit={onSetCode}>
-            <p
-              className="modal__text"
-              dangerouslySetInnerHTML={{__html: translate('modalAppLockSetupMessage', undefined, {br: '<br><br>'})}}
-              data-uie-name="label-applock-set-text"
-            />
+            {renderAppLockSetupMessage({isReactTranslationRenderingEnabled, translate})}
 
             {/* eslint jsx-a11y/no-autofocus : "off" */}
             <Input
@@ -384,17 +490,7 @@ const AppLock = ({
 
         {localAppLockState === APPLOCK_STATE.SETUP_CHANGE && (
           <form onSubmit={onSetCode}>
-            <div
-              className="modal__text"
-              dangerouslySetInnerHTML={{
-                __html: translate(
-                  'modalAppLockSetupChangeMessage',
-                  {brandName: Config.getConfig().BRAND_NAME},
-                  {br: '<br><br>'},
-                ),
-              }}
-              data-uie-name="label-applock-set-text"
-            />
+            {renderAppLockSetupChangeMessage({brandName, isReactTranslationRenderingEnabled, translate})}
 
             <Input
               aria-label={translate('modalAppLockSetupChangeTitle', {brandName: Config.getConfig().BRAND_NAME})}

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/teamCreation/teamCreationSteps/introduction.test.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/teamCreation/teamCreationSteps/introduction.test.tsx
@@ -1,0 +1,126 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render} from '@testing-library/react';
+
+import en from 'I18n/en-US.json';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {setStrings, translate} from 'Util/localizerUtil';
+
+import {Introduction} from './introduction';
+
+const legacyRootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName) {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
+type RenderIntroductionOptions = {
+  readonly rootProviderWrapper: ReturnType<typeof createRootProviderWrapperForTest>;
+};
+
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
+
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
+}
+
+function renderIntroduction(options: RenderIntroductionOptions): ReturnType<typeof render> {
+  const {rootProviderWrapper} = options;
+
+  return render(
+    withThemeAndRootContext(
+      <Introduction
+        onNextStep={jest.fn()}
+        onPreviousStep={jest.fn()}
+        onSuccess={jest.fn()}
+        teamName=""
+        setTeamName={jest.fn()}
+        userName="test-user"
+        goToFirstStep={jest.fn()}
+      />,
+      rootProviderWrapper,
+    ),
+  );
+}
+
+describe('Introduction', () => {
+  it(
+    'keeps the legacy list-item rendering when React translation rendering is disabled',
+    withTranslationStrings(en, () => {
+      const {container} = renderIntroduction({rootProviderWrapper: legacyRootProviderWrapper});
+      const listItems = container.querySelectorAll('[data-uie-name="team-creation-intro-list-item"]');
+
+      expect(listItems).toHaveLength(5);
+      expect(listItems[0]).toHaveTextContent('Admin Console: Invite team members and manage settings.');
+      expect(listItems[0].querySelector('strong')).toHaveTextContent('Admin Console:');
+    }),
+  );
+
+  it(
+    'renders translated bold formatting as React elements when enabled',
+    withTranslationStrings(en, () => {
+      const {container} = renderIntroduction({rootProviderWrapper: reactTranslationRenderingRootProviderWrapper});
+      const listItems = container.querySelectorAll('[data-uie-name="team-creation-intro-list-item"]');
+
+      expect(listItems).toHaveLength(5);
+      expect(listItems[0]).toHaveTextContent('Admin Console: Invite team members and manage settings.');
+      expect(listItems[0].querySelectorAll('strong')).toHaveLength(1);
+      expect(listItems[0].querySelector('strong')).toHaveTextContent('Admin Console:');
+    }),
+  );
+
+  it(
+    'keeps unsupported translation markup as text when enabled',
+    withTranslationStrings(
+      {
+        ...en,
+        teamCreationIntroListItem1: '<img src="example">[bold]Admin Console:[/bold] Invite team members.',
+      },
+      () => {
+        const {container} = renderIntroduction({rootProviderWrapper: reactTranslationRenderingRootProviderWrapper});
+        const listItems = container.querySelectorAll('[data-uie-name="team-creation-intro-list-item"]');
+
+        expect(listItems[0]).toHaveTextContent('<img src="example">Admin Console: Invite team members.');
+        expect(listItems[0].querySelectorAll('strong')).toHaveLength(1);
+        expect(listItems[0].querySelector('img')).toBeNull();
+      },
+    ),
+  );
+});

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/teamCreation/teamCreationSteps/introduction.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/teamCreation/teamCreationSteps/introduction.tsx
@@ -17,10 +17,14 @@
  *
  */
 
+import type {ReactNode} from 'react';
+
 import {Button, CheckRoundIcon, Link} from '@wireapp/react-ui-kit';
 
 import {Config} from 'src/script/Config';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
+import {renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
 
 import {StepProps} from './stepProps';
 import {
@@ -33,8 +37,49 @@ import {
 
 import {buttonCss} from '../teamCreation.styles';
 
+type RenderIntroductionListItemOptions = {
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly translatedText: string;
+};
+
+function renderIntroductionListItem(options: RenderIntroductionListItemOptions): ReactNode {
+  const {isReactTranslationRenderingEnabled, translatedText} = options;
+
+  if (isReactTranslationRenderingEnabled) {
+    return (
+      <span className="text" data-uie-name="team-creation-intro-list-item">
+        {renderReactTranslation({
+          translatedText,
+          componentReplacements: [
+            {
+              start: '<strong>',
+              end: '</strong>',
+              render(children): ReactNode {
+                return <strong>{children}</strong>;
+              },
+            },
+          ],
+          nodeReplacements: [],
+          valueReplacements: [],
+        })}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      dangerouslySetInnerHTML={{
+        __html: translatedText,
+      }}
+      className="text"
+      data-uie-name="team-creation-intro-list-item"
+    />
+  );
+}
+
 export const Introduction = ({onNextStep}: StepProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
   const featuresList = [
     translate('teamCreationIntroListItem1'),
     translate('teamCreationIntroListItem2'),
@@ -51,19 +96,18 @@ export const Introduction = ({onNextStep}: StepProps) => {
       <p className="text-regular" data-uie-name="team-creation-intro-sub-title" css={introStepSubHeaderCss}>
         {translate('teamCreationIntroSubTitle')}
       </p>
-      {featuresList.map(listItem => (
-        <div css={introItemCss} key={listItem}>
-          <CheckRoundIcon css={checkIconCss} />
+      {featuresList.map(listItem => {
+        return (
+          <div css={introItemCss} key={listItem}>
+            <CheckRoundIcon css={checkIconCss} />
 
-          <span
-            dangerouslySetInnerHTML={{
-              __html: listItem,
-            }}
-            className="text"
-            data-uie-name="team-creation-intro-list-item"
-          />
-        </div>
-      ))}
+            {renderIntroductionListItem({
+              isReactTranslationRenderingEnabled,
+              translatedText: listItem,
+            })}
+          </div>
+        );
+      })}
 
       <Link block css={introStepLinkCss} href={Config.getConfig().URL.PRICING} targetBlank>
         <span className="text-medium" data-uie-name="team-creation-intro-link">

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/optionPreferences.test.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/optionPreferences.test.tsx
@@ -1,0 +1,177 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+import {render} from '@testing-library/react';
+
+import en from 'I18n/en-US.json';
+import {User} from 'Repositories/entity/User';
+import type {PropertiesRepository} from 'Repositories/properties/propertiesRepository';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {setStrings, translate} from 'Util/localizerUtil';
+import {translateForTest} from 'Util/test/translateForTest';
+import {createUuid} from 'Util/uuid';
+
+import {OptionPreferences} from './optionPreferences';
+
+const legacyRootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName) {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+
+async function withTranslationStrings(strings: typeof en, testFunction: TranslationTestFunction): Promise<void> {
+  setStrings({en: strings});
+
+  try {
+    await testFunction();
+  } finally {
+    setStrings({en});
+  }
+}
+
+function createPropertiesRepositoryForTest(): PropertiesRepository {
+  return {
+    properties: {
+      settings: {
+        call: {
+          enable_press_space_to_unmute: false,
+          enable_soundless_incoming_calls: false,
+          enable_vbr_encoding: true,
+        },
+        emoji: {
+          replace_inline: true,
+        },
+        interface: {
+          font_size: '16px',
+          markdown_preview: true,
+          theme: 'default',
+          view_folders: false,
+        },
+        notifications: 'on',
+        previews: {
+          send: true,
+        },
+        privacy: {
+          marketing_consent: undefined,
+          telemetry_data_sharing: undefined,
+        },
+        sound: {
+          alerts: 'all',
+        },
+      },
+    },
+    savePreference: jest.fn(),
+  } as unknown as PropertiesRepository;
+}
+
+function createSelfUserForTest(): User {
+  return new User(createUuid(), '', translateForTest);
+}
+
+describe('OptionPreferences', () => {
+  it('keeps the legacy emoji detail rendering when React translation rendering is disabled', async () => {
+    await withTranslationStrings(en, () => {
+      const {container} = render(
+        withThemeAndRootContext(
+          <OptionPreferences
+            propertiesRepository={createPropertiesRepositoryForTest()}
+            selfUser={createSelfUserForTest()}
+          />,
+          legacyRootProviderWrapper,
+        ),
+      );
+
+      expect(container.querySelector('.icon-emoji')).toBeTruthy();
+    });
+  });
+
+  it('renders the emoji detail icon as a React node when React translation rendering is enabled', async () => {
+    await withTranslationStrings(en, () => {
+      const {container} = render(
+        withThemeAndRootContext(
+          <OptionPreferences
+            propertiesRepository={createPropertiesRepositoryForTest()}
+            selfUser={createSelfUserForTest()}
+          />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+
+      expect(container.querySelector('.icon-emoji')).toBeTruthy();
+    });
+  });
+
+  it('follows the translated emoji icon marker position', async () => {
+    await withTranslationStrings(
+      {
+        ...en,
+        preferencesOptionsEmojiReplaceDetail: '[icon] :-)',
+      },
+      () => {
+        const {container} = render(
+          withThemeAndRootContext(
+            <OptionPreferences
+              propertiesRepository={createPropertiesRepositoryForTest()}
+              selfUser={createSelfUserForTest()}
+            />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+
+        const emojiDetail = container.querySelector('.preferences-detail-intended');
+        expect(emojiDetail?.firstElementChild).toHaveClass('icon-emoji');
+      },
+    );
+  });
+
+  it('keeps unsupported emoji translation markup as text', async () => {
+    await withTranslationStrings(
+      {
+        ...en,
+        preferencesOptionsEmojiReplaceDetail: '<img src="example"> :-) → [icon]',
+      },
+      () => {
+        const {container} = render(
+          withThemeAndRootContext(
+            <OptionPreferences
+              propertiesRepository={createPropertiesRepositoryForTest()}
+              selfUser={createSelfUserForTest()}
+            />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+
+        const emojiDetail = container.querySelector('.preferences-detail-intended');
+        expect(emojiDetail).toHaveTextContent('<img src="example"> :-) →');
+        expect(emojiDetail?.querySelector('img')).toBeNull();
+        expect(emojiDetail?.querySelector('.icon-emoji')).toBeTruthy();
+      },
+    );
+  });
+});

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/optionPreferences.test.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/optionPreferences.test.tsx
@@ -44,15 +44,21 @@ const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperFo
 );
 
 type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
 
-async function withTranslationStrings(strings: typeof en, testFunction: TranslationTestFunction): Promise<void> {
-  setStrings({en: strings});
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
 
-  try {
-    await testFunction();
-  } finally {
-    setStrings({en});
-  }
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
 }
 
 function createPropertiesRepositoryForTest(): PropertiesRepository {
@@ -95,8 +101,9 @@ function createSelfUserForTest(): User {
 }
 
 describe('OptionPreferences', () => {
-  it('keeps the legacy emoji detail rendering when React translation rendering is disabled', async () => {
-    await withTranslationStrings(en, () => {
+  it(
+    'keeps the legacy emoji detail rendering when React translation rendering is disabled',
+    withTranslationStrings(en, () => {
       const {container} = render(
         withThemeAndRootContext(
           <OptionPreferences
@@ -108,11 +115,12 @@ describe('OptionPreferences', () => {
       );
 
       expect(container.querySelector('.icon-emoji')).toBeTruthy();
-    });
-  });
+    }),
+  );
 
-  it('renders the emoji detail icon as a React node when React translation rendering is enabled', async () => {
-    await withTranslationStrings(en, () => {
+  it(
+    'renders the emoji detail icon as a React node when React translation rendering is enabled',
+    withTranslationStrings(en, () => {
       const {container} = render(
         withThemeAndRootContext(
           <OptionPreferences
@@ -124,11 +132,12 @@ describe('OptionPreferences', () => {
       );
 
       expect(container.querySelector('.icon-emoji')).toBeTruthy();
-    });
-  });
+    }),
+  );
 
-  it('follows the translated emoji icon marker position', async () => {
-    await withTranslationStrings(
+  it(
+    'follows the translated emoji icon marker position',
+    withTranslationStrings(
       {
         ...en,
         preferencesOptionsEmojiReplaceDetail: '[icon] :-)',
@@ -147,11 +156,12 @@ describe('OptionPreferences', () => {
         const emojiDetail = container.querySelector('.preferences-detail-intended');
         expect(emojiDetail?.firstElementChild).toHaveClass('icon-emoji');
       },
-    );
-  });
+    ),
+  );
 
-  it('keeps unsupported emoji translation markup as text', async () => {
-    await withTranslationStrings(
+  it(
+    'keeps unsupported emoji translation markup as text',
+    withTranslationStrings(
       {
         ...en,
         preferencesOptionsEmojiReplaceDetail: '<img src="example"> :-) → [icon]',
@@ -172,6 +182,6 @@ describe('OptionPreferences', () => {
         expect(emojiDetail?.querySelector('img')).toBeNull();
         expect(emojiDetail?.querySelector('.icon-emoji')).toBeTruthy();
       },
-    );
-  });
+    ),
+  );
 });

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/optionPreferences.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/optionPreferences.tsx
@@ -31,8 +31,11 @@ import {User} from 'Repositories/entity/User';
 import {PropertiesRepository} from 'Repositories/properties/propertiesRepository';
 import {PROPERTIES_TYPE} from 'Repositories/properties/propertiesType';
 import {Config} from 'src/script/Config';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 
 import {PreferencesPage} from './components/preferencesPage';
 import {PreferencesSection} from './components/preferencesSection';
@@ -60,9 +63,58 @@ const notificationPreferenceValues = {
 } as const satisfies Record<'NONE' | 'OBFUSCATE' | 'OBFUSCATE_MESSAGE' | 'ON', NotificationPreferenceValue>;
 
 const fontSizes = Object.values(RootFontSize);
+const emojiIconMarker = createReactTranslationMarker('emoji-preference-icon');
+
+type RenderEmojiReplaceDetailOptions = {
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly translate: Translate;
+};
+
+function renderEmojiReplaceDetail(options: RenderEmojiReplaceDetailOptions): React.ReactNode {
+  const {isReactTranslationRenderingEnabled, translate} = options;
+
+  if (isReactTranslationRenderingEnabled) {
+    const iconSubstitution = emojiIconMarker.substitution;
+    const translatedText = translate(
+      'preferencesOptionsEmojiReplaceDetail',
+      {icon: iconSubstitution},
+      {icon: iconSubstitution},
+    );
+
+    return (
+      <p className="preferences-detail preferences-detail-intended" aria-hidden="true">
+        {renderReactTranslation({
+          translatedText,
+          componentReplacements: [],
+          nodeReplacements: [
+            {
+              marker: emojiIconMarker,
+              render() {
+                return <span className="font-size-xs icon-emoji" />;
+              },
+            },
+          ],
+          valueReplacements: [],
+        })}
+      </p>
+    );
+  }
+
+  return (
+    <p
+      className="preferences-detail preferences-detail-intended"
+      aria-hidden="true"
+      dangerouslySetInnerHTML={{
+        __html: translate('preferencesOptionsEmojiReplaceDetail', undefined, {
+          icon: "<span class='font-size-xs icon-emoji'></span>",
+        }),
+      }}
+    />
+  );
+}
 
 const OptionPreferences = ({propertiesRepository, selfUser}: OptionPreferencesProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
   const {isActivatedAccount} = useKoSubscribableChildren(selfUser, ['isActivatedAccount']);
   const {
     properties: {settings},
@@ -153,6 +205,7 @@ const OptionPreferences = ({propertiesRepository, selfUser}: OptionPreferencesPr
 
   const isMessageFormatButtonsFlagEnabled = Config.getConfig().FEATURE.ENABLE_MESSAGE_FORMAT_BUTTONS;
   const isLinkPreviewsEnabled = Config.getConfig().FEATURE.ALLOW_LINK_PREVIEWS;
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
 
   return (
     <PreferencesPage title={translate('preferencesOptions')}>
@@ -255,15 +308,7 @@ const OptionPreferences = ({propertiesRepository, selfUser}: OptionPreferencesPr
                 </CheckboxLabel>
               </Checkbox>
 
-              <p
-                className="preferences-detail preferences-detail-intended"
-                aria-hidden="true"
-                dangerouslySetInnerHTML={{
-                  __html: translate('preferencesOptionsEmojiReplaceDetail', undefined, {
-                    icon: "<span class='font-size-xs icon-emoji'></span>",
-                  }),
-                }}
-              />
+              {renderEmojiReplaceDetail({isReactTranslationRenderingEnabled, translate})}
             </div>
 
             {isMessageFormatButtonsFlagEnabled && (

--- a/apps/webapp/src/script/util/localizerUtil/reactLocalizerUtil.test.tsx
+++ b/apps/webapp/src/script/util/localizerUtil/reactLocalizerUtil.test.tsx
@@ -177,6 +177,7 @@ describe('replaceReactComponents', () => {
           },
         },
       ],
+      nodeReplacements: [],
       valueReplacements: [{marker: senderNameMarker, runtimeText: senderName}],
     });
 
@@ -187,6 +188,103 @@ describe('replaceReactComponents', () => {
     expect(actualText).toBe(expectedText);
     expect(container.querySelectorAll('strong')).toHaveLength(1);
     expect(container.querySelector('test')).toBeNull();
+  });
+
+  it('renders a trusted React node outside translated components', () => {
+    const iconMarker = createReactTranslationMarker('permission-icon');
+    const result = renderReactTranslation({
+      translatedText: `Allow ${iconMarker.substitution} access`,
+      componentReplacements: [],
+      nodeReplacements: [
+        {
+          marker: iconMarker,
+          render() {
+            return <span data-uie-name="permission-icon" />;
+          },
+        },
+      ],
+      valueReplacements: [],
+    });
+
+    const {getByTestId} = render(<p>{result}</p>);
+
+    expect(getByTestId('permission-icon')).toBeInTheDocument();
+  });
+
+  it('renders a trusted React node inside a translated component', () => {
+    const lineBreakMarker = createReactTranslationMarker('line-break');
+    const result = renderReactTranslation({
+      translatedText: `<strong>First${lineBreakMarker.substitution}Second</strong>`,
+      componentReplacements: [
+        {
+          start: '<strong>',
+          end: '</strong>',
+          render(children) {
+            return <strong>{children}</strong>;
+          },
+        },
+      ],
+      nodeReplacements: [
+        {
+          marker: lineBreakMarker,
+          render() {
+            return <br data-uie-name="line-break" />;
+          },
+        },
+      ],
+      valueReplacements: [],
+    });
+
+    const {container, getByTestId} = render(<p>{result}</p>);
+    const strongElement = container.querySelector('strong');
+
+    expect(getByTestId('line-break')).toBeInTheDocument();
+    expect(strongElement).toHaveTextContent('FirstSecond');
+  });
+
+  it('renders multiple occurrences of the same trusted React node marker', () => {
+    const iconMarker = createReactTranslationMarker('permission-icon');
+    const result = renderReactTranslation({
+      translatedText: `${iconMarker.substitution} Camera ${iconMarker.substitution} Microphone`,
+      componentReplacements: [],
+      nodeReplacements: [
+        {
+          marker: iconMarker,
+          render() {
+            return <span data-uie-name="permission-icon" />;
+          },
+        },
+      ],
+      valueReplacements: [],
+    });
+
+    const {getAllByTestId} = render(<p>{result}</p>);
+
+    expect(getAllByTestId('permission-icon')).toHaveLength(2);
+  });
+
+  it('renders runtime text and trusted React nodes in translator-controlled order', () => {
+    const userNameMarker = createReactTranslationMarker('user-name');
+    const iconMarker = createReactTranslationMarker('permission-icon');
+    const result = renderReactTranslation({
+      translatedText: `${userNameMarker.substitution} ${iconMarker.substitution} was granted`,
+      componentReplacements: [],
+      nodeReplacements: [
+        {
+          marker: iconMarker,
+          render() {
+            return <span data-uie-name="permission-icon" />;
+          },
+        },
+      ],
+      valueReplacements: [{marker: userNameMarker, runtimeText: 'R&D <Test>'}],
+    });
+
+    const {container, getByTestId} = render(<p>{result}</p>);
+
+    expect(container.querySelector('test')).toBeNull();
+    expect(container.querySelector('p')).toHaveTextContent('R&D <Test> was granted');
+    expect(getByTestId('permission-icon')).toBeInTheDocument();
   });
 
   it('keeps translation-looking runtime values literal', () => {
@@ -203,6 +301,7 @@ describe('replaceReactComponents', () => {
           },
         },
       ],
+      nodeReplacements: [],
       valueReplacements: [{marker: senderNameMarker, runtimeText: senderName}],
     });
 
@@ -224,6 +323,7 @@ describe('replaceReactComponents', () => {
           },
         },
       ],
+      nodeReplacements: [],
       valueReplacements: [],
     });
 

--- a/apps/webapp/src/script/util/localizerUtil/reactLocalizerUtil.tsx
+++ b/apps/webapp/src/script/util/localizerUtil/reactLocalizerUtil.tsx
@@ -49,9 +49,15 @@ export type ReactTranslationValueReplacement = {
   readonly runtimeText: string;
 };
 
+export type ReactTranslationNodeReplacement = {
+  readonly marker: ReactTranslationMarker;
+  render(): ReactNode;
+};
+
 type RenderReactTranslationOptions = {
   readonly translatedText: string;
   readonly componentReplacements: readonly ReactTranslationComponentReplacement[];
+  readonly nodeReplacements: readonly ReactTranslationNodeReplacement[];
   readonly valueReplacements: readonly ReactTranslationValueReplacement[];
 };
 
@@ -72,7 +78,7 @@ export function createReactTranslationMarker(markerName: string): ReactTranslati
 }
 
 export function renderReactTranslation(options: RenderReactTranslationOptions): React.ReactNode[] {
-  const {translatedText, componentReplacements, valueReplacements} = options;
+  const {translatedText, componentReplacements, nodeReplacements, valueReplacements} = options;
 
   const renderedValueReplacements = valueReplacements.map(valueReplacement => {
     return {
@@ -84,8 +90,20 @@ export function renderReactTranslation(options: RenderReactTranslationOptions): 
     };
   });
 
-  function renderRuntimeValues(text: string): React.ReactNode[] {
-    return replaceReactComponents(text, renderedValueReplacements);
+  const renderedNodeReplacements = nodeReplacements.map(nodeReplacement => {
+    return {
+      start: nodeReplacement.marker.start,
+      end: nodeReplacement.marker.end,
+      render() {
+        return nodeReplacement.render();
+      },
+    };
+  });
+
+  const renderedNestedReplacements = [...renderedValueReplacements, ...renderedNodeReplacements];
+
+  function renderNestedReplacements(text: string): React.ReactNode[] {
+    return replaceReactComponents(text, renderedNestedReplacements);
   }
 
   const renderedComponentReplacements = componentReplacements.map(componentReplacement => {
@@ -93,12 +111,16 @@ export function renderReactTranslation(options: RenderReactTranslationOptions): 
       start: componentReplacement.start,
       end: componentReplacement.end,
       render(text: string) {
-        return componentReplacement.render(renderRuntimeValues(text));
+        return componentReplacement.render(renderNestedReplacements(text));
       },
     };
   });
 
-  return replaceReactComponents(translatedText, [...renderedComponentReplacements, ...renderedValueReplacements]);
+  return replaceReactComponents(translatedText, [
+    ...renderedComponentReplacements,
+    ...renderedValueReplacements,
+    ...renderedNodeReplacements,
+  ]);
 }
 
 /**

--- a/apps/webapp/src/script/view_model/WarningsContainer/WarningsContainer.test.tsx
+++ b/apps/webapp/src/script/view_model/WarningsContainer/WarningsContainer.test.tsx
@@ -19,6 +19,9 @@
 
 import {act, cleanup, fireEvent, render} from '@testing-library/react';
 
+import en from 'I18n/en-US.json';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {setStrings, translate} from 'Util/localizerUtil';
 import {translateForTest} from 'Util/test/translateForTest';
 import {
   createRootContextValueForTest,
@@ -33,6 +36,29 @@ import {Warnings} from '.';
 const rootProviderWrapper = createRootProviderWrapperForTest(
   createRootContextValueForTest({translate: translateForTest}),
 );
+const legacyTranslationRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate}),
+);
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName) {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+
+async function withTranslationStrings(strings: typeof en, testFunction: TranslationTestFunction): Promise<void> {
+  setStrings({en: strings});
+
+  try {
+    await testFunction();
+  } finally {
+    setStrings({en});
+  }
+}
 
 describe('WarningsContainer', () => {
   beforeEach(() => {
@@ -132,6 +158,120 @@ describe('WarningsContainer', () => {
     });
     const WarningElement = getByTestId('request-notification');
     expect(WarningElement).toBeTruthy();
+  });
+
+  it('keeps legacy permission request rendering when React translation rendering is disabled', async () => {
+    await withTranslationStrings(en, () => {
+      const {container} = render(<WarningsContainer onRefresh={jest.fn()} />, {
+        wrapper: legacyTranslationRootProviderWrapper,
+      });
+      act(() => {
+        Warnings.showWarning(Warnings.TYPE.REQUEST_CAMERA);
+      });
+
+      expect(container.querySelector('.warning-bar-message')).toHaveTextContent('Allow access to camera');
+      expect(container.querySelector('.icon-camera')).toBeTruthy();
+    });
+  });
+
+  it('renders the camera permission request icon as a React node', async () => {
+    await withTranslationStrings(en, () => {
+      const {container} = render(<WarningsContainer onRefresh={jest.fn()} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+      act(() => {
+        Warnings.showWarning(Warnings.TYPE.REQUEST_CAMERA);
+      });
+
+      expect(container.querySelector('.warning-bar-message')).toHaveTextContent('Allow access to camera');
+      expect(container.querySelector('.icon-camera')).toBeTruthy();
+    });
+  });
+
+  it('renders exactly one microphone permission request icon as a React node', async () => {
+    await withTranslationStrings(en, () => {
+      const {container} = render(<WarningsContainer onRefresh={jest.fn()} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+      act(() => {
+        Warnings.showWarning(Warnings.TYPE.REQUEST_MICROPHONE);
+      });
+
+      expect(container.querySelector('.warning-bar-message')).toHaveTextContent('Allow access to microphone');
+      expect(container.querySelectorAll('.warning-bar-icon')).toHaveLength(1);
+    });
+  });
+
+  it('renders the screen and notification permission request icons as React nodes', async () => {
+    await withTranslationStrings(en, () => {
+      const {container: screenContainer} = render(<WarningsContainer onRefresh={jest.fn()} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+      act(() => {
+        Warnings.showWarning(Warnings.TYPE.REQUEST_SCREEN);
+      });
+
+      expect(screenContainer.querySelector('.warning-bar-message')).toHaveTextContent('Allow access to screen');
+      expect(screenContainer.querySelector('.icon-screensharing')).toBeTruthy();
+
+      cleanup();
+      act(() => {
+        Warnings.hideWarning();
+      });
+
+      const {container: notificationContainer} = render(<WarningsContainer onRefresh={jest.fn()} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+      act(() => {
+        Warnings.showWarning(Warnings.TYPE.REQUEST_NOTIFICATION);
+      });
+
+      expect(notificationContainer.querySelector('.warning-bar-message')).toHaveTextContent('Allow notifications');
+      expect(notificationContainer.querySelector('.icon-envelope')).toBeTruthy();
+    });
+  });
+
+  it('follows a translated permission icon marker moved after the text', async () => {
+    await withTranslationStrings(
+      {
+        ...en,
+        warningPermissionRequestCamera: 'Allow access to camera [icon]',
+      },
+      () => {
+        const {container} = render(<WarningsContainer onRefresh={jest.fn()} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        act(() => {
+          Warnings.showWarning(Warnings.TYPE.REQUEST_CAMERA);
+        });
+
+        const warningMessage = container.querySelector('.warning-bar-message');
+        expect(warningMessage).toHaveTextContent('Allow access to camera');
+        expect(warningMessage?.querySelector('.icon-camera')).toBeTruthy();
+      },
+    );
+  });
+
+  it('keeps unsupported permission translation markup as text', async () => {
+    await withTranslationStrings(
+      {
+        ...en,
+        warningPermissionRequestCamera: '<img src="example">[icon] Allow access to camera',
+      },
+      () => {
+        const {container} = render(<WarningsContainer onRefresh={jest.fn()} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        act(() => {
+          Warnings.showWarning(Warnings.TYPE.REQUEST_CAMERA);
+        });
+
+        const warningMessage = container.querySelector('.warning-bar-message');
+        expect(warningMessage).toHaveTextContent('<img src="example"> Allow access to camera');
+        expect(warningMessage?.querySelector('img')).toBeNull();
+        expect(warningMessage?.querySelector('.icon-camera')).toBeTruthy();
+      },
+    );
   });
 
   it('correctly renders warning of type unsupported_incoming_call', () => {

--- a/apps/webapp/src/script/view_model/WarningsContainer/WarningsContainer.test.tsx
+++ b/apps/webapp/src/script/view_model/WarningsContainer/WarningsContainer.test.tsx
@@ -49,15 +49,21 @@ const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperFo
 );
 
 type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
 
-async function withTranslationStrings(strings: typeof en, testFunction: TranslationTestFunction): Promise<void> {
-  setStrings({en: strings});
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
 
-  try {
-    await testFunction();
-  } finally {
-    setStrings({en});
-  }
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
 }
 
 describe('WarningsContainer', () => {
@@ -160,8 +166,9 @@ describe('WarningsContainer', () => {
     expect(WarningElement).toBeTruthy();
   });
 
-  it('keeps legacy permission request rendering when React translation rendering is disabled', async () => {
-    await withTranslationStrings(en, () => {
+  it(
+    'keeps legacy permission request rendering when React translation rendering is disabled',
+    withTranslationStrings(en, () => {
       const {container} = render(<WarningsContainer onRefresh={jest.fn()} />, {
         wrapper: legacyTranslationRootProviderWrapper,
       });
@@ -171,11 +178,12 @@ describe('WarningsContainer', () => {
 
       expect(container.querySelector('.warning-bar-message')).toHaveTextContent('Allow access to camera');
       expect(container.querySelector('.icon-camera')).toBeTruthy();
-    });
-  });
+    }),
+  );
 
-  it('renders the camera permission request icon as a React node', async () => {
-    await withTranslationStrings(en, () => {
+  it(
+    'renders the camera permission request icon as a React node',
+    withTranslationStrings(en, () => {
       const {container} = render(<WarningsContainer onRefresh={jest.fn()} />, {
         wrapper: reactTranslationRenderingRootProviderWrapper,
       });
@@ -185,11 +193,12 @@ describe('WarningsContainer', () => {
 
       expect(container.querySelector('.warning-bar-message')).toHaveTextContent('Allow access to camera');
       expect(container.querySelector('.icon-camera')).toBeTruthy();
-    });
-  });
+    }),
+  );
 
-  it('renders exactly one microphone permission request icon as a React node', async () => {
-    await withTranslationStrings(en, () => {
+  it(
+    'renders exactly one microphone permission request icon as a React node',
+    withTranslationStrings(en, () => {
       const {container} = render(<WarningsContainer onRefresh={jest.fn()} />, {
         wrapper: reactTranslationRenderingRootProviderWrapper,
       });
@@ -199,11 +208,12 @@ describe('WarningsContainer', () => {
 
       expect(container.querySelector('.warning-bar-message')).toHaveTextContent('Allow access to microphone');
       expect(container.querySelectorAll('.warning-bar-icon')).toHaveLength(1);
-    });
-  });
+    }),
+  );
 
-  it('renders the screen and notification permission request icons as React nodes', async () => {
-    await withTranslationStrings(en, () => {
+  it(
+    'renders the screen and notification permission request icons as React nodes',
+    withTranslationStrings(en, () => {
       const {container: screenContainer} = render(<WarningsContainer onRefresh={jest.fn()} />, {
         wrapper: reactTranslationRenderingRootProviderWrapper,
       });
@@ -228,11 +238,12 @@ describe('WarningsContainer', () => {
 
       expect(notificationContainer.querySelector('.warning-bar-message')).toHaveTextContent('Allow notifications');
       expect(notificationContainer.querySelector('.icon-envelope')).toBeTruthy();
-    });
-  });
+    }),
+  );
 
-  it('follows a translated permission icon marker moved after the text', async () => {
-    await withTranslationStrings(
+  it(
+    'follows a translated permission icon marker moved after the text',
+    withTranslationStrings(
       {
         ...en,
         warningPermissionRequestCamera: 'Allow access to camera [icon]',
@@ -249,11 +260,12 @@ describe('WarningsContainer', () => {
         expect(warningMessage).toHaveTextContent('Allow access to camera');
         expect(warningMessage?.querySelector('.icon-camera')).toBeTruthy();
       },
-    );
-  });
+    ),
+  );
 
-  it('keeps unsupported permission translation markup as text', async () => {
-    await withTranslationStrings(
+  it(
+    'keeps unsupported permission translation markup as text',
+    withTranslationStrings(
       {
         ...en,
         warningPermissionRequestCamera: '<img src="example">[icon] Allow access to camera',
@@ -271,8 +283,8 @@ describe('WarningsContainer', () => {
         expect(warningMessage?.querySelector('img')).toBeNull();
         expect(warningMessage?.querySelector('.icon-camera')).toBeTruthy();
       },
-    );
-  });
+    ),
+  );
 
   it('correctly renders warning of type unsupported_incoming_call', () => {
     const {getByTestId} = render(<WarningsContainer onRefresh={jest.fn()} />, {wrapper: rootProviderWrapper});

--- a/apps/webapp/src/script/view_model/WarningsContainer/WarningsContainer.tsx
+++ b/apps/webapp/src/script/view_model/WarningsContainer/WarningsContainer.tsx
@@ -17,14 +17,17 @@
  *
  */
 
-import {useEffect} from 'react';
+import {ReactNode, useEffect} from 'react';
 
 import cx from 'classnames';
 
 import {Runtime} from '@wireapp/commons';
 
 import * as Icon from 'Components/icon';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 import {afterRender} from 'Util/util';
 
 import {closeWarning, useWarningsState} from './WarningsState';
@@ -36,8 +39,59 @@ interface WarningProps {
   readonly onRefresh: () => void;
 }
 
+type PermissionRequestTranslationKey =
+  | 'warningPermissionRequestCamera'
+  | 'warningPermissionRequestMicrophone'
+  | 'warningPermissionRequestNotification'
+  | 'warningPermissionRequestScreen';
+
+type RenderPermissionRequestTranslationOptions = {
+  readonly icon: ReactNode;
+  readonly translate: Translate;
+  readonly translationKey: PermissionRequestTranslationKey;
+};
+
+type RenderPermissionRequestWarningMessageOptions = RenderPermissionRequestTranslationOptions & {
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly legacyMessage: ReactNode;
+};
+
+const permissionRequestIconMarker = createReactTranslationMarker('permission-request-icon');
+
+function renderPermissionRequestTranslation(options: RenderPermissionRequestTranslationOptions): ReactNode[] {
+  const {icon, translate, translationKey} = options;
+  const iconSubstitution = permissionRequestIconMarker.substitution;
+  const translatedText = translate(translationKey, {icon: iconSubstitution}, {icon: iconSubstitution});
+
+  return renderReactTranslation({
+    translatedText,
+    componentReplacements: [],
+    nodeReplacements: [
+      {
+        marker: permissionRequestIconMarker,
+        render() {
+          return icon;
+        },
+      },
+    ],
+    valueReplacements: [],
+  });
+}
+
+function renderPermissionRequestWarningMessage(options: RenderPermissionRequestWarningMessageOptions): ReactNode {
+  const {icon, isReactTranslationRenderingEnabled, legacyMessage, translate, translationKey} = options;
+
+  if (isReactTranslationRenderingEnabled) {
+    return (
+      <div className="warning-bar-message">{renderPermissionRequestTranslation({icon, translate, translationKey})}</div>
+    );
+  }
+
+  return legacyMessage;
+}
+
 const WarningsContainer = ({onRefresh}: WarningProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
   const name = useWarningsState(state => state.name);
   const warnings = useWarningsState(state => state.warnings);
   const type = TYPE;
@@ -61,6 +115,7 @@ const WarningsContainer = ({onRefresh}: WarningProps) => {
 
   const brandName = Config.getConfig().BRAND_NAME;
   const URL = Config.getConfig().URL;
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
 
   const closeButton = (
     <button
@@ -79,14 +134,22 @@ const WarningsContainer = ({onRefresh}: WarningProps) => {
     <div className={cx('warning', {'warning-dimmed': warningDimmed})}>
       {visibleWarning === type.REQUEST_CAMERA && (
         <div data-uie-name="request-camera" className="warning-bar warning-bar-feature">
-          <div
-            className="warning-bar-message"
-            dangerouslySetInnerHTML={{
-              __html: translate('warningPermissionRequestCamera', undefined, {
-                icon: "<span class='warning-bar-icon icon-camera'></span>",
-              }),
-            }}
-          />
+          {renderPermissionRequestWarningMessage({
+            icon: <span className="warning-bar-icon icon-camera" />,
+            isReactTranslationRenderingEnabled,
+            legacyMessage: (
+              <div
+                className="warning-bar-message"
+                dangerouslySetInnerHTML={{
+                  __html: translate('warningPermissionRequestCamera', undefined, {
+                    icon: "<span class='warning-bar-icon icon-camera'></span>",
+                  }),
+                }}
+              />
+            ),
+            translate,
+            translationKey: 'warningPermissionRequestCamera',
+          })}
           {closeButton}
         </div>
       )}
@@ -108,12 +171,22 @@ const WarningsContainer = ({onRefresh}: WarningProps) => {
       )}
       {visibleWarning === type.REQUEST_MICROPHONE && (
         <div data-uie-name="request-microphone" className="warning-bar warning-bar-feature">
-          <div className="warning-bar-message">
-            <Icon.MicOnIcon className="warning-bar-icon" />
-            <span
-              dangerouslySetInnerHTML={{__html: translate('warningPermissionRequestMicrophone', undefined, {icon: ''})}}
-            />
-          </div>
+          {renderPermissionRequestWarningMessage({
+            icon: <Icon.MicOnIcon className="warning-bar-icon" />,
+            isReactTranslationRenderingEnabled,
+            legacyMessage: (
+              <div className="warning-bar-message">
+                <Icon.MicOnIcon className="warning-bar-icon" />
+                <span
+                  dangerouslySetInnerHTML={{
+                    __html: translate('warningPermissionRequestMicrophone', undefined, {icon: ''}),
+                  }}
+                />
+              </div>
+            ),
+            translate,
+            translationKey: 'warningPermissionRequestMicrophone',
+          })}
           {closeButton}
         </div>
       )}
@@ -135,14 +208,22 @@ const WarningsContainer = ({onRefresh}: WarningProps) => {
       )}
       {visibleWarning === type.REQUEST_SCREEN && (
         <div data-uie-name="request-screen" className="warning-bar warning-bar-feature">
-          <div
-            className="warning-bar-message"
-            dangerouslySetInnerHTML={{
-              __html: translate('warningPermissionRequestScreen', undefined, {
-                icon: "<span class='warning-bar-icon icon-screensharing'></span>",
-              }),
-            }}
-          />
+          {renderPermissionRequestWarningMessage({
+            icon: <span className="warning-bar-icon icon-screensharing" />,
+            isReactTranslationRenderingEnabled,
+            legacyMessage: (
+              <div
+                className="warning-bar-message"
+                dangerouslySetInnerHTML={{
+                  __html: translate('warningPermissionRequestScreen', undefined, {
+                    icon: "<span class='warning-bar-icon icon-screensharing'></span>",
+                  }),
+                }}
+              />
+            ),
+            translate,
+            translationKey: 'warningPermissionRequestScreen',
+          })}
           {closeButton}
         </div>
       )}
@@ -196,14 +277,22 @@ const WarningsContainer = ({onRefresh}: WarningProps) => {
       )}
       {visibleWarning === type.REQUEST_NOTIFICATION && (
         <div data-uie-name="request-notification" className="warning-bar warning-bar-feature">
-          <div
-            className="warning-bar-message"
-            dangerouslySetInnerHTML={{
-              __html: translate('warningPermissionRequestNotification', undefined, {
-                icon: "<span class='warning-bar-icon icon-envelope'></span>",
-              }),
-            }}
-          />
+          {renderPermissionRequestWarningMessage({
+            icon: <span className="warning-bar-icon icon-envelope" />,
+            isReactTranslationRenderingEnabled,
+            legacyMessage: (
+              <div
+                className="warning-bar-message"
+                dangerouslySetInnerHTML={{
+                  __html: translate('warningPermissionRequestNotification', undefined, {
+                    icon: "<span class='warning-bar-icon icon-envelope'></span>",
+                  }),
+                }}
+              />
+            ),
+            translate,
+            translationKey: 'warningPermissionRequestNotification',
+          })}
           {closeButton}
         </div>
       )}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27666" title="WPB-27666" target="_blank"><img alt="Security" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/13902?size=medium" />WPB-27666</a>  [Web] Text rendering
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This pull request continues the localized rich-text rendering migration from #22411 and #22431.

It moves another set of UI translations to React-based rendering behind the existing startup feature toggle:

```text
react-translation-rendering
```

### Changes

This batch covers:

* permission-request warnings
* AppLock setup copy
* the emoji replacement preference description
* team creation introduction copy

It also extends the shared React translation renderer to support application-owned React node replacements in addition to runtime text values.

This allows translated placeholders to represent elements such as icons and line breaks without converting them into HTML strings.
