### PR TITLE
Enable strict boolean checks for generic webapp UI [WPB-22420]

### DIFF
--- a/apps/webapp/src/script/components/SearchInput/SearchInput.tsx
+++ b/apps/webapp/src/script/components/SearchInput/SearchInput.tsx
@@ -55,7 +55,7 @@ export const SearchInput = ({
   const noSelectedUsers = selectedUsers.length === 0;
 
   useLayoutEffect(() => {
-    if (inputElement.current && innerElement.current) {
+    if (inputElement.current !== null && innerElement.current !== null) {
       inputElement.current.focus();
       innerElement.current.scrollTop = inputElement.current.scrollHeight;
     }

--- a/apps/webapp/src/script/components/TextInput/TextInput.tsx
+++ b/apps/webapp/src/script/components/TextInput/TextInput.tsx
@@ -130,7 +130,7 @@ const TextInput = forwardRef<HTMLInputElement, UserInputProps>(
             css={cancelButtonCSS}
             onClick={() => {
               onCancel();
-              if (textInputRef && 'current' in textInputRef) {
+              if (textInputRef !== null && 'current' in textInputRef) {
                 textInputRef.current?.focus();
               }
             }}

--- a/apps/webapp/src/script/components/ZoomableImage/ZoomableImage.tsx
+++ b/apps/webapp/src/script/components/ZoomableImage/ZoomableImage.tsx
@@ -35,7 +35,7 @@ const DEFAULT_OFFSET: Offset = {x: 0, y: 0};
 function calculateZoomRatio(element: HTMLImageElement) {
   const parentElement = element.parentElement;
 
-  if (!parentElement) {
+  if (parentElement === null) {
     return 1;
   }
 
@@ -49,7 +49,7 @@ function calculateZoomRatio(element: HTMLImageElement) {
 
 // if we will add more image zooming, we need to pass 2 props, for check if is image is zoomed and imageScale
 function calculateMaxOffset(containerRef: RefObject<HTMLDivElement>, imgRef: RefObject<HTMLImageElement>) {
-  if (!containerRef.current || !imgRef.current) {
+  if (containerRef.current === null || imgRef.current === null) {
     return {
       maxXOffset: 0,
       maxYOffset: 0,
@@ -120,7 +120,7 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
     });
 
     if (!draggingRef.current && !isZoomEnabled) {
-      if (!imageRef.current) {
+      if (imageRef.current === null) {
         return;
       }
 
@@ -186,7 +186,7 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
   };
 
   const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (!isZoomEnabled || !mouseDownRef.current || !containerRef.current || !imageRef.current) {
+    if (!isZoomEnabled || !mouseDownRef.current || containerRef.current === null || imageRef.current === null) {
       return;
     }
 
@@ -198,7 +198,7 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
 
     draggingRef.current = true;
 
-    if (element.style.transition) {
+    if (element.style.transition.length > 0) {
       element.style.transition = '';
     }
 
@@ -217,7 +217,7 @@ export const ZoomableImage = (props: ZoomableImageProps) => {
   };
 
   const updateZoomRatio = () => {
-    if (!imageRef.current) {
+    if (imageRef.current === null) {
       return;
     }
 

--- a/apps/webapp/src/script/components/fadingScrollbar/fadingScrollbar.tsx
+++ b/apps/webapp/src/script/components/fadingScrollbar/fadingScrollbar.tsx
@@ -54,7 +54,7 @@ export const FadingScrollbar = forwardRef<HTMLDivElement, React.HTMLAttributes<H
   const currentAlpha = useRef<number>(0);
 
   const getInitialColor = (element: HTMLElement) => {
-    if (!initalColor.current) {
+    if (initalColor.current === undefined) {
       initalColor.current = parseColor(window.getComputedStyle(element).getPropertyValue('--scrollbar-color'));
       currentAlpha.current = initalColor.current[3];
     }

--- a/apps/webapp/src/script/components/inViewport/inViewport.tsx
+++ b/apps/webapp/src/script/components/inViewport/inViewport.tsx
@@ -46,7 +46,7 @@ export const InViewport = ({
 
   useEffect(() => {
     const element = domNode.current;
-    if (!element) {
+    if (element === null) {
       return undefined;
     }
 
@@ -71,7 +71,7 @@ export const InViewport = ({
           onVisibilityLostTriggered = false;
         }
 
-        if (!onVisibilityLost) {
+        if (onVisibilityLost === undefined) {
           releaseTrackers();
         }
       }

--- a/apps/webapp/src/script/components/toggle/BaseToggle.tsx
+++ b/apps/webapp/src/script/components/toggle/BaseToggle.tsx
@@ -52,7 +52,7 @@ const BaseToggle = ({
 
   const handleToggleChange = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    if (inputRef.current) {
+    if (inputRef.current !== null) {
       setIsChecked(inputRef.current.checked);
     }
   };

--- a/apps/webapp/src/script/hooks/useActiveWindow.ts
+++ b/apps/webapp/src/script/hooks/useActiveWindow.ts
@@ -34,7 +34,7 @@ export const useActiveWindowState = create<ActiveWindowState>((set, get) => ({
 export const useActiveWindow = (windowObj: Window | null) => {
   const {setActiveWindow} = useActiveWindowState();
 
-  const windowRef = windowObj || window;
+  const windowRef = windowObj !== null ? windowObj : window;
 
   useEffect(() => {
     const handleFocus = () => setActiveWindow(windowRef);

--- a/apps/webapp/src/script/hooks/useClickOutside.tsx
+++ b/apps/webapp/src/script/hooks/useClickOutside.tsx
@@ -27,10 +27,12 @@ export const useClickOutside = (
 ) => {
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
-      const isOutsideClick = ref.current && ref.current !== event.target && !ref.current.contains(event.target as Node);
+      const isOutsideClick =
+        ref.current !== null && ref.current !== event.target && !ref.current.contains(event.target as Node);
       if (isOutsideClick) {
-        const isNonExcludedAreaClicked = exclude && exclude.current && !exclude.current.contains(event.target as Node);
-        if (isNonExcludedAreaClicked || !exclude) {
+        const isNonExcludedAreaClicked =
+          exclude !== undefined && exclude.current !== null && !exclude.current.contains(event.target as Node);
+        if (isNonExcludedAreaClicked || exclude === undefined) {
           onClick(event);
         }
       }

--- a/apps/webapp/src/script/hooks/useElementSize/useElementSize.ts
+++ b/apps/webapp/src/script/hooks/useElementSize/useElementSize.ts
@@ -41,7 +41,7 @@ export const useElementSize = <Element extends HTMLElement = HTMLDivElement>(): 
     }
 
     const entry = entries[0];
-    if (entry) {
+    if (entry !== undefined) {
       const {width: newWidth, height: newHeight} = entry.contentRect;
       setWidth(newWidth);
       setHeight(newHeight);
@@ -49,7 +49,7 @@ export const useElementSize = <Element extends HTMLElement = HTMLDivElement>(): 
   }, []);
 
   useEffect(() => {
-    if (!ref.current) {
+    if (ref.current === null) {
       return undefined;
     }
 

--- a/apps/webapp/src/script/hooks/useInView/useInView.ts
+++ b/apps/webapp/src/script/hooks/useInView/useInView.ts
@@ -35,7 +35,7 @@ export const useInView = <Element extends HTMLElement = HTMLDivElement>(options:
 
   useEffect(() => {
     const element = elementRef.current;
-    if (!element) {
+    if (element === null) {
       return undefined;
     }
 

--- a/apps/webapp/src/script/hooks/useKeyPressAndHold/useKeyPressAndHold.ts
+++ b/apps/webapp/src/script/hooks/useKeyPressAndHold/useKeyPressAndHold.ts
@@ -44,7 +44,7 @@ export const useKeyPressAndHold = ({
   const isPressHandledRef = useRef(false);
 
   const handlePress = useCallback(() => {
-    if (holdTimeoutRef.current) {
+    if (holdTimeoutRef.current !== null) {
       clearTimeout(holdTimeoutRef.current);
     }
 
@@ -60,7 +60,7 @@ export const useKeyPressAndHold = ({
   }, [onHold, holdDelayMs]);
 
   const clearHoldTimeout = useCallback(() => {
-    if (holdTimeoutRef.current) {
+    if (holdTimeoutRef.current !== null) {
       clearTimeout(holdTimeoutRef.current);
       holdTimeoutRef.current = null;
     }

--- a/apps/webapp/src/script/hooks/useRoveFocus.ts
+++ b/apps/webapp/src/script/hooks/useRoveFocus.ts
@@ -31,7 +31,7 @@ export function useRoveFocus(elements: string[]) {
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent | KeyboardEvent) => {
-      const currentIndex = focusedId ? elements.indexOf(focusedId) : -1;
+      const currentIndex = focusedId !== undefined && focusedId.length > 0 ? elements.indexOf(focusedId) : -1;
       if (isKey(event, KEY.ARROW_DOWN)) {
         event.preventDefault();
         if (currentIndex < lastIndex) {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -539,6 +539,13 @@ const productionConfigs = [
       'apps/webapp/src/script/components/draggableClickWrapper/draggableClickWrapper.tsx',
       'apps/webapp/src/script/components/dropFileArea/dropFileArea.tsx',
       'apps/webapp/src/script/components/toggle/BaseToggle.tsx',
+      'apps/webapp/src/script/hooks/useActiveWindow.ts',
+      'apps/webapp/src/script/hooks/useClickOutside.tsx',
+      'apps/webapp/src/script/hooks/useElementSize/useElementSize.ts',
+      'apps/webapp/src/script/hooks/useInView/useInView.ts',
+      'apps/webapp/src/script/hooks/useKeyPressAndHold/useKeyPressAndHold.ts',
+      'apps/webapp/src/script/hooks/useRoveFocus.ts',
+      'apps/webapp/src/script/hooks/useToggleState.ts',
     ],
     rules: {
       '@typescript-eslint/strict-boolean-expressions': strictBooleanExpressionsRule,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -535,6 +535,10 @@ const productionConfigs = [
       'apps/webapp/src/script/components/fadingScrollbar/fadingScrollbar.tsx',
       'apps/webapp/src/script/components/inViewport/inViewport.tsx',
       'apps/webapp/src/script/components/ZoomableImage/ZoomableImage.tsx',
+      'apps/webapp/src/script/components/copyToClipboardButton/copyToClipboardButton.tsx',
+      'apps/webapp/src/script/components/draggableClickWrapper/draggableClickWrapper.tsx',
+      'apps/webapp/src/script/components/dropFileArea/dropFileArea.tsx',
+      'apps/webapp/src/script/components/toggle/BaseToggle.tsx',
     ],
     rules: {
       '@typescript-eslint/strict-boolean-expressions': strictBooleanExpressionsRule,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -522,6 +522,25 @@ const productionConfigs = [
     },
   },
   {
+    files: [
+      'apps/webapp/src/script/components/LoadingBar/LoadingBar.tsx',
+      'apps/webapp/src/script/components/Note/Note.tsx',
+      'apps/webapp/src/script/components/ProgressBar/ProgressBar.tsx',
+      'apps/webapp/src/script/components/Radio/RadioGroup.tsx',
+      'apps/webapp/src/script/components/SearchInput/SearchInput.tsx',
+      'apps/webapp/src/script/components/SelectText/SelectText.tsx',
+      'apps/webapp/src/script/components/TextInput/TextInput.tsx',
+      'apps/webapp/src/script/components/UserName/UserName.tsx',
+      'apps/webapp/src/script/components/VerificationIcon/VerificationIcon.tsx',
+      'apps/webapp/src/script/components/fadingScrollbar/fadingScrollbar.tsx',
+      'apps/webapp/src/script/components/inViewport/inViewport.tsx',
+      'apps/webapp/src/script/components/ZoomableImage/ZoomableImage.tsx',
+    ],
+    rules: {
+      '@typescript-eslint/strict-boolean-expressions': strictBooleanExpressionsRule,
+    },
+  },
+  {
     files: ['libraries/react-ui-kit/**/*.{ts,tsx}'],
     rules: {
       'import/no-default-export': 'off',


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

This is the next step of the strict boolean expressions migration.

It enables and fixes @typescript-eslint/strict-boolean-expressions for a small set of generic webapp UI components and hooks.

The migration intentionally preserves existing JavaScript truthy/falsy behavior and avoids application/domain logic.