### PR TITLE
Add WebApp version synchronization orchestration [WPB-26469]

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -93,7 +93,7 @@ const legacySettings = {
     version: 'detect',
   },
   'import/parsers': {
-    '@typescript-eslint/parser': ['.js', '.jsx', '.ts', '.tsx'],
+    '@typescript-eslint/parser': ['.js', '.jsx', '.ts', '.tsx', '.mts'],
   },
   'import/resolver': {
     typescript: {
@@ -344,7 +344,7 @@ const productionConfigs = [
     },
   },
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ['**/*.{ts,tsx}', 'tools/release-cli/webappVersionSynchronization.mts'],
     languageOptions: {
       parser: tsParser,
       parserOptions: {
@@ -443,6 +443,15 @@ const productionConfigs = [
         node: {
           extensions: ['.js', '.jsx', '.ts', '.tsx'],
         },
+      },
+    },
+  },
+  {
+    files: ['tools/release-cli/webappVersionSynchronization.mts'],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.release-cli.json',
+        projectService: false,
       },
     },
   },

--- a/project.json
+++ b/project.json
@@ -31,7 +31,7 @@
       "executor": "nx:run-commands",
       "dependsOn": [],
       "options": {
-        "command": "eslint --config eslint.config.mjs --max-warnings=0 tools/release-appearance tools/release-metadata/webappVersionSynchronizationCli.ts tools/release-cli/webappVersionSynchronization.mts 'tools/**/*.test.ts'"
+        "command": "eslint --config eslint.config.mjs --max-warnings=0 tools/release-appearance tools/release-metadata/webappVersionSynchronizationCli.ts tools/release-metadata/webappVersionSynchronizationRuntime.ts tools/release-cli/webappVersionSynchronization.mts 'tools/**/*.test.ts'"
       }
     },
     "e2e": {

--- a/project.json
+++ b/project.json
@@ -31,7 +31,7 @@
       "executor": "nx:run-commands",
       "dependsOn": [],
       "options": {
-        "command": "eslint --config eslint.config.mjs --max-warnings=0 tools/release-appearance tools/release-metadata/webappVersionSynchronizationCli.ts tools/release-metadata/webappVersionSynchronizationRuntime.ts tools/release-cli/webappVersionSynchronization.mts 'tools/**/*.test.ts'"
+        "command": "eslint --config eslint.config.mjs --max-warnings=0 tools/release-appearance 'tools/release-metadata/web*Version*.ts' tools/release-cli/webappVersionSynchronization.mts 'tools/**/*.test.ts'"
       }
     },
     "e2e": {

--- a/project.json
+++ b/project.json
@@ -31,7 +31,7 @@
       "executor": "nx:run-commands",
       "dependsOn": [],
       "options": {
-        "command": "eslint --config eslint.config.mjs --max-warnings=0 tools/release-appearance 'tools/**/*.test.ts'"
+        "command": "eslint --config eslint.config.mjs --max-warnings=0 tools/release-appearance tools/release-metadata/webappVersionSynchronizationCli.ts tools/release-cli/webappVersionSynchronization.mts 'tools/**/*.test.ts'"
       }
     },
     "e2e": {

--- a/tools/release-cli/releaseCliEntrypoints.test.ts
+++ b/tools/release-cli/releaseCliEntrypoints.test.ts
@@ -39,6 +39,10 @@ const releaseMetadataEntrypointPath = join(process.cwd(), 'tools/release-cli/rel
 const productionDistributionEntrypointPath = join(process.cwd(), 'tools/release-cli/productionDistributionCli.mts');
 const releaseAppearanceEntrypointPath = join(process.cwd(), 'tools/release-cli/releaseAppearanceCommand.mts');
 const previewNextBetaEntrypointPath = join(process.cwd(), 'tools/release-cli/previewNextBetaCommand.mts');
+const webAppVersionSynchronizationEntrypointPath = join(
+  process.cwd(),
+  'tools/release-cli/webappVersionSynchronization.mts',
+);
 const ensureProductionGitHubReleaseEntrypointPath = join(
   process.cwd(),
   'tools/release-cli/ensureProductionGitHubRelease.mts',
@@ -126,6 +130,22 @@ describe('ensure Production GitHub Release CLI entrypoint', () => {
 
     expect(actualResult.exitCode).toBe(1);
     expect(actualResult.standardError).toContain("error: missing required argument 'production-tag'");
+  });
+});
+
+describe('WebApp version synchronization CLI entrypoint', () => {
+  it('writes help to standard output without requiring runtime credentials', () => {
+    const actualResult = runNativeCommand(webAppVersionSynchronizationEntrypointPath, ['--help']);
+
+    expect(actualResult.exitCode).toBe(0);
+    expect(actualResult.standardOutput).toContain('Usage: webappVersionSynchronization');
+  });
+
+  it('rejects a missing synchronization command without contacting GitHub', () => {
+    const actualResult = runNativeCommand(webAppVersionSynchronizationEntrypointPath, ['inspect']);
+
+    expect(actualResult.exitCode).toBe(1);
+    expect(actualResult.standardError).toContain("error: missing required argument 'release-identifier'");
   });
 });
 

--- a/tools/release-cli/webappVersionSynchronization.mts
+++ b/tools/release-cli/webappVersionSynchronization.mts
@@ -17,9 +17,8 @@
  *
  */
 
-import {isError, isNonEmptyStringAndNotWhitespace, isString} from '@sindresorhus/is';
+import {isError, isString} from '@sindresorhus/is';
 import {Command, CommanderError} from 'commander';
-import {Result} from 'true-myth';
 
 import {resolve} from 'node:path';
 import process from 'node:process';
@@ -45,6 +44,11 @@ import {
   inspectWebAppVersionSynchronization,
   synchronizeWebAppVersion,
 } from '../release-metadata/webappVersionSynchronizationOrchestration.ts';
+import {
+  readInspectionRuntimeEnvironment,
+  readSynchronizationRuntimeEnvironment,
+} from '../release-metadata/webappVersionSynchronizationRuntime.ts';
+import type {WebAppVersionSynchronizationSynchronizationRuntimeEnvironment} from '../release-metadata/webappVersionSynchronizationRuntime.ts';
 
 type InspectCommand = {
   readonly kind: 'inspect';
@@ -66,69 +70,9 @@ type CreateWebAppVersionSynchronizationCommandOptions = {
   readonly writeError: (message: string) => void;
 };
 
-type RuntimeEnvironment = {
-  readonly githubApiUrl: URL;
-  readonly githubRepository: string;
-  readonly githubToken: string;
-  readonly repositoryPath: string;
-};
-
 const ottoTheBotName = 'otto-the-bot';
 const ottoTheBotEmail = '8736538+otto-the-bot@users.noreply.github.com';
 const runtimeCommandLineArgumentStartIndex = 2;
-
-function readRequiredEnvironmentValue(
-  environment: NodeJS.ProcessEnv,
-  environmentVariableName: string,
-): Result<string, Error> {
-  const environmentValue = environment[environmentVariableName];
-
-  if (isNonEmptyStringAndNotWhitespace(environmentValue) === false) {
-    return Result.err(new Error(`Required environment variable is missing: ${environmentVariableName}`));
-  }
-
-  return Result.ok(environmentValue);
-}
-
-function readRuntimeEnvironment(environment: NodeJS.ProcessEnv): Result<RuntimeEnvironment, Error> {
-  const githubApiUrlValueResult = readRequiredEnvironmentValue(environment, 'GITHUB_API_URL');
-  const githubRepositoryResult = readRequiredEnvironmentValue(environment, 'GITHUB_REPOSITORY');
-  const githubTokenResult = readRequiredEnvironmentValue(environment, 'OTTO_THE_BOT_GH_TOKEN');
-  const repositoryPath = environment.GITHUB_WORKSPACE;
-
-  if (githubApiUrlValueResult.isErr) {
-    return Result.err(githubApiUrlValueResult.error);
-  }
-
-  if (githubRepositoryResult.isErr) {
-    return Result.err(githubRepositoryResult.error);
-  }
-
-  if (githubTokenResult.isErr) {
-    return Result.err(githubTokenResult.error);
-  }
-
-  const {value: githubApiUrlValue} = githubApiUrlValueResult;
-  const {value: githubRepository} = githubRepositoryResult;
-  const {value: githubToken} = githubTokenResult;
-
-  let githubApiUrl: URL;
-
-  try {
-    githubApiUrl = new URL(githubApiUrlValue);
-  } catch (error: unknown) {
-    const errorMessage = isError(error) ? error.message : String(error);
-
-    return Result.err(new Error(`Invalid GITHUB_API_URL: ${errorMessage}`, {cause: error}));
-  }
-
-  return Result.ok({
-    githubApiUrl,
-    githubRepository,
-    githubToken,
-    repositoryPath: isNonEmptyStringAndNotWhitespace(repositoryPath) ? repositoryPath : process.cwd(),
-  });
-}
 
 function writeRuntimeError(message: string): void {
   process.stderr.write(`${message}\n`);
@@ -138,12 +82,18 @@ function writeRuntimeOutput(message: string): void {
   process.stdout.write(`${message}\n`);
 }
 
-function createRuntimeGitHubClient(runtimeEnvironment: RuntimeEnvironment): WebAppVersionSynchronizationGitHubClient {
+type RuntimeGitHubClientOptions = {
+  readonly githubApiUrl: URL;
+  readonly githubRepository: string;
+  readonly githubToken: string;
+};
+
+function createRuntimeGitHubClient(options: RuntimeGitHubClientOptions): WebAppVersionSynchronizationGitHubClient {
   return createWebAppVersionSynchronizationGitHubClient({
     httpClient: createRuntimeKyHttpClient(),
-    githubApiUrl: runtimeEnvironment.githubApiUrl,
-    githubRepository: runtimeEnvironment.githubRepository,
-    githubToken: runtimeEnvironment.githubToken,
+    githubApiUrl: options.githubApiUrl,
+    githubRepository: options.githubRepository,
+    githubToken: options.githubToken,
   });
 }
 
@@ -171,7 +121,7 @@ async function executeInspectionCommand(
 
 async function executeSynchronizationCommand(
   command: SynchronizeCommand,
-  runtimeEnvironment: RuntimeEnvironment,
+  runtimeEnvironment: WebAppVersionSynchronizationSynchronizationRuntimeEnvironment,
   githubClient: WebAppVersionSynchronizationGitHubClient,
   writeOutput: (message: string) => void,
 ): Promise<void> {
@@ -258,20 +208,37 @@ export async function runWebAppVersionSynchronizationCommand(
 }
 
 async function executeRuntimeCommand(command: WebAppVersionSynchronizationCommand): Promise<void> {
-  const runtimeEnvironmentResult = readRuntimeEnvironment(process.env);
+  if (command.kind === 'inspect') {
+    const runtimeEnvironmentResult = readInspectionRuntimeEnvironment(process.env);
+
+    if (runtimeEnvironmentResult.isErr) {
+      throw runtimeEnvironmentResult.error;
+    }
+
+    const {value: runtimeEnvironment} = runtimeEnvironmentResult;
+    const githubClient = createRuntimeGitHubClient({
+      githubApiUrl: runtimeEnvironment.githubApiUrl,
+      githubRepository: runtimeEnvironment.githubRepository,
+      githubToken: runtimeEnvironment.githubToken,
+    });
+
+    await executeInspectionCommand(command, githubClient, writeRuntimeOutput);
+
+    return;
+  }
+
+  const runtimeEnvironmentResult = readSynchronizationRuntimeEnvironment(process.env);
 
   if (runtimeEnvironmentResult.isErr) {
     throw runtimeEnvironmentResult.error;
   }
 
   const {value: runtimeEnvironment} = runtimeEnvironmentResult;
-  const githubClient = createRuntimeGitHubClient(runtimeEnvironment);
-
-  if (command.kind === 'inspect') {
-    await executeInspectionCommand(command, githubClient, writeRuntimeOutput);
-
-    return;
-  }
+  const githubClient = createRuntimeGitHubClient({
+    githubApiUrl: runtimeEnvironment.githubApiUrl,
+    githubRepository: runtimeEnvironment.githubRepository,
+    githubToken: runtimeEnvironment.ottoTheBotGitHubToken,
+  });
 
   await executeSynchronizationCommand(command, runtimeEnvironment, githubClient, writeRuntimeOutput);
 }

--- a/tools/release-cli/webappVersionSynchronization.mts
+++ b/tools/release-cli/webappVersionSynchronization.mts
@@ -128,6 +128,7 @@ async function executeSynchronizationCommand(
   const gitClient = createSimpleGitWebAppVersionSynchronizationClient({
     repositoryPath: runtimeEnvironment.repositoryPath,
     fileSystem: createRuntimeWebAppVersionSynchronizationFileSystem(),
+    authentication: {githubToken: runtimeEnvironment.ottoTheBotGitHubToken},
   });
   const synchronizationOptions: SynchronizeWebAppVersionOptions = {
     releaseIdentifier: command.releaseIdentifier,

--- a/tools/release-cli/webappVersionSynchronization.mts
+++ b/tools/release-cli/webappVersionSynchronization.mts
@@ -1,0 +1,309 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isError, isNonEmptyStringAndNotWhitespace, isString} from '@sindresorhus/is';
+import {Command, CommanderError} from 'commander';
+import {Result} from 'true-myth';
+
+import {resolve} from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+import {createRuntimeKyHttpClient} from '../release-appearance/httpClient.ts';
+import {
+  createWebAppVersionSynchronizationInspectionOutput,
+  createWebAppVersionSynchronizationResultOutput,
+  serializeWebAppVersionSynchronizationOutput,
+} from '../release-metadata/webappVersionSynchronizationCli.ts';
+import {
+  createRuntimeWebAppVersionSynchronizationFileSystem,
+  createSimpleGitWebAppVersionSynchronizationClient,
+} from '../release-metadata/webappVersionSynchronizationGit.ts';
+import {createWebAppVersionSynchronizationGitHubClient} from '../release-metadata/webappVersionSynchronizationGitHubClient.ts';
+import type {WebAppVersionSynchronizationGitHubClient} from '../release-metadata/webappVersionSynchronizationGitHubClient.ts';
+import type {
+  InspectWebAppVersionSynchronizationOptions,
+  SynchronizeWebAppVersionOptions,
+} from '../release-metadata/webappVersionSynchronizationOrchestration.ts';
+import {
+  inspectWebAppVersionSynchronization,
+  synchronizeWebAppVersion,
+} from '../release-metadata/webappVersionSynchronizationOrchestration.ts';
+
+type InspectCommand = {
+  readonly kind: 'inspect';
+  readonly releaseIdentifier: string;
+  readonly productionTagName: string;
+};
+
+type SynchronizeCommand = {
+  readonly kind: 'synchronize';
+  readonly releaseIdentifier: string;
+  readonly productionTagName: string;
+};
+
+type WebAppVersionSynchronizationCommand = InspectCommand | SynchronizeCommand;
+
+type CreateWebAppVersionSynchronizationCommandOptions = {
+  readonly executeCommand: (command: WebAppVersionSynchronizationCommand) => Promise<void> | void;
+  readonly writeOutput: (message: string) => void;
+  readonly writeError: (message: string) => void;
+};
+
+type RuntimeEnvironment = {
+  readonly githubApiUrl: URL;
+  readonly githubRepository: string;
+  readonly githubToken: string;
+  readonly repositoryPath: string;
+};
+
+const ottoTheBotName = 'otto-the-bot';
+const ottoTheBotEmail = '8736538+otto-the-bot@users.noreply.github.com';
+const runtimeCommandLineArgumentStartIndex = 2;
+
+function readRequiredEnvironmentValue(
+  environment: NodeJS.ProcessEnv,
+  environmentVariableName: string,
+): Result<string, Error> {
+  const environmentValue = environment[environmentVariableName];
+
+  if (isNonEmptyStringAndNotWhitespace(environmentValue) === false) {
+    return Result.err(new Error(`Required environment variable is missing: ${environmentVariableName}`));
+  }
+
+  return Result.ok(environmentValue);
+}
+
+function readRuntimeEnvironment(environment: NodeJS.ProcessEnv): Result<RuntimeEnvironment, Error> {
+  const githubApiUrlValueResult = readRequiredEnvironmentValue(environment, 'GITHUB_API_URL');
+  const githubRepositoryResult = readRequiredEnvironmentValue(environment, 'GITHUB_REPOSITORY');
+  const githubTokenResult = readRequiredEnvironmentValue(environment, 'OTTO_THE_BOT_GH_TOKEN');
+  const repositoryPath = environment.GITHUB_WORKSPACE;
+
+  if (githubApiUrlValueResult.isErr) {
+    return Result.err(githubApiUrlValueResult.error);
+  }
+
+  if (githubRepositoryResult.isErr) {
+    return Result.err(githubRepositoryResult.error);
+  }
+
+  if (githubTokenResult.isErr) {
+    return Result.err(githubTokenResult.error);
+  }
+
+  const {value: githubApiUrlValue} = githubApiUrlValueResult;
+  const {value: githubRepository} = githubRepositoryResult;
+  const {value: githubToken} = githubTokenResult;
+
+  let githubApiUrl: URL;
+
+  try {
+    githubApiUrl = new URL(githubApiUrlValue);
+  } catch (error: unknown) {
+    const errorMessage = isError(error) ? error.message : String(error);
+
+    return Result.err(new Error(`Invalid GITHUB_API_URL: ${errorMessage}`, {cause: error}));
+  }
+
+  return Result.ok({
+    githubApiUrl,
+    githubRepository,
+    githubToken,
+    repositoryPath: isNonEmptyStringAndNotWhitespace(repositoryPath) ? repositoryPath : process.cwd(),
+  });
+}
+
+function writeRuntimeError(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
+function writeRuntimeOutput(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+function createRuntimeGitHubClient(runtimeEnvironment: RuntimeEnvironment): WebAppVersionSynchronizationGitHubClient {
+  return createWebAppVersionSynchronizationGitHubClient({
+    httpClient: createRuntimeKyHttpClient(),
+    githubApiUrl: runtimeEnvironment.githubApiUrl,
+    githubRepository: runtimeEnvironment.githubRepository,
+    githubToken: runtimeEnvironment.githubToken,
+  });
+}
+
+async function executeInspectionCommand(
+  command: InspectCommand,
+  githubClient: WebAppVersionSynchronizationGitHubClient,
+  writeOutput: (message: string) => void,
+): Promise<void> {
+  const inspectionOptions: InspectWebAppVersionSynchronizationOptions = {
+    releaseIdentifier: command.releaseIdentifier,
+    productionTagName: command.productionTagName,
+    githubClient,
+  };
+  const inspectionResult = await inspectWebAppVersionSynchronization(inspectionOptions);
+
+  if (inspectionResult.isErr) {
+    throw inspectionResult.error;
+  }
+
+  const {value: inspection} = inspectionResult;
+  const output = createWebAppVersionSynchronizationInspectionOutput(inspection);
+
+  writeOutput(serializeWebAppVersionSynchronizationOutput(output));
+}
+
+async function executeSynchronizationCommand(
+  command: SynchronizeCommand,
+  runtimeEnvironment: RuntimeEnvironment,
+  githubClient: WebAppVersionSynchronizationGitHubClient,
+  writeOutput: (message: string) => void,
+): Promise<void> {
+  const gitClient = createSimpleGitWebAppVersionSynchronizationClient({
+    repositoryPath: runtimeEnvironment.repositoryPath,
+    fileSystem: createRuntimeWebAppVersionSynchronizationFileSystem(),
+  });
+  const synchronizationOptions: SynchronizeWebAppVersionOptions = {
+    releaseIdentifier: command.releaseIdentifier,
+    productionTagName: command.productionTagName,
+    commitAuthorName: ottoTheBotName,
+    commitAuthorEmail: ottoTheBotEmail,
+    dependencies: {githubClient, gitClient},
+  };
+  const synchronizationResult = await synchronizeWebAppVersion(synchronizationOptions);
+
+  if (synchronizationResult.isErr) {
+    throw synchronizationResult.error;
+  }
+
+  const {value: synchronization} = synchronizationResult;
+  const output = createWebAppVersionSynchronizationResultOutput(synchronization);
+
+  writeOutput(serializeWebAppVersionSynchronizationOutput(output));
+}
+
+export function createCommand(createCommandOptions: CreateWebAppVersionSynchronizationCommandOptions): Command {
+  const command = new Command()
+    .name('webappVersionSynchronization')
+    .description('Inspect or synchronize WebApp Production package metadata.')
+    .configureOutput({
+      writeOut: createCommandOptions.writeOutput,
+      writeErr: createCommandOptions.writeError,
+    })
+    .exitOverride();
+
+  command
+    .command('inspect')
+    .argument('<release-identifier>')
+    .argument('<production-tag>')
+    .action(async (releaseIdentifier: string, productionTagName: string): Promise<void> => {
+      await createCommandOptions.executeCommand({kind: 'inspect', releaseIdentifier, productionTagName});
+    });
+
+  command
+    .command('synchronize')
+    .argument('<release-identifier>')
+    .argument('<production-tag>')
+    .action(async (releaseIdentifier: string, productionTagName: string): Promise<void> => {
+      await createCommandOptions.executeCommand({kind: 'synchronize', releaseIdentifier, productionTagName});
+    });
+
+  return command;
+}
+
+export async function runWebAppVersionSynchronizationCommand(
+  commandLineArguments: readonly string[],
+  createCommandOptions: CreateWebAppVersionSynchronizationCommandOptions,
+): Promise<number> {
+  let executionExitCode = 0;
+  const command = createCommand({
+    ...createCommandOptions,
+    async executeCommand(applicationCommand: WebAppVersionSynchronizationCommand): Promise<void> {
+      await createCommandOptions.executeCommand(applicationCommand);
+      executionExitCode = 0;
+    },
+  });
+
+  try {
+    await command.parseAsync(['node', 'webappVersionSynchronization', ...commandLineArguments]);
+
+    return executionExitCode;
+  } catch (error: unknown) {
+    if (error instanceof CommanderError) {
+      return error.exitCode;
+    }
+
+    const errorMessage = isError(error) ? error.message : String(error);
+
+    createCommandOptions.writeError(`${errorMessage}\n`);
+
+    return 1;
+  }
+}
+
+async function executeRuntimeCommand(command: WebAppVersionSynchronizationCommand): Promise<void> {
+  const runtimeEnvironmentResult = readRuntimeEnvironment(process.env);
+
+  if (runtimeEnvironmentResult.isErr) {
+    throw runtimeEnvironmentResult.error;
+  }
+
+  const {value: runtimeEnvironment} = runtimeEnvironmentResult;
+  const githubClient = createRuntimeGitHubClient(runtimeEnvironment);
+
+  if (command.kind === 'inspect') {
+    await executeInspectionCommand(command, githubClient, writeRuntimeOutput);
+
+    return;
+  }
+
+  await executeSynchronizationCommand(command, runtimeEnvironment, githubClient, writeRuntimeOutput);
+}
+
+async function main(): Promise<void> {
+  process.exitCode = await runWebAppVersionSynchronizationCommand(
+    process.argv.slice(runtimeCommandLineArgumentStartIndex),
+    {
+      executeCommand: executeRuntimeCommand,
+      writeError: writeRuntimeError,
+      writeOutput: writeRuntimeOutput,
+    },
+  );
+}
+
+function isCurrentModuleEntrypoint(): boolean {
+  const entrypointPath = process.argv[1];
+
+  return isString(entrypointPath) && fileURLToPath(import.meta.url) === resolve(entrypointPath);
+}
+
+function crash(error: unknown): void {
+  const errorMessage = isError(error) ? error.message : String(error);
+
+  writeRuntimeError(errorMessage);
+  process.exitCode = 1;
+}
+
+if (isCurrentModuleEntrypoint()) {
+  try {
+    await main();
+  } catch (error: unknown) {
+    crash(error);
+  }
+}

--- a/tools/release-metadata/webappVersion.ts
+++ b/tools/release-metadata/webappVersion.ts
@@ -107,6 +107,8 @@ function validateWebAppPackageDocuments(
     return Result.err(new Error(validatedRootPackageDocumentResult.error.message));
   }
 
+  const {value: validatedRootPackageDocument} = validatedRootPackageDocumentResult;
+
   const validatedWebAppPackageDocumentResult = validateWebAppPackageDocument(
     webAppPackageDocument,
     'apps/webapp/package.json',
@@ -116,14 +118,18 @@ function validateWebAppPackageDocuments(
     return Result.err(new Error(validatedWebAppPackageDocumentResult.error.message));
   }
 
-  const rootVersionResult = validatePackageDocumentVersion(validatedRootPackageDocumentResult.value, 'package.json');
+  const {value: validatedWebAppPackageDocument} = validatedWebAppPackageDocumentResult;
+
+  const rootVersionResult = validatePackageDocumentVersion(validatedRootPackageDocument, 'package.json');
 
   if (rootVersionResult.isErr) {
     return Result.err(new Error(rootVersionResult.error.message));
   }
 
+  const {value: rootVersion} = rootVersionResult;
+
   const webAppVersionResult = validatePackageDocumentVersion(
-    validatedWebAppPackageDocumentResult.value,
+    validatedWebAppPackageDocument,
     'apps/webapp/package.json',
   );
 
@@ -131,19 +137,21 @@ function validateWebAppPackageDocuments(
     return Result.err(new Error(webAppVersionResult.error.message));
   }
 
-  if (rootVersionResult.value !== webAppVersionResult.value) {
+  const {value: webAppVersion} = webAppVersionResult;
+
+  if (rootVersion !== webAppVersion) {
     return Result.err(
       new Error(
-        `WebApp package versions disagree: package.json=${rootVersionResult.value}, apps/webapp/package.json=${webAppVersionResult.value}`,
+        `WebApp package versions disagree: package.json=${rootVersion}, apps/webapp/package.json=${webAppVersion}`,
       ),
     );
   }
 
   return Result.ok({
-    rootPackageDocument: validatedRootPackageDocumentResult.value,
-    webAppPackageDocument: validatedWebAppPackageDocumentResult.value,
-    rootVersion: rootVersionResult.value,
-    webAppVersion: webAppVersionResult.value,
+    rootPackageDocument: validatedRootPackageDocument,
+    webAppPackageDocument: validatedWebAppPackageDocument,
+    rootVersion,
+    webAppVersion,
   });
 }
 
@@ -156,7 +164,9 @@ function createWebAppVersionSynchronizationMarkerValue(
     return Result.err(new Error(productionTagResult.error.message));
   }
 
-  if (productionTagResult.value !== options.productionTagName) {
+  const {value: validatedProductionTagName} = productionTagResult;
+
+  if (validatedProductionTagName !== options.productionTagName) {
     return Result.err(
       new Error(
         `Production tag ${options.productionTagName} does not match release identifier ${options.releaseIdentifier}`,
@@ -170,10 +180,12 @@ function createWebAppVersionSynchronizationMarkerValue(
     return Result.err(new Error(webAppVersionResult.error.message));
   }
 
+  const {value: validatedWebAppVersion} = webAppVersionResult;
+
   return Result.ok({
     releaseIdentifier: options.releaseIdentifier as ReleaseIdentifier,
-    productionTagName: productionTagResult.value,
-    webAppVersion: webAppVersionResult.value,
+    productionTagName: validatedProductionTagName,
+    webAppVersion: validatedWebAppVersion,
   });
 }
 
@@ -196,7 +208,8 @@ export function resolveNextWebAppVersion(currentVersion: string): Result<WebAppV
     return Result.err(new Error(currentVersionResult.error.message));
   }
 
-  const [majorVersion, minorVersion, patchVersion] = currentVersionResult.value.split('.');
+  const {value: validatedCurrentVersion} = currentVersionResult;
+  const [majorVersion, minorVersion, patchVersion] = validatedCurrentVersion.split('.');
 
   if (majorVersion === '0') {
     return Result.ok('1.0.0' as WebAppVersion);
@@ -215,9 +228,11 @@ export function validateMatchingWebAppPackageVersions(
     return Result.err(new Error(validatedPackageDocumentsResult.error.message));
   }
 
+  const {value: validatedPackageDocuments} = validatedPackageDocumentsResult;
+
   return Result.ok({
-    rootVersion: validatedPackageDocumentsResult.value.rootVersion,
-    webAppVersion: validatedPackageDocumentsResult.value.webAppVersion,
+    rootVersion: validatedPackageDocuments.rootVersion,
+    webAppVersion: validatedPackageDocuments.webAppVersion,
   });
 }
 
@@ -239,11 +254,14 @@ export function updateWebAppPackageDocuments(
     return Result.err(new Error(targetVersionResult.error.message));
   }
 
-  const {rootPackageDocument, webAppPackageDocument} = validatedPackageDocumentsResult.value;
+  const {value: targetVersion} = targetVersionResult;
+
+  const {value: validatedPackageDocuments} = validatedPackageDocumentsResult;
+  const {rootPackageDocument, webAppPackageDocument} = validatedPackageDocuments;
 
   return Result.ok({
-    rootPackageDocument: {...rootPackageDocument, version: targetVersionResult.value},
-    webAppPackageDocument: {...webAppPackageDocument, version: targetVersionResult.value},
+    rootPackageDocument: {...rootPackageDocument, version: targetVersion},
+    webAppPackageDocument: {...webAppPackageDocument, version: targetVersion},
   });
 }
 
@@ -256,7 +274,7 @@ export function createWebAppVersionSynchronizationMarker(
     return Result.err(new Error(markerValueResult.error.message));
   }
 
-  const marker = markerValueResult.value;
+  const {value: marker} = markerValueResult;
 
   return Result.ok(
     `<!-- wire-webapp-version-sync release=${marker.releaseIdentifier} production-tag=${marker.productionTagName} version=${marker.webAppVersion} -->`,

--- a/tools/release-metadata/webappVersionSynchronization.test.ts
+++ b/tools/release-metadata/webappVersionSynchronization.test.ts
@@ -1,0 +1,257 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+
+import {Maybe} from 'true-myth';
+
+import {
+  createWebAppVersionSynchronizationBranchName,
+  createWebAppVersionSynchronizationPullRequestBody,
+  createWebAppVersionSynchronizationPullRequestTitle,
+  parseWebAppVersionSynchronizationPullRequest,
+  resolveWebAppVersionSynchronizationState,
+  validateWebAppVersionSynchronizationBranchName,
+} from './webappVersionSynchronization.ts';
+import type {WebAppVersionSynchronizationPullRequest} from './webappVersionSynchronization.ts';
+
+const releaseIdentifier = '2026-09-09.1';
+const productionTagName = '2026-09-09.1-production';
+
+type CreatePullRequestOptions = {
+  readonly releaseIdentifier?: string;
+  readonly productionTagName?: string;
+  readonly webAppVersion?: string;
+  readonly state?: 'open' | 'closed';
+  readonly mergedAt?: string | null;
+  readonly baseBranch?: string;
+  readonly headBranch?: string;
+  readonly body?: string;
+  readonly title?: string;
+  readonly number?: number;
+};
+
+function createPullRequest(options: CreatePullRequestOptions = {}): WebAppVersionSynchronizationPullRequest {
+  const actualReleaseIdentifier = options.releaseIdentifier ?? releaseIdentifier;
+  const actualProductionTagName = options.productionTagName ?? productionTagName;
+  const actualWebAppVersion = options.webAppVersion ?? '1.0.0';
+  const actualBranchName = `webapp-version-${actualReleaseIdentifier}-${actualWebAppVersion}`;
+
+  return {
+    number: options.number ?? 1,
+    url: `https://github.com/wireapp/wire-webapp/pull/${options.number ?? 1}`,
+    title: options.title ?? `Update WebApp version to ${actualWebAppVersion}`,
+    body:
+      options.body ??
+      `<!-- wire-webapp-version-sync release=${actualReleaseIdentifier} production-tag=${actualProductionTagName} version=${actualWebAppVersion} -->`,
+    state: options.state ?? 'open',
+    mergedAt: options.mergedAt ?? null,
+    baseBranch: options.baseBranch ?? 'main',
+    headBranch: options.headBranch ?? actualBranchName,
+  };
+}
+
+describe('WebApp version synchronization branch planning', () => {
+  it('creates and validates a deterministic branch name', () => {
+    const branchNameResult = createWebAppVersionSynchronizationBranchName(releaseIdentifier, '1.0.0');
+
+    assert(branchNameResult.isOk);
+    expect(branchNameResult.value).toBe('webapp-version-2026-09-09.1-1.0.0');
+
+    const validatedBranchNameResult = validateWebAppVersionSynchronizationBranchName(branchNameResult.value);
+
+    assert(validatedBranchNameResult.isOk);
+    expect(validatedBranchNameResult.value).toEqual({
+      branchName: 'webapp-version-2026-09-09.1-1.0.0',
+      releaseIdentifier,
+      webAppVersion: '1.0.0',
+    });
+  });
+
+  it.each([
+    'webapp-version-2026-09-09.1-1.0',
+    'webapp-version-2026-09-09.1-1.0.0-beta.1',
+    'webapp-version-2026-09-09.0-1.0.0',
+    'webapp-version-2026-09-09.1-01.0.0',
+  ])('rejects invalid branch name %s', branchName => {
+    const actualBranchNameResult = validateWebAppVersionSynchronizationBranchName(branchName);
+
+    assert(actualBranchNameResult.isErr);
+  });
+
+  it('creates the descriptive pull request title and body', () => {
+    const actualTitleResult = createWebAppVersionSynchronizationPullRequestTitle('1.0.0');
+    const actualBodyResult = createWebAppVersionSynchronizationPullRequestBody({
+      releaseIdentifier,
+      productionTagName,
+      webAppVersion: '1.0.0',
+    });
+
+    assert(actualTitleResult.isOk);
+    assert(actualBodyResult.isOk);
+    expect(actualTitleResult.value).toBe('Update WebApp version to 1.0.0');
+    expect(actualBodyResult.value).toContain('WebApp version: 1.0.0');
+    expect(actualBodyResult.value).toContain(`Release: ${releaseIdentifier}`);
+    expect(actualBodyResult.value).toContain(`Production tag: ${productionTagName}`);
+    expect(actualBodyResult.value).toContain('Production was already deployed and runtime-verified.');
+    expect(actualBodyResult.value).toContain(
+      `<!-- wire-webapp-version-sync release=${releaseIdentifier} production-tag=${productionTagName} version=1.0.0 -->`,
+    );
+  });
+});
+
+describe('WebApp version synchronization pull request discovery', () => {
+  it('ignores unrelated pull requests', () => {
+    const actualResult = parseWebAppVersionSynchronizationPullRequest(
+      createPullRequest({
+        title: 'Update documentation',
+        body: 'Documentation change',
+        headBranch: 'documentation-update',
+      }),
+    );
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toEqual(Maybe.nothing());
+  });
+
+  it('parses a valid synchronization pull request', () => {
+    const actualResult = parseWebAppVersionSynchronizationPullRequest(createPullRequest());
+
+    assert(actualResult.isOk);
+    assert(actualResult.value.isJust);
+    expect(actualResult.value.value.marker).toEqual({
+      releaseIdentifier,
+      productionTagName,
+      webAppVersion: '1.0.0',
+    });
+  });
+
+  it.each([
+    {title: 'Update WebApp version to 1.0.0', body: 'missing marker'},
+    {
+      headBranch: 'webapp-version-2026-09-09.1-1.0.1',
+      body: 'missing marker',
+      title: 'Update WebApp version to 1.0.1',
+    },
+    {
+      body: '<!-- wire-webapp-version-sync release=2026-09-09.1 production-tag=2026-09-09.1-production -->',
+    },
+    {
+      baseBranch: 'release/2026-09-09.1',
+    },
+    {
+      headBranch: 'webapp-version-2026-09-09.1-1.0.1',
+    },
+    {
+      state: 'open' as const,
+      mergedAt: '2026-09-09T12:00:00Z',
+    },
+  ])('rejects a claimed synchronization pull request with invalid state', options => {
+    const actualResult = parseWebAppVersionSynchronizationPullRequest(createPullRequest(options));
+
+    assert(actualResult.isErr);
+  });
+});
+
+describe('WebApp version synchronization state resolution', () => {
+  it('reports available when no synchronization history exists', () => {
+    const actualResult = resolveWebAppVersionSynchronizationState(releaseIdentifier, productionTagName, []);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toEqual({
+      kind: 'available',
+      releaseIdentifier,
+      productionTagName,
+    });
+  });
+
+  it('reuses the version from a matching open pull request', () => {
+    const actualResult = resolveWebAppVersionSynchronizationState(releaseIdentifier, productionTagName, [
+      createPullRequest(),
+    ]);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toMatchObject({
+      kind: 'matching-open',
+      webAppVersion: '1.0.0',
+      pullRequestNumber: 1,
+    });
+  });
+
+  it('reuses the version from a matching merged pull request', () => {
+    const actualResult = resolveWebAppVersionSynchronizationState(releaseIdentifier, productionTagName, [
+      createPullRequest({state: 'closed', mergedAt: '2026-09-09T12:00:00Z'}),
+    ]);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toMatchObject({kind: 'matching-merged', webAppVersion: '1.0.0'});
+  });
+
+  it('reports a matching closed pull request that was not merged', () => {
+    const actualResult = resolveWebAppVersionSynchronizationState(releaseIdentifier, productionTagName, [
+      createPullRequest({state: 'closed'}),
+    ]);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toMatchObject({kind: 'closed-without-merge', webAppVersion: '1.0.0'});
+  });
+
+  it('blocks a new release when another synchronization pull request is open', () => {
+    const actualResult = resolveWebAppVersionSynchronizationState(releaseIdentifier, productionTagName, [
+      createPullRequest({
+        releaseIdentifier: '2026-09-02.1',
+        productionTagName: '2026-09-02.1-production',
+        number: 2,
+      }),
+    ]);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toMatchObject({
+      kind: 'blocked-by-previous-open',
+      blockingReleaseIdentifier: '2026-09-02.1',
+      blockingWebAppVersion: '1.0.0',
+      pullRequestNumber: 2,
+    });
+  });
+
+  it('reports a conflict when multiple records exist for one release', () => {
+    const actualResult = resolveWebAppVersionSynchronizationState(releaseIdentifier, productionTagName, [
+      createPullRequest(),
+      createPullRequest({number: 2}),
+    ]);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toMatchObject({kind: 'conflict'});
+  });
+
+  it('fails closed when a claimed synchronization pull request has a malformed marker', () => {
+    const actualResult = resolveWebAppVersionSynchronizationState(releaseIdentifier, productionTagName, [
+      createPullRequest({body: '<!-- wire-webapp-version-sync release=invalid -->'}),
+    ]);
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toContain('claims to synchronize the WebApp version');
+  });
+
+  it('rejects a request whose Production tag does not match its release identifier', () => {
+    const actualResult = resolveWebAppVersionSynchronizationState(releaseIdentifier, '2026-09-10.1-production', []);
+
+    assert(actualResult.isErr);
+  });
+});

--- a/tools/release-metadata/webappVersionSynchronization.test.ts
+++ b/tools/release-metadata/webappVersionSynchronization.test.ts
@@ -223,11 +223,122 @@ describe('WebApp version synchronization state resolution', () => {
 
     assert(actualResult.isOk);
     expect(actualResult.value).toMatchObject({
-      kind: 'blocked-by-previous-open',
+      kind: 'blocked-by-previous-unresolved',
       blockingReleaseIdentifier: '2026-09-02.1',
       blockingWebAppVersion: '1.0.0',
+      blockingSynchronizationState: 'open',
       pullRequestNumber: 2,
     });
+  });
+
+  it('blocks a new release when another synchronization pull request is closed without merging', () => {
+    const actualResult = resolveWebAppVersionSynchronizationState(releaseIdentifier, productionTagName, [
+      createPullRequest({
+        releaseIdentifier: '2026-09-02.1',
+        productionTagName: '2026-09-02.1-production',
+        state: 'closed',
+        number: 2,
+      }),
+    ]);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toMatchObject({
+      kind: 'blocked-by-previous-unresolved',
+      blockingReleaseIdentifier: '2026-09-02.1',
+      blockingWebAppVersion: '1.0.0',
+      blockingSynchronizationState: 'closed-without-merge',
+      pullRequestNumber: 2,
+    });
+  });
+
+  it('does not block a new release when another synchronization pull request was merged', () => {
+    const actualResult = resolveWebAppVersionSynchronizationState(releaseIdentifier, productionTagName, [
+      createPullRequest({
+        releaseIdentifier: '2026-09-02.1',
+        productionTagName: '2026-09-02.1-production',
+        state: 'closed',
+        mergedAt: '2026-09-02T12:00:00Z',
+        number: 2,
+      }),
+    ]);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toMatchObject({kind: 'available'});
+  });
+
+  it.each([
+    {
+      description: 'multiple open synchronization pull requests',
+      pullRequests: [
+        createPullRequest({
+          releaseIdentifier: '2026-09-02.1',
+          productionTagName: '2026-09-02.1-production',
+          number: 2,
+        }),
+        createPullRequest({
+          releaseIdentifier: '2026-09-03.1',
+          productionTagName: '2026-09-03.1-production',
+          number: 3,
+        }),
+      ],
+    },
+    {
+      description: 'a matching open pull request and another open synchronization pull request',
+      pullRequests: [
+        createPullRequest(),
+        createPullRequest({
+          releaseIdentifier: '2026-09-02.1',
+          productionTagName: '2026-09-02.1-production',
+          number: 2,
+        }),
+      ],
+    },
+    {
+      description: 'a matching open pull request and another closed-unmerged synchronization pull request',
+      pullRequests: [
+        createPullRequest(),
+        createPullRequest({
+          releaseIdentifier: '2026-09-02.1',
+          productionTagName: '2026-09-02.1-production',
+          state: 'closed',
+          number: 2,
+        }),
+      ],
+    },
+    {
+      description: 'a matching merged pull request and another closed-unmerged synchronization pull request',
+      pullRequests: [
+        createPullRequest({state: 'closed', mergedAt: '2026-09-09T12:00:00Z'}),
+        createPullRequest({
+          releaseIdentifier: '2026-09-02.1',
+          productionTagName: '2026-09-02.1-production',
+          state: 'closed',
+          number: 2,
+        }),
+      ],
+    },
+    {
+      description: 'multiple closed-unmerged synchronization pull requests',
+      pullRequests: [
+        createPullRequest({
+          releaseIdentifier: '2026-09-02.1',
+          productionTagName: '2026-09-02.1-production',
+          state: 'closed',
+          number: 2,
+        }),
+        createPullRequest({
+          releaseIdentifier: '2026-09-03.1',
+          productionTagName: '2026-09-03.1-production',
+          state: 'closed',
+          number: 3,
+        }),
+      ],
+    },
+  ])('reports a conflict for $description', ({pullRequests}) => {
+    const actualResult = resolveWebAppVersionSynchronizationState(releaseIdentifier, productionTagName, pullRequests);
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toMatchObject({kind: 'conflict'});
   });
 
   it('reports a conflict when multiple records exist for one release', () => {

--- a/tools/release-metadata/webappVersionSynchronization.ts
+++ b/tools/release-metadata/webappVersionSynchronization.ts
@@ -274,23 +274,25 @@ export function resolveWebAppVersionSynchronizationState(
 
   const {value: synchronizationRequest} = synchronizationRequestResult;
 
-  const synchronizationRecords: WebAppVersionSynchronizationRecord[] = [];
+  const synchronizationRecordsResult = pullRequests.reduce((recordsResult, pullRequest) => {
+    return recordsResult.andThen(synchronizationRecords => {
+      return parseWebAppVersionSynchronizationPullRequest(pullRequest).andThen(synchronizationRecordMaybe => {
+        if (synchronizationRecordMaybe.isNothing) {
+          return Result.ok(synchronizationRecords);
+        }
 
-  for (const pullRequest of pullRequests) {
-    const synchronizationRecordResult = parseWebAppVersionSynchronizationPullRequest(pullRequest);
+        const {value: synchronizationRecord} = synchronizationRecordMaybe;
 
-    if (synchronizationRecordResult.isErr) {
-      return Result.err(synchronizationRecordResult.error);
-    }
+        return Result.ok([...synchronizationRecords, synchronizationRecord]);
+      });
+    });
+  }, Result.ok<readonly WebAppVersionSynchronizationRecord[], Error>([]));
 
-    const {value: synchronizationRecordMaybe} = synchronizationRecordResult;
-
-    if (synchronizationRecordMaybe.isJust) {
-      const {value: synchronizationRecord} = synchronizationRecordMaybe;
-
-      synchronizationRecords.push(synchronizationRecord);
-    }
+  if (synchronizationRecordsResult.isErr) {
+    return Result.err(synchronizationRecordsResult.error);
   }
+
+  const {value: synchronizationRecords} = synchronizationRecordsResult;
 
   const requestedReleaseRecords = synchronizationRecords.filter(record => {
     return record.marker.releaseIdentifier === synchronizationRequest.releaseIdentifier;

--- a/tools/release-metadata/webappVersionSynchronization.ts
+++ b/tools/release-metadata/webappVersionSynchronization.ts
@@ -1,0 +1,376 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isNull, isString, isUndefined} from '@sindresorhus/is';
+import {Maybe, Result} from 'true-myth';
+
+import {createProductionTagName} from './releaseMetadata.ts';
+import type {ProductionTagName, ReleaseIdentifier} from './releaseMetadata.ts';
+import {
+  createWebAppVersionSynchronizationMarker,
+  parseWebAppVersionSynchronizationMarker,
+  validateWebAppVersion,
+} from './webappVersion.ts';
+import type {WebAppVersion, WebAppVersionSynchronizationMarker} from './webappVersion.ts';
+
+declare const webAppVersionSynchronizationBranchNameBrand: unique symbol;
+
+export type WebAppVersionSynchronizationBranchName = string & {
+  readonly [webAppVersionSynchronizationBranchNameBrand]: 'WebAppVersionSynchronizationBranchName';
+};
+
+export type WebAppVersionSynchronizationPullRequest = {
+  readonly number: number;
+  readonly url: string;
+  readonly title: string;
+  readonly body: string;
+  readonly state: 'open' | 'closed';
+  readonly mergedAt: string | null;
+  readonly baseBranch: string;
+  readonly headBranch: string;
+};
+
+export type WebAppVersionSynchronizationRecord = {
+  readonly pullRequest: WebAppVersionSynchronizationPullRequest;
+  readonly marker: WebAppVersionSynchronizationMarker;
+};
+
+export type WebAppVersionSynchronizationInspection =
+  | {
+      readonly kind: 'available';
+      readonly releaseIdentifier: ReleaseIdentifier;
+      readonly productionTagName: ProductionTagName;
+    }
+  | {
+      readonly kind: 'matching-open' | 'matching-merged' | 'closed-without-merge';
+      readonly releaseIdentifier: ReleaseIdentifier;
+      readonly productionTagName: ProductionTagName;
+      readonly webAppVersion: WebAppVersion;
+      readonly pullRequestNumber: number;
+      readonly pullRequestUrl: string;
+      readonly branchName: WebAppVersionSynchronizationBranchName;
+    }
+  | {
+      readonly kind: 'blocked-by-previous-open';
+      readonly releaseIdentifier: ReleaseIdentifier;
+      readonly productionTagName: ProductionTagName;
+      readonly blockingReleaseIdentifier: ReleaseIdentifier;
+      readonly blockingProductionTagName: ProductionTagName;
+      readonly blockingWebAppVersion: WebAppVersion;
+      readonly pullRequestNumber: number;
+      readonly pullRequestUrl: string;
+      readonly branchName: WebAppVersionSynchronizationBranchName;
+    }
+  | {
+      readonly kind: 'conflict';
+      readonly releaseIdentifier: ReleaseIdentifier;
+      readonly productionTagName: ProductionTagName;
+      readonly reason: string;
+    };
+
+export type WebAppVersionSynchronizationBranch = {
+  readonly branchName: WebAppVersionSynchronizationBranchName;
+  readonly releaseIdentifier: ReleaseIdentifier;
+  readonly webAppVersion: WebAppVersion;
+};
+
+export type CreateWebAppVersionSynchronizationPullRequestBodyOptions = {
+  readonly releaseIdentifier: string;
+  readonly productionTagName: string;
+  readonly webAppVersion: string;
+};
+
+const synchronizationBranchPrefix = 'webapp-version-';
+const synchronizationPullRequestTitlePrefix = 'Update WebApp version to ';
+const synchronizationBranchPattern = new RegExp(
+  String.raw`^${synchronizationBranchPrefix}(\d{4}-\d{2}-\d{2}\.[1-9]\d*)-((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))$`,
+);
+const synchronizationMarkerPrefix = '<!-- wire-webapp-version-sync';
+
+function createSynchronizationRequest(
+  releaseIdentifier: string,
+  productionTagName: string,
+): Result<{readonly releaseIdentifier: ReleaseIdentifier; readonly productionTagName: ProductionTagName}, Error> {
+  const productionTagNameResult = createProductionTagName(releaseIdentifier);
+
+  if (productionTagNameResult.isErr) {
+    return Result.err(productionTagNameResult.error);
+  }
+
+  if (productionTagNameResult.value !== productionTagName) {
+    return Result.err(
+      new Error(`Production tag ${productionTagName} does not match release identifier ${releaseIdentifier}`),
+    );
+  }
+
+  return Result.ok({
+    releaseIdentifier: releaseIdentifier as ReleaseIdentifier,
+    productionTagName: productionTagNameResult.value,
+  });
+}
+
+function isClaimedWebAppVersionSynchronizationPullRequest(
+  pullRequest: WebAppVersionSynchronizationPullRequest,
+): boolean {
+  return (
+    pullRequest.body.includes(synchronizationMarkerPrefix) ||
+    pullRequest.headBranch.startsWith(synchronizationBranchPrefix) ||
+    pullRequest.title.startsWith(synchronizationPullRequestTitlePrefix)
+  );
+}
+
+function createExistingSynchronizationInspection(
+  kind: 'matching-open' | 'matching-merged' | 'closed-without-merge',
+  synchronizationRecord: WebAppVersionSynchronizationRecord,
+): WebAppVersionSynchronizationInspection {
+  return {
+    kind,
+    releaseIdentifier: synchronizationRecord.marker.releaseIdentifier,
+    productionTagName: synchronizationRecord.marker.productionTagName,
+    webAppVersion: synchronizationRecord.marker.webAppVersion,
+    pullRequestNumber: synchronizationRecord.pullRequest.number,
+    pullRequestUrl: synchronizationRecord.pullRequest.url,
+    branchName: synchronizationRecord.pullRequest.headBranch as WebAppVersionSynchronizationBranchName,
+  };
+}
+
+export function createWebAppVersionSynchronizationBranchName(
+  releaseIdentifier: string,
+  webAppVersion: string,
+): Result<WebAppVersionSynchronizationBranchName, Error> {
+  const productionTagNameResult = createProductionTagName(releaseIdentifier);
+
+  if (productionTagNameResult.isErr) {
+    return Result.err(productionTagNameResult.error);
+  }
+
+  const webAppVersionResult = validateWebAppVersion(webAppVersion);
+
+  if (webAppVersionResult.isErr) {
+    return Result.err(webAppVersionResult.error);
+  }
+
+  return Result.ok(
+    `${synchronizationBranchPrefix}${releaseIdentifier}-${webAppVersionResult.value}` as WebAppVersionSynchronizationBranchName,
+  );
+}
+
+export function validateWebAppVersionSynchronizationBranchName(
+  branchName: string,
+): Result<WebAppVersionSynchronizationBranch, Error> {
+  const branchNameMatch = synchronizationBranchPattern.exec(branchName);
+
+  if (isNull(branchNameMatch)) {
+    return Result.err(new Error(`Invalid WebApp version synchronization branch name: ${branchName}`));
+  }
+
+  const releaseIdentifier = branchNameMatch[1];
+  const webAppVersion = branchNameMatch[2];
+
+  if (isString(releaseIdentifier) === false || isString(webAppVersion) === false) {
+    return Result.err(new Error(`Invalid WebApp version synchronization branch name: ${branchName}`));
+  }
+
+  const expectedBranchNameResult = createWebAppVersionSynchronizationBranchName(releaseIdentifier, webAppVersion);
+
+  if (expectedBranchNameResult.isErr) {
+    return Result.err(expectedBranchNameResult.error);
+  }
+
+  if (expectedBranchNameResult.value !== branchName) {
+    return Result.err(new Error(`Invalid WebApp version synchronization branch name: ${branchName}`));
+  }
+
+  return Result.ok({
+    branchName: expectedBranchNameResult.value,
+    releaseIdentifier: releaseIdentifier as ReleaseIdentifier,
+    webAppVersion: webAppVersion as WebAppVersion,
+  });
+}
+
+export function parseWebAppVersionSynchronizationPullRequest(
+  pullRequest: WebAppVersionSynchronizationPullRequest,
+): Result<Maybe<WebAppVersionSynchronizationRecord>, Error> {
+  if (isClaimedWebAppVersionSynchronizationPullRequest(pullRequest) === false) {
+    return Result.ok(Maybe.nothing<WebAppVersionSynchronizationRecord>());
+  }
+
+  const markerResult = parseWebAppVersionSynchronizationMarker(pullRequest.body);
+
+  if (markerResult.isErr) {
+    return Result.err(
+      new Error(
+        `Pull request #${pullRequest.number} claims to synchronize the WebApp version but has an invalid marker: ${markerResult.error.message}`,
+      ),
+    );
+  }
+
+  if (pullRequest.baseBranch !== 'main') {
+    return Result.err(
+      new Error(`WebApp version synchronization pull request #${pullRequest.number} does not target main`),
+    );
+  }
+
+  const expectedBranchNameResult = createWebAppVersionSynchronizationBranchName(
+    markerResult.value.releaseIdentifier,
+    markerResult.value.webAppVersion,
+  );
+
+  if (expectedBranchNameResult.isErr) {
+    return Result.err(expectedBranchNameResult.error);
+  }
+
+  if (expectedBranchNameResult.value !== pullRequest.headBranch) {
+    return Result.err(
+      new Error(
+        `WebApp version synchronization pull request #${pullRequest.number} has unexpected branch ${pullRequest.headBranch}`,
+      ),
+    );
+  }
+
+  if (pullRequest.state === 'open' && isNull(pullRequest.mergedAt) === false) {
+    return Result.err(new Error(`Open WebApp version synchronization pull request #${pullRequest.number} is merged`));
+  }
+
+  return Result.ok(Maybe.just({pullRequest, marker: markerResult.value}));
+}
+
+export function resolveWebAppVersionSynchronizationState(
+  releaseIdentifier: string,
+  productionTagName: string,
+  pullRequests: readonly WebAppVersionSynchronizationPullRequest[],
+): Result<WebAppVersionSynchronizationInspection, Error> {
+  const synchronizationRequestResult = createSynchronizationRequest(releaseIdentifier, productionTagName);
+
+  if (synchronizationRequestResult.isErr) {
+    return Result.err(synchronizationRequestResult.error);
+  }
+
+  const synchronizationRecords: WebAppVersionSynchronizationRecord[] = [];
+
+  for (const pullRequest of pullRequests) {
+    const synchronizationRecordResult = parseWebAppVersionSynchronizationPullRequest(pullRequest);
+
+    if (synchronizationRecordResult.isErr) {
+      return Result.err(synchronizationRecordResult.error);
+    }
+
+    if (synchronizationRecordResult.value.isJust) {
+      synchronizationRecords.push(synchronizationRecordResult.value.value);
+    }
+  }
+
+  const requestedReleaseRecords = synchronizationRecords.filter(record => {
+    return record.marker.releaseIdentifier === synchronizationRequestResult.value.releaseIdentifier;
+  });
+
+  const conflictingProductionTagRecord = requestedReleaseRecords.find(record => {
+    return record.marker.productionTagName !== synchronizationRequestResult.value.productionTagName;
+  });
+
+  if (isUndefined(conflictingProductionTagRecord) === false) {
+    return Result.ok({
+      kind: 'conflict',
+      releaseIdentifier: synchronizationRequestResult.value.releaseIdentifier,
+      productionTagName: synchronizationRequestResult.value.productionTagName,
+      reason: `A synchronization record for the release uses a different Production tag: ${conflictingProductionTagRecord.marker.productionTagName}`,
+    });
+  }
+
+  if (requestedReleaseRecords.length > 1) {
+    return Result.ok({
+      kind: 'conflict',
+      releaseIdentifier: synchronizationRequestResult.value.releaseIdentifier,
+      productionTagName: synchronizationRequestResult.value.productionTagName,
+      reason: 'Multiple synchronization records exist for the requested release',
+    });
+  }
+
+  const requestedReleaseRecord = requestedReleaseRecords.at(0);
+
+  if (isUndefined(requestedReleaseRecord) === false) {
+    if (requestedReleaseRecord.pullRequest.state === 'open') {
+      return Result.ok(createExistingSynchronizationInspection('matching-open', requestedReleaseRecord));
+    }
+
+    if (isNull(requestedReleaseRecord.pullRequest.mergedAt)) {
+      return Result.ok(createExistingSynchronizationInspection('closed-without-merge', requestedReleaseRecord));
+    }
+
+    return Result.ok(createExistingSynchronizationInspection('matching-merged', requestedReleaseRecord));
+  }
+
+  const previousOpenRecord = synchronizationRecords.find(record => {
+    return record.pullRequest.state === 'open';
+  });
+
+  if (isUndefined(previousOpenRecord) === false) {
+    return Result.ok({
+      kind: 'blocked-by-previous-open',
+      releaseIdentifier: synchronizationRequestResult.value.releaseIdentifier,
+      productionTagName: synchronizationRequestResult.value.productionTagName,
+      blockingReleaseIdentifier: previousOpenRecord.marker.releaseIdentifier,
+      blockingProductionTagName: previousOpenRecord.marker.productionTagName,
+      blockingWebAppVersion: previousOpenRecord.marker.webAppVersion,
+      pullRequestNumber: previousOpenRecord.pullRequest.number,
+      pullRequestUrl: previousOpenRecord.pullRequest.url,
+      branchName: previousOpenRecord.pullRequest.headBranch as WebAppVersionSynchronizationBranchName,
+    });
+  }
+
+  return Result.ok({
+    kind: 'available',
+    releaseIdentifier: synchronizationRequestResult.value.releaseIdentifier,
+    productionTagName: synchronizationRequestResult.value.productionTagName,
+  });
+}
+
+export function createWebAppVersionSynchronizationPullRequestTitle(webAppVersion: string): Result<string, Error> {
+  const webAppVersionResult = validateWebAppVersion(webAppVersion);
+
+  if (webAppVersionResult.isErr) {
+    return Result.err(webAppVersionResult.error);
+  }
+
+  return Result.ok(`${synchronizationPullRequestTitlePrefix}${webAppVersionResult.value}`);
+}
+
+export function createWebAppVersionSynchronizationPullRequestBody(
+  options: CreateWebAppVersionSynchronizationPullRequestBodyOptions,
+): Result<string, Error> {
+  const markerResult = createWebAppVersionSynchronizationMarker(options);
+
+  if (markerResult.isErr) {
+    return Result.err(markerResult.error);
+  }
+
+  return Result.ok(
+    [
+      'Synchronizes the WebApp package version with the successfully deployed Production release.',
+      '',
+      `WebApp version: ${options.webAppVersion}`,
+      `Release: ${options.releaseIdentifier}`,
+      `Production tag: ${options.productionTagName}`,
+      '',
+      'Production was already deployed and runtime-verified. This pull request only synchronizes repository package metadata; it does not modify the released artifact.',
+      '',
+      markerResult.value,
+    ].join('\n'),
+  );
+}

--- a/tools/release-metadata/webappVersionSynchronization.ts
+++ b/tools/release-metadata/webappVersionSynchronization.ts
@@ -51,6 +51,8 @@ export type WebAppVersionSynchronizationRecord = {
   readonly marker: WebAppVersionSynchronizationMarker;
 };
 
+export type WebAppVersionSynchronizationUnresolvedState = 'open' | 'closed-without-merge';
+
 export type WebAppVersionSynchronizationInspection =
   | {
       readonly kind: 'available';
@@ -67,12 +69,13 @@ export type WebAppVersionSynchronizationInspection =
       readonly branchName: WebAppVersionSynchronizationBranchName;
     }
   | {
-      readonly kind: 'blocked-by-previous-open';
+      readonly kind: 'blocked-by-previous-unresolved';
       readonly releaseIdentifier: ReleaseIdentifier;
       readonly productionTagName: ProductionTagName;
       readonly blockingReleaseIdentifier: ReleaseIdentifier;
       readonly blockingProductionTagName: ProductionTagName;
       readonly blockingWebAppVersion: WebAppVersion;
+      readonly blockingSynchronizationState: WebAppVersionSynchronizationUnresolvedState;
       readonly pullRequestNumber: number;
       readonly pullRequestUrl: string;
       readonly branchName: WebAppVersionSynchronizationBranchName;
@@ -326,6 +329,32 @@ export function resolveWebAppVersionSynchronizationState(
     return record.marker.releaseIdentifier === synchronizationRequest.releaseIdentifier;
   }, synchronizationRecords);
 
+  const unresolvedSynchronizationRecords = synchronizationRecords.filter(record => {
+    return record.pullRequest.state === 'open' || isNull(record.pullRequest.mergedAt);
+  });
+
+  if (unresolvedSynchronizationRecords.length > 1) {
+    return Result.ok({
+      kind: 'conflict',
+      releaseIdentifier: synchronizationRequest.releaseIdentifier,
+      productionTagName: synchronizationRequest.productionTagName,
+      reason: 'Multiple unresolved synchronization records exist',
+    });
+  }
+
+  const unresolvedDifferentReleaseRecord = maybe.find(record => {
+    return record.marker.releaseIdentifier !== synchronizationRequest.releaseIdentifier;
+  }, unresolvedSynchronizationRecords);
+
+  if (requestedReleaseRecord.isJust && unresolvedDifferentReleaseRecord.isJust) {
+    return Result.ok({
+      kind: 'conflict',
+      releaseIdentifier: synchronizationRequest.releaseIdentifier,
+      productionTagName: synchronizationRequest.productionTagName,
+      reason: 'A synchronization record for the requested release coexists with an unresolved different release',
+    });
+  }
+
   if (requestedReleaseRecord.isJust) {
     const {value: synchronizationRecord} = requestedReleaseRecord;
 
@@ -340,20 +369,23 @@ export function resolveWebAppVersionSynchronizationState(
     return Result.ok(createExistingSynchronizationInspection('matching-merged', synchronizationRecord));
   }
 
-  const previousOpenRecord = maybe.find(record => {
-    return record.pullRequest.state === 'open';
+  const previousUnresolvedRecord = maybe.find(record => {
+    return record.pullRequest.state === 'open' || isNull(record.pullRequest.mergedAt);
   }, synchronizationRecords);
 
-  if (previousOpenRecord.isJust) {
-    const {value: synchronizationRecord} = previousOpenRecord;
+  if (previousUnresolvedRecord.isJust) {
+    const {value: synchronizationRecord} = previousUnresolvedRecord;
+    const blockingSynchronizationState: WebAppVersionSynchronizationUnresolvedState =
+      synchronizationRecord.pullRequest.state === 'open' ? 'open' : 'closed-without-merge';
 
     return Result.ok({
-      kind: 'blocked-by-previous-open',
+      kind: 'blocked-by-previous-unresolved',
       releaseIdentifier: synchronizationRequest.releaseIdentifier,
       productionTagName: synchronizationRequest.productionTagName,
       blockingReleaseIdentifier: synchronizationRecord.marker.releaseIdentifier,
       blockingProductionTagName: synchronizationRecord.marker.productionTagName,
       blockingWebAppVersion: synchronizationRecord.marker.webAppVersion,
+      blockingSynchronizationState,
       pullRequestNumber: synchronizationRecord.pullRequest.number,
       pullRequestUrl: synchronizationRecord.pullRequest.url,
       branchName: synchronizationRecord.pullRequest.headBranch as WebAppVersionSynchronizationBranchName,

--- a/tools/release-metadata/webappVersionSynchronization.ts
+++ b/tools/release-metadata/webappVersionSynchronization.ts
@@ -17,8 +17,8 @@
  *
  */
 
-import {isNull, isString, isUndefined} from '@sindresorhus/is';
-import {Maybe, Result} from 'true-myth';
+import {isNull, isString} from '@sindresorhus/is';
+import {Maybe, maybe, Result} from 'true-myth';
 
 import {createProductionTagName} from './releaseMetadata.ts';
 import type {ProductionTagName, ReleaseIdentifier} from './releaseMetadata.ts';
@@ -113,7 +113,9 @@ function createSynchronizationRequest(
     return Result.err(productionTagNameResult.error);
   }
 
-  if (productionTagNameResult.value !== productionTagName) {
+  const {value: validatedProductionTagName} = productionTagNameResult;
+
+  if (validatedProductionTagName !== productionTagName) {
     return Result.err(
       new Error(`Production tag ${productionTagName} does not match release identifier ${releaseIdentifier}`),
     );
@@ -121,7 +123,7 @@ function createSynchronizationRequest(
 
   return Result.ok({
     releaseIdentifier: releaseIdentifier as ReleaseIdentifier,
-    productionTagName: productionTagNameResult.value,
+    productionTagName: validatedProductionTagName,
   });
 }
 
@@ -166,8 +168,10 @@ export function createWebAppVersionSynchronizationBranchName(
     return Result.err(webAppVersionResult.error);
   }
 
+  const {value: validatedWebAppVersion} = webAppVersionResult;
+
   return Result.ok(
-    `${synchronizationBranchPrefix}${releaseIdentifier}-${webAppVersionResult.value}` as WebAppVersionSynchronizationBranchName,
+    `${synchronizationBranchPrefix}${releaseIdentifier}-${validatedWebAppVersion}` as WebAppVersionSynchronizationBranchName,
   );
 }
 
@@ -193,12 +197,14 @@ export function validateWebAppVersionSynchronizationBranchName(
     return Result.err(expectedBranchNameResult.error);
   }
 
-  if (expectedBranchNameResult.value !== branchName) {
+  const {value: expectedBranchName} = expectedBranchNameResult;
+
+  if (expectedBranchName !== branchName) {
     return Result.err(new Error(`Invalid WebApp version synchronization branch name: ${branchName}`));
   }
 
   return Result.ok({
-    branchName: expectedBranchNameResult.value,
+    branchName: expectedBranchName,
     releaseIdentifier: releaseIdentifier as ReleaseIdentifier,
     webAppVersion: webAppVersion as WebAppVersion,
   });
@@ -221,6 +227,8 @@ export function parseWebAppVersionSynchronizationPullRequest(
     );
   }
 
+  const {value: marker} = markerResult;
+
   if (pullRequest.baseBranch !== 'main') {
     return Result.err(
       new Error(`WebApp version synchronization pull request #${pullRequest.number} does not target main`),
@@ -228,15 +236,17 @@ export function parseWebAppVersionSynchronizationPullRequest(
   }
 
   const expectedBranchNameResult = createWebAppVersionSynchronizationBranchName(
-    markerResult.value.releaseIdentifier,
-    markerResult.value.webAppVersion,
+    marker.releaseIdentifier,
+    marker.webAppVersion,
   );
 
   if (expectedBranchNameResult.isErr) {
     return Result.err(expectedBranchNameResult.error);
   }
 
-  if (expectedBranchNameResult.value !== pullRequest.headBranch) {
+  const {value: expectedBranchName} = expectedBranchNameResult;
+
+  if (expectedBranchName !== pullRequest.headBranch) {
     return Result.err(
       new Error(
         `WebApp version synchronization pull request #${pullRequest.number} has unexpected branch ${pullRequest.headBranch}`,
@@ -248,7 +258,7 @@ export function parseWebAppVersionSynchronizationPullRequest(
     return Result.err(new Error(`Open WebApp version synchronization pull request #${pullRequest.number} is merged`));
   }
 
-  return Result.ok(Maybe.just({pullRequest, marker: markerResult.value}));
+  return Result.ok(Maybe.just({pullRequest, marker}));
 }
 
 export function resolveWebAppVersionSynchronizationState(
@@ -262,6 +272,8 @@ export function resolveWebAppVersionSynchronizationState(
     return Result.err(synchronizationRequestResult.error);
   }
 
+  const {value: synchronizationRequest} = synchronizationRequestResult;
+
   const synchronizationRecords: WebAppVersionSynchronizationRecord[] = [];
 
   for (const pullRequest of pullRequests) {
@@ -271,73 +283,85 @@ export function resolveWebAppVersionSynchronizationState(
       return Result.err(synchronizationRecordResult.error);
     }
 
-    if (synchronizationRecordResult.value.isJust) {
-      synchronizationRecords.push(synchronizationRecordResult.value.value);
+    const {value: synchronizationRecordMaybe} = synchronizationRecordResult;
+
+    if (synchronizationRecordMaybe.isJust) {
+      const {value: synchronizationRecord} = synchronizationRecordMaybe;
+
+      synchronizationRecords.push(synchronizationRecord);
     }
   }
 
   const requestedReleaseRecords = synchronizationRecords.filter(record => {
-    return record.marker.releaseIdentifier === synchronizationRequestResult.value.releaseIdentifier;
+    return record.marker.releaseIdentifier === synchronizationRequest.releaseIdentifier;
   });
 
-  const conflictingProductionTagRecord = requestedReleaseRecords.find(record => {
-    return record.marker.productionTagName !== synchronizationRequestResult.value.productionTagName;
-  });
+  const conflictingProductionTagRecord = maybe.find(record => {
+    return record.marker.productionTagName !== synchronizationRequest.productionTagName;
+  }, requestedReleaseRecords);
 
-  if (isUndefined(conflictingProductionTagRecord) === false) {
+  if (conflictingProductionTagRecord.isJust) {
+    const {value: conflictingRecord} = conflictingProductionTagRecord;
+
     return Result.ok({
       kind: 'conflict',
-      releaseIdentifier: synchronizationRequestResult.value.releaseIdentifier,
-      productionTagName: synchronizationRequestResult.value.productionTagName,
-      reason: `A synchronization record for the release uses a different Production tag: ${conflictingProductionTagRecord.marker.productionTagName}`,
+      releaseIdentifier: synchronizationRequest.releaseIdentifier,
+      productionTagName: synchronizationRequest.productionTagName,
+      reason: `A synchronization record for the release uses a different Production tag: ${conflictingRecord.marker.productionTagName}`,
     });
   }
 
   if (requestedReleaseRecords.length > 1) {
     return Result.ok({
       kind: 'conflict',
-      releaseIdentifier: synchronizationRequestResult.value.releaseIdentifier,
-      productionTagName: synchronizationRequestResult.value.productionTagName,
+      releaseIdentifier: synchronizationRequest.releaseIdentifier,
+      productionTagName: synchronizationRequest.productionTagName,
       reason: 'Multiple synchronization records exist for the requested release',
     });
   }
 
-  const requestedReleaseRecord = requestedReleaseRecords.at(0);
+  const requestedReleaseRecord = maybe.find(record => {
+    return record.marker.releaseIdentifier === synchronizationRequest.releaseIdentifier;
+  }, synchronizationRecords);
 
-  if (isUndefined(requestedReleaseRecord) === false) {
-    if (requestedReleaseRecord.pullRequest.state === 'open') {
-      return Result.ok(createExistingSynchronizationInspection('matching-open', requestedReleaseRecord));
+  if (requestedReleaseRecord.isJust) {
+    const {value: synchronizationRecord} = requestedReleaseRecord;
+
+    if (synchronizationRecord.pullRequest.state === 'open') {
+      return Result.ok(createExistingSynchronizationInspection('matching-open', synchronizationRecord));
     }
 
-    if (isNull(requestedReleaseRecord.pullRequest.mergedAt)) {
-      return Result.ok(createExistingSynchronizationInspection('closed-without-merge', requestedReleaseRecord));
+    if (isNull(synchronizationRecord.pullRequest.mergedAt)) {
+      return Result.ok(createExistingSynchronizationInspection('closed-without-merge', synchronizationRecord));
     }
 
-    return Result.ok(createExistingSynchronizationInspection('matching-merged', requestedReleaseRecord));
+    return Result.ok(createExistingSynchronizationInspection('matching-merged', synchronizationRecord));
   }
 
-  const previousOpenRecord = synchronizationRecords.find(record => {
+  const previousOpenRecord = maybe.find(record => {
     return record.pullRequest.state === 'open';
-  });
+  }, synchronizationRecords);
 
-  if (isUndefined(previousOpenRecord) === false) {
+  if (previousOpenRecord.isJust) {
+    const {value: synchronizationRecord} = previousOpenRecord;
+
     return Result.ok({
       kind: 'blocked-by-previous-open',
-      releaseIdentifier: synchronizationRequestResult.value.releaseIdentifier,
-      productionTagName: synchronizationRequestResult.value.productionTagName,
-      blockingReleaseIdentifier: previousOpenRecord.marker.releaseIdentifier,
-      blockingProductionTagName: previousOpenRecord.marker.productionTagName,
-      blockingWebAppVersion: previousOpenRecord.marker.webAppVersion,
-      pullRequestNumber: previousOpenRecord.pullRequest.number,
-      pullRequestUrl: previousOpenRecord.pullRequest.url,
-      branchName: previousOpenRecord.pullRequest.headBranch as WebAppVersionSynchronizationBranchName,
+      releaseIdentifier: synchronizationRequest.releaseIdentifier,
+      productionTagName: synchronizationRequest.productionTagName,
+      blockingReleaseIdentifier: synchronizationRecord.marker.releaseIdentifier,
+      blockingProductionTagName: synchronizationRecord.marker.productionTagName,
+      blockingWebAppVersion: synchronizationRecord.marker.webAppVersion,
+      pullRequestNumber: synchronizationRecord.pullRequest.number,
+      pullRequestUrl: synchronizationRecord.pullRequest.url,
+      branchName: synchronizationRecord.pullRequest.headBranch as WebAppVersionSynchronizationBranchName,
     });
   }
 
   return Result.ok({
     kind: 'available',
-    releaseIdentifier: synchronizationRequestResult.value.releaseIdentifier,
-    productionTagName: synchronizationRequestResult.value.productionTagName,
+    releaseIdentifier: synchronizationRequest.releaseIdentifier,
+    productionTagName: synchronizationRequest.productionTagName,
   });
 }
 
@@ -348,7 +372,9 @@ export function createWebAppVersionSynchronizationPullRequestTitle(webAppVersion
     return Result.err(webAppVersionResult.error);
   }
 
-  return Result.ok(`${synchronizationPullRequestTitlePrefix}${webAppVersionResult.value}`);
+  const {value: validatedWebAppVersion} = webAppVersionResult;
+
+  return Result.ok(`${synchronizationPullRequestTitlePrefix}${validatedWebAppVersion}`);
 }
 
 export function createWebAppVersionSynchronizationPullRequestBody(
@@ -360,6 +386,8 @@ export function createWebAppVersionSynchronizationPullRequestBody(
     return Result.err(markerResult.error);
   }
 
+  const {value: marker} = markerResult;
+
   return Result.ok(
     [
       'Synchronizes the WebApp package version with the successfully deployed Production release.',
@@ -370,7 +398,7 @@ export function createWebAppVersionSynchronizationPullRequestBody(
       '',
       'Production was already deployed and runtime-verified. This pull request only synchronizes repository package metadata; it does not modify the released artifact.',
       '',
-      markerResult.value,
+      marker,
     ].join('\n'),
   );
 }

--- a/tools/release-metadata/webappVersionSynchronizationCli.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationCli.test.ts
@@ -1,0 +1,187 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {
+  createWebAppVersionSynchronizationInspectionOutput,
+  createWebAppVersionSynchronizationResultOutput,
+  serializeWebAppVersionSynchronizationOutput,
+} from './webappVersionSynchronizationCli.ts';
+import {validateWebAppVersion} from './webappVersion.ts';
+import type {WebAppVersionSynchronizationResult} from './webappVersionSynchronizationOrchestration.ts';
+import type {WebAppVersion} from './webappVersion.ts';
+import {createWebAppVersionSynchronizationBranchName} from './webappVersionSynchronization.ts';
+import type {
+  WebAppVersionSynchronizationBranchName,
+  WebAppVersionSynchronizationInspection,
+} from './webappVersionSynchronization.ts';
+
+const pullRequestDetails = {
+  pullRequestNumber: 123,
+  pullRequestUrl: 'https://github.com/wireapp/wire-webapp/pull/123',
+};
+
+function createWebAppVersion(version: string): WebAppVersion {
+  const versionResult = validateWebAppVersion(version);
+
+  if (versionResult.isErr) {
+    throw versionResult.error;
+  }
+
+  const {value: validatedVersion} = versionResult;
+
+  return validatedVersion;
+}
+
+function createSynchronizationBranchName(): WebAppVersionSynchronizationBranchName {
+  const branchNameResult = createWebAppVersionSynchronizationBranchName('2026-09-09.1', '1.0.0');
+
+  if (branchNameResult.isErr) {
+    throw branchNameResult.error;
+  }
+
+  const {value: branchName} = branchNameResult;
+
+  return branchName;
+}
+
+describe('WebApp version synchronization CLI output', () => {
+  it('serializes an available inspection', () => {
+    const inspection: WebAppVersionSynchronizationInspection = {
+      kind: 'available',
+      releaseIdentifier: '2026-09-09.1',
+      productionTagName: '2026-09-09.1-production',
+    };
+
+    const output = createWebAppVersionSynchronizationInspectionOutput(inspection);
+
+    expect(output).toEqual({
+      state: 'available',
+      release_identifier: '2026-09-09.1',
+      production_tag_name: '2026-09-09.1-production',
+    });
+  });
+
+  it.each(['matching-open', 'matching-merged', 'closed-without-merge'] as const)(
+    'serializes a %s inspection with synchronization details',
+    state => {
+      const inspection: WebAppVersionSynchronizationInspection = {
+        kind: state,
+        releaseIdentifier: '2026-09-09.1',
+        productionTagName: '2026-09-09.1-production',
+        webAppVersion: createWebAppVersion('1.0.0'),
+        branchName: createSynchronizationBranchName(),
+        ...pullRequestDetails,
+      };
+
+      const output = createWebAppVersionSynchronizationInspectionOutput(inspection);
+
+      expect(output).toEqual({
+        state,
+        release_identifier: '2026-09-09.1',
+        production_tag_name: '2026-09-09.1-production',
+        webapp_version: '1.0.0',
+        pull_request_number: 123,
+        pull_request_url: 'https://github.com/wireapp/wire-webapp/pull/123',
+        branch_name: createSynchronizationBranchName(),
+      });
+    },
+  );
+
+  it('serializes a previous open synchronization blocker', () => {
+    const inspection: WebAppVersionSynchronizationInspection = {
+      kind: 'blocked-by-previous-open',
+      releaseIdentifier: '2026-09-16.1',
+      productionTagName: '2026-09-16.1-production',
+      blockingReleaseIdentifier: '2026-09-09.1',
+      blockingProductionTagName: '2026-09-09.1-production',
+      blockingWebAppVersion: createWebAppVersion('1.0.0'),
+      branchName: createSynchronizationBranchName(),
+      ...pullRequestDetails,
+    };
+
+    const output = createWebAppVersionSynchronizationInspectionOutput(inspection);
+
+    expect(output).toEqual({
+      state: 'blocked-by-previous-open',
+      release_identifier: '2026-09-16.1',
+      production_tag_name: '2026-09-16.1-production',
+      blocking_release_identifier: '2026-09-09.1',
+      blocking_production_tag_name: '2026-09-09.1-production',
+      blocking_webapp_version: '1.0.0',
+      pull_request_number: 123,
+      pull_request_url: 'https://github.com/wireapp/wire-webapp/pull/123',
+      branch_name: createSynchronizationBranchName(),
+    });
+  });
+
+  it('serializes a synchronization conflict', () => {
+    const inspection: WebAppVersionSynchronizationInspection = {
+      kind: 'conflict',
+      releaseIdentifier: '2026-09-09.1',
+      productionTagName: '2026-09-09.1-production',
+      reason: 'Multiple synchronization records exist',
+    };
+
+    const output = createWebAppVersionSynchronizationInspectionOutput(inspection);
+
+    expect(output).toEqual({
+      state: 'conflict',
+      release_identifier: '2026-09-09.1',
+      production_tag_name: '2026-09-09.1-production',
+      reason: 'Multiple synchronization records exist',
+    });
+  });
+
+  it('serializes a synchronization action', () => {
+    const synchronizationResult: WebAppVersionSynchronizationResult = {
+      action: 'created',
+      releaseIdentifier: '2026-09-09.1',
+      productionTagName: '2026-09-09.1-production',
+      webAppVersion: createWebAppVersion('1.0.0'),
+      branchName: createSynchronizationBranchName(),
+      ...pullRequestDetails,
+    };
+
+    const output = createWebAppVersionSynchronizationResultOutput(synchronizationResult);
+
+    expect(output).toEqual({
+      action: 'created',
+      release_identifier: '2026-09-09.1',
+      production_tag_name: '2026-09-09.1-production',
+      webapp_version: '1.0.0',
+      branch_name: createSynchronizationBranchName(),
+      pull_request_number: 123,
+      pull_request_url: 'https://github.com/wireapp/wire-webapp/pull/123',
+    });
+  });
+
+  it('serializes output as one JSON document', () => {
+    const output = serializeWebAppVersionSynchronizationOutput({
+      state: 'available',
+      release_identifier: '2026-09-09.1',
+      production_tag_name: '2026-09-09.1-production',
+    });
+
+    expect(JSON.parse(output)).toEqual({
+      state: 'available',
+      release_identifier: '2026-09-09.1',
+      production_tag_name: '2026-09-09.1-production',
+    });
+  });
+});

--- a/tools/release-metadata/webappVersionSynchronizationCli.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationCli.test.ts
@@ -105,12 +105,13 @@ describe('WebApp version synchronization CLI output', () => {
 
   it('serializes a previous open synchronization blocker', () => {
     const inspection: WebAppVersionSynchronizationInspection = {
-      kind: 'blocked-by-previous-open',
+      kind: 'blocked-by-previous-unresolved',
       releaseIdentifier: '2026-09-16.1',
       productionTagName: '2026-09-16.1-production',
       blockingReleaseIdentifier: '2026-09-09.1',
       blockingProductionTagName: '2026-09-09.1-production',
       blockingWebAppVersion: createWebAppVersion('1.0.0'),
+      blockingSynchronizationState: 'open',
       branchName: createSynchronizationBranchName(),
       ...pullRequestDetails,
     };
@@ -118,12 +119,13 @@ describe('WebApp version synchronization CLI output', () => {
     const output = createWebAppVersionSynchronizationInspectionOutput(inspection);
 
     expect(output).toEqual({
-      state: 'blocked-by-previous-open',
+      state: 'blocked-by-previous-unresolved',
       release_identifier: '2026-09-16.1',
       production_tag_name: '2026-09-16.1-production',
       blocking_release_identifier: '2026-09-09.1',
       blocking_production_tag_name: '2026-09-09.1-production',
       blocking_webapp_version: '1.0.0',
+      blocking_synchronization_state: 'open',
       pull_request_number: 123,
       pull_request_url: 'https://github.com/wireapp/wire-webapp/pull/123',
       branch_name: createSynchronizationBranchName(),

--- a/tools/release-metadata/webappVersionSynchronizationCli.ts
+++ b/tools/release-metadata/webappVersionSynchronizationCli.ts
@@ -36,12 +36,13 @@ export type WebAppVersionSynchronizationInspectionOutput =
       readonly branch_name: string;
     }
   | {
-      readonly state: 'blocked-by-previous-open';
+      readonly state: 'blocked-by-previous-unresolved';
       readonly release_identifier: string;
       readonly production_tag_name: string;
       readonly blocking_release_identifier: string;
       readonly blocking_production_tag_name: string;
       readonly blocking_webapp_version: string;
+      readonly blocking_synchronization_state: 'open' | 'closed-without-merge';
       readonly pull_request_number: number;
       readonly pull_request_url: string;
       readonly branch_name: string;
@@ -101,7 +102,7 @@ export function createWebAppVersionSynchronizationInspectionOutput(
     };
   }
 
-  if (inspection.kind === 'blocked-by-previous-open') {
+  if (inspection.kind === 'blocked-by-previous-unresolved') {
     return {
       state: inspection.kind,
       release_identifier: inspection.releaseIdentifier,
@@ -109,6 +110,7 @@ export function createWebAppVersionSynchronizationInspectionOutput(
       blocking_release_identifier: inspection.blockingReleaseIdentifier,
       blocking_production_tag_name: inspection.blockingProductionTagName,
       blocking_webapp_version: inspection.blockingWebAppVersion,
+      blocking_synchronization_state: inspection.blockingSynchronizationState,
       pull_request_number: inspection.pullRequestNumber,
       pull_request_url: inspection.pullRequestUrl,
       branch_name: inspection.branchName,

--- a/tools/release-metadata/webappVersionSynchronizationCli.ts
+++ b/tools/release-metadata/webappVersionSynchronizationCli.ts
@@ -1,0 +1,146 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {WebAppVersionSynchronizationInspection} from './webappVersionSynchronization.ts';
+import type {WebAppVersionSynchronizationResult} from './webappVersionSynchronizationOrchestration.ts';
+
+export type WebAppVersionSynchronizationInspectionOutput =
+  | {
+      readonly state: 'available';
+      readonly release_identifier: string;
+      readonly production_tag_name: string;
+    }
+  | {
+      readonly state: 'matching-open' | 'matching-merged' | 'closed-without-merge';
+      readonly release_identifier: string;
+      readonly production_tag_name: string;
+      readonly webapp_version: string;
+      readonly pull_request_number: number;
+      readonly pull_request_url: string;
+      readonly branch_name: string;
+    }
+  | {
+      readonly state: 'blocked-by-previous-open';
+      readonly release_identifier: string;
+      readonly production_tag_name: string;
+      readonly blocking_release_identifier: string;
+      readonly blocking_production_tag_name: string;
+      readonly blocking_webapp_version: string;
+      readonly pull_request_number: number;
+      readonly pull_request_url: string;
+      readonly branch_name: string;
+    }
+  | {
+      readonly state: 'conflict';
+      readonly release_identifier: string;
+      readonly production_tag_name: string;
+      readonly reason: string;
+    };
+
+export type WebAppVersionSynchronizationResultOutput = {
+  readonly action: WebAppVersionSynchronizationResult['action'];
+  readonly release_identifier: string;
+  readonly production_tag_name: string;
+  readonly webapp_version: string;
+  readonly branch_name: string;
+  readonly pull_request_number: number;
+  readonly pull_request_url: string;
+};
+
+type WebAppVersionSynchronizationOutput =
+  WebAppVersionSynchronizationInspectionOutput | WebAppVersionSynchronizationResultOutput;
+
+export function createWebAppVersionSynchronizationInspectionOutput(
+  inspection: WebAppVersionSynchronizationInspection,
+): WebAppVersionSynchronizationInspectionOutput {
+  if (inspection.kind === 'available') {
+    return {
+      state: inspection.kind,
+      release_identifier: inspection.releaseIdentifier,
+      production_tag_name: inspection.productionTagName,
+    };
+  }
+
+  if (inspection.kind === 'matching-open' || inspection.kind === 'matching-merged') {
+    return {
+      state: inspection.kind,
+      release_identifier: inspection.releaseIdentifier,
+      production_tag_name: inspection.productionTagName,
+      webapp_version: inspection.webAppVersion,
+      pull_request_number: inspection.pullRequestNumber,
+      pull_request_url: inspection.pullRequestUrl,
+      branch_name: inspection.branchName,
+    };
+  }
+
+  if (inspection.kind === 'closed-without-merge') {
+    return {
+      state: inspection.kind,
+      release_identifier: inspection.releaseIdentifier,
+      production_tag_name: inspection.productionTagName,
+      webapp_version: inspection.webAppVersion,
+      pull_request_number: inspection.pullRequestNumber,
+      pull_request_url: inspection.pullRequestUrl,
+      branch_name: inspection.branchName,
+    };
+  }
+
+  if (inspection.kind === 'blocked-by-previous-open') {
+    return {
+      state: inspection.kind,
+      release_identifier: inspection.releaseIdentifier,
+      production_tag_name: inspection.productionTagName,
+      blocking_release_identifier: inspection.blockingReleaseIdentifier,
+      blocking_production_tag_name: inspection.blockingProductionTagName,
+      blocking_webapp_version: inspection.blockingWebAppVersion,
+      pull_request_number: inspection.pullRequestNumber,
+      pull_request_url: inspection.pullRequestUrl,
+      branch_name: inspection.branchName,
+    };
+  }
+
+  if (inspection.kind === 'conflict') {
+    return {
+      state: inspection.kind,
+      release_identifier: inspection.releaseIdentifier,
+      production_tag_name: inspection.productionTagName,
+      reason: inspection.reason,
+    };
+  }
+
+  throw new Error('Unknown WebApp version synchronization inspection state');
+}
+
+export function createWebAppVersionSynchronizationResultOutput(
+  synchronizationResult: WebAppVersionSynchronizationResult,
+): WebAppVersionSynchronizationResultOutput {
+  return {
+    action: synchronizationResult.action,
+    release_identifier: synchronizationResult.releaseIdentifier,
+    production_tag_name: synchronizationResult.productionTagName,
+    webapp_version: synchronizationResult.webAppVersion,
+    branch_name: synchronizationResult.branchName,
+    pull_request_number: synchronizationResult.pullRequestNumber,
+    pull_request_url: synchronizationResult.pullRequestUrl,
+  };
+}
+
+export function serializeWebAppVersionSynchronizationOutput(output: WebAppVersionSynchronizationOutput): string {
+  return JSON.stringify(output);
+}

--- a/tools/release-metadata/webappVersionSynchronizationGit.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGit.test.ts
@@ -18,8 +18,11 @@
  */
 
 import assert from 'node:assert';
+import {Buffer} from 'node:buffer';
 
 import {
+  createWebAppVersionSynchronizationGitAuthenticationEnvironment,
+  redactWebAppVersionSynchronizationGitFailureMessage,
   parseWebAppVersionSynchronizationPackageDocument,
   validateWebAppVersionSynchronizationBranch,
   webAppVersionSynchronizationPackageFilePaths,
@@ -104,6 +107,36 @@ function validateBranch(
     expectedWebAppVersion: options.expectedWebAppVersion ?? '1.0.0',
   });
 }
+
+describe('WebApp synchronization Git authentication', () => {
+  it('creates process-scoped GitHub authentication configuration', () => {
+    const githubToken = 'otto-write-token';
+    const basicCredential = Buffer.from(`x-access-token:${githubToken}`, 'utf8').toString('base64');
+    const actualEnvironment = createWebAppVersionSynchronizationGitAuthenticationEnvironment({githubToken});
+
+    expect(actualEnvironment).toEqual({
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'http.https://github.com/.extraheader',
+      GIT_CONFIG_VALUE_0: `AUTHORIZATION: basic ${basicCredential}`,
+      GIT_TERMINAL_PROMPT: '0',
+    });
+    expect(JSON.stringify(actualEnvironment)).not.toContain(githubToken);
+  });
+
+  it('redacts credentials from a simulated Git push failure', () => {
+    const githubToken = 'otto-write-token';
+    const basicCredential = Buffer.from(`x-access-token:${githubToken}`, 'utf8').toString('base64');
+    const simulatedFailureMessage = `fatal: authorization failed for ${githubToken} (${basicCredential})`;
+    const actualFailureMessage = redactWebAppVersionSynchronizationGitFailureMessage(simulatedFailureMessage, [
+      githubToken,
+      basicCredential,
+    ]);
+
+    expect(actualFailureMessage).toBe('fatal: authorization failed for [REDACTED] ([REDACTED])');
+    expect(actualFailureMessage).not.toContain(githubToken);
+    expect(actualFailureMessage).not.toContain(basicCredential);
+  });
+});
 
 describe('WebApp synchronization branch validation', () => {
   it('accepts a branch with one safe synchronization commit', () => {

--- a/tools/release-metadata/webappVersionSynchronizationGit.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGit.test.ts
@@ -211,6 +211,15 @@ describe('WebApp synchronization branch validation', () => {
       expectedReleaseIdentifier: releaseIdentifier,
       expectedWebAppVersion: '1.0.0',
     },
+    {
+      description: 'an unexpected package metadata change',
+      branchInspection: {
+        ...createValidBranchInspection(),
+        branchRootPackageDocument: {...createPackageDocument('1.0.0'), description: 'unexpected'},
+      },
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.0',
+    },
   ])('rejects %s', ({branchInspection, expectedReleaseIdentifier, expectedWebAppVersion}) => {
     const actualResult = validateBranch({
       branchInspection,

--- a/tools/release-metadata/webappVersionSynchronizationGit.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGit.test.ts
@@ -1,0 +1,231 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+
+import {
+  parseWebAppVersionSynchronizationPackageDocument,
+  validateWebAppVersionSynchronizationBranch,
+  webAppVersionSynchronizationPackageFilePaths,
+} from './webappVersionSynchronizationGit.ts';
+import type {WebAppVersionSynchronizationBranchInspection} from './webappVersionSynchronizationGit.ts';
+
+const releaseIdentifier = '2026-09-09.1';
+const synchronizationBranchName = 'webapp-version-2026-09-09.1-1.0.0';
+const mainCommitSha = 'a'.repeat(40);
+const branchTipCommitSha = 'b'.repeat(40);
+
+describe('WebApp synchronization package document parsing', () => {
+  it('parses a JSON package document as a validated object', () => {
+    const actualResult = parseWebAppVersionSynchronizationPackageDocument(
+      '{"name":"@wireapp/example","version":"0.27.0"}',
+      'package.json',
+    );
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toEqual({name: '@wireapp/example', version: '0.27.0'});
+  });
+
+  it.each([
+    ['malformed JSON', '{'],
+    ['an array', '[]'],
+    ['null', 'null'],
+    ['a string', '"package"'],
+    ['a number', '42'],
+    ['a boolean', 'true'],
+  ])('rejects %s', (_description, packageContents) => {
+    const actualResult = parseWebAppVersionSynchronizationPackageDocument(packageContents, 'package.json');
+
+    assert(actualResult.isErr);
+  });
+
+  it('rejects an empty package document', () => {
+    const actualResult = parseWebAppVersionSynchronizationPackageDocument('', 'package.json');
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('Empty package document: package.json');
+  });
+});
+
+function createPackageDocument(version: string): Readonly<Record<string, unknown>> {
+  return {
+    name: '@wireapp/example',
+    private: true,
+    version,
+    scripts: {test: 'jest'},
+  };
+}
+
+function createValidBranchInspection(): WebAppVersionSynchronizationBranchInspection {
+  return {
+    branchName: synchronizationBranchName,
+    mainCommitSha,
+    branchTipCommitSha,
+    baseCommitSha: mainCommitSha,
+    commitParentCount: 1,
+    isNormalCommit: true,
+    isBasedOnMainHistory: true,
+    changedFilePaths: webAppVersionSynchronizationPackageFilePaths,
+    baseRootPackageDocument: createPackageDocument('0.27.0'),
+    baseWebAppPackageDocument: createPackageDocument('0.27.0'),
+    branchRootPackageDocument: createPackageDocument('1.0.0'),
+    branchWebAppPackageDocument: createPackageDocument('1.0.0'),
+  };
+}
+
+type ValidateBranchOptions = {
+  readonly branchInspection?: WebAppVersionSynchronizationBranchInspection;
+  readonly expectedReleaseIdentifier?: string;
+  readonly expectedWebAppVersion?: string;
+};
+
+function validateBranch(
+  options: ValidateBranchOptions = {},
+): ReturnType<typeof validateWebAppVersionSynchronizationBranch> {
+  return validateWebAppVersionSynchronizationBranch({
+    branchInspection: options.branchInspection ?? createValidBranchInspection(),
+    expectedReleaseIdentifier: options.expectedReleaseIdentifier ?? releaseIdentifier,
+    expectedWebAppVersion: options.expectedWebAppVersion ?? '1.0.0',
+  });
+}
+
+describe('WebApp synchronization branch validation', () => {
+  it('accepts a branch with one safe synchronization commit', () => {
+    const actualResult = validateBranch();
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toEqual({
+      branchName: synchronizationBranchName,
+      releaseIdentifier,
+      webAppVersion: '1.0.0',
+    });
+  });
+
+  it.each([
+    {
+      description: 'a different release identifier',
+      branchInspection: createValidBranchInspection(),
+      expectedReleaseIdentifier: '2026-09-16.1',
+      expectedWebAppVersion: '1.0.0',
+    },
+    {
+      description: 'a different branch version',
+      branchInspection: createValidBranchInspection(),
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.1',
+    },
+    {
+      description: 'an empty main commit',
+      branchInspection: {...createValidBranchInspection(), mainCommitSha: ''},
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.0',
+    },
+    {
+      description: 'a branch tip equal to its base',
+      branchInspection: {...createValidBranchInspection(), branchTipCommitSha: mainCommitSha},
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.0',
+    },
+    {
+      description: 'multiple commits',
+      branchInspection: {...createValidBranchInspection(), commitParentCount: 2},
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.0',
+    },
+    {
+      description: 'a non-normal commit',
+      branchInspection: {...createValidBranchInspection(), isNormalCommit: false},
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.0',
+    },
+    {
+      description: 'a base outside main history',
+      branchInspection: {...createValidBranchInspection(), isBasedOnMainHistory: false},
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.0',
+    },
+    {
+      description: 'an unexpected file change',
+      branchInspection: {
+        ...createValidBranchInspection(),
+        changedFilePaths: [...webAppVersionSynchronizationPackageFilePaths, 'README.md'],
+      },
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.0',
+    },
+    {
+      description: 'a missing package file change',
+      branchInspection: {...createValidBranchInspection(), changedFilePaths: ['package.json']},
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.0',
+    },
+    {
+      description: 'a malformed base package document',
+      branchInspection: {...createValidBranchInspection(), baseRootPackageDocument: []},
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.0',
+    },
+    {
+      description: 'disagreeing base package versions',
+      branchInspection: {
+        ...createValidBranchInspection(),
+        baseWebAppPackageDocument: createPackageDocument('0.27.1'),
+      },
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.0',
+    },
+    {
+      description: 'a branch version that does not follow its base version',
+      branchInspection: createValidBranchInspection(),
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.1',
+    },
+    {
+      description: 'a malformed branch package document',
+      branchInspection: {...createValidBranchInspection(), branchRootPackageDocument: 'not-an-object'},
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.0',
+    },
+    {
+      description: 'disagreeing branch package versions',
+      branchInspection: {
+        ...createValidBranchInspection(),
+        branchWebAppPackageDocument: createPackageDocument('1.0.1'),
+      },
+      expectedReleaseIdentifier: releaseIdentifier,
+      expectedWebAppVersion: '1.0.0',
+    },
+  ])('rejects %s', ({branchInspection, expectedReleaseIdentifier, expectedWebAppVersion}) => {
+    const actualResult = validateBranch({
+      branchInspection,
+      expectedReleaseIdentifier,
+      expectedWebAppVersion,
+    });
+
+    assert(actualResult.isErr);
+  });
+
+  it('rejects an invalid synchronization branch name', () => {
+    const actualResult = validateBranch({
+      branchInspection: {...createValidBranchInspection(), branchName: 'webapp-version-invalid'},
+    });
+
+    assert(actualResult.isErr);
+  });
+});

--- a/tools/release-metadata/webappVersionSynchronizationGit.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGit.ts
@@ -23,6 +23,7 @@ import type {SimpleGit} from 'simple-git';
 import {Result, Task, Unit, task} from 'true-myth';
 import {z} from 'zod';
 
+import {Buffer} from 'node:buffer';
 import {readFile as readFileFromFileSystem, writeFile as writeFileToFileSystem} from 'node:fs/promises';
 import {resolve} from 'node:path';
 import {isDeepStrictEqual} from 'node:util';
@@ -104,6 +105,11 @@ export type PushWebAppVersionSynchronizationBranchOptions = {
 export type CreateWebAppVersionSynchronizationGitClientOptions = {
   readonly repositoryPath: string;
   readonly fileSystem: WebAppVersionSynchronizationFileSystem;
+  readonly authentication: WebAppVersionSynchronizationGitAuthentication;
+};
+
+export type WebAppVersionSynchronizationGitAuthentication = {
+  readonly githubToken: string;
 };
 
 export type WebAppVersionSynchronizationFileSystem = {
@@ -116,6 +122,7 @@ export const webAppVersionSynchronizationPackageFilePaths = ['apps/webapp/packag
 type RunGitOperationOptions<valueType> = {
   readonly description: string;
   readonly execute: () => Promise<valueType>;
+  readonly redactedSecretValues?: readonly string[];
 };
 
 type CreateBranchInspectionOptions = {
@@ -141,6 +148,9 @@ const packageJsonIndentationSpaces = 2;
 const normalCommitPartCount = 2;
 const singleCommitParentCount = 1;
 const webAppPackageDocumentSchema = z.record(z.string(), z.unknown());
+const githubServerOrigin = 'https://github.com';
+const gitAuthenticationHeaderKey = `http.${githubServerOrigin}/.extraheader`;
+const gitAuthenticationHeaderPrefix = 'AUTHORIZATION: basic';
 
 function errorMessage(error: unknown): string {
   if (isError(error)) {
@@ -150,10 +160,51 @@ function errorMessage(error: unknown): string {
   return 'Unknown Git failure';
 }
 
+export function redactWebAppVersionSynchronizationGitFailureMessage(
+  failureMessage: string,
+  redactedSecretValues: readonly string[],
+): string {
+  return redactedSecretValues.reduce((redactedMessage, secretValue) => {
+    if (isNonEmptyString(secretValue) === false) {
+      return redactedMessage;
+    }
+
+    return redactedMessage.replaceAll(secretValue, '[REDACTED]');
+  }, failureMessage);
+}
+
+function createGitHubBasicCredential(githubToken: string): string {
+  return Buffer.from(`x-access-token:${githubToken}`, 'utf8').toString('base64');
+}
+
+export function createWebAppVersionSynchronizationGitAuthenticationEnvironment(
+  authentication: WebAppVersionSynchronizationGitAuthentication,
+): Readonly<Record<string, string>> {
+  const basicCredential = createGitHubBasicCredential(authentication.githubToken);
+
+  return {
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: gitAuthenticationHeaderKey,
+    GIT_CONFIG_VALUE_0: `${gitAuthenticationHeaderPrefix} ${basicCredential}`,
+    GIT_TERMINAL_PROMPT: '0',
+  };
+}
+
 function runGitOperation<valueType>(options: RunGitOperationOptions<valueType>): Task<valueType, Error> {
+  const redactedSecretValues = options.redactedSecretValues ?? [];
+
   return task.tryOrElse(
     (error: unknown): Error => {
-      return new Error(`${options.description}: ${errorMessage(error)}`, {cause: error});
+      const redactedFailureMessage = redactWebAppVersionSynchronizationGitFailureMessage(
+        errorMessage(error),
+        redactedSecretValues,
+      );
+
+      if (redactedSecretValues.length > 0) {
+        return new Error(`${options.description}: ${redactedFailureMessage}`);
+      }
+
+      return new Error(`${options.description}: ${redactedFailureMessage}`, {cause: error});
     },
     async (): Promise<valueType> => {
       return options.execute();
@@ -444,6 +495,12 @@ export function createSimpleGitWebAppVersionSynchronizationClient(
   options: CreateWebAppVersionSynchronizationGitClientOptions,
 ): WebAppVersionSynchronizationGitClient {
   const git = simpleGit(options.repositoryPath);
+  const authenticationEnvironment = createWebAppVersionSynchronizationGitAuthenticationEnvironment(
+    options.authentication,
+  );
+  const authenticatedGit = simpleGit(options.repositoryPath).env(authenticationEnvironment);
+  const basicCredential = createGitHubBasicCredential(options.authentication.githubToken);
+  const redactedAuthenticationValues = [options.authentication.githubToken, basicCredential];
 
   function readCurrentMainCommit(): Task<string, Error> {
     return runGitOperation({
@@ -803,8 +860,13 @@ export function createSimpleGitWebAppVersionSynchronizationClient(
       return runGitOperation({
         description: `Unable to push synchronization branch ${pushOptions.branchName}`,
         async execute() {
-          return git.raw(['push', 'origin', `${pushOptions.branchName}:refs/heads/${pushOptions.branchName}`]);
+          return authenticatedGit.raw([
+            'push',
+            'origin',
+            `${pushOptions.branchName}:refs/heads/${pushOptions.branchName}`,
+          ]);
         },
+        redactedSecretValues: redactedAuthenticationValues,
       }).map(() => Unit);
     },
 

--- a/tools/release-metadata/webappVersionSynchronizationGit.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGit.ts
@@ -206,23 +206,25 @@ function createPackageDocumentContents(packageDocument: WebAppPackageDocument): 
   return `${JSON.stringify(packageDocument, null, packageJsonIndentationSpaces)}\n`;
 }
 
-function parseRemoteBranchNames(remoteBranchesOutput: string, branchPrefix: string): readonly string[] {
-  return remoteBranchesOutput.split('\n').flatMap(remoteBranchLine => {
-    const remoteBranchFields = remoteBranchLine.split('\t');
-    const remoteReference = remoteBranchFields.at(1);
+function parseRemoteBranchNames(remoteBranchesOutput: string, branchPrefix: string): ReadonlySet<string> {
+  return new Set(
+    remoteBranchesOutput.split('\n').flatMap(remoteBranchLine => {
+      const remoteBranchFields = remoteBranchLine.split('\t');
+      const remoteReference = remoteBranchFields.at(1);
 
-    if (isString(remoteReference) === false || remoteReference.startsWith('refs/heads/') === false) {
-      return [];
-    }
+      if (isString(remoteReference) === false || remoteReference.startsWith('refs/heads/') === false) {
+        return [];
+      }
 
-    const branchName = remoteReference.slice('refs/heads/'.length);
+      const branchName = remoteReference.slice('refs/heads/'.length);
 
-    if (branchName.startsWith(branchPrefix) === false) {
-      return [];
-    }
+      if (branchName.startsWith(branchPrefix) === false) {
+        return [];
+      }
 
-    return [branchName];
-  });
+      return [branchName];
+    }),
+  );
 }
 
 function parseCommitSha(commitOutput: string, description: string): Result<string, Error> {
@@ -418,7 +420,7 @@ export function createSimpleGitWebAppVersionSynchronizationClient(
       return Result.err(remoteBranchesResult.error);
     }
 
-    return Result.ok(parseRemoteBranchNames(remoteBranchesResult.value, branchPrefix));
+    return Result.ok([...parseRemoteBranchNames(remoteBranchesResult.value, branchPrefix)].toSorted());
   }
 
   async function readPackageDocumentsFromWorkingTree(): Promise<Result<WebAppPackageDocuments, Error>> {
@@ -453,7 +455,7 @@ export function createSimpleGitWebAppVersionSynchronizationClient(
       remoteBranchOutputResult.value,
       `${synchronizationBranchPrefix}${inspectOptions.branchName.slice(synchronizationBranchPrefix.length)}`,
     );
-    const remoteBranchExists = remoteBranchNames.includes(inspectOptions.branchName);
+    const remoteBranchExists = remoteBranchNames.has(inspectOptions.branchName);
     let branchReference: string;
 
     if (remoteBranchExists) {

--- a/tools/release-metadata/webappVersionSynchronizationGit.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGit.ts
@@ -1,0 +1,825 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isError, isNonEmptyString, isString} from '@sindresorhus/is';
+import {simpleGit} from 'simple-git';
+import type {SimpleGit} from 'simple-git';
+import {Result, Unit} from 'true-myth';
+import {z} from 'zod';
+
+import {readFile as readFileFromFileSystem, writeFile as writeFileToFileSystem} from 'node:fs/promises';
+import {resolve} from 'node:path';
+
+import {resolveNextWebAppVersion, validateMatchingWebAppPackageVersions} from './webappVersion.ts';
+import type {WebAppPackageDocument, WebAppPackageDocuments} from './webappVersion.ts';
+import {
+  createWebAppVersionSynchronizationBranchName,
+  validateWebAppVersionSynchronizationBranchName,
+} from './webappVersionSynchronization.ts';
+import type {WebAppVersionSynchronizationBranch} from './webappVersionSynchronization.ts';
+
+export type WebAppVersionSynchronizationMainSnapshot = {
+  readonly commitSha: string;
+  readonly rootPackageDocument: WebAppPackageDocument;
+  readonly webAppPackageDocument: WebAppPackageDocument;
+};
+
+export type WebAppVersionSynchronizationBranchInspection = {
+  readonly branchName: string;
+  readonly mainCommitSha: string;
+  readonly branchTipCommitSha: string;
+  readonly baseCommitSha: string;
+  readonly commitParentCount: number;
+  readonly isNormalCommit: boolean;
+  readonly isBasedOnMainHistory: boolean;
+  readonly changedFilePaths: readonly string[];
+  readonly baseRootPackageDocument: unknown;
+  readonly baseWebAppPackageDocument: unknown;
+  readonly branchRootPackageDocument: unknown;
+  readonly branchWebAppPackageDocument: unknown;
+};
+
+export type ValidateWebAppVersionSynchronizationBranchOptions = {
+  readonly branchInspection: WebAppVersionSynchronizationBranchInspection;
+  readonly expectedReleaseIdentifier: string;
+  readonly expectedWebAppVersion: string;
+};
+
+export type WebAppVersionSynchronizationGitClient = {
+  readonly prepareLatestMain: () => Promise<Result<WebAppVersionSynchronizationMainSnapshot, Error>>;
+  readonly listExistingBranchNames: (releaseIdentifier: string) => Promise<Result<readonly string[], Error>>;
+  readonly inspectBranch: (
+    options: InspectWebAppVersionSynchronizationBranchOptions,
+  ) => Promise<Result<WebAppVersionSynchronizationBranchInspection | undefined, Error>>;
+  readonly createBranchFromMain: (
+    options: CreateWebAppVersionSynchronizationBranchOptions,
+  ) => Promise<Result<Unit, Error>>;
+  readonly readWorkingTreePackageDocuments: () => Promise<Result<WebAppPackageDocuments, Error>>;
+  readonly writePackageDocuments: (
+    options: WriteWebAppVersionSynchronizationPackageDocumentsOptions,
+  ) => Promise<Result<Unit, Error>>;
+  readonly getWorkingTreeChangedFilePaths: () => Promise<Result<readonly string[], Error>>;
+  readonly commit: (options: CommitWebAppVersionSynchronizationOptions) => Promise<Result<string, Error>>;
+  readonly pushBranch: (options: PushWebAppVersionSynchronizationBranchOptions) => Promise<Result<Unit, Error>>;
+  readonly verifyMainCommit: (mainCommitSha: string) => Promise<Result<Unit, Error>>;
+};
+
+export type InspectWebAppVersionSynchronizationBranchOptions = {
+  readonly branchName: string;
+  readonly mainCommitSha: string;
+};
+
+export type CreateWebAppVersionSynchronizationBranchOptions = {
+  readonly branchName: string;
+  readonly mainCommitSha: string;
+};
+
+export type WriteWebAppVersionSynchronizationPackageDocumentsOptions = WebAppPackageDocuments;
+
+export type CommitWebAppVersionSynchronizationOptions = {
+  readonly message: string;
+  readonly authorName: string;
+  readonly authorEmail: string;
+};
+
+export type PushWebAppVersionSynchronizationBranchOptions = {
+  readonly branchName: string;
+};
+
+export type CreateWebAppVersionSynchronizationGitClientOptions = {
+  readonly repositoryPath: string;
+  readonly fileSystem: WebAppVersionSynchronizationFileSystem;
+};
+
+export type WebAppVersionSynchronizationFileSystem = {
+  readonly readFile: (filePath: string) => Promise<string>;
+  readonly writeFile: (filePath: string, fileContents: string) => Promise<void>;
+};
+
+export const webAppVersionSynchronizationPackageFilePaths = ['apps/webapp/package.json', 'package.json'] as const;
+
+type RunGitCommandOptions = {
+  readonly description: string;
+  readonly execute: () => Promise<string>;
+};
+
+type CreateBranchInspectionOptions = {
+  readonly branchName: string;
+  readonly mainCommitSha: string;
+  readonly branchTipCommitSha: string;
+  readonly parentCommitOutput: string;
+  readonly isBasedOnMainHistory: boolean;
+  readonly changedFilePaths: readonly string[];
+  readonly basePackageDocuments: WebAppPackageDocuments | undefined;
+  readonly branchPackageDocuments: WebAppPackageDocuments | undefined;
+};
+
+const synchronizationBranchPrefix = 'webapp-version-';
+const commitShaPattern = /^[0-9a-f]{40}$/;
+const packageJsonIndentationSpaces = 2;
+const normalCommitPartCount = 2;
+const singleCommitParentCount = 1;
+const webAppPackageDocumentSchema = z.record(z.string(), z.unknown());
+
+function errorMessage(error: unknown): string {
+  if (isError(error)) {
+    return error.message;
+  }
+
+  return 'Unknown Git failure';
+}
+
+async function runGitCommand(options: RunGitCommandOptions): Promise<Result<string, Error>> {
+  try {
+    return Result.ok(await options.execute());
+  } catch (error: unknown) {
+    return Result.err(new Error(`${options.description}: ${errorMessage(error)}`, {cause: error}));
+  }
+}
+
+export function parseWebAppVersionSynchronizationPackageDocument(
+  packageContents: string,
+  packagePath: string,
+): Result<WebAppPackageDocument, Error> {
+  if (isNonEmptyString(packageContents) === false) {
+    return Result.err(new Error(`Empty package document: ${packagePath}`));
+  }
+
+  try {
+    const packageDocumentResult = webAppPackageDocumentSchema.safeParse(JSON.parse(packageContents));
+
+    if (packageDocumentResult.success === false) {
+      return Result.err(new Error(`Invalid package document: ${packagePath}: ${packageDocumentResult.error.message}`));
+    }
+
+    return Result.ok(packageDocumentResult.data);
+  } catch (error: unknown) {
+    return Result.err(new Error(`Malformed package document: ${packagePath}: ${errorMessage(error)}`, {cause: error}));
+  }
+}
+
+function parsePackageDocumentPaths(
+  contents: readonly string[],
+  paths: readonly string[],
+): Result<WebAppPackageDocuments, Error> {
+  const rootPackageContents = contents.at(0);
+  const webAppPackageContents = contents.at(1);
+
+  if (isString(rootPackageContents) === false || isString(webAppPackageContents) === false) {
+    return Result.err(new Error('Git did not return both WebApp package documents'));
+  }
+
+  const rootPackageDocumentResult = parseWebAppVersionSynchronizationPackageDocument(rootPackageContents, paths[0]);
+  const webAppPackageDocumentResult = parseWebAppVersionSynchronizationPackageDocument(webAppPackageContents, paths[1]);
+
+  if (rootPackageDocumentResult.isErr) {
+    return Result.err(rootPackageDocumentResult.error);
+  }
+
+  if (webAppPackageDocumentResult.isErr) {
+    return Result.err(webAppPackageDocumentResult.error);
+  }
+
+  return Result.ok({
+    rootPackageDocument: rootPackageDocumentResult.value,
+    webAppPackageDocument: webAppPackageDocumentResult.value,
+  });
+}
+
+function createPackageDocumentContents(packageDocument: WebAppPackageDocument): string {
+  return `${JSON.stringify(packageDocument, null, packageJsonIndentationSpaces)}\n`;
+}
+
+function parseRemoteBranchNames(remoteBranchesOutput: string, branchPrefix: string): readonly string[] {
+  return remoteBranchesOutput.split('\n').flatMap(remoteBranchLine => {
+    const remoteBranchFields = remoteBranchLine.split('\t');
+    const remoteReference = remoteBranchFields.at(1);
+
+    if (isString(remoteReference) === false || remoteReference.startsWith('refs/heads/') === false) {
+      return [];
+    }
+
+    const branchName = remoteReference.slice('refs/heads/'.length);
+
+    if (branchName.startsWith(branchPrefix) === false) {
+      return [];
+    }
+
+    return [branchName];
+  });
+}
+
+function parseCommitSha(commitOutput: string, description: string): Result<string, Error> {
+  const commitSha = commitOutput.trim();
+
+  if (commitShaPattern.test(commitSha) === false) {
+    return Result.err(new Error(`Malformed Git commit returned for ${description}`));
+  }
+
+  return Result.ok(commitSha);
+}
+
+function parseChangedFilePaths(changedFilesOutput: string): readonly string[] {
+  return changedFilesOutput
+    .split('\n')
+    .map(changedFilePath => {
+      return changedFilePath.trim();
+    })
+    .filter(changedFilePath => {
+      return changedFilePath.length > 0;
+    })
+    .toSorted();
+}
+
+async function readPackageDocumentsAtRevision(
+  git: SimpleGit,
+  revision: string,
+): Promise<Result<WebAppPackageDocuments, Error>> {
+  const packageContents: string[] = [];
+
+  for (const packageFilePath of ['package.json', 'apps/webapp/package.json']) {
+    const packageContentsResult = await runGitCommand({
+      description: `Unable to read ${packageFilePath} at ${revision}`,
+      async execute() {
+        return git.raw(['show', `${revision}:${packageFilePath}`]);
+      },
+    });
+
+    if (packageContentsResult.isErr) {
+      return Result.err(packageContentsResult.error);
+    }
+
+    packageContents.push(packageContentsResult.value);
+  }
+
+  return parsePackageDocumentPaths(packageContents, ['package.json', 'apps/webapp/package.json']);
+}
+
+function createBranchInspection(options: CreateBranchInspectionOptions): WebAppVersionSynchronizationBranchInspection {
+  const parentCommitParts = options.parentCommitOutput
+    .trim()
+    .split(/\s+/)
+    .filter(part => {
+      return part.length > 0;
+    });
+  const isNormalCommit =
+    parentCommitParts.length === normalCommitPartCount && parentCommitParts[0] === options.branchTipCommitSha;
+
+  return {
+    branchName: options.branchName,
+    mainCommitSha: options.mainCommitSha,
+    branchTipCommitSha: options.branchTipCommitSha,
+    baseCommitSha: parentCommitParts.at(1) ?? '',
+    commitParentCount: Math.max(parentCommitParts.length - singleCommitParentCount, 0),
+    isNormalCommit,
+    isBasedOnMainHistory: options.isBasedOnMainHistory,
+    changedFilePaths: options.changedFilePaths,
+    baseRootPackageDocument: options.basePackageDocuments?.rootPackageDocument,
+    baseWebAppPackageDocument: options.basePackageDocuments?.webAppPackageDocument,
+    branchRootPackageDocument: options.branchPackageDocuments?.rootPackageDocument,
+    branchWebAppPackageDocument: options.branchPackageDocuments?.webAppPackageDocument,
+  };
+}
+
+export function createRuntimeWebAppVersionSynchronizationFileSystem(): WebAppVersionSynchronizationFileSystem {
+  return {
+    async readFile(filePath) {
+      return readFileFromFileSystem(filePath, 'utf8');
+    },
+    async writeFile(filePath, fileContents) {
+      await writeFileToFileSystem(filePath, fileContents, 'utf8');
+    },
+  };
+}
+
+export function validateWebAppVersionSynchronizationBranch(
+  options: ValidateWebAppVersionSynchronizationBranchOptions,
+): Result<WebAppVersionSynchronizationBranch, Error> {
+  const branchNameResult = validateWebAppVersionSynchronizationBranchName(options.branchInspection.branchName);
+
+  if (branchNameResult.isErr) {
+    return Result.err(branchNameResult.error);
+  }
+
+  if (branchNameResult.value.releaseIdentifier !== options.expectedReleaseIdentifier) {
+    return Result.err(new Error('Synchronization branch belongs to a different release identifier'));
+  }
+
+  if (branchNameResult.value.webAppVersion !== options.expectedWebAppVersion) {
+    return Result.err(new Error('Synchronization branch contains an unexpected WebApp version'));
+  }
+
+  if (options.branchInspection.mainCommitSha.length === 0) {
+    return Result.err(new Error('Synchronization branch has no validated main commit'));
+  }
+
+  if (options.branchInspection.branchTipCommitSha === options.branchInspection.baseCommitSha) {
+    return Result.err(new Error('Synchronization branch tip is not ahead of its base commit'));
+  }
+
+  if (options.branchInspection.commitParentCount !== 1 || options.branchInspection.isNormalCommit === false) {
+    return Result.err(new Error('Synchronization branch must contain exactly one normal commit'));
+  }
+
+  if (options.branchInspection.isBasedOnMainHistory === false) {
+    return Result.err(new Error('Synchronization branch base is not part of main history'));
+  }
+
+  const changedFilePaths = options.branchInspection.changedFilePaths.toSorted();
+
+  if (changedFilePaths.join('\n') !== webAppVersionSynchronizationPackageFilePaths.join('\n')) {
+    return Result.err(
+      new Error(`Synchronization branch changes unexpected files: ${changedFilePaths.join(', ') || 'none'}`),
+    );
+  }
+
+  const basePackageVersionsResult = validateMatchingWebAppPackageVersions(
+    options.branchInspection.baseRootPackageDocument,
+    options.branchInspection.baseWebAppPackageDocument,
+  );
+
+  if (basePackageVersionsResult.isErr) {
+    return Result.err(new Error(`Synchronization branch base is invalid: ${basePackageVersionsResult.error.message}`));
+  }
+
+  const expectedNextVersionResult = resolveNextWebAppVersion(basePackageVersionsResult.value.rootVersion);
+
+  if (expectedNextVersionResult.isErr) {
+    return Result.err(expectedNextVersionResult.error);
+  }
+
+  if (expectedNextVersionResult.value !== options.expectedWebAppVersion) {
+    return Result.err(new Error('Synchronization branch version does not follow its main base version'));
+  }
+
+  const branchPackageVersionsResult = validateMatchingWebAppPackageVersions(
+    options.branchInspection.branchRootPackageDocument,
+    options.branchInspection.branchWebAppPackageDocument,
+  );
+
+  if (branchPackageVersionsResult.isErr) {
+    return Result.err(
+      new Error(`Synchronization branch package files are invalid: ${branchPackageVersionsResult.error.message}`),
+    );
+  }
+
+  if (branchPackageVersionsResult.value.rootVersion !== options.expectedWebAppVersion) {
+    return Result.err(new Error('Synchronization branch package files contain an unexpected version'));
+  }
+
+  return Result.ok(branchNameResult.value);
+}
+
+export function createSimpleGitWebAppVersionSynchronizationClient(
+  options: CreateWebAppVersionSynchronizationGitClientOptions,
+): WebAppVersionSynchronizationGitClient {
+  const git = simpleGit(options.repositoryPath);
+
+  async function readCurrentMainCommit(): Promise<Result<string, Error>> {
+    const commitOutputResult = await runGitCommand({
+      description: 'Unable to read origin/main commit',
+      async execute() {
+        return git.raw(['rev-parse', 'refs/remotes/origin/main']);
+      },
+    });
+
+    if (commitOutputResult.isErr) {
+      return Result.err(commitOutputResult.error);
+    }
+
+    return parseCommitSha(commitOutputResult.value, 'origin/main');
+  }
+
+  async function readBranchNamesFromRemote(branchPrefix: string): Promise<Result<readonly string[], Error>> {
+    const remoteBranchesResult = await runGitCommand({
+      description: 'Unable to list remote WebApp version synchronization branches',
+      async execute() {
+        return git.raw(['ls-remote', '--heads', 'origin']);
+      },
+    });
+
+    if (remoteBranchesResult.isErr) {
+      return Result.err(remoteBranchesResult.error);
+    }
+
+    return Result.ok(parseRemoteBranchNames(remoteBranchesResult.value, branchPrefix));
+  }
+
+  async function readPackageDocumentsFromWorkingTree(): Promise<Result<WebAppPackageDocuments, Error>> {
+    const packageContents: string[] = [];
+
+    for (const packageFilePath of ['package.json', 'apps/webapp/package.json']) {
+      try {
+        packageContents.push(await options.fileSystem.readFile(resolve(options.repositoryPath, packageFilePath)));
+      } catch (error: unknown) {
+        return Result.err(new Error(`Unable to read ${packageFilePath}: ${errorMessage(error)}`, {cause: error}));
+      }
+    }
+
+    return parsePackageDocumentPaths(packageContents, ['package.json', 'apps/webapp/package.json']);
+  }
+
+  async function inspectRemoteOrLocalBranch(
+    inspectOptions: InspectWebAppVersionSynchronizationBranchOptions,
+  ): Promise<Result<WebAppVersionSynchronizationBranchInspection | undefined, Error>> {
+    const remoteBranchOutputResult = await runGitCommand({
+      description: `Unable to inspect whether branch ${inspectOptions.branchName} exists remotely`,
+      async execute() {
+        return git.raw(['ls-remote', '--heads', 'origin', inspectOptions.branchName]);
+      },
+    });
+
+    if (remoteBranchOutputResult.isErr) {
+      return Result.err(remoteBranchOutputResult.error);
+    }
+
+    const remoteBranchNames = parseRemoteBranchNames(
+      remoteBranchOutputResult.value,
+      `${synchronizationBranchPrefix}${inspectOptions.branchName.slice(synchronizationBranchPrefix.length)}`,
+    );
+    const remoteBranchExists = remoteBranchNames.includes(inspectOptions.branchName);
+    let branchReference: string;
+
+    if (remoteBranchExists) {
+      const fetchBranchResult = await runGitCommand({
+        description: `Unable to fetch synchronization branch ${inspectOptions.branchName}`,
+        async execute() {
+          return git.raw([
+            'fetch',
+            '--no-tags',
+            'origin',
+            `${inspectOptions.branchName}:refs/remotes/origin/${inspectOptions.branchName}`,
+          ]);
+        },
+      });
+
+      if (fetchBranchResult.isErr) {
+        return Result.err(fetchBranchResult.error);
+      }
+
+      branchReference = `refs/remotes/origin/${inspectOptions.branchName}`;
+    } else {
+      const localBranches = await git.branchLocal();
+
+      if (localBranches.all.includes(inspectOptions.branchName) === false) {
+        return Result.ok(undefined);
+      }
+
+      branchReference = `refs/heads/${inspectOptions.branchName}`;
+    }
+
+    const branchTipCommitOutputResult = await runGitCommand({
+      description: `Unable to read synchronization branch ${inspectOptions.branchName} tip`,
+      async execute() {
+        return git.raw(['rev-parse', branchReference]);
+      },
+    });
+
+    if (branchTipCommitOutputResult.isErr) {
+      return Result.err(branchTipCommitOutputResult.error);
+    }
+
+    const branchTipCommitResult = parseCommitSha(
+      branchTipCommitOutputResult.value,
+      `synchronization branch ${inspectOptions.branchName}`,
+    );
+
+    if (branchTipCommitResult.isErr) {
+      return Result.err(branchTipCommitResult.error);
+    }
+
+    const commitTypeResult = await runGitCommand({
+      description: `Unable to validate synchronization branch ${inspectOptions.branchName} tip`,
+      async execute() {
+        return git.raw(['cat-file', '-t', branchTipCommitResult.value]);
+      },
+    });
+
+    if (commitTypeResult.isErr) {
+      return Result.err(commitTypeResult.error);
+    }
+
+    const parentCommitOutputResult = await runGitCommand({
+      description: `Unable to read synchronization branch ${inspectOptions.branchName} history`,
+      async execute() {
+        return git.raw(['rev-list', '--parents', '-n', '1', branchReference]);
+      },
+    });
+
+    if (parentCommitOutputResult.isErr) {
+      return Result.err(parentCommitOutputResult.error);
+    }
+
+    const parentCommitParts = parentCommitOutputResult.value.trim().split(/\s+/);
+    const baseCommitSha = parentCommitParts.at(1);
+    let isBasedOnMainHistory = false;
+
+    if (isString(baseCommitSha)) {
+      const mergeBaseResult = await runGitCommand({
+        description: `Unable to validate synchronization branch ${inspectOptions.branchName} base`,
+        async execute() {
+          return git.raw(['merge-base', baseCommitSha, inspectOptions.mainCommitSha]);
+        },
+      });
+
+      isBasedOnMainHistory = mergeBaseResult.isOk && mergeBaseResult.value.trim() === baseCommitSha;
+    }
+
+    const changedFilePathsResult = isString(baseCommitSha)
+      ? await runGitCommand({
+          description: `Unable to inspect synchronization branch ${inspectOptions.branchName} changes`,
+          async execute() {
+            return git.raw(['diff', '--name-only', `${baseCommitSha}..${branchTipCommitResult.value}`]);
+          },
+        })
+      : Result.ok('');
+
+    if (changedFilePathsResult.isErr) {
+      return Result.err(changedFilePathsResult.error);
+    }
+
+    const basePackageDocuments = isString(baseCommitSha)
+      ? await readPackageDocumentsAtRevision(git, baseCommitSha)
+      : Result.ok<WebAppPackageDocuments | undefined, Error>(undefined);
+    const branchPackageDocuments = await readPackageDocumentsAtRevision(git, branchTipCommitResult.value);
+
+    if (basePackageDocuments.isErr) {
+      return Result.err(basePackageDocuments.error);
+    }
+
+    if (branchPackageDocuments.isErr) {
+      return Result.err(branchPackageDocuments.error);
+    }
+
+    return Result.ok(
+      createBranchInspection({
+        branchName: inspectOptions.branchName,
+        mainCommitSha: inspectOptions.mainCommitSha,
+        branchTipCommitSha: branchTipCommitResult.value,
+        parentCommitOutput: parentCommitOutputResult.value,
+        isBasedOnMainHistory: isBasedOnMainHistory && commitTypeResult.value.trim() === 'commit',
+        changedFilePaths: parseChangedFilePaths(changedFilePathsResult.value),
+        basePackageDocuments: basePackageDocuments.value,
+        branchPackageDocuments: branchPackageDocuments.value,
+      }),
+    );
+  }
+
+  return {
+    async prepareLatestMain() {
+      const status = await git.status();
+
+      if (status.isClean() === false) {
+        return Result.err(new Error('Git working tree must be clean before WebApp version synchronization'));
+      }
+
+      const fetchMainResult = await runGitCommand({
+        description: 'Unable to fetch origin/main',
+        async execute() {
+          return git.raw(['fetch', '--no-tags', 'origin', 'main']);
+        },
+      });
+
+      if (fetchMainResult.isErr) {
+        return Result.err(fetchMainResult.error);
+      }
+
+      const checkoutMainResult = await runGitCommand({
+        description: 'Unable to checkout origin/main',
+        async execute() {
+          return git.raw(['switch', '--detach', 'refs/remotes/origin/main']);
+        },
+      });
+
+      if (checkoutMainResult.isErr) {
+        return Result.err(checkoutMainResult.error);
+      }
+
+      const mainCommitResult = await readCurrentMainCommit();
+
+      if (mainCommitResult.isErr) {
+        return Result.err(mainCommitResult.error);
+      }
+
+      const packageDocumentsResult = await readPackageDocumentsAtRevision(git, mainCommitResult.value);
+
+      if (packageDocumentsResult.isErr) {
+        return Result.err(packageDocumentsResult.error);
+      }
+
+      return Result.ok({
+        commitSha: mainCommitResult.value,
+        rootPackageDocument: packageDocumentsResult.value.rootPackageDocument,
+        webAppPackageDocument: packageDocumentsResult.value.webAppPackageDocument,
+      });
+    },
+
+    async listExistingBranchNames(releaseIdentifier) {
+      const branchNameResult = createWebAppVersionSynchronizationBranchName(releaseIdentifier, '1.0.0');
+
+      if (branchNameResult.isErr) {
+        return Result.err(branchNameResult.error);
+      }
+
+      const branchPrefix = branchNameResult.value.slice(0, -'1.0.0'.length);
+      const remoteBranchNamesResult = await readBranchNamesFromRemote(branchPrefix);
+
+      if (remoteBranchNamesResult.isErr) {
+        return Result.err(remoteBranchNamesResult.error);
+      }
+
+      const localBranches = await git.branchLocal();
+      const localBranchNames = localBranches.all.filter(branchName => {
+        return branchName.startsWith(branchPrefix);
+      });
+
+      return Result.ok([...new Set([...remoteBranchNamesResult.value, ...localBranchNames])].toSorted());
+    },
+
+    async inspectBranch(inspectOptions) {
+      const branchNameResult = validateWebAppVersionSynchronizationBranchName(inspectOptions.branchName);
+
+      if (branchNameResult.isErr) {
+        return Result.err(branchNameResult.error);
+      }
+
+      return inspectRemoteOrLocalBranch(inspectOptions);
+    },
+
+    async createBranchFromMain(createBranchOptions) {
+      const branchNameResult = validateWebAppVersionSynchronizationBranchName(createBranchOptions.branchName);
+
+      if (branchNameResult.isErr) {
+        return Result.err(branchNameResult.error);
+      }
+
+      const mainCommitResult = await readCurrentMainCommit();
+
+      if (mainCommitResult.isErr) {
+        return Result.err(mainCommitResult.error);
+      }
+
+      if (mainCommitResult.value !== createBranchOptions.mainCommitSha) {
+        return Result.err(new Error('origin/main changed before synchronization branch creation'));
+      }
+
+      const createBranchResult = await runGitCommand({
+        description: `Unable to create synchronization branch ${createBranchOptions.branchName}`,
+        async execute() {
+          return git.raw(['switch', '--create', createBranchOptions.branchName, createBranchOptions.mainCommitSha]);
+        },
+      });
+
+      if (createBranchResult.isErr) {
+        return Result.err(createBranchResult.error);
+      }
+
+      return Result.ok();
+    },
+
+    async readWorkingTreePackageDocuments() {
+      return readPackageDocumentsFromWorkingTree();
+    },
+
+    async writePackageDocuments(writeOptions) {
+      const packageFiles = [
+        {
+          path: 'package.json',
+          document: writeOptions.rootPackageDocument,
+        },
+        {
+          path: 'apps/webapp/package.json',
+          document: writeOptions.webAppPackageDocument,
+        },
+      ];
+
+      try {
+        for (const packageFile of packageFiles) {
+          await options.fileSystem.writeFile(
+            resolve(options.repositoryPath, packageFile.path),
+            createPackageDocumentContents(packageFile.document),
+          );
+        }
+      } catch (error: unknown) {
+        return Result.err(
+          new Error(`Unable to write WebApp package documents: ${errorMessage(error)}`, {cause: error}),
+        );
+      }
+
+      return Result.ok();
+    },
+
+    async getWorkingTreeChangedFilePaths() {
+      try {
+        const status = await git.status();
+
+        return Result.ok(status.files.map(file => file.path).toSorted());
+      } catch (error: unknown) {
+        return Result.err(new Error(`Unable to inspect Git working tree: ${errorMessage(error)}`, {cause: error}));
+      }
+    },
+
+    async commit(commitOptions) {
+      const addResult = await runGitCommand({
+        description: 'Unable to stage WebApp package documents',
+        async execute() {
+          return git.raw(['add', '--', ...webAppVersionSynchronizationPackageFilePaths]);
+        },
+      });
+
+      if (addResult.isErr) {
+        return Result.err(addResult.error);
+      }
+
+      const commitResult = await runGitCommand({
+        description: 'Unable to commit WebApp version synchronization',
+        async execute() {
+          return git.raw([
+            '-c',
+            `user.name=${commitOptions.authorName}`,
+            '-c',
+            `user.email=${commitOptions.authorEmail}`,
+            'commit',
+            '--message',
+            commitOptions.message,
+            '--',
+            ...webAppVersionSynchronizationPackageFilePaths,
+          ]);
+        },
+      });
+
+      if (commitResult.isErr) {
+        return Result.err(commitResult.error);
+      }
+
+      const commitShaResult = await runGitCommand({
+        description: 'Unable to read WebApp synchronization commit',
+        async execute() {
+          return git.raw(['rev-parse', 'HEAD']);
+        },
+      });
+
+      if (commitShaResult.isErr) {
+        return Result.err(commitShaResult.error);
+      }
+
+      return parseCommitSha(commitShaResult.value, 'WebApp synchronization commit');
+    },
+
+    async pushBranch(pushOptions) {
+      const pushResult = await runGitCommand({
+        description: `Unable to push synchronization branch ${pushOptions.branchName}`,
+        async execute() {
+          return git.raw(['push', 'origin', `${pushOptions.branchName}:refs/heads/${pushOptions.branchName}`]);
+        },
+      });
+
+      if (pushResult.isErr) {
+        return Result.err(pushResult.error);
+      }
+
+      return Result.ok();
+    },
+
+    async verifyMainCommit(mainCommitSha) {
+      const fetchMainResult = await runGitCommand({
+        description: 'Unable to refresh origin/main before synchronization mutation',
+        async execute() {
+          return git.raw(['fetch', '--no-tags', 'origin', 'main']);
+        },
+      });
+
+      if (fetchMainResult.isErr) {
+        return Result.err(fetchMainResult.error);
+      }
+
+      const currentMainCommitResult = await readCurrentMainCommit();
+
+      if (currentMainCommitResult.isErr) {
+        return Result.err(currentMainCommitResult.error);
+      }
+
+      if (currentMainCommitResult.value !== mainCommitSha) {
+        return Result.err(new Error('origin/main changed during WebApp version synchronization'));
+      }
+
+      return Result.ok();
+    },
+  };
+}

--- a/tools/release-metadata/webappVersionSynchronizationGit.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGit.ts
@@ -17,10 +17,10 @@
  *
  */
 
-import {isError, isNonEmptyString, isString} from '@sindresorhus/is';
+import {isError, isNonEmptyString, isString, isUndefined} from '@sindresorhus/is';
 import {simpleGit} from 'simple-git';
 import type {SimpleGit} from 'simple-git';
-import {Result, Unit} from 'true-myth';
+import {Result, Task, Unit, task} from 'true-myth';
 import {z} from 'zod';
 
 import {readFile as readFileFromFileSystem, writeFile as writeFileToFileSystem} from 'node:fs/promises';
@@ -62,22 +62,20 @@ export type ValidateWebAppVersionSynchronizationBranchOptions = {
 };
 
 export type WebAppVersionSynchronizationGitClient = {
-  readonly prepareLatestMain: () => Promise<Result<WebAppVersionSynchronizationMainSnapshot, Error>>;
-  readonly listExistingBranchNames: (releaseIdentifier: string) => Promise<Result<readonly string[], Error>>;
+  readonly prepareLatestMain: () => Task<WebAppVersionSynchronizationMainSnapshot, Error>;
+  readonly listExistingBranchNames: (releaseIdentifier: string) => Task<readonly string[], Error>;
   readonly inspectBranch: (
     options: InspectWebAppVersionSynchronizationBranchOptions,
-  ) => Promise<Result<WebAppVersionSynchronizationBranchInspection | undefined, Error>>;
-  readonly createBranchFromMain: (
-    options: CreateWebAppVersionSynchronizationBranchOptions,
-  ) => Promise<Result<Unit, Error>>;
-  readonly readWorkingTreePackageDocuments: () => Promise<Result<WebAppPackageDocuments, Error>>;
+  ) => Task<WebAppVersionSynchronizationBranchInspection | undefined, Error>;
+  readonly createBranchFromMain: (options: CreateWebAppVersionSynchronizationBranchOptions) => Task<Unit, Error>;
+  readonly readWorkingTreePackageDocuments: () => Task<WebAppPackageDocuments, Error>;
   readonly writePackageDocuments: (
     options: WriteWebAppVersionSynchronizationPackageDocumentsOptions,
-  ) => Promise<Result<Unit, Error>>;
-  readonly getWorkingTreeChangedFilePaths: () => Promise<Result<readonly string[], Error>>;
-  readonly commit: (options: CommitWebAppVersionSynchronizationOptions) => Promise<Result<string, Error>>;
-  readonly pushBranch: (options: PushWebAppVersionSynchronizationBranchOptions) => Promise<Result<Unit, Error>>;
-  readonly verifyMainCommit: (mainCommitSha: string) => Promise<Result<Unit, Error>>;
+  ) => Task<Unit, Error>;
+  readonly getWorkingTreeChangedFilePaths: () => Task<readonly string[], Error>;
+  readonly commit: (options: CommitWebAppVersionSynchronizationOptions) => Task<string, Error>;
+  readonly pushBranch: (options: PushWebAppVersionSynchronizationBranchOptions) => Task<Unit, Error>;
+  readonly verifyMainCommit: (mainCommitSha: string) => Task<Unit, Error>;
 };
 
 export type InspectWebAppVersionSynchronizationBranchOptions = {
@@ -114,9 +112,9 @@ export type WebAppVersionSynchronizationFileSystem = {
 
 export const webAppVersionSynchronizationPackageFilePaths = ['apps/webapp/package.json', 'package.json'] as const;
 
-type RunGitCommandOptions = {
+type RunGitOperationOptions<valueType> = {
   readonly description: string;
-  readonly execute: () => Promise<string>;
+  readonly execute: () => Promise<valueType>;
 };
 
 type CreateBranchInspectionOptions = {
@@ -145,12 +143,15 @@ function errorMessage(error: unknown): string {
   return 'Unknown Git failure';
 }
 
-async function runGitCommand(options: RunGitCommandOptions): Promise<Result<string, Error>> {
-  try {
-    return Result.ok(await options.execute());
-  } catch (error: unknown) {
-    return Result.err(new Error(`${options.description}: ${errorMessage(error)}`, {cause: error}));
-  }
+function runGitOperation<valueType>(options: RunGitOperationOptions<valueType>): Task<valueType, Error> {
+  return task.tryOrElse(
+    (error: unknown): Error => {
+      return new Error(`${options.description}: ${errorMessage(error)}`, {cause: error});
+    },
+    async (): Promise<valueType> => {
+      return options.execute();
+    },
+  );
 }
 
 export function parseWebAppVersionSynchronizationPackageDocument(
@@ -172,34 +173,6 @@ export function parseWebAppVersionSynchronizationPackageDocument(
   } catch (error: unknown) {
     return Result.err(new Error(`Malformed package document: ${packagePath}: ${errorMessage(error)}`, {cause: error}));
   }
-}
-
-function parsePackageDocumentPaths(
-  contents: readonly string[],
-  paths: readonly string[],
-): Result<WebAppPackageDocuments, Error> {
-  const rootPackageContents = contents.at(0);
-  const webAppPackageContents = contents.at(1);
-
-  if (isString(rootPackageContents) === false || isString(webAppPackageContents) === false) {
-    return Result.err(new Error('Git did not return both WebApp package documents'));
-  }
-
-  const rootPackageDocumentResult = parseWebAppVersionSynchronizationPackageDocument(rootPackageContents, paths[0]);
-  const webAppPackageDocumentResult = parseWebAppVersionSynchronizationPackageDocument(webAppPackageContents, paths[1]);
-
-  if (rootPackageDocumentResult.isErr) {
-    return Result.err(rootPackageDocumentResult.error);
-  }
-
-  if (webAppPackageDocumentResult.isErr) {
-    return Result.err(webAppPackageDocumentResult.error);
-  }
-
-  return Result.ok({
-    rootPackageDocument: rootPackageDocumentResult.value,
-    webAppPackageDocument: webAppPackageDocumentResult.value,
-  });
 }
 
 function createPackageDocumentContents(packageDocument: WebAppPackageDocument): string {
@@ -249,28 +222,39 @@ function parseChangedFilePaths(changedFilesOutput: string): readonly string[] {
     .toSorted();
 }
 
-async function readPackageDocumentsAtRevision(
-  git: SimpleGit,
-  revision: string,
-): Promise<Result<WebAppPackageDocuments, Error>> {
-  const packageContents: string[] = [];
+type ReadPackageDocumentAtRevisionOptions = {
+  readonly git: SimpleGit;
+  readonly revision: string;
+  readonly packageFilePath: string;
+};
 
-  for (const packageFilePath of ['package.json', 'apps/webapp/package.json']) {
-    const packageContentsResult = await runGitCommand({
-      description: `Unable to read ${packageFilePath} at ${revision}`,
-      async execute() {
-        return git.raw(['show', `${revision}:${packageFilePath}`]);
-      },
+function readPackageDocumentAtRevision(
+  options: ReadPackageDocumentAtRevisionOptions,
+): Task<WebAppPackageDocument, Error> {
+  return runGitOperation({
+    description: `Unable to read ${options.packageFilePath} at ${options.revision}`,
+    async execute() {
+      return options.git.raw(['show', `${options.revision}:${options.packageFilePath}`]);
+    },
+  }).andThen(packageContents => {
+    return parseWebAppVersionSynchronizationPackageDocument(packageContents, options.packageFilePath);
+  });
+}
+
+function readPackageDocumentsAtRevision(git: SimpleGit, revision: string): Task<WebAppPackageDocuments, Error> {
+  return readPackageDocumentAtRevision({
+    git,
+    revision,
+    packageFilePath: 'package.json',
+  }).andThen(rootPackageDocument => {
+    return readPackageDocumentAtRevision({
+      git,
+      revision,
+      packageFilePath: 'apps/webapp/package.json',
+    }).map(webAppPackageDocument => {
+      return {rootPackageDocument, webAppPackageDocument};
     });
-
-    if (packageContentsResult.isErr) {
-      return Result.err(packageContentsResult.error);
-    }
-
-    packageContents.push(packageContentsResult.value);
-  }
-
-  return parsePackageDocumentPaths(packageContents, ['package.json', 'apps/webapp/package.json']);
+  });
 }
 
 function createBranchInspection(options: CreateBranchInspectionOptions): WebAppVersionSynchronizationBranchInspection {
@@ -319,11 +303,13 @@ export function validateWebAppVersionSynchronizationBranch(
     return Result.err(branchNameResult.error);
   }
 
-  if (branchNameResult.value.releaseIdentifier !== options.expectedReleaseIdentifier) {
+  const {value: validatedBranchName} = branchNameResult;
+
+  if (validatedBranchName.releaseIdentifier !== options.expectedReleaseIdentifier) {
     return Result.err(new Error('Synchronization branch belongs to a different release identifier'));
   }
 
-  if (branchNameResult.value.webAppVersion !== options.expectedWebAppVersion) {
+  if (validatedBranchName.webAppVersion !== options.expectedWebAppVersion) {
     return Result.err(new Error('Synchronization branch contains an unexpected WebApp version'));
   }
 
@@ -360,13 +346,16 @@ export function validateWebAppVersionSynchronizationBranch(
     return Result.err(new Error(`Synchronization branch base is invalid: ${basePackageVersionsResult.error.message}`));
   }
 
-  const expectedNextVersionResult = resolveNextWebAppVersion(basePackageVersionsResult.value.rootVersion);
+  const {value: basePackageVersions} = basePackageVersionsResult;
+  const expectedNextVersionResult = resolveNextWebAppVersion(basePackageVersions.rootVersion);
 
   if (expectedNextVersionResult.isErr) {
     return Result.err(expectedNextVersionResult.error);
   }
 
-  if (expectedNextVersionResult.value !== options.expectedWebAppVersion) {
+  const {value: expectedNextVersion} = expectedNextVersionResult;
+
+  if (expectedNextVersion !== options.expectedWebAppVersion) {
     return Result.err(new Error('Synchronization branch version does not follow its main base version'));
   }
 
@@ -381,11 +370,13 @@ export function validateWebAppVersionSynchronizationBranch(
     );
   }
 
-  if (branchPackageVersionsResult.value.rootVersion !== options.expectedWebAppVersion) {
+  const {value: branchPackageVersions} = branchPackageVersionsResult;
+
+  if (branchPackageVersions.rootVersion !== options.expectedWebAppVersion) {
     return Result.err(new Error('Synchronization branch package files contain an unexpected version'));
   }
 
-  return Result.ok(branchNameResult.value);
+  return Result.ok(validatedBranchName);
 }
 
 export function createSimpleGitWebAppVersionSynchronizationClient(
@@ -393,435 +384,386 @@ export function createSimpleGitWebAppVersionSynchronizationClient(
 ): WebAppVersionSynchronizationGitClient {
   const git = simpleGit(options.repositoryPath);
 
-  async function readCurrentMainCommit(): Promise<Result<string, Error>> {
-    const commitOutputResult = await runGitCommand({
+  function readCurrentMainCommit(): Task<string, Error> {
+    return runGitOperation({
       description: 'Unable to read origin/main commit',
       async execute() {
         return git.raw(['rev-parse', 'refs/remotes/origin/main']);
       },
+    }).andThen(commitOutput => {
+      return parseCommitSha(commitOutput, 'origin/main');
     });
-
-    if (commitOutputResult.isErr) {
-      return Result.err(commitOutputResult.error);
-    }
-
-    return parseCommitSha(commitOutputResult.value, 'origin/main');
   }
 
-  async function readBranchNamesFromRemote(branchPrefix: string): Promise<Result<readonly string[], Error>> {
-    const remoteBranchesResult = await runGitCommand({
+  function readBranchNamesFromRemote(branchPrefix: string): Task<readonly string[], Error> {
+    return runGitOperation({
       description: 'Unable to list remote WebApp version synchronization branches',
       async execute() {
         return git.raw(['ls-remote', '--heads', 'origin']);
       },
+    }).map(remoteBranchesOutput => {
+      return [...parseRemoteBranchNames(remoteBranchesOutput, branchPrefix)].toSorted();
     });
-
-    if (remoteBranchesResult.isErr) {
-      return Result.err(remoteBranchesResult.error);
-    }
-
-    return Result.ok([...parseRemoteBranchNames(remoteBranchesResult.value, branchPrefix)].toSorted());
   }
 
-  async function readPackageDocumentsFromWorkingTree(): Promise<Result<WebAppPackageDocuments, Error>> {
-    const packageContents: string[] = [];
-
-    for (const packageFilePath of ['package.json', 'apps/webapp/package.json']) {
-      try {
-        packageContents.push(await options.fileSystem.readFile(resolve(options.repositoryPath, packageFilePath)));
-      } catch (error: unknown) {
-        return Result.err(new Error(`Unable to read ${packageFilePath}: ${errorMessage(error)}`, {cause: error}));
-      }
-    }
-
-    return parsePackageDocumentPaths(packageContents, ['package.json', 'apps/webapp/package.json']);
+  function readPackageContentsFromWorkingTree(packageFilePath: string): Task<WebAppPackageDocument, Error> {
+    return runGitOperation({
+      description: `Unable to read ${packageFilePath}`,
+      async execute() {
+        return options.fileSystem.readFile(resolve(options.repositoryPath, packageFilePath));
+      },
+    }).andThen(packageContents => {
+      return parseWebAppVersionSynchronizationPackageDocument(packageContents, packageFilePath);
+    });
   }
 
-  async function inspectRemoteOrLocalBranch(
-    inspectOptions: InspectWebAppVersionSynchronizationBranchOptions,
-  ): Promise<Result<WebAppVersionSynchronizationBranchInspection | undefined, Error>> {
-    const remoteBranchOutputResult = await runGitCommand({
-      description: `Unable to inspect whether branch ${inspectOptions.branchName} exists remotely`,
-      async execute() {
-        return git.raw(['ls-remote', '--heads', 'origin', inspectOptions.branchName]);
-      },
-    });
-
-    if (remoteBranchOutputResult.isErr) {
-      return Result.err(remoteBranchOutputResult.error);
-    }
-
-    const remoteBranchNames = parseRemoteBranchNames(
-      remoteBranchOutputResult.value,
-      `${synchronizationBranchPrefix}${inspectOptions.branchName.slice(synchronizationBranchPrefix.length)}`,
-    );
-    const remoteBranchExists = remoteBranchNames.has(inspectOptions.branchName);
-    let branchReference: string;
-
-    if (remoteBranchExists) {
-      const fetchBranchResult = await runGitCommand({
-        description: `Unable to fetch synchronization branch ${inspectOptions.branchName}`,
-        async execute() {
-          return git.raw([
-            'fetch',
-            '--no-tags',
-            'origin',
-            `${inspectOptions.branchName}:refs/remotes/origin/${inspectOptions.branchName}`,
-          ]);
-        },
+  function readPackageDocumentsFromWorkingTree(): Task<WebAppPackageDocuments, Error> {
+    return readPackageContentsFromWorkingTree('package.json').andThen(rootPackageDocument => {
+      return readPackageContentsFromWorkingTree('apps/webapp/package.json').map(webAppPackageDocument => {
+        return {rootPackageDocument, webAppPackageDocument};
       });
-
-      if (fetchBranchResult.isErr) {
-        return Result.err(fetchBranchResult.error);
-      }
-
-      branchReference = `refs/remotes/origin/${inspectOptions.branchName}`;
-    } else {
-      const localBranches = await git.branchLocal();
-
-      if (localBranches.all.includes(inspectOptions.branchName) === false) {
-        return Result.ok(undefined);
-      }
-
-      branchReference = `refs/heads/${inspectOptions.branchName}`;
-    }
-
-    const branchTipCommitOutputResult = await runGitCommand({
-      description: `Unable to read synchronization branch ${inspectOptions.branchName} tip`,
-      async execute() {
-        return git.raw(['rev-parse', branchReference]);
-      },
     });
+  }
 
-    if (branchTipCommitOutputResult.isErr) {
-      return Result.err(branchTipCommitOutputResult.error);
-    }
+  type ResolveBranchReferenceOptions = {
+    readonly inspectOptions: InspectWebAppVersionSynchronizationBranchOptions;
+    readonly git: SimpleGit;
+  };
 
-    const branchTipCommitResult = parseCommitSha(
-      branchTipCommitOutputResult.value,
-      `synchronization branch ${inspectOptions.branchName}`,
-    );
+  type InspectBranchReferenceOptions = ResolveBranchReferenceOptions & {
+    readonly branchReference: string;
+  };
 
-    if (branchTipCommitResult.isErr) {
-      return Result.err(branchTipCommitResult.error);
-    }
-
-    const commitTypeResult = await runGitCommand({
-      description: `Unable to validate synchronization branch ${inspectOptions.branchName} tip`,
+  function resolveBranchReference(options: ResolveBranchReferenceOptions): Task<string | undefined, Error> {
+    return runGitOperation({
+      description: `Unable to inspect whether branch ${options.inspectOptions.branchName} exists remotely`,
       async execute() {
-        return git.raw(['cat-file', '-t', branchTipCommitResult.value]);
+        return options.git.raw(['ls-remote', '--heads', 'origin', options.inspectOptions.branchName]);
       },
-    });
+    }).andThen(remoteBranchOutput => {
+      const remoteBranchNames = parseRemoteBranchNames(
+        remoteBranchOutput,
+        `${synchronizationBranchPrefix}${options.inspectOptions.branchName.slice(synchronizationBranchPrefix.length)}`,
+      );
 
-    if (commitTypeResult.isErr) {
-      return Result.err(commitTypeResult.error);
-    }
-
-    const parentCommitOutputResult = await runGitCommand({
-      description: `Unable to read synchronization branch ${inspectOptions.branchName} history`,
-      async execute() {
-        return git.raw(['rev-list', '--parents', '-n', '1', branchReference]);
-      },
-    });
-
-    if (parentCommitOutputResult.isErr) {
-      return Result.err(parentCommitOutputResult.error);
-    }
-
-    const parentCommitParts = parentCommitOutputResult.value.trim().split(/\s+/);
-    const baseCommitSha = parentCommitParts.at(1);
-    let isBasedOnMainHistory = false;
-
-    if (isString(baseCommitSha)) {
-      const mergeBaseResult = await runGitCommand({
-        description: `Unable to validate synchronization branch ${inspectOptions.branchName} base`,
-        async execute() {
-          return git.raw(['merge-base', baseCommitSha, inspectOptions.mainCommitSha]);
-        },
-      });
-
-      isBasedOnMainHistory = mergeBaseResult.isOk && mergeBaseResult.value.trim() === baseCommitSha;
-    }
-
-    const changedFilePathsResult = isString(baseCommitSha)
-      ? await runGitCommand({
-          description: `Unable to inspect synchronization branch ${inspectOptions.branchName} changes`,
+      if (remoteBranchNames.has(options.inspectOptions.branchName)) {
+        return runGitOperation({
+          description: `Unable to fetch synchronization branch ${options.inspectOptions.branchName}`,
           async execute() {
-            return git.raw(['diff', '--name-only', `${baseCommitSha}..${branchTipCommitResult.value}`]);
+            return options.git.raw([
+              'fetch',
+              '--no-tags',
+              'origin',
+              `${options.inspectOptions.branchName}:refs/remotes/origin/${options.inspectOptions.branchName}`,
+            ]);
           },
-        })
-      : Result.ok('');
+        }).map(() => {
+          return `refs/remotes/origin/${options.inspectOptions.branchName}`;
+        });
+      }
 
-    if (changedFilePathsResult.isErr) {
-      return Result.err(changedFilePathsResult.error);
-    }
+      return runGitOperation({
+        description: `Unable to inspect local synchronization branches`,
+        async execute() {
+          return options.git.branchLocal();
+        },
+      }).map(localBranches => {
+        if (localBranches.all.includes(options.inspectOptions.branchName)) {
+          return `refs/heads/${options.inspectOptions.branchName}`;
+        }
 
-    const basePackageDocuments = isString(baseCommitSha)
-      ? await readPackageDocumentsAtRevision(git, baseCommitSha)
-      : Result.ok<WebAppPackageDocuments | undefined, Error>(undefined);
-    const branchPackageDocuments = await readPackageDocumentsAtRevision(git, branchTipCommitResult.value);
+        return undefined;
+      });
+    });
+  }
 
-    if (basePackageDocuments.isErr) {
-      return Result.err(basePackageDocuments.error);
-    }
+  function inspectBranchReference(
+    options: InspectBranchReferenceOptions,
+  ): Task<WebAppVersionSynchronizationBranchInspection, Error> {
+    return runGitOperation({
+      description: `Unable to read synchronization branch ${options.inspectOptions.branchName} tip`,
+      async execute() {
+        return options.git.raw(['rev-parse', options.branchReference]);
+      },
+    }).andThen(branchTipCommitOutput => {
+      const branchTipCommitResult = parseCommitSha(
+        branchTipCommitOutput,
+        `synchronization branch ${options.inspectOptions.branchName}`,
+      );
 
-    if (branchPackageDocuments.isErr) {
-      return Result.err(branchPackageDocuments.error);
-    }
+      if (branchTipCommitResult.isErr) {
+        return Task.reject<WebAppVersionSynchronizationBranchInspection, Error>(branchTipCommitResult.error);
+      }
 
-    return Result.ok(
-      createBranchInspection({
-        branchName: inspectOptions.branchName,
-        mainCommitSha: inspectOptions.mainCommitSha,
-        branchTipCommitSha: branchTipCommitResult.value,
-        parentCommitOutput: parentCommitOutputResult.value,
-        isBasedOnMainHistory: isBasedOnMainHistory && commitTypeResult.value.trim() === 'commit',
-        changedFilePaths: parseChangedFilePaths(changedFilePathsResult.value),
-        basePackageDocuments: basePackageDocuments.value,
-        branchPackageDocuments: branchPackageDocuments.value,
-      }),
-    );
+      const {value: branchTipCommitSha} = branchTipCommitResult;
+
+      return runGitOperation({
+        description: `Unable to validate synchronization branch ${options.inspectOptions.branchName} tip`,
+        async execute() {
+          return options.git.raw(['cat-file', '-t', branchTipCommitSha]);
+        },
+      }).andThen(commitTypeOutput => {
+        return runGitOperation({
+          description: `Unable to read synchronization branch ${options.inspectOptions.branchName} history`,
+          async execute() {
+            return options.git.raw(['rev-list', '--parents', '-n', '1', options.branchReference]);
+          },
+        }).andThen(parentCommitOutput => {
+          const parentCommitParts = parentCommitOutput.trim().split(/\s+/);
+          const baseCommitSha = parentCommitParts.at(1);
+          const basedOnMainHistoryTask = isString(baseCommitSha)
+            ? runGitOperation({
+                description: `Unable to validate synchronization branch ${options.inspectOptions.branchName} base`,
+                async execute() {
+                  return options.git.raw(['merge-base', baseCommitSha, options.inspectOptions.mainCommitSha]);
+                },
+              }).map(mergeBaseOutput => {
+                return mergeBaseOutput.trim() === baseCommitSha;
+              })
+            : Task.resolve(false);
+          const changedFilePathsTask = isString(baseCommitSha)
+            ? runGitOperation({
+                description: `Unable to inspect synchronization branch ${options.inspectOptions.branchName} changes`,
+                async execute() {
+                  return options.git.raw(['diff', '--name-only', `${baseCommitSha}..${branchTipCommitSha}`]);
+                },
+              }).map(parseChangedFilePaths)
+            : Task.resolve<readonly string[], Error>([]);
+          const basePackageDocumentsTask = isString(baseCommitSha)
+            ? readPackageDocumentsAtRevision(options.git, baseCommitSha)
+            : Task.resolve<WebAppPackageDocuments | undefined, Error>(undefined);
+
+          return basedOnMainHistoryTask.andThen(isBasedOnMainHistory => {
+            return changedFilePathsTask.andThen(changedFilePaths => {
+              return basePackageDocumentsTask.andThen(basePackageDocuments => {
+                return readPackageDocumentsAtRevision(options.git, branchTipCommitSha).map(branchPackageDocuments => {
+                  return createBranchInspection({
+                    branchName: options.inspectOptions.branchName,
+                    mainCommitSha: options.inspectOptions.mainCommitSha,
+                    branchTipCommitSha,
+                    parentCommitOutput,
+                    isBasedOnMainHistory: isBasedOnMainHistory && commitTypeOutput.trim() === 'commit',
+                    changedFilePaths,
+                    basePackageDocuments,
+                    branchPackageDocuments,
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  }
+
+  function inspectRemoteOrLocalBranch(
+    inspectOptions: InspectWebAppVersionSynchronizationBranchOptions,
+  ): Task<WebAppVersionSynchronizationBranchInspection | undefined, Error> {
+    return resolveBranchReference({git, inspectOptions}).andThen(branchReference => {
+      if (isUndefined(branchReference)) {
+        return Task.resolve<WebAppVersionSynchronizationBranchInspection | undefined, Error>(undefined);
+      }
+
+      return inspectBranchReference({git, inspectOptions, branchReference});
+    });
+  }
+
+  function writePackageDocument(packageFilePath: string, packageDocument: WebAppPackageDocument): Task<Unit, Error> {
+    return runGitOperation({
+      description: `Unable to write ${packageFilePath}`,
+      async execute() {
+        await options.fileSystem.writeFile(
+          resolve(options.repositoryPath, packageFilePath),
+          createPackageDocumentContents(packageDocument),
+        );
+      },
+    }).map(() => Unit);
   }
 
   return {
-    async prepareLatestMain() {
-      const status = await git.status();
-
-      if (status.isClean() === false) {
-        return Result.err(new Error('Git working tree must be clean before WebApp version synchronization'));
-      }
-
-      const fetchMainResult = await runGitCommand({
-        description: 'Unable to fetch origin/main',
+    prepareLatestMain() {
+      return runGitOperation({
+        description: 'Unable to inspect Git working tree',
         async execute() {
-          return git.raw(['fetch', '--no-tags', 'origin', 'main']);
+          return git.status();
         },
-      });
+      })
+        .andThen(status => {
+          if (status.isClean() === false) {
+            return Result.err(new Error('Git working tree must be clean before WebApp version synchronization'));
+          }
 
-      if (fetchMainResult.isErr) {
-        return Result.err(fetchMainResult.error);
-      }
-
-      const checkoutMainResult = await runGitCommand({
-        description: 'Unable to checkout origin/main',
-        async execute() {
-          return git.raw(['switch', '--detach', 'refs/remotes/origin/main']);
-        },
-      });
-
-      if (checkoutMainResult.isErr) {
-        return Result.err(checkoutMainResult.error);
-      }
-
-      const mainCommitResult = await readCurrentMainCommit();
-
-      if (mainCommitResult.isErr) {
-        return Result.err(mainCommitResult.error);
-      }
-
-      const packageDocumentsResult = await readPackageDocumentsAtRevision(git, mainCommitResult.value);
-
-      if (packageDocumentsResult.isErr) {
-        return Result.err(packageDocumentsResult.error);
-      }
-
-      return Result.ok({
-        commitSha: mainCommitResult.value,
-        rootPackageDocument: packageDocumentsResult.value.rootPackageDocument,
-        webAppPackageDocument: packageDocumentsResult.value.webAppPackageDocument,
-      });
+          return runGitOperation({
+            description: 'Unable to fetch origin/main',
+            async execute() {
+              return git.raw(['fetch', '--no-tags', 'origin', 'main']);
+            },
+          });
+        })
+        .andThen(() => {
+          return runGitOperation({
+            description: 'Unable to checkout origin/main',
+            async execute() {
+              return git.raw(['switch', '--detach', 'refs/remotes/origin/main']);
+            },
+          });
+        })
+        .andThen(() => {
+          return readCurrentMainCommit();
+        })
+        .andThen(commitSha => {
+          return readPackageDocumentsAtRevision(git, commitSha).map(packageDocuments => {
+            return {
+              commitSha,
+              rootPackageDocument: packageDocuments.rootPackageDocument,
+              webAppPackageDocument: packageDocuments.webAppPackageDocument,
+            };
+          });
+        });
     },
 
-    async listExistingBranchNames(releaseIdentifier) {
+    listExistingBranchNames(releaseIdentifier) {
       const branchNameResult = createWebAppVersionSynchronizationBranchName(releaseIdentifier, '1.0.0');
 
       if (branchNameResult.isErr) {
-        return Result.err(branchNameResult.error);
+        return Task.reject<readonly string[], Error>(branchNameResult.error);
       }
 
-      const branchPrefix = branchNameResult.value.slice(0, -'1.0.0'.length);
-      const remoteBranchNamesResult = await readBranchNamesFromRemote(branchPrefix);
+      const {value: bootstrapBranchName} = branchNameResult;
+      const branchPrefix = bootstrapBranchName.slice(0, -'1.0.0'.length);
 
-      if (remoteBranchNamesResult.isErr) {
-        return Result.err(remoteBranchNamesResult.error);
-      }
+      return readBranchNamesFromRemote(branchPrefix).andThen(remoteBranchNames => {
+        return runGitOperation({
+          description: 'Unable to inspect local synchronization branches',
+          async execute() {
+            return git.branchLocal();
+          },
+        }).map(localBranches => {
+          const localBranchNames = localBranches.all.filter(branchName => {
+            return branchName.startsWith(branchPrefix);
+          });
 
-      const localBranches = await git.branchLocal();
-      const localBranchNames = localBranches.all.filter(branchName => {
-        return branchName.startsWith(branchPrefix);
+          return [...new Set([...remoteBranchNames, ...localBranchNames])].toSorted();
+        });
       });
-
-      return Result.ok([...new Set([...remoteBranchNamesResult.value, ...localBranchNames])].toSorted());
     },
 
-    async inspectBranch(inspectOptions) {
+    inspectBranch(inspectOptions) {
       const branchNameResult = validateWebAppVersionSynchronizationBranchName(inspectOptions.branchName);
 
       if (branchNameResult.isErr) {
-        return Result.err(branchNameResult.error);
+        return Task.reject<WebAppVersionSynchronizationBranchInspection | undefined, Error>(branchNameResult.error);
       }
 
       return inspectRemoteOrLocalBranch(inspectOptions);
     },
 
-    async createBranchFromMain(createBranchOptions) {
+    createBranchFromMain(createBranchOptions) {
       const branchNameResult = validateWebAppVersionSynchronizationBranchName(createBranchOptions.branchName);
 
       if (branchNameResult.isErr) {
-        return Result.err(branchNameResult.error);
+        return Task.reject<Unit, Error>(branchNameResult.error);
       }
 
-      const mainCommitResult = await readCurrentMainCommit();
+      return readCurrentMainCommit().andThen(mainCommitSha => {
+        if (mainCommitSha !== createBranchOptions.mainCommitSha) {
+          return Result.err(new Error('origin/main changed before synchronization branch creation'));
+        }
 
-      if (mainCommitResult.isErr) {
-        return Result.err(mainCommitResult.error);
-      }
-
-      if (mainCommitResult.value !== createBranchOptions.mainCommitSha) {
-        return Result.err(new Error('origin/main changed before synchronization branch creation'));
-      }
-
-      const createBranchResult = await runGitCommand({
-        description: `Unable to create synchronization branch ${createBranchOptions.branchName}`,
-        async execute() {
-          return git.raw(['switch', '--create', createBranchOptions.branchName, createBranchOptions.mainCommitSha]);
-        },
+        return runGitOperation({
+          description: `Unable to create synchronization branch ${createBranchOptions.branchName}`,
+          async execute() {
+            return git.raw(['switch', '--create', createBranchOptions.branchName, createBranchOptions.mainCommitSha]);
+          },
+        }).map(() => Unit);
       });
-
-      if (createBranchResult.isErr) {
-        return Result.err(createBranchResult.error);
-      }
-
-      return Result.ok();
     },
 
-    async readWorkingTreePackageDocuments() {
+    readWorkingTreePackageDocuments() {
       return readPackageDocumentsFromWorkingTree();
     },
 
-    async writePackageDocuments(writeOptions) {
-      const packageFiles = [
-        {
-          path: 'package.json',
-          document: writeOptions.rootPackageDocument,
-        },
-        {
-          path: 'apps/webapp/package.json',
-          document: writeOptions.webAppPackageDocument,
-        },
-      ];
-
-      try {
-        for (const packageFile of packageFiles) {
-          await options.fileSystem.writeFile(
-            resolve(options.repositoryPath, packageFile.path),
-            createPackageDocumentContents(packageFile.document),
-          );
-        }
-      } catch (error: unknown) {
-        return Result.err(
-          new Error(`Unable to write WebApp package documents: ${errorMessage(error)}`, {cause: error}),
-        );
-      }
-
-      return Result.ok();
+    writePackageDocuments(writeOptions) {
+      return writePackageDocument('package.json', writeOptions.rootPackageDocument).andThen(() => {
+        return writePackageDocument('apps/webapp/package.json', writeOptions.webAppPackageDocument);
+      });
     },
 
-    async getWorkingTreeChangedFilePaths() {
-      try {
-        const status = await git.status();
-
-        return Result.ok(status.files.map(file => file.path).toSorted());
-      } catch (error: unknown) {
-        return Result.err(new Error(`Unable to inspect Git working tree: ${errorMessage(error)}`, {cause: error}));
-      }
+    getWorkingTreeChangedFilePaths() {
+      return runGitOperation({
+        description: 'Unable to inspect Git working tree',
+        async execute() {
+          return git.status();
+        },
+      }).map(status => {
+        return status.files.map(file => file.path).toSorted();
+      });
     },
 
-    async commit(commitOptions) {
-      const addResult = await runGitCommand({
+    commit(commitOptions) {
+      return runGitOperation({
         description: 'Unable to stage WebApp package documents',
         async execute() {
           return git.raw(['add', '--', ...webAppVersionSynchronizationPackageFilePaths]);
         },
-      });
-
-      if (addResult.isErr) {
-        return Result.err(addResult.error);
-      }
-
-      const commitResult = await runGitCommand({
-        description: 'Unable to commit WebApp version synchronization',
-        async execute() {
-          return git.raw([
-            '-c',
-            `user.name=${commitOptions.authorName}`,
-            '-c',
-            `user.email=${commitOptions.authorEmail}`,
-            'commit',
-            '--message',
-            commitOptions.message,
-            '--',
-            ...webAppVersionSynchronizationPackageFilePaths,
-          ]);
-        },
-      });
-
-      if (commitResult.isErr) {
-        return Result.err(commitResult.error);
-      }
-
-      const commitShaResult = await runGitCommand({
-        description: 'Unable to read WebApp synchronization commit',
-        async execute() {
-          return git.raw(['rev-parse', 'HEAD']);
-        },
-      });
-
-      if (commitShaResult.isErr) {
-        return Result.err(commitShaResult.error);
-      }
-
-      return parseCommitSha(commitShaResult.value, 'WebApp synchronization commit');
+      })
+        .andThen(() => {
+          return runGitOperation({
+            description: 'Unable to commit WebApp version synchronization',
+            async execute() {
+              return git.raw([
+                '-c',
+                `user.name=${commitOptions.authorName}`,
+                '-c',
+                `user.email=${commitOptions.authorEmail}`,
+                'commit',
+                '--message',
+                commitOptions.message,
+                '--',
+                ...webAppVersionSynchronizationPackageFilePaths,
+              ]);
+            },
+          });
+        })
+        .andThen(() => {
+          return runGitOperation({
+            description: 'Unable to read WebApp synchronization commit',
+            async execute() {
+              return git.raw(['rev-parse', 'HEAD']);
+            },
+          });
+        })
+        .andThen(commitShaOutput => {
+          return parseCommitSha(commitShaOutput, 'WebApp synchronization commit');
+        });
     },
 
-    async pushBranch(pushOptions) {
-      const pushResult = await runGitCommand({
+    pushBranch(pushOptions) {
+      return runGitOperation({
         description: `Unable to push synchronization branch ${pushOptions.branchName}`,
         async execute() {
           return git.raw(['push', 'origin', `${pushOptions.branchName}:refs/heads/${pushOptions.branchName}`]);
         },
-      });
-
-      if (pushResult.isErr) {
-        return Result.err(pushResult.error);
-      }
-
-      return Result.ok();
+      }).map(() => Unit);
     },
 
-    async verifyMainCommit(mainCommitSha) {
-      const fetchMainResult = await runGitCommand({
+    verifyMainCommit(mainCommitSha) {
+      return runGitOperation({
         description: 'Unable to refresh origin/main before synchronization mutation',
         async execute() {
           return git.raw(['fetch', '--no-tags', 'origin', 'main']);
         },
-      });
+      })
+        .andThen(() => {
+          return readCurrentMainCommit();
+        })
+        .andThen(currentMainCommitSha => {
+          if (currentMainCommitSha !== mainCommitSha) {
+            return Result.err(new Error('origin/main changed during WebApp version synchronization'));
+          }
 
-      if (fetchMainResult.isErr) {
-        return Result.err(fetchMainResult.error);
-      }
-
-      const currentMainCommitResult = await readCurrentMainCommit();
-
-      if (currentMainCommitResult.isErr) {
-        return Result.err(currentMainCommitResult.error);
-      }
-
-      if (currentMainCommitResult.value !== mainCommitSha) {
-        return Result.err(new Error('origin/main changed during WebApp version synchronization'));
-      }
-
-      return Result.ok();
+          return Result.ok(Unit);
+        });
     },
   };
 }

--- a/tools/release-metadata/webappVersionSynchronizationGit.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGit.ts
@@ -25,6 +25,7 @@ import {z} from 'zod';
 
 import {readFile as readFileFromFileSystem, writeFile as writeFileToFileSystem} from 'node:fs/promises';
 import {resolve} from 'node:path';
+import {isDeepStrictEqual} from 'node:util';
 
 import {resolveNextWebAppVersion, validateMatchingWebAppPackageVersions} from './webappVersion.ts';
 import type {WebAppPackageDocument, WebAppPackageDocuments} from './webappVersion.ts';
@@ -128,6 +129,12 @@ type CreateBranchInspectionOptions = {
   readonly branchPackageDocuments: WebAppPackageDocuments | undefined;
 };
 
+type ValidatePackageDocumentVersionChangeOptions = {
+  readonly basePackageDocument: unknown;
+  readonly branchPackageDocument: unknown;
+  readonly packagePath: string;
+};
+
 const synchronizationBranchPrefix = 'webapp-version-';
 const commitShaPattern = /^[0-9a-f]{40}$/;
 const packageJsonIndentationSpaces = 2;
@@ -222,6 +229,39 @@ function parseChangedFilePaths(changedFilesOutput: string): readonly string[] {
     .toSorted();
 }
 
+function removePackageDocumentVersion(packageDocument: WebAppPackageDocument): Readonly<Record<string, unknown>> {
+  return Object.fromEntries(
+    Object.entries(packageDocument).filter(([propertyName]) => {
+      return propertyName !== 'version';
+    }),
+  );
+}
+
+function validatePackageDocumentVersionChange(
+  options: ValidatePackageDocumentVersionChangeOptions,
+): Result<Unit, Error> {
+  const basePackageDocumentResult = webAppPackageDocumentSchema.safeParse(options.basePackageDocument);
+
+  if (basePackageDocumentResult.success === false) {
+    return Result.err(new Error(`Synchronization branch base has an invalid ${options.packagePath}`));
+  }
+
+  const branchPackageDocumentResult = webAppPackageDocumentSchema.safeParse(options.branchPackageDocument);
+
+  if (branchPackageDocumentResult.success === false) {
+    return Result.err(new Error(`Synchronization branch tip has an invalid ${options.packagePath}`));
+  }
+
+  const basePackageDocumentWithoutVersion = removePackageDocumentVersion(basePackageDocumentResult.data);
+  const branchPackageDocumentWithoutVersion = removePackageDocumentVersion(branchPackageDocumentResult.data);
+
+  if (isDeepStrictEqual(basePackageDocumentWithoutVersion, branchPackageDocumentWithoutVersion) === false) {
+    return Result.err(new Error(`Synchronization branch changes ${options.packagePath} beyond its version field`));
+  }
+
+  return Result.ok();
+}
+
 type ReadPackageDocumentAtRevisionOptions = {
   readonly git: SimpleGit;
   readonly revision: string;
@@ -297,7 +337,8 @@ export function createRuntimeWebAppVersionSynchronizationFileSystem(): WebAppVer
 export function validateWebAppVersionSynchronizationBranch(
   options: ValidateWebAppVersionSynchronizationBranchOptions,
 ): Result<WebAppVersionSynchronizationBranch, Error> {
-  const branchNameResult = validateWebAppVersionSynchronizationBranchName(options.branchInspection.branchName);
+  const {branchInspection} = options;
+  const branchNameResult = validateWebAppVersionSynchronizationBranchName(branchInspection.branchName);
 
   if (branchNameResult.isErr) {
     return Result.err(branchNameResult.error);
@@ -313,23 +354,23 @@ export function validateWebAppVersionSynchronizationBranch(
     return Result.err(new Error('Synchronization branch contains an unexpected WebApp version'));
   }
 
-  if (options.branchInspection.mainCommitSha.length === 0) {
+  if (branchInspection.mainCommitSha.length === 0) {
     return Result.err(new Error('Synchronization branch has no validated main commit'));
   }
 
-  if (options.branchInspection.branchTipCommitSha === options.branchInspection.baseCommitSha) {
+  if (branchInspection.branchTipCommitSha === branchInspection.baseCommitSha) {
     return Result.err(new Error('Synchronization branch tip is not ahead of its base commit'));
   }
 
-  if (options.branchInspection.commitParentCount !== 1 || options.branchInspection.isNormalCommit === false) {
+  if (branchInspection.commitParentCount !== 1 || branchInspection.isNormalCommit === false) {
     return Result.err(new Error('Synchronization branch must contain exactly one normal commit'));
   }
 
-  if (options.branchInspection.isBasedOnMainHistory === false) {
+  if (branchInspection.isBasedOnMainHistory === false) {
     return Result.err(new Error('Synchronization branch base is not part of main history'));
   }
 
-  const changedFilePaths = options.branchInspection.changedFilePaths.toSorted();
+  const changedFilePaths = branchInspection.changedFilePaths.toSorted();
 
   if (changedFilePaths.join('\n') !== webAppVersionSynchronizationPackageFilePaths.join('\n')) {
     return Result.err(
@@ -338,8 +379,8 @@ export function validateWebAppVersionSynchronizationBranch(
   }
 
   const basePackageVersionsResult = validateMatchingWebAppPackageVersions(
-    options.branchInspection.baseRootPackageDocument,
-    options.branchInspection.baseWebAppPackageDocument,
+    branchInspection.baseRootPackageDocument,
+    branchInspection.baseWebAppPackageDocument,
   );
 
   if (basePackageVersionsResult.isErr) {
@@ -360,8 +401,8 @@ export function validateWebAppVersionSynchronizationBranch(
   }
 
   const branchPackageVersionsResult = validateMatchingWebAppPackageVersions(
-    options.branchInspection.branchRootPackageDocument,
-    options.branchInspection.branchWebAppPackageDocument,
+    branchInspection.branchRootPackageDocument,
+    branchInspection.branchWebAppPackageDocument,
   );
 
   if (branchPackageVersionsResult.isErr) {
@@ -374,6 +415,26 @@ export function validateWebAppVersionSynchronizationBranch(
 
   if (branchPackageVersions.rootVersion !== options.expectedWebAppVersion) {
     return Result.err(new Error('Synchronization branch package files contain an unexpected version'));
+  }
+
+  const rootPackageDocumentChangeResult = validatePackageDocumentVersionChange({
+    basePackageDocument: branchInspection.baseRootPackageDocument,
+    branchPackageDocument: branchInspection.branchRootPackageDocument,
+    packagePath: 'package.json',
+  });
+
+  if (rootPackageDocumentChangeResult.isErr) {
+    return Result.err(rootPackageDocumentChangeResult.error);
+  }
+
+  const webAppPackageDocumentChangeResult = validatePackageDocumentVersionChange({
+    basePackageDocument: branchInspection.baseWebAppPackageDocument,
+    branchPackageDocument: branchInspection.branchWebAppPackageDocument,
+    packagePath: 'apps/webapp/package.json',
+  });
+
+  if (webAppPackageDocumentChangeResult.isErr) {
+    return Result.err(webAppPackageDocumentChangeResult.error);
   }
 
   return Result.ok(validatedBranchName);

--- a/tools/release-metadata/webappVersionSynchronizationGitHubClient.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGitHubClient.test.ts
@@ -1,0 +1,330 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+
+import {isUndefined} from '@sindresorhus/is';
+
+import {createWebAppVersionSynchronizationGitHubClient} from './webappVersionSynchronizationGitHubClient.ts';
+
+import type {HttpClient, HttpRequest} from '../release-appearance/httpClient.ts';
+
+const githubToken = 'otto-secret-token';
+
+type CreateGitHubPullRequestResponseOptions = {
+  readonly number: number;
+  readonly state?: 'open' | 'closed';
+  readonly mergedAt?: string | null;
+  readonly body?: string | null;
+  readonly baseBranch?: string;
+  readonly headBranch?: string;
+};
+
+function createGitHubPullRequestResponse(options: CreateGitHubPullRequestResponseOptions): Record<string, unknown> {
+  const responseBody = isUndefined(options.body) ? '<!-- marker -->' : options.body;
+
+  return {
+    number: options.number,
+    html_url: `https://github.com/wireapp/wire-webapp/pull/${options.number}`,
+    title: 'Update WebApp version to 1.0.0',
+    body: responseBody,
+    state: options.state ?? 'open',
+    merged_at: options.mergedAt ?? null,
+    base: {ref: options.baseBranch ?? 'main'},
+    head: {ref: options.headBranch ?? 'webapp-version-2026-09-09.1-1.0.0'},
+  };
+}
+
+function createGitHubPullRequestResponseWithoutProperty(
+  response: Record<string, unknown>,
+  propertyName: string,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(response).filter(([responsePropertyName]) => {
+      return responsePropertyName !== propertyName;
+    }),
+  );
+}
+
+type FakeHttpClient = {
+  readonly client: HttpClient;
+  readonly requests: HttpRequest[];
+};
+
+function createFakeHttpClient(responses: readonly unknown[], failure?: Error): FakeHttpClient {
+  let responseIndex = 0;
+  const requests: HttpRequest[] = [];
+
+  return {
+    requests,
+    client: {
+      async requestJson(request) {
+        requests.push(request);
+
+        if (failure !== undefined) {
+          throw failure;
+        }
+
+        if (responseIndex >= responses.length) {
+          throw new Error('No fake GitHub response configured');
+        }
+
+        const response = responses[responseIndex];
+        responseIndex += 1;
+
+        return response;
+      },
+    },
+  };
+}
+
+function createGitHubClient(
+  fakeHttpClient: FakeHttpClient['client'],
+): ReturnType<typeof createWebAppVersionSynchronizationGitHubClient> {
+  return createWebAppVersionSynchronizationGitHubClient({
+    httpClient: fakeHttpClient,
+    githubApiUrl: new URL('https://api.github.example/'),
+    githubRepository: 'wireapp/wire-webapp',
+    githubToken,
+  });
+}
+
+describe('WebApp version synchronization GitHub client', () => {
+  it('lists pull requests and normalizes GitHub fields', async () => {
+    const fakeHttpClient = createFakeHttpClient([
+      [
+        createGitHubPullRequestResponse({
+          number: 42,
+          body: null,
+          mergedAt: '2026-09-09T12:00:00Z',
+          state: 'closed',
+        }),
+      ],
+    ]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toEqual([
+      {
+        number: 42,
+        url: 'https://github.com/wireapp/wire-webapp/pull/42',
+        title: 'Update WebApp version to 1.0.0',
+        body: '',
+        state: 'closed',
+        mergedAt: '2026-09-09T12:00:00Z',
+        baseBranch: 'main',
+        headBranch: 'webapp-version-2026-09-09.1-1.0.0',
+      },
+    ]);
+    expect(fakeHttpClient.requests[0].url.searchParams).toEqual(
+      new URLSearchParams({state: 'all', sort: 'created', direction: 'asc', per_page: '100', page: '1'}),
+    );
+  });
+
+  it('paginates until a page is shorter than the GitHub page size', async () => {
+    const firstPage = Array.from({length: 100}, (_, index) => {
+      return createGitHubPullRequestResponse({number: index + 1});
+    });
+    const secondPage = [createGitHubPullRequestResponse({number: 101})];
+    const fakeHttpClient = createFakeHttpClient([firstPage, secondPage]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toHaveLength(101);
+    expect(fakeHttpClient.requests).toHaveLength(2);
+    expect(fakeHttpClient.requests[1].url.searchParams.get('page')).toBe('2');
+  });
+
+  it.each([
+    {
+      description: 'a non-array response',
+      response: createGitHubPullRequestResponse({number: 42}),
+    },
+    {
+      description: 'a missing number',
+      response: createGitHubPullRequestResponseWithoutProperty(createGitHubPullRequestResponse({number: 42}), 'number'),
+    },
+    {
+      description: 'a non-numeric number',
+      response: {...createGitHubPullRequestResponse({number: 42}), number: 'not-a-number'},
+    },
+    {
+      description: 'a zero number',
+      response: {...createGitHubPullRequestResponse({number: 42}), number: 0},
+    },
+    {
+      description: 'a fractional number',
+      response: {...createGitHubPullRequestResponse({number: 42}), number: 1.5},
+    },
+    {
+      description: 'a missing URL',
+      response: createGitHubPullRequestResponseWithoutProperty(
+        createGitHubPullRequestResponse({number: 42}),
+        'html_url',
+      ),
+    },
+    {
+      description: 'an invalid URL',
+      response: {...createGitHubPullRequestResponse({number: 42}), html_url: 'not-a-url'},
+    },
+    {
+      description: 'a missing title',
+      response: createGitHubPullRequestResponseWithoutProperty(createGitHubPullRequestResponse({number: 42}), 'title'),
+    },
+    {
+      description: 'an empty title',
+      response: {...createGitHubPullRequestResponse({number: 42}), title: ''},
+    },
+    {
+      description: 'a non-string title',
+      response: {...createGitHubPullRequestResponse({number: 42}), title: 42},
+    },
+    {
+      description: 'a non-string body',
+      response: {...createGitHubPullRequestResponse({number: 42}), body: 42},
+    },
+    {
+      description: 'a missing body',
+      response: createGitHubPullRequestResponseWithoutProperty(createGitHubPullRequestResponse({number: 42}), 'body'),
+    },
+    {
+      description: 'an invalid state',
+      response: {...createGitHubPullRequestResponse({number: 42}), state: 'draft'},
+    },
+    {
+      description: 'a missing state',
+      response: createGitHubPullRequestResponseWithoutProperty(createGitHubPullRequestResponse({number: 42}), 'state'),
+    },
+    {
+      description: 'a non-string merged timestamp',
+      response: {...createGitHubPullRequestResponse({number: 42}), merged_at: 42},
+    },
+    {
+      description: 'a missing merged timestamp',
+      response: createGitHubPullRequestResponseWithoutProperty(
+        createGitHubPullRequestResponse({number: 42}),
+        'merged_at',
+      ),
+    },
+    {
+      description: 'a missing base branch',
+      response: createGitHubPullRequestResponseWithoutProperty(createGitHubPullRequestResponse({number: 42}), 'base'),
+    },
+    {
+      description: 'a null base branch',
+      response: {...createGitHubPullRequestResponse({number: 42}), base: null},
+    },
+    {
+      description: 'an empty base branch name',
+      response: {...createGitHubPullRequestResponse({number: 42}), base: {ref: ''}},
+    },
+    {
+      description: 'a missing base branch name',
+      response: {...createGitHubPullRequestResponse({number: 42}), base: {}},
+    },
+    {
+      description: 'a non-string base branch name',
+      response: {...createGitHubPullRequestResponse({number: 42}), base: {ref: 42}},
+    },
+    {
+      description: 'a missing head branch',
+      response: createGitHubPullRequestResponseWithoutProperty(createGitHubPullRequestResponse({number: 42}), 'head'),
+    },
+    {
+      description: 'a null head branch',
+      response: {...createGitHubPullRequestResponse({number: 42}), head: null},
+    },
+    {
+      description: 'an empty head branch name',
+      response: {...createGitHubPullRequestResponse({number: 42}), head: {ref: ''}},
+    },
+    {
+      description: 'a missing head branch name',
+      response: {...createGitHubPullRequestResponse({number: 42}), head: {}},
+    },
+    {
+      description: 'a non-string head branch name',
+      response: {...createGitHubPullRequestResponse({number: 42}), head: {ref: 42}},
+    },
+  ])('rejects malformed pull request responses: $description', async ({response}) => {
+    const fakeHttpClient = createFakeHttpClient([response]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('Malformed GitHub pull request response');
+  });
+
+  it('rejects a malformed created pull request response', async () => {
+    const fakeHttpClient = createFakeHttpClient([{...createGitHubPullRequestResponse({number: 84}), head: {ref: 42}}]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.createPullRequest({
+      title: 'Update WebApp version to 1.0.0',
+      body: 'created body',
+      headBranch: 'webapp-version-2026-09-09.1-1.0.0',
+    });
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('Malformed GitHub created pull request response');
+  });
+
+  it('creates a pull request against main with the supplied body and branch', async () => {
+    const fakeHttpClient = createFakeHttpClient([createGitHubPullRequestResponse({number: 84, body: 'created body'})]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.createPullRequest({
+      title: 'Update WebApp version to 1.0.0',
+      body: 'created body',
+      headBranch: 'webapp-version-2026-09-09.1-1.0.0',
+    });
+
+    assert(actualResult.isOk);
+    expect(actualResult.value.number).toBe(84);
+    expect(fakeHttpClient.requests).toHaveLength(1);
+    expect(fakeHttpClient.requests[0].method).toBe('post');
+    expect(fakeHttpClient.requests[0].url.toString()).toBe(
+      'https://api.github.example/repos/wireapp/wire-webapp/pulls',
+    );
+    expect(fakeHttpClient.requests[0].headers.Authorization).toBe(`Bearer ${githubToken}`);
+    assert(fakeHttpClient.requests[0].json.isJust);
+    expect(fakeHttpClient.requests[0].json.value).toEqual({
+      title: 'Update WebApp version to 1.0.0',
+      head: 'webapp-version-2026-09-09.1-1.0.0',
+      base: 'main',
+      body: 'created body',
+    });
+  });
+
+  it('redacts the GitHub token from transport failures', async () => {
+    const fakeHttpClient = createFakeHttpClient([], new Error(`GitHub rejected ${githubToken}`));
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).not.toContain(githubToken);
+    expect(actualResult.error.message).toContain('[REDACTED]');
+  });
+});

--- a/tools/release-metadata/webappVersionSynchronizationGitHubClient.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGitHubClient.test.ts
@@ -21,6 +21,7 @@ import assert from 'node:assert';
 
 import {isUndefined} from '@sindresorhus/is';
 
+import {resolveWebAppVersionSynchronizationState} from './webappVersionSynchronization.ts';
 import {createWebAppVersionSynchronizationGitHubClient} from './webappVersionSynchronizationGitHubClient.ts';
 
 import type {HttpClient, HttpRequest} from '../release-appearance/httpClient.ts';
@@ -29,6 +30,7 @@ const githubToken = 'otto-secret-token';
 
 type CreateGitHubPullRequestResponseOptions = {
   readonly number: number;
+  readonly title?: string;
   readonly state?: 'open' | 'closed';
   readonly mergedAt?: string | null;
   readonly body?: string | null;
@@ -42,7 +44,7 @@ function createGitHubPullRequestResponse(options: CreateGitHubPullRequestRespons
   return {
     number: options.number,
     html_url: `https://github.com/wireapp/wire-webapp/pull/${options.number}`,
-    title: 'Update WebApp version to 1.0.0',
+    title: options.title ?? 'Update WebApp version to 1.0.0',
     body: responseBody,
     state: options.state ?? 'open',
     merged_at: options.mergedAt ?? null,
@@ -143,6 +145,7 @@ describe('WebApp version synchronization GitHub client', () => {
   it('lists pull requests and normalizes GitHub fields', async () => {
     const fakeHttpClient = createFakeHttpClient([
       createGitHubPullRequestSearchResponse([42]),
+      createGitHubPullRequestSearchResponse([]),
       createGitHubPullRequestResponse({
         number: 42,
         body: null,
@@ -169,14 +172,17 @@ describe('WebApp version synchronization GitHub client', () => {
     ]);
     expect(fakeHttpClient.requests[0].url.searchParams).toEqual(
       new URLSearchParams({
-        q: 'repo:wireapp/wire-webapp is:pr (in:body "wire-webapp-version-sync" OR in:title "Update WebApp version to")',
+        q: 'repo:wireapp/wire-webapp is:pr in:body "wire-webapp-version-sync"',
         sort: 'created',
         order: 'asc',
         per_page: '100',
         page: '1',
       }),
     );
-    expect(fakeHttpClient.requests[1].url.toString()).toBe(
+    expect(fakeHttpClient.requests[1].url.searchParams.get('q')).toBe(
+      'repo:wireapp/wire-webapp is:pr in:title "Update WebApp version to"',
+    );
+    expect(fakeHttpClient.requests[2].url.toString()).toBe(
       'https://api.github.example/repos/wireapp/wire-webapp/pulls/42',
     );
   });
@@ -187,6 +193,7 @@ describe('WebApp version synchronization GitHub client', () => {
   ])('retrieves a $description synchronization pull request through targeted discovery', async options => {
     const fakeHttpClient = createFakeHttpClient([
       createGitHubPullRequestSearchResponse([7]),
+      createGitHubPullRequestSearchResponse([]),
       createGitHubPullRequestResponse({number: 7, state: options.state, mergedAt: options.mergedAt}),
     ]);
     const githubClient = createGitHubClient(fakeHttpClient.client);
@@ -197,19 +204,26 @@ describe('WebApp version synchronization GitHub client', () => {
     expect(actualResult.value).toHaveLength(1);
     expect(actualResult.value[0].state).toBe(options.state);
     expect(actualResult.value[0].mergedAt).toBeNull();
-    expect(fakeHttpClient.requests).toHaveLength(2);
+    expect(fakeHttpClient.requests).toHaveLength(3);
   });
 
-  it('paginates until a page is shorter than the GitHub page size', async () => {
-    const firstPageNumbers = Array.from({length: 100}, (_, index) => {
+  it('paginates both searches independently and deduplicates pull requests', async () => {
+    const firstMarkerSearchPageNumbers = Array.from({length: 100}, (_, index) => {
       return index + 1;
     });
-    const pullRequestDetails = Array.from({length: 101}, (_, index) => {
+    const secondMarkerSearchPageNumbers = [101];
+    const firstTitleSearchPageNumbers = Array.from({length: 100}, (_, index) => {
+      return index + 101;
+    });
+    const secondTitleSearchPageNumbers = [201];
+    const pullRequestDetails = Array.from({length: 201}, (_, index) => {
       return createGitHubPullRequestResponse({number: index + 1});
     });
     const fakeHttpClient = createFakeHttpClient([
-      createGitHubPullRequestSearchResponse(firstPageNumbers, 101),
-      createGitHubPullRequestSearchResponse([101], 101),
+      createGitHubPullRequestSearchResponse(firstMarkerSearchPageNumbers, 101),
+      createGitHubPullRequestSearchResponse(secondMarkerSearchPageNumbers, 101),
+      createGitHubPullRequestSearchResponse(firstTitleSearchPageNumbers, 101),
+      createGitHubPullRequestSearchResponse(secondTitleSearchPageNumbers, 101),
       ...pullRequestDetails,
     ]);
     const githubClient = createGitHubClient(fakeHttpClient.client);
@@ -217,9 +231,101 @@ describe('WebApp version synchronization GitHub client', () => {
     const actualResult = await githubClient.listPullRequests();
 
     assert(actualResult.isOk);
-    expect(actualResult.value).toHaveLength(101);
-    expect(fakeHttpClient.requests).toHaveLength(103);
+    expect(actualResult.value).toHaveLength(201);
+    expect(actualResult.value.map(pullRequest => pullRequest.number)).toEqual(
+      Array.from({length: 201}, (_, index) => {
+        return index + 1;
+      }),
+    );
+    expect(fakeHttpClient.requests).toHaveLength(205);
+    expect(fakeHttpClient.requests[0].url.searchParams.get('q')).toBe(
+      'repo:wireapp/wire-webapp is:pr in:body "wire-webapp-version-sync"',
+    );
+    expect(fakeHttpClient.requests[1].url.searchParams.get('q')).toBe(
+      'repo:wireapp/wire-webapp is:pr in:body "wire-webapp-version-sync"',
+    );
     expect(fakeHttpClient.requests[1].url.searchParams.get('page')).toBe('2');
+    expect(fakeHttpClient.requests[2].url.searchParams.get('q')).toBe(
+      'repo:wireapp/wire-webapp is:pr in:title "Update WebApp version to"',
+    );
+    expect(fakeHttpClient.requests[3].url.searchParams.get('q')).toBe(
+      'repo:wireapp/wire-webapp is:pr in:title "Update WebApp version to"',
+    );
+    expect(fakeHttpClient.requests[3].url.searchParams.get('page')).toBe('2');
+  });
+
+  it('combines search results in deterministic order and fetches duplicate pull requests once', async () => {
+    const fakeHttpClient = createFakeHttpClient([
+      createGitHubPullRequestSearchResponse([42, 99]),
+      createGitHubPullRequestSearchResponse([7, 42]),
+      createGitHubPullRequestResponse({number: 7}),
+      createGitHubPullRequestResponse({number: 42}),
+      createGitHubPullRequestResponse({number: 99}),
+    ]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isOk);
+    expect(actualResult.value.map(pullRequest => pullRequest.number)).toEqual([7, 42, 99]);
+    expect(fakeHttpClient.requests.map(request => request.url.pathname)).toEqual([
+      '/search/issues',
+      '/search/issues',
+      '/repos/wireapp/wire-webapp/pulls/7',
+      '/repos/wireapp/wire-webapp/pulls/42',
+      '/repos/wireapp/wire-webapp/pulls/99',
+    ]);
+  });
+
+  it('discovers a marker-only synchronization pull request', async () => {
+    const fakeHttpClient = createFakeHttpClient([
+      createGitHubPullRequestSearchResponse([42]),
+      createGitHubPullRequestSearchResponse([]),
+      createGitHubPullRequestResponse({
+        number: 42,
+        title: 'Synchronize package metadata',
+        body: '<!-- wire-webapp-version-sync release=2026-09-09.1 production-tag=2026-09-09.1-production version=1.0.0 -->',
+      }),
+    ]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isOk);
+    const synchronizationStateResult = resolveWebAppVersionSynchronizationState(
+      '2026-09-09.1',
+      '2026-09-09.1-production',
+      actualResult.value,
+    );
+
+    assert(synchronizationStateResult.isOk);
+    expect(synchronizationStateResult.value.kind).toBe('matching-open');
+  });
+
+  it('discovers and rejects a title-only synchronization claim without a marker', async () => {
+    const fakeHttpClient = createFakeHttpClient([
+      createGitHubPullRequestSearchResponse([]),
+      createGitHubPullRequestSearchResponse([42]),
+      createGitHubPullRequestResponse({
+        number: 42,
+        title: 'Update WebApp version to 1.0.0',
+        body: '',
+        headBranch: 'release-not-metadata',
+      }),
+    ]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isOk);
+    const synchronizationStateResult = resolveWebAppVersionSynchronizationState(
+      '2026-09-09.1',
+      '2026-09-09.1-production',
+      actualResult.value,
+    );
+
+    assert(synchronizationStateResult.isErr);
+    expect(synchronizationStateResult.error.message).toContain('invalid marker');
   });
 
   it.each([
@@ -334,7 +440,11 @@ describe('WebApp version synchronization GitHub client', () => {
       response: {...createGitHubPullRequestResponse({number: 42}), head: {ref: 42}},
     },
   ])('rejects malformed pull request responses: $description', async ({response}) => {
-    const fakeHttpClient = createFakeHttpClient([createGitHubPullRequestSearchResponse([42]), response]);
+    const fakeHttpClient = createFakeHttpClient([
+      createGitHubPullRequestSearchResponse([42]),
+      createGitHubPullRequestSearchResponse([]),
+      response,
+    ]);
     const githubClient = createGitHubClient(fakeHttpClient.client);
 
     const actualResult = await githubClient.listPullRequests();
@@ -387,8 +497,17 @@ describe('WebApp version synchronization GitHub client', () => {
     expect(actualResult.error.message).toBe('Malformed GitHub pull request search response');
   });
 
-  it('rejects incomplete search results', async () => {
-    const fakeHttpClient = createFakeHttpClient([createGitHubPullRequestSearchResponse([], 0, true)]);
+  it.each([
+    {
+      description: 'the marker search',
+      responses: [createGitHubPullRequestSearchResponse([], 0, true)],
+    },
+    {
+      description: 'the title search',
+      responses: [createGitHubPullRequestSearchResponse([]), createGitHubPullRequestSearchResponse([], 0, true)],
+    },
+  ])('rejects incomplete results from $description', async ({responses}) => {
+    const fakeHttpClient = createFakeHttpClient(responses);
     const githubClient = createGitHubClient(fakeHttpClient.client);
 
     const actualResult = await githubClient.listPullRequests();
@@ -397,8 +516,17 @@ describe('WebApp version synchronization GitHub client', () => {
     expect(actualResult.error.message).toBe('GitHub pull request search returned incomplete results');
   });
 
-  it('rejects search results beyond the GitHub result limit', async () => {
-    const fakeHttpClient = createFakeHttpClient([createGitHubPullRequestSearchResponse([], 1001)]);
+  it.each([
+    {
+      description: 'the marker search',
+      responses: [createGitHubPullRequestSearchResponse([], 1001)],
+    },
+    {
+      description: 'the title search',
+      responses: [createGitHubPullRequestSearchResponse([]), createGitHubPullRequestSearchResponse([], 1001)],
+    },
+  ])('rejects results beyond the GitHub limit from $description', async ({responses}) => {
+    const fakeHttpClient = createFakeHttpClient(responses);
     const githubClient = createGitHubClient(fakeHttpClient.client);
 
     const actualResult = await githubClient.listPullRequests();
@@ -420,16 +548,23 @@ describe('WebApp version synchronization GitHub client', () => {
   });
 
   it('uses targeted search instead of enumerating repository pull requests', async () => {
-    const fakeHttpClient = createFakeHttpClient([createGitHubPullRequestSearchResponse([])]);
+    const fakeHttpClient = createFakeHttpClient([
+      createGitHubPullRequestSearchResponse([]),
+      createGitHubPullRequestSearchResponse([]),
+    ]);
     const githubClient = createGitHubClient(fakeHttpClient.client);
 
     const actualResult = await githubClient.listPullRequests();
 
     assert(actualResult.isOk);
-    expect(fakeHttpClient.requests).toHaveLength(1);
+    expect(fakeHttpClient.requests).toHaveLength(2);
     expect(fakeHttpClient.requests[0].url.pathname).toBe('/search/issues');
     expect(fakeHttpClient.requests[0].url.searchParams.get('q')).toBe(
-      'repo:wireapp/wire-webapp is:pr (in:body "wire-webapp-version-sync" OR in:title "Update WebApp version to")',
+      'repo:wireapp/wire-webapp is:pr in:body "wire-webapp-version-sync"',
+    );
+    expect(fakeHttpClient.requests[1].url.pathname).toBe('/search/issues');
+    expect(fakeHttpClient.requests[1].url.searchParams.get('q')).toBe(
+      'repo:wireapp/wire-webapp is:pr in:title "Update WebApp version to"',
     );
   });
 

--- a/tools/release-metadata/webappVersionSynchronizationGitHubClient.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGitHubClient.test.ts
@@ -51,6 +51,40 @@ function createGitHubPullRequestResponse(options: CreateGitHubPullRequestRespons
   };
 }
 
+function createGitHubPullRequestSearchResponse(
+  pullRequestNumbers: readonly number[],
+  totalCount: number = pullRequestNumbers.length,
+  incompleteResults: boolean = false,
+): Record<string, unknown> {
+  return {
+    total_count: totalCount,
+    incomplete_results: incompleteResults,
+    items: pullRequestNumbers.map(pullRequestNumber => {
+      return {
+        number: pullRequestNumber,
+        html_url: `https://github.com/wireapp/wire-webapp/pull/${pullRequestNumber}`,
+        title: 'Update WebApp version to 1.0.0',
+        body: '<!-- wire-webapp-version-sync -->',
+        pull_request: {
+          url: `https://api.github.example/repos/wireapp/wire-webapp/pulls/${pullRequestNumber}`,
+          html_url: `https://github.com/wireapp/wire-webapp/pull/${pullRequestNumber}`,
+        },
+      };
+    }),
+  };
+}
+
+function createGitHubPullRequestSearchResponseWithoutProperty(
+  response: Record<string, unknown>,
+  propertyName: string,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(response).filter(([responsePropertyName]) => {
+      return responsePropertyName !== propertyName;
+    }),
+  );
+}
+
 function createGitHubPullRequestResponseWithoutProperty(
   response: Record<string, unknown>,
   propertyName: string,
@@ -108,14 +142,13 @@ function createGitHubClient(
 describe('WebApp version synchronization GitHub client', () => {
   it('lists pull requests and normalizes GitHub fields', async () => {
     const fakeHttpClient = createFakeHttpClient([
-      [
-        createGitHubPullRequestResponse({
-          number: 42,
-          body: null,
-          mergedAt: '2026-09-09T12:00:00Z',
-          state: 'closed',
-        }),
-      ],
+      createGitHubPullRequestSearchResponse([42]),
+      createGitHubPullRequestResponse({
+        number: 42,
+        body: null,
+        mergedAt: '2026-09-09T12:00:00Z',
+        state: 'closed',
+      }),
     ]);
     const githubClient = createGitHubClient(fakeHttpClient.client);
 
@@ -135,30 +168,64 @@ describe('WebApp version synchronization GitHub client', () => {
       },
     ]);
     expect(fakeHttpClient.requests[0].url.searchParams).toEqual(
-      new URLSearchParams({state: 'all', sort: 'created', direction: 'asc', per_page: '100', page: '1'}),
+      new URLSearchParams({
+        q: 'repo:wireapp/wire-webapp is:pr (in:body "wire-webapp-version-sync" OR in:title "Update WebApp version to")',
+        sort: 'created',
+        order: 'asc',
+        per_page: '100',
+        page: '1',
+      }),
+    );
+    expect(fakeHttpClient.requests[1].url.toString()).toBe(
+      'https://api.github.example/repos/wireapp/wire-webapp/pulls/42',
     );
   });
 
+  it.each([
+    {description: 'open', state: 'open' as const, mergedAt: null},
+    {description: 'closed without merging', state: 'closed' as const, mergedAt: null},
+  ])('retrieves a $description synchronization pull request through targeted discovery', async options => {
+    const fakeHttpClient = createFakeHttpClient([
+      createGitHubPullRequestSearchResponse([7]),
+      createGitHubPullRequestResponse({number: 7, state: options.state, mergedAt: options.mergedAt}),
+    ]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toHaveLength(1);
+    expect(actualResult.value[0].state).toBe(options.state);
+    expect(actualResult.value[0].mergedAt).toBeNull();
+    expect(fakeHttpClient.requests).toHaveLength(2);
+  });
+
   it('paginates until a page is shorter than the GitHub page size', async () => {
-    const firstPage = Array.from({length: 100}, (_, index) => {
+    const firstPageNumbers = Array.from({length: 100}, (_, index) => {
+      return index + 1;
+    });
+    const pullRequestDetails = Array.from({length: 101}, (_, index) => {
       return createGitHubPullRequestResponse({number: index + 1});
     });
-    const secondPage = [createGitHubPullRequestResponse({number: 101})];
-    const fakeHttpClient = createFakeHttpClient([firstPage, secondPage]);
+    const fakeHttpClient = createFakeHttpClient([
+      createGitHubPullRequestSearchResponse(firstPageNumbers, 101),
+      createGitHubPullRequestSearchResponse([101], 101),
+      ...pullRequestDetails,
+    ]);
     const githubClient = createGitHubClient(fakeHttpClient.client);
 
     const actualResult = await githubClient.listPullRequests();
 
     assert(actualResult.isOk);
     expect(actualResult.value).toHaveLength(101);
-    expect(fakeHttpClient.requests).toHaveLength(2);
+    expect(fakeHttpClient.requests).toHaveLength(103);
     expect(fakeHttpClient.requests[1].url.searchParams.get('page')).toBe('2');
   });
 
   it.each([
     {
-      description: 'a non-array response',
-      response: createGitHubPullRequestResponse({number: 42}),
+      description: 'a non-object response',
+      response: 'not-an-object',
     },
     {
       description: 'a missing number',
@@ -267,13 +334,103 @@ describe('WebApp version synchronization GitHub client', () => {
       response: {...createGitHubPullRequestResponse({number: 42}), head: {ref: 42}},
     },
   ])('rejects malformed pull request responses: $description', async ({response}) => {
-    const fakeHttpClient = createFakeHttpClient([response]);
+    const fakeHttpClient = createFakeHttpClient([createGitHubPullRequestSearchResponse([42]), response]);
     const githubClient = createGitHubClient(fakeHttpClient.client);
 
     const actualResult = await githubClient.listPullRequests();
 
     assert(actualResult.isErr);
     expect(actualResult.error.message).toBe('Malformed GitHub pull request response');
+  });
+
+  it.each([
+    {
+      description: 'a non-object response',
+      response: [],
+    },
+    {
+      description: 'a missing total count',
+      response: createGitHubPullRequestSearchResponseWithoutProperty(
+        createGitHubPullRequestSearchResponse([]),
+        'total_count',
+      ),
+    },
+    {
+      description: 'a negative total count',
+      response: {...createGitHubPullRequestSearchResponse([]), total_count: -1},
+    },
+    {
+      description: 'a missing incomplete-results flag',
+      response: createGitHubPullRequestSearchResponseWithoutProperty(
+        createGitHubPullRequestSearchResponse([]),
+        'incomplete_results',
+      ),
+    },
+    {
+      description: 'a non-array item collection',
+      response: {...createGitHubPullRequestSearchResponse([]), items: {}},
+    },
+    {
+      description: 'a search item without pull-request metadata',
+      response: {
+        ...createGitHubPullRequestSearchResponse([42]),
+        items: [{number: 42}],
+      },
+    },
+  ])('rejects malformed pull request search responses: $description', async ({response}) => {
+    const fakeHttpClient = createFakeHttpClient([response]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('Malformed GitHub pull request search response');
+  });
+
+  it('rejects incomplete search results', async () => {
+    const fakeHttpClient = createFakeHttpClient([createGitHubPullRequestSearchResponse([], 0, true)]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('GitHub pull request search returned incomplete results');
+  });
+
+  it('rejects search results beyond the GitHub result limit', async () => {
+    const fakeHttpClient = createFakeHttpClient([createGitHubPullRequestSearchResponse([], 1001)]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('GitHub pull request search returned more than 1000 results');
+  });
+
+  it('rejects a short search page before all reported results are retrieved', async () => {
+    const fakeHttpClient = createFakeHttpClient([createGitHubPullRequestSearchResponse([42], 101)]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe(
+      'GitHub pull request search pagination ended before all results were retrieved',
+    );
+  });
+
+  it('uses targeted search instead of enumerating repository pull requests', async () => {
+    const fakeHttpClient = createFakeHttpClient([createGitHubPullRequestSearchResponse([])]);
+    const githubClient = createGitHubClient(fakeHttpClient.client);
+
+    const actualResult = await githubClient.listPullRequests();
+
+    assert(actualResult.isOk);
+    expect(fakeHttpClient.requests).toHaveLength(1);
+    expect(fakeHttpClient.requests[0].url.pathname).toBe('/search/issues');
+    expect(fakeHttpClient.requests[0].url.searchParams.get('q')).toBe(
+      'repo:wireapp/wire-webapp is:pr (in:body "wire-webapp-version-sync" OR in:title "Update WebApp version to")',
+    );
   });
 
   it('rejects a malformed created pull request response', async () => {

--- a/tools/release-metadata/webappVersionSynchronizationGitHubClient.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGitHubClient.ts
@@ -318,6 +318,17 @@ function searchPullRequestNumbers(
   });
 }
 
+function combinePullRequestNumbers(
+  bodySearchPullRequestNumbers: readonly number[],
+  titleSearchPullRequestNumbers: readonly number[],
+): readonly number[] {
+  return [...new Set([...bodySearchPullRequestNumbers, ...titleSearchPullRequestNumbers])].toSorted(
+    (firstPullRequestNumber, secondPullRequestNumber) => {
+      return firstPullRequestNumber - secondPullRequestNumber;
+    },
+  );
+}
+
 function getPullRequest(
   options: GetPullRequestOptions,
   pullRequestNumber: number,
@@ -366,13 +377,22 @@ export function createWebAppVersionSynchronizationGitHubClient(
   const writeHeaders = createGitHubHeaders(options.githubToken, true);
   const pullRequestsEndpoint = new URL(`repos/${encodedRepositoryName}/pulls`, githubApiRoot);
   const pullRequestSearchEndpoint = new URL('search/issues', githubApiRoot);
-  const synchronizationSearchQuery = `repo:${options.githubRepository} is:pr (in:body "${synchronizationMarkerSearchTerm}" OR in:title "${synchronizationPullRequestTitleSearchTerm}")`;
+  const synchronizationMarkerSearchQuery = `repo:${options.githubRepository} is:pr in:body "${synchronizationMarkerSearchTerm}"`;
+  const synchronizationTitleSearchQuery = `repo:${options.githubRepository} is:pr in:title "${synchronizationPullRequestTitleSearchTerm}"`;
 
-  const searchPullRequestsPageOptions = {
+  const synchronizationMarkerSearchOptions = {
     httpClient: options.httpClient,
     endpoint: pullRequestSearchEndpoint,
     headers: readHeaders,
-    searchQuery: synchronizationSearchQuery,
+    searchQuery: synchronizationMarkerSearchQuery,
+    githubToken: options.githubToken,
+  };
+
+  const synchronizationTitleSearchOptions = {
+    httpClient: options.httpClient,
+    endpoint: pullRequestSearchEndpoint,
+    headers: readHeaders,
+    searchQuery: synchronizationTitleSearchQuery,
     githubToken: options.githubToken,
   };
 
@@ -385,9 +405,20 @@ export function createWebAppVersionSynchronizationGitHubClient(
 
   return {
     listPullRequests() {
-      return searchPullRequestNumbers(searchPullRequestsPageOptions, 1, []).andThen(pullRequestNumbers => {
-        return getPullRequests(getPullRequestOptions, pullRequestNumbers, []);
-      });
+      return searchPullRequestNumbers(synchronizationMarkerSearchOptions, 1, []).andThen(
+        synchronizationMarkerPullRequestNumbers => {
+          return searchPullRequestNumbers(synchronizationTitleSearchOptions, 1, []).andThen(
+            synchronizationTitlePullRequestNumbers => {
+              const pullRequestNumbers = combinePullRequestNumbers(
+                synchronizationMarkerPullRequestNumbers,
+                synchronizationTitlePullRequestNumbers,
+              );
+
+              return getPullRequests(getPullRequestOptions, pullRequestNumbers, []);
+            },
+          );
+        },
+      );
     },
 
     createPullRequest(createPullRequestOptions) {

--- a/tools/release-metadata/webappVersionSynchronizationGitHubClient.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGitHubClient.ts
@@ -18,7 +18,7 @@
  */
 
 import {isError} from '@sindresorhus/is';
-import {Maybe, Result} from 'true-myth';
+import {Maybe, Result, Task, task} from 'true-myth';
 import {z} from 'zod';
 
 import type {WebAppVersionSynchronizationPullRequest} from './webappVersionSynchronization.ts';
@@ -33,10 +33,10 @@ export type CreateWebAppVersionSynchronizationPullRequestOptions = {
 };
 
 export type WebAppVersionSynchronizationGitHubClient = {
-  readonly listPullRequests: () => Promise<Result<readonly WebAppVersionSynchronizationPullRequest[], Error>>;
+  readonly listPullRequests: () => Task<readonly WebAppVersionSynchronizationPullRequest[], Error>;
   readonly createPullRequest: (
     options: CreateWebAppVersionSynchronizationPullRequestOptions,
-  ) => Promise<Result<WebAppVersionSynchronizationPullRequest, Error>>;
+  ) => Task<WebAppVersionSynchronizationPullRequest, Error>;
 };
 
 export type CreateWebAppVersionSynchronizationGitHubClientOptions = {
@@ -186,16 +186,17 @@ function parsePullRequestPage(githubResponse: unknown): Result<ParsedPullRequest
   });
 }
 
-async function requestGitHubJson(options: RequestGitHubJsonOptions): Promise<Result<unknown, Error>> {
-  try {
-    return Result.ok(await options.httpClient.requestJson(options.request));
-  } catch (error: unknown) {
-    return Result.err(
-      new Error(`${options.failureMessage}: ${redactSecret(errorMessage(error), options.githubToken)}`, {
+function requestGitHubJson(options: RequestGitHubJsonOptions): Task<unknown, Error> {
+  return task.tryOrElse(
+    (error: unknown): Error => {
+      return new Error(`${options.failureMessage}: ${redactSecret(errorMessage(error), options.githubToken)}`, {
         cause: error,
-      }),
-    );
-  }
+      });
+    },
+    async (): Promise<unknown> => {
+      return options.httpClient.requestJson(options.request);
+    },
+  );
 }
 
 function createPullRequestRequestBody(
@@ -216,7 +217,8 @@ function parseCreatedPullRequest(githubResponse: unknown): Result<WebAppVersionS
     return Result.err(new Error('Malformed GitHub created pull request response'));
   }
 
-  const createdPullRequest = pullRequestResult.value.pullRequests.at(0);
+  const {value: parsedPullRequestPage} = pullRequestResult;
+  const createdPullRequest = parsedPullRequestPage.pullRequests.at(0);
 
   if (createdPullRequest === undefined) {
     return Result.err(new Error('Malformed GitHub created pull request response'));
@@ -225,41 +227,38 @@ function parseCreatedPullRequest(githubResponse: unknown): Result<WebAppVersionS
   return Result.ok(createdPullRequest);
 }
 
-async function listPullRequestsPage(
+function listPullRequestsPage(
   options: ListPullRequestsPageOptions,
   page: number,
   accumulatedPullRequests: readonly WebAppVersionSynchronizationPullRequest[],
-): Promise<Result<readonly WebAppVersionSynchronizationPullRequest[], Error>> {
+): Task<readonly WebAppVersionSynchronizationPullRequest[], Error> {
   const request = createHttpRequest(
     'get',
     createPageUrl(options.endpoint, page),
     options.headers,
     Maybe.nothing<NonNullable<unknown>>(),
   );
-  const githubResponseResult = await requestGitHubJson({
+  return requestGitHubJson({
     httpClient: options.httpClient,
     request,
     failureMessage: 'Unable to list GitHub pull requests',
     githubToken: options.githubToken,
+  }).andThen(githubResponse => {
+    const pageResult = parsePullRequestPage(githubResponse);
+
+    if (pageResult.isErr) {
+      return Task.reject<readonly WebAppVersionSynchronizationPullRequest[], Error>(pageResult.error);
+    }
+
+    const {value: parsedPullRequestPage} = pageResult;
+    const pullRequests = [...accumulatedPullRequests, ...parsedPullRequestPage.pullRequests];
+
+    if (parsedPullRequestPage.rawItemCount !== githubPageSize) {
+      return Task.resolve<readonly WebAppVersionSynchronizationPullRequest[], Error>(pullRequests);
+    }
+
+    return listPullRequestsPage(options, page + 1, pullRequests);
   });
-
-  if (githubResponseResult.isErr) {
-    return Result.err(githubResponseResult.error);
-  }
-
-  const pageResult = parsePullRequestPage(githubResponseResult.value);
-
-  if (pageResult.isErr) {
-    return Result.err(pageResult.error);
-  }
-
-  const pullRequests = [...accumulatedPullRequests, ...pageResult.value.pullRequests];
-
-  if (pageResult.value.rawItemCount !== githubPageSize) {
-    return Result.ok(pullRequests);
-  }
-
-  return listPullRequestsPage(options, page + 1, pullRequests);
 }
 
 export function createWebAppVersionSynchronizationGitHubClient(
@@ -279,29 +278,23 @@ export function createWebAppVersionSynchronizationGitHubClient(
   };
 
   return {
-    async listPullRequests() {
+    listPullRequests() {
       return listPullRequestsPage(listPullRequestsOptions, 1, []);
     },
 
-    async createPullRequest(createPullRequestOptions) {
+    createPullRequest(createPullRequestOptions) {
       const request = createHttpRequest(
         'post',
         pullRequestsEndpoint,
         writeHeaders,
         Maybe.just(createPullRequestRequestBody(createPullRequestOptions)),
       );
-      const githubResponseResult = await requestGitHubJson({
+      return requestGitHubJson({
         httpClient: options.httpClient,
         request,
         failureMessage: 'Unable to create WebApp version synchronization pull request',
         githubToken: options.githubToken,
-      });
-
-      if (githubResponseResult.isErr) {
-        return Result.err(githubResponseResult.error);
-      }
-
-      return parseCreatedPullRequest(githubResponseResult.value);
+      }).andThen(parseCreatedPullRequest);
     },
   };
 }

--- a/tools/release-metadata/webappVersionSynchronizationGitHubClient.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGitHubClient.ts
@@ -18,7 +18,7 @@
  */
 
 import {isError} from '@sindresorhus/is';
-import {Maybe, Result, Task, task} from 'true-myth';
+import {Maybe, maybe, Result, Task, task} from 'true-myth';
 import {z} from 'zod';
 
 import type {WebAppVersionSynchronizationPullRequest} from './webappVersionSynchronization.ts';
@@ -46,9 +46,11 @@ export type CreateWebAppVersionSynchronizationGitHubClientOptions = {
   readonly githubToken: string;
 };
 
-type ParsedPullRequestPage = {
+type ParsedPullRequestSearchPage = {
+  readonly totalCount: number;
+  readonly incompleteResults: boolean;
   readonly rawItemCount: number;
-  readonly pullRequests: readonly WebAppVersionSynchronizationPullRequest[];
+  readonly pullRequestNumbers: readonly number[];
 };
 
 type GitHubPullRequestRequestBody = {
@@ -65,7 +67,15 @@ type RequestGitHubJsonOptions = {
   readonly githubToken: string;
 };
 
-type ListPullRequestsPageOptions = {
+type SearchPullRequestsPageOptions = {
+  readonly httpClient: HttpClient;
+  readonly endpoint: URL;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly searchQuery: string;
+  readonly githubToken: string;
+};
+
+type GetPullRequestOptions = {
   readonly httpClient: HttpClient;
   readonly endpoint: URL;
   readonly headers: Readonly<Record<string, string>>;
@@ -73,7 +83,10 @@ type ListPullRequestsPageOptions = {
 };
 
 const githubPageSize = 100;
+const githubSearchResultLimit = 1000;
 const githubApiVersion = '2022-11-28';
+const synchronizationMarkerSearchTerm = 'wire-webapp-version-sync';
+const synchronizationPullRequestTitleSearchTerm = 'Update WebApp version to';
 
 const githubPullRequestResponseSchema = z.object({
   number: z.number().int().positive(),
@@ -90,7 +103,22 @@ const githubPullRequestResponseSchema = z.object({
   }),
 });
 
-const githubPullRequestPageResponseSchema = z.array(githubPullRequestResponseSchema);
+const githubPullRequestSearchItemResponseSchema = z.object({
+  number: z.number().int().positive(),
+  html_url: z.string().url(),
+  title: z.string().min(1),
+  body: z.string().nullable(),
+  pull_request: z.object({
+    url: z.string().url(),
+    html_url: z.string().url(),
+  }),
+});
+
+const githubPullRequestSearchResponseSchema = z.object({
+  total_count: z.number().int().nonnegative(),
+  incomplete_results: z.boolean(),
+  items: z.array(githubPullRequestSearchItemResponseSchema),
+});
 
 function errorMessage(error: unknown): string {
   if (isHttpRequestFailure(error)) {
@@ -141,16 +169,20 @@ function createGitHubHeaders(githubToken: string, includesBody: boolean): Readon
   return headers;
 }
 
-function createPageUrl(endpoint: URL, page: number): URL {
+function createSearchPageUrl(endpoint: URL, searchQuery: string, page: number): URL {
   const pageUrl = new URL(endpoint);
 
-  pageUrl.searchParams.set('state', 'all');
+  pageUrl.searchParams.set('q', searchQuery);
   pageUrl.searchParams.set('sort', 'created');
-  pageUrl.searchParams.set('direction', 'asc');
+  pageUrl.searchParams.set('order', 'asc');
   pageUrl.searchParams.set('per_page', githubPageSize.toString());
   pageUrl.searchParams.set('page', page.toString());
 
   return pageUrl;
+}
+
+function createPullRequestDetailUrl(endpoint: URL, pullRequestNumber: number): URL {
+  return new URL(`${pullRequestNumber}`, `${endpoint.toString()}/`);
 }
 
 function createHttpRequest(
@@ -162,26 +194,42 @@ function createHttpRequest(
   return {method, url, headers, json};
 }
 
-function parsePullRequestPage(githubResponse: unknown): Result<ParsedPullRequestPage, Error> {
-  const validationResult = githubPullRequestPageResponseSchema.safeParse(githubResponse);
+function parsePullRequest(githubResponse: unknown): Result<WebAppVersionSynchronizationPullRequest, Error> {
+  const validationResult = githubPullRequestResponseSchema.safeParse(githubResponse);
 
   if (validationResult.success === false) {
     return Result.err(new Error('Malformed GitHub pull request response'));
   }
 
+  const {data: pullRequest} = validationResult;
+
   return Result.ok({
-    rawItemCount: validationResult.data.length,
-    pullRequests: validationResult.data.map(pullRequest => {
-      return {
-        number: pullRequest.number,
-        url: pullRequest.html_url,
-        title: pullRequest.title,
-        body: pullRequest.body ?? '',
-        state: pullRequest.state,
-        mergedAt: pullRequest.merged_at,
-        baseBranch: pullRequest.base.ref,
-        headBranch: pullRequest.head.ref,
-      };
+    number: pullRequest.number,
+    url: pullRequest.html_url,
+    title: pullRequest.title,
+    body: pullRequest.body ?? '',
+    state: pullRequest.state,
+    mergedAt: pullRequest.merged_at,
+    baseBranch: pullRequest.base.ref,
+    headBranch: pullRequest.head.ref,
+  });
+}
+
+function parsePullRequestSearchPage(githubResponse: unknown): Result<ParsedPullRequestSearchPage, Error> {
+  const validationResult = githubPullRequestSearchResponseSchema.safeParse(githubResponse);
+
+  if (validationResult.success === false) {
+    return Result.err(new Error('Malformed GitHub pull request search response'));
+  }
+
+  const {data: searchResponse} = validationResult;
+
+  return Result.ok({
+    totalCount: searchResponse.total_count,
+    incompleteResults: searchResponse.incomplete_results,
+    rawItemCount: searchResponse.items.length,
+    pullRequestNumbers: searchResponse.items.map(searchItem => {
+      return searchItem.number;
     }),
   });
 }
@@ -211,30 +259,22 @@ function createPullRequestRequestBody(
 }
 
 function parseCreatedPullRequest(githubResponse: unknown): Result<WebAppVersionSynchronizationPullRequest, Error> {
-  const pullRequestResult = parsePullRequestPage([githubResponse]);
+  const pullRequestResult = parsePullRequest(githubResponse);
 
   if (pullRequestResult.isErr) {
     return Result.err(new Error('Malformed GitHub created pull request response'));
   }
 
-  const {value: parsedPullRequestPage} = pullRequestResult;
-  const createdPullRequest = parsedPullRequestPage.pullRequests.at(0);
-
-  if (createdPullRequest === undefined) {
-    return Result.err(new Error('Malformed GitHub created pull request response'));
-  }
-
-  return Result.ok(createdPullRequest);
+  return pullRequestResult;
 }
 
-function listPullRequestsPage(
-  options: ListPullRequestsPageOptions,
+function searchPullRequestsPage(
+  options: SearchPullRequestsPageOptions,
   page: number,
-  accumulatedPullRequests: readonly WebAppVersionSynchronizationPullRequest[],
-): Task<readonly WebAppVersionSynchronizationPullRequest[], Error> {
+): Task<ParsedPullRequestSearchPage, Error> {
   const request = createHttpRequest(
     'get',
-    createPageUrl(options.endpoint, page),
+    createSearchPageUrl(options.endpoint, options.searchQuery, page),
     options.headers,
     Maybe.nothing<NonNullable<unknown>>(),
   );
@@ -243,21 +283,77 @@ function listPullRequestsPage(
     request,
     failureMessage: 'Unable to list GitHub pull requests',
     githubToken: options.githubToken,
-  }).andThen(githubResponse => {
-    const pageResult = parsePullRequestPage(githubResponse);
+  }).andThen(parsePullRequestSearchPage);
+}
 
-    if (pageResult.isErr) {
-      return Task.reject<readonly WebAppVersionSynchronizationPullRequest[], Error>(pageResult.error);
+function searchPullRequestNumbers(
+  options: SearchPullRequestsPageOptions,
+  page: number,
+  accumulatedPullRequestNumbers: readonly number[],
+): Task<readonly number[], Error> {
+  return searchPullRequestsPage(options, page).andThen(parsedSearchPage => {
+    if (parsedSearchPage.incompleteResults) {
+      return Task.reject<readonly number[], Error>(new Error('GitHub pull request search returned incomplete results'));
     }
 
-    const {value: parsedPullRequestPage} = pageResult;
-    const pullRequests = [...accumulatedPullRequests, ...parsedPullRequestPage.pullRequests];
-
-    if (parsedPullRequestPage.rawItemCount !== githubPageSize) {
-      return Task.resolve<readonly WebAppVersionSynchronizationPullRequest[], Error>(pullRequests);
+    if (parsedSearchPage.totalCount > githubSearchResultLimit) {
+      return Task.reject<readonly number[], Error>(
+        new Error(`GitHub pull request search returned more than ${githubSearchResultLimit} results`),
+      );
     }
 
-    return listPullRequestsPage(options, page + 1, pullRequests);
+    const pullRequestNumbers = [...accumulatedPullRequestNumbers, ...parsedSearchPage.pullRequestNumbers];
+
+    if (pullRequestNumbers.length >= parsedSearchPage.totalCount) {
+      return Task.resolve<readonly number[], Error>(pullRequestNumbers);
+    }
+
+    if (parsedSearchPage.rawItemCount !== githubPageSize) {
+      return Task.reject<readonly number[], Error>(
+        new Error('GitHub pull request search pagination ended before all results were retrieved'),
+      );
+    }
+
+    return searchPullRequestNumbers(options, page + 1, pullRequestNumbers);
+  });
+}
+
+function getPullRequest(
+  options: GetPullRequestOptions,
+  pullRequestNumber: number,
+): Task<WebAppVersionSynchronizationPullRequest, Error> {
+  const request = createHttpRequest(
+    'get',
+    createPullRequestDetailUrl(options.endpoint, pullRequestNumber),
+    options.headers,
+    Maybe.nothing<NonNullable<unknown>>(),
+  );
+
+  return requestGitHubJson({
+    httpClient: options.httpClient,
+    request,
+    failureMessage: `Unable to read GitHub pull request #${pullRequestNumber}`,
+    githubToken: options.githubToken,
+  }).andThen(parsePullRequest);
+}
+
+function getPullRequests(
+  options: GetPullRequestOptions,
+  pullRequestNumbers: readonly number[],
+  accumulatedPullRequests: readonly WebAppVersionSynchronizationPullRequest[],
+): Task<readonly WebAppVersionSynchronizationPullRequest[], Error> {
+  const pullRequestNumberMaybe = maybe.first(pullRequestNumbers).andThen(maybePullRequestNumber => {
+    return maybePullRequestNumber;
+  });
+
+  if (pullRequestNumberMaybe.isNothing) {
+    return Task.resolve(accumulatedPullRequests);
+  }
+
+  const {value: pullRequestNumber} = pullRequestNumberMaybe;
+
+  return getPullRequest(options, pullRequestNumber).andThen(pullRequest => {
+    return getPullRequests(options, pullRequestNumbers.slice(1), [...accumulatedPullRequests, pullRequest]);
   });
 }
 
@@ -269,8 +365,18 @@ export function createWebAppVersionSynchronizationGitHubClient(
   const readHeaders = createGitHubHeaders(options.githubToken, false);
   const writeHeaders = createGitHubHeaders(options.githubToken, true);
   const pullRequestsEndpoint = new URL(`repos/${encodedRepositoryName}/pulls`, githubApiRoot);
+  const pullRequestSearchEndpoint = new URL('search/issues', githubApiRoot);
+  const synchronizationSearchQuery = `repo:${options.githubRepository} is:pr (in:body "${synchronizationMarkerSearchTerm}" OR in:title "${synchronizationPullRequestTitleSearchTerm}")`;
 
-  const listPullRequestsOptions = {
+  const searchPullRequestsPageOptions = {
+    httpClient: options.httpClient,
+    endpoint: pullRequestSearchEndpoint,
+    headers: readHeaders,
+    searchQuery: synchronizationSearchQuery,
+    githubToken: options.githubToken,
+  };
+
+  const getPullRequestOptions = {
     httpClient: options.httpClient,
     endpoint: pullRequestsEndpoint,
     headers: readHeaders,
@@ -279,7 +385,9 @@ export function createWebAppVersionSynchronizationGitHubClient(
 
   return {
     listPullRequests() {
-      return listPullRequestsPage(listPullRequestsOptions, 1, []);
+      return searchPullRequestNumbers(searchPullRequestsPageOptions, 1, []).andThen(pullRequestNumbers => {
+        return getPullRequests(getPullRequestOptions, pullRequestNumbers, []);
+      });
     },
 
     createPullRequest(createPullRequestOptions) {

--- a/tools/release-metadata/webappVersionSynchronizationGitHubClient.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGitHubClient.ts
@@ -1,0 +1,307 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isError} from '@sindresorhus/is';
+import {Maybe, Result} from 'true-myth';
+import {z} from 'zod';
+
+import type {WebAppVersionSynchronizationPullRequest} from './webappVersionSynchronization.ts';
+
+import {formatHttpRequestFailure, isHttpRequestFailure} from '../release-appearance/httpClient.ts';
+import type {HttpClient, HttpMethod, HttpRequest} from '../release-appearance/httpClient.ts';
+
+export type CreateWebAppVersionSynchronizationPullRequestOptions = {
+  readonly title: string;
+  readonly body: string;
+  readonly headBranch: string;
+};
+
+export type WebAppVersionSynchronizationGitHubClient = {
+  readonly listPullRequests: () => Promise<Result<readonly WebAppVersionSynchronizationPullRequest[], Error>>;
+  readonly createPullRequest: (
+    options: CreateWebAppVersionSynchronizationPullRequestOptions,
+  ) => Promise<Result<WebAppVersionSynchronizationPullRequest, Error>>;
+};
+
+export type CreateWebAppVersionSynchronizationGitHubClientOptions = {
+  readonly httpClient: HttpClient;
+  readonly githubApiUrl: URL;
+  readonly githubRepository: string;
+  readonly githubToken: string;
+};
+
+type ParsedPullRequestPage = {
+  readonly rawItemCount: number;
+  readonly pullRequests: readonly WebAppVersionSynchronizationPullRequest[];
+};
+
+type GitHubPullRequestRequestBody = {
+  readonly title: string;
+  readonly head: string;
+  readonly base: 'main';
+  readonly body: string;
+};
+
+type RequestGitHubJsonOptions = {
+  readonly httpClient: HttpClient;
+  readonly request: HttpRequest;
+  readonly failureMessage: string;
+  readonly githubToken: string;
+};
+
+type ListPullRequestsPageOptions = {
+  readonly httpClient: HttpClient;
+  readonly endpoint: URL;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly githubToken: string;
+};
+
+const githubPageSize = 100;
+const githubApiVersion = '2022-11-28';
+
+const githubPullRequestResponseSchema = z.object({
+  number: z.number().int().positive(),
+  html_url: z.string().url(),
+  title: z.string().min(1),
+  body: z.string().nullable(),
+  state: z.enum(['open', 'closed']),
+  merged_at: z.string().nullable(),
+  base: z.object({
+    ref: z.string().min(1),
+  }),
+  head: z.object({
+    ref: z.string().min(1),
+  }),
+});
+
+const githubPullRequestPageResponseSchema = z.array(githubPullRequestResponseSchema);
+
+function errorMessage(error: unknown): string {
+  if (isHttpRequestFailure(error)) {
+    return formatHttpRequestFailure(error);
+  }
+
+  if (isError(error)) {
+    return error.message;
+  }
+
+  return 'Unknown failure';
+}
+
+function redactSecret(message: string, secret: string): string {
+  if (secret.length === 0) {
+    return message;
+  }
+
+  return message.replaceAll(secret, '[REDACTED]');
+}
+
+function createGitHubApiRoot(githubApiUrl: URL): URL {
+  const githubApiUrlString = githubApiUrl.toString();
+
+  return new URL(githubApiUrlString.endsWith('/') ? githubApiUrlString : `${githubApiUrlString}/`);
+}
+
+function encodeRepositoryName(githubRepository: string): string {
+  return githubRepository
+    .split('/')
+    .map(repositoryPart => {
+      return encodeURIComponent(repositoryPart);
+    })
+    .join('/');
+}
+
+function createGitHubHeaders(githubToken: string, includesBody: boolean): Readonly<Record<string, string>> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${githubToken}`,
+    'X-GitHub-Api-Version': githubApiVersion,
+  };
+
+  if (includesBody) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  return headers;
+}
+
+function createPageUrl(endpoint: URL, page: number): URL {
+  const pageUrl = new URL(endpoint);
+
+  pageUrl.searchParams.set('state', 'all');
+  pageUrl.searchParams.set('sort', 'created');
+  pageUrl.searchParams.set('direction', 'asc');
+  pageUrl.searchParams.set('per_page', githubPageSize.toString());
+  pageUrl.searchParams.set('page', page.toString());
+
+  return pageUrl;
+}
+
+function createHttpRequest(
+  method: HttpMethod,
+  url: URL,
+  headers: Readonly<Record<string, string>>,
+  json: Maybe<NonNullable<unknown>>,
+): HttpRequest {
+  return {method, url, headers, json};
+}
+
+function parsePullRequestPage(githubResponse: unknown): Result<ParsedPullRequestPage, Error> {
+  const validationResult = githubPullRequestPageResponseSchema.safeParse(githubResponse);
+
+  if (validationResult.success === false) {
+    return Result.err(new Error('Malformed GitHub pull request response'));
+  }
+
+  return Result.ok({
+    rawItemCount: validationResult.data.length,
+    pullRequests: validationResult.data.map(pullRequest => {
+      return {
+        number: pullRequest.number,
+        url: pullRequest.html_url,
+        title: pullRequest.title,
+        body: pullRequest.body ?? '',
+        state: pullRequest.state,
+        mergedAt: pullRequest.merged_at,
+        baseBranch: pullRequest.base.ref,
+        headBranch: pullRequest.head.ref,
+      };
+    }),
+  });
+}
+
+async function requestGitHubJson(options: RequestGitHubJsonOptions): Promise<Result<unknown, Error>> {
+  try {
+    return Result.ok(await options.httpClient.requestJson(options.request));
+  } catch (error: unknown) {
+    return Result.err(
+      new Error(`${options.failureMessage}: ${redactSecret(errorMessage(error), options.githubToken)}`, {
+        cause: error,
+      }),
+    );
+  }
+}
+
+function createPullRequestRequestBody(
+  options: CreateWebAppVersionSynchronizationPullRequestOptions,
+): GitHubPullRequestRequestBody {
+  return {
+    title: options.title,
+    head: options.headBranch,
+    base: 'main',
+    body: options.body,
+  };
+}
+
+function parseCreatedPullRequest(githubResponse: unknown): Result<WebAppVersionSynchronizationPullRequest, Error> {
+  const pullRequestResult = parsePullRequestPage([githubResponse]);
+
+  if (pullRequestResult.isErr) {
+    return Result.err(new Error('Malformed GitHub created pull request response'));
+  }
+
+  const createdPullRequest = pullRequestResult.value.pullRequests.at(0);
+
+  if (createdPullRequest === undefined) {
+    return Result.err(new Error('Malformed GitHub created pull request response'));
+  }
+
+  return Result.ok(createdPullRequest);
+}
+
+async function listPullRequestsPage(
+  options: ListPullRequestsPageOptions,
+  page: number,
+  accumulatedPullRequests: readonly WebAppVersionSynchronizationPullRequest[],
+): Promise<Result<readonly WebAppVersionSynchronizationPullRequest[], Error>> {
+  const request = createHttpRequest(
+    'get',
+    createPageUrl(options.endpoint, page),
+    options.headers,
+    Maybe.nothing<NonNullable<unknown>>(),
+  );
+  const githubResponseResult = await requestGitHubJson({
+    httpClient: options.httpClient,
+    request,
+    failureMessage: 'Unable to list GitHub pull requests',
+    githubToken: options.githubToken,
+  });
+
+  if (githubResponseResult.isErr) {
+    return Result.err(githubResponseResult.error);
+  }
+
+  const pageResult = parsePullRequestPage(githubResponseResult.value);
+
+  if (pageResult.isErr) {
+    return Result.err(pageResult.error);
+  }
+
+  const pullRequests = [...accumulatedPullRequests, ...pageResult.value.pullRequests];
+
+  if (pageResult.value.rawItemCount !== githubPageSize) {
+    return Result.ok(pullRequests);
+  }
+
+  return listPullRequestsPage(options, page + 1, pullRequests);
+}
+
+export function createWebAppVersionSynchronizationGitHubClient(
+  options: CreateWebAppVersionSynchronizationGitHubClientOptions,
+): WebAppVersionSynchronizationGitHubClient {
+  const githubApiRoot = createGitHubApiRoot(options.githubApiUrl);
+  const encodedRepositoryName = encodeRepositoryName(options.githubRepository);
+  const readHeaders = createGitHubHeaders(options.githubToken, false);
+  const writeHeaders = createGitHubHeaders(options.githubToken, true);
+  const pullRequestsEndpoint = new URL(`repos/${encodedRepositoryName}/pulls`, githubApiRoot);
+
+  const listPullRequestsOptions = {
+    httpClient: options.httpClient,
+    endpoint: pullRequestsEndpoint,
+    headers: readHeaders,
+    githubToken: options.githubToken,
+  };
+
+  return {
+    async listPullRequests() {
+      return listPullRequestsPage(listPullRequestsOptions, 1, []);
+    },
+
+    async createPullRequest(createPullRequestOptions: CreateWebAppVersionSynchronizationPullRequestOptions) {
+      const request = createHttpRequest(
+        'post',
+        pullRequestsEndpoint,
+        writeHeaders,
+        Maybe.just(createPullRequestRequestBody(createPullRequestOptions)),
+      );
+      const githubResponseResult = await requestGitHubJson({
+        httpClient: options.httpClient,
+        request,
+        failureMessage: 'Unable to create WebApp version synchronization pull request',
+        githubToken: options.githubToken,
+      });
+
+      if (githubResponseResult.isErr) {
+        return Result.err(githubResponseResult.error);
+      }
+
+      return parseCreatedPullRequest(githubResponseResult.value);
+    },
+  };
+}

--- a/tools/release-metadata/webappVersionSynchronizationGitHubClient.ts
+++ b/tools/release-metadata/webappVersionSynchronizationGitHubClient.ts
@@ -283,7 +283,7 @@ export function createWebAppVersionSynchronizationGitHubClient(
       return listPullRequestsPage(listPullRequestsOptions, 1, []);
     },
 
-    async createPullRequest(createPullRequestOptions: CreateWebAppVersionSynchronizationPullRequestOptions) {
+    async createPullRequest(createPullRequestOptions) {
       const request = createHttpRequest(
         'post',
         pullRequestsEndpoint,

--- a/tools/release-metadata/webappVersionSynchronizationOrchestration.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationOrchestration.test.ts
@@ -1,0 +1,680 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isUndefined} from '@sindresorhus/is';
+import assert from 'node:assert';
+import {Result, Task} from 'true-myth';
+
+import {createProductionTagName} from './releaseMetadata.ts';
+import {
+  inspectWebAppVersionSynchronization,
+  synchronizeWebAppVersion,
+} from './webappVersionSynchronizationOrchestration.ts';
+import type {
+  SynchronizeWebAppVersionOptions,
+  WebAppVersionSynchronizationResult,
+} from './webappVersionSynchronizationOrchestration.ts';
+import {createWebAppVersionSynchronizationMarker, parseWebAppVersionSynchronizationMarker} from './webappVersion.ts';
+import type {WebAppPackageDocuments} from './webappVersion.ts';
+import {createWebAppVersionSynchronizationBranchName} from './webappVersionSynchronization.ts';
+import type {WebAppVersionSynchronizationPullRequest} from './webappVersionSynchronization.ts';
+import type {
+  CommitWebAppVersionSynchronizationOptions,
+  CreateWebAppVersionSynchronizationBranchOptions,
+  InspectWebAppVersionSynchronizationBranchOptions,
+  PushWebAppVersionSynchronizationBranchOptions,
+  WebAppVersionSynchronizationBranchInspection,
+  WebAppVersionSynchronizationGitClient,
+  WebAppVersionSynchronizationMainSnapshot,
+  WriteWebAppVersionSynchronizationPackageDocumentsOptions,
+} from './webappVersionSynchronizationGit.ts';
+import type {
+  CreateWebAppVersionSynchronizationPullRequestOptions,
+  WebAppVersionSynchronizationGitHubClient,
+} from './webappVersionSynchronizationGitHubClient.ts';
+
+const releaseIdentifier = '2026-09-09.1';
+const productionTagName = '2026-09-09.1-production';
+const mainCommitSha = 'a'.repeat(40);
+const branchTipCommitSha = 'b'.repeat(40);
+const synchronizationBranchName = 'webapp-version-2026-09-09.1-1.0.0';
+
+function createPackageDocument(version: string): Readonly<Record<string, unknown>> {
+  return {
+    name: '@wireapp/example',
+    private: true,
+    version,
+    scripts: {test: 'jest'},
+  };
+}
+
+function createMainSnapshot(version: string = '0.27.0'): WebAppVersionSynchronizationMainSnapshot {
+  return {
+    commitSha: mainCommitSha,
+    rootPackageDocument: createPackageDocument(version),
+    webAppPackageDocument: createPackageDocument(version),
+  };
+}
+
+function createValidBranchInspection(): WebAppVersionSynchronizationBranchInspection {
+  return {
+    branchName: synchronizationBranchName,
+    mainCommitSha,
+    branchTipCommitSha,
+    baseCommitSha: mainCommitSha,
+    commitParentCount: 1,
+    isNormalCommit: true,
+    isBasedOnMainHistory: true,
+    changedFilePaths: ['apps/webapp/package.json', 'package.json'],
+    baseRootPackageDocument: createPackageDocument('0.27.0'),
+    baseWebAppPackageDocument: createPackageDocument('0.27.0'),
+    branchRootPackageDocument: createPackageDocument('1.0.0'),
+    branchWebAppPackageDocument: createPackageDocument('1.0.0'),
+  };
+}
+
+type CreateSynchronizationPullRequestOptions = {
+  readonly releaseIdentifier?: string;
+  readonly webAppVersion?: string;
+  readonly number?: number;
+  readonly state?: 'open' | 'closed';
+  readonly mergedAt?: string | null;
+  readonly body?: string;
+  readonly headBranch?: string;
+  readonly baseBranch?: string;
+};
+
+function createSynchronizationPullRequest(
+  options: CreateSynchronizationPullRequestOptions = {},
+): WebAppVersionSynchronizationPullRequest {
+  const requestedReleaseIdentifier = options.releaseIdentifier ?? releaseIdentifier;
+  const requestedWebAppVersion = options.webAppVersion ?? '1.0.0';
+  const requestedProductionTagNameResult = createProductionTagName(requestedReleaseIdentifier);
+
+  assert(requestedProductionTagNameResult.isOk);
+
+  const requestedBranchNameResult = createWebAppVersionSynchronizationBranchName(
+    requestedReleaseIdentifier,
+    requestedWebAppVersion,
+  );
+
+  assert(requestedBranchNameResult.isOk);
+
+  const markerResult = createWebAppVersionSynchronizationMarker({
+    releaseIdentifier: requestedReleaseIdentifier,
+    productionTagName: requestedProductionTagNameResult.value,
+    webAppVersion: requestedWebAppVersion,
+  });
+
+  assert(markerResult.isOk);
+
+  return {
+    number: options.number ?? 1,
+    url: `https://github.com/wireapp/wire-webapp/pull/${options.number ?? 1}`,
+    title: `Update WebApp version to ${requestedWebAppVersion}`,
+    body: options.body ?? markerResult.value,
+    state: options.state ?? 'open',
+    mergedAt: options.mergedAt ?? null,
+    baseBranch: options.baseBranch ?? 'main',
+    headBranch: options.headBranch ?? requestedBranchNameResult.value,
+  };
+}
+
+type FakeGitHubClientState = {
+  readonly pullRequestsByListCall: readonly (readonly WebAppVersionSynchronizationPullRequest[])[];
+  readonly createdPullRequest: WebAppVersionSynchronizationPullRequest | undefined;
+  readonly createPullRequestError: Error | undefined;
+  listPullRequestsCallCount: number;
+  createPullRequestOptions: CreateWebAppVersionSynchronizationPullRequestOptions[];
+};
+
+type FakeGitHubClient = {
+  readonly client: WebAppVersionSynchronizationGitHubClient;
+  readonly state: FakeGitHubClientState;
+};
+
+type CreateFakeGitHubClientOptions = {
+  readonly pullRequestsByListCall?: readonly (readonly WebAppVersionSynchronizationPullRequest[])[];
+  readonly createdPullRequest?: WebAppVersionSynchronizationPullRequest;
+  readonly createPullRequestError?: Error;
+};
+
+function createFakeGitHubClient(options: CreateFakeGitHubClientOptions = {}): FakeGitHubClient {
+  const state: FakeGitHubClientState = {
+    pullRequestsByListCall: options.pullRequestsByListCall ?? [[]],
+    createdPullRequest: options.createdPullRequest,
+    createPullRequestError: options.createPullRequestError,
+    listPullRequestsCallCount: 0,
+    createPullRequestOptions: [],
+  };
+
+  const client: WebAppVersionSynchronizationGitHubClient = {
+    listPullRequests() {
+      const responseIndex = Math.min(state.listPullRequestsCallCount, state.pullRequestsByListCall.length - 1);
+      const pullRequests = state.pullRequestsByListCall.at(responseIndex) ?? [];
+      state.listPullRequestsCallCount += 1;
+
+      return Task.resolve(pullRequests);
+    },
+
+    createPullRequest(createOptions) {
+      state.createPullRequestOptions.push(createOptions);
+
+      if (isUndefined(state.createPullRequestError) === false) {
+        return Task.reject(state.createPullRequestError);
+      }
+
+      const createdPullRequest =
+        state.createdPullRequest ??
+        createSynchronizationPullRequest({
+          webAppVersion: createOptions.title.replace('Update WebApp version to ', ''),
+          body: createOptions.body,
+          headBranch: createOptions.headBranch,
+        });
+
+      return Task.resolve(createdPullRequest);
+    },
+  };
+
+  return {client, state};
+}
+
+type FakeGitClientState = {
+  mainSnapshot: WebAppVersionSynchronizationMainSnapshot;
+  existingBranchNames: readonly string[];
+  branchInspection: WebAppVersionSynchronizationBranchInspection | undefined;
+  workingTreePackageDocuments: WebAppPackageDocuments;
+  changedFilePaths: readonly string[];
+  mainVerificationError: Error | undefined;
+  prepareLatestMainCallCount: number;
+  createBranchOptions: CreateWebAppVersionSynchronizationBranchOptions[];
+  inspectBranchOptions: InspectWebAppVersionSynchronizationBranchOptions[];
+  writePackageDocumentsOptions: WriteWebAppVersionSynchronizationPackageDocumentsOptions[];
+  commitOptions: CommitWebAppVersionSynchronizationOptions[];
+  pushBranchOptions: PushWebAppVersionSynchronizationBranchOptions[];
+  verifyMainCommitArguments: string[];
+};
+
+type FakeGitClient = {
+  readonly client: WebAppVersionSynchronizationGitClient;
+  readonly state: FakeGitClientState;
+};
+
+type CreateFakeGitClientOptions = {
+  readonly mainSnapshot?: WebAppVersionSynchronizationMainSnapshot;
+  readonly existingBranchNames?: readonly string[];
+  readonly branchInspection?: WebAppVersionSynchronizationBranchInspection;
+  readonly changedFilePaths?: readonly string[];
+  readonly mainVerificationError?: Error;
+};
+
+function createFakeGitClient(options: CreateFakeGitClientOptions = {}): FakeGitClient {
+  const mainSnapshot = options.mainSnapshot ?? createMainSnapshot();
+  const state: FakeGitClientState = {
+    mainSnapshot,
+    existingBranchNames: options.existingBranchNames ?? [],
+    branchInspection: options.branchInspection,
+    workingTreePackageDocuments: {
+      rootPackageDocument: mainSnapshot.rootPackageDocument,
+      webAppPackageDocument: mainSnapshot.webAppPackageDocument,
+    },
+    changedFilePaths: options.changedFilePaths ?? ['apps/webapp/package.json', 'package.json'],
+    mainVerificationError: options.mainVerificationError,
+    prepareLatestMainCallCount: 0,
+    createBranchOptions: [],
+    inspectBranchOptions: [],
+    writePackageDocumentsOptions: [],
+    commitOptions: [],
+    pushBranchOptions: [],
+    verifyMainCommitArguments: [],
+  };
+
+  const client: WebAppVersionSynchronizationGitClient = {
+    prepareLatestMain() {
+      state.prepareLatestMainCallCount += 1;
+
+      return Task.resolve(state.mainSnapshot);
+    },
+
+    listExistingBranchNames() {
+      return Task.resolve(state.existingBranchNames);
+    },
+
+    inspectBranch(inspectOptions) {
+      state.inspectBranchOptions.push(inspectOptions);
+
+      return Task.resolve(state.branchInspection);
+    },
+
+    createBranchFromMain(createOptions) {
+      state.createBranchOptions.push(createOptions);
+
+      return Task.resolve();
+    },
+
+    readWorkingTreePackageDocuments() {
+      return Task.resolve(state.workingTreePackageDocuments);
+    },
+
+    writePackageDocuments(writeOptions) {
+      state.writePackageDocumentsOptions.push(writeOptions);
+      state.workingTreePackageDocuments = writeOptions;
+
+      return Task.resolve();
+    },
+
+    getWorkingTreeChangedFilePaths() {
+      return Task.resolve(state.changedFilePaths);
+    },
+
+    commit(commitOptions) {
+      state.commitOptions.push(commitOptions);
+
+      return Task.resolve(branchTipCommitSha);
+    },
+
+    pushBranch(pushOptions) {
+      state.pushBranchOptions.push(pushOptions);
+
+      return Task.resolve();
+    },
+
+    verifyMainCommit(mainCommitSha) {
+      state.verifyMainCommitArguments.push(mainCommitSha);
+
+      if (isUndefined(state.mainVerificationError) === false) {
+        return Task.reject(state.mainVerificationError);
+      }
+
+      return Task.resolve();
+    },
+  };
+
+  return {client, state};
+}
+
+type CreateSynchronizationOptions = {
+  readonly githubClient: WebAppVersionSynchronizationGitHubClient;
+  readonly gitClient: WebAppVersionSynchronizationGitClient;
+  readonly releaseIdentifier?: string;
+  readonly productionTagName?: string;
+};
+
+function createSynchronizationOptions(options: CreateSynchronizationOptions): SynchronizeWebAppVersionOptions {
+  return {
+    releaseIdentifier: options.releaseIdentifier ?? releaseIdentifier,
+    productionTagName: options.productionTagName ?? productionTagName,
+    commitAuthorName: 'otto-the-bot',
+    commitAuthorEmail: 'otto@example.com',
+    dependencies: {
+      githubClient: options.githubClient,
+      gitClient: options.gitClient,
+    },
+  };
+}
+
+function expectSynchronizationResult(
+  actualResult: Result<WebAppVersionSynchronizationResult, Error>,
+): WebAppVersionSynchronizationResult {
+  assert(actualResult.isOk);
+
+  return actualResult.value;
+}
+
+describe('WebApp version synchronization orchestration', () => {
+  it('reports available without accessing Git', async () => {
+    const fakeGitHubClient = createFakeGitHubClient();
+
+    const actualResult = await inspectWebAppVersionSynchronization({
+      releaseIdentifier,
+      productionTagName,
+      githubClient: fakeGitHubClient.client,
+    });
+
+    assert(actualResult.isOk);
+    expect(actualResult.value).toEqual({
+      kind: 'available',
+      releaseIdentifier,
+      productionTagName,
+    });
+  });
+
+  it('allocates 1.0.0 and creates the synchronization branch, commit, and pull request', async () => {
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByListCall: [[], [], [], []],
+    });
+    const fakeGitClient = createFakeGitClient();
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+    const synchronizationResult = expectSynchronizationResult(actualResult);
+
+    expect(synchronizationResult).toMatchObject({
+      action: 'created',
+      releaseIdentifier,
+      productionTagName,
+      webAppVersion: '1.0.0',
+      branchName: synchronizationBranchName,
+      pullRequestNumber: 1,
+    });
+    expect(fakeGitClient.state.prepareLatestMainCallCount).toBe(1);
+    expect(fakeGitClient.state.createBranchOptions).toEqual([{branchName: synchronizationBranchName, mainCommitSha}]);
+    expect(fakeGitClient.state.writePackageDocumentsOptions[0]).toEqual({
+      rootPackageDocument: {...createPackageDocument('0.27.0'), version: '1.0.0'},
+      webAppPackageDocument: {...createPackageDocument('0.27.0'), version: '1.0.0'},
+    });
+    expect(fakeGitClient.state.commitOptions).toEqual([
+      {
+        message: 'Update WebApp version to 1.0.0',
+        authorName: 'otto-the-bot',
+        authorEmail: 'otto@example.com',
+      },
+    ]);
+    expect(fakeGitClient.state.pushBranchOptions).toEqual([{branchName: synchronizationBranchName}]);
+    expect(fakeGitClient.state.verifyMainCommitArguments).toEqual([mainCommitSha, mainCommitSha]);
+    expect(fakeGitHubClient.state.createPullRequestOptions).toHaveLength(1);
+    expect(fakeGitHubClient.state.createPullRequestOptions[0]).toMatchObject({
+      title: 'Update WebApp version to 1.0.0',
+      headBranch: synchronizationBranchName,
+    });
+
+    const createdPullRequestBody = fakeGitHubClient.state.createPullRequestOptions[0].body;
+    const markerResult = parseWebAppVersionSynchronizationMarker(createdPullRequestBody);
+
+    assert(markerResult.isOk);
+    expect(markerResult.value).toEqual({
+      releaseIdentifier,
+      productionTagName,
+      webAppVersion: '1.0.0',
+    });
+  });
+
+  it('increments only the patch version after the bootstrap release', async () => {
+    const fakeGitHubClient = createFakeGitHubClient({pullRequestsByListCall: [[], [], [], []]});
+    const fakeGitClient = createFakeGitClient({mainSnapshot: createMainSnapshot('1.0.9')});
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    expect(expectSynchronizationResult(actualResult).webAppVersion).toBe('1.0.10');
+    expect(fakeGitClient.state.createBranchOptions[0].branchName).toBe('webapp-version-2026-09-09.1-1.0.10');
+  });
+
+  it('reuses a matching open pull request without incrementing or mutating Git', async () => {
+    const matchingPullRequest = createSynchronizationPullRequest();
+    const fakeGitHubClient = createFakeGitHubClient({pullRequestsByListCall: [[matchingPullRequest]]});
+    const fakeGitClient = createFakeGitClient();
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+    const synchronizationResult = expectSynchronizationResult(actualResult);
+
+    expect(synchronizationResult.action).toBe('already-open');
+    expect(synchronizationResult.webAppVersion).toBe('1.0.0');
+    expect(fakeGitClient.state.prepareLatestMainCallCount).toBe(0);
+    expect(fakeGitHubClient.state.createPullRequestOptions).toHaveLength(0);
+  });
+
+  it('reuses a matching merged pull request even when main has advanced', async () => {
+    const matchingPullRequest = createSynchronizationPullRequest({state: 'closed', mergedAt: '2026-09-09T12:00:00Z'});
+    const fakeGitHubClient = createFakeGitHubClient({pullRequestsByListCall: [[matchingPullRequest]]});
+    const fakeGitClient = createFakeGitClient({mainSnapshot: createMainSnapshot('1.0.4')});
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    expect(expectSynchronizationResult(actualResult)).toMatchObject({
+      action: 'already-merged',
+      webAppVersion: '1.0.0',
+    });
+    expect(fakeGitClient.state.prepareLatestMainCallCount).toBe(0);
+    expect(fakeGitHubClient.state.createPullRequestOptions).toHaveLength(0);
+  });
+
+  it('fails closed when a matching pull request was closed without merge', async () => {
+    const closedPullRequest = createSynchronizationPullRequest({state: 'closed'});
+    const fakeGitHubClient = createFakeGitHubClient({pullRequestsByListCall: [[closedPullRequest]]});
+    const fakeGitClient = createFakeGitClient();
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toContain('closed without merging');
+    expect(fakeGitClient.state.prepareLatestMainCallCount).toBe(0);
+    expect(fakeGitHubClient.state.createPullRequestOptions).toHaveLength(0);
+  });
+
+  it('blocks allocation when a previous release has an open synchronization pull request', async () => {
+    const previousReleasePullRequest = createSynchronizationPullRequest({
+      releaseIdentifier: '2026-09-02.1',
+      number: 7,
+    });
+    const fakeGitHubClient = createFakeGitHubClient({pullRequestsByListCall: [[previousReleasePullRequest]]});
+    const fakeGitClient = createFakeGitClient();
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toContain('#7');
+    expect(actualResult.error.message).toContain(previousReleasePullRequest.url);
+    expect(fakeGitClient.state.prepareLatestMainCallCount).toBe(0);
+  });
+
+  it('fails closed when duplicate synchronization records exist for the release', async () => {
+    const firstPullRequest = createSynchronizationPullRequest({number: 1});
+    const secondPullRequest = createSynchronizationPullRequest({number: 2});
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByListCall: [[firstPullRequest, secondPullRequest]],
+    });
+    const fakeGitClient = createFakeGitClient();
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toContain('Multiple synchronization records');
+    expect(fakeGitClient.state.prepareLatestMainCallCount).toBe(0);
+  });
+
+  it('fails closed when a claimed synchronization marker is malformed', async () => {
+    const malformedPullRequest = createSynchronizationPullRequest({
+      body: '<!-- wire-webapp-version-sync release=invalid -->',
+    });
+    const fakeGitHubClient = createFakeGitHubClient({pullRequestsByListCall: [[malformedPullRequest]]});
+
+    const actualResult = await inspectWebAppVersionSynchronization({
+      releaseIdentifier,
+      productionTagName,
+      githubClient: fakeGitHubClient.client,
+    });
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toContain('invalid marker');
+  });
+
+  it('recovers a valid deterministic branch without creating another commit or pushing it', async () => {
+    const fakeGitHubClient = createFakeGitHubClient({pullRequestsByListCall: [[], [], []]});
+    const fakeGitClient = createFakeGitClient({
+      existingBranchNames: [synchronizationBranchName],
+      branchInspection: createValidBranchInspection(),
+    });
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    expect(expectSynchronizationResult(actualResult).action).toBe('recovered');
+    expect(fakeGitClient.state.createBranchOptions).toHaveLength(0);
+    expect(fakeGitClient.state.writePackageDocumentsOptions).toHaveLength(0);
+    expect(fakeGitClient.state.commitOptions).toHaveLength(0);
+    expect(fakeGitClient.state.pushBranchOptions).toHaveLength(0);
+    expect(fakeGitClient.state.verifyMainCommitArguments).toEqual([mainCommitSha]);
+    expect(fakeGitHubClient.state.createPullRequestOptions).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      description: 'a branch with an unexpected version',
+      existingBranchNames: ['webapp-version-2026-09-09.1-1.0.1'],
+      branchInspection: undefined,
+    },
+    {
+      description: 'a branch with an unrelated changed file',
+      existingBranchNames: [synchronizationBranchName],
+      branchInspection: {...createValidBranchInspection(), changedFilePaths: ['README.md']},
+    },
+    {
+      description: 'a branch with an unexpected extra commit',
+      existingBranchNames: [synchronizationBranchName],
+      branchInspection: {...createValidBranchInspection(), commitParentCount: 2},
+    },
+    {
+      description: 'a branch whose base is outside main history',
+      existingBranchNames: [synchronizationBranchName],
+      branchInspection: {...createValidBranchInspection(), isBasedOnMainHistory: false},
+    },
+  ])('rejects $description during interrupted-branch recovery', async ({existingBranchNames, branchInspection}) => {
+    const fakeGitHubClient = createFakeGitHubClient({pullRequestsByListCall: [[], []]});
+    const fakeGitClient = createFakeGitClient({existingBranchNames, branchInspection});
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    assert(actualResult.isErr);
+    expect(fakeGitHubClient.state.createPullRequestOptions).toHaveLength(0);
+    expect(fakeGitClient.state.pushBranchOptions).toHaveLength(0);
+  });
+
+  it('fails before pushing when main changes during allocation', async () => {
+    const fakeGitHubClient = createFakeGitHubClient({pullRequestsByListCall: [[], [], []]});
+    const fakeGitClient = createFakeGitClient({
+      mainVerificationError: new Error('origin/main changed during WebApp version synchronization'),
+    });
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toContain('origin/main changed');
+    expect(fakeGitClient.state.commitOptions).toHaveLength(1);
+    expect(fakeGitClient.state.pushBranchOptions).toHaveLength(0);
+    expect(fakeGitHubClient.state.createPullRequestOptions).toHaveLength(0);
+  });
+
+  it('does not create a duplicate when another matching pull request appears before commit', async () => {
+    const matchingPullRequest = createSynchronizationPullRequest();
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByListCall: [[], [], [matchingPullRequest]],
+    });
+    const fakeGitClient = createFakeGitClient();
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    expect(expectSynchronizationResult(actualResult).action).toBe('already-open');
+    expect(fakeGitClient.state.commitOptions).toHaveLength(0);
+    expect(fakeGitClient.state.pushBranchOptions).toHaveLength(0);
+    expect(fakeGitHubClient.state.createPullRequestOptions).toHaveLength(0);
+  });
+
+  it('does not create a duplicate when another matching pull request appears after push', async () => {
+    const matchingPullRequest = createSynchronizationPullRequest();
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByListCall: [[], [], [], [matchingPullRequest]],
+    });
+    const fakeGitClient = createFakeGitClient();
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    expect(expectSynchronizationResult(actualResult).action).toBe('already-open');
+    expect(fakeGitClient.state.commitOptions).toHaveLength(1);
+    expect(fakeGitClient.state.pushBranchOptions).toHaveLength(1);
+    expect(fakeGitHubClient.state.createPullRequestOptions).toHaveLength(0);
+  });
+
+  it('reports a post-push pull request failure without retrying or changing GitHub state', async () => {
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByListCall: [[], [], [], []],
+      createPullRequestError: new Error('GitHub unavailable'),
+    });
+    const fakeGitClient = createFakeGitClient();
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toBe('GitHub unavailable');
+    expect(fakeGitClient.state.pushBranchOptions).toHaveLength(1);
+    expect(fakeGitHubClient.state.createPullRequestOptions).toHaveLength(1);
+  });
+});

--- a/tools/release-metadata/webappVersionSynchronizationOrchestration.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationOrchestration.test.ts
@@ -502,6 +502,78 @@ describe('WebApp version synchronization orchestration', () => {
     expect(fakeGitClient.state.prepareLatestMainCallCount).toBe(0);
   });
 
+  it('blocks allocation when a previous release synchronization pull request was closed without merging', async () => {
+    const previousReleasePullRequest = createSynchronizationPullRequest({
+      releaseIdentifier: '2026-09-02.1',
+      state: 'closed',
+      number: 7,
+    });
+    const fakeGitHubClient = createFakeGitHubClient({pullRequestsByListCall: [[previousReleasePullRequest]]});
+    const fakeGitClient = createFakeGitClient();
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toContain('closed-without-merge');
+    expect(actualResult.error.message).toContain('#7');
+    expect(fakeGitClient.state.prepareLatestMainCallCount).toBe(0);
+    expect(fakeGitHubClient.state.createPullRequestOptions).toHaveLength(0);
+  });
+
+  it('allocates after a previous release synchronization pull request was merged', async () => {
+    const previousReleasePullRequest = createSynchronizationPullRequest({
+      releaseIdentifier: '2026-09-02.1',
+      state: 'closed',
+      mergedAt: '2026-09-02T12:00:00Z',
+      number: 7,
+    });
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByListCall: [[previousReleasePullRequest], [], [], []],
+    });
+    const fakeGitClient = createFakeGitClient();
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    expect(expectSynchronizationResult(actualResult)).toMatchObject({
+      action: 'created',
+      webAppVersion: '1.0.0',
+    });
+  });
+
+  it('fails closed when a matching synchronization pull request hides another unresolved release', async () => {
+    const matchingPullRequest = createSynchronizationPullRequest();
+    const previousReleasePullRequest = createSynchronizationPullRequest({
+      releaseIdentifier: '2026-09-02.1',
+      number: 7,
+    });
+    const fakeGitHubClient = createFakeGitHubClient({
+      pullRequestsByListCall: [[matchingPullRequest, previousReleasePullRequest]],
+    });
+    const fakeGitClient = createFakeGitClient();
+
+    const actualResult = await synchronizeWebAppVersion(
+      createSynchronizationOptions({
+        githubClient: fakeGitHubClient.client,
+        gitClient: fakeGitClient.client,
+      }),
+    );
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toContain('conflict');
+    expect(fakeGitClient.state.prepareLatestMainCallCount).toBe(0);
+    expect(fakeGitHubClient.state.createPullRequestOptions).toHaveLength(0);
+  });
+
   it('fails closed when duplicate synchronization records exist for the release', async () => {
     const firstPullRequest = createSynchronizationPullRequest({number: 1});
     const secondPullRequest = createSynchronizationPullRequest({number: 2});

--- a/tools/release-metadata/webappVersionSynchronizationOrchestration.ts
+++ b/tools/release-metadata/webappVersionSynchronizationOrchestration.ts
@@ -157,10 +157,10 @@ function resolveInspectionOutcome(
     );
   }
 
-  if (inspection.kind === 'blocked-by-previous-open') {
+  if (inspection.kind === 'blocked-by-previous-unresolved') {
     return Result.err(
       new Error(
-        `WebApp version synchronization is blocked by unresolved pull request #${inspection.pullRequestNumber} for ${inspection.blockingReleaseIdentifier}: ${inspection.pullRequestUrl}`,
+        `WebApp version synchronization is blocked by ${inspection.blockingSynchronizationState} pull request #${inspection.pullRequestNumber} for ${inspection.blockingReleaseIdentifier}: ${inspection.pullRequestUrl}`,
       ),
     );
   }

--- a/tools/release-metadata/webappVersionSynchronizationOrchestration.ts
+++ b/tools/release-metadata/webappVersionSynchronizationOrchestration.ts
@@ -1,0 +1,548 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isUndefined} from '@sindresorhus/is';
+import {Maybe, Result, Task, Unit} from 'true-myth';
+
+import {
+  resolveNextWebAppVersion,
+  updateWebAppPackageDocuments,
+  validateMatchingWebAppPackageVersions,
+} from './webappVersion.ts';
+import type {WebAppVersion} from './webappVersion.ts';
+import {
+  createWebAppVersionSynchronizationBranchName,
+  createWebAppVersionSynchronizationPullRequestBody,
+  createWebAppVersionSynchronizationPullRequestTitle,
+  parseWebAppVersionSynchronizationPullRequest,
+  resolveWebAppVersionSynchronizationState,
+  validateWebAppVersionSynchronizationBranchName,
+} from './webappVersionSynchronization.ts';
+import type {
+  WebAppVersionSynchronizationBranchName,
+  WebAppVersionSynchronizationInspection,
+} from './webappVersionSynchronization.ts';
+import {
+  validateWebAppVersionSynchronizationBranch,
+  webAppVersionSynchronizationPackageFilePaths,
+} from './webappVersionSynchronizationGit.ts';
+import type {
+  CommitWebAppVersionSynchronizationOptions,
+  WebAppVersionSynchronizationBranchInspection,
+  WebAppVersionSynchronizationGitClient,
+  WebAppVersionSynchronizationMainSnapshot,
+} from './webappVersionSynchronizationGit.ts';
+import type {WebAppVersionSynchronizationGitHubClient} from './webappVersionSynchronizationGitHubClient.ts';
+
+export type InspectWebAppVersionSynchronizationOptions = {
+  readonly releaseIdentifier: string;
+  readonly productionTagName: string;
+  readonly githubClient: WebAppVersionSynchronizationGitHubClient;
+};
+
+export type WebAppVersionSynchronizationDependencies = {
+  readonly githubClient: WebAppVersionSynchronizationGitHubClient;
+  readonly gitClient: WebAppVersionSynchronizationGitClient;
+};
+
+export type SynchronizeWebAppVersionOptions = {
+  readonly releaseIdentifier: string;
+  readonly productionTagName: string;
+  readonly commitAuthorName: string;
+  readonly commitAuthorEmail: string;
+  readonly dependencies: WebAppVersionSynchronizationDependencies;
+};
+
+export type WebAppVersionSynchronizationAction = 'created' | 'already-open' | 'already-merged' | 'recovered';
+
+export type WebAppVersionSynchronizationResult = {
+  readonly action: WebAppVersionSynchronizationAction;
+  readonly releaseIdentifier: string;
+  readonly productionTagName: string;
+  readonly webAppVersion: WebAppVersion;
+  readonly branchName: WebAppVersionSynchronizationBranchName;
+  readonly pullRequestNumber: number;
+  readonly pullRequestUrl: string;
+};
+
+type SynchronizationRequestDetails = {
+  readonly title: string;
+  readonly body: string;
+};
+
+type AllocateWebAppVersionOptions = {
+  readonly synchronizationOptions: SynchronizeWebAppVersionOptions;
+  readonly mainSnapshot: WebAppVersionSynchronizationMainSnapshot;
+};
+
+type SynchronizeBranchOptions = AllocateWebAppVersionOptions & {
+  readonly branchName: WebAppVersionSynchronizationBranchName;
+  readonly webAppVersion: WebAppVersion;
+};
+
+type CreatePullRequestOptions = SynchronizeBranchOptions & {
+  readonly action: 'created' | 'recovered';
+};
+
+type ExistingSynchronizationDetails = {
+  readonly releaseIdentifier: string;
+  readonly productionTagName: string;
+  readonly webAppVersion: WebAppVersion;
+  readonly pullRequestNumber: number;
+  readonly pullRequestUrl: string;
+  readonly branchName: WebAppVersionSynchronizationBranchName;
+};
+
+export function inspectWebAppVersionSynchronization(
+  options: InspectWebAppVersionSynchronizationOptions,
+): Task<WebAppVersionSynchronizationInspection, Error> {
+  return options.githubClient.listPullRequests().andThen(pullRequests => {
+    return resolveWebAppVersionSynchronizationState(options.releaseIdentifier, options.productionTagName, pullRequests);
+  });
+}
+
+function createResultFromExistingInspection(
+  action: 'already-open' | 'already-merged',
+  inspection: ExistingSynchronizationDetails,
+): Result<Maybe<WebAppVersionSynchronizationResult>, Error> {
+  return Result.ok(
+    Maybe.just({
+      action,
+      releaseIdentifier: inspection.releaseIdentifier,
+      productionTagName: inspection.productionTagName,
+      webAppVersion: inspection.webAppVersion,
+      branchName: inspection.branchName,
+      pullRequestNumber: inspection.pullRequestNumber,
+      pullRequestUrl: inspection.pullRequestUrl,
+    }),
+  );
+}
+
+function resolveInspectionOutcome(
+  inspection: WebAppVersionSynchronizationInspection,
+): Result<Maybe<WebAppVersionSynchronizationResult>, Error> {
+  if (inspection.kind === 'available') {
+    return Result.ok(Maybe.nothing<WebAppVersionSynchronizationResult>());
+  }
+
+  if (inspection.kind === 'matching-open') {
+    return createResultFromExistingInspection('already-open', inspection);
+  }
+
+  if (inspection.kind === 'matching-merged') {
+    return createResultFromExistingInspection('already-merged', inspection);
+  }
+
+  if (inspection.kind === 'closed-without-merge') {
+    return Result.err(
+      new Error(
+        `WebApp version synchronization pull request #${inspection.pullRequestNumber} for ${inspection.releaseIdentifier} was closed without merging: ${inspection.pullRequestUrl}`,
+      ),
+    );
+  }
+
+  if (inspection.kind === 'blocked-by-previous-open') {
+    return Result.err(
+      new Error(
+        `WebApp version synchronization is blocked by unresolved pull request #${inspection.pullRequestNumber} for ${inspection.blockingReleaseIdentifier}: ${inspection.pullRequestUrl}`,
+      ),
+    );
+  }
+
+  if (inspection.kind === 'conflict') {
+    return Result.err(
+      new Error(`WebApp version synchronization conflict for ${inspection.releaseIdentifier}: ${inspection.reason}`),
+    );
+  }
+
+  return Result.err(new Error('Unknown WebApp version synchronization state'));
+}
+
+function resolveCurrentSynchronizationOutcome(
+  options: SynchronizeWebAppVersionOptions,
+): Task<Maybe<WebAppVersionSynchronizationResult>, Error> {
+  return inspectWebAppVersionSynchronization({
+    releaseIdentifier: options.releaseIdentifier,
+    productionTagName: options.productionTagName,
+    githubClient: options.dependencies.githubClient,
+  }).andThen(resolveInspectionOutcome);
+}
+
+function createSynchronizationRequestDetails(
+  releaseIdentifier: string,
+  productionTagName: string,
+  webAppVersion: WebAppVersion,
+): Result<SynchronizationRequestDetails, Error> {
+  const titleResult = createWebAppVersionSynchronizationPullRequestTitle(webAppVersion);
+
+  if (titleResult.isErr) {
+    return Result.err(titleResult.error);
+  }
+
+  const {value: title} = titleResult;
+
+  const bodyResult = createWebAppVersionSynchronizationPullRequestBody({
+    releaseIdentifier,
+    productionTagName,
+    webAppVersion,
+  });
+
+  if (bodyResult.isErr) {
+    return Result.err(bodyResult.error);
+  }
+
+  const {value: body} = bodyResult;
+
+  return Result.ok({title, body});
+}
+
+function validateExpectedWorkingTreeChanges(changedFilePaths: readonly string[]): Result<Unit, Error> {
+  const sortedChangedFilePaths = changedFilePaths.toSorted();
+  const expectedChangedFilePaths = webAppVersionSynchronizationPackageFilePaths.toSorted();
+
+  if (sortedChangedFilePaths.join('\n') !== expectedChangedFilePaths.join('\n')) {
+    return Result.err(
+      new Error(
+        `WebApp version synchronization changes unexpected files: ${sortedChangedFilePaths.join(', ') || 'none'}`,
+      ),
+    );
+  }
+
+  return Result.ok();
+}
+
+function prepareSynchronizationCommit(options: SynchronizeBranchOptions): Task<Unit, Error> {
+  const updateResult = updateWebAppPackageDocuments({
+    rootPackageDocument: options.mainSnapshot.rootPackageDocument,
+    webAppPackageDocument: options.mainSnapshot.webAppPackageDocument,
+    targetVersion: options.webAppVersion,
+  });
+
+  if (updateResult.isErr) {
+    return Task.reject<Unit, Error>(updateResult.error);
+  }
+
+  const {value: updatedPackageDocuments} = updateResult;
+
+  const gitClient = options.synchronizationOptions.dependencies.gitClient;
+
+  return gitClient
+    .writePackageDocuments(updatedPackageDocuments)
+    .andThen(() => {
+      return gitClient.readWorkingTreePackageDocuments();
+    })
+    .andThen(workingTreePackageDocuments => {
+      const packageVersionsResult = validateMatchingWebAppPackageVersions(
+        workingTreePackageDocuments.rootPackageDocument,
+        workingTreePackageDocuments.webAppPackageDocument,
+      );
+
+      if (packageVersionsResult.isErr) {
+        return Task.reject<readonly string[], Error>(packageVersionsResult.error);
+      }
+
+      const {value: packageVersions} = packageVersionsResult;
+
+      if (packageVersions.rootVersion !== options.webAppVersion) {
+        return Task.reject<readonly string[], Error>(
+          new Error('Working tree package documents contain an unexpected WebApp version'),
+        );
+      }
+
+      return gitClient.getWorkingTreeChangedFilePaths();
+    })
+    .andThen(validateExpectedWorkingTreeChanges);
+}
+
+function createPullRequestForBranch(
+  options: CreatePullRequestOptions,
+): Task<WebAppVersionSynchronizationResult, Error> {
+  const requestDetailsResult = createSynchronizationRequestDetails(
+    options.synchronizationOptions.releaseIdentifier,
+    options.synchronizationOptions.productionTagName,
+    options.webAppVersion,
+  );
+
+  if (requestDetailsResult.isErr) {
+    return Task.reject<WebAppVersionSynchronizationResult, Error>(requestDetailsResult.error);
+  }
+
+  const {value: requestDetails} = requestDetailsResult;
+
+  return options.synchronizationOptions.dependencies.githubClient
+    .createPullRequest({
+      title: requestDetails.title,
+      body: requestDetails.body,
+      headBranch: options.branchName,
+    })
+    .andThen(pullRequest => {
+      const synchronizationRecordResult = parseWebAppVersionSynchronizationPullRequest(pullRequest);
+
+      if (synchronizationRecordResult.isErr) {
+        return Task.reject<WebAppVersionSynchronizationResult, Error>(synchronizationRecordResult.error);
+      }
+
+      const {value: synchronizationRecordMaybe} = synchronizationRecordResult;
+
+      if (synchronizationRecordMaybe.isNothing) {
+        return Task.reject<WebAppVersionSynchronizationResult, Error>(
+          new Error('Created WebApp version synchronization pull request has no synchronization marker'),
+        );
+      }
+
+      const {value: synchronizationRecord} = synchronizationRecordMaybe;
+
+      if (
+        synchronizationRecord.marker.releaseIdentifier !== options.synchronizationOptions.releaseIdentifier ||
+        synchronizationRecord.marker.productionTagName !== options.synchronizationOptions.productionTagName ||
+        synchronizationRecord.marker.webAppVersion !== options.webAppVersion ||
+        synchronizationRecord.pullRequest.state !== 'open'
+      ) {
+        return Task.reject<WebAppVersionSynchronizationResult, Error>(
+          new Error('Created pull request does not match the requested WebApp synchronization'),
+        );
+      }
+
+      const branchNameResult = createWebAppVersionSynchronizationBranchName(
+        synchronizationRecord.marker.releaseIdentifier,
+        synchronizationRecord.marker.webAppVersion,
+      );
+
+      if (branchNameResult.isErr) {
+        return Task.reject<WebAppVersionSynchronizationResult, Error>(branchNameResult.error);
+      }
+
+      const {value: validatedBranchName} = branchNameResult;
+
+      if (validatedBranchName !== options.branchName) {
+        return Task.reject<WebAppVersionSynchronizationResult, Error>(
+          new Error('Created pull request uses an unexpected synchronization branch'),
+        );
+      }
+
+      return Result.ok({
+        action: options.action,
+        releaseIdentifier: synchronizationRecord.marker.releaseIdentifier,
+        productionTagName: synchronizationRecord.marker.productionTagName,
+        webAppVersion: synchronizationRecord.marker.webAppVersion,
+        branchName: validatedBranchName,
+        pullRequestNumber: synchronizationRecord.pullRequest.number,
+        pullRequestUrl: synchronizationRecord.pullRequest.url,
+      });
+    });
+}
+
+function recoverExistingBranch(
+  options: SynchronizeBranchOptions,
+  branchInspection: WebAppVersionSynchronizationBranchInspection,
+): Task<WebAppVersionSynchronizationResult, Error> {
+  const branchValidationResult = validateWebAppVersionSynchronizationBranch({
+    branchInspection,
+    expectedReleaseIdentifier: options.synchronizationOptions.releaseIdentifier,
+    expectedWebAppVersion: options.webAppVersion,
+  });
+
+  if (branchValidationResult.isErr) {
+    return Task.reject<WebAppVersionSynchronizationResult, Error>(branchValidationResult.error);
+  }
+
+  const gitClient = options.synchronizationOptions.dependencies.gitClient;
+
+  return gitClient
+    .verifyMainCommit(options.mainSnapshot.commitSha)
+    .andThen(() => {
+      return resolveCurrentSynchronizationOutcome(options.synchronizationOptions);
+    })
+    .andThen(currentSynchronizationOutcome => {
+      if (currentSynchronizationOutcome.isJust) {
+        const {value: synchronizationResult} = currentSynchronizationOutcome;
+
+        return Result.ok(synchronizationResult);
+      }
+
+      return createPullRequestForBranch({...options, action: 'recovered'});
+    });
+}
+
+function createNewSynchronizationBranch(
+  options: SynchronizeBranchOptions,
+): Task<WebAppVersionSynchronizationResult, Error> {
+  const gitClient = options.synchronizationOptions.dependencies.gitClient;
+
+  return gitClient
+    .createBranchFromMain({
+      branchName: options.branchName,
+      mainCommitSha: options.mainSnapshot.commitSha,
+    })
+    .andThen(() => {
+      return prepareSynchronizationCommit(options);
+    })
+    .andThen(() => {
+      return resolveCurrentSynchronizationOutcome(options.synchronizationOptions);
+    })
+    .andThen(currentSynchronizationOutcome => {
+      if (currentSynchronizationOutcome.isJust) {
+        const {value: synchronizationResult} = currentSynchronizationOutcome;
+
+        return Task.resolve<WebAppVersionSynchronizationResult, Error>(synchronizationResult);
+      }
+
+      const commitOptions: CommitWebAppVersionSynchronizationOptions = {
+        message: `Update WebApp version to ${options.webAppVersion}`,
+        authorName: options.synchronizationOptions.commitAuthorName,
+        authorEmail: options.synchronizationOptions.commitAuthorEmail,
+      };
+
+      return gitClient
+        .commit(commitOptions)
+        .andThen(() => {
+          return gitClient.verifyMainCommit(options.mainSnapshot.commitSha);
+        })
+        .andThen(() => {
+          return gitClient.pushBranch({branchName: options.branchName});
+        })
+        .andThen(() => {
+          return gitClient.verifyMainCommit(options.mainSnapshot.commitSha);
+        })
+        .andThen(() => {
+          return resolveCurrentSynchronizationOutcome(options.synchronizationOptions);
+        })
+        .andThen(latestSynchronizationOutcome => {
+          if (latestSynchronizationOutcome.isJust) {
+            const {value: synchronizationResult} = latestSynchronizationOutcome;
+
+            return Result.ok(synchronizationResult);
+          }
+
+          return createPullRequestForBranch({...options, action: 'created'});
+        });
+    });
+}
+
+function allocateAndSynchronizeWebAppVersion(
+  options: AllocateWebAppVersionOptions,
+): Task<WebAppVersionSynchronizationResult, Error> {
+  const packageVersionsResult = validateMatchingWebAppPackageVersions(
+    options.mainSnapshot.rootPackageDocument,
+    options.mainSnapshot.webAppPackageDocument,
+  );
+
+  if (packageVersionsResult.isErr) {
+    return Task.reject<WebAppVersionSynchronizationResult, Error>(packageVersionsResult.error);
+  }
+
+  const {value: packageVersions} = packageVersionsResult;
+
+  const webAppVersionResult = resolveNextWebAppVersion(packageVersions.rootVersion);
+
+  if (webAppVersionResult.isErr) {
+    return Task.reject<WebAppVersionSynchronizationResult, Error>(webAppVersionResult.error);
+  }
+
+  const {value: webAppVersion} = webAppVersionResult;
+
+  const expectedBranchNameResult = createWebAppVersionSynchronizationBranchName(
+    options.synchronizationOptions.releaseIdentifier,
+    webAppVersion,
+  );
+
+  if (expectedBranchNameResult.isErr) {
+    return Task.reject<WebAppVersionSynchronizationResult, Error>(expectedBranchNameResult.error);
+  }
+
+  const {value: expectedBranchName} = expectedBranchNameResult;
+
+  return options.synchronizationOptions.dependencies.gitClient
+    .listExistingBranchNames(options.synchronizationOptions.releaseIdentifier)
+    .andThen(existingBranchNames => {
+      if (existingBranchNames.length > 1) {
+        return Task.reject<SynchronizeBranchOptions, Error>(
+          new Error(
+            `Multiple WebApp version synchronization branches exist for ${options.synchronizationOptions.releaseIdentifier}`,
+          ),
+        );
+      }
+
+      const existingBranchName = existingBranchNames.at(0);
+      const branchName = existingBranchName ?? expectedBranchName;
+      const branchNameResult = validateWebAppVersionSynchronizationBranchName(branchName);
+
+      if (branchNameResult.isErr) {
+        return Task.reject<SynchronizeBranchOptions, Error>(branchNameResult.error);
+      }
+
+      const {value: validatedBranchName} = branchNameResult;
+
+      if (validatedBranchName.releaseIdentifier !== options.synchronizationOptions.releaseIdentifier) {
+        return Task.reject<SynchronizeBranchOptions, Error>(
+          new Error('Existing synchronization branch belongs to a different release identifier'),
+        );
+      }
+
+      if (validatedBranchName.webAppVersion !== webAppVersion) {
+        return Task.reject<SynchronizeBranchOptions, Error>(
+          new Error('Existing synchronization branch contains an unexpected WebApp version'),
+        );
+      }
+
+      return Result.ok({
+        ...options,
+        branchName: validatedBranchName.branchName,
+        webAppVersion,
+      });
+    })
+    .andThen(branchOptions => {
+      return options.synchronizationOptions.dependencies.gitClient
+        .inspectBranch({
+          branchName: branchOptions.branchName,
+          mainCommitSha: options.mainSnapshot.commitSha,
+        })
+        .andThen(branchInspection => {
+          if (isUndefined(branchInspection) === false) {
+            return recoverExistingBranch(branchOptions, branchInspection);
+          }
+
+          return createNewSynchronizationBranch(branchOptions);
+        });
+    });
+}
+
+export function synchronizeWebAppVersion(
+  options: SynchronizeWebAppVersionOptions,
+): Task<WebAppVersionSynchronizationResult, Error> {
+  return resolveCurrentSynchronizationOutcome(options).andThen(initialSynchronizationOutcome => {
+    if (initialSynchronizationOutcome.isJust) {
+      const {value: synchronizationResult} = initialSynchronizationOutcome;
+
+      return Task.resolve<WebAppVersionSynchronizationResult, Error>(synchronizationResult);
+    }
+
+    return options.dependencies.gitClient.prepareLatestMain().andThen(mainSnapshot => {
+      return resolveCurrentSynchronizationOutcome(options).andThen(postPreparationSynchronizationOutcome => {
+        if (postPreparationSynchronizationOutcome.isJust) {
+          const {value: synchronizationResult} = postPreparationSynchronizationOutcome;
+
+          return Result.ok(synchronizationResult);
+        }
+
+        return allocateAndSynchronizeWebAppVersion({synchronizationOptions: options, mainSnapshot});
+      });
+    });
+  });
+}

--- a/tools/release-metadata/webappVersionSynchronizationRuntime.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationRuntime.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+
+import {
+  readInspectionRuntimeEnvironment,
+  readSynchronizationRuntimeEnvironment,
+} from './webappVersionSynchronizationRuntime.ts';
+
+function createRuntimeEnvironment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    GITHUB_API_URL: 'https://api.github.com',
+    GITHUB_REPOSITORY: 'wireapp/wire-webapp',
+    GITHUB_WORKSPACE: '/workspace/wire-webapp',
+    ...overrides,
+  };
+}
+
+describe('WebApp version synchronization runtime environment', () => {
+  it('allows inspection with GITHUB_TOKEN without an Otto token', () => {
+    const actualResult = readInspectionRuntimeEnvironment(
+      createRuntimeEnvironment({GITHUB_TOKEN: 'github-read-token'}),
+    );
+
+    assert(actualResult.isOk);
+    expect(actualResult.value.githubToken).toBe('github-read-token');
+  });
+
+  it('requires GITHUB_TOKEN for inspection', () => {
+    const actualResult = readInspectionRuntimeEnvironment(createRuntimeEnvironment());
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toContain('GITHUB_TOKEN');
+  });
+
+  it('allows synchronization with the Otto token without GITHUB_TOKEN', () => {
+    const actualResult = readSynchronizationRuntimeEnvironment(
+      createRuntimeEnvironment({OTTO_THE_BOT_GH_TOKEN: 'otto-write-token'}),
+    );
+
+    assert(actualResult.isOk);
+    expect(actualResult.value.ottoTheBotGitHubToken).toBe('otto-write-token');
+  });
+
+  it('requires the Otto token for synchronization', () => {
+    const actualResult = readSynchronizationRuntimeEnvironment(createRuntimeEnvironment());
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).toContain('OTTO_THE_BOT_GH_TOKEN');
+  });
+
+  it('does not include credentials in validation failures', () => {
+    const actualResult = readInspectionRuntimeEnvironment(
+      createRuntimeEnvironment({GITHUB_API_URL: 'not-a-url', GITHUB_TOKEN: 'github-read-token'}),
+    );
+
+    assert(actualResult.isErr);
+    expect(actualResult.error.message).not.toContain('github-read-token');
+    expect(actualResult.error.message).not.toContain('otto-write-token');
+  });
+});

--- a/tools/release-metadata/webappVersionSynchronizationRuntime.ts
+++ b/tools/release-metadata/webappVersionSynchronizationRuntime.ts
@@ -1,0 +1,137 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {isError, isNonEmptyStringAndNotWhitespace} from '@sindresorhus/is';
+import {Result} from 'true-myth';
+
+import process from 'node:process';
+
+export type WebAppVersionSynchronizationInspectionRuntimeEnvironment = {
+  readonly githubApiUrl: URL;
+  readonly githubRepository: string;
+  readonly githubToken: string;
+  readonly repositoryPath: string;
+};
+
+export type WebAppVersionSynchronizationSynchronizationRuntimeEnvironment = {
+  readonly githubApiUrl: URL;
+  readonly githubRepository: string;
+  readonly ottoTheBotGitHubToken: string;
+  readonly repositoryPath: string;
+};
+
+type CommonRuntimeEnvironment = {
+  readonly githubApiUrl: URL;
+  readonly githubRepository: string;
+  readonly repositoryPath: string;
+};
+
+function readRequiredEnvironmentValue(
+  environment: NodeJS.ProcessEnv,
+  environmentVariableName: string,
+): Result<string, Error> {
+  const environmentValue = environment[environmentVariableName];
+
+  if (isNonEmptyStringAndNotWhitespace(environmentValue) === false) {
+    return Result.err(new Error(`Required environment variable is missing: ${environmentVariableName}`));
+  }
+
+  return Result.ok(environmentValue);
+}
+
+function readCommonRuntimeEnvironment(environment: NodeJS.ProcessEnv): Result<CommonRuntimeEnvironment, Error> {
+  const githubApiUrlValueResult = readRequiredEnvironmentValue(environment, 'GITHUB_API_URL');
+  const githubRepositoryResult = readRequiredEnvironmentValue(environment, 'GITHUB_REPOSITORY');
+  const repositoryPath = environment.GITHUB_WORKSPACE;
+
+  if (githubApiUrlValueResult.isErr) {
+    return Result.err(githubApiUrlValueResult.error);
+  }
+
+  if (githubRepositoryResult.isErr) {
+    return Result.err(githubRepositoryResult.error);
+  }
+
+  const {value: githubApiUrlValue} = githubApiUrlValueResult;
+  const {value: githubRepository} = githubRepositoryResult;
+
+  let githubApiUrl: URL;
+
+  try {
+    githubApiUrl = new URL(githubApiUrlValue);
+  } catch (error: unknown) {
+    const errorMessage = isError(error) ? error.message : String(error);
+
+    return Result.err(new Error(`Invalid GITHUB_API_URL: ${errorMessage}`, {cause: error}));
+  }
+
+  return Result.ok({
+    githubApiUrl,
+    githubRepository,
+    repositoryPath: isNonEmptyStringAndNotWhitespace(repositoryPath) ? repositoryPath : process.cwd(),
+  });
+}
+
+export function readInspectionRuntimeEnvironment(
+  environment: NodeJS.ProcessEnv,
+): Result<WebAppVersionSynchronizationInspectionRuntimeEnvironment, Error> {
+  const commonRuntimeEnvironmentResult = readCommonRuntimeEnvironment(environment);
+
+  if (commonRuntimeEnvironmentResult.isErr) {
+    return Result.err(commonRuntimeEnvironmentResult.error);
+  }
+
+  const githubTokenResult = readRequiredEnvironmentValue(environment, 'GITHUB_TOKEN');
+
+  if (githubTokenResult.isErr) {
+    return Result.err(githubTokenResult.error);
+  }
+
+  const {value: commonRuntimeEnvironment} = commonRuntimeEnvironmentResult;
+  const {value: githubToken} = githubTokenResult;
+
+  return Result.ok({
+    ...commonRuntimeEnvironment,
+    githubToken,
+  });
+}
+
+export function readSynchronizationRuntimeEnvironment(
+  environment: NodeJS.ProcessEnv,
+): Result<WebAppVersionSynchronizationSynchronizationRuntimeEnvironment, Error> {
+  const commonRuntimeEnvironmentResult = readCommonRuntimeEnvironment(environment);
+
+  if (commonRuntimeEnvironmentResult.isErr) {
+    return Result.err(commonRuntimeEnvironmentResult.error);
+  }
+
+  const ottoTheBotGitHubTokenResult = readRequiredEnvironmentValue(environment, 'OTTO_THE_BOT_GH_TOKEN');
+
+  if (ottoTheBotGitHubTokenResult.isErr) {
+    return Result.err(ottoTheBotGitHubTokenResult.error);
+  }
+
+  const {value: commonRuntimeEnvironment} = commonRuntimeEnvironmentResult;
+  const {value: ottoTheBotGitHubToken} = ottoTheBotGitHubTokenResult;
+
+  return Result.ok({
+    ...commonRuntimeEnvironment,
+    ottoTheBotGitHubToken,
+  });
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Adds the orchestration required to synchronize a successfully deployed WebApp Production version back to `main`.

This builds on the version domain logic from pull request #22438 and adds:

* synchronization-state discovery
* idempotent resolution of existing open and merged synchronization pull requests
* fail-closed handling for closed or conflicting synchronization records
* detection of unresolved synchronization from a previous Production release
* deterministic synchronization branch planning
* interrupted-branch recovery and validation
* GitHub API integration with runtime validation and pagination
* Git abstraction for testable branch/commit orchestration
* read-only inspection and mutating synchronization commands
* focused tests for reruns, conflicts, recovery, and stale state

## Idempotency

A Production release is assigned exactly one WebApp version.

For example:

```text
2026-09-09.1-production -> 1.0.0
```

Rerunning synchronization for the same Production release always resolves to `1.0.0`, even after the synchronization pull request has been merged and `main` has advanced.

The existing machine-readable synchronization marker is used as the authoritative mapping between:

* release identifier
* Production tag
* WebApp version
