### PR TITLE
Render translated links with React [WPB-27666]

### DIFF
--- a/apps/webapp/src/script/components/messagesList/message/e2eiVerificationMessage/e2eiVerificationMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/e2eiVerificationMessage/e2eiVerificationMessage.test.tsx
@@ -20,6 +20,7 @@
 import {render} from '@testing-library/react';
 import {isNull} from '@sindresorhus/is';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
+import {Maybe} from 'true-myth';
 
 import en from 'I18n/en-US.json';
 import {Conversation} from 'Repositories/entity/Conversation';
@@ -109,13 +110,13 @@ function createConversation(options: CreateConversationOptions = {}): Conversati
   const {participatingUser, selfUser} = options;
   const conversation = new Conversation('', '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
 
-  if (participatingUser !== undefined) {
+  Maybe.of(participatingUser).inspect(participatingUser => {
     conversation.participating_user_ets([participatingUser]);
-  }
+  });
 
-  if (selfUser !== undefined) {
+  Maybe.of(selfUser).inspect(selfUser => {
     conversation.selfUser(selfUser);
-  }
+  });
 
   return conversation;
 }

--- a/apps/webapp/src/script/components/messagesList/message/e2eiVerificationMessage/e2eiVerificationMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/e2eiVerificationMessage/e2eiVerificationMessage.test.tsx
@@ -18,24 +18,135 @@
  */
 
 import {render} from '@testing-library/react';
+import {isNull} from '@sindresorhus/is';
+import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 
+import en from 'I18n/en-US.json';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {E2EIVerificationMessage as VerificationMessageEntity} from 'Repositories/entity/message/e2eiVerificationMessage';
 import {User} from 'Repositories/entity/User';
+import {Config} from 'src/script/Config';
 import {E2EIVerificationMessageType} from 'src/script/message/e2eiVerificationMessageType';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {setStrings, translate} from 'Util/localizerUtil';
 
 import {E2EIVerificationMessage} from './e2eiVerificationMessage';
 
-import {withTheme} from '../../../../auth/util/test/testUtil';
+import {withTheme, withThemeAndRootContext} from '../../../../auth/util/test/testUtil';
 import {translateForTest} from 'Util/test/translateForTest';
-import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
 
-const createVerificationMessage = (partialVerificationMessage: Partial<VerificationMessageEntity>) => {
+const legacyRootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName) {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
+const e2eiVerificationSupportUrl = 'https://support.example/e2ei-verification';
+
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
+
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
+}
+
+function withE2EIConfiguration(testFunction: TranslationTestFunction): IsolatedTranslationTestFunction {
+  return async function runE2EIConfigurationTest(): Promise<void> {
+    const originalConfig = Config.getConfig();
+    const configWithTestValues = {
+      ...originalConfig,
+      URL: {
+        ...originalConfig.URL,
+        SUPPORT: {
+          ...originalConfig.URL.SUPPORT,
+          E2EI_VERIFICATION: e2eiVerificationSupportUrl,
+        },
+      },
+    };
+    const configSpy = jest.spyOn(Config, 'getConfig').mockReturnValue(configWithTestValues);
+
+    try {
+      await testFunction();
+    } finally {
+      configSpy.mockRestore();
+    }
+  };
+}
+
+function createVerificationMessage(
+  partialVerificationMessage: Partial<VerificationMessageEntity>,
+): VerificationMessageEntity {
   const verificationMessage: Partial<VerificationMessageEntity> = {
     ...partialVerificationMessage,
   };
   return verificationMessage as VerificationMessageEntity;
+}
+
+type CreateConversationOptions = {
+  readonly participatingUser?: User;
+  readonly selfUser?: User;
 };
