### PR TITLE
feat: Add shared drive upload status indicator to files tab(WPB-28319)

### DIFF
--- a/apps/webapp/src/script/components/conversation/conversation.tsx
+++ b/apps/webapp/src/script/components/conversation/conversation.tsx
@@ -720,6 +720,8 @@ function ConversationContent({
                       activeTabIndex={activeTabIndex}
                       onIndexChange={setActiveTabIndex}
                       conversationQualifiedId={activeConversation.qualifiedId}
+                      sharedDriveUploadController={sharedDriveUploadController}
+                      isUploadStatusIndicatorEnabled={isSharedDriveDirectUploadFeatureEnabled}
                     />
                   </div>
                   {isSharedDriveSearchViewOpen && (

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.ts
@@ -19,6 +19,8 @@
 
 import type {UploadState} from 'Repositories/cells/upload';
 
+import type {SharedDriveUploadController} from './sharedDriveUploadController';
+
 export type SharedDriveUploadStatusKind = 'uploading' | 'uploaded' | 'failed';
 
 export type SharedDriveUploadStatus = {
@@ -66,4 +68,16 @@ export const toSharedDriveUploadStatus = (
     kind,
     canCancel: state.kind === 'queued' || state.kind === 'uploading',
   };
+};
+
+export const getLatestSharedDriveUploadStatus = (
+  controller: SharedDriveUploadController,
+  conversationQualifiedId: string,
+): SharedDriveUploadStatus | null => {
+  const statuses = controller.snapshots(conversationQualifiedId).flatMap(snapshot => {
+    const status = toSharedDriveUploadStatus(snapshot, conversationQualifiedId);
+    return status ? [status] : [];
+  });
+
+  return statuses[statuses.length - 1] ?? null;
 };

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
@@ -25,7 +25,7 @@ import {useApplicationContext} from 'src/script/page/rootProvider';
 import {formatBytes} from 'Util/util';
 
 import type {SharedDriveUploadController} from './sharedDriveUploadController';
-import {toSharedDriveUploadStatus, type SharedDriveUploadStatus} from './sharedDriveUploadStatus';
+import {getLatestSharedDriveUploadStatus} from './sharedDriveUploadStatus';
 import {SharedDriveUploadStatusPopup} from './sharedDriveUploadStatusPopup';
 
 type DismissedUpload = {
@@ -40,18 +40,6 @@ interface SharedDriveUploadStatusPopupHostProps {
   readonly isFileTabActive: boolean;
 }
 
-const getLatestStatus = (
-  controller: SharedDriveUploadController,
-  conversationQualifiedId: string,
-): SharedDriveUploadStatus | null => {
-  const statuses = controller.snapshots(conversationQualifiedId).flatMap(snapshot => {
-    const status = toSharedDriveUploadStatus(snapshot, conversationQualifiedId);
-    return status ? [status] : [];
-  });
-
-  return statuses[statuses.length - 1] ?? null;
-};
-
 export const SharedDriveUploadStatusPopupHost = ({
   controller,
   conversationQualifiedId,
@@ -60,7 +48,7 @@ export const SharedDriveUploadStatusPopupHost = ({
 }: SharedDriveUploadStatusPopupHostProps) => {
   const {translate} = useApplicationContext();
   const readStatus = useCallback(
-    () => getLatestStatus(controller, conversationQualifiedId),
+    () => getLatestSharedDriveUploadStatus(controller, conversationQualifiedId),
     [controller, conversationQualifiedId],
   );
   const [status, setStatus] = useState(() => ({

--- a/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.test.tsx
@@ -1,0 +1,150 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {act, render} from '@testing-library/react';
+import {ThemeProvider} from '@wireapp/react-ui-kit';
+
+import type {UploadState} from 'Repositories/cells/upload';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import type {SharedDriveUploadController} from '../conversationCells/sharedDriveUploadController';
+
+import {ConversationTabs} from './conversationTabs';
+
+const conversationQualifiedId = {id: 'conversation', domain: 'example.com'};
+const conversationQualifiedIdString = 'conversation@example.com';
+const uploadSource = {blob: new Blob(['data']), name: 'report.pdf', contentType: 'application/pdf', size: 4};
+const uploadingState: UploadState = {
+  kind: 'uploading',
+  identity: {uploadId: 'upload-1'},
+  source: uploadSource,
+  progress: 0,
+};
+const uploadedState: UploadState = {
+  kind: 'published',
+  identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+  source: uploadSource,
+};
+const failedState: UploadState = {
+  kind: 'uploadFailed',
+  identity: {uploadId: 'upload-1'},
+  source: uploadSource,
+  error: {kind: 'uploadFailed', cause: new Error('upload failed')},
+};
+
+type TestController = SharedDriveUploadController & {
+  snapshots: jest.MockedFunction<SharedDriveUploadController['snapshots']>;
+  subscribe: jest.MockedFunction<SharedDriveUploadController['subscribe']>;
+};
+
+const createController = (state: UploadState | null = null) => {
+  let currentState = state;
+  let notify = () => undefined;
+  const controller: TestController = {
+    snapshots: jest.fn(scope => (scope === conversationQualifiedIdString && currentState ? [currentState] : [])),
+    subscribe: jest.fn(listener => {
+      notify = listener;
+      return jest.fn();
+    }),
+    upload: jest.fn(),
+    cancel: jest.fn(),
+    retryUpload: jest.fn(),
+    retryPublish: jest.fn(),
+    discard: jest.fn(),
+    retryDiscard: jest.fn(),
+  };
+
+  return {
+    controller,
+    setState: (nextState: UploadState | null) => {
+      currentState = nextState;
+      notify();
+    },
+  };
+};
+
+const renderTabs = (controller: SharedDriveUploadController, isUploadStatusIndicatorEnabled = true) =>
+  render(
+    <ThemeProvider>
+      <ConversationTabs
+        activeTabIndex={0}
+        onIndexChange={jest.fn()}
+        conversationQualifiedId={conversationQualifiedId}
+        sharedDriveUploadController={controller}
+        isUploadStatusIndicatorEnabled={isUploadStatusIndicatorEnabled}
+      />
+    </ThemeProvider>,
+    {wrapper: createRootProviderWrapperForTest(createRootContextValueForTest({translate: translateForTest}))},
+  );
+
+describe('ConversationTabs', () => {
+  beforeEach(() => {
+    window.location.hash = '';
+  });
+
+  it('does not render a shared drive upload icon when there is no file upload', () => {
+    const {controller} = createController();
+    const view = renderTabs(controller);
+
+    expect(view.queryByTestId('shared-drive-tab-upload-uploading')).not.toBeInTheDocument();
+    expect(view.queryByTestId('shared-drive-tab-upload-completed')).not.toBeInTheDocument();
+  });
+
+  it('renders a moving shared drive upload indicator while a file is uploading', () => {
+    const {controller} = createController(uploadingState);
+    const view = renderTabs(controller);
+
+    expect(view.getByTestId('shared-drive-tab-upload-uploading')).toHaveClass(
+      'conversation-tabs__upload-status-icon--uploading',
+    );
+    expect(view.queryByTestId('shared-drive-tab-upload-completed')).not.toBeInTheDocument();
+  });
+
+  it('updates the shared drive tab icon as the upload status changes', () => {
+    const {controller, setState} = createController(uploadingState);
+    const view = renderTabs(controller);
+
+    expect(view.getByTestId('shared-drive-tab-upload-uploading')).toBeInTheDocument();
+
+    act(() => setState(uploadedState));
+
+    expect(view.queryByTestId('shared-drive-tab-upload-uploading')).not.toBeInTheDocument();
+    expect(view.getByTestId('shared-drive-tab-upload-completed')).toBeInTheDocument();
+  });
+
+  it('renders the completion icon for failed uploads', () => {
+    const {controller} = createController(failedState);
+    const view = renderTabs(controller);
+
+    expect(view.getByTestId('shared-drive-tab-upload-completed')).toBeInTheDocument();
+    expect(view.queryByTestId('shared-drive-tab-upload-uploading')).not.toBeInTheDocument();
+  });
+
+  it('does not render a shared drive upload icon when the indicator is disabled', () => {
+    const {controller} = createController(uploadingState);
+    const view = renderTabs(controller, false);
+
+    expect(view.queryByTestId('shared-drive-tab-upload-uploading')).not.toBeInTheDocument();
+    expect(view.queryByTestId('shared-drive-tab-upload-completed')).not.toBeInTheDocument();
+  });
+});

--- a/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.test.tsx
@@ -59,7 +59,7 @@ type TestController = SharedDriveUploadController & {
 
 const createController = (state: UploadState | null = null) => {
   let currentState = state;
-  let notify = () => undefined;
+  let notify: () => void = () => undefined;
   const controller: TestController = {
     snapshots: jest.fn(scope => (scope === conversationQualifiedIdString && currentState ? [currentState] : [])),
     subscribe: jest.fn(listener => {

--- a/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.test.tsx
@@ -98,16 +98,13 @@ const renderTabs = (controller: SharedDriveUploadController, isUploadStatusIndic
   );
 
 describe('ConversationTabs', () => {
-  beforeEach(() => {
-    window.location.hash = '';
-  });
-
   it('does not render a shared drive upload icon when there is no file upload', () => {
     const {controller} = createController();
     const view = renderTabs(controller);
 
     expect(view.queryByTestId('shared-drive-tab-upload-uploading')).not.toBeInTheDocument();
     expect(view.queryByTestId('shared-drive-tab-upload-completed')).not.toBeInTheDocument();
+    expect(view.queryByRole('status')).not.toBeInTheDocument();
   });
 
   it('renders a moving shared drive upload indicator while a file is uploading', () => {
@@ -117,6 +114,7 @@ describe('ConversationTabs', () => {
     expect(view.getByTestId('shared-drive-tab-upload-uploading')).toHaveClass(
       'conversation-tabs__upload-status-icon--uploading',
     );
+    expect(view.getByRole('status')).toHaveTextContent('cells.uploadStatus.uploading');
     expect(view.queryByTestId('shared-drive-tab-upload-completed')).not.toBeInTheDocument();
   });
 
@@ -130,6 +128,7 @@ describe('ConversationTabs', () => {
 
     expect(view.queryByTestId('shared-drive-tab-upload-uploading')).not.toBeInTheDocument();
     expect(view.getByTestId('shared-drive-tab-upload-completed')).toBeInTheDocument();
+    expect(view.getByRole('status')).toHaveTextContent('cells.uploadStatus.uploaded');
   });
 
   it('renders the completion icon for failed uploads', () => {
@@ -137,6 +136,7 @@ describe('ConversationTabs', () => {
     const view = renderTabs(controller);
 
     expect(view.getByTestId('shared-drive-tab-upload-completed')).toBeInTheDocument();
+    expect(view.getByRole('status')).toHaveTextContent('cells.uploadStatus.failed');
     expect(view.queryByTestId('shared-drive-tab-upload-uploading')).not.toBeInTheDocument();
   });
 
@@ -146,5 +146,6 @@ describe('ConversationTabs', () => {
 
     expect(view.queryByTestId('shared-drive-tab-upload-uploading')).not.toBeInTheDocument();
     expect(view.queryByTestId('shared-drive-tab-upload-completed')).not.toBeInTheDocument();
+    expect(view.queryByRole('status')).not.toBeInTheDocument();
   });
 });

--- a/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.tsx
@@ -20,6 +20,7 @@
 import {useCallback, KeyboardEvent, MouseEvent, useEffect, useState} from 'react';
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {stringifyQualifiedId} from '@wireapp/core/lib/util/qualifiedIdUtil';
 
 import {SharedDriveUploadCompletedIcon, SharedDriveUploadSpinnerIcon} from '@wireapp/react-ui-kit';
 
@@ -31,7 +32,7 @@ import {KEY} from 'Util/keyboardUtil';
 import type {SharedDriveUploadController} from '../conversationCells/sharedDriveUploadController';
 import {
   getLatestSharedDriveUploadStatus,
-  type SharedDriveUploadStatusKind,
+  type SharedDriveUploadStatus,
 } from '../conversationCells/sharedDriveUploadStatus';
 
 interface ConversationTabsProps {
@@ -43,8 +44,11 @@ interface ConversationTabsProps {
 }
 
 const FILE_PATH = 'files';
-
-const toConversationQualifiedIdString = ({id, domain}: QualifiedId): string => `${id}@${domain}`;
+const sharedDriveUploadTabStatusLabelKey = {
+  uploading: 'cells.uploadStatus.uploading',
+  uploaded: 'cells.uploadStatus.uploaded',
+  failed: 'cells.uploadStatus.failed',
+} as const;
 
 export const ConversationTabs = ({
   activeTabIndex,
@@ -56,12 +60,12 @@ export const ConversationTabs = ({
   const {translate} = useApplicationContext();
   const filesUrl = generateConversationUrl({...conversationQualifiedId, filePath: FILE_PATH});
   const messagesUrl = generateConversationUrl(conversationQualifiedId);
-  const conversationQualifiedIdString = toConversationQualifiedIdString(conversationQualifiedId);
-  const readUploadStatusKind = useCallback(
-    () => getLatestSharedDriveUploadStatus(sharedDriveUploadController, conversationQualifiedIdString)?.kind ?? null,
+  const conversationQualifiedIdString = stringifyQualifiedId(conversationQualifiedId);
+  const readUploadStatus = useCallback(
+    () => getLatestSharedDriveUploadStatus(sharedDriveUploadController, conversationQualifiedIdString),
     [sharedDriveUploadController, conversationQualifiedIdString],
   );
-  const [uploadStatusKind, setUploadStatusKind] = useState<SharedDriveUploadStatusKind | null>(readUploadStatusKind);
+  const [uploadStatus, setUploadStatus] = useState<SharedDriveUploadStatus | null>(readUploadStatus);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLButtonElement>) => {
@@ -104,10 +108,10 @@ export const ConversationTabs = ({
   }, [handleHashChange]);
 
   useEffect(() => {
-    const updateUploadStatusKind = () => setUploadStatusKind(readUploadStatusKind());
-    updateUploadStatusKind();
-    return sharedDriveUploadController.subscribe(updateUploadStatusKind);
-  }, [readUploadStatusKind, sharedDriveUploadController]);
+    const updateUploadStatus = () => setUploadStatus(readUploadStatus());
+    updateUploadStatus();
+    return sharedDriveUploadController.subscribe(updateUploadStatus);
+  }, [readUploadStatus, sharedDriveUploadController]);
 
   return (
     <div className="conversation-tabs">
@@ -126,7 +130,7 @@ export const ConversationTabs = ({
           id="files"
           label={translate('conversationDetailsActionCellsTitle')}
           isActive={activeTabIndex === 1}
-          uploadStatusKind={isUploadStatusIndicatorEnabled ? uploadStatusKind : null}
+          uploadStatus={isUploadStatusIndicatorEnabled ? uploadStatus : null}
           onClick={event => {
             createNavigate(filesUrl)(event);
             onIndexChange(1);
@@ -142,12 +146,18 @@ interface ConversationTabProps {
   id: string;
   label: string;
   isActive: boolean;
-  uploadStatusKind?: SharedDriveUploadStatusKind | null;
+  uploadStatus?: SharedDriveUploadStatus | null;
   onClick: (event: MouseEvent<HTMLButtonElement>) => void;
   onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
 }
 
-const ConversationTab = ({id, label, isActive, uploadStatusKind = null, onClick, onKeyDown}: ConversationTabProps) => {
+const ConversationTab = ({id, label, isActive, uploadStatus = null, onClick, onKeyDown}: ConversationTabProps) => {
+  const {translate} = useApplicationContext();
+  const uploadStatusLabel =
+    uploadStatus !== null
+      ? translate(sharedDriveUploadTabStatusLabelKey[uploadStatus.kind], {name: uploadStatus.fileName})
+      : null;
+
   return (
     <button
       id={`conversation-tab-${id}`}
@@ -161,13 +171,18 @@ const ConversationTab = ({id, label, isActive, uploadStatusKind = null, onClick,
     >
       <span className="conversation-tabs__button-content">
         {label}
-        {uploadStatusKind && <SharedDriveTabUploadStatusIcon kind={uploadStatusKind} />}
+        {uploadStatus && <SharedDriveTabUploadStatusIcon kind={uploadStatus.kind} />}
+        {uploadStatusLabel !== null && (
+          <span className="visually-hidden" role="status" aria-live="polite" aria-atomic="true">
+            {uploadStatusLabel}
+          </span>
+        )}
       </span>
     </button>
   );
 };
 
-const SharedDriveTabUploadStatusIcon = ({kind}: {kind: SharedDriveUploadStatusKind}) => {
+const SharedDriveTabUploadStatusIcon = ({kind}: {kind: SharedDriveUploadStatus['kind']}) => {
   if (kind === 'uploading') {
     return (
       <SharedDriveUploadSpinnerIcon

--- a/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.tsx
@@ -17,27 +17,51 @@
  *
  */
 
-import {useCallback, KeyboardEvent, MouseEvent, useEffect} from 'react';
+import {useCallback, KeyboardEvent, MouseEvent, useEffect, useState} from 'react';
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
+
+import {SharedDriveUploadCompletedIcon, SharedDriveUploadSpinnerIcon} from '@wireapp/react-ui-kit';
 
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {generateConversationUrl} from 'src/script/router/routeGenerator';
 import {createNavigate, createNavigateKeyboard} from 'src/script/router/routerBindings';
 import {KEY} from 'Util/keyboardUtil';
 
+import type {SharedDriveUploadController} from '../conversationCells/sharedDriveUploadController';
+import {
+  getLatestSharedDriveUploadStatus,
+  type SharedDriveUploadStatusKind,
+} from '../conversationCells/sharedDriveUploadStatus';
+
 interface ConversationTabsProps {
   activeTabIndex: number;
   onIndexChange: (index: number) => void;
   conversationQualifiedId: QualifiedId;
+  sharedDriveUploadController: SharedDriveUploadController;
+  isUploadStatusIndicatorEnabled: boolean;
 }
 
 const FILE_PATH = 'files';
 
-export const ConversationTabs = ({activeTabIndex, onIndexChange, conversationQualifiedId}: ConversationTabsProps) => {
+const toConversationQualifiedIdString = ({id, domain}: QualifiedId): string => `${id}@${domain}`;
+
+export const ConversationTabs = ({
+  activeTabIndex,
+  onIndexChange,
+  conversationQualifiedId,
+  sharedDriveUploadController,
+  isUploadStatusIndicatorEnabled,
+}: ConversationTabsProps) => {
   const {translate} = useApplicationContext();
   const filesUrl = generateConversationUrl({...conversationQualifiedId, filePath: FILE_PATH});
   const messagesUrl = generateConversationUrl(conversationQualifiedId);
+  const conversationQualifiedIdString = toConversationQualifiedIdString(conversationQualifiedId);
+  const readUploadStatusKind = useCallback(
+    () => getLatestSharedDriveUploadStatus(sharedDriveUploadController, conversationQualifiedIdString)?.kind ?? null,
+    [sharedDriveUploadController, conversationQualifiedIdString],
+  );
+  const [uploadStatusKind, setUploadStatusKind] = useState<SharedDriveUploadStatusKind | null>(readUploadStatusKind);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLButtonElement>) => {
@@ -79,6 +103,12 @@ export const ConversationTabs = ({activeTabIndex, onIndexChange, conversationQua
     return () => window.removeEventListener('hashchange', handleHashChange);
   }, [handleHashChange]);
 
+  useEffect(() => {
+    const updateUploadStatusKind = () => setUploadStatusKind(readUploadStatusKind());
+    updateUploadStatusKind();
+    return sharedDriveUploadController.subscribe(updateUploadStatusKind);
+  }, [readUploadStatusKind, sharedDriveUploadController]);
+
   return (
     <div className="conversation-tabs">
       <div className="conversation-tabs__list" role="tablist" aria-label={translate('conversationTabs')}>
@@ -96,6 +126,7 @@ export const ConversationTabs = ({activeTabIndex, onIndexChange, conversationQua
           id="files"
           label={translate('conversationDetailsActionCellsTitle')}
           isActive={activeTabIndex === 1}
+          uploadStatusKind={isUploadStatusIndicatorEnabled ? uploadStatusKind : null}
           onClick={event => {
             createNavigate(filesUrl)(event);
             onIndexChange(1);
@@ -111,11 +142,12 @@ interface ConversationTabProps {
   id: string;
   label: string;
   isActive: boolean;
+  uploadStatusKind?: SharedDriveUploadStatusKind | null;
   onClick: (event: MouseEvent<HTMLButtonElement>) => void;
   onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
 }
 
-const ConversationTab = ({id, label, isActive, onClick, onKeyDown}: ConversationTabProps) => {
+const ConversationTab = ({id, label, isActive, uploadStatusKind = null, onClick, onKeyDown}: ConversationTabProps) => {
   return (
     <button
       id={`conversation-tab-${id}`}
@@ -127,7 +159,36 @@ const ConversationTab = ({id, label, isActive, onClick, onKeyDown}: Conversation
       onKeyDown={onKeyDown}
       className="conversation-tabs__button"
     >
-      {label}
+      <span className="conversation-tabs__button-content">
+        {label}
+        {uploadStatusKind && <SharedDriveTabUploadStatusIcon kind={uploadStatusKind} />}
+      </span>
     </button>
+  );
+};
+
+const SharedDriveTabUploadStatusIcon = ({kind}: {kind: SharedDriveUploadStatusKind}) => {
+  if (kind === 'uploading') {
+    return (
+      <SharedDriveUploadSpinnerIcon
+        className="conversation-tabs__upload-status-icon conversation-tabs__upload-status-icon--uploading"
+        width={16}
+        height={16}
+        data-uie-name="shared-drive-tab-upload-uploading"
+        data-testid="shared-drive-tab-upload-uploading"
+        aria-hidden="true"
+      />
+    );
+  }
+
+  return (
+    <SharedDriveUploadCompletedIcon
+      className="conversation-tabs__upload-status-icon"
+      width={16}
+      height={16}
+      data-uie-name="shared-drive-tab-upload-completed"
+      data-testid="shared-drive-tab-upload-completed"
+      aria-hidden="true"
+    />
   );
 };

--- a/apps/webapp/src/style/content/conversation.less
+++ b/apps/webapp/src/style/content/conversation.less
@@ -116,6 +116,12 @@
     cursor: pointer;
     font-size: var(--font-size-medium);
 
+    &-content {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
     &:focus {
       outline: none;
     }
@@ -132,6 +138,22 @@
         content: '';
       }
     }
+  }
+
+  &__upload-status-icon {
+    width: 16px;
+    height: 16px;
+    flex: 0 0 auto;
+
+    &--uploading {
+      animation: conversation-tab-upload-spinner 1s linear infinite;
+    }
+  }
+}
+
+@keyframes conversation-tab-upload-spinner {
+  100% {
+    transform: rotate(360deg);
   }
 }
 

--- a/apps/webapp/src/style/content/conversation.less
+++ b/apps/webapp/src/style/content/conversation.less
@@ -147,6 +147,10 @@
 
     &--uploading {
       animation: conversation-tab-upload-spinner 1s linear infinite;
+
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
     }
   }
 }

--- a/libraries/react-ui-kit/src/dataDisplay/icon/index.ts
+++ b/libraries/react-ui-kit/src/dataDisplay/icon/index.ts
@@ -89,6 +89,8 @@ export * from './searchIcon';
 export * from './servicesIcon';
 export * from './settingsIcon';
 export * from './shareLinkIcon';
+export * from './sharedDriveUploadCompletedIcon';
+export * from './sharedDriveUploadSpinnerIcon';
 export * from './showIcon';
 export * from './signIcon';
 export * from './sortIcon';

--- a/libraries/react-ui-kit/src/dataDisplay/icon/sharedDriveUploadCompletedIcon.tsx
+++ b/libraries/react-ui-kit/src/dataDisplay/icon/sharedDriveUploadCompletedIcon.tsx
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {SVGIcon, SVGIconProps} from './svgIcon';
+
+const DEFAULT_COLOR = '#0667C8';
+
+export const SharedDriveUploadCompletedIcon = ({color = DEFAULT_COLOR, ...props}: SVGIconProps) => (
+  <SVGIcon realWidth={16} realHeight={16} {...props}>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M14 8C14 11.3137 11.3137 14 8 14C4.68629 14 2 11.3137 2 8C2 4.68629 4.68629 2 8 2C11.3137 2 14 4.68629 14 8ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM7.34126 11.2704L12.469 6.14265L11.0548 4.72844L6.63421 9.14905L4.9452 7.45978L3.53088 8.87389L5.92699 11.2704L6.6341 11.9776L7.34126 11.2704Z"
+      fill={color}
+    />
+  </SVGIcon>
+);

--- a/libraries/react-ui-kit/src/dataDisplay/icon/sharedDriveUploadCompletedIcon.tsx
+++ b/libraries/react-ui-kit/src/dataDisplay/icon/sharedDriveUploadCompletedIcon.tsx
@@ -17,17 +17,25 @@
  *
  */
 
+import {useTheme} from '@emotion/react';
+
 import {SVGIcon, SVGIconProps} from './svgIcon';
 
-const DEFAULT_COLOR = '#0667C8';
+import {COLOR_V2, THEME_ID, Theme} from '../../identity';
 
-export const SharedDriveUploadCompletedIcon = ({color = DEFAULT_COLOR, ...props}: SVGIconProps) => (
-  <SVGIcon realWidth={16} realHeight={16} {...props}>
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M14 8C14 11.3137 11.3137 14 8 14C4.68629 14 2 11.3137 2 8C2 4.68629 4.68629 2 8 2C11.3137 2 14 4.68629 14 8ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM7.34126 11.2704L12.469 6.14265L11.0548 4.72844L6.63421 9.14905L4.9452 7.45978L3.53088 8.87389L5.92699 11.2704L6.6341 11.9776L7.34126 11.2704Z"
-      fill={color}
-    />
-  </SVGIcon>
-);
+export const SharedDriveUploadCompletedIcon = ({color, ...props}: SVGIconProps) => {
+  const theme = useTheme() as Theme;
+  const isDarkTheme = theme?.themeId === THEME_ID.DARK;
+  const resolvedColor = color ?? (isDarkTheme ? COLOR_V2.BLUE_DARK_500 : COLOR_V2.BLUE_LIGHT_500);
+
+  return (
+    <SVGIcon realWidth={16} realHeight={16} {...props}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M14 8C14 11.3137 11.3137 14 8 14C4.68629 14 2 11.3137 2 8C2 4.68629 4.68629 2 8 2C11.3137 2 14 4.68629 14 8ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM7.34126 11.2704L12.469 6.14265L11.0548 4.72844L6.63421 9.14905L4.9452 7.45978L3.53088 8.87389L5.92699 11.2704L6.6341 11.9776L7.34126 11.2704Z"
+        fill={resolvedColor}
+      />
+    </SVGIcon>
+  );
+};

--- a/libraries/react-ui-kit/src/dataDisplay/icon/sharedDriveUploadSpinnerIcon.tsx
+++ b/libraries/react-ui-kit/src/dataDisplay/icon/sharedDriveUploadSpinnerIcon.tsx
@@ -17,25 +17,40 @@
  *
  */
 
+import {useTheme} from '@emotion/react';
+
 import {SVGIcon, SVGIconProps} from './svgIcon';
 
-const DEFAULT_COLOR = '#0667C8';
-const DEFAULT_TRACK_COLOR = '#E7F0FA';
+import {COLOR_V2, THEME_ID, Theme} from '../../identity';
 
 interface SharedDriveUploadSpinnerIconProps extends SVGIconProps {
+  colorDark?: string;
   trackColor?: string;
+  trackColorDark?: string;
 }
 
 export const SharedDriveUploadSpinnerIcon = ({
-  color = DEFAULT_COLOR,
-  trackColor = DEFAULT_TRACK_COLOR,
+  color,
+  colorDark,
+  trackColor,
+  trackColorDark,
   ...props
-}: SharedDriveUploadSpinnerIconProps) => (
-  <SVGIcon realWidth={16} realHeight={16} {...props}>
-    <circle cx="8" cy="8" r="7" fill="none" stroke={trackColor} strokeWidth="2" />
-    <path
-      d="M8.1556 0.00171717L8.10956 2.00119C11.4224 2.07747 14.0461 4.82489 13.9698 8.13772C13.8936 11.4505 11.1461 14.0743 7.83332 13.998C6.76788 13.9735 5.77371 13.6727 4.91772 13.1656L3.42979 14.5865C4.67045 15.4437 6.16705 15.9602 7.78728 15.9975C12.2044 16.0992 15.8676 12.6009 15.9693 8.18376C16.071 3.76665 12.5727 0.103428 8.1556 0.00171717Z"
-      fill={color}
-    />
-  </SVGIcon>
-);
+}: SharedDriveUploadSpinnerIconProps) => {
+  const theme = useTheme() as Theme;
+  const isDarkTheme = theme?.themeId === THEME_ID.DARK;
+  const resolvedColor =
+    (isDarkTheme ? (colorDark ?? color) : color) ?? (isDarkTheme ? COLOR_V2.BLUE_DARK_500 : COLOR_V2.BLUE_LIGHT_500);
+  const resolvedTrackColor =
+    (isDarkTheme ? (trackColorDark ?? trackColor) : trackColor) ??
+    (isDarkTheme ? COLOR_V2.BLUE_DARK_900 : COLOR_V2.BLUE_LIGHT_50);
+
+  return (
+    <SVGIcon realWidth={16} realHeight={16} {...props}>
+      <circle cx="8" cy="8" r="7" fill="none" stroke={resolvedTrackColor} strokeWidth="2" />
+      <path
+        d="M8.1556 0.00171717L8.10956 2.00119C11.4224 2.07747 14.0461 4.82489 13.9698 8.13772C13.8936 11.4505 11.1461 14.0743 7.83332 13.998C6.76788 13.9735 5.77371 13.6727 4.91772 13.1656L3.42979 14.5865C4.67045 15.4437 6.16705 15.9602 7.78728 15.9975C12.2044 16.0992 15.8676 12.6009 15.9693 8.18376C16.071 3.76665 12.5727 0.103428 8.1556 0.00171717Z"
+        fill={resolvedColor}
+      />
+    </SVGIcon>
+  );
+};

--- a/libraries/react-ui-kit/src/dataDisplay/icon/sharedDriveUploadSpinnerIcon.tsx
+++ b/libraries/react-ui-kit/src/dataDisplay/icon/sharedDriveUploadSpinnerIcon.tsx
@@ -1,0 +1,41 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {SVGIcon, SVGIconProps} from './svgIcon';
+
+const DEFAULT_COLOR = '#0667C8';
+const DEFAULT_TRACK_COLOR = '#E7F0FA';
+
+interface SharedDriveUploadSpinnerIconProps extends SVGIconProps {
+  trackColor?: string;
+}
+
+export const SharedDriveUploadSpinnerIcon = ({
+  color = DEFAULT_COLOR,
+  trackColor = DEFAULT_TRACK_COLOR,
+  ...props
+}: SharedDriveUploadSpinnerIconProps) => (
+  <SVGIcon realWidth={16} realHeight={16} {...props}>
+    <circle cx="8" cy="8" r="7" fill="none" stroke={trackColor} strokeWidth="2" />
+    <path
+      d="M8.1556 0.00171717L8.10956 2.00119C11.4224 2.07747 14.0461 4.82489 13.9698 8.13772C13.8936 11.4505 11.1461 14.0743 7.83332 13.998C6.76788 13.9735 5.77371 13.6727 4.91772 13.1656L3.42979 14.5865C4.67045 15.4437 6.16705 15.9602 7.78728 15.9975C12.2044 16.0992 15.8676 12.6009 15.9693 8.18376C16.071 3.76665 12.5727 0.103428 8.1556 0.00171717Z"
+      fill={color}
+    />
+  </SVGIcon>
+);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28319" title="WPB-28319" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28319</a>  [web] Shared drive tab icon status indication
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Show upload progress state in the conversation Files tab by subscribing to the existing shared drive upload controller. Reuse the same latest-upload status resolution as the popup, render a spinner while uploads are active, and show the completion icon for both successful and failed uploads per the acceptance criteria.

## Summary

- Adds a Shared Drive upload status indicator to the conversation Files tab.
- Shows a spinner while an upload is in progress.
- Shows the completion icon after upload completion.
- Uses the same completion icon for failed uploads, matching the acceptance criteria.
- Extracts latest shared drive upload status lookup for reuse by both the popup host and the tab.
- Adds Shared Drive upload spinner/completed icons to `react-ui-kit`.

<img width="1512" height="982" alt="Screenshot 2026-09-09 at 13 47 41" src="https://github.com/user-attachments/assets/587db87b-8037-49fa-ab65-0f0fa2d25de2" />
<img width="1512" height="982" alt="Screenshot 2026-09-09 at 13 48 01" src="https://github.com/user-attachments/assets/d4b6233f-9a9a-4b8f-8032-96766c53f9c8" />

