### PR TITLE
fix(wire-drive): report precise upload progress [WPB-28307]

### DIFF
--- a/apps/webapp/src/script/components/conversation/conversation.tsx
+++ b/apps/webapp/src/script/components/conversation/conversation.tsx
@@ -77,7 +77,7 @@ import {getCurrentFolderName} from './conversationCells/common/getCurrentFolderN
 import {ConversationCells} from './conversationCells/conversationCells';
 import {SharedDriveUploadProvider} from './conversationCells/sharedDriveUploadContext';
 import {
-  createDirectSharedDriveUploadStrategy,
+  createDraftSharedDriveUploadStrategy,
   createSharedDriveUploadController,
 } from './conversationCells/sharedDriveUploadController';
 import {SharedDriveUploadStatusPopupHost} from './conversationCells/sharedDriveUploadStatusPopupHost';
@@ -98,6 +98,8 @@ import {isServiceEntity} from '../../guards/Service';
 import {MotionDuration} from '../../motion/MotionDuration';
 import {RightSidebarParams} from '../../page/appMain';
 import {PanelState} from '../../page/rightSidebar';
+import {createCellsRepositoryGateway} from '../../repositories/cells/cellsRepositoryGateway';
+import {createCellsUploadManager} from '../../repositories/cells/upload/manager';
 import {ElementType, MessageDetails} from '../messagesList/message/contentMessage/asset/textMessageRenderer';
 
 interface ConversationProps {
@@ -143,15 +145,18 @@ function ConversationContent({
   const {conversationRepository, repositories} = contentViewModel;
   const sharedDriveUploadController = useMemo(() => {
     const createSource = (file: File) => ({blob: file, name: file.name, contentType: file.type, size: file.size});
+    const uploadManager = createCellsUploadManager({
+      gateway: createCellsRepositoryGateway(repositories.cells),
+      createResourceUuid: createUuid,
+      createVersionUuid: createUuid,
+      createAttemptId: createUuid,
+      createAbortController: () => new AbortController(),
+    });
 
     return createSharedDriveUploadController({
       createUploadId: createUuid,
       createSource,
-      uploadStrategy: createDirectSharedDriveUploadStrategy({
-        cellsRepository: repositories.cells,
-        createAbortController: () => new AbortController(),
-        createSource,
-      }),
+      uploadStrategy: createDraftSharedDriveUploadStrategy({manager: uploadManager}),
     });
   }, [repositories.cells]);
   const [isConversationLoaded, setIsConversationLoaded] = useState<boolean>(false);

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadController.test.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadController.test.ts
@@ -18,8 +18,10 @@
  */
 
 import type {UploadSource} from 'Repositories/cells/upload';
-import type {CellsUploadManager} from 'Repositories/cells/upload/manager';
-import {Result} from 'true-myth';
+import {createCellsUploadManager, type CellsUploadManager} from 'Repositories/cells/upload/manager';
+import type {CellsUploadGateway, CellsUploadGatewayError, UploadDraftRequest} from 'Repositories/cells/upload/gateway';
+import type {DraftIdentity} from 'Repositories/cells/upload/identity';
+import {Result, Task} from 'true-myth';
 
 import {
   createDirectSharedDriveUploadStrategy,
@@ -78,9 +80,12 @@ function createDraftManager(): jest.Mocked<CellsUploadManager> {
   };
 }
 
-function createDraftController(manager = createDraftManager()) {
+function createDraftController<T extends CellsUploadManager = jest.Mocked<CellsUploadManager>>(
+  manager: T = createDraftManager() as T,
+  createUploadId: jest.Mock = jest.fn().mockReturnValue('upload-1'),
+): {controller: ReturnType<typeof createSharedDriveUploadController>; manager: T} {
   const controller = createSharedDriveUploadController({
-    createUploadId: jest.fn().mockReturnValue('upload-1'),
+    createUploadId,
     createSource: jest.fn((sourceFile: File): UploadSource => ({
       blob: sourceFile,
       name: sourceFile.name,
@@ -91,6 +96,19 @@ function createDraftController(manager = createDraftManager()) {
   });
 
   return {controller, manager};
+}
+
+function createDeferredTask<Value, Failure>(defaultValue: Value) {
+  let resolveTask: ((value?: Value) => void) | undefined;
+  const value = new Task<Value, Failure>(resolve => {
+    resolveTask = nextValue => resolve(nextValue === undefined ? defaultValue : nextValue);
+  });
+
+  if (resolveTask === undefined) {
+    throw new Error('Deferred task callback was not created');
+  }
+
+  return {value, resolve: resolveTask};
 }
 
 describe('createSharedDriveUploadController', () => {
@@ -181,6 +199,40 @@ describe('createSharedDriveUploadController', () => {
     ]);
   });
 
+  it('ignores late progress from a cancelled direct upload before the next upload', async () => {
+    const cellsRepository = createCellsRepository();
+    let firstProgress: ((progress: number) => void) | undefined;
+    cellsRepository.uploadNode.mockImplementationOnce(
+      ({
+        progressCallback,
+        abortController,
+      }: {
+        progressCallback?: (progress: number) => void;
+        abortController?: AbortController;
+      }) => {
+        firstProgress = progressCallback;
+        return new Promise((_resolve, reject) => {
+          abortController?.signal.addEventListener('abort', () => reject(new Error('cancelled')));
+        });
+      },
+    );
+    const {controller} = createController(cellsRepository);
+    const firstUpload = controller.upload(
+      [new File(['one'], 'one.txt')],
+      uploadPath,
+      jest.fn(),
+      conversationQualifiedId,
+    );
+
+    await controller.cancel('upload-1');
+    await firstUpload;
+    firstProgress?.(0.9);
+
+    expect(controller.snapshots(conversationQualifiedId)).toEqual([
+      expect.objectContaining({identity: {uploadId: 'upload-1'}, kind: 'cancelled'}),
+    ]);
+  });
+
   it('retries a failed direct upload', async () => {
     const cellsRepository = createCellsRepository();
     cellsRepository.uploadNode
@@ -240,6 +292,65 @@ describe('createSharedDriveUploadController', () => {
     expect(controller.snapshots(conversationQualifiedId)).toEqual([
       expect.objectContaining({identity: expect.objectContaining({uploadId: 'upload-1'}), kind: 'published'}),
     ]);
+  });
+
+  it('ignores late progress from a cancelled upload when the next upload starts', async () => {
+    const uploadRequests: UploadDraftRequest[] = [];
+    const uploadTasks: Array<{resolve: (value?: DraftIdentity) => void}> = [];
+    const remoteIdentity: DraftIdentity = {
+      uploadId: 'remote-upload',
+      resourceUuid: 'remote-resource',
+      versionId: 'remote-version',
+    };
+    const gateway: CellsUploadGateway = {
+      uploadDraft: request => {
+        uploadRequests.push(request);
+        const deferred = createDeferredTask<DraftIdentity, CellsUploadGatewayError<'upload'>>(remoteIdentity);
+        uploadTasks.push(deferred);
+        return deferred.value;
+      },
+      publishDraft: () => Task.resolve<void, never>(undefined),
+      discardDraft: () => Task.resolve<void, never>(undefined),
+    };
+    const manager = createCellsUploadManager({
+      gateway,
+      createResourceUuid: () => 'resource-1',
+      createVersionUuid: () => 'version-1',
+      createAttemptId: () => 'attempt-1',
+      createAbortController: () => new AbortController(),
+    });
+    const createUploadId = jest.fn().mockReturnValueOnce('upload-1').mockReturnValueOnce('upload-2');
+    const {controller} = createDraftController(manager, createUploadId);
+    const firstUpload = controller.upload(
+      [new File(['one'], 'one.txt')],
+      uploadPath,
+      jest.fn(),
+      conversationQualifiedId,
+    );
+
+    expect(uploadRequests).toHaveLength(1);
+    await controller.cancel('upload-1');
+    uploadRequests[0].onProgress(0.9);
+
+    const secondUpload = controller.upload(
+      [new File(['two'], 'two.txt')],
+      uploadPath,
+      jest.fn(),
+      conversationQualifiedId,
+    );
+    expect(uploadRequests).toHaveLength(2);
+    uploadRequests[1].onProgress(0.1);
+    uploadRequests[1].onProgress(0.45);
+    uploadRequests[1].onProgress(0.8);
+
+    expect(controller.snapshots(conversationQualifiedId)).toEqual([
+      expect.objectContaining({identity: {uploadId: 'upload-1'}, kind: 'cancelled'}),
+      expect.objectContaining({identity: {uploadId: 'upload-2'}, kind: 'uploading', progress: 0.8}),
+    ]);
+
+    uploadTasks[0].resolve();
+    uploadTasks[1].resolve();
+    await Promise.all([firstUpload, secondUpload]);
   });
 
   it('does not publish draft uploads when start fails', async () => {

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadController.test.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadController.test.ts
@@ -32,13 +32,13 @@ import {
 const uploadPath = 'conversation-id@example.com/files';
 const conversationQualifiedId = 'conversation-id@example.com';
 
-function createCellsRepository() {
+function createCellsRepositoryMock() {
   return {
     uploadNode: jest.fn().mockResolvedValue({uuid: 'remote-id', versionId: 'version-id'}),
   };
 }
 
-function createController(cellsRepository = createCellsRepository()) {
+function createDirectUploadControllerHelper(cellsRepository = createCellsRepositoryMock()) {
   const createSource = jest.fn((file: File): UploadSource => ({
     blob: file,
     name: file.name,
@@ -57,7 +57,7 @@ function createController(cellsRepository = createCellsRepository()) {
   return {cellsRepository, controller};
 }
 
-function createDraftManager(): jest.Mocked<CellsUploadManager> {
+function createDraftUploadManagerMock(): jest.Mocked<CellsUploadManager> {
   const source: UploadSource = {blob: new Blob(['data']), name: 'one.txt', contentType: 'text/plain', size: 3};
   const state = {
     kind: 'published',
@@ -80,8 +80,8 @@ function createDraftManager(): jest.Mocked<CellsUploadManager> {
   };
 }
 
-function createDraftController<T extends CellsUploadManager = jest.Mocked<CellsUploadManager>>(
-  manager: T = createDraftManager() as T,
+function createDraftUploadControllerHelper<T extends CellsUploadManager = jest.Mocked<CellsUploadManager>>(
+  manager: T = createDraftUploadManagerMock() as T,
   createUploadId: jest.Mock = jest.fn().mockReturnValue('upload-1'),
 ): {controller: ReturnType<typeof createSharedDriveUploadController>; manager: T} {
   const controller = createSharedDriveUploadController({
@@ -98,7 +98,7 @@ function createDraftController<T extends CellsUploadManager = jest.Mocked<CellsU
   return {controller, manager};
 }
 
-function createDeferredTask<Value, Failure>(defaultValue: Value) {
+function createDeferredTaskHelper<Value, Failure>(defaultValue: Value) {
   let resolveTask: ((value?: Value) => void) | undefined;
   const value = new Task<Value, Failure>(resolve => {
     resolveTask = nextValue => resolve(nextValue === undefined ? defaultValue : nextValue);
@@ -113,7 +113,7 @@ function createDeferredTask<Value, Failure>(defaultValue: Value) {
 
 describe('createSharedDriveUploadController', () => {
   it('notifies listeners as soon as a file is registered', async () => {
-    const {controller} = createController();
+    const {controller} = createDirectUploadControllerHelper();
     const listener = jest.fn();
     controller.subscribe(listener);
 
@@ -133,7 +133,7 @@ describe('createSharedDriveUploadController', () => {
   });
 
   it('directly uploads files and refreshes after successful files', async () => {
-    const {cellsRepository, controller} = createController();
+    const {cellsRepository, controller} = createDirectUploadControllerHelper();
     const onRefresh = jest.fn();
     const listener = jest.fn();
     const files = [new File(['one'], 'one.txt'), new File(['two'], 'two.txt')];
@@ -158,9 +158,9 @@ describe('createSharedDriveUploadController', () => {
   });
 
   it('does not refresh when a direct upload fails', async () => {
-    const cellsRepository = createCellsRepository();
+    const cellsRepository = createCellsRepositoryMock();
     cellsRepository.uploadNode.mockRejectedValueOnce(new Error('upload failed'));
-    const {controller} = createController(cellsRepository);
+    const {controller} = createDirectUploadControllerHelper(cellsRepository);
     const onRefresh = jest.fn();
 
     await controller.upload([new File(['one'], 'one.txt')], uploadPath, onRefresh, conversationQualifiedId);
@@ -172,7 +172,7 @@ describe('createSharedDriveUploadController', () => {
   });
 
   it('cancels an active direct upload', async () => {
-    const cellsRepository = createCellsRepository();
+    const cellsRepository = createCellsRepositoryMock();
     let rejectUpload: (error: unknown) => void = () => undefined;
     cellsRepository.uploadNode.mockImplementationOnce(
       ({abortController}: {abortController?: AbortController}) =>
@@ -181,7 +181,7 @@ describe('createSharedDriveUploadController', () => {
           abortController?.signal.addEventListener('abort', () => reject(new Error('cancelled')));
         }),
     );
-    const {controller} = createController(cellsRepository);
+    const {controller} = createDirectUploadControllerHelper(cellsRepository);
 
     const uploadPromise = controller.upload(
       [new File(['one'], 'one.txt')],
@@ -200,7 +200,7 @@ describe('createSharedDriveUploadController', () => {
   });
 
   it('ignores late progress from a cancelled direct upload before the next upload', async () => {
-    const cellsRepository = createCellsRepository();
+    const cellsRepository = createCellsRepositoryMock();
     let firstProgress: ((progress: number) => void) | undefined;
     cellsRepository.uploadNode.mockImplementationOnce(
       ({
@@ -216,7 +216,8 @@ describe('createSharedDriveUploadController', () => {
         });
       },
     );
-    const {controller} = createController(cellsRepository);
+    const {controller} = createDirectUploadControllerHelper(cellsRepository);
+
     const firstUpload = controller.upload(
       [new File(['one'], 'one.txt')],
       uploadPath,
@@ -234,11 +235,11 @@ describe('createSharedDriveUploadController', () => {
   });
 
   it('retries a failed direct upload', async () => {
-    const cellsRepository = createCellsRepository();
+    const cellsRepository = createCellsRepositoryMock();
     cellsRepository.uploadNode
       .mockRejectedValueOnce(new Error('upload failed'))
       .mockResolvedValueOnce({uuid: 'remote-id', versionId: 'version-id'});
-    const {controller} = createController(cellsRepository);
+    const {controller} = createDirectUploadControllerHelper(cellsRepository);
     const file = new File(['one'], 'one.txt');
 
     await controller.upload([file], uploadPath, jest.fn(), conversationQualifiedId);
@@ -255,7 +256,7 @@ describe('createSharedDriveUploadController', () => {
   });
 
   it('does not retry an already published direct upload', async () => {
-    const {cellsRepository, controller} = createController();
+    const {cellsRepository, controller} = createDirectUploadControllerHelper();
 
     await controller.upload([new File(['one'], 'one.txt')], uploadPath, jest.fn(), conversationQualifiedId);
     await controller.retryUpload('upload-1');
@@ -264,7 +265,7 @@ describe('createSharedDriveUploadController', () => {
   });
 
   it('returns only uploads belonging to the requested conversation', async () => {
-    const {controller} = createController();
+    const {controller} = createDirectUploadControllerHelper();
     const onRefresh = jest.fn();
 
     await controller.upload([new File(['one'], 'one.txt')], uploadPath, onRefresh, conversationQualifiedId);
@@ -281,7 +282,7 @@ describe('createSharedDriveUploadController', () => {
   it('can run with the draft manager strategy for staged uploads', async () => {
     const onRefresh = jest.fn();
     const file = new File(['one'], 'one.txt', {type: 'text/plain'});
-    const {controller, manager} = createDraftController();
+    const {controller, manager} = createDraftUploadControllerHelper();
 
     await controller.upload([file], uploadPath, onRefresh, conversationQualifiedId);
 
@@ -305,7 +306,7 @@ describe('createSharedDriveUploadController', () => {
     const gateway: CellsUploadGateway = {
       uploadDraft: request => {
         uploadRequests.push(request);
-        const deferred = createDeferredTask<DraftIdentity, CellsUploadGatewayError<'upload'>>(remoteIdentity);
+        const deferred = createDeferredTaskHelper<DraftIdentity, CellsUploadGatewayError<'upload'>>(remoteIdentity);
         uploadTasks.push(deferred);
         return deferred.value;
       },
@@ -320,7 +321,7 @@ describe('createSharedDriveUploadController', () => {
       createAbortController: () => new AbortController(),
     });
     const createUploadId = jest.fn().mockReturnValueOnce('upload-1').mockReturnValueOnce('upload-2');
-    const {controller} = createDraftController(manager, createUploadId);
+    const {controller} = createDraftUploadControllerHelper(manager, createUploadId);
     const firstUpload = controller.upload(
       [new File(['one'], 'one.txt')],
       uploadPath,
@@ -354,9 +355,9 @@ describe('createSharedDriveUploadController', () => {
   });
 
   it('does not publish draft uploads when start fails', async () => {
-    const manager = createDraftManager();
+    const manager = createDraftUploadManagerMock();
     manager.start.mockResolvedValueOnce(Result.err({kind: 'unknownUpload', uploadId: 'upload-1'}));
-    const {controller} = createDraftController(manager);
+    const {controller} = createDraftUploadControllerHelper(manager);
     const onRefresh = jest.fn();
 
     await controller.upload([new File(['one'], 'one.txt')], uploadPath, onRefresh, conversationQualifiedId);
@@ -366,9 +367,9 @@ describe('createSharedDriveUploadController', () => {
   });
 
   it('does not start draft uploads when register fails', async () => {
-    const manager = createDraftManager();
+    const manager = createDraftUploadManagerMock();
     manager.register.mockReturnValueOnce(Result.err({kind: 'duplicateUpload', uploadId: 'upload-1'}));
-    const {controller} = createDraftController(manager);
+    const {controller} = createDraftUploadControllerHelper(manager);
     const onRefresh = jest.fn();
 
     await controller.upload([new File(['one'], 'one.txt')], uploadPath, onRefresh, conversationQualifiedId);
@@ -379,9 +380,9 @@ describe('createSharedDriveUploadController', () => {
   });
 
   it('does not refresh when draft publish fails', async () => {
-    const manager = createDraftManager();
+    const manager = createDraftUploadManagerMock();
     manager.publish.mockResolvedValueOnce(Result.err({kind: 'unknownUpload', uploadId: 'upload-1'}));
-    const {controller} = createDraftController(manager);
+    const {controller} = createDraftUploadControllerHelper(manager);
     const onRefresh = jest.fn();
 
     await controller.upload([new File(['one'], 'one.txt')], uploadPath, onRefresh, conversationQualifiedId);
@@ -392,8 +393,8 @@ describe('createSharedDriveUploadController', () => {
   });
 
   it('publishes and refreshes after retrying a failed draft upload', async () => {
-    const manager = createDraftManager();
-    const {controller} = createDraftController(manager);
+    const manager = createDraftUploadManagerMock();
+    const {controller} = createDraftUploadControllerHelper(manager);
     const onRefresh = jest.fn();
 
     await controller.upload([new File(['one'], 'one.txt')], uploadPath, onRefresh, conversationQualifiedId);
@@ -405,9 +406,9 @@ describe('createSharedDriveUploadController', () => {
   });
 
   it('does not publish or refresh when retrying a draft upload fails', async () => {
-    const manager = createDraftManager();
+    const manager = createDraftUploadManagerMock();
     manager.retryUpload.mockResolvedValueOnce(Result.err({kind: 'unknownUpload', uploadId: 'upload-1'}));
-    const {controller} = createDraftController(manager);
+    const {controller} = createDraftUploadControllerHelper(manager);
     const onRefresh = jest.fn();
 
     await controller.upload([new File(['one'], 'one.txt')], uploadPath, onRefresh, conversationQualifiedId);

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadController.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadController.ts
@@ -157,7 +157,13 @@ export const createDirectSharedDriveUploadStrategy = ({
         uuid: uploadId,
         file: request.file,
         path: request.path,
-        progressCallback: progress => setState(uploadId, {kind: 'uploading', identity: {uploadId}, source, progress}),
+        progressCallback: progress => {
+          if (abortController.signal.aborted || abortControllersByUploadId.get(uploadId) !== abortController) {
+            return;
+          }
+
+          setState(uploadId, {kind: 'uploading', identity: {uploadId}, source, progress});
+        },
         abortController,
       });
 

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.test.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.test.ts
@@ -27,6 +27,7 @@ const state = (kind: string) => ({
   kind,
   identity: {uploadId: 'upload-1'},
   source,
+  ...(kind === 'uploading' ? {progress: 0} : {}),
 });
 
 describe('toSharedDriveUploadStatus', () => {
@@ -37,6 +38,9 @@ describe('toSharedDriveUploadStatus', () => {
       fileName: 'report.pdf',
       fileSize: 4,
       kind: 'uploading',
+      progress: 0,
+      hasProgress: false,
+      isTransferActive: kind === 'uploading',
       canCancel: true,
       canRetry: false,
     });
@@ -44,8 +48,20 @@ describe('toSharedDriveUploadStatus', () => {
 
   it.each(['draftReady', 'publishing'])('maps %s to uploading but marks it not cancellable', kind => {
     expect(toSharedDriveUploadStatus(state(kind) as never, conversationQualifiedId)).toEqual(
-      expect.objectContaining({kind: 'uploading', canCancel: false}),
+      expect.objectContaining({
+        kind: 'uploading',
+        progress: 0,
+        hasProgress: false,
+        isTransferActive: false,
+        canCancel: false,
+      }),
     );
+  });
+
+  it('preserves reported transfer progress', () => {
+    expect(
+      toSharedDriveUploadStatus({...state('uploading'), progress: 0.45} as never, conversationQualifiedId),
+    ).toEqual(expect.objectContaining({progress: 0.45, hasProgress: true, isTransferActive: true}));
   });
 
   it('maps published to uploaded', () => {
@@ -59,8 +75,14 @@ describe('toSharedDriveUploadStatus', () => {
     );
   });
 
-  it.each(['publishFailed', 'discardFailed'])('does not make a %s retryable', kind => {
-    expect(toSharedDriveUploadStatus(state(kind) as never, conversationQualifiedId)).toEqual(
+  it('makes a publish failure retryable without allowing upload cancellation', () => {
+    expect(toSharedDriveUploadStatus(state('publishFailed') as never, conversationQualifiedId)).toEqual(
+      expect.objectContaining({kind: 'failed', canCancel: false, canRetry: true}),
+    );
+  });
+
+  it('does not make a discard failure retryable', () => {
+    expect(toSharedDriveUploadStatus(state('discardFailed') as never, conversationQualifiedId)).toEqual(
       expect.objectContaining({kind: 'failed', canCancel: false, canRetry: false}),
     );
   });

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.ts
@@ -27,6 +27,9 @@ export type SharedDriveUploadStatus = {
   readonly fileName: string;
   readonly fileSize: number;
   readonly kind: SharedDriveUploadStatusKind;
+  readonly progress: number;
+  readonly hasProgress: boolean;
+  readonly isTransferActive: boolean;
   readonly canCancel: boolean;
   readonly canRetry: boolean;
 };
@@ -65,7 +68,10 @@ export const toSharedDriveUploadStatus = (
     fileName: state.source.name,
     fileSize: state.source.size,
     kind,
+    progress: state.kind === 'uploading' ? state.progress : 0,
+    hasProgress: state.kind === 'uploading' && state.progress > 0,
+    isTransferActive: state.kind === 'uploading',
     canCancel: state.kind === 'queued' || state.kind === 'uploading',
-    canRetry: state.kind === 'uploadFailed',
+    canRetry: state.kind === 'uploadFailed' || state.kind === 'publishFailed',
   };
 };

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
@@ -23,6 +23,7 @@ import type {SharedDriveUploadStatusKind} from './sharedDriveUploadStatus';
 
 const SHARED_DRIVE_UPLOAD_PROGRESS_EXPANDED_TOP = 51;
 const SHARED_DRIVE_UPLOAD_PROGRESS_COLLAPSED_LEFT = 3;
+const PROGRESS_PERCENTAGE_MAX = 100;
 
 export const sharedDriveUploadStatusPopupStyles: CSSObject = {
   position: 'absolute',
@@ -250,17 +251,21 @@ export const sharedDriveUploadStatusPopupRowActionIconStyles: CSSObject = {
   height: 14,
 };
 
-export const sharedDriveUploadStatusPopupProgressStyles = (
-  isExpanded: boolean,
-  kind: SharedDriveUploadStatusKind = 'uploading',
-): CSSObject => ({
+const sharedDriveUploadStatusPopupProgressBaseStyles = (isExpanded: boolean): CSSObject => ({
   position: 'absolute',
   top: isExpanded ? SHARED_DRIVE_UPLOAD_PROGRESS_EXPANDED_TOP : undefined,
   bottom: isExpanded ? undefined : 0,
   left: isExpanded ? 0 : SHARED_DRIVE_UPLOAD_PROGRESS_COLLAPSED_LEFT,
-  width: kind === 'uploading' ? 'min(209px, calc(50% + 3px))' : 'calc(100% + 4px)',
   height: 3,
   overflow: 'hidden',
+});
+
+export const sharedDriveUploadStatusPopupProgressStyles = (
+  isExpanded: boolean,
+  kind: SharedDriveUploadStatusKind = 'uploading',
+): CSSObject => ({
+  ...sharedDriveUploadStatusPopupProgressBaseStyles(isExpanded),
+  width: kind === 'uploading' ? 'min(209px, calc(50% + 3px))' : 'calc(100% + 4px)',
   backgroundColor: kind === 'failed' ? 'var(--danger-color, #c20013)' : 'var(--accent-color, #0667c8)',
   animation: kind === 'uploading' ? 'shared-drive-upload-progress 1.5s ease-in-out infinite' : 'none',
   '@keyframes shared-drive-upload-progress': {
@@ -270,4 +275,11 @@ export const sharedDriveUploadStatusPopupProgressStyles = (
   '@media (prefers-reduced-motion: reduce)': {
     animation: 'none',
   },
+});
+
+export const sharedDriveUploadStatusPopupDeterminateProgressStyles = (isExpanded: boolean): CSSObject => ({
+  ...sharedDriveUploadStatusPopupProgressBaseStyles(isExpanded),
+  width: `${PROGRESS_PERCENTAGE_MAX}%`,
+  transformOrigin: 'left center',
+  backgroundColor: 'var(--accent-color, #0667c8)',
 });

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.test.tsx
@@ -29,6 +29,9 @@ const upload: SharedDriveUploadStatus = {
   fileName: 'report.pdf',
   fileSize: 4,
   kind: 'uploading',
+  progress: 0,
+  hasProgress: false,
+  isTransferActive: true,
   canCancel: true,
   canRetry: false,
 };
@@ -42,7 +45,14 @@ const renderPopup = (
   render(
     <ThemeProvider>
       <SharedDriveUploadStatusPopup
-        upload={{...upload, fileName, kind, canCancel: kind === 'uploading', canRetry: kind === 'failed'}}
+        upload={{
+          ...upload,
+          fileName,
+          kind,
+          isTransferActive: kind === 'uploading',
+          canCancel: kind === 'uploading',
+          canRetry: kind === 'failed',
+        }}
         title={`${kind} report.pdf`}
         statusLabel={
           kind === 'failed' ? 'Couldn’t upload file' : `${kind === 'uploading' ? 'Uploading' : 'Uploaded'} 4 KB`
@@ -70,7 +80,90 @@ describe('SharedDriveUploadStatusPopup', () => {
     expect(getByRole('status')).toBeInTheDocument();
     expect(getByText('uploading report.pdf')).toBeInTheDocument();
     expect(getByText('to Shared Drive')).toBeInTheDocument();
+    const progress = getByRole('progressbar', {name: 'report.pdf'});
+    expect(progress).not.toHaveAttribute('aria-valuenow');
+    expect(progress).not.toHaveAttribute('aria-valuemin');
+    expect(progress).not.toHaveAttribute('aria-valuemax');
     expect(getByTestId('shared-drive-upload-progress')).toBeInTheDocument();
+  });
+
+  it('shows determinate progress when Cells reports bytes sent', () => {
+    render(
+      <ThemeProvider>
+        <SharedDriveUploadStatusPopup
+          upload={{...upload, progress: 0.45, hasProgress: true}}
+          title="Uploading report.pdf"
+          statusLabel="Uploading 4 B"
+          destination="to Shared Drive"
+          isExpanded={false}
+          toggleLabel="Expand upload details"
+          cancelLabel="Cancel"
+          retryLabel="Retry"
+          isCancelling={false}
+          isRetrying={false}
+          onToggle={jest.fn()}
+          onCancel={jest.fn()}
+          onRetry={jest.fn()}
+        />
+      </ThemeProvider>,
+    );
+
+    const progress = screen.getByRole('progressbar', {name: 'report.pdf'});
+    expect(progress).toHaveAttribute('aria-valuemin', '0');
+    expect(progress).toHaveAttribute('aria-valuemax', '100');
+    expect(progress).toHaveAttribute('aria-valuenow', '45');
+    expect(progress).toHaveStyle({width: '100%', transform: 'scaleX(0.45)'});
+  });
+
+  it('updates progress without replacing the bar or its style rule', () => {
+    const {rerender} = render(
+      <ThemeProvider>
+        <SharedDriveUploadStatusPopup
+          upload={{...upload, progress: 0.45, hasProgress: true}}
+          title="Uploading report.pdf"
+          statusLabel="Uploading 4 B"
+          destination="to Shared Drive"
+          isExpanded={false}
+          toggleLabel="Expand upload details"
+          cancelLabel="Cancel"
+          retryLabel="Retry"
+          isCancelling={false}
+          isRetrying={false}
+          onToggle={jest.fn()}
+          onCancel={jest.fn()}
+          onRetry={jest.fn()}
+        />
+      </ThemeProvider>,
+    );
+
+    const progress = screen.getByRole('progressbar', {name: 'report.pdf'});
+    const progressClassName = progress.className;
+    const statusIcon = screen.getByTestId('shared-drive-upload-uploading');
+
+    rerender(
+      <ThemeProvider>
+        <SharedDriveUploadStatusPopup
+          upload={{...upload, progress: 0.46, hasProgress: true}}
+          title="Uploading report.pdf"
+          statusLabel="Uploading 4 B"
+          destination="to Shared Drive"
+          isExpanded={false}
+          toggleLabel="Expand upload details"
+          cancelLabel="Cancel"
+          retryLabel="Retry"
+          isCancelling={false}
+          isRetrying={false}
+          onToggle={jest.fn()}
+          onCancel={jest.fn()}
+          onRetry={jest.fn()}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByRole('progressbar', {name: 'report.pdf'})).toBe(progress);
+    expect(screen.getByRole('progressbar', {name: 'report.pdf'})).toHaveClass(progressClassName);
+    expect(screen.getByRole('progressbar', {name: 'report.pdf'})).toHaveStyle({transform: 'scaleX(0.46)'});
+    expect(screen.getByTestId('shared-drive-upload-uploading')).toBe(statusIcon);
   });
 
   it.each([

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
@@ -27,6 +27,7 @@ import {getFileExtension} from 'Util/util';
 import type {SharedDriveUploadStatus} from './sharedDriveUploadStatus';
 import {
   sharedDriveUploadStatusPopupContentStyles,
+  sharedDriveUploadStatusPopupDeterminateProgressStyles,
   sharedDriveUploadStatusPopupDestinationStyles,
   sharedDriveUploadStatusPopupHeaderActionsStyles,
   sharedDriveUploadStatusPopupHeaderCancelStyles,
@@ -49,6 +50,10 @@ import {
   sharedDriveUploadStatusPopupToggleIconStyles,
   sharedDriveUploadStatusPopupToggleStyles,
 } from './sharedDriveUploadStatusPopup.styles';
+
+const PROGRESS_PERCENTAGE_MAX = 100;
+
+const getProgressTransform = (progress: number): string => `scaleX(${Math.min(1, Math.max(0, progress))})`;
 
 interface SharedDriveUploadStatusPopupProps {
   readonly upload: SharedDriveUploadStatus;
@@ -121,6 +126,47 @@ export const SharedDriveUploadStatusPopup = ({
   onDismiss,
 }: SharedDriveUploadStatusPopupProps) => {
   const statusRowId = `shared-drive-upload-status-${upload.uploadId}`;
+  const progressIndicator = (() => {
+    if (upload.isTransferActive && upload.hasProgress) {
+      return (
+        <div
+          role="progressbar"
+          aria-label={upload.fileName}
+          aria-valuemin={0}
+          aria-valuemax={PROGRESS_PERCENTAGE_MAX}
+          aria-valuenow={Math.round(upload.progress * PROGRESS_PERCENTAGE_MAX)}
+          css={sharedDriveUploadStatusPopupDeterminateProgressStyles(isExpanded)}
+          style={{transform: getProgressTransform(upload.progress)}}
+          data-testid="shared-drive-upload-progress"
+          data-uie-name="shared-drive-upload-progress"
+        />
+      );
+    }
+
+    if (upload.isTransferActive) {
+      return (
+        <div
+          role="progressbar"
+          aria-label={upload.fileName}
+          css={sharedDriveUploadStatusPopupProgressStyles(isExpanded)}
+          data-testid="shared-drive-upload-progress"
+          data-uie-name="shared-drive-upload-progress"
+        />
+      );
+    }
+
+    if (upload.kind !== 'uploading') {
+      return (
+        <div
+          css={sharedDriveUploadStatusPopupProgressStyles(isExpanded, upload.kind)}
+          data-testid="shared-drive-upload-progress"
+          data-uie-name="shared-drive-upload-progress"
+        />
+      );
+    }
+
+    return null;
+  })();
 
   return (
     <div css={sharedDriveUploadStatusPopupStyles} data-uie-name="shared-drive-upload-status-popup">
@@ -230,10 +276,7 @@ export const SharedDriveUploadStatusPopup = ({
           )}
         </div>
       </div>
-      <div
-        css={sharedDriveUploadStatusPopupProgressStyles(isExpanded, upload.kind)}
-        data-uie-name="shared-drive-upload-progress"
-      />
+      {progressIndicator}
     </div>
   );
 };

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.test.tsx
@@ -50,11 +50,18 @@ const failedState: UploadState = {
   source: uploadSource,
   error: {kind: 'uploadFailed', cause: new Error('upload failed')},
 };
+const publishFailedState: UploadState = {
+  kind: 'publishFailed',
+  identity: {uploadId: 'upload-1', resourceUuid: 'resource-1', versionId: 'version-1'},
+  source: uploadSource,
+  error: {kind: 'publishFailed', cause: new Error('publish failed')},
+};
 type TestController = SharedDriveUploadController & {
   snapshots: jest.MockedFunction<SharedDriveUploadController['snapshots']>;
   subscribe: jest.MockedFunction<SharedDriveUploadController['subscribe']>;
   cancel: jest.MockedFunction<SharedDriveUploadController['cancel']>;
   retryUpload: jest.MockedFunction<SharedDriveUploadController['retryUpload']>;
+  retryPublish: jest.MockedFunction<SharedDriveUploadController['retryPublish']>;
 };
 
 const createController = (state: UploadState = uploadState): TestController => ({
@@ -204,6 +211,52 @@ describe('SharedDriveUploadStatusPopupHost', () => {
     await waitFor(() =>
       expect(view.getByRole('button', {name: 'conversationFilePreviewErrorRetry'})).not.toBeDisabled(),
     );
+  });
+
+  it('retries publication when the upload succeeded but promotion failed', async () => {
+    const user = userEvent.setup();
+    const controller = createController(publishFailedState);
+    controller.retryPublish.mockResolvedValue(undefined);
+    const view = renderHost(controller, conversationQualifiedId);
+    await user.click(view.getByRole('button', {name: 'cells.uploadStatus.expand'}));
+
+    await user.click(view.getByRole('button', {name: 'conversationFilePreviewErrorRetry'}));
+
+    expect(controller.retryPublish).toHaveBeenCalledWith('upload-1');
+    expect(controller.retryUpload).not.toHaveBeenCalled();
+  });
+
+  it('renders every incremental progress update before completion', () => {
+    const controller = createController(uploadState);
+    let state: UploadState = uploadState;
+    let notify: () => void = jest.fn();
+    controller.snapshots.mockImplementation(scope => (scope === conversationQualifiedId ? [state] : []));
+    controller.subscribe.mockImplementation(listener => {
+      notify = listener;
+      return jest.fn();
+    });
+
+    renderHost(controller, conversationQualifiedId);
+    const progress = screen.getByRole('progressbar', {name: 'report.pdf'});
+    const indeterminateClassName = progress.className;
+    let determinateClassName: string | undefined;
+
+    for (const [index, nextProgress] of [0.1, 0.45, 0.8].entries()) {
+      state = {...uploadState, progress: nextProgress};
+      act(() => notify());
+      expect(document.querySelectorAll('[data-uie-name="shared-drive-upload-status-popup"]')).toHaveLength(1);
+      expect(screen.getAllByTestId('shared-drive-upload-progress')).toHaveLength(1);
+      expect(screen.getAllByTestId('shared-drive-upload-uploading')).toHaveLength(1);
+      expect(screen.getByRole('progressbar', {name: 'report.pdf'})).toBe(progress);
+      expect(progress).toHaveAttribute('aria-valuenow', `${nextProgress * 100}`);
+      expect(progress).toHaveStyle({transform: `scaleX(${nextProgress})`});
+      if (index === 0) {
+        determinateClassName = progress.className;
+        expect(progress).not.toHaveClass(indeterminateClassName);
+      } else {
+        expect(progress.className).toBe(determinateClassName);
+      }
+    }
   });
 
   it('shows the uploading status when retry updates the upload lifecycle', async () => {

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
@@ -106,9 +106,13 @@ export const SharedDriveUploadStatusPopupHost = ({
         setRetryingUploadId(current =>
           maybe.isJust(current) && current.value === uploadId ? Maybe.nothing() : current,
         );
-      void controller.retryUpload(uploadId).then(finishRetry, finishRetry);
+      const snapshot = controller
+        .snapshots(conversationQualifiedId)
+        .find(state => state.identity.uploadId === uploadId);
+      const retry = snapshot?.kind === 'publishFailed' ? controller.retryPublish : controller.retryUpload;
+      void retry(uploadId).then(finishRetry, finishRetry);
     },
-    [controller, retryingUploadId],
+    [controller, conversationQualifiedId, retryingUploadId],
   );
 
   useEffect(() => {

--- a/apps/webapp/src/script/repositories/cells/upload/process.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.test.ts
@@ -158,6 +158,26 @@ describe('createCellsUploadProcess', () => {
     expect(snapshots).toEqual(['queued', 'uploading', 'uploading', 'draftReady']);
   });
 
+  it('forwards every progress update before upload completion', async () => {
+    const fixture = setup();
+    const progressSnapshots: number[] = [];
+    fixture.process.subscribe(snapshot => {
+      if (snapshot.kind === 'uploading') {
+        progressSnapshots.push(snapshot.progress);
+      }
+    });
+
+    const start = fixture.process.start();
+    const request = required(fixture.uploads[0]);
+    request.onProgress(0.1);
+    request.onProgress(0.45);
+    request.onProgress(0.8);
+    expect(progressSnapshots).toEqual([0, 0.1, 0.45, 0.8]);
+
+    required(fixture.uploadTasks[0]).resolve(undefined);
+    await unwrap(start);
+  });
+
   it('uses the repository-returned remote identity after upload', async () => {
     const remoteIdentity: DraftIdentity = {
       uploadId: 'upload-1',

--- a/libraries/api-client/package.json
+++ b/libraries/api-client/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.1127.0",
     "@aws-sdk/lib-storage": "3.1127.0",
+    "@aws-sdk/xhr-http-handler": "3.1127.0",
     "@sindresorhus/is": "8.1.0",
     "@wireapp/commons": "workspace:^",
     "@wireapp/priority-queue": "workspace:^",

--- a/libraries/api-client/src/cells/cellsStorage/s3Service.test.ts
+++ b/libraries/api-client/src/cells/cellsStorage/s3Service.test.ts
@@ -19,9 +19,10 @@
 
 import {S3Client, S3ServiceException} from '@aws-sdk/client-s3';
 import {Upload} from '@aws-sdk/lib-storage';
+import {XhrHttpHandler} from '@aws-sdk/xhr-http-handler';
 
 import {CellsStorageError} from './cellsStorage';
-import {MAX_QUEUE_SIZE, PART_SIZE, S3Service} from './s3Service';
+import {createAbortableXhrHttpHandler, MAX_QUEUE_SIZE, PART_SIZE, S3Service} from './s3Service';
 
 import {AccessTokenStore} from '../../auth/accessTokenStore';
 
@@ -63,9 +64,64 @@ describe('S3Service', () => {
         endpoint: testConfig.endpoint,
         forcePathStyle: true,
         region: testConfig.region,
+        requestHandler: expect.any(XhrHttpHandler),
         requestChecksumCalculation: 'WHEN_REQUIRED',
       }),
     );
+  });
+
+  it('passes the upload abort signal to the XHR handler', async () => {
+    const abortController = new AbortController();
+    const request = {} as never;
+    const handle = jest.spyOn(XhrHttpHandler.prototype, 'handle').mockResolvedValue({response: {} as never});
+    const requestHandler = createAbortableXhrHttpHandler(abortController.signal);
+
+    await requestHandler.handle(request);
+
+    expect(handle).toHaveBeenCalledWith(request, expect.objectContaining({abortSignal: abortController.signal}));
+    handle.mockRestore();
+  });
+
+  it('aborts the underlying XHR when the upload signal is cancelled', async () => {
+    const abortController = new AbortController();
+    const xhr = {
+      upload: {addEventListener: jest.fn()},
+      addEventListener: jest.fn(),
+      open: jest.fn(),
+      setRequestHeader: jest.fn(),
+      send: jest.fn(),
+      abort: jest.fn(),
+    };
+    const originalXMLHttpRequest = globalThis.XMLHttpRequest;
+    Object.defineProperty(globalThis, 'XMLHttpRequest', {
+      configurable: true,
+      value: jest.fn(() => xhr),
+      writable: true,
+    });
+
+    try {
+      const requestHandler = createAbortableXhrHttpHandler(abortController.signal);
+      const pending = requestHandler.handle({
+        protocol: 'https:',
+        hostname: 's3.example.test',
+        path: '/bucket/object',
+        method: 'PUT',
+        headers: {},
+        query: {},
+      } as never);
+
+      await Promise.resolve();
+      abortController.abort();
+
+      await expect(pending).rejects.toMatchObject({name: 'AbortError'});
+      expect(xhr.abort).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(globalThis, 'XMLHttpRequest', {
+        configurable: true,
+        value: originalXMLHttpRequest,
+        writable: true,
+      });
+    }
   });
 
   describe('putObject', () => {
@@ -164,12 +220,14 @@ describe('S3Service', () => {
       await expect(service.putObject({path: testFilePath, file: testFile})).rejects.toBe(error);
     });
 
-    it('calls progress callback with correct progress values', async () => {
+    it('forwards every incremental progress event to the callback', async () => {
       const progressCallback = jest.fn();
       const mockUpload = {
         on: jest.fn().mockImplementation((event, callback) => {
           if (event === 'httpUploadProgress') {
-            callback({loaded: 50, total: 100});
+            callback({loaded: 10, total: 100});
+            callback({loaded: 45, total: 100});
+            callback({loaded: 80, total: 100});
           }
         }),
         done: jest.fn().mockResolvedValue(undefined),
@@ -179,7 +237,9 @@ describe('S3Service', () => {
 
       await service.putObject({path: testFilePath, file: testFile, progressCallback});
 
-      expect(progressCallback).toHaveBeenCalledWith(0.5);
+      expect(progressCallback).toHaveBeenNthCalledWith(1, 0.1);
+      expect(progressCallback).toHaveBeenNthCalledWith(2, 0.45);
+      expect(progressCallback).toHaveBeenNthCalledWith(3, 0.8);
     });
 
     it('does not call progress callback when progress information is missing', async () => {

--- a/libraries/api-client/src/cells/cellsStorage/s3Service.ts
+++ b/libraries/api-client/src/cells/cellsStorage/s3Service.ts
@@ -19,6 +19,7 @@
 
 import {S3Client, S3ServiceException} from '@aws-sdk/client-s3';
 import {Upload} from '@aws-sdk/lib-storage';
+import {XhrHttpHandler} from '@aws-sdk/xhr-http-handler';
 
 import {CellsStorage, CellsStorageError} from './cellsStorage';
 
@@ -33,6 +34,13 @@ interface S3ServiceConfig {
 
 export const MAX_QUEUE_SIZE = 3;
 export const PART_SIZE = 10 * 1024 * 1024; // 10MB
+
+export const createAbortableXhrHttpHandler = (abortSignal: AbortSignal): XhrHttpHandler => {
+  const requestHandler = new XhrHttpHandler();
+  const handle = requestHandler.handle.bind(requestHandler);
+  requestHandler.handle = (request, options) => handle(request, {...(options ?? {}), abortSignal});
+  return requestHandler;
+};
 
 export class S3Service implements CellsStorage {
   private config: S3ServiceConfig;
@@ -63,7 +71,7 @@ export class S3Service implements CellsStorage {
     progressCallback?: (progress: number) => void;
     abortController?: AbortController;
   }): Promise<void> {
-    const client = this.getS3Client();
+    const client = this.getS3Client(abortController?.signal);
 
     const upload = new Upload({
       client,
@@ -113,7 +121,11 @@ export class S3Service implements CellsStorage {
     }
   }
 
-  private getS3Client(): S3Client {
+  private getS3Client(abortSignal?: AbortSignal): S3Client {
+    if (abortSignal !== undefined) {
+      return this.createS3Client({accessToken: this.accessTokenStore.getAccessToken(), abortSignal});
+    }
+
     if (this.config.apiKey !== undefined && this.config.apiKey.length > 0) {
       return this.client;
     }
@@ -135,11 +147,18 @@ export class S3Service implements CellsStorage {
     return this.client;
   }
 
-  private createS3Client({accessToken}: {accessToken: string | undefined}): S3Client {
+  private createS3Client({
+    accessToken,
+    abortSignal,
+  }: {
+    accessToken: string | undefined;
+    abortSignal?: AbortSignal;
+  }): S3Client {
     return new S3Client({
       endpoint: this.config.endpoint,
       forcePathStyle: true,
       region: this.config.region,
+      requestHandler: abortSignal === undefined ? new XhrHttpHandler() : createAbortableXhrHttpHandler(abortSignal),
       credentials: async () => {
         if (this.config.apiKey !== undefined && this.config.apiKey.length > 0) {
           return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,6 +375,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/xhr-http-handler@npm:3.1127.0":
+  version: 3.1127.0
+  resolution: "@aws-sdk/xhr-http-handler@npm:3.1127.0"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/types": "npm:^4.17.2"
+    events: "npm:3.3.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/54ed5abee01bff1b5939da1c7ec582622cedbc2fe1c23ae77f94f33cadc36852e339b4d2ff33a7eb9e37c4727f7ad58215cb4c53b4f198c662ab33985cac4b9e
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/xml-builder@npm:^3.972.40":
   version: 3.972.40
   resolution: "@aws-sdk/xml-builder@npm:3.972.40"
@@ -11642,6 +11655,7 @@ __metadata:
   dependencies:
     "@aws-sdk/client-s3": "npm:3.1127.0"
     "@aws-sdk/lib-storage": "npm:3.1127.0"
+    "@aws-sdk/xhr-http-handler": "npm:3.1127.0"
     "@sindresorhus/is": "npm:8.1.0"
     "@swc/core": "npm:1.16.2"
     "@swc/jest": "npm:0.2.39"


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28307" title="WPB-28307" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28307</a>  [web] precise progress visual feedback to shared drive upload
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Problem
Shared Drive uploads exposed progress only after a request completed. Cancelling an upload could leave its underlying S3 XHR pending, allowing stale callbacks to compete with a later upload's status.

## Solution
- Use XHR-backed S3 progress events to render determinate uploaded-byte progress, with an indeterminate fallback when total size is unavailable.
- Keep success authoritative: upload the draft, then mark it published only after promotion succeeds; allow failed promotion to retry without re-uploading.
- Keep progress rendering stable across updates and preserve current upload state when returning to the initiating conversation's Shared Drive.
- Ignore stale callbacks after cancellation and explicitly forward each upload's abort signal to the XHR transport so cancellation calls `xhr.abort()`.

## Tradeoffs
- Percentage represents bytes sent to storage, not server-side processing or promotion.
- A per-upload S3 client/handler is created to bind the AbortSignal because `@aws-sdk/lib-storage` 3.1127.0 does not forward its controller to `client.send()`.

## External dependencies
- Adds `@aws-sdk/xhr-http-handler@3.1127.0`, matching the existing pinned AWS SDK version. Its lockfile entry uses existing AWS/Smithy support packages plus `events` and `tslib`.

## Security
- Ran `yarn npm audit --all` (Yarn 4.18.0). No advisory was reported for the added XHR handler.
- The audit reports existing workspace findings outside this dependency change: high `@faker-js/faker@9.9.0`; moderate deprecation/advisories for `eslint`, `jsrsasign`, `opn`, and `react-router@6.30.6`. This PR does not remediate them.
- Transport cancellation has a regression test that verifies the upload signal reaches `xhr.abort()`.

## Demo

https://github.com/user-attachments/assets/de46f77d-dc00-44d1-bea6-361139b1ffbf


## References
- https://wearezeta.atlassian.net/browse/WPB-28307
