### PR TITLE
Add WebApp Production version logic [WPB-26469]

### DIFF
--- a/tools/release-metadata/tsconfig.json
+++ b/tools/release-metadata/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "es2024",
+    "lib": ["ES2024"],
+    "types": ["node", "jest"],
+    "rootDir": "..",
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist", "tmp"]
+}

--- a/tools/release-metadata/webappVersion.test.ts
+++ b/tools/release-metadata/webappVersion.test.ts
@@ -1,0 +1,212 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+
+import {isString} from '@sindresorhus/is';
+
+import {
+  createWebAppVersionSynchronizationMarker,
+  parseWebAppVersionSynchronizationMarker,
+  resolveNextWebAppVersion,
+  updateWebAppPackageDocuments,
+  validateMatchingWebAppPackageVersions,
+  validateWebAppVersion,
+} from './webappVersion.ts';
+
+type TestPackageDocument = Readonly<Record<string, unknown>>;
+
+function createTestPackageDocument(version?: string): TestPackageDocument {
+  const packageDocument: Record<string, unknown> = {
+    name: '@wireapp/example',
+    private: true,
+    scripts: {test: 'jest'},
+  };
+
+  if (isString(version)) {
+    packageDocument.version = version;
+  }
+
+  return packageDocument;
+}
+
+function expectNextVersion(currentVersion: string, expectedVersion: string): void {
+  const actualVersionResult = resolveNextWebAppVersion(currentVersion);
+
+  assert(actualVersionResult.isOk);
+  expect(actualVersionResult.value).toBe(expectedVersion);
+}
+
+describe('WebApp version domain logic', () => {
+  it.each([
+    ['0.27.0', '1.0.0'],
+    ['0.99.999', '1.0.0'],
+    ['1.0.0', '1.0.1'],
+    ['1.0.9', '1.0.10'],
+    ['1.2.99', '1.2.100'],
+    ['2.4.7', '2.4.8'],
+  ])('resolves %s to %s', (currentVersion, expectedVersion) => {
+    expectNextVersion(currentVersion, expectedVersion);
+  });
+
+  it.each([undefined, null, '', '1.0', '1.0.0-beta.1', '1.0.0+abc', '-1.0.0', '1.-1.0', 'one.0.0', '01.0.0'])(
+    'rejects invalid WebApp version %s',
+    invalidVersion => {
+      const actualVersionResult = validateWebAppVersion(invalidVersion);
+
+      assert(actualVersionResult.isErr);
+    },
+  );
+
+  it('accepts matching root and WebApp package versions', () => {
+    const actualVersionsResult = validateMatchingWebAppPackageVersions(
+      createTestPackageDocument('0.27.0'),
+      createTestPackageDocument('0.27.0'),
+    );
+
+    assert(actualVersionsResult.isOk);
+    expect(actualVersionsResult.value).toEqual({rootVersion: '0.27.0', webAppVersion: '0.27.0'});
+  });
+
+  it('rejects mismatching root and WebApp package versions', () => {
+    const actualVersionsResult = validateMatchingWebAppPackageVersions(
+      createTestPackageDocument('0.27.0'),
+      createTestPackageDocument('1.0.0'),
+    );
+
+    assert(actualVersionsResult.isErr);
+    expect(actualVersionsResult.error.message).toContain('WebApp package versions disagree');
+  });
+
+  it('rejects a missing package version', () => {
+    const actualVersionsResult = validateMatchingWebAppPackageVersions(
+      createTestPackageDocument(),
+      createTestPackageDocument('0.27.0'),
+    );
+
+    assert(actualVersionsResult.isErr);
+    expect(actualVersionsResult.error.message).toBe('Missing WebApp package version: package.json');
+  });
+
+  it('rejects a malformed package version', () => {
+    const actualVersionsResult = validateMatchingWebAppPackageVersions(
+      createTestPackageDocument('1.0.0-beta.1'),
+      createTestPackageDocument('1.0.0-beta.1'),
+    );
+
+    assert(actualVersionsResult.isErr);
+    expect(actualVersionsResult.error.message).toContain('Invalid WebApp version: 1.0.0-beta.1');
+  });
+
+  it('updates only the version field in both package documents', () => {
+    const rootPackageDocument = createTestPackageDocument('0.27.0');
+    const webAppPackageDocument = createTestPackageDocument('0.27.0');
+    const actualUpdateResult = updateWebAppPackageDocuments({
+      rootPackageDocument,
+      webAppPackageDocument,
+      targetVersion: '1.0.0',
+    });
+
+    assert(actualUpdateResult.isOk);
+    expect(actualUpdateResult.value).toEqual({
+      rootPackageDocument: {...rootPackageDocument, version: '1.0.0'},
+      webAppPackageDocument: {...webAppPackageDocument, version: '1.0.0'},
+    });
+  });
+
+  it('rejects package updates before changing anything when versions disagree', () => {
+    const actualUpdateResult = updateWebAppPackageDocuments({
+      rootPackageDocument: createTestPackageDocument('0.27.0'),
+      webAppPackageDocument: createTestPackageDocument('1.0.0'),
+      targetVersion: '1.0.1',
+    });
+
+    assert(actualUpdateResult.isErr);
+    expect(actualUpdateResult.error.message).toContain('WebApp package versions disagree');
+  });
+});
+
+describe('WebApp version synchronization marker', () => {
+  const markerOptions = {
+    releaseIdentifier: '2026-09-09.1',
+    productionTagName: '2026-09-09.1-production',
+    webAppVersion: '1.0.0',
+  };
+
+  it('round-trips a synchronization marker', () => {
+    const actualMarkerResult = createWebAppVersionSynchronizationMarker(markerOptions);
+
+    assert(actualMarkerResult.isOk);
+
+    const actualParsedMarkerResult = parseWebAppVersionSynchronizationMarker(actualMarkerResult.value);
+
+    assert(actualParsedMarkerResult.isOk);
+    expect(actualParsedMarkerResult.value).toEqual({
+      releaseIdentifier: '2026-09-09.1',
+      productionTagName: '2026-09-09.1-production',
+      webAppVersion: '1.0.0',
+    });
+  });
+
+  it('parses a marker embedded in a pull request body', () => {
+    const markerResult = createWebAppVersionSynchronizationMarker(markerOptions);
+
+    assert(markerResult.isOk);
+
+    const actualMarkerResult = parseWebAppVersionSynchronizationMarker(
+      `Synchronize deployed metadata.\n\n${markerResult.value}\n`,
+    );
+
+    assert(actualMarkerResult.isOk);
+    expect(actualMarkerResult.value.webAppVersion).toBe('1.0.0');
+  });
+
+  it.each([
+    '<!-- wire-webapp-version-sync release=2026-09-09.1 production-tag=2026-09-09.1-production -->',
+    '<!-- wire-webapp-version-sync release=2026-09-09.1 version=1.0.0 -->',
+    '<!-- wire-webapp-version-sync release=2026-09-09.1 production-tag=2026-09-09.1-production version=1.0.0',
+    '<!-- wire-webapp-version-sync release=2026-09-09.1 production-tag=2026-09-09.1-production version=1.0.0-beta.1 -->',
+    '<!-- wire-webapp-version-sync release=2026-09-09.1 production-tag=2026-09-10.1-production version=1.0.0 -->',
+  ])('rejects malformed or incomplete marker %s', invalidMarker => {
+    const actualMarkerResult = parseWebAppVersionSynchronizationMarker(invalidMarker);
+
+    assert(actualMarkerResult.isErr);
+  });
+
+  it('rejects duplicate synchronization markers', () => {
+    const markerResult = createWebAppVersionSynchronizationMarker(markerOptions);
+
+    assert(markerResult.isOk);
+
+    const actualMarkerResult = parseWebAppVersionSynchronizationMarker(`${markerResult.value}\n${markerResult.value}`);
+
+    assert(actualMarkerResult.isErr);
+    expect(actualMarkerResult.error.message).toBe('WebApp version synchronization marker must occur exactly once');
+  });
+
+  it('rejects a marker with an invalid release identifier', () => {
+    const actualMarkerResult = createWebAppVersionSynchronizationMarker({
+      ...markerOptions,
+      releaseIdentifier: '2026-09-09.0',
+      productionTagName: '2026-09-09.0-production',
+    });
+
+    assert(actualMarkerResult.isErr);
+  });
+});

