### PR TITLE
feat: disable read receipts for MLS/Mixed protocol [WPB-27943]

### DIFF
--- a/apps/webapp/src/script/page/rightSidebar/conversationDetails/components/conversationDetailsOptions/conversationDetailsOptions.tsx
+++ b/apps/webapp/src/script/page/rightSidebar/conversationDetails/components/conversationDetailsOptions/conversationDetailsOptions.tsx
@@ -36,7 +36,7 @@ import {PanelActions} from 'Components/panel/panelActions';
 import {ReceiptModeToggle} from 'Components/toggle/ReceiptModeToggle';
 import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
 import {ConversationRoleRepository} from 'Repositories/conversation/ConversationRoleRepository';
-import {isGroupMLSConversation} from 'Repositories/conversation/ConversationSelectors';
+import {supportsReadReceipts} from 'Repositories/conversation/ConversationSelectors';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {TeamState} from 'Repositories/team/TeamState';
@@ -165,7 +165,7 @@ function ConversationDetailsOptionsContent({
   const showOptionTimedMessages = isActiveGroupParticipant && isSelfDeletingMessagesEnabled;
   const showOptionServices = isActiveGroupParticipant && isTeamConversation;
   const showOptionNotifications1To1 = isMutable && !isGroupOrChannel;
-  const showOptionReadReceipts = isTeamConversation && !isGroupMLSConversation(activeConversation);
+  const showOptionReadReceipts = isTeamConversation && supportsReadReceipts(activeConversation);
   const showChannelOptions = isChannel && isChannelsEnabled;
 
   const hasReceiptsEnabled = conversationRepository.expectReadReceipt(activeConversation);

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.test.ts
@@ -3281,6 +3281,17 @@ describe('ConversationRepository', () => {
   });
 
   describe('shouldSendReadReceipt', () => {
+    it.each([CONVERSATION_PROTOCOL.MIXED, CONVERSATION_PROTOCOL.MLS])(
+      'does not expect group read receipts for %s even with a stale enabled setting',
+      protocol => {
+        const conversation = _generateConversation({type: CONVERSATION_TYPE.REGULAR, protocol});
+        conversation.teamId = 'team';
+        conversation.receiptMode(RECEIPT_MODE.ON);
+
+        expect(testFactory.conversation_repository.expectReadReceipt(conversation)).toBe(false);
+      },
+    );
+
     it('uses the account preference for 1:1 conversations', () => {
       // Set a receipt mode on account-level
       const preferenceMode = RECEIPT_MODE.ON;
@@ -3736,12 +3747,61 @@ describe('ConversationRepository', () => {
   });
 
   describe('updateConversationProtocol', () => {
+    it('clears receipt mode when another client starts migration', async () => {
+      const conversation = _generateConversation({type: CONVERSATION_TYPE.REGULAR});
+      conversation.receiptMode(RECEIPT_MODE.ON);
+      const repository = await testFactory.exposeConversationActors();
+      jest.spyOn(repository['conversationService'], 'saveConversationStateInDb').mockResolvedValue(conversation);
+      jest
+        .spyOn(repository['conversationService'], 'getConversationById')
+        .mockResolvedValue(generateAPIConversation({protocol: CONVERSATION_PROTOCOL.MIXED}));
+      const eventHandler = repository as unknown as {
+        addEventToConversation: ConversationRepository['addEventToConversation'];
+      };
+      jest.spyOn(eventHandler, 'addEventToConversation').mockResolvedValue({
+        conversationEntity: conversation,
+        messageEntity: new Message('protocol-update', undefined, translateForTest),
+      });
+      const event = {
+        data: {protocol: CONVERSATION_PROTOCOL.MIXED},
+        qualified_conversation: conversation.qualifiedId,
+        time: '2020-10-13T14:00:00.000Z',
+        type: CONVERSATION_EVENT.PROTOCOL_UPDATE,
+      } as ConversationProtocolUpdateEvent;
+
+      await repository['onProtocolUpdate'](conversation, event);
+
+      expect(conversation.receiptMode()).toBe(RECEIPT_MODE.OFF);
+    });
+
+    it.each([CONVERSATION_PROTOCOL.MIXED, CONVERSATION_PROTOCOL.MLS])(
+      'clears and persists group receipt mode when refreshing protocol %s',
+      async protocol => {
+        const conversation = _generateConversation({type: CONVERSATION_TYPE.REGULAR});
+        conversation.receiptMode(RECEIPT_MODE.ON);
+        const repository = await testFactory.exposeConversationActors();
+        const save = jest
+          .spyOn(repository['conversationService'], 'saveConversationStateInDb')
+          .mockResolvedValue(conversation);
+        jest
+          .spyOn(repository['conversationService'], 'getConversationById')
+          .mockResolvedValue(generateAPIConversation({protocol, overwites: {receipt_mode: RECEIPT_MODE.ON}}));
+
+        const updated = await repository['refreshConversationProtocolProperties'](conversation);
+
+        expect(updated.receiptMode()).toBe(RECEIPT_MODE.OFF);
+        expect(save).toHaveBeenCalledWith(updated);
+        expect(updated.serialize().receipt_mode).toBe(RECEIPT_MODE.OFF);
+      },
+    );
+
     afterEach(() => {
       jest.clearAllMocks();
     });
 
     it('should update the protocol-related fields after protocol was updated to mixed and inject event', async () => {
-      const conversation = _generateConversation();
+      const conversation = _generateConversation({type: CONVERSATION_TYPE.REGULAR});
+      conversation.receiptMode(RECEIPT_MODE.ON);
       const conversationRepository = await testFactory.exposeConversationActors();
 
       const mockedProtocolUpdateEventResponse = {
@@ -3789,6 +3849,7 @@ describe('ConversationRepository', () => {
         EventRepository.SOURCE.BACKEND_RESPONSE,
       );
 
+      expect(updatedConversation.receiptMode()).toBe(RECEIPT_MODE.OFF);
       expect(updatedConversation.protocol).toEqual(CONVERSATION_PROTOCOL.MIXED);
       expect(updatedConversation.cipherSuite).toEqual(newCipherSuite);
       expect(updatedConversation.epoch).toEqual(newEpoch);

--- a/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationRepository.ts
@@ -134,6 +134,7 @@ import {
   MLSCapableConversation,
   MLSConversation,
   ProteusConversation,
+  supportsReadReceipts,
 } from './ConversationSelectors';
 import {ConversationService} from './ConversationService';
 import {ConversationState} from './ConversationState';
@@ -3211,6 +3212,10 @@ export class ConversationRepository {
       protocol: newProtocol,
     });
 
+    if (!supportsReadReceipts(updatedConversation)) {
+      updatedConversation.receiptMode(RECEIPT_MODE.OFF);
+    }
+
     await this.saveConversationStateInDb(updatedConversation);
     return updatedConversation;
   }
@@ -5066,6 +5071,10 @@ export class ConversationRepository {
   //##############################################################################
 
   expectReadReceipt(conversationEntity: Conversation): boolean {
+    if (!supportsReadReceipts(conversationEntity)) {
+      return false;
+    }
+
     if (conversationEntity.is1to1()) {
       return this.propertyRepository.receiptMode() === RECEIPT_MODE.ON;
     }

--- a/apps/webapp/src/script/repositories/conversation/ConversationSelectors.ts
+++ b/apps/webapp/src/script/repositories/conversation/ConversationSelectors.ts
@@ -54,6 +54,14 @@ export function isGroupMLSConversation(conversation: Conversation): conversation
   return isMLSConversation(conversation) && conversation.isGroupOrChannel();
 }
 
+/** MLS groups cannot target read receipts to individual members yet. */
+export function supportsReadReceipts(conversation: Conversation): boolean {
+  return (
+    !conversation.isGroupOrChannel() ||
+    (conversation.protocol !== CONVERSATION_PROTOCOL.MIXED && conversation.protocol !== CONVERSATION_PROTOCOL.MLS)
+  );
+}
+
 export function isSelfConversation(conversation: Conversation): boolean {
   return conversation.type() === CONVERSATION_TYPE.SELF;
 }

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.test.ts
@@ -25,7 +25,7 @@ import {assertNotNullOrUndefined} from '@sindresorhus/is';
 import {amplify} from 'amplify';
 
 import {Account} from '@wireapp/core';
-import {GenericMessage, LegalHoldStatus} from '@wireapp/protocol-messaging';
+import {Confirmation, GenericMessage, LegalHoldStatus} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {AssetRepository} from 'Repositories/assets/assetRepository';
@@ -43,6 +43,8 @@ import {Message} from 'Repositories/entity/message/message';
 import {Text} from 'Repositories/entity/message/text';
 import {User} from 'Repositories/entity/User';
 import {EventRepository} from 'Repositories/event/EventRepository';
+import {ClientEvent} from 'Repositories/event/Client';
+import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
 import {EventService} from 'Repositories/event/EventService';
 import {PropertiesRepository} from 'Repositories/properties/propertiesRepository';
 import {ReactionMap} from 'Repositories/storage';
@@ -57,6 +59,7 @@ import {translateForTest} from 'Util/test/translateForTest';
 import {createUuid} from 'Util/uuid';
 
 import {ConversationRepository} from './ConversationRepository';
+import {ConversationMapper} from './ConversationMapper';
 import {ConversationState} from './ConversationState';
 import {MessageRepository} from './MessageRepository';
 import {ConversationVerificationState} from './ConversationVerificationState';
@@ -166,6 +169,32 @@ describe('MessageRepository', () => {
     id: createUuid(),
     state: MessageSendingState.OUTGOING_SENT,
   };
+
+  describe('read receipts after migration', () => {
+    it.each([
+      [CONVERSATION_PROTOCOL.PROTEUS, CONVERSATION_TYPE.REGULAR, true],
+      [CONVERSATION_PROTOCOL.MIXED, CONVERSATION_TYPE.REGULAR, false],
+      [CONVERSATION_PROTOCOL.MLS, CONVERSATION_TYPE.REGULAR, false],
+      [CONVERSATION_PROTOCOL.MLS, CONVERSATION_TYPE.ONE_TO_ONE, true],
+    ])('checks the current protocol %s and conversation type %s before sending', async (protocol, type, shouldSend) => {
+      const [messageRepository] = await buildMessageRepository(translateForTest);
+      const send = jest
+        .spyOn(messageRepository as unknown as MessageRepositoryPrivateMethodsForTest, 'sendAndInjectMessage')
+        .mockResolvedValue(successPayload);
+      const conversation = generateConversation(type);
+      conversation.receiptMode(RECEIPT_MODE.ON);
+      const message = new ContentMessage('unread-message', translateForTest);
+      message.type = ClientEvent.CONVERSATION.MESSAGE_ADD;
+      message.user(new User('sender', '', translateForTest));
+      message.expectsReadConfirmation = true;
+
+      // The message was received before migration; group metadata may still be missing.
+      ConversationMapper.updateProperties(conversation, {protocol});
+      await messageRepository.sendConfirmationStatus(conversation, message, Confirmation.Type.READ, [message]);
+
+      expect(send).toHaveBeenCalledTimes(shouldSend ? 1 : 0);
+    });
+  });
 
   describe('sendPing', () => {
     it('sends a ping', async () => {

--- a/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
+++ b/apps/webapp/src/script/repositories/conversation/MessageRepository.ts
@@ -100,7 +100,7 @@ import {createUuid} from 'Util/uuid';
 
 import {findDeletedClients} from './ClientMismatchUtil';
 import {ConversationRepository} from './ConversationRepository';
-import {isMLSConversation} from './ConversationSelectors';
+import {isMLSConversation, supportsReadReceipts} from './ConversationSelectors';
 import {ConversationState} from './ConversationState';
 import {ConversationVerificationState} from './ConversationVerificationState';
 import {EventBuilder} from './EventBuilder';
@@ -1221,6 +1221,10 @@ export class MessageRepository {
     type: Confirmation.Type,
     moreMessageEntities: Message[] = [],
   ) {
+    if (type === Confirmation.Type.READ && !supportsReadReceipts(conversationEntity)) {
+      return;
+    }
+
     const typeToConfirm = (EventTypeHandling.CONFIRM as string[]).includes(messageEntity.type);
 
     if (messageEntity.user().isMe || !typeToConfirm) {
@@ -1286,6 +1290,10 @@ export class MessageRepository {
   }
 
   private expectReadReceipt(conversationEntity: Conversation): boolean {
+    if (!supportsReadReceipts(conversationEntity)) {
+      return false;
+    }
+
     if (conversationEntity.is1to1()) {
       return !!this.propertyRepository.receiptMode();
     }

--- a/apps/webapp/src/script/repositories/event/preprocessor/ReceiptsMiddleware.test.ts
+++ b/apps/webapp/src/script/repositories/event/preprocessor/ReceiptsMiddleware.test.ts
@@ -17,6 +17,13 @@
  *
  */
 
+import {CONVERSATION_TYPE} from '@wireapp/api-client/lib/conversation';
+import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
+import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
+
+import {Conversation} from 'Repositories/entity/Conversation';
+import type {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
+import type {IncomingEvent} from '../EventProcessor';
 import {ConfirmationEvent} from 'Repositories/conversation/EventBuilder';
 import {User} from 'Repositories/entity/User';
 import {StatusType} from 'src/script/message/statusType';
@@ -36,6 +43,30 @@ function buildReadReceiptMiddleware() {
 
 describe('ReceiptsMiddleware', () => {
   describe('processEvent', () => {
+    it.each([
+      [CONVERSATION_PROTOCOL.PROTEUS, CONVERSATION_TYPE.REGULAR, true],
+      [CONVERSATION_PROTOCOL.MIXED, CONVERSATION_TYPE.REGULAR, false],
+      [CONVERSATION_PROTOCOL.MLS, CONVERSATION_TYPE.REGULAR, false],
+      [CONVERSATION_PROTOCOL.MLS, CONVERSATION_TYPE.ONE_TO_ONE, true],
+    ])('sets receipt expectations for protocol %s and type %s', async (protocol, type, expected) => {
+      const conversation = new Conversation('conversation', '', protocol, translateForTest);
+      conversation.type(type);
+      conversation.receiptMode(RECEIPT_MODE.ON);
+      const repository = {
+        getConversationById: jest.fn().mockResolvedValue(conversation),
+      } as unknown as ConversationRepository;
+      const middleware = new ReceiptsMiddleware({} as any, repository, new User('self', '', translateForTest));
+      const event = {
+        conversation: conversation.id,
+        type: ClientEvent.CONVERSATION.MESSAGE_ADD,
+        data: {expects_read_confirmation: true},
+      };
+
+      await middleware.processEvent(event as IncomingEvent);
+
+      expect(event.data.expects_read_confirmation).toBe(expected);
+    });
+
     it('ignores read receipt for which original message is not found', async () => {
       const event = createConfirmationEvent(3);
       const [readReceiptMiddleware, {eventService}] = buildReadReceiptMiddleware();

--- a/apps/webapp/src/script/repositories/event/preprocessor/ReceiptsMiddleware.ts
+++ b/apps/webapp/src/script/repositories/event/preprocessor/ReceiptsMiddleware.ts
@@ -20,6 +20,7 @@
 import {RECEIPT_MODE} from '@wireapp/api-client/lib/conversation/data';
 
 import type {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
+import {supportsReadReceipts} from 'Repositories/conversation/ConversationSelectors';
 import {ConfirmationEvent} from 'Repositories/conversation/EventBuilder';
 import {User} from 'Repositories/entity/User';
 import type {EventRecord} from 'Repositories/storage/record/eventRecord';
@@ -54,7 +55,8 @@ export class ReceiptsMiddleware implements EventMiddleware {
         const conversation = await this.conversationRepository.getConversationById(qualifiedConversation);
         if (conversation?.isGroupOrChannel()) {
           // We only override the value of expects_read_confirmation for group conversations (one to one conversation use the value set by the sender)
-          event.data.expects_read_confirmation = conversation.receiptMode() === RECEIPT_MODE.ON;
+          event.data.expects_read_confirmation =
+            supportsReadReceipts(conversation) && conversation.receiptMode() === RECEIPT_MODE.ON;
         }
         return event;
       }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27943" title="WPB-27943" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27943</a>  [Web] Read receipts are still enable after migration to mls
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Description

Disable group read receipts when conversations migrate to MIXED or MLS, without requiring a reload. Reset and persist the receipt setting, block queued receipts, and hide the toggle. Preserve one-to-one behavior.