### PR TITLE
Integrate WebApp version synchronization into releases [WPB-26469]

### DIFF
--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -1224,6 +1224,7 @@ jobs:
         create_production_tag,
         publish_production_distribution,
         ensure_github_release,
+        synchronize_webapp_version,
       ]
     if: >-
       ${{
@@ -1234,7 +1235,8 @@ jobs:
         needs.verify_production_runtime.result == 'success' &&
         needs.create_production_tag.result == 'success' &&
         needs.publish_production_distribution.result == 'success' &&
-        needs.ensure_github_release.result == 'success'
+        needs.ensure_github_release.result == 'success' &&
+        needs.synchronize_webapp_version.result == 'success'
       }}
     permissions:
       contents: read
@@ -1359,6 +1361,9 @@ jobs:
             GitHub Release URL: ${{ needs.ensure_github_release.outputs.github_release_url }}
             GitHub Release handoff: ${{ needs.ensure_github_release.outputs.github_release_action }}
             ${{ needs.ensure_github_release.outputs.github_release_state == 'draft' && 'The GitHub Release is a draft. Review or edit the generated customer-facing changelog and publish it manually.' || 'The existing published GitHub Release was preserved.' }}
+            WebApp package version: ${{ needs.synchronize_webapp_version.outputs.webapp_version }}
+            Version synchronization action: ${{ needs.synchronize_webapp_version.outputs.version_sync_action }}
+            Version synchronization PR: ${{ needs.synchronize_webapp_version.outputs.version_sync_pr_url }}
             Triggering actor: ${{ github.actor }}
             Workflow-run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -1378,6 +1383,9 @@ jobs:
         create_production_tag,
         publish_production_distribution,
         ensure_github_release,
+        webapp_version_synchronization_preflight,
+        webapp_version_synchronization_production_preflight,
+        synchronize_webapp_version,
       ]
     if: ${{ always() }}
     permissions:
@@ -1438,6 +1446,20 @@ jobs:
           GITHUB_RELEASE_STATE: ${{ needs.ensure_github_release.outputs.github_release_state }}
           GITHUB_RELEASE_TAG_NAME: ${{ needs.ensure_github_release.outputs.production_tag_name }}
           GITHUB_RELEASE_URL: ${{ needs.ensure_github_release.outputs.github_release_url }}
+          WEBAPP_VERSION_SYNC_INITIAL_PREFLIGHT_JOB_RESULT: ${{ needs.webapp_version_synchronization_preflight.result }}
+          WEBAPP_VERSION_SYNC_INITIAL_PREFLIGHT_PR_NUMBER: ${{ needs.webapp_version_synchronization_preflight.outputs.pull_request_number }}
+          WEBAPP_VERSION_SYNC_INITIAL_PREFLIGHT_PR_URL: ${{ needs.webapp_version_synchronization_preflight.outputs.pull_request_url }}
+          WEBAPP_VERSION_SYNC_INITIAL_PREFLIGHT_STATE: ${{ needs.webapp_version_synchronization_preflight.outputs.state }}
+          WEBAPP_VERSION_SYNC_PRODUCTION_PREFLIGHT_JOB_RESULT: ${{ needs.webapp_version_synchronization_production_preflight.result }}
+          WEBAPP_VERSION_SYNC_PRODUCTION_PREFLIGHT_PR_NUMBER: ${{ needs.webapp_version_synchronization_production_preflight.outputs.pull_request_number }}
+          WEBAPP_VERSION_SYNC_PRODUCTION_PREFLIGHT_PR_URL: ${{ needs.webapp_version_synchronization_production_preflight.outputs.pull_request_url }}
+          WEBAPP_VERSION_SYNC_PRODUCTION_PREFLIGHT_STATE: ${{ needs.webapp_version_synchronization_production_preflight.outputs.state }}
+          WEBAPP_VERSION_SYNC_ACTION: ${{ needs.synchronize_webapp_version.outputs.version_sync_action }}
+          WEBAPP_VERSION_SYNC_BRANCH_NAME: ${{ needs.synchronize_webapp_version.outputs.version_sync_branch_name }}
+          WEBAPP_VERSION_SYNC_JOB_RESULT: ${{ needs.synchronize_webapp_version.result }}
+          WEBAPP_VERSION_SYNC_PR_NUMBER: ${{ needs.synchronize_webapp_version.outputs.version_sync_pr_number }}
+          WEBAPP_VERSION_SYNC_PR_URL: ${{ needs.synchronize_webapp_version.outputs.version_sync_pr_url }}
+          WEBAPP_VERSION: ${{ needs.synchronize_webapp_version.outputs.webapp_version }}
           PRODUCTION_DEPLOYMENT_REQUIRED: ${{ needs.production_preflight.outputs.should_deploy }}
           PRODUCTION_ENVIRONMENT_NAME: ${{ env.PRODUCTION_ENVIRONMENT_NAME }}
           PRODUCTION_PREFLIGHT_JOB_RESULT: ${{ needs.production_preflight.result }}
@@ -1482,8 +1504,23 @@ jobs:
         create_production_tag,
         publish_production_distribution,
         ensure_github_release,
+        webapp_version_synchronization_preflight,
+        webapp_version_synchronization_production_preflight,
+        synchronize_webapp_version,
       ]
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
+    env:
+      POST_PRODUCTION_SYNCHRONIZATION_FAILURE: >-
+        ${{
+          needs.synchronize_webapp_version.result == 'failure' &&
+          needs.deploy_to_production.result == 'success' &&
+          needs.verify_production_runtime.result == 'success' &&
+          needs.create_production_tag.result == 'success' &&
+          needs.publish_production_distribution.result == 'success' &&
+          needs.ensure_github_release.result == 'success' &&
+          'true' ||
+          'false'
+        }}
     permissions:
       contents: read
 
@@ -1500,11 +1537,16 @@ jobs:
           webhook-url: ${{ secrets.WIRE_DEPLOYOHOLICS_WEBHOOK_URL }}
           status: failure
           text: |
-            ❌ WebApp release failed ❌
+            ${{ env.POST_PRODUCTION_SYNCHRONIZATION_FAILURE == 'true' && '⚠️ Production release succeeded; WebApp version synchronization bookkeeping is incomplete ⚠️' || '❌ WebApp release failed ❌' }}
 
             Release: ${{ needs.build_artifact.outputs.release_identifier || 'unavailable' }}
             Branch: ${{ needs.build_artifact.outputs.release_branch || needs.validate_request.outputs.release_branch || 'unavailable' }}
             Triggered by: ${{ github.actor }}
+
+            ${{ env.POST_PRODUCTION_SYNCHRONIZATION_FAILURE == 'true' && 'Production deployment, runtime verification, immutable tagging, distribution, and GitHub Release handoff succeeded.' || '' }}
+            ${{ env.POST_PRODUCTION_SYNCHRONIZATION_FAILURE == 'true' && 'WebApp version synchronization bookkeeping failed.' || '' }}
+            ${{ env.POST_PRODUCTION_SYNCHRONIZATION_FAILURE == 'true' && 'Release bookkeeping: incomplete.' || '' }}
+            ${{ env.POST_PRODUCTION_SYNCHRONIZATION_FAILURE == 'true' && 'Production must not be rolled back. Resolve the synchronization problem and rerun the failed bookkeeping operation.' || '' }}
 
             Request validation: ${{ needs.validate_request.result }}
             Build: ${{ needs.build_artifact.result }}
@@ -1523,6 +1565,12 @@ jobs:
             GitHub Release URL: ${{ needs.ensure_github_release.outputs.github_release_url || 'unavailable' }}
             GitHub Release state: ${{ needs.ensure_github_release.outputs.github_release_state || 'unavailable' }}
             GitHub Release action: ${{ needs.ensure_github_release.outputs.github_release_action || 'unavailable' }}
+            WebApp synchronization preflight: ${{ needs.webapp_version_synchronization_preflight.result }}
+            WebApp synchronization Production preflight: ${{ needs.webapp_version_synchronization_production_preflight.result }}
+            WebApp version synchronization: ${{ needs.synchronize_webapp_version.result }}
+            WebApp package version: ${{ needs.synchronize_webapp_version.outputs.webapp_version || 'unavailable' }}
+            Version synchronization action: ${{ needs.synchronize_webapp_version.outputs.version_sync_action || 'unavailable' }}
+            Version synchronization PR: ${{ needs.synchronize_webapp_version.outputs.version_sync_pr_url || 'unavailable' }}
 
             Production runtime verification result: ${{ needs.verify_production_runtime.result }}
             Expected Production webapp version: ${{ needs.build_artifact.outputs.artifact_version || 'unavailable' }}
@@ -1535,8 +1583,8 @@ jobs:
             Playwright report: ${{ needs.run_e2e.outputs.reportUrl || 'unavailable' }}
             Source workflow URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-            ${{ needs.production_preflight.outputs.production_preflight_result == 'already_tagged' && needs.ensure_github_release.result == 'failure' && 'Production was already tagged; deployment was not repeated.' || needs.create_production_tag.result == 'success' && (needs.publish_production_distribution.result == 'failure' || needs.ensure_github_release.result == 'failure') && 'Hosted Production deployment and verification succeeded.' || 'Production was blocked because a release gate failed.' }}
