### PR TITLE
Use 24-hour formatting for meeting times across all views [WPB-28510]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/formatMeetingTimeRange.test.ts
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/formatMeetingTimeRange.test.ts
@@ -18,6 +18,7 @@
  */
 
 import {formatMeetingTimeRange} from './formatMeetingTimeRange';
+import {getRegionalDateLocale, setRegionalDateLocale} from 'Util/timeUtil';
 
 describe('formatMeetingTimeRange', () => {
   it('places the meridiem once for a same-period range', () => {
@@ -29,5 +30,16 @@ describe('formatMeetingTimeRange', () => {
     expect(formatMeetingTimeRange(new Date(2026, 5, 15, 11, 30), new Date(2026, 5, 15, 13, 15))).toBe(
       '11:30 AM - 01:15 PM',
     );
+  });
+
+  it('uses the system locale time convention', () => {
+    const originalLocale = getRegionalDateLocale();
+    setRegionalDateLocale('de-DE');
+    try {
+      expect(formatMeetingTimeRange(new Date(2026, 5, 15, 7, 30), new Date(2026, 5, 15, 7, 40))).toBe('07:30 - 07:40');
+      expect(formatMeetingTimeRange(new Date(2026, 5, 15, 14), new Date(2026, 5, 15, 15, 15))).toBe('14:00 - 15:15');
+    } finally {
+      setRegionalDateLocale(originalLocale);
+    }
   });
 });

--- a/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/formatMeetingTimeRange.ts
+++ b/apps/webapp/src/script/components/meeting/meetingList/meetingListItemGroup/meetingListItem/formatMeetingTimeRange.ts
@@ -17,12 +17,30 @@
  *
  */
 
-import {formatLocale} from 'Util/timeUtil';
+import {getRegionalDateLocale} from 'Util/timeUtil';
+
+const timeFormatterOptions: Intl.DateTimeFormatOptions = {
+  hour: '2-digit',
+  minute: '2-digit',
+};
+
+const getTimeParts = (date: Date): Intl.DateTimeFormatPart[] =>
+  new Intl.DateTimeFormat(getRegionalDateLocale(), timeFormatterOptions).formatToParts(date);
+
+const formatTime = (parts: Intl.DateTimeFormatPart[], includeDayPeriod: boolean): string =>
+  parts
+    .filter(({type}) => includeDayPeriod || type !== 'dayPeriod')
+    .map(({value}) => value)
+    .join('')
+    .trim()
+    .replace(/[\u00a0\u202f]/g, ' ');
 
 export const formatMeetingTimeRange = (start: Date, end: Date): string => {
-  const sameMeridiem = formatLocale(start, 'a') === formatLocale(end, 'a');
+  const startParts = getTimeParts(start);
+  const endParts = getTimeParts(end);
+  const startDayPeriod = startParts.find(({type}) => type === 'dayPeriod')?.value;
+  const endDayPeriod = endParts.find(({type}) => type === 'dayPeriod')?.value;
+  const sameDayPeriod = startDayPeriod === endDayPeriod;
 
-  return sameMeridiem
-    ? `${formatLocale(start, 'hh:mm')} - ${formatLocale(end, 'hh:mm a')}`
-    : `${formatLocale(start, 'hh:mm a')} - ${formatLocale(end, 'hh:mm a')}`;
+  return `${formatTime(startParts, !sameDayPeriod)} - ${formatTime(endParts, true)}`;
 };

--- a/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingForm.tsx
+++ b/apps/webapp/src/script/components/meeting/scheduleMeetingModal/scheduleMeetingForm.tsx
@@ -50,6 +50,7 @@ import {
 import type {User} from 'Repositories/entity/User';
 import {currentLanguage} from 'src/script/auth/localeConfig';
 import {useApplicationContext} from 'src/script/page/rootProvider';
+import {getRegionalDateLocale} from 'src/script/util/timeUtil';
 
 import {
   SCHEDULE_MEETING_RECURRENCE_OPTIONS,
@@ -101,6 +102,7 @@ export const ScheduleMeetingForm = ({
   const {mainViewModel, translate, wallClock} = useApplicationContext();
   const {users} = useMeetingParticipants();
   const portalContainer = getOverlayPortalContainer();
+  const regionalLocale = getRegionalDateLocale();
 
   const contentViewModel = mainViewModel.content;
   const conversationRepository = contentViewModel.repositories.conversation;
@@ -254,6 +256,7 @@ export const ScheduleMeetingForm = ({
           onChange={date => onStartChange(fromDateTimePickerValue(date))}
           labels={dateTimePickerLabels}
           locale={currentLanguage()}
+          timeLocale={regionalLocale}
           markInvalid={isNonEmptyString(startErrorText)}
           errorText={startErrorText}
           minValue={todayValue}
@@ -269,6 +272,7 @@ export const ScheduleMeetingForm = ({
           onChange={date => onEndChange(fromDateTimePickerValue(date))}
           labels={dateTimePickerLabels}
           locale={currentLanguage()}
+          timeLocale={regionalLocale}
           markInvalid={isNonEmptyString(endErrorText)}
           errorText={endErrorText}
           minValue={endDateMinValue}

--- a/apps/webapp/src/script/util/timeUtil.ts
+++ b/apps/webapp/src/script/util/timeUtil.ts
@@ -160,6 +160,8 @@ export function setRegionalDateLocale(newLocale: string): void {
   regionalDateLocale = resolveRegionalDateLocale(newLocale);
 }
 
+export const getRegionalDateLocale = (): string => regionalDateLocale;
+
 export const formatLocale = (date: FnDate | string | number, formatString: string) =>
   format(new Date(date), formatString, {locale: dateFnsLocale});
 

--- a/libraries/react-ui-kit/src/inputs/dateTimePickerField/dateTimePickerField.tsx
+++ b/libraries/react-ui-kit/src/inputs/dateTimePickerField/dateTimePickerField.tsx
@@ -53,6 +53,8 @@ export interface DateTimePickerFieldProps {
   label?: string;
   labels: DateTimePickerFieldLabels;
   locale?: string;
+  /** Regional locale for time formatting, separate from `locale`, which controls the application language. */
+  timeLocale?: string;
   markInvalid?: boolean;
   disabled?: boolean;
   dateDisabled?: boolean;
@@ -76,6 +78,7 @@ export const DateTimePickerField = ({
   label,
   labels,
   locale = 'de-DE',
+  timeLocale,
   markInvalid = false,
   disabled = false,
   dateDisabled,
@@ -89,7 +92,10 @@ export const DateTimePickerField = ({
 }: DateTimePickerFieldProps) => {
   const labelId = `${dataUieName}-label`;
   const selectedDate = useMemo(() => (value !== null ? dateValueFromDate(value) : null), [value]);
-  const selectedTime = useMemo(() => (value !== null ? nearestTimeOptionFromDate(value) : null), [value]);
+  const selectedTime = useMemo(
+    () => (value !== null ? nearestTimeOptionFromDate(value, timeLocale) : null),
+    [timeLocale, value],
+  );
   const isDateDisabled = dateDisabled ?? disabled;
   const isTimeDisabled = timeDisabled ?? disabled;
   const effectiveMinTime = useMemo(() => {
@@ -153,6 +159,7 @@ export const DateTimePickerField = ({
           ariaLabel={labels.timeAriaLabel}
           markInvalid={markInvalid}
           disabled={isTimeDisabled}
+          locale={timeLocale}
           minTime={effectiveMinTime}
           menuPortalTarget={menuPortalTarget}
           wrapperCSS={dateTimePickerTimeFieldWrapperStyles}

--- a/libraries/react-ui-kit/src/inputs/timePickerField/timePickerField.tsx
+++ b/libraries/react-ui-kit/src/inputs/timePickerField/timePickerField.tsx
@@ -47,6 +47,7 @@ export interface TimePickerFieldProps {
   ariaLabel?: string;
   markInvalid?: boolean;
   disabled?: boolean;
+  locale?: string;
   /** When set, only time options strictly after this time of day are shown. */
   minTime?: Date | null;
   menuPortalTarget?: HTMLElement;
@@ -64,6 +65,7 @@ export const TimePickerField = ({
   ariaLabel,
   markInvalid = false,
   disabled = false,
+  locale,
   minTime = null,
   menuPortalTarget,
   menuPlacement = 'bottom',
@@ -71,7 +73,7 @@ export const TimePickerField = ({
   wrapperCSS = {},
 }: TimePickerFieldProps) => {
   const timeOptions = useMemo(() => {
-    let options = buildTimeOptions();
+    let options = buildTimeOptions(locale);
 
     if (minTime !== null) {
       options = filterTimeOptionsAfter(options, minTime);
@@ -82,7 +84,7 @@ export const TimePickerField = ({
     }
 
     return options;
-  }, [minTime, value]);
+  }, [locale, minTime, value]);
   const portalTarget = menuPortalTarget ?? (typeof document !== 'undefined' ? document.body : undefined);
   const labelId = `${id}-label`;
 

--- a/libraries/react-ui-kit/src/inputs/timePickerField/timePickerUtils.test.ts
+++ b/libraries/react-ui-kit/src/inputs/timePickerField/timePickerUtils.test.ts
@@ -19,11 +19,11 @@
 
 import {isUndefined} from '@sindresorhus/is';
 
-import {buildTimeOptions, filterTimeOptionsAfter, getTimeOptionTotalMinutes} from './timePickerUtils';
+import {buildTimeOptions, filterTimeOptionsAfter, getTimeOptionTotalMinutes, parseTimeLabel} from './timePickerUtils';
 
 describe('timePickerUtils', () => {
   it('filters out time options at or before the minimum time', () => {
-    const options = buildTimeOptions();
+    const options = buildTimeOptions('en-US');
     const minTime = new Date(2026, 6, 13, 16, 27, 0, 0);
 
     const filteredOptions = filterTimeOptionsAfter(options, minTime);
@@ -35,5 +35,25 @@ describe('timePickerUtils', () => {
       throw new Error('Expected filtered time options to be non-empty');
     }
     expect(getTimeOptionTotalMinutes(firstFilteredOption)).toBeGreaterThan(16 * 60 + 27);
+  });
+
+  it('formats options according to the provided regional locale', () => {
+    const options = buildTimeOptions('de-DE');
+
+    expect(options.find(option => option.value === '14:00')).toEqual({value: '14:00', label: '14:00'});
+  });
+
+  it('formats a regional locale not supported for application translations', () => {
+    const options = buildTimeOptions('en-GB');
+
+    expect(options.find(option => option.value === '14:00')).toEqual({value: '14:00', label: '14:00'});
+  });
+
+  it.each([
+    {input: '3:00 PM', expected: {hour24: 15, minutes: 0}},
+    {input: ' 3:00   PM ', expected: {hour24: 15, minutes: 0}},
+    {input: '15:00', expected: {hour24: 15, minutes: 0}},
+  ])('parses both legacy and canonical time values: $input', ({input, expected}) => {
+    expect(parseTimeLabel(input)).toEqual(expected);
   });
 });

--- a/libraries/react-ui-kit/src/inputs/timePickerField/timePickerUtils.ts
+++ b/libraries/react-ui-kit/src/inputs/timePickerField/timePickerUtils.ts
@@ -22,58 +22,78 @@ import type {Option} from '../select';
 export const TIME_INTERVAL_MINUTES = 15;
 export const TIME_OPTIONS_COUNT = 96;
 
+const HOURS_PER_HALF_DAY = 12;
+const MINUTES_PER_HOUR = 60;
+const TIME_LABEL_DIGITS = 2;
+const TIME_LABEL_REFERENCE_YEAR = 2026;
+
+const timeFormatterOptions: Intl.DateTimeFormatOptions = {
+  hour: 'numeric',
+  minute: '2-digit',
+};
+
+const getTimeFormatter = (locale: string = navigator.language): Intl.DateTimeFormat =>
+  new Intl.DateTimeFormat(locale, timeFormatterOptions);
+
 export const parseTimeLabel = (value: string | number): {hour24: number; minutes: number} => {
-  const [timePart, periodPart] = `${value}`.trim().split(' ');
+  const [timePart, periodPart] = `${value}`.trim().split(/\s+/);
   const [hourPart, minutePart] = (Boolean(timePart) ? timePart : '').split(':');
   const hour = Number(hourPart);
   const minutes = Number(minutePart);
   const isPm = (Boolean(periodPart) ? periodPart : '').toUpperCase() === 'PM';
   let hour24 = 0;
   if (Number.isFinite(hour)) {
-    hour24 = isPm ? (hour % 12) + 12 : hour % 12;
+    if (Boolean(periodPart)) {
+      hour24 = isPm ? (hour % HOURS_PER_HALF_DAY) + HOURS_PER_HALF_DAY : hour % HOURS_PER_HALF_DAY;
+    } else {
+      hour24 = hour;
+    }
   }
   const safeMinutes = Number.isFinite(minutes) ? minutes : 0;
 
   return {hour24, minutes: safeMinutes};
 };
 
-export const formatTimeLabel = (hour24: number, minutes: number): string => {
-  const hour12 = ((hour24 + 11) % 12) + 1;
-  const period = hour24 < 12 ? 'AM' : 'PM';
-  return `${hour12}:${String(minutes).padStart(2, '0')} ${period}`;
+export const formatTimeLabel = (hour24: number, minutes: number, locale?: string): string => {
+  const date = new Date(TIME_LABEL_REFERENCE_YEAR, 0, 1, hour24, minutes);
+  return getTimeFormatter(locale)
+    .format(date)
+    .replace(/[\u00a0\u202f]/g, ' ');
 };
 
-export const buildTimeOptions = (): Option[] =>
-  Array.from({length: TIME_OPTIONS_COUNT}, (_, index) => {
+export const buildTimeOptions = (locale?: string): Option[] =>
+  Array.from({length: TIME_OPTIONS_COUNT}, (_value, index) => {
     const totalMinutes = index * TIME_INTERVAL_MINUTES;
-    const hour24 = Math.floor(totalMinutes / 60);
-    const minutes = totalMinutes % 60;
-    const label = formatTimeLabel(hour24, minutes);
-    return {value: label, label};
+    const hour24 = Math.floor(totalMinutes / MINUTES_PER_HOUR);
+    const minutes = totalMinutes % MINUTES_PER_HOUR;
+    const value = `${String(hour24).padStart(TIME_LABEL_DIGITS, '0')}:${String(minutes).padStart(TIME_LABEL_DIGITS, '0')}`;
+    return {value, label: formatTimeLabel(hour24, minutes, locale)};
   });
 
 export const getTimeOptionTotalMinutes = (option: Option): number => {
   const {hour24, minutes} = parseTimeLabel(option.value);
-  return hour24 * 60 + minutes;
+  return hour24 * MINUTES_PER_HOUR + minutes;
 };
 
 export const filterTimeOptionsAfter = (options: Option[], minTime: Date): Option[] => {
-  const minTotalMinutes = minTime.getHours() * 60 + minTime.getMinutes();
+  const minTotalMinutes = minTime.getHours() * MINUTES_PER_HOUR + minTime.getMinutes();
 
   return options.filter(option => getTimeOptionTotalMinutes(option) > minTotalMinutes);
 };
 
-export const timeOptionFromDate = (date: Date): Option => {
-  const label = formatTimeLabel(date.getHours(), date.getMinutes());
-  return {value: label, label};
+export const timeOptionFromDate = (date: Date, locale?: string): Option => {
+  const hour24 = date.getHours();
+  const minutes = date.getMinutes();
+  const value = `${String(hour24).padStart(TIME_LABEL_DIGITS, '0')}:${String(minutes).padStart(TIME_LABEL_DIGITS, '0')}`;
+  return {value, label: formatTimeLabel(hour24, minutes, locale)};
 };
 
-export const nearestTimeOptionFromDate = (date: Date): Option => {
-  const totalMinutes = date.getHours() * 60 + date.getMinutes();
+export const nearestTimeOptionFromDate = (date: Date, locale?: string): Option => {
+  const totalMinutes = date.getHours() * MINUTES_PER_HOUR + date.getMinutes();
   const roundedMinutes = Math.round(totalMinutes / TIME_INTERVAL_MINUTES) * TIME_INTERVAL_MINUTES;
   const normalizedMinutes = Math.min(roundedMinutes, (TIME_OPTIONS_COUNT - 1) * TIME_INTERVAL_MINUTES);
-  const hour24 = Math.floor(normalizedMinutes / 60);
-  const minutes = normalizedMinutes % 60;
-  const label = formatTimeLabel(hour24, minutes);
-  return {value: label, label};
+  const hour24 = Math.floor(normalizedMinutes / MINUTES_PER_HOUR);
+  const minutes = normalizedMinutes % MINUTES_PER_HOUR;
+  const value = `${String(hour24).padStart(TIME_LABEL_DIGITS, '0')}:${String(minutes).padStart(TIME_LABEL_DIGITS, '0')}`;
+  return {value, label: formatTimeLabel(hour24, minutes, locale)};
 };


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28510" title="WPB-28510" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28510</a>  [Web] Use 24-hour format for meeting date and time
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->




Make meeting time ranges and scheduling time pickers respect the user’s regional locale.

  - Support localized 12/24-hour formats.
  - Preserve AM/PM parsing compatibility.
  - Add regression tests for regional locales and legacy time values.
  
**German**
<img width="1179" height="329" alt="image" src="https://github.com/user-attachments/assets/21796189-99c5-4828-b2a5-2854acc26c09" />

**English**
<img width="1179" height="327" alt="image" src="https://github.com/user-attachments/assets/18580df0-3218-447e-9555-0919158bee61" />