+
+function createConversation(options: CreateConversationOptions = {}): Conversation {
+  const {participatingUser, selfUser} = options;
+  const conversation = new Conversation('', '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
+
+  if (participatingUser !== undefined) {
+    conversation.participating_user_ets([participatingUser]);
+  }
+
+  if (selfUser !== undefined) {
+    conversation.selfUser(selfUser);
+  }
+
+  return conversation;
+}
+
+function createUser(name: string): User {
+  const user = new User('user1', '', translateForTest);
+  user.name(name);
+  return user;
+}
+
+function getVerificationMessageContent(container: HTMLElement): HTMLElement {
+  const verificationMessageContent = container.querySelector<HTMLElement>(
+    '[data-uie-name="element-message-verification"]',
+  );
+
+  if (isNull(verificationMessageContent)) {
+    throw new Error('Expected E2EI verification message content to be rendered');
+  }
+
+  return verificationMessageContent;
+}
+
+function getLearnMoreLink(container: HTMLElement): HTMLAnchorElement {
+  const learnMoreLink = container.querySelector<HTMLAnchorElement>('[data-uie-name="element-message-verification"] a');
+
+  if (isNull(learnMoreLink)) {
+    throw new Error('Expected an E2EI learn-more link to be rendered');
+  }
+
+  return learnMoreLink;
+}
 
 describe('E2EIVerificationMessage', () => {
   const conversation = new Conversation('', '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
@@ -53,6 +164,50 @@ describe('E2EIVerificationMessage', () => {
       const elementMessageVerification = getByTestId('element-message-verification');
       expect(elementMessageVerification.getAttribute('data-uie-value')).toEqual(E2EIVerificationMessageType.VERIFIED);
     });
+
+    it(
+      'preserves the legacy HTML translation when rendering is disabled',
+      withE2EIConfiguration(
+        withTranslationStrings(en, () => {
+          const message = createVerificationMessage({
+            messageType: E2EIVerificationMessageType.VERIFIED,
+          });
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <E2EIVerificationMessage message={message} conversation={createConversation()} />,
+              legacyRootProviderWrapper,
+            ),
+          );
+
+          expect(getLearnMoreLink(container)).toHaveTextContent('Learn more');
+        }),
+      ),
+    );
+
+    it(
+      'renders the learn-more link as React when rendering is enabled',
+      withE2EIConfiguration(
+        withTranslationStrings(en, () => {
+          const message = createVerificationMessage({
+            messageType: E2EIVerificationMessageType.VERIFIED,
+          });
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <E2EIVerificationMessage message={message} conversation={createConversation()} />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+
+          const learnMoreLink = getLearnMoreLink(container);
+          expect(learnMoreLink).toHaveTextContent('Learn more');
+          expect(learnMoreLink).toHaveAttribute('href', e2eiVerificationSupportUrl);
+          expect(learnMoreLink).toHaveAttribute('target', '_blank');
+          expect(learnMoreLink).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+        }),
+      ),
+    );
   });
 
   describe('with degraded message', () => {
@@ -129,5 +284,196 @@ describe('E2EIVerificationMessage', () => {
         E2EIVerificationMessageType.NO_LONGER_VERIFIED,
       );
     });
+
+    it.each([
+      E2EIVerificationMessageType.EXPIRED,
+      E2EIVerificationMessageType.NEW_DEVICE,
+      E2EIVerificationMessageType.NEW_MEMBER,
+    ])('renders the remote %s user name as React text when enabled', messageType => {
+      return withE2EIConfiguration(
+        withTranslationStrings(en, () => {
+          const remoteUser = createUser('R&D <Test>');
+          const message = createVerificationMessage({
+            messageType,
+            userIds: [remoteUser.qualifiedId],
+          });
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <E2EIVerificationMessage
+                message={message}
+                conversation={createConversation({participatingUser: remoteUser})}
+              />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+
+          const verificationMessageContent = getVerificationMessageContent(container);
+          expect(verificationMessageContent).toHaveTextContent('R&D <Test>');
+          expect(verificationMessageContent.querySelector('test')).toBeNull();
+          expect(verificationMessageContent.querySelector('strong')).toHaveTextContent('R&D <Test>');
+        }),
+      )();
+    });
+
+    it(
+      'renders the remote revoked message with a React learn-more link',
+      withE2EIConfiguration(
+        withTranslationStrings(en, () => {
+          const remoteUser = createUser('Alice');
+          const message = createVerificationMessage({
+            messageType: E2EIVerificationMessageType.REVOKED,
+            userIds: [remoteUser.qualifiedId],
+          });
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <E2EIVerificationMessage
+                message={message}
+                conversation={createConversation({participatingUser: remoteUser})}
+              />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+
+          const verificationMessageContent = getVerificationMessageContent(container);
+          const learnMoreLink = getLearnMoreLink(container);
+          expect(verificationMessageContent).toHaveTextContent('Alice');
+          expect(verificationMessageContent.querySelector('strong')).toHaveTextContent('Alice');
+          expect(learnMoreLink).toHaveTextContent('Learn more');
+          expect(learnMoreLink).toHaveAttribute('href', e2eiVerificationSupportUrl);
+        }),
+      ),
+    );
+
+    it(
+      'renders the self-user revoked message with a React learn-more link',
+      withE2EIConfiguration(
+        withTranslationStrings(en, () => {
+          const selfUser = createUser('Alice');
+          const message = createVerificationMessage({
+            messageType: E2EIVerificationMessageType.REVOKED,
+            userIds: [selfUser.qualifiedId],
+          });
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <E2EIVerificationMessage message={message} conversation={createConversation({selfUser})} />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+
+          expect(getLearnMoreLink(container)).toHaveTextContent('Learn more');
+        }),
+      ),
+    );
+
+    it(
+      'renders the generic no-longer-verified message with a React learn-more link',
+      withE2EIConfiguration(
+        withTranslationStrings(en, () => {
+          const message = createVerificationMessage({
+            messageType: E2EIVerificationMessageType.NO_LONGER_VERIFIED,
+          });
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <E2EIVerificationMessage message={message} conversation={createConversation()} />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+
+          expect(getLearnMoreLink(container)).toHaveTextContent('Learn more');
+        }),
+      ),
+    );
+
+    it(
+      'keeps a translation-looking remote user name literal',
+      withTranslationStrings(en, () => {
+        const remoteUser = createUser('[link]Alice[/link]');
+        const message = createVerificationMessage({
+          messageType: E2EIVerificationMessageType.EXPIRED,
+          userIds: [remoteUser.qualifiedId],
+        });
+
+        const {container} = render(
+          withThemeAndRootContext(
+            <E2EIVerificationMessage
+              message={message}
+              conversation={createConversation({participatingUser: remoteUser})}
+            />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+
+        const verificationMessageContent = getVerificationMessageContent(container);
+        expect(verificationMessageContent).toHaveTextContent('[link]Alice[/link]');
+        expect(verificationMessageContent.querySelectorAll('a')).toHaveLength(0);
+        expect(verificationMessageContent.querySelectorAll('strong')).toHaveLength(1);
+      }),
+    );
+
+    it(
+      'renders a moved remote user placeholder without formatting',
+      withTranslationStrings(
+        {
+          ...en,
+          'conversation.E2EICertificateExpired': 'Certificate expired for {user}.',
+        },
+        () => {
+          const remoteUser = createUser('Alice');
+          const message = createVerificationMessage({
+            messageType: E2EIVerificationMessageType.EXPIRED,
+            userIds: [remoteUser.qualifiedId],
+          });
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <E2EIVerificationMessage
+                message={message}
+                conversation={createConversation({participatingUser: remoteUser})}
+              />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+
+          const verificationMessageContent = getVerificationMessageContent(container);
+          expect(verificationMessageContent).toHaveTextContent('Certificate expired for Alice.');
+          expect(verificationMessageContent.querySelectorAll('strong')).toHaveLength(0);
+        },
+      ),
+    );
+
+    it(
+      'keeps unsupported translation markup as text',
+      withTranslationStrings(
+        {
+          ...en,
+          'conversation.E2EICertificateExpired': '<img src="example">Certificate expired for [bold]{user}[/bold].',
+        },
+        () => {
+          const remoteUser = createUser('Alice');
+          const message = createVerificationMessage({
+            messageType: E2EIVerificationMessageType.EXPIRED,
+            userIds: [remoteUser.qualifiedId],
+          });
+
+          const {container} = render(
+            withThemeAndRootContext(
+              <E2EIVerificationMessage
+                message={message}
+                conversation={createConversation({participatingUser: remoteUser})}
+              />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+
+          const verificationMessageContent = getVerificationMessageContent(container);
+          expect(verificationMessageContent).toHaveTextContent('<img src="example">Certificate expired for Alice.');
+          expect(verificationMessageContent.querySelector('img')).toBeNull();
+        },
+      ),
+    );
   });
 });

--- a/apps/webapp/src/script/components/messagesList/message/e2eiVerificationMessage/e2eiVerificationMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/e2eiVerificationMessage/e2eiVerificationMessage.tsx
@@ -19,6 +19,9 @@
 
 import type {ReactNode} from 'react';
 
+import type {QualifiedId} from '@wireapp/api-client/lib/user';
+import {Maybe} from 'true-myth';
+
 import {Link, LinkVariant, MLSVerified} from '@wireapp/react-ui-kit';
 
 import * as Icon from 'Components/icon';
@@ -68,10 +71,10 @@ interface E2EIVerificationMessageProps {
 
 type RenderE2EITranslationOptions = {
   readonly isReactTranslationRenderingEnabled: boolean;
-  readonly legacyDangerousSubstitutions: Record<string, string> | undefined;
+  readonly legacyDangerousSubstitutions: Maybe<Record<string, string>>;
   readonly translationKey: TranslationKey;
   readonly translate: Translate;
-  readonly userName: string | undefined;
+  readonly userName: Maybe<string>;
 };
 
 const e2eiUserMarker = createReactTranslationMarker('e2ei-user');
@@ -85,6 +88,17 @@ const e2eiReactDangerousSubstitutions = {
   link: e2eiLearnMoreLinkMarker.start,
 };
 
+const noE2EIUserName = Maybe.nothing<string>();
+const noE2EILegacyDangerousSubstitutions = Maybe.nothing<Record<string, string>>();
+
+function getSingleMessageUserId(userIds: readonly QualifiedId[]): Maybe<QualifiedId> {
+  if (userIds.length === 1) {
+    return Maybe.of(userIds[0]);
+  }
+
+  return Maybe.nothing();
+}
+
 function renderE2EITranslation(options: RenderE2EITranslationOptions): ReactNode {
   const {isReactTranslationRenderingEnabled, legacyDangerousSubstitutions, translationKey, translate, userName} =
     options;
@@ -93,12 +107,12 @@ function renderE2EITranslation(options: RenderE2EITranslationOptions): ReactNode
     let translatedText: string;
     let valueReplacements: ReactTranslationValueReplacement[];
 
-    if (userName === undefined) {
-      translatedText = translate(translationKey, undefined, e2eiReactDangerousSubstitutions);
+    if (userName.isNothing) {
+      translatedText = translate(translationKey, {}, e2eiReactDangerousSubstitutions);
       valueReplacements = [];
     } else {
       translatedText = translate(translationKey, {user: e2eiUserMarker.substitution}, e2eiReactDangerousSubstitutions);
-      valueReplacements = [{marker: e2eiUserMarker, runtimeText: userName}];
+      valueReplacements = [{marker: e2eiUserMarker, runtimeText: userName.value}];
     }
 
     return (
@@ -139,10 +153,16 @@ function renderE2EITranslation(options: RenderE2EITranslationOptions): ReactNode
   }
 
   let legacyTranslation: string;
-  if (userName === undefined) {
-    legacyTranslation = translate(translationKey, undefined, legacyDangerousSubstitutions);
+  if (userName.isJust) {
+    if (legacyDangerousSubstitutions.isNothing) {
+      legacyTranslation = translate(translationKey, {user: userName.value});
+    } else {
+      legacyTranslation = translate(translationKey, {user: userName.value}, legacyDangerousSubstitutions.value);
+    }
+  } else if (legacyDangerousSubstitutions.isNothing) {
+    legacyTranslation = translate(translationKey);
   } else {
-    legacyTranslation = translate(translationKey, {user: userName}, legacyDangerousSubstitutions);
+    legacyTranslation = translate(translationKey, {}, legacyDangerousSubstitutions.value);
   }
 
   return <span dangerouslySetInnerHTML={{__html: legacyTranslation}} />;
@@ -157,9 +177,14 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
     'selfUser',
   ]);
 
-  const messageUserId = userIds.length === 1 ? userIds[0] : undefined;
-  const isSelfUser =
-    messageUserId !== undefined && selfUser !== undefined && matchQualifiedIds(messageUserId, selfUser.qualifiedId);
+  const messageUserId = getSingleMessageUserId(userIds);
+  const isSelfUser = messageUserId
+    .andThen(messageUserId => {
+      return Maybe.of(selfUser).map(selfUser => {
+        return matchQualifiedIds(messageUserId, selfUser.qualifiedId);
+      });
+    })
+    .unwrapOr(false);
 
   const degradedUsers = participatingUserEts.filter(user =>
     userIds.find(userId => matchQualifiedIds(userId, user.qualifiedId)),
@@ -174,7 +199,7 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
   const isRevoked = messageType === E2EIVerificationMessageType.REVOKED;
   const isNoLongerVerified = messageType === E2EIVerificationMessageType.NO_LONGER_VERIFIED;
 
-  const learnMoreReplacement = replaceLink(Config.getConfig().URL.SUPPORT.E2EI_VERIFICATION);
+  const learnMoreReplacement = Maybe.just(replaceLink(Config.getConfig().URL.SUPPORT.E2EI_VERIFICATION));
   const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
 
   const getCertificate = async () => {
@@ -206,17 +231,17 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
             legacyDangerousSubstitutions: learnMoreReplacement,
             translationKey: 'conversation.AllE2EIDevicesVerified',
             translate,
-            userName: undefined,
+            userName: noE2EIUserName,
           })}
 
         {isExpired &&
           (isSelfUser === false ? (
             renderE2EITranslation({
               isReactTranslationRenderingEnabled,
-              legacyDangerousSubstitutions: undefined,
+              legacyDangerousSubstitutions: noE2EILegacyDangerousSubstitutions,
               translationKey: 'conversation.E2EICertificateExpired',
               translate,
-              userName: usersName,
+              userName: Maybe.of(usersName),
             })
           ) : (
             <span>
@@ -234,10 +259,10 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
           (isSelfUser === false ? (
             renderE2EITranslation({
               isReactTranslationRenderingEnabled,
-              legacyDangerousSubstitutions: undefined,
+              legacyDangerousSubstitutions: noE2EILegacyDangerousSubstitutions,
               translationKey: 'conversation.E2EINewDeviceAdded',
               translate,
-              userName: usersName,
+              userName: Maybe.of(usersName),
             })
           ) : (
             <span>
@@ -255,10 +280,10 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
           (isSelfUser === false ? (
             renderE2EITranslation({
               isReactTranslationRenderingEnabled,
-              legacyDangerousSubstitutions: undefined,
+              legacyDangerousSubstitutions: noE2EILegacyDangerousSubstitutions,
               translationKey: 'conversation.E2EINewUserAdded',
               translate,
-              userName: usersName,
+              userName: Maybe.of(usersName),
             })
           ) : (
             <span>
@@ -279,14 +304,14 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
                 legacyDangerousSubstitutions: learnMoreReplacement,
                 translationKey: 'conversation.E2EICertificateRevoked',
                 translate,
-                userName: usersName,
+                userName: Maybe.of(usersName),
               })
             : renderE2EITranslation({
                 isReactTranslationRenderingEnabled,
                 legacyDangerousSubstitutions: learnMoreReplacement,
                 translationKey: 'conversation.E2EISelfUserCertificateRevoked',
                 translate,
-                userName: undefined,
+                userName: noE2EIUserName,
               }))}
 
         {isNoLongerVerified &&
@@ -295,7 +320,7 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
             legacyDangerousSubstitutions: learnMoreReplacement,
             translationKey: 'conversation.E2EICertificateNoLongerVerifiedGeneric',
             translate,
-            userName: undefined,
+            userName: noE2EIUserName,
           })}
       </div>
     </div>

--- a/apps/webapp/src/script/components/messagesList/message/e2eiVerificationMessage/e2eiVerificationMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/e2eiVerificationMessage/e2eiVerificationMessage.tsx
@@ -17,14 +17,21 @@
  *
  */
 
+import type {ReactNode} from 'react';
+
 import {Link, LinkVariant, MLSVerified} from '@wireapp/react-ui-kit';
 
 import * as Icon from 'Components/icon';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {E2EIVerificationMessage as E2EIVerificationMessageEntity} from 'Repositories/entity/message/e2eiVerificationMessage';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {replaceLink} from 'Util/localizerUtil';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {ReactTranslationValueReplacement} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {TranslationKey} from 'Util/localizerUtil/translationTypes';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 import {getLogger} from 'Util/logger';
 import {matchQualifiedIds} from 'Util/qualifiedId';
 
@@ -59,8 +66,90 @@ interface E2EIVerificationMessageProps {
   conversation: Conversation;
 }
 
+type RenderE2EITranslationOptions = {
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly legacyDangerousSubstitutions: Record<string, string> | undefined;
+  readonly translationKey: TranslationKey;
+  readonly translate: Translate;
+  readonly userName: string | undefined;
+};
+
+const e2eiUserMarker = createReactTranslationMarker('e2ei-user');
+const e2eiBoldMarker = createReactTranslationMarker('e2ei-bold');
+const e2eiLearnMoreLinkMarker = createReactTranslationMarker('e2ei-learn-more-link');
+
+const e2eiReactDangerousSubstitutions = {
+  '/bold': e2eiBoldMarker.end,
+  '/link': e2eiLearnMoreLinkMarker.end,
+  bold: e2eiBoldMarker.start,
+  link: e2eiLearnMoreLinkMarker.start,
+};
+
+function renderE2EITranslation(options: RenderE2EITranslationOptions): ReactNode {
+  const {isReactTranslationRenderingEnabled, legacyDangerousSubstitutions, translationKey, translate, userName} =
+    options;
+
+  if (isReactTranslationRenderingEnabled) {
+    let translatedText: string;
+    let valueReplacements: ReactTranslationValueReplacement[];
+
+    if (userName === undefined) {
+      translatedText = translate(translationKey, undefined, e2eiReactDangerousSubstitutions);
+      valueReplacements = [];
+    } else {
+      translatedText = translate(translationKey, {user: e2eiUserMarker.substitution}, e2eiReactDangerousSubstitutions);
+      valueReplacements = [{marker: e2eiUserMarker, runtimeText: userName}];
+    }
+
+    return (
+      <span>
+        {renderReactTranslation({
+          translatedText,
+          componentReplacements: [
+            {
+              start: e2eiBoldMarker.start,
+              end: e2eiBoldMarker.end,
+              render(children): ReactNode {
+                return <strong>{children}</strong>;
+              },
+            },
+            {
+              start: e2eiLearnMoreLinkMarker.start,
+              end: e2eiLearnMoreLinkMarker.end,
+              render(children): ReactNode {
+                return (
+                  <a
+                    href={Config.getConfig().URL.SUPPORT.E2EI_VERIFICATION}
+                    className=""
+                    data-uie-name=""
+                    rel="nofollow noopener noreferrer"
+                    target="_blank"
+                  >
+                    {children}
+                  </a>
+                );
+              },
+            },
+          ],
+          nodeReplacements: [],
+          valueReplacements,
+        })}
+      </span>
+    );
+  }
+
+  let legacyTranslation: string;
+  if (userName === undefined) {
+    legacyTranslation = translate(translationKey, undefined, legacyDangerousSubstitutions);
+  } else {
+    legacyTranslation = translate(translationKey, {user: userName}, legacyDangerousSubstitutions);
+  }
+
+  return <span dangerouslySetInnerHTML={{__html: legacyTranslation}} />;
+}
+
 export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificationMessageProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
   const {messageType, userIds = []} = message;
 
   const {participating_user_ets: participatingUserEts, selfUser} = useKoSubscribableChildren(conversation, [
@@ -86,6 +175,7 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
   const isNoLongerVerified = messageType === E2EIVerificationMessageType.NO_LONGER_VERIFIED;
 
   const learnMoreReplacement = replaceLink(Config.getConfig().URL.SUPPORT.E2EI_VERIFICATION);
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
 
   const getCertificate = async () => {
     try {
@@ -110,21 +200,24 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
         data-uie-name="element-message-verification"
         data-uie-value={messageType}
       >
-        {isVerified && (
-          <span
-            dangerouslySetInnerHTML={{
-              __html: translate('conversation.AllE2EIDevicesVerified', undefined, learnMoreReplacement),
-            }}
-          />
-        )}
+        {isVerified &&
+          renderE2EITranslation({
+            isReactTranslationRenderingEnabled,
+            legacyDangerousSubstitutions: learnMoreReplacement,
+            translationKey: 'conversation.AllE2EIDevicesVerified',
+            translate,
+            userName: undefined,
+          })}
 
         {isExpired &&
           (isSelfUser === false ? (
-            <span
-              dangerouslySetInnerHTML={{
-                __html: translate('conversation.E2EICertificateExpired', {user: usersName}),
-              }}
-            />
+            renderE2EITranslation({
+              isReactTranslationRenderingEnabled,
+              legacyDangerousSubstitutions: undefined,
+              translationKey: 'conversation.E2EICertificateExpired',
+              translate,
+              userName: usersName,
+            })
           ) : (
             <span>
               {translate('conversation.E2EISelfUserCertificateExpired')}
@@ -139,11 +232,13 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
 
         {isNewDevice &&
           (isSelfUser === false ? (
-            <span
-              dangerouslySetInnerHTML={{
-                __html: translate('conversation.E2EINewDeviceAdded', {user: usersName}),
-              }}
-            />
+            renderE2EITranslation({
+              isReactTranslationRenderingEnabled,
+              legacyDangerousSubstitutions: undefined,
+              translationKey: 'conversation.E2EINewDeviceAdded',
+              translate,
+              userName: usersName,
+            })
           ) : (
             <span>
               {translate('conversation.E2EISelfUserUnverifiedDeviceAdded')}
@@ -158,11 +253,13 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
 
         {isNewMember &&
           (isSelfUser === false ? (
-            <span
-              dangerouslySetInnerHTML={{
-                __html: translate('conversation.E2EINewUserAdded', {user: usersName}),
-              }}
-            />
+            renderE2EITranslation({
+              isReactTranslationRenderingEnabled,
+              legacyDangerousSubstitutions: undefined,
+              translationKey: 'conversation.E2EINewUserAdded',
+              translate,
+              userName: usersName,
+            })
           ) : (
             <span>
               {translate('conversation.E2EISelfUserUnverifiedUserAdded')}
@@ -176,27 +273,30 @@ export const E2EIVerificationMessage = ({message, conversation}: E2EIVerificatio
           ))}
 
         {isRevoked &&
-          (isSelfUser === false ? (
-            <span
-              dangerouslySetInnerHTML={{
-                __html: translate('conversation.E2EICertificateRevoked', {user: usersName}, learnMoreReplacement),
-              }}
-            />
-          ) : (
-            <span
-              dangerouslySetInnerHTML={{
-                __html: translate('conversation.E2EISelfUserCertificateRevoked', undefined, learnMoreReplacement),
-              }}
-            />
-          ))}
+          (isSelfUser === false
+            ? renderE2EITranslation({
+                isReactTranslationRenderingEnabled,
+                legacyDangerousSubstitutions: learnMoreReplacement,
+                translationKey: 'conversation.E2EICertificateRevoked',
+                translate,
+                userName: usersName,
+              })
+            : renderE2EITranslation({
+                isReactTranslationRenderingEnabled,
+                legacyDangerousSubstitutions: learnMoreReplacement,
+                translationKey: 'conversation.E2EISelfUserCertificateRevoked',
+                translate,
+                userName: undefined,
+              }))}
 
-        {isNoLongerVerified && (
-          <span
-            dangerouslySetInnerHTML={{
-              __html: translate('conversation.E2EICertificateNoLongerVerifiedGeneric', undefined, learnMoreReplacement),
-            }}
-          />
-        )}
+        {isNoLongerVerified &&
+          renderE2EITranslation({
+            isReactTranslationRenderingEnabled,
+            legacyDangerousSubstitutions: learnMoreReplacement,
+            translationKey: 'conversation.E2EICertificateNoLongerVerifiedGeneric',
+            translate,
+            userName: undefined,
+          })}
       </div>
     </div>
   );

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/conversationTabs.test.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/conversationTabs.test.tsx
@@ -1,0 +1,209 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ko from 'knockout';
+
+import {ConversationRepository} from 'Repositories/conversation/ConversationRepository';
+import {ConversationLabelRepository} from 'Repositories/conversation/ConversationLabelRepository';
+import {User} from 'Repositories/entity/User';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import * as DataDog from 'Util/dataDog';
+import * as Environment from 'Util/environment';
+import {setStrings, translate} from 'Util/localizerUtil';
+
+import en from 'I18n/en-US.json';
+
+import {ConversationTabs} from './conversationTabs';
+import {SidebarTabs} from '../useSidebarStore';
+
+const internalEnvironmentUrl = 'https://app.wire.com';
+const conversationRepository = {
+  conversationLabelRepository: {
+    getLabelConversations: jest.fn().mockReturnValue([]),
+    labels: ko.observableArray([]),
+  } as unknown as ConversationLabelRepository,
+} as unknown as ConversationRepository;
+const legacyRootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName): boolean {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
+
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
+
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
+}
+
+function withInternalEnvironment(testFunction: TranslationTestFunction): IsolatedTranslationTestFunction {
+  return async function runInternalEnvironmentTest(): Promise<void> {
+    const environmentSpy = jest.spyOn(Environment, 'getWebEnvironment').mockReturnValue({
+      isDev: false,
+      isEdge: false,
+      isInternal: true,
+      isLinked: false,
+      isLocalhost: false,
+      isProduction: false,
+      isStaging: false,
+      name: 'Internal Environment',
+    });
+    const dataDogSpy = jest.spyOn(DataDog, 'isDataDogEnabled').mockReturnValue(true);
+
+    try {
+      await testFunction();
+    } finally {
+      environmentSpy.mockRestore();
+      dataDogSpy.mockRestore();
+    }
+  };
+}
+
+function renderConversationTabs(
+  rootProviderWrapper: ReturnType<typeof createRootProviderWrapperForTest>,
+): ReturnType<typeof render> {
+  return render(
+    <div id="wire-app">
+      {withThemeAndRootContext(
+        <ConversationTabs
+          unreadConversations={[]}
+          favoriteConversations={[]}
+          archivedConversations={[]}
+          groupConversations={[]}
+          directConversations={[]}
+          channelConversations={[]}
+          draftConversations={[]}
+          conversationRepository={conversationRepository}
+          onChangeTab={jest.fn()}
+          currentTab={SidebarTabs.RECENT}
+          onClickPreferences={jest.fn()}
+          showNotificationsBadge={false}
+          selfUser={new User('self-user', '', translate)}
+        />,
+        rootProviderWrapper,
+      )}
+    </div>,
+  );
+}
+
+describe('ConversationTabs', () => {
+  it(
+    'keeps the legacy environment disclaimer rendering when React translation rendering is disabled',
+    withInternalEnvironment(
+      withTranslationStrings(en, () => {
+        const {container, getByRole} = renderConversationTabs(legacyRootProviderWrapper);
+        const disclaimerLink = container.querySelector(`a[href="${internalEnvironmentUrl}"]`);
+
+        expect(disclaimerLink).toHaveTextContent(internalEnvironmentUrl);
+        expect(disclaimerLink).toHaveAttribute('target', '_blank');
+        expect(disclaimerLink).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+        expect(getByRole('presentation')).toBeInTheDocument();
+      }),
+    ),
+  );
+
+  it(
+    'renders the environment disclaimer link as React content in the tooltip and footer',
+    withInternalEnvironment(
+      withTranslationStrings(en, async () => {
+        const {container, getByRole} = renderConversationTabs(reactTranslationRenderingRootProviderWrapper);
+        const disclaimerLink = container.querySelector(`a[href="${internalEnvironmentUrl}"]`);
+        const user = userEvent.setup();
+
+        expect(disclaimerLink).toHaveTextContent(internalEnvironmentUrl);
+        expect(disclaimerLink).toHaveAttribute('target', '_blank');
+        expect(disclaimerLink).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+
+        await user.hover(getByRole('presentation'));
+
+        const tooltipContent = document.querySelector('[data-testid="tooltip-content"]');
+        const tooltipLink = tooltipContent?.querySelector(`a[href="${internalEnvironmentUrl}"]`);
+        expect(tooltipLink).toHaveTextContent(internalEnvironmentUrl);
+        expect(tooltipLink).toHaveAttribute('target', '_blank');
+        expect(tooltipLink).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+      }),
+    ),
+  );
+
+  it(
+    'keeps translated link and URL positions controlled by the translation',
+    withInternalEnvironment(
+      withTranslationStrings(
+        {
+          ...en,
+          conversationInternalEnvironmentDisclaimer: 'Open [link]{url}[/link] instead.',
+        },
+        async () => {
+          const {container, getByRole} = renderConversationTabs(reactTranslationRenderingRootProviderWrapper);
+          const disclaimerLink = container.querySelector(`a[href="${internalEnvironmentUrl}"]`);
+          const user = userEvent.setup();
+
+          expect(container).toHaveTextContent(`Open ${internalEnvironmentUrl} instead.`);
+          expect(disclaimerLink).toHaveTextContent(internalEnvironmentUrl);
+
+          await user.hover(getByRole('presentation'));
+
+          const tooltipContent = document.querySelector('[data-testid="tooltip-content"]');
+          const tooltipLink = tooltipContent?.querySelector(`a[href="${internalEnvironmentUrl}"]`);
+          expect(tooltipLink).toHaveTextContent(internalEnvironmentUrl);
+        },
+      ),
+    ),
+  );
+
+  it(
+    'keeps unsupported translated markup as text when React translation rendering is enabled',
+    withInternalEnvironment(
+      withTranslationStrings(
+        {
+          ...en,
+          conversationInternalEnvironmentDisclaimer: '<img src="example"> [link]{url}[/link]',
+        },
+        async () => {
+          const {container} = renderConversationTabs(reactTranslationRenderingRootProviderWrapper);
+
+          expect(container).toHaveTextContent(`<img src="example"> ${internalEnvironmentUrl}`);
+          expect(container.querySelector('img')).toBeNull();
+        },
+      ),
+    ),
+  );
+});

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/conversationTabs.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/conversationTabs.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import type {ReactNode} from 'react';
+
 import {container} from 'tsyringe';
 
 import {
@@ -39,6 +41,7 @@ import {User} from 'Repositories/entity/User';
 import {TeamState} from 'Repositories/team/TeamState';
 import {FEATURES, hasAccessToFeature} from 'Repositories/user/userPermission';
 import {getManageTeamUrl} from 'src/script/externalRoute';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {ConversationFolderTab} from 'src/script/page/leftSidebar/panels/conversations/conversationTab/conversationFolderTab';
 import {
   isTabVisible,
@@ -51,6 +54,8 @@ import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {isDataDogEnabled} from 'Util/dataDog';
 import {getWebEnvironment} from 'Util/environment';
 import {replaceLink} from 'Util/localizerUtil';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 import {useChannelsFeatureFlag} from 'Util/useChannelsFeatureFlag';
 import {useMeetingsFeatureFlag} from 'Util/useMeetingsFeatureFlag';
 
@@ -71,6 +76,121 @@ import {ContentState} from '../../../../useAppState';
 import {ConversationTab} from '../conversationTab';
 import {conversationFilters} from '../helpers';
 import {TabAndFilterSettings} from '../tabAndFilterSettings';
+
+const wireCloudUrl = 'https://app.wire.com';
+const environmentDisclaimerUrlMarker = createReactTranslationMarker('environment-disclaimer-url');
+const environmentDisclaimerLinkMarker = createReactTranslationMarker('environment-disclaimer-link');
+
+type RenderEnvironmentDisclaimerOptions = {
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly translate: Translate;
+};
+
+type RenderedEnvironmentDisclaimer =
+  | {
+      readonly kind: 'react';
+      readonly content: ReactNode[];
+    }
+  | {
+      readonly kind: 'legacy';
+      readonly html: string;
+    };
+
+function renderEnvironmentDisclaimer(options: RenderEnvironmentDisclaimerOptions): RenderedEnvironmentDisclaimer {
+  const {isReactTranslationRenderingEnabled, translate} = options;
+
+  if (isReactTranslationRenderingEnabled) {
+    const translatedText = translate(
+      'conversationInternalEnvironmentDisclaimer',
+      {url: environmentDisclaimerUrlMarker.substitution},
+      {
+        '/link': environmentDisclaimerLinkMarker.end,
+        link: environmentDisclaimerLinkMarker.start,
+      },
+    );
+
+    return {
+      kind: 'react',
+      content: renderReactTranslation({
+        translatedText,
+        componentReplacements: [
+          {
+            start: environmentDisclaimerLinkMarker.start,
+            end: environmentDisclaimerLinkMarker.end,
+            render(children): ReactNode {
+              return (
+                <a href={wireCloudUrl} data-uie-name="" className="" rel="nofollow noopener noreferrer" target="_blank">
+                  {children}
+                </a>
+              );
+            },
+          },
+        ],
+        nodeReplacements: [],
+        valueReplacements: [
+          {
+            marker: environmentDisclaimerUrlMarker,
+            runtimeText: wireCloudUrl,
+          },
+        ],
+      }),
+    };
+  }
+
+  const replaceWireLink = replaceLink(wireCloudUrl, '', '');
+  const translatedText = translate('conversationInternalEnvironmentDisclaimer', {url: wireCloudUrl}, replaceWireLink);
+
+  return {
+    kind: 'legacy',
+    html: translatedText,
+  };
+}
+
+function renderEnvironmentDisclaimerTooltipBody(environmentDisclaimer: RenderedEnvironmentDisclaimer): ReactNode {
+  if (environmentDisclaimer.kind === 'react') {
+    return <div>{environmentDisclaimer.content}</div>;
+  }
+
+  return (
+    <div
+      dangerouslySetInnerHTML={{
+        __html: environmentDisclaimer.html,
+      }}
+    />
+  );
+}
+
+function renderEnvironmentDisclaimerFooterContent(environmentDisclaimer: RenderedEnvironmentDisclaimer): ReactNode {
+  if (environmentDisclaimer.kind === 'react') {
+    return <div css={footerDisclaimerEllipsis}>{environmentDisclaimer.content}</div>;
+  }
+
+  return (
+    <div
+      css={footerDisclaimerEllipsis}
+      dangerouslySetInnerHTML={{
+        __html: environmentDisclaimer.html,
+      }}
+    />
+  );
+}
+
+function renderEnvironmentDisclaimerSection(options: RenderEnvironmentDisclaimerOptions): ReactNode {
+  const renderedEnvironmentDisclaimer = renderEnvironmentDisclaimer(options);
+
+  return (
+    <div css={footerDisclaimer}>
+      <Tooltip
+        css={footerDisclaimerTooltip}
+        body={renderEnvironmentDisclaimerTooltipBody(renderedEnvironmentDisclaimer)}
+      >
+        <Icon.ExclamationMark css={iconStyle} />
+      </Tooltip>
+
+      {renderEnvironmentDisclaimerFooterContent(renderedEnvironmentDisclaimer)}
+    </div>
+  );
+}
 
 interface ConversationTabsProps {
   unreadConversations: Conversation[];
@@ -103,7 +223,7 @@ export const ConversationTabs = ({
   selfUser,
   channelConversations,
 }: ConversationTabsProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
   const {visibleTabs} = useSidebarStore();
   const {isChannelsEnabled, shouldShowChannelTab} = useChannelsFeatureFlag();
   const core = container.resolve(Core);
@@ -244,7 +364,7 @@ export const ConversationTabs = ({
   const visibleConversationTabs = conversationTabs.filter(tab => isTabVisible(tab.type, visibleTabs));
 
   const manageTeamUrl = getManageTeamUrl();
-  const replaceWireLink = replaceLink('https://app.wire.com', '', '');
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
 
   const showCellsTab = Config.getConfig().FEATURE.ENABLE_CELLS && isCellsEnabledForTeam;
   const connectTabIndex = visibleConversationTabs.length + 1;
@@ -353,37 +473,9 @@ export const ConversationTabs = ({
       >
         {isTeamCreationEnabled && !teamState.isInTeam(selfUser) && <TeamCreationBanner />}
 
-        {!getWebEnvironment().isProduction && isDataDogEnabled() && (
-          <div css={footerDisclaimer}>
-            <Tooltip
-              css={footerDisclaimerTooltip}
-              body={
-                <div
-                  dangerouslySetInnerHTML={{
-                    __html: translate(
-                      'conversationInternalEnvironmentDisclaimer',
-                      {url: 'https://app.wire.com'},
-                      replaceWireLink,
-                    ),
-                  }}
-                />
-              }
-            >
-              <Icon.ExclamationMark css={iconStyle} />
-            </Tooltip>
-
-            <div
-              css={footerDisclaimerEllipsis}
-              dangerouslySetInnerHTML={{
-                __html: translate(
-                  'conversationInternalEnvironmentDisclaimer',
-                  {url: 'https://app.wire.com'},
-                  replaceWireLink,
-                ),
-              }}
-            />
-          </div>
-        )}
+        {!getWebEnvironment().isProduction &&
+          isDataDogEnabled() &&
+          renderEnvironmentDisclaimerSection({isReactTranslationRenderingEnabled, translate})}
 
         <SettingsTab
           settingsLabel={translate('preferencesHeadline')}

--- a/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/conversationTabs.tsx
+++ b/apps/webapp/src/script/page/leftSidebar/panels/conversations/conversationTabs/conversationTabs.tsx
@@ -192,6 +192,21 @@ function renderEnvironmentDisclaimerSection(options: RenderEnvironmentDisclaimer
   );
 }
 
+function renderEnvironmentDisclaimerIfNeeded(options: RenderEnvironmentDisclaimerOptions): ReactNode {
+  const {isReactTranslationRenderingEnabled, translate} = options;
+  const webEnvironment = getWebEnvironment();
+
+  if (webEnvironment.isProduction) {
+    return null;
+  }
+
+  if (isDataDogEnabled() === false) {
+    return null;
+  }
+
+  return renderEnvironmentDisclaimerSection({isReactTranslationRenderingEnabled, translate});
+}
+
 interface ConversationTabsProps {
   unreadConversations: Conversation[];
   favoriteConversations: Conversation[];
@@ -473,9 +488,7 @@ export const ConversationTabs = ({
       >
         {isTeamCreationEnabled && !teamState.isInTeam(selfUser) && <TeamCreationBanner />}
 
-        {!getWebEnvironment().isProduction &&
-          isDataDogEnabled() &&
-          renderEnvironmentDisclaimerSection({isReactTranslationRenderingEnabled, translate})}
+        {renderEnvironmentDisclaimerIfNeeded({isReactTranslationRenderingEnabled, translate})}
 
         <SettingsTab
           settingsLabel={translate('preferencesHeadline')}

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/avPreferences/cameraPreferences.test.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/avPreferences/cameraPreferences.test.tsx
@@ -1,0 +1,224 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {render} from '@testing-library/react';
+
+import {Config} from 'src/script/Config';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {setStrings, translate} from 'Util/localizerUtil';
+
+import type {MediaStreamHandler} from 'Repositories/media/MediaStreamHandler';
+
+import en from 'I18n/en-US.json';
+
+import {CameraPreferences} from './cameraPreferences';
+
+const legacyRootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName): boolean {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+const cameraAccessDeniedUrl = 'https://support.example/camera-access-denied';
+
+type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
+type CameraConfigurationOptions = {
+  readonly brandName?: string;
+};
+
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
+
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
+}
+
+function withCameraConfiguration(
+  options: CameraConfigurationOptions,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runCameraTest(): Promise<void> {
+    const originalConfig = Config.getConfig();
+    const {brandName = originalConfig.BRAND_NAME} = options;
+    const configWithTestValues = {
+      ...originalConfig,
+      BRAND_NAME: brandName,
+      URL: {
+        ...originalConfig.URL,
+        SUPPORT: {
+          ...originalConfig.URL.SUPPORT,
+          CAMERA_ACCESS_DENIED: cameraAccessDeniedUrl,
+        },
+      },
+    };
+    const configSpy = jest.spyOn(Config, 'getConfig').mockReturnValue(configWithTestValues);
+
+    try {
+      await testFunction();
+    } finally {
+      configSpy.mockRestore();
+    }
+  };
+}
+
+function createStreamHandlerForTest(): MediaStreamHandler {
+  return {
+    requestMediaStream: jest.fn().mockResolvedValue(undefined),
+    releaseTracksFromStream: jest.fn(),
+  } as unknown as MediaStreamHandler;
+}
+
+function renderCameraPreferences(
+  rootProviderWrapper: ReturnType<typeof createRootProviderWrapperForTest>,
+): ReturnType<typeof render> {
+  return render(
+    withThemeAndRootContext(
+      <CameraPreferences
+        hasActiveCameraStream={false}
+        refreshStream={jest.fn().mockResolvedValue(undefined)}
+        streamHandler={createStreamHandlerForTest()}
+      />,
+      rootProviderWrapper,
+    ),
+  );
+}
+
+describe('CameraPreferences', () => {
+  it(
+    'keeps the legacy no-camera translation rendering when React translation rendering is disabled',
+    withCameraConfiguration(
+      {},
+      withTranslationStrings(en, () => {
+        const {container} = renderCameraPreferences(legacyRootProviderWrapper);
+        const noCameraMessage = container.querySelector('.preferences-av-video-disabled__info');
+        const faqLink = noCameraMessage?.querySelector('a');
+
+        expect(noCameraMessage).toHaveTextContent('doesn’t have access to the camera.');
+        expect(noCameraMessage?.querySelectorAll('br')).toHaveLength(1);
+        expect(faqLink).toHaveTextContent('Read this support article');
+        expect(faqLink).toHaveAttribute('href', cameraAccessDeniedUrl);
+        expect(faqLink).toHaveAttribute('target', '_blank');
+        expect(faqLink).toHaveAttribute('rel', 'noopener noreferrer');
+        expect(faqLink).toHaveAttribute('data-uie-name', 'go-no-camera-faq');
+      }),
+    ),
+  );
+
+  it(
+    'renders the FAQ link and line break as React nodes when enabled',
+    withCameraConfiguration(
+      {},
+      withTranslationStrings(en, () => {
+        const {container} = renderCameraPreferences(reactTranslationRenderingRootProviderWrapper);
+        const noCameraMessage = container.querySelector('.preferences-av-video-disabled__info');
+        const faqLink = noCameraMessage?.querySelector('a');
+
+        expect(noCameraMessage).toHaveTextContent('doesn’t have access to the camera.');
+        expect(noCameraMessage?.querySelectorAll('br')).toHaveLength(1);
+        expect(faqLink).toHaveTextContent('Read this support article');
+        expect(faqLink).toHaveAttribute('href', cameraAccessDeniedUrl);
+        expect(faqLink).toHaveAttribute('target', '_blank');
+        expect(faqLink).toHaveAttribute('rel', 'noopener noreferrer');
+        expect(faqLink).toHaveAttribute('data-uie-name', 'go-no-camera-faq');
+      }),
+    ),
+  );
+
+  it(
+    'follows translated FAQ link and brand-name positions while keeping the brand name literal',
+    withCameraConfiguration(
+      {brandName: 'R&D <Test>'},
+      withTranslationStrings(
+        {
+          ...en,
+          preferencesAVNoCamera: 'Need help? [faqLink]Camera troubleshooting[/faqLink][br]{brandName}',
+        },
+        () => {
+          const {container} = renderCameraPreferences(reactTranslationRenderingRootProviderWrapper);
+          const noCameraMessage = container.querySelector('.preferences-av-video-disabled__info');
+          const faqLink = noCameraMessage?.querySelector('a');
+
+          expect(noCameraMessage?.textContent).toBe('Need help? Camera troubleshootingR&D <Test>');
+          expect(faqLink).toHaveTextContent('Camera troubleshooting');
+          expect(noCameraMessage?.querySelectorAll('br')).toHaveLength(1);
+          expect(container.querySelector('test')).toBeNull();
+        },
+      ),
+    ),
+  );
+
+  it(
+    'keeps a translation-looking brand name literal instead of creating another link',
+    withCameraConfiguration(
+      {brandName: '[faqLink]Wire[/faqLink]'},
+      withTranslationStrings(
+        {
+          ...en,
+          preferencesAVNoCamera: '{brandName}[br][faqLink]Read this support article[/faqLink]',
+        },
+        () => {
+          const {container} = renderCameraPreferences(reactTranslationRenderingRootProviderWrapper);
+          const noCameraMessage = container.querySelector('.preferences-av-video-disabled__info');
+
+          expect(noCameraMessage?.textContent).toBe('[faqLink]Wire[/faqLink]Read this support article');
+          expect(noCameraMessage?.querySelectorAll('a')).toHaveLength(1);
+          expect(noCameraMessage?.querySelector('a')).toHaveTextContent('Read this support article');
+        },
+      ),
+    ),
+  );
+
+  it(
+    'keeps unsupported translation markup as text when enabled',
+    withCameraConfiguration(
+      {},
+      withTranslationStrings(
+        {
+          ...en,
+          preferencesAVNoCamera: '<img src="example">[br][faqLink]Read this support article[/faqLink]',
+        },
+        () => {
+          const {container} = renderCameraPreferences(reactTranslationRenderingRootProviderWrapper);
+          const noCameraMessage = container.querySelector('.preferences-av-video-disabled__info');
+
+          expect(noCameraMessage).toHaveTextContent('<img src="example">Read this support article');
+          expect(noCameraMessage?.querySelector('img')).toBeNull();
+          expect(noCameraMessage?.querySelectorAll('br')).toHaveLength(1);
+        },
+      ),
+    ),
+  );
+});

--- a/apps/webapp/src/script/page/mainContent/panels/preferences/avPreferences/cameraPreferences.tsx
+++ b/apps/webapp/src/script/page/mainContent/panels/preferences/avPreferences/cameraPreferences.tsx
@@ -18,6 +18,7 @@
  */
 
 import {memo, useCallback, useEffect, useRef, useState} from 'react';
+import type {ReactNode} from 'react';
 
 import {useDebouncedCallback} from 'use-debounce';
 
@@ -25,7 +26,10 @@ import * as Icon from 'Components/icon';
 import {MediaStreamHandler} from 'Repositories/media/MediaStreamHandler';
 import {MediaType} from 'Repositories/media/MediaType';
 import {useMediaDevicesStore} from 'Repositories/media/useMediaDevicesStore';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 import {getLogger} from 'Util/logger';
 
 import {DeviceSelect} from './deviceSelect';
@@ -43,8 +47,90 @@ interface CameraPreferencesProps {
 
 const DEBOUNCE_TIMEOUT = 100;
 
+const cameraBrandNameMarker = createReactTranslationMarker('camera-brand-name');
+const cameraLineBreakMarker = createReactTranslationMarker('camera-line-break');
+const cameraFaqLinkMarker = createReactTranslationMarker('camera-faq-link');
+
+type RenderNoCameraMessageOptions = {
+  readonly brandName: string;
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly translate: Translate;
+};
+
+function renderNoCameraMessage(options: RenderNoCameraMessageOptions): ReactNode {
+  const {brandName, isReactTranslationRenderingEnabled, translate} = options;
+
+  if (isReactTranslationRenderingEnabled) {
+    const translatedText = translate(
+      'preferencesAVNoCamera',
+      {brandName: cameraBrandNameMarker.substitution},
+      {
+        '/faqLink': cameraFaqLinkMarker.end,
+        br: cameraLineBreakMarker.substitution,
+        faqLink: cameraFaqLinkMarker.start,
+      },
+    );
+
+    return (
+      <div className="preferences-av-video-disabled__info">
+        {renderReactTranslation({
+          translatedText,
+          componentReplacements: [
+            {
+              start: cameraFaqLinkMarker.start,
+              end: cameraFaqLinkMarker.end,
+              render(children): ReactNode {
+                return (
+                  <a
+                    href={Config.getConfig().URL.SUPPORT.CAMERA_ACCESS_DENIED}
+                    data-uie-name="go-no-camera-faq"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {children}
+                  </a>
+                );
+              },
+            },
+          ],
+          nodeReplacements: [
+            {
+              marker: cameraLineBreakMarker,
+              render(): ReactNode {
+                return <br />;
+              },
+            },
+          ],
+          valueReplacements: [{marker: cameraBrandNameMarker, runtimeText: brandName}],
+        })}
+      </div>
+    );
+  }
+
+  const legacyTranslatedText = translate(
+    'preferencesAVNoCamera',
+    {brandName},
+    {
+      '/faqLink': '</a>',
+      br: '<br>',
+      faqLink: `<a href='${
+        Config.getConfig().URL.SUPPORT.CAMERA_ACCESS_DENIED
+      }' data-uie-name='go-no-camera-faq' target='_blank' rel='noopener noreferrer'>`,
+    },
+  );
+
+  return (
+    <div
+      className="preferences-av-video-disabled__info"
+      dangerouslySetInnerHTML={{
+        __html: legacyTranslatedText,
+      }}
+    />
+  );
+}
+
 const CameraPreferencesComponent = ({streamHandler, refreshStream, hasActiveCameraStream}: CameraPreferencesProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
   const [isRequesting, setIsRequesting] = useState(false);
   const [stream, setStream] = useState<MediaStream | null>(null);
   const videoElement = useRef<HTMLVideoElement>(null);
@@ -56,6 +142,7 @@ const CameraPreferencesComponent = ({streamHandler, refreshStream, hasActiveCame
   }));
 
   const {URL: urls, BRAND_NAME: brandName} = Config.getConfig();
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
 
   const requestStream = useCallback(async () => {
     setIsRequesting(true);
@@ -150,22 +237,7 @@ const CameraPreferencesComponent = ({streamHandler, refreshStream, hasActiveCame
             <video className="preferences-av-video mirror" autoPlay playsInline muted ref={videoElement} />
           ) : (
             <div className="preferences-av-video-disabled">
-              <div
-                className="preferences-av-video-disabled__info"
-                dangerouslySetInnerHTML={{
-                  __html: translate(
-                    'preferencesAVNoCamera',
-                    {brandName},
-                    {
-                      '/faqLink': '</a>',
-                      br: '<br>',
-                      faqLink: `<a href='${
-                        Config.getConfig().URL.SUPPORT.CAMERA_ACCESS_DENIED
-                      }' data-uie-name='go-no-camera-faq' target='_blank' rel='noopener noreferrer'>`,
-                    },
-                  ),
-                }}
-              />
+              {renderNoCameraMessage({brandName, isReactTranslationRenderingEnabled, translate})}
               <button
                 type="button"
                 className="button-reset-default preferences-av-video-disabled__try-again"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27666" title="WPB-27666" target="_blank"><img alt="Security" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/13902?size=medium" />WPB-27666</a>  [Web] Text rendering
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This pull request continues the localized rich-text rendering migration from #22411, #22431, and #22433.

It moves translation-controlled links to React-based rendering behind the existing startup feature toggle:

```text
react-translation-rendering
```