-            ${{ needs.production_preflight.outputs.production_preflight_result == 'already_tagged' && needs.ensure_github_release.result == 'failure' && 'The existing Production tag remains unchanged.' || needs.create_production_tag.result == 'success' && (needs.publish_production_distribution.result == 'failure' || needs.ensure_github_release.result == 'failure') && 'The Production tag exists.' || 'Production tag creation was blocked by the failed release gate.' }}
+            ${{ env.POST_PRODUCTION_SYNCHRONIZATION_FAILURE == 'true' && 'Production lifecycle succeeded.' || needs.production_preflight.outputs.production_preflight_result == 'already_tagged' && needs.ensure_github_release.result == 'failure' && 'Production was already tagged; deployment was not repeated.' || needs.create_production_tag.result == 'success' && (needs.publish_production_distribution.result == 'failure' || needs.ensure_github_release.result == 'failure') && 'Hosted Production deployment and verification succeeded.' || 'Production was blocked because a release gate failed.' }}
+            ${{ env.POST_PRODUCTION_SYNCHRONIZATION_FAILURE == 'true' && 'The immutable Production tag remains unchanged.' || needs.production_preflight.outputs.production_preflight_result == 'already_tagged' && needs.ensure_github_release.result == 'failure' && 'The existing Production tag remains unchanged.' || needs.create_production_tag.result == 'success' && (needs.publish_production_distribution.result == 'failure' || needs.ensure_github_release.result == 'failure') && 'The Production tag exists.' || 'Production tag creation was blocked by the failed release gate.' }}
             ${{ needs.publish_production_distribution.result == 'failure' && needs.create_production_tag.result == 'success' && 'Docker, Helm, or wire-builds publication failed.' || needs.ensure_github_release.result == 'failure' && (needs.create_production_tag.result == 'success' || needs.production_preflight.outputs.production_preflight_result == 'already_tagged') && 'GitHub Release draft creation or verification failed.' || '' }}
             ${{ needs.publish_production_distribution.result == 'failure' && needs.create_production_tag.result == 'success' && 'The release is incomplete for on-premises distribution.' || needs.ensure_github_release.result == 'failure' && (needs.create_production_tag.result == 'success' || needs.production_preflight.outputs.production_preflight_result == 'already_tagged') && 'The automated release lifecycle is incomplete until the GitHub Release handoff succeeds.' || '' }}
             ${{ needs.create_production_tag.result == 'success' && (needs.publish_production_distribution.result == 'failure' || needs.ensure_github_release.result == 'failure') && 'No Production tag was moved or deleted.' || '' }}

--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Enforce WebApp version synchronization preflight
         if: ${{ steps.inspect.outcome == 'failure' }}
         run: |
-          echo 'Merge or resolve the previous WebApp version synchronization pull request before starting this Production release.' >&2
+          echo 'WebApp version synchronization preflight failed. See the inspection error above.' >&2
           exit 1
 
   prepare_release_branch:
@@ -790,7 +790,7 @@ jobs:
       - name: Enforce WebApp version synchronization preflight before Production approval
         if: ${{ steps.inspect.outcome == 'failure' }}
         run: |
-          echo 'Merge or resolve the previous WebApp version synchronization pull request before Production approval.' >&2
+          echo 'WebApp version synchronization preflight before Production approval failed. See the inspection error above.' >&2
           exit 1
 
   notify_e2e_success:

--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -1224,7 +1224,6 @@ jobs:
         create_production_tag,
         publish_production_distribution,
         ensure_github_release,
-        synchronize_webapp_version,
       ]
     if: >-
       ${{
@@ -1235,8 +1234,7 @@ jobs:
         needs.verify_production_runtime.result == 'success' &&
         needs.create_production_tag.result == 'success' &&
         needs.publish_production_distribution.result == 'success' &&
-        needs.ensure_github_release.result == 'success' &&
-        needs.synchronize_webapp_version.result == 'success'
+        needs.ensure_github_release.result == 'success'
       }}
     permissions:
       contents: read
@@ -1314,6 +1312,7 @@ jobs:
         create_production_tag,
         publish_production_distribution,
         ensure_github_release,
+        synchronize_webapp_version,
       ]
     if: >-
       ${{
@@ -1322,7 +1321,8 @@ jobs:
         needs.verify_production_runtime.result == 'success' &&
         needs.create_production_tag.result == 'success' &&
         needs.publish_production_distribution.result == 'success' &&
-        needs.ensure_github_release.result == 'success'
+        needs.ensure_github_release.result == 'success' &&
+        needs.synchronize_webapp_version.result == 'success'
       }}
     continue-on-error: true
     permissions:

--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -1212,6 +1212,93 @@ jobs:
           PRODUCTION_TAG_NAME: ${{ needs.create_production_tag.outputs.production_tag_name || needs.production_preflight.outputs.production_tag_name }}
         run: node ./tools/release-cli/ensureProductionGitHubRelease.mts "${PRODUCTION_TAG_NAME}" >> "${GITHUB_OUTPUT}"
 
+  synchronize_webapp_version:
+    name: Synchronize WebApp version
+    runs-on: ubuntu-24.04
+    needs:
+      [
+        build_artifact,
+        production_preflight,
+        deploy_to_production,
+        verify_production_runtime,
+        create_production_tag,
+        publish_production_distribution,
+        ensure_github_release,
+      ]
+    if: >-
+      ${{
+        always() &&
+        needs.production_preflight.result == 'success' &&
+        needs.production_preflight.outputs.production_preflight_result == 'ready' &&
+        needs.deploy_to_production.result == 'success' &&
+        needs.verify_production_runtime.result == 'success' &&
+        needs.create_production_tag.result == 'success' &&
+        needs.publish_production_distribution.result == 'success' &&
+        needs.ensure_github_release.result == 'success'
+      }}
+    permissions:
+      contents: read
+    concurrency:
+      group: webapp-version-synchronization
+      cancel-in-progress: false
+      queue: max
+    outputs:
+      webapp_version: ${{ steps.synchronize.outputs.webapp_version }}
+      version_sync_action: ${{ steps.synchronize.outputs.action }}
+      version_sync_pr_number: ${{ steps.synchronize.outputs.pull_request_number }}
+      version_sync_pr_url: ${{ steps.synchronize.outputs.pull_request_url }}
+      version_sync_branch_name: ${{ steps.synchronize.outputs.branch_name }}
+
+    steps:
+      - name: Checkout workflow tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install synchronization tooling dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Synchronize WebApp version with Production
+        id: synchronize
+        env:
+          OTTO_THE_BOT_GH_TOKEN: ${{ secrets.OTTO_THE_BOT_GH_TOKEN }}
+          PRODUCTION_TAG_NAME: ${{ needs.create_production_tag.outputs.production_tag_name }}
+          RELEASE_IDENTIFIER: ${{ needs.build_artifact.outputs.release_identifier }}
+        run: |
+          set -euo pipefail
+
+          synchronization_output="$(node ./tools/release-cli/webappVersionSynchronization.mts synchronize "${RELEASE_IDENTIFIER}" "${PRODUCTION_TAG_NAME}")"
+
+          jq -e '
+            type == "object" and
+            (.action | type == "string") and
+            (.webapp_version | type == "string") and
+            (.branch_name | type == "string") and
+            (.pull_request_number | type == "number") and
+            (.pull_request_url | type == "string")
+          ' <<< "${synchronization_output}" > /dev/null
+
+          {
+            echo "webapp_version=$(jq --raw-output '.webapp_version' <<< "${synchronization_output}")"
+            echo "action=$(jq --raw-output '.action' <<< "${synchronization_output}")"
+            echo "pull_request_number=$(jq --raw-output '.pull_request_number' <<< "${synchronization_output}")"
+            echo "pull_request_url=$(jq --raw-output '.pull_request_url' <<< "${synchronization_output}")"
+            echo "branch_name=$(jq --raw-output '.branch_name' <<< "${synchronization_output}")"
+          } >> "$GITHUB_OUTPUT"
+
   notify_production_release_success:
     name: Notify successful Production release
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-webapp.yml
+++ b/.github/workflows/release-webapp.yml
@@ -60,6 +60,7 @@ jobs:
     outputs:
       release_identifier: ${{ steps.validate_request.outputs.release_identifier }}
       release_branch: ${{ steps.validate_request.outputs.release_branch }}
+      production_tag_name: ${{ steps.validate_request.outputs.production_tag_name }}
 
     steps:
       - name: Checkout workflow tools
@@ -106,16 +107,86 @@ jobs:
           fi
 
           release_branch="$(node ./tools/release-cli/releaseMetadataCli.mts release-branch "${RELEASE_IDENTIFIER}")"
+          production_tag_name="$(node ./tools/release-cli/releaseMetadataCli.mts production-tag "${RELEASE_IDENTIFIER}")"
 
           {
             echo "release_identifier=${RELEASE_IDENTIFIER}"
             echo "release_branch=${release_branch}"
+            echo "production_tag_name=${production_tag_name}"
           } >> "$GITHUB_OUTPUT"
+
+  webapp_version_synchronization_preflight:
+    name: WebApp version synchronization preflight
+    runs-on: ubuntu-24.04
+    needs: validate_request
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      state: ${{ steps.inspect.outputs.state }}
+      pull_request_number: ${{ steps.inspect.outputs.pull_request_number }}
+      pull_request_url: ${{ steps.inspect.outputs.pull_request_url }}
+
+    steps:
+      - name: Checkout workflow tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install synchronization tooling dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Inspect WebApp version synchronization
+        id: inspect
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PRODUCTION_TAG_NAME: ${{ needs.validate_request.outputs.production_tag_name }}
+          RELEASE_IDENTIFIER: ${{ needs.validate_request.outputs.release_identifier }}
+        run: |
+          set -euo pipefail
+
+          inspection_output=''
+          set +e
+          inspection_output="$(node ./tools/release-cli/webappVersionSynchronization.mts inspect "${RELEASE_IDENTIFIER}" "${PRODUCTION_TAG_NAME}")"
+          inspection_exit_code="$?"
+          set -e
+
+          if [[ -n "${inspection_output}" ]]; then
+            {
+              echo "state=$(jq --raw-output '.state // empty' <<< "${inspection_output}")"
+              echo "pull_request_number=$(jq --raw-output '.pull_request_number // empty' <<< "${inspection_output}")"
+              echo "pull_request_url=$(jq --raw-output '.pull_request_url // empty' <<< "${inspection_output}")"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "${inspection_exit_code}" -ne 0 ]]; then
+            exit "${inspection_exit_code}"
+          fi
+
+      - name: Enforce WebApp version synchronization preflight
+        if: ${{ steps.inspect.outcome == 'failure' }}
+        run: |
+          echo 'Merge or resolve the previous WebApp version synchronization pull request before starting this Production release.' >&2
+          exit 1
 
   prepare_release_branch:
     name: Prepare release branch
     runs-on: ubuntu-24.04