--- a/tools/release-metadata/webappVersion.ts
+++ b/tools/release-metadata/webappVersion.ts
@@ -1,0 +1,312 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isNonEmptyArray, isNull, isPlainObject, isString, isUndefined} from '@sindresorhus/is';
+import {Result} from 'true-myth';
+
+import {createProductionTagName} from './releaseMetadata.ts';
+import type {ProductionTagName, ReleaseIdentifier} from './releaseMetadata.ts';
+
+declare const webAppVersionBrand: unique symbol;
+
+export type WebAppVersion = string & {readonly [webAppVersionBrand]: 'WebAppVersion'};
+
+export type WebAppPackageDocument = Readonly<Record<string, unknown>>;
+
+export type WebAppPackageVersions = {
+  readonly rootVersion: WebAppVersion;
+  readonly webAppVersion: WebAppVersion;
+};
+
+export type WebAppPackageDocuments = {
+  readonly rootPackageDocument: WebAppPackageDocument;
+  readonly webAppPackageDocument: WebAppPackageDocument;
+};
+
+export type UpdateWebAppPackageDocumentsOptions = {
+  readonly rootPackageDocument: unknown;
+  readonly webAppPackageDocument: unknown;
+  readonly targetVersion: string;
+};
+
+export type CreateWebAppVersionSynchronizationMarkerOptions = {
+  readonly releaseIdentifier: string;
+  readonly productionTagName: string;
+  readonly webAppVersion: string;
+};
+
+export type WebAppVersionSynchronizationMarker = {
+  readonly releaseIdentifier: ReleaseIdentifier;
+  readonly productionTagName: ProductionTagName;
+  readonly webAppVersion: WebAppVersion;
+};
+
+type ValidatedWebAppPackageDocuments = WebAppPackageDocuments & WebAppPackageVersions;
+
+const strictWebAppVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const releaseIdentifierPattern = String.raw`\d{4}-\d{2}-\d{2}\.[1-9]\d*`;
+const patchVersionIncrement = BigInt('1');
+const synchronizationMarkerPattern = new RegExp(
+  String.raw`<!-- wire-webapp-version-sync release=(${releaseIdentifierPattern}) production-tag=(${releaseIdentifierPattern}-production) version=((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)) -->`,
+);
+const synchronizationMarkerSearchPattern = new RegExp(synchronizationMarkerPattern.source, 'g');
+
+function validateWebAppPackageDocument(
+  packageDocument: unknown,
+  packagePath: string,
+): Result<WebAppPackageDocument, Error> {
+  if (isPlainObject(packageDocument) === false) {
+    return Result.err(new Error(`WebApp package document is not an object: ${packagePath}`));
+  }
+
+  return Result.ok(packageDocument);
+}
+
+function validatePackageDocumentVersion(
+  packageDocument: WebAppPackageDocument,
+  packagePath: string,
+): Result<WebAppVersion, Error> {
+  const packageVersion = packageDocument.version;
+
+  if (isUndefined(packageVersion)) {
+    return Result.err(new Error(`Missing WebApp package version: ${packagePath}`));
+  }
+
+  const versionResult = validateWebAppVersion(packageVersion);
+
+  if (versionResult.isErr) {
+    return Result.err(new Error(`${versionResult.error.message} in ${packagePath}`));
+  }
+
+  return versionResult;
+}
+
+function validateWebAppPackageDocuments(
+  rootPackageDocument: unknown,
+  webAppPackageDocument: unknown,
+): Result<ValidatedWebAppPackageDocuments, Error> {
+  const validatedRootPackageDocumentResult = validateWebAppPackageDocument(rootPackageDocument, 'package.json');
+
+  if (validatedRootPackageDocumentResult.isErr) {
+    return Result.err(new Error(validatedRootPackageDocumentResult.error.message));
+  }
+
+  const validatedWebAppPackageDocumentResult = validateWebAppPackageDocument(
+    webAppPackageDocument,
+    'apps/webapp/package.json',
+  );
+
+  if (validatedWebAppPackageDocumentResult.isErr) {
+    return Result.err(new Error(validatedWebAppPackageDocumentResult.error.message));
+  }
+
+  const rootVersionResult = validatePackageDocumentVersion(validatedRootPackageDocumentResult.value, 'package.json');
+
+  if (rootVersionResult.isErr) {
+    return Result.err(new Error(rootVersionResult.error.message));
+  }
+
+  const webAppVersionResult = validatePackageDocumentVersion(
+    validatedWebAppPackageDocumentResult.value,
+    'apps/webapp/package.json',
+  );
+
+  if (webAppVersionResult.isErr) {
+    return Result.err(new Error(webAppVersionResult.error.message));
+  }
+
+  if (rootVersionResult.value !== webAppVersionResult.value) {
+    return Result.err(
+      new Error(
+        `WebApp package versions disagree: package.json=${rootVersionResult.value}, apps/webapp/package.json=${webAppVersionResult.value}`,
+      ),
+    );
+  }
+
+  return Result.ok({
+    rootPackageDocument: validatedRootPackageDocumentResult.value,
+    webAppPackageDocument: validatedWebAppPackageDocumentResult.value,
+    rootVersion: rootVersionResult.value,
+    webAppVersion: webAppVersionResult.value,
+  });
+}
+
+function createWebAppVersionSynchronizationMarkerValue(
+  options: CreateWebAppVersionSynchronizationMarkerOptions,
+): Result<WebAppVersionSynchronizationMarker, Error> {
+  const productionTagResult = createProductionTagName(options.releaseIdentifier);
+
+  if (productionTagResult.isErr) {
+    return Result.err(new Error(productionTagResult.error.message));
+  }
+
+  if (productionTagResult.value !== options.productionTagName) {
+    return Result.err(
+      new Error(
+        `Production tag ${options.productionTagName} does not match release identifier ${options.releaseIdentifier}`,
+      ),
+    );
+  }
+
+  const webAppVersionResult = validateWebAppVersion(options.webAppVersion);
+
+  if (webAppVersionResult.isErr) {
+    return Result.err(new Error(webAppVersionResult.error.message));
+  }
+
+  return Result.ok({
+    releaseIdentifier: options.releaseIdentifier as ReleaseIdentifier,
+    productionTagName: productionTagResult.value,
+    webAppVersion: webAppVersionResult.value,
+  });
+}
+
+export function validateWebAppVersion(version: unknown): Result<WebAppVersion, Error> {
+  if (isString(version) === false) {
+    return Result.err(new Error('WebApp version must be a string'));
+  }
+
+  if (strictWebAppVersionPattern.test(version) === false) {
+    return Result.err(new Error(`Invalid WebApp version: ${version}`));
+  }
+
+  return Result.ok(version as WebAppVersion);
+}
+
+export function resolveNextWebAppVersion(currentVersion: string): Result<WebAppVersion, Error> {
+  const currentVersionResult = validateWebAppVersion(currentVersion);
+
+  if (currentVersionResult.isErr) {
+    return Result.err(new Error(currentVersionResult.error.message));
+  }
+
+  const [majorVersion, minorVersion, patchVersion] = currentVersionResult.value.split('.');
+
+  if (majorVersion === '0') {
+    return Result.ok('1.0.0' as WebAppVersion);
+  }
+
+  return Result.ok(`${majorVersion}.${minorVersion}.${BigInt(patchVersion) + patchVersionIncrement}` as WebAppVersion);
+}
+
+export function validateMatchingWebAppPackageVersions(
+  rootPackageDocument: unknown,
+  webAppPackageDocument: unknown,
+): Result<WebAppPackageVersions, Error> {
+  const validatedPackageDocumentsResult = validateWebAppPackageDocuments(rootPackageDocument, webAppPackageDocument);
+
+  if (validatedPackageDocumentsResult.isErr) {
+    return Result.err(new Error(validatedPackageDocumentsResult.error.message));
+  }
+
+  return Result.ok({
+    rootVersion: validatedPackageDocumentsResult.value.rootVersion,
+    webAppVersion: validatedPackageDocumentsResult.value.webAppVersion,
+  });
+}
+
+export function updateWebAppPackageDocuments(
+  options: UpdateWebAppPackageDocumentsOptions,
+): Result<WebAppPackageDocuments, Error> {
+  const validatedPackageDocumentsResult = validateWebAppPackageDocuments(
+    options.rootPackageDocument,
+    options.webAppPackageDocument,
+  );
+
+  if (validatedPackageDocumentsResult.isErr) {
+    return Result.err(new Error(validatedPackageDocumentsResult.error.message));
+  }
+
+  const targetVersionResult = validateWebAppVersion(options.targetVersion);
+
+  if (targetVersionResult.isErr) {
+    return Result.err(new Error(targetVersionResult.error.message));
+  }
+
+  const {rootPackageDocument, webAppPackageDocument} = validatedPackageDocumentsResult.value;
+
+  return Result.ok({
+    rootPackageDocument: {...rootPackageDocument, version: targetVersionResult.value},
+    webAppPackageDocument: {...webAppPackageDocument, version: targetVersionResult.value},
+  });
+}
+
+export function createWebAppVersionSynchronizationMarker(
+  options: CreateWebAppVersionSynchronizationMarkerOptions,
+): Result<string, Error> {
+  const markerValueResult = createWebAppVersionSynchronizationMarkerValue(options);
+
+  if (markerValueResult.isErr) {
+    return Result.err(new Error(markerValueResult.error.message));
+  }
+
+  const marker = markerValueResult.value;
+
+  return Result.ok(
+    `<!-- wire-webapp-version-sync release=${marker.releaseIdentifier} production-tag=${marker.productionTagName} version=${marker.webAppVersion} -->`,
+  );
+}
+
+export function parseWebAppVersionSynchronizationMarker(
+  value: unknown,
+): Result<WebAppVersionSynchronizationMarker, Error> {
+  if (isString(value) === false) {
+    return Result.err(new Error('WebApp version synchronization marker must be a string'));
+  }
+
+  const markerMatches = value.match(synchronizationMarkerSearchPattern);
+
+  if (isNonEmptyArray(markerMatches) === false) {
+    return Result.err(new Error('Malformed WebApp version synchronization marker'));
+  }
+
+  if (markerMatches.length > 1) {
+    return Result.err(new Error('WebApp version synchronization marker must occur exactly once'));
+  }
+
+  const firstMarker = markerMatches.at(0);
+
+  if (isString(firstMarker) === false) {
+    return Result.err(new Error('Malformed WebApp version synchronization marker'));
+  }
+
+  const markerMatch = synchronizationMarkerPattern.exec(firstMarker);
+
+  if (isNull(markerMatch)) {
+    return Result.err(new Error('Malformed WebApp version synchronization marker'));
+  }
+
+  const releaseIdentifier = markerMatch[1];
+  const productionTagName = markerMatch[2];
+  const webAppVersion = markerMatch[3];
+
+  if (
+    isString(releaseIdentifier) === false ||
+    isString(productionTagName) === false ||
+    isString(webAppVersion) === false
+  ) {
+    return Result.err(new Error('Malformed WebApp version synchronization marker'));
+  }
+
+  return createWebAppVersionSynchronizationMarkerValue({
+    releaseIdentifier,
+    productionTagName,
+    webAppVersion,
+  });
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Adds the pure domain logic required for synchronizing the WebApp package version with successful Production releases.

This introduces:

* strict WebApp version parsing and validation
* validation that the root package and `apps/webapp/package.json` use the same version
* deterministic calculation of the next Production version
* package-version update logic
* machine-readable synchronization marker generation and parsing
* focused tests for version calculation, validation, and marker handling

The new versioning scheme is:

```text
legacy 0.x.y -> 1.0.0
1.0.0 -> 1.0.1
1.0.1 -> 1.0.2
...
```