-    needs: validate_request
+    needs: [validate_request, webapp_version_synchronization_preflight]
     permissions:
       contents: write
     concurrency:
@@ -653,6 +724,75 @@ jobs:
       WEBTEAM_AWS_SECRET_ACCESS_KEY: ${{ secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY }}
       TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
 
+  webapp_version_synchronization_production_preflight:
+    name: WebApp version synchronization Production preflight
+    runs-on: ubuntu-24.04
+    needs: [build_artifact, create_beta_tag, run_e2e]
+    if: ${{ needs.run_e2e.result == 'success' }}
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      state: ${{ steps.inspect.outputs.state }}
+      pull_request_number: ${{ steps.inspect.outputs.pull_request_number }}
+      pull_request_url: ${{ steps.inspect.outputs.pull_request_url }}
+
+    steps:
+      - name: Checkout workflow tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+
+      - name: Add repository Yarn wrapper to PATH
+        run: echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install synchronization tooling dependencies
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
+        run: ./bin/yarn install --immutable --mode=skip-build
+
+      - name: Inspect WebApp version synchronization before Production approval
+        id: inspect
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PRODUCTION_TAG_NAME: ${{ needs.build_artifact.outputs.release_identifier }}-production
+          RELEASE_IDENTIFIER: ${{ needs.build_artifact.outputs.release_identifier }}
+        run: |
+          set -euo pipefail
+
+          inspection_output=''
+          set +e
+          inspection_output="$(node ./tools/release-cli/webappVersionSynchronization.mts inspect "${RELEASE_IDENTIFIER}" "${PRODUCTION_TAG_NAME}")"
+          inspection_exit_code="$?"
+          set -e
+
+          if [[ -n "${inspection_output}" ]]; then
+            {
+              echo "state=$(jq --raw-output '.state // empty' <<< "${inspection_output}")"
+              echo "pull_request_number=$(jq --raw-output '.pull_request_number // empty' <<< "${inspection_output}")"
+              echo "pull_request_url=$(jq --raw-output '.pull_request_url // empty' <<< "${inspection_output}")"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "${inspection_exit_code}" -ne 0 ]]; then
+            exit "${inspection_exit_code}"
+          fi
+
+      - name: Enforce WebApp version synchronization preflight before Production approval
+        if: ${{ steps.inspect.outcome == 'failure' }}
+        run: |
+          echo 'Merge or resolve the previous WebApp version synchronization pull request before Production approval.' >&2
+          exit 1
+
   notify_e2e_success:
     name: Notify successful release E2E gate
     runs-on: ubuntu-24.04
@@ -708,7 +848,7 @@ jobs:
   production_preflight:
     name: Production preflight
     runs-on: ubuntu-24.04
-    needs: [build_artifact, create_beta_tag, run_e2e]
+    needs: [build_artifact, create_beta_tag, run_e2e, webapp_version_synchronization_production_preflight]
     permissions:
       contents: read
     outputs:

--- a/docs/decision-records/0002-trunk-based-automated-release-process.md
+++ b/docs/decision-records/0002-trunk-based-automated-release-process.md
@@ -39,6 +39,9 @@ flowchart LR
   productionRuntimeVerification[Verify live Production runtime<br/>Artifact version and Production backends]
   productionTag[YYYY-MM-DD.N-production]
   productionDistribution[Publish Docker image and Helm chart<br/>Update wire-builds/main]
+  githubReleaseHandoff[GitHub Release handoff]
+  webAppVersionSynchronization[Create WebApp version synchronization PR<br/>against current main]
+  mergeWebAppVersionSynchronization[Merge through normal protected main flow]
   manualDistributionRepair[Manual distribution repair<br/>Validate confirmation, reason, and tag]
   maintenanceBranch[maintenance/maintenance-line-key]
   maintenanceTag[maintenance-line-key-maintenance.X]
@@ -56,6 +59,10 @@ flowchart LR
   productionEnvironment -->|Deploy promoted artifact| productionRuntimeVerification
   productionRuntimeVerification -->|Verified runtime creates| productionTag
   productionTag -->|Explicit reusable workflow| productionDistribution
+  productionTag --> githubReleaseHandoff
+  productionDistribution --> webAppVersionSynchronization
+  githubReleaseHandoff --> webAppVersionSynchronization --> mergeWebAppVersionSynchronization
+  mergeWebAppVersionSynchronization --> mainBranch
   manualDistributionRepair -->|Explicit reusable workflow| productionDistribution
   productionTag -->|Create only when needed| maintenanceBranch
   maintenanceBranch -->|Validated maintenance artifact creates| maintenanceTag
@@ -170,6 +177,24 @@ Each Beta candidate processes only its delta. Production reconstructs candidate 
 - If Production runtime verification fails, Production remains untagged, the release workflow fails, Deployoholics receives a failure notification, and the release captain performs incident assessment.
 - If the current release branch commit already has the matching production tag, the release workflow must not redeploy that commit.
 - Production tags are immutable release history and are never moved or deleted.
+
+### WebApp package version synchronization
+
+The release process has two separate version identities:
+
+- The operational release identity is `YYYY-MM-DD.N`, with Beta and Production tags such as `YYYY-MM-DD.N-beta.M` and `YYYY-MM-DD.N-production`. This identity remains authoritative for release branches, artifacts, Docker and Helm versions, `wire-builds`, runtime `BuildMetadata`, and release verification.
+- The WebApp package SemVer is repository metadata. The `version` fields in `package.json` and `apps/webapp/package.json` on `main` represent the latest successfully synchronized Production WebApp version, not the next development version. `apps/server/package.json` is unrelated.
+
+The existing legacy `0.x.y` package state bootstraps to `1.0.0` on the first successful Production synchronization under this process. Each subsequent normal Production synchronization increments only the patch component: `1.0.0` becomes `1.0.1`, then `1.0.2`, and so on. The package files remain unchanged on the release branch and on the immutable Production-tagged commit; the Production source commit may therefore still contain the previous package SemVer.
+
+After a new Production release has completed deployment, runtime verification, immutable Production tag creation, Docker, Helm, and `wire-builds/main` distribution, and GitHub Release handoff, the workflow performs repository bookkeeping. It checks out the current `main`, creates a dedicated branch, and opens an Otto pull request that changes only the two WebApp package `version` fields. The synchronization PR is not auto-merged and must pass normal `main` review, CI, branch protection, and merge-queue requirements. The workflow does not wait for that PR to merge.
+
+The synchronization marker in the pull request body is the authoritative mapping from ADR release identifier and immutable Production tag to WebApp package SemVer. Rerunning the same Production release reuses its recorded version forever, even after later releases advance `main`; it never allocates another patch version. A new or different Production release must not proceed while a previous synchronization is open or closed without merge. Conflicting or ambiguous synchronization history fails closed.
+
+Version allocation is protected by an early release-start preflight, a fresh pre-Production preflight after the blocking E2E gate, a repository-wide non-cancellable synchronization lock, and fresh `main` and synchronization-history validation inside the post-Production orchestration. If a race still allows another release to reach Production first, its already deployed and verified Production artifact remains untouched while its bookkeeping fails closed until the unresolved synchronization is resolved.
+
+Merging the synchronization PR is an ordinary `main` merge. It therefore continues through the normal `publish-main.yml` delivery path; no metadata-only exception or special CI bypass is introduced.
+
 Release workflows must be serialized:
 
 - Only one Beta deployment may run at a time for a given release branch.

--- a/tools/release-cli/webappVersionSynchronization.mts
+++ b/tools/release-cli/webappVersionSynchronization.mts
@@ -44,6 +44,7 @@ import {
   inspectWebAppVersionSynchronization,
   synchronizeWebAppVersion,
 } from '../release-metadata/webappVersionSynchronizationOrchestration.ts';
+import {validateWebAppVersionSynchronizationPreflight} from '../release-metadata/webappVersionSynchronizationPreflight.ts';
 import {
   readInspectionRuntimeEnvironment,
   readSynchronizationRuntimeEnvironment,
@@ -117,6 +118,12 @@ async function executeInspectionCommand(
   const output = createWebAppVersionSynchronizationInspectionOutput(inspection);
 
   writeOutput(serializeWebAppVersionSynchronizationOutput(output));
+
+  const preflightResult = validateWebAppVersionSynchronizationPreflight(inspection);
+
+  if (preflightResult.isErr) {
+    throw preflightResult.error;
+  }
 }
 
 async function executeSynchronizationCommand(

--- a/tools/release-metadata/webappVersionSynchronizationPreflight.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationPreflight.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {decideWebAppVersionSynchronizationPreflight} from './webappVersionSynchronizationPreflight.ts';
+import {
+  createWebAppVersionSynchronizationBranchName,
+  type WebAppVersionSynchronizationBranchName,
+  type WebAppVersionSynchronizationInspection,
+} from './webappVersionSynchronization.ts';
+import {validateWebAppVersion} from './webappVersion.ts';
+import type {WebAppVersion} from './webappVersion.ts';
+
+type MatchingPullRequestDetails = {
+  readonly branchName: WebAppVersionSynchronizationBranchName;
+  readonly pullRequestNumber: number;
+  readonly pullRequestUrl: string;
+  readonly webAppVersion: WebAppVersion;
+};
+
+function createMatchingPullRequestDetails(): MatchingPullRequestDetails {
+  const branchNameResult = createWebAppVersionSynchronizationBranchName('2026-09-09.1', '1.0.0');
+
+  if (branchNameResult.isErr) {
+    throw branchNameResult.error;
+  }
+
+  const {value: branchName} = branchNameResult;
+  const webAppVersionResult = validateWebAppVersion('1.0.0');
+
+  if (webAppVersionResult.isErr) {
+    throw webAppVersionResult.error;
+  }
+
+  const {value: webAppVersion} = webAppVersionResult;
+
+  return {
+    branchName,
+    pullRequestNumber: 123,
+    pullRequestUrl: 'https://github.com/wireapp/wire-webapp/pull/123',
+    webAppVersion,
+  };
+}
+
+describe('WebApp version synchronization preflight', () => {
+  it.each(['available', 'matching-open', 'matching-merged'] as const)('allows %s inspection state', state => {
+    const inspection: WebAppVersionSynchronizationInspection =
+      state === 'available'
+        ? {
+            kind: state,
+            releaseIdentifier: '2026-09-09.1',
+            productionTagName: '2026-09-09.1-production',
+          }
+        : {
+            kind: state,
+            releaseIdentifier: '2026-09-09.1',
+            productionTagName: '2026-09-09.1-production',
+            ...createMatchingPullRequestDetails(),
+          };
+
+    const decision = decideWebAppVersionSynchronizationPreflight(inspection);
+
+    expect(decision).toEqual({state: 'allowed', inspection});
+  });
+
+  it('blocks a matching synchronization pull request that was closed without merging', () => {
+    const matchingPullRequestDetails = createMatchingPullRequestDetails();
+    const inspection: WebAppVersionSynchronizationInspection = {
+      kind: 'closed-without-merge',
+      releaseIdentifier: '2026-09-09.1',
+      productionTagName: '2026-09-09.1-production',
+      ...matchingPullRequestDetails,
+    };
+
+    const decision = decideWebAppVersionSynchronizationPreflight(inspection);
+
+    expect(decision.state).toBe('blocked');
+    expect(decision).toMatchObject({
+      diagnostic: expect.stringContaining('#123'),
+    });
+    expect(decision).toMatchObject({
+      diagnostic: expect.stringContaining('https://github.com/wireapp/wire-webapp/pull/123'),
+    });
+  });
+
+  it('blocks a release with a previous unresolved synchronization pull request', () => {
+    const matchingPullRequestDetails = createMatchingPullRequestDetails();
+    const inspection: WebAppVersionSynchronizationInspection = {
+      kind: 'blocked-by-previous-unresolved',
+      releaseIdentifier: '2026-09-16.1',
+      productionTagName: '2026-09-16.1-production',
+      blockingReleaseIdentifier: '2026-09-09.1',
+      blockingProductionTagName: '2026-09-09.1-production',
+      blockingWebAppVersion: matchingPullRequestDetails.webAppVersion,
+      blockingSynchronizationState: 'open',
+      branchName: matchingPullRequestDetails.branchName,
+      pullRequestNumber: matchingPullRequestDetails.pullRequestNumber,
+      pullRequestUrl: matchingPullRequestDetails.pullRequestUrl,
+    };
+
+    const decision = decideWebAppVersionSynchronizationPreflight(inspection);
+
+    expect(decision.state).toBe('blocked');
+    expect(decision).toMatchObject({
+      diagnostic: expect.stringContaining('2026-09-09.1'),
+    });
+    expect(decision).toMatchObject({
+      diagnostic: expect.stringContaining('https://github.com/wireapp/wire-webapp/pull/123'),
+    });
+  });
+
+  it('blocks conflicting synchronization history', () => {
+    const inspection: WebAppVersionSynchronizationInspection = {
+      kind: 'conflict',
+      releaseIdentifier: '2026-09-09.1',
+      productionTagName: '2026-09-09.1-production',
+      reason: 'Multiple unresolved synchronization records exist',
+    };
+
+    const decision = decideWebAppVersionSynchronizationPreflight(inspection);
+
+    expect(decision).toEqual({state: 'blocked', inspection, diagnostic: expect.any(String)});
+    expect(decision).toMatchObject({
+      diagnostic: expect.stringContaining('Multiple unresolved synchronization records exist'),
+    });
+  });
+});

--- a/tools/release-metadata/webappVersionSynchronizationPreflight.test.ts
+++ b/tools/release-metadata/webappVersionSynchronizationPreflight.test.ts
@@ -17,7 +17,10 @@
  *
  */
 
-import {decideWebAppVersionSynchronizationPreflight} from './webappVersionSynchronizationPreflight.ts';
+import {
+  decideWebAppVersionSynchronizationPreflight,
+  validateWebAppVersionSynchronizationPreflight,
+} from './webappVersionSynchronizationPreflight.ts';
 import {
   createWebAppVersionSynchronizationBranchName,
   type WebAppVersionSynchronizationBranchName,
@@ -138,5 +141,34 @@ describe('WebApp version synchronization preflight', () => {
     expect(decision).toMatchObject({
       diagnostic: expect.stringContaining('Multiple unresolved synchronization records exist'),
     });
+  });
+
+  it('returns an error for a blocked preflight decision', () => {
+    const inspection: WebAppVersionSynchronizationInspection = {
+      kind: 'conflict',
+      releaseIdentifier: '2026-09-09.1',
+      productionTagName: '2026-09-09.1-production',
+      reason: 'Multiple unresolved synchronization records exist',
+    };
+
+    const result = validateWebAppVersionSynchronizationPreflight(inspection);
+
+    expect(result.isErr).toBe(true);
+
+    if (result.isErr) {
+      expect(result.error.message).toContain('Multiple unresolved synchronization records exist');
+    }
+  });
+
+  it('returns success for an allowed preflight decision', () => {
+    const inspection: WebAppVersionSynchronizationInspection = {
+      kind: 'available',
+      releaseIdentifier: '2026-09-09.1',
+      productionTagName: '2026-09-09.1-production',
+    };
+
+    const result = validateWebAppVersionSynchronizationPreflight(inspection);
+
+    expect(result.isOk).toBe(true);
   });
 });

--- a/tools/release-metadata/webappVersionSynchronizationPreflight.ts
+++ b/tools/release-metadata/webappVersionSynchronizationPreflight.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {Result, Unit} from 'true-myth';
 import {match, P} from 'ts-pattern';
 
 import type {WebAppVersionSynchronizationInspection} from './webappVersionSynchronization.ts';
@@ -65,4 +66,17 @@ export function decideWebAppVersionSynchronizationPreflight(
         diagnostic: createBlockingDiagnostic(blockedInspection),
       };
     });
+}
+
+export function validateWebAppVersionSynchronizationPreflight(
+  inspection: WebAppVersionSynchronizationInspection,
+): Result<Unit, Error> {
+  return match(decideWebAppVersionSynchronizationPreflight(inspection))
+    .with({state: 'allowed'}, () => {
+      return Result.ok();
+    })
+    .with({state: 'blocked'}, blockedDecision => {
+      return Result.err(new Error(blockedDecision.diagnostic));
+    })
+    .exhaustive();
 }

--- a/tools/release-metadata/webappVersionSynchronizationPreflight.ts
+++ b/tools/release-metadata/webappVersionSynchronizationPreflight.ts
@@ -53,6 +53,7 @@ export function decideWebAppVersionSynchronizationPreflight(
   inspection: WebAppVersionSynchronizationInspection,
 ): WebAppVersionSynchronizationPreflightDecision {
   return match(inspection)
+    .returnType<WebAppVersionSynchronizationPreflightDecision>()
     .with({kind: P.union('available', 'matching-open', 'matching-merged')}, allowedInspection => {
       return {
         state: 'allowed',

--- a/tools/release-metadata/webappVersionSynchronizationPreflight.ts
+++ b/tools/release-metadata/webappVersionSynchronizationPreflight.ts
@@ -1,0 +1,68 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {match, P} from 'ts-pattern';
+
+import type {WebAppVersionSynchronizationInspection} from './webappVersionSynchronization.ts';
+
+export type WebAppVersionSynchronizationPreflightDecision =
+  | {
+      readonly state: 'allowed';
+      readonly inspection: WebAppVersionSynchronizationInspection;
+    }
+  | {
+      readonly state: 'blocked';
+      readonly inspection: WebAppVersionSynchronizationInspection;
+      readonly diagnostic: string;
+    };
+
+function createBlockingDiagnostic(inspection: WebAppVersionSynchronizationInspection): string {
+  return match(inspection)
+    .with({kind: 'closed-without-merge'}, closedSynchronization => {
+      return `Merge or resolve WebApp version synchronization pull request #${closedSynchronization.pullRequestNumber} for ${closedSynchronization.releaseIdentifier} before starting another Production release: ${closedSynchronization.pullRequestUrl}`;
+    })
+    .with({kind: 'blocked-by-previous-unresolved'}, blockedSynchronization => {
+      return `Merge or resolve the previous WebApp version synchronization pull request #${blockedSynchronization.pullRequestNumber} for ${blockedSynchronization.blockingReleaseIdentifier} before starting another Production release: ${blockedSynchronization.pullRequestUrl}`;
+    })
+    .with({kind: 'conflict'}, conflictingSynchronization => {
+      return `WebApp version synchronization history is conflicting for ${conflictingSynchronization.releaseIdentifier}: ${conflictingSynchronization.reason}`;
+    })
+    .otherwise(() => {
+      return 'WebApp version synchronization preflight is blocked by an unknown state';
+    });
+}
+
+export function decideWebAppVersionSynchronizationPreflight(
+  inspection: WebAppVersionSynchronizationInspection,
+): WebAppVersionSynchronizationPreflightDecision {
+  return match(inspection)
+    .with({kind: P.union('available', 'matching-open', 'matching-merged')}, allowedInspection => {
+      return {
+        state: 'allowed',
+        inspection: allowedInspection,
+      };
+    })
+    .otherwise(blockedInspection => {
+      return {
+        state: 'blocked',
+        inspection: blockedInspection,
+        diagnostic: createBlockingDiagnostic(blockedInspection),
+      };
+    });
+}

--- a/tools/release-summary/renderWebappReleaseSummary.test.ts
+++ b/tools/release-summary/renderWebappReleaseSummary.test.ts
@@ -138,6 +138,56 @@ function countOccurrences(value: string, searchedValue: string): number {
   return value.split(searchedValue).length - 1;
 }
 
+type ReleaseSummaryOutcomeScenario = {
+  readonly expectedOutcome: string;
+  readonly input: WebappReleaseSummaryInput;
+  readonly name: string;
+};
+
+type CompletedProductionSynchronizationScenario = {
+  readonly expectedStage: string;
+  readonly name: string;
+  readonly synchronizationJobResult: 'failure' | 'cancelled' | 'skipped';
+};
+
+function createCompletedProductionReleaseInput(
+  synchronizationJobResult: 'failure' | 'cancelled' | 'skipped',
+): WebappReleaseSummaryInput {
+  return {
+    ...baselineWebappReleaseSummaryInput,
+    distribution: {
+      ...baselineWebappReleaseSummaryInput.distribution,
+      distributionJobResult: Maybe.just('success'),
+      distributionResult: Maybe.just('success'),
+    },
+    githubRelease: {
+      action: Maybe.just('created'),
+      jobResult: Maybe.just('success'),
+      state: Maybe.just('draft'),
+      tagName: Maybe.just(productionTagName),
+      url: Maybe.just(githubReleaseUrl),
+    },
+    production: {
+      ...baselineWebappReleaseSummaryInput.production,
+      createdTagName: Maybe.just(productionTagName),
+      deploymentResult: Maybe.just('success'),
+      deploymentRequired: Maybe.just(true),
+      preflightJobResult: Maybe.just('success'),
+      preflightResult: Maybe.just('ready'),
+      runtimeVerificationResult: Maybe.just('success'),
+      tagCreationResult: Maybe.just('success'),
+    },
+    webAppVersionSynchronization: {
+      ...baselineWebappReleaseSummaryInput.webAppVersionSynchronization,
+      initialPreflightJobResult: Maybe.just('success'),
+      initialPreflightState: Maybe.just('available'),
+      productionPreflightJobResult: Maybe.just('success'),
+      productionPreflightState: Maybe.just('available'),
+      synchronizationJobResult: Maybe.just(synchronizationJobResult),
+    },
+  };
+}
+
 function assertMarkdownContract(summary: string, includesDistribution: boolean): void {
   const visibleContent = visibleSummary(summary);
   const detailsContent = technicalEvidence(summary);
@@ -471,6 +521,129 @@ describe('WebApp release summary renderer', () => {
     expect(detailsContent).toContain('- Synchronization job: failed');
     expect(detailsContent).toContain('- WebApp package version: `1.0.0`');
   });
+
+  const skippedSynchronizationAfterFailedReleaseScenarios: readonly ReleaseSummaryOutcomeScenario[] = [
+    {
+      name: 'E2E failure',
+      input: {
+        ...baselineWebappReleaseSummaryInput,
+        e2e: {...baselineWebappReleaseSummaryInput.e2e, result: Maybe.just('failure')},
+        webAppVersionSynchronization: {
+          ...baselineWebappReleaseSummaryInput.webAppVersionSynchronization,
+          synchronizationJobResult: Maybe.just('skipped'),
+        },
+      },
+      expectedOutcome: 'Release stopped because the E2E system gate failed',
+    },
+    {
+      name: 'Production deployment failure',
+      input: {
+        ...baselineWebappReleaseSummaryInput,
+        production: {
+          ...baselineWebappReleaseSummaryInput.production,
+          preflightJobResult: Maybe.just('success'),
+          preflightResult: Maybe.just('ready'),
+          approvalResult: Maybe.just('success'),
+          deploymentResult: Maybe.just('failure'),
+          runtimeVerificationResult: Maybe.just('skipped'),
+          tagCreationResult: Maybe.just('skipped'),
+        },
+        webAppVersionSynchronization: {
+          ...baselineWebappReleaseSummaryInput.webAppVersionSynchronization,
+          synchronizationJobResult: Maybe.just('skipped'),
+        },
+      },
+      expectedOutcome: 'Release stopped because Hosted Production deployment failed',
+    },
+    {
+      name: 'Production runtime verification failure',
+      input: {
+        ...baselineWebappReleaseSummaryInput,
+        production: {
+          ...baselineWebappReleaseSummaryInput.production,
+          preflightJobResult: Maybe.just('success'),
+          preflightResult: Maybe.just('ready'),
+          approvalResult: Maybe.just('success'),
+          deploymentResult: Maybe.just('success'),
+          runtimeVerificationResult: Maybe.just('failure'),
+          tagCreationResult: Maybe.just('skipped'),
+        },
+        webAppVersionSynchronization: {
+          ...baselineWebappReleaseSummaryInput.webAppVersionSynchronization,
+          synchronizationJobResult: Maybe.just('skipped'),
+        },
+      },
+      expectedOutcome: 'Hosted Production was deployed, but runtime verification failed',
+    },
+    {
+      name: 'Production distribution failure',
+      input: {
+        ...createCompletedProductionReleaseInput('skipped'),
+        distribution: {
+          ...baselineWebappReleaseSummaryInput.distribution,
+          distributionJobResult: Maybe.just('failure'),
+          distributionResult: Maybe.just('failure'),
+        },
+      },
+      expectedOutcome: 'Hosted Production completed, but release distribution failed',
+    },
+    {
+      name: 'GitHub Release handoff failure',
+      input: {
+        ...createCompletedProductionReleaseInput('skipped'),
+        githubRelease: {
+          ...baselineWebappReleaseSummaryInput.githubRelease,
+          jobResult: Maybe.just('failure'),
+        },
+      },
+      expectedOutcome: 'Hosted Production and release distribution completed, but GitHub Release handoff failed',
+    },
+  ];
+
+  it.each(skippedSynchronizationAfterFailedReleaseScenarios)(
+    'does not report skipped synchronization as incomplete bookkeeping after $name',
+    ({input, expectedOutcome}) => {
+      const summary = renderWebappReleaseSummary(input);
+      const visibleContent = visibleSummary(summary);
+
+      expect(visibleContent).toContain(`- Outcome: ${expectedOutcome}`);
+      expect(visibleContent).toContain('- WebApp version synchronization: not run');
+      expect(visibleContent).not.toContain('bookkeeping incomplete');
+    },
+  );
+
+  const completedProductionSynchronizationScenarios: readonly CompletedProductionSynchronizationScenario[] = [
+    {
+      name: 'failure',
+      synchronizationJobResult: 'failure',
+      expectedStage: 'failed; release bookkeeping incomplete',
+    },
+    {
+      name: 'cancellation',
+      synchronizationJobResult: 'cancelled',
+      expectedStage: 'cancelled; release bookkeeping incomplete',
+    },
+    {
+      name: 'unexpected skip',
+      synchronizationJobResult: 'skipped',
+      expectedStage: 'not run; release bookkeeping incomplete',
+    },
+  ];
+
+  it.each(completedProductionSynchronizationScenarios)(
+    'reports completed Production with synchronization $name as incomplete bookkeeping',
+    scenario => {
+      const summary = renderWebappReleaseSummary(
+        createCompletedProductionReleaseInput(scenario.synchronizationJobResult),
+      );
+      const visibleContent = visibleSummary(summary);
+
+      expect(visibleContent).toContain(
+        '- Outcome: Production release completed successfully, but WebApp version synchronization bookkeeping is incomplete',
+      );
+      expect(visibleContent).toContain(`- WebApp version synchronization: ${scenario.expectedStage}`);
+    },
+  );
 
   it('renders an existing published GitHub Release as a successful handoff', () => {
     const input: WebappReleaseSummaryInput = {

--- a/tools/release-summary/renderWebappReleaseSummary.test.ts
+++ b/tools/release-summary/renderWebappReleaseSummary.test.ts
@@ -108,6 +108,22 @@ const baselineWebappReleaseSummaryInput: WebappReleaseSummaryInput = {
     identifier: Maybe.just('2026-07-17.1'),
     manualReason: Maybe.nothing<string>(),
   },
+  webAppVersionSynchronization: {
+    initialPreflightJobResult: Maybe.nothing(),
+    initialPreflightPullRequestNumber: Maybe.nothing<string>(),
+    initialPreflightPullRequestUrl: Maybe.nothing<string>(),
+    initialPreflightState: Maybe.nothing(),
+    productionPreflightJobResult: Maybe.nothing(),
+    productionPreflightPullRequestNumber: Maybe.nothing<string>(),
+    productionPreflightPullRequestUrl: Maybe.nothing<string>(),
+    productionPreflightState: Maybe.nothing(),
+    synchronizationAction: Maybe.nothing(),
+    synchronizationBranchName: Maybe.nothing<string>(),
+    synchronizationJobResult: Maybe.nothing(),
+    synchronizationPullRequestNumber: Maybe.nothing<string>(),
+    synchronizationPullRequestUrl: Maybe.nothing<string>(),
+    webAppVersion: Maybe.nothing<string>(),
+  },
 };
 
 function visibleSummary(summary: string): string {
@@ -311,6 +327,22 @@ describe('WebApp release summary renderer', () => {
         tagName: Maybe.just(productionTagName),
         url: Maybe.just(githubReleaseUrl),
       },
+      webAppVersionSynchronization: {
+        initialPreflightJobResult: Maybe.just('success'),
+        initialPreflightPullRequestNumber: Maybe.nothing<string>(),
+        initialPreflightPullRequestUrl: Maybe.nothing<string>(),
+        initialPreflightState: Maybe.just('available'),
+        productionPreflightJobResult: Maybe.just('success'),
+        productionPreflightPullRequestNumber: Maybe.nothing<string>(),
+        productionPreflightPullRequestUrl: Maybe.nothing<string>(),
+        productionPreflightState: Maybe.just('available'),
+        synchronizationAction: Maybe.just('created'),
+        synchronizationBranchName: Maybe.just('webapp-version-2026-07-17.1-1.0.0'),
+        synchronizationJobResult: Maybe.just('success'),
+        synchronizationPullRequestNumber: Maybe.just('123'),
+        synchronizationPullRequestUrl: Maybe.just('https://github.com/wireapp/wire-webapp/pull/123'),
+        webAppVersion: Maybe.just('1.0.0'),
+      },
     };
     const summary = renderWebappReleaseSummary(input);
     const visibleContent = visibleSummary(summary);
@@ -334,6 +366,15 @@ describe('WebApp release summary renderer', () => {
     expect(detailsContent).toContain('- Helm chart repository: https://charts.example.com/webapp');
     expect(visibleContent).toContain(
       `- GitHub Release handoff: completed successfully; action: new draft created; state: draft; URL: [GitHub Release](${githubReleaseUrl})`,
+    );
+    expect(visibleContent).toContain(
+      '- WebApp version synchronization: completed successfully; WebApp package version: `1.0.0`; Version synchronization action: PR created; Version synchronization PR: [#123](https://github.com/wireapp/wire-webapp/pull/123)',
+    );
+    expect(detailsContent).toContain(
+      '- Initial preflight: job: completed successfully; state: available; PR: not available',
+    );
+    expect(detailsContent).toContain(
+      '- Synchronization pull request: [#123](https://github.com/wireapp/wire-webapp/pull/123)',
     );
     expect(detailsContent).toContain('- Action: new draft created');
     expect(detailsContent).toContain(`- Release URL: [GitHub Release](${githubReleaseUrl})`);
@@ -381,6 +422,54 @@ describe('WebApp release summary renderer', () => {
     expect(detailsContent).toContain(
       '- Manual follow-up: Review or edit the generated customer-facing changelog and publish the GitHub Release manually.',
     );
+  });
+
+  it('distinguishes a successful Production release from incomplete version synchronization bookkeeping', () => {
+    const input: WebappReleaseSummaryInput = {
+      ...baselineWebappReleaseSummaryInput,
+      distribution: {
+        ...baselineWebappReleaseSummaryInput.distribution,
+        distributionJobResult: Maybe.just('success'),
+        distributionResult: Maybe.just('success'),
+      },
+      githubRelease: {
+        action: Maybe.just('created'),
+        jobResult: Maybe.just('success'),
+        state: Maybe.just('draft'),
+        tagName: Maybe.just(productionTagName),
+        url: Maybe.just(githubReleaseUrl),
+      },
+      production: {
+        ...baselineWebappReleaseSummaryInput.production,
+        createdTagName: Maybe.just(productionTagName),
+        deploymentResult: Maybe.just('success'),
+        deploymentRequired: Maybe.just(true),
+        preflightJobResult: Maybe.just('success'),
+        preflightResult: Maybe.just('ready'),
+        runtimeVerificationResult: Maybe.just('success'),
+        tagCreationResult: Maybe.just('success'),
+      },
+      webAppVersionSynchronization: {
+        ...baselineWebappReleaseSummaryInput.webAppVersionSynchronization,
+        initialPreflightJobResult: Maybe.just('success'),
+        initialPreflightState: Maybe.just('available'),
+        productionPreflightJobResult: Maybe.just('success'),
+        productionPreflightState: Maybe.just('available'),
+        synchronizationJobResult: Maybe.just('failure'),
+        webAppVersion: Maybe.just('1.0.0'),
+      },
+    };
+    const summary = renderWebappReleaseSummary(input);
+    const visibleContent = visibleSummary(summary);
+    const detailsContent = technicalEvidence(summary);
+
+    expect(visibleContent).toContain(
+      '- Outcome: Production release completed successfully, but WebApp version synchronization bookkeeping is incomplete',
+    );
+    expect(visibleContent).toContain('- Hosted Production: deployed, verified, and tagged successfully');
+    expect(visibleContent).toContain('- WebApp version synchronization: failed; release bookkeeping incomplete');
+    expect(detailsContent).toContain('- Synchronization job: failed');
+    expect(detailsContent).toContain('- WebApp package version: `1.0.0`');
   });
 
   it('renders an existing published GitHub Release as a successful handoff', () => {
@@ -1025,6 +1114,16 @@ describe('WebApp release summary renderer', () => {
       RELEASE_BRANCH_ACTION: 'created',
       SOURCE_COMMIT_SHA: sourceCommitSha,
       SOURCE_REF: 'main',
+      WEBAPP_VERSION: '1.0.0',
+      WEBAPP_VERSION_SYNC_ACTION: 'created',
+      WEBAPP_VERSION_SYNC_BRANCH_NAME: 'webapp-version-2026-07-17.1-1.0.0',
+      WEBAPP_VERSION_SYNC_INITIAL_PREFLIGHT_JOB_RESULT: 'success',
+      WEBAPP_VERSION_SYNC_INITIAL_PREFLIGHT_STATE: 'available',
+      WEBAPP_VERSION_SYNC_JOB_RESULT: 'success',
+      WEBAPP_VERSION_SYNC_PR_NUMBER: '123',
+      WEBAPP_VERSION_SYNC_PR_URL: 'https://github.com/wireapp/wire-webapp/pull/123',
+      WEBAPP_VERSION_SYNC_PRODUCTION_PREFLIGHT_JOB_RESULT: 'success',
+      WEBAPP_VERSION_SYNC_PRODUCTION_PREFLIGHT_STATE: 'available',
     });
 
     expect(input.release.artifactAssetVersion.unwrapOr('not available')).toBe('2026-07-17.1-1234567');
@@ -1041,6 +1140,18 @@ describe('WebApp release summary renderer', () => {
     expect(input.githubRelease.state.unwrapOr('published')).toBe('draft');
     expect(input.githubRelease.tagName.unwrapOr('not available')).toBe(productionTagName);
     expect(input.githubRelease.url.unwrapOr('not available')).toBe(githubReleaseUrl);
+    expect(input.webAppVersionSynchronization.webAppVersion.unwrapOr('not available')).toBe('1.0.0');
+    expect(input.webAppVersionSynchronization.synchronizationAction.unwrapOr('already-merged')).toBe('created');
+    expect(input.webAppVersionSynchronization.synchronizationBranchName.unwrapOr('not available')).toBe(
+      'webapp-version-2026-07-17.1-1.0.0',
+    );
+    expect(input.webAppVersionSynchronization.synchronizationJobResult.unwrapOr('failure')).toBe('success');
+    expect(input.webAppVersionSynchronization.synchronizationPullRequestNumber.unwrapOr('not available')).toBe('123');
+    expect(input.webAppVersionSynchronization.synchronizationPullRequestUrl.unwrapOr('not available')).toBe(
+      'https://github.com/wireapp/wire-webapp/pull/123',
+    );
+    expect(input.webAppVersionSynchronization.initialPreflightState.unwrapOr('conflict')).toBe('available');
+    expect(input.webAppVersionSynchronization.productionPreflightState.unwrapOr('conflict')).toBe('available');
   });
 
   it('does not create a link for an invalid E2E report URL', () => {

--- a/tools/release-summary/renderWebappReleaseSummary.ts
+++ b/tools/release-summary/renderWebappReleaseSummary.ts
@@ -99,6 +99,33 @@ export type GitHubReleaseSummaryInput = {
   readonly url: Maybe<string>;
 };
 
+export type WebAppVersionSynchronizationPreflightState =
+  | 'available'
+  | 'matching-open'
+  | 'matching-merged'
+  | 'closed-without-merge'
+  | 'blocked-by-previous-unresolved'
+  | 'conflict';
+
+export type WebAppVersionSynchronizationAction = 'already-open' | 'already-merged' | 'created' | 'recovered';
+
+export type WebAppVersionSynchronizationSummaryInput = {
+  readonly initialPreflightJobResult: Maybe<WorkflowJobResult>;
+  readonly initialPreflightPullRequestNumber: Maybe<string>;
+  readonly initialPreflightPullRequestUrl: Maybe<string>;
+  readonly initialPreflightState: Maybe<WebAppVersionSynchronizationPreflightState>;
+  readonly productionPreflightJobResult: Maybe<WorkflowJobResult>;
+  readonly productionPreflightPullRequestNumber: Maybe<string>;
+  readonly productionPreflightPullRequestUrl: Maybe<string>;
+  readonly productionPreflightState: Maybe<WebAppVersionSynchronizationPreflightState>;
+  readonly synchronizationAction: Maybe<WebAppVersionSynchronizationAction>;
+  readonly synchronizationBranchName: Maybe<string>;
+  readonly synchronizationJobResult: Maybe<WorkflowJobResult>;
+  readonly synchronizationPullRequestNumber: Maybe<string>;
+  readonly synchronizationPullRequestUrl: Maybe<string>;
+  readonly webAppVersion: Maybe<string>;
+};
+
 export type GitHubLinkContext = {
   readonly actor: Maybe<string>;
   readonly repository: Maybe<string>;
@@ -122,6 +149,7 @@ export type WebappReleaseSummaryInput = {
   readonly preparation: ReleasePreparationSummaryInput;
   readonly production: ProductionSummaryInput;
   readonly release: ReleaseMetadata;
+  readonly webAppVersionSynchronization: WebAppVersionSynchronizationSummaryInput;
 };
 
 type RenderReleaseIdentityParameters = {
@@ -227,6 +255,49 @@ function readGitHubReleaseState(environment: NodeJS.ProcessEnv): Maybe<GitHubRel
   });
 }
 
+function readWebAppVersionSynchronizationPreflightState(
+  environment: NodeJS.ProcessEnv,
+  variableName: string,
+): Maybe<WebAppVersionSynchronizationPreflightState> {
+  const environmentValue = readOptionalEnvironmentValue(environment, variableName);
+
+  return environmentValue.andThen(value => {
+    return match(value)
+      .with(
+        P.union(
+          'available',
+          'matching-open',
+          'matching-merged',
+          'closed-without-merge',
+          'blocked-by-previous-unresolved',
+          'conflict',
+        ),
+        validState => {
+          return Maybe.just(validState);
+        },
+      )
+      .otherwise(() => {
+        return Maybe.nothing<WebAppVersionSynchronizationPreflightState>();
+      });
+  });
+}
+
+function readWebAppVersionSynchronizationAction(
+  environment: NodeJS.ProcessEnv,
+): Maybe<WebAppVersionSynchronizationAction> {
+  const environmentValue = readOptionalEnvironmentValue(environment, 'WEBAPP_VERSION_SYNC_ACTION');
+
+  return environmentValue.andThen(value => {
+    return match(value)
+      .with(P.union('already-open', 'already-merged', 'created', 'recovered'), validAction => {
+        return Maybe.just(validAction);
+      })
+      .otherwise(() => {
+        return Maybe.nothing<WebAppVersionSynchronizationAction>();
+      });
+  });
+}
+
 export function readWebappReleaseSummaryInput(environment: NodeJS.ProcessEnv): WebappReleaseSummaryInput {
   return {
     beta: {
@@ -303,6 +374,43 @@ export function readWebappReleaseSummaryInput(environment: NodeJS.ProcessEnv): W
       commitSha: readOptionalEnvironmentValue(environment, 'RELEASE_COMMIT_SHA'),
       identifier: readOptionalEnvironmentValue(environment, 'RELEASE_IDENTIFIER'),
       manualReason: readOptionalEnvironmentValue(environment, 'RELEASE_REASON'),
+    },
+    webAppVersionSynchronization: {
+      initialPreflightJobResult: readWorkflowJobResult(environment, 'WEBAPP_VERSION_SYNC_INITIAL_PREFLIGHT_JOB_RESULT'),
+      initialPreflightPullRequestNumber: readOptionalEnvironmentValue(
+        environment,
+        'WEBAPP_VERSION_SYNC_INITIAL_PREFLIGHT_PR_NUMBER',
+      ),
+      initialPreflightPullRequestUrl: readOptionalEnvironmentValue(
+        environment,
+        'WEBAPP_VERSION_SYNC_INITIAL_PREFLIGHT_PR_URL',
+      ),
+      initialPreflightState: readWebAppVersionSynchronizationPreflightState(
+        environment,
+        'WEBAPP_VERSION_SYNC_INITIAL_PREFLIGHT_STATE',
+      ),
+      productionPreflightJobResult: readWorkflowJobResult(
+        environment,
+        'WEBAPP_VERSION_SYNC_PRODUCTION_PREFLIGHT_JOB_RESULT',
+      ),
+      productionPreflightPullRequestNumber: readOptionalEnvironmentValue(
+        environment,
+        'WEBAPP_VERSION_SYNC_PRODUCTION_PREFLIGHT_PR_NUMBER',
+      ),
+      productionPreflightPullRequestUrl: readOptionalEnvironmentValue(
+        environment,
+        'WEBAPP_VERSION_SYNC_PRODUCTION_PREFLIGHT_PR_URL',
+      ),
+      productionPreflightState: readWebAppVersionSynchronizationPreflightState(
+        environment,
+        'WEBAPP_VERSION_SYNC_PRODUCTION_PREFLIGHT_STATE',
+      ),
+      synchronizationAction: readWebAppVersionSynchronizationAction(environment),
+      synchronizationBranchName: readOptionalEnvironmentValue(environment, 'WEBAPP_VERSION_SYNC_BRANCH_NAME'),
+      synchronizationJobResult: readWorkflowJobResult(environment, 'WEBAPP_VERSION_SYNC_JOB_RESULT'),
+      synchronizationPullRequestNumber: readOptionalEnvironmentValue(environment, 'WEBAPP_VERSION_SYNC_PR_NUMBER'),
+      synchronizationPullRequestUrl: readOptionalEnvironmentValue(environment, 'WEBAPP_VERSION_SYNC_PR_URL'),
+      webAppVersion: readOptionalEnvironmentValue(environment, 'WEBAPP_VERSION'),
     },
   };
 }
@@ -618,6 +726,87 @@ function formatGitHubReleaseStageOverview(input: WebappReleaseSummaryInput): str
     `state: ${formatGitHubReleaseState(input.githubRelease.state)}`,
     `URL: ${formatGitHubReleaseUrl(input)}`,
   ].join('; ');
+}
+
+function formatWebAppVersionSynchronizationPreflightState(
+  state: Maybe<WebAppVersionSynchronizationPreflightState>,
+): string {
+  return state.mapOr('not available', actualState => {
+    return actualState;
+  });
+}
+
+function formatWebAppVersionSynchronizationAction(action: Maybe<WebAppVersionSynchronizationAction>): string {
+  return action.mapOr('not available', actualAction => {
+    return match(actualAction)
+      .with('created', () => {
+        return 'PR created';
+      })
+      .with('recovered', () => {
+        return 'interrupted branch recovered and PR created';
+      })
+      .with('already-open', () => {
+        return 'existing open PR reused';
+      })
+      .with('already-merged', () => {
+        return 'existing merged PR verified';
+      })
+      .exhaustive();
+  });
+}
+
+function formatWebAppVersionSynchronizationPullRequest(
+  pullRequestNumber: Maybe<string>,
+  pullRequestUrl: Maybe<string>,
+): string {
+  return pullRequestNumber
+    .andThen(number => {
+      return pullRequestUrl.map(url => {
+        return formatMarkdownLink(`#${number}`, url);
+      });
+    })
+    .unwrapOr('not available');
+}
+
+function formatWebAppVersionSynchronizationPreflight(
+  jobResult: Maybe<WorkflowJobResult>,
+  state: Maybe<WebAppVersionSynchronizationPreflightState>,
+  pullRequestNumber: Maybe<string>,
+  pullRequestUrl: Maybe<string>,
+): string {
+  return [
+    `job: ${formatWorkflowJobResult(jobResult)}`,
+    `state: ${formatWebAppVersionSynchronizationPreflightState(state)}`,
+    `PR: ${formatWebAppVersionSynchronizationPullRequest(pullRequestNumber, pullRequestUrl)}`,
+  ].join('; ');
+}
+
+function formatWebAppVersionSynchronizationStageOverview(input: WebappReleaseSummaryInput): string {
+  if (hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'failure')) {
+    return 'failed; release bookkeeping incomplete';
+  }
+
+  if (hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'cancelled')) {
+    return 'cancelled; release bookkeeping incomplete';
+  }
+
+  if (hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'skipped')) {
+    return 'not run; release bookkeeping incomplete';
+  }
+
+  if (hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'success')) {
+    return [
+      'completed successfully',
+      `WebApp package version: ${formatCodeValue(input.webAppVersionSynchronization.webAppVersion)}`,
+      `Version synchronization action: ${formatWebAppVersionSynchronizationAction(input.webAppVersionSynchronization.synchronizationAction)}`,
+      `Version synchronization PR: ${formatWebAppVersionSynchronizationPullRequest(
+        input.webAppVersionSynchronization.synchronizationPullRequestNumber,
+        input.webAppVersionSynchronization.synchronizationPullRequestUrl,
+      )}`,
+    ].join('; ');
+  }
+
+  return 'not available';
 }
 
 function formatRuntimeVerificationResult(result: WorkflowJobResult): string {
@@ -1112,6 +1301,29 @@ function hasHostedProductionCompleted(input: ProductionSummaryInput): boolean {
   );
 }
 
+function hasSuccessfulReleaseDistribution(input: WebappReleaseSummaryInput): boolean {
+  return (
+    hasWorkflowJobResult(input.distribution.distributionJobResult, 'success') &&
+    hasWorkflowJobResult(input.distribution.distributionResult, 'success')
+  );
+}
+
+function hasWebAppVersionSynchronizationFailure(input: WebappReleaseSummaryInput): boolean {
+  return (
+    hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'failure') ||
+    hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'cancelled') ||
+    hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'skipped')
+  );
+}
+
+function hasSuccessfulProductionReleaseLifecycle(input: WebappReleaseSummaryInput): boolean {
+  return (
+    hasHostedProductionCompleted(input.production) &&
+    hasSuccessfulReleaseDistribution(input) &&
+    hasSuccessfulGitHubReleaseHandoff(input)
+  );
+}
+
 function formatAlreadyTaggedReleaseOutcome(input: WebappReleaseSummaryInput): string {
   const alreadyTaggedProductionOutcome = 'Release already has the matching Production tag; deployment was not repeated';
 
@@ -1325,6 +1537,10 @@ function formatFinalReleaseOutcome(input: WebappReleaseSummaryInput): string {
     hasWorkflowJobResult(input.githubRelease.jobResult, 'skipped')
   ) {
     return 'Hosted Production and release distribution completed, but GitHub Release handoff did not run';
+  }
+
+  if (hasSuccessfulProductionReleaseLifecycle(input) && hasWebAppVersionSynchronizationFailure(input)) {
+    return 'Production release completed successfully, but WebApp version synchronization bookkeeping is incomplete';
   }
 
   if (
@@ -1566,6 +1782,35 @@ function renderGitHubReleaseSection(input: WebappReleaseSummaryInput): string {
   ].join('\n');
 }
 
+function renderWebAppVersionSynchronizationSection(input: WebappReleaseSummaryInput): string {
+  const synchronization = input.webAppVersionSynchronization;
+
+  return [
+    '### WebApp version synchronization',
+    '',
+    `- Initial preflight: ${formatWebAppVersionSynchronizationPreflight(
+      synchronization.initialPreflightJobResult,
+      synchronization.initialPreflightState,
+      synchronization.initialPreflightPullRequestNumber,
+      synchronization.initialPreflightPullRequestUrl,
+    )}`,
+    `- Production preflight: ${formatWebAppVersionSynchronizationPreflight(
+      synchronization.productionPreflightJobResult,
+      synchronization.productionPreflightState,
+      synchronization.productionPreflightPullRequestNumber,
+      synchronization.productionPreflightPullRequestUrl,
+    )}`,
+    `- Synchronization job: ${formatWorkflowJobResult(synchronization.synchronizationJobResult)}`,
+    `- WebApp package version: ${formatCodeValue(synchronization.webAppVersion)}`,
+    `- Synchronization action: ${formatWebAppVersionSynchronizationAction(synchronization.synchronizationAction)}`,
+    `- Synchronization branch: ${formatValueOrFallback(synchronization.synchronizationBranchName)}`,
+    `- Synchronization pull request: ${formatWebAppVersionSynchronizationPullRequest(
+      synchronization.synchronizationPullRequestNumber,
+      synchronization.synchronizationPullRequestUrl,
+    )}`,
+  ].join('\n');
+}
+
 function renderReleasePreparationSection(input: WebappReleaseSummaryInput): string {
   const commitLink = formatCommitLink(input.release.commitSha, input.github);
   const sourceCommitLink = formatSourceCommit(input);
@@ -1603,7 +1848,11 @@ function renderTechnicalReleaseEvidence(input: WebappReleaseSummaryInput, phase:
 
   if (phase === 'final') {
     technicalSections.push(renderE2ESection(input), renderProductionSection(input));
-    technicalSections.push(renderProductionDistributionSection(input), renderGitHubReleaseSection(input));
+    technicalSections.push(
+      renderProductionDistributionSection(input),
+      renderGitHubReleaseSection(input),
+      renderWebAppVersionSynchronizationSection(input),
+    );
   }
 
   return [
@@ -1656,6 +1905,7 @@ export function renderWebappReleaseSummary(input: WebappReleaseSummaryInput): st
       `- Hosted Production: ${productionOverview}`,
       `- Release distribution: ${distributionOverview}`,
       `- GitHub Release handoff: ${formatGitHubReleaseStageOverview(input)}`,
+      `- WebApp version synchronization: ${formatWebAppVersionSynchronizationStageOverview(input)}`,
     ].join('\n'),
   ].join('\n\n');
 

--- a/tools/release-summary/renderWebappReleaseSummary.ts
+++ b/tools/release-summary/renderWebappReleaseSummary.ts
@@ -782,31 +782,42 @@ function formatWebAppVersionSynchronizationPreflight(
 }
 
 function formatWebAppVersionSynchronizationStageOverview(input: WebappReleaseSummaryInput): string {
-  if (hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'failure')) {
-    return 'failed; release bookkeeping incomplete';
-  }
+  const synchronizationJobResult = input.webAppVersionSynchronization.synchronizationJobResult;
+  const bookkeepingIncomplete = isWebAppVersionSynchronizationBookkeepingIncomplete(input);
 
-  if (hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'cancelled')) {
-    return 'cancelled; release bookkeeping incomplete';
-  }
-
-  if (hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'skipped')) {
-    return 'not run; release bookkeeping incomplete';
-  }
-
-  if (hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'success')) {
-    return [
-      'completed successfully',
-      `WebApp package version: ${formatCodeValue(input.webAppVersionSynchronization.webAppVersion)}`,
-      `Version synchronization action: ${formatWebAppVersionSynchronizationAction(input.webAppVersionSynchronization.synchronizationAction)}`,
-      `Version synchronization PR: ${formatWebAppVersionSynchronizationPullRequest(
-        input.webAppVersionSynchronization.synchronizationPullRequestNumber,
-        input.webAppVersionSynchronization.synchronizationPullRequestUrl,
-      )}`,
-    ].join('; ');
-  }
-
-  return 'not available';
+  return synchronizationJobResult.mapOr('not available', actualSynchronizationJobResult => {
+    return match({actualSynchronizationJobResult, bookkeepingIncomplete})
+      .with({actualSynchronizationJobResult: 'failure', bookkeepingIncomplete: true}, () => {
+        return 'failed; release bookkeeping incomplete';
+      })
+      .with({actualSynchronizationJobResult: 'cancelled', bookkeepingIncomplete: true}, () => {
+        return 'cancelled; release bookkeeping incomplete';
+      })
+      .with({actualSynchronizationJobResult: 'skipped', bookkeepingIncomplete: true}, () => {
+        return 'not run; release bookkeeping incomplete';
+      })
+      .with({actualSynchronizationJobResult: 'failure'}, () => {
+        return 'failed';
+      })
+      .with({actualSynchronizationJobResult: 'cancelled'}, () => {
+        return 'cancelled';
+      })
+      .with({actualSynchronizationJobResult: 'skipped'}, () => {
+        return 'not run';
+      })
+      .with({actualSynchronizationJobResult: 'success'}, () => {
+        return [
+          'completed successfully',
+          `WebApp package version: ${formatCodeValue(input.webAppVersionSynchronization.webAppVersion)}`,
+          `Version synchronization action: ${formatWebAppVersionSynchronizationAction(input.webAppVersionSynchronization.synchronizationAction)}`,
+          `Version synchronization PR: ${formatWebAppVersionSynchronizationPullRequest(
+            input.webAppVersionSynchronization.synchronizationPullRequestNumber,
+            input.webAppVersionSynchronization.synchronizationPullRequestUrl,
+          )}`,
+        ].join('; ');
+      })
+      .exhaustive();
+  });
 }
 
 function formatRuntimeVerificationResult(result: WorkflowJobResult): string {
@@ -1308,19 +1319,27 @@ function hasSuccessfulReleaseDistribution(input: WebappReleaseSummaryInput): boo
   );
 }
 
-function hasWebAppVersionSynchronizationFailure(input: WebappReleaseSummaryInput): boolean {
-  return (
-    hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'failure') ||
-    hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'cancelled') ||
-    hasWorkflowJobResult(input.webAppVersionSynchronization.synchronizationJobResult, 'skipped')
-  );
-}
-
 function hasSuccessfulProductionReleaseLifecycle(input: WebappReleaseSummaryInput): boolean {
   return (
     hasHostedProductionCompleted(input.production) &&
     hasSuccessfulReleaseDistribution(input) &&
     hasSuccessfulGitHubReleaseHandoff(input)
+  );
+}
+
+function isWebAppVersionSynchronizationBookkeepingIncomplete(input: WebappReleaseSummaryInput): boolean {
+  return (
+    hasSuccessfulProductionReleaseLifecycle(input) &&
+    input.webAppVersionSynchronization.synchronizationJobResult.mapOr(false, synchronizationJobResult => {
+      return match(synchronizationJobResult)
+        .with('success', () => {
+          return false;
+        })
+        .with(P.union('failure', 'cancelled', 'skipped'), () => {
+          return true;
+        })
+        .exhaustive();
+    })
   );
 }
 
@@ -1539,7 +1558,7 @@ function formatFinalReleaseOutcome(input: WebappReleaseSummaryInput): string {
     return 'Hosted Production and release distribution completed, but GitHub Release handoff did not run';
   }
 
-  if (hasSuccessfulProductionReleaseLifecycle(input) && hasWebAppVersionSynchronizationFailure(input)) {
+  if (isWebAppVersionSynchronizationBookkeepingIncomplete(input)) {
     return 'Production release completed successfully, but WebApp version synchronization bookkeeping is incomplete';
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Integrates WebApp package-version synchronization into the normal `Release WebApp` lifecycle.

This completes the work started in pull requests #22438 and #22441 by adding:

* an early read-only synchronization preflight before release-branch mutation
* a fresh synchronization-state check before Production approval
* post-Production WebApp version synchronization after the immutable Production release is fully completed
* repository-wide serialization of WebApp version allocation
* Otto-authenticated creation of the version synchronization pull request
* release summary and notification support for synchronization state
* explicit handling of successful Production releases with incomplete synchronization bookkeeping
* corresponding ADR 0002 documentation

## Release flow

The immutable release process remains unchanged through Production:

```text
release branch
-> build once
-> Beta
-> E2E
-> Production approval
-> Production deployment
-> runtime verification
-> immutable Production tag
-> Docker / Helm / wire-builds distribution
-> GitHub Release handoff
```

Only after the complete Production lifecycle succeeds does the workflow synchronize the repository WebApp version:

```text
Production release completed
-> resolve WebApp SemVer
-> create or recover Otto synchronization pull request against main
```

The generated pull request goes through normal `main` branch protection, CI, review and merge queue. It is not auto-merged.

## Version semantics

The existing release identity remains authoritative:

```text
YYYY-MM-DD.N
YYYY-MM-DD.N-production
```

`WIRE_WEBAPP_BUILD_VERSION` and runtime `BuildMetadata.version` continue to use the date-based release identifier.

The WebApp package SemVer is separate repository metadata.

`package.json` and `apps/webapp/package.json` on `main` represent the latest successfully synchronized Production version, not the next development version.

The first Production synchronization bootstraps the existing legacy `0.x.y` version to:

```text
1.0.0
```

Subsequent normal Production releases increment the patch version.