### PR TITLE
Provide direct option to “Meet Now” and “Schedule Meeting” actions [WPB-28651]

### DIFF
--- a/apps/webapp/src/script/components/meeting/meetingMultiActionButton/meetingMultiActionButton.styles.ts
+++ b/apps/webapp/src/script/components/meeting/meetingMultiActionButton/meetingMultiActionButton.styles.ts
@@ -17,8 +17,12 @@
  *
  */
 
-export const callingButtonStyles = {
+export const callingButtonGroupStyles = {
   margin: '7px 0',
+};
+
+export const callingButtonStyles = {
+  marginBottom: '0px',
 };
 
 export const callingButtonIconStyles = {

--- a/apps/webapp/src/script/components/meeting/meetingMultiActionButton/meetingMultiActionButton.test.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingMultiActionButton/meetingMultiActionButton.test.tsx
@@ -31,77 +31,57 @@ import {MeetingMultiActionButton, MeetingMultiActionButtonProps} from './meeting
 const createTestProps = () => {
   const handleMeetNow = jest.fn();
   const handleScheduleMeeting = jest.fn();
-  const triggerContextMenu = jest.fn();
 
   const props: MeetingMultiActionButtonProps = {
     useMeetingActionsHook: () => ({
       handleMeetNow,
       handleScheduleMeeting,
     }),
-    triggerContextMenu,
   };
 
-  return {props, handleMeetNow, handleScheduleMeeting, triggerContextMenu};
+  return {props, handleMeetNow, handleScheduleMeeting};
 };
 
 const rootContextValue = createRootContextValueForTest({translate: translateForTest});
 const rootProviderWrapper = createRootProviderWrapperForTest(rootContextValue);
 
 describe('MeetingMultiActionButton', () => {
-  it('opens the meeting actions menu when clicking Create meeting', () => {
-    const {props, handleMeetNow, handleScheduleMeeting, triggerContextMenu} = createTestProps();
+  it('renders grouped Meet Now and Schedule Meeting buttons', () => {
+    const {props} = createTestProps();
 
     render(withThemeAndRootContext(<MeetingMultiActionButton {...props} />, rootProviderWrapper));
 
-    fireEvent.click(screen.getByRole('button', {name: translateForTest('meetings.action.createMeeting')}));
+    const meetNowButton = screen.getByRole('button', {name: translateForTest('meetings.action.meetNow')});
+    const scheduleMeetingButton = screen.getByRole('button', {
+      name: translateForTest('meetings.action.scheduleMeeting'),
+    });
 
-    expect(triggerContextMenu).toHaveBeenCalledTimes(1);
-    expect(handleMeetNow).not.toHaveBeenCalled();
-    expect(handleScheduleMeeting).not.toHaveBeenCalled();
+    expect(meetNowButton).toHaveAttribute('data-uie-name', 'meet-now');
+    expect(meetNowButton).toHaveClass('buttons-group-button', 'buttons-group-button-left');
+    expect(scheduleMeetingButton).toHaveAttribute('data-uie-name', 'schedule-meeting');
+    expect(scheduleMeetingButton).toHaveClass('buttons-group-button', 'buttons-group-button-right');
+    expect(meetNowButton.parentElement).toHaveClass('buttons-group');
   });
 
-  it('shows Meet Now and Schedule meeting in the dropdown menu', () => {
-    const {props, triggerContextMenu} = createTestProps();
+  it('calls Meet Now when its button is clicked', () => {
+    const {props, handleMeetNow, handleScheduleMeeting} = createTestProps();
 
     render(withThemeAndRootContext(<MeetingMultiActionButton {...props} />, rootProviderWrapper));
 
-    fireEvent.click(screen.getByRole('button', {name: translateForTest('meetings.action.createMeeting')}));
+    fireEvent.click(screen.getByRole('button', {name: translateForTest('meetings.action.meetNow')}));
 
-    expect(triggerContextMenu).toHaveBeenCalledWith(
-      expect.objectContaining({
-        identifier: 'meeting-actions-menu',
-        placement: 'bottom-start',
-        entries: [
-          expect.objectContaining({
-            title: translateForTest('meetings.action.meetNow'),
-            label: translateForTest('meetings.action.meetNow'),
-          }),
-          expect.objectContaining({
-            title: translateForTest('meetings.action.scheduleMeeting'),
-            label: translateForTest('meetings.action.scheduleMeeting'),
-          }),
-        ],
-      }),
-    );
-
-    const {entries} = triggerContextMenu.mock.calls[0][0];
-    expect(entries).toHaveLength(2);
-  });
-
-  it('calls the correct action when a menu entry is clicked', () => {
-    const {props, handleMeetNow, handleScheduleMeeting, triggerContextMenu} = createTestProps();
-
-    render(withThemeAndRootContext(<MeetingMultiActionButton {...props} />, rootProviderWrapper));
-
-    fireEvent.click(screen.getByRole('button', {name: translateForTest('meetings.action.createMeeting')}));
-
-    const {entries} = triggerContextMenu.mock.calls[0][0];
-
-    entries[0].click();
     expect(handleMeetNow).toHaveBeenCalledTimes(1);
     expect(handleScheduleMeeting).not.toHaveBeenCalled();
+  });
 
-    entries[1].click();
+  it('calls Schedule Meeting when its button is clicked', () => {
+    const {props, handleMeetNow, handleScheduleMeeting} = createTestProps();
+
+    render(withThemeAndRootContext(<MeetingMultiActionButton {...props} />, rootProviderWrapper));
+
+    fireEvent.click(screen.getByRole('button', {name: translateForTest('meetings.action.scheduleMeeting')}));
+
+    expect(handleMeetNow).not.toHaveBeenCalled();
     expect(handleScheduleMeeting).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/webapp/src/script/components/meeting/meetingMultiActionButton/meetingMultiActionButton.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingMultiActionButton/meetingMultiActionButton.tsx
@@ -46,7 +46,7 @@ export const MeetingMultiActionButton = ({
         data-uie-name="meet-now"
         css={callingButtonStyles}
       >
-        <CallIcon css={callingButtonIconStyles} /> {translate('meetings.action.meetNow')}
+        <CallIcon css={callingButtonIconStyles} aria-hidden="true" /> {translate('meetings.action.meetNow')}
       </Button>
       <Button
         className="buttons-group-button buttons-group-button-right"
@@ -55,7 +55,7 @@ export const MeetingMultiActionButton = ({
         data-uie-name="schedule-meeting"
         css={callingButtonStyles}
       >
-        <CalendarIcon css={callingButtonIconStyles} /> {translate('meetings.action.scheduleMeeting')}
+        <CalendarIcon css={callingButtonIconStyles} aria-hidden="true" /> {translate('meetings.action.scheduleMeeting')}
       </Button>
     </div>
   );

--- a/apps/webapp/src/script/components/meeting/meetingMultiActionButton/meetingMultiActionButton.tsx
+++ b/apps/webapp/src/script/components/meeting/meetingMultiActionButton/meetingMultiActionButton.tsx
@@ -17,65 +17,46 @@
  *
  */
 
-import {MouseEvent} from 'react';
-
-import {Button, ButtonVariant, CallIcon} from '@wireapp/react-ui-kit';
+import {Button, ButtonVariant, CalendarIcon, CallIcon} from '@wireapp/react-ui-kit';
 
 import {
+  callingButtonGroupStyles,
   callingButtonIconStyles,
   callingButtonStyles,
 } from 'Components/meeting/meetingMultiActionButton/meetingMultiActionButton.styles';
 import {useMeetingActions} from 'Components/meeting/useMeetingActions';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 
-import {showContextMenu} from '../../../ui/contextMenu';
-
 export interface MeetingMultiActionButtonProps {
   useMeetingActionsHook?: typeof useMeetingActions;
-  triggerContextMenu?: typeof showContextMenu;
 }
 
 export const MeetingMultiActionButton = ({
-  triggerContextMenu = showContextMenu,
   useMeetingActionsHook = useMeetingActions,
 }: MeetingMultiActionButtonProps) => {
   const {translate} = useApplicationContext();
   const {handleMeetNow, handleScheduleMeeting} = useMeetingActionsHook();
 
-  const handleCreateMeetingClick = (event: MouseEvent<HTMLElement>) => {
-    triggerContextMenu({
-      event,
-      anchor: event.currentTarget,
-      placement: 'bottom-start',
-      offset: 0,
-      entries: [
-        {
-          title: translate('meetings.action.meetNow'),
-          label: translate('meetings.action.meetNow'),
-          click: () => {
-            handleMeetNow();
-          },
-        },
-        {
-          title: translate('meetings.action.scheduleMeeting'),
-          label: translate('meetings.action.scheduleMeeting'),
-          click: () => {
-            handleScheduleMeeting();
-          },
-        },
-      ],
-      identifier: 'meeting-actions-menu',
-    });
-  };
-
   return (
-    <Button
-      variant={ButtonVariant.TERTIARY}
-      css={callingButtonStyles}
-      onClick={handleCreateMeetingClick}
-      data-uie-name="create-meeting"
-    >
-      <CallIcon css={callingButtonIconStyles} /> {translate('meetings.action.createMeeting')}
-    </Button>
+    <div className="buttons-group" css={callingButtonGroupStyles}>
+      <Button
+        className="buttons-group-button buttons-group-button-left"
+        variant={ButtonVariant.TERTIARY}
+        onClick={handleMeetNow}
+        data-uie-name="meet-now"
+        css={callingButtonStyles}
+      >
+        <CallIcon css={callingButtonIconStyles} /> {translate('meetings.action.meetNow')}
+      </Button>
+      <Button
+        className="buttons-group-button buttons-group-button-right"
+        variant={ButtonVariant.TERTIARY}
+        onClick={handleScheduleMeeting}
+        data-uie-name="schedule-meeting"
+        css={callingButtonStyles}
+      >
+        <CalendarIcon css={callingButtonIconStyles} /> {translate('meetings.action.scheduleMeeting')}
+      </Button>
+    </div>
   );
 };

--- a/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
+++ b/apps/webapp/test/e2e_tests/pageManager/webapp/pages/meetings.page.ts
@@ -37,8 +37,8 @@ export class MeetingsPage {
   readonly meetingsTab: Locator;
   readonly meetingsList: Locator;
   readonly emptyMeetingsList: Locator;
+  readonly meetNowButton: Locator;
   readonly scheduleMeetingButton: Locator;
-  readonly createMeetingButton: Locator;
   readonly scheduleMeetingModal: Locator;
   readonly meetNowModal: Locator;
   readonly notificationHost: Locator;
@@ -49,8 +49,8 @@ export class MeetingsPage {
     this.meetingsTab = page.getByTestId('go-meetings');
     this.meetingsList = page.getByTestId('meetings-list');
     this.emptyMeetingsList = page.getByTestId('empty-meetings-list');
+    this.meetNowButton = page.getByTestId('meet-now');
     this.scheduleMeetingButton = page.getByTestId('schedule-meeting');
-    this.createMeetingButton = page.getByTestId('create-meeting');
     this.scheduleMeetingModal = page.getByTestId('schedule-meeting-modal');
     this.meetNowModal = page.getByTestId('meet-now-modal');
     this.notificationHost = page.getByTestId('meeting-notification-host');
@@ -70,14 +70,12 @@ export class MeetingsPage {
       return;
     }
 
-    await this.createMeetingButton.click();
-    await this.page.getByRole('menu').getByRole('button', {name: 'Schedule Meeting'}).click();
+    await this.scheduleMeetingButton.click();
   }
 
   async openMeetNowModal() {
     await this.openMeetingsTab();
-    await this.createMeetingButton.click();
-    await this.page.getByRole('menu').getByRole('button', {name: 'Meet now'}).click();
+    await this.meetNowButton.click();
     await expect(this.meetNowModal).toBeVisible();
   }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28651" title="WPB-28651" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28651</a>  [Web] Provide direct option to “Meet Now” and “Schedule Meeting” actions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


Replace the “Create meeting” dropdown with separate “Meet now” and “Schedule meeting” buttons to reduce the number of clicks needed to start or schedule a meeting.

Before
<img width="736" height="155" alt="image" src="https://github.com/user-attachments/assets/784ff8fe-5d79-479b-8630-db6a8d3a0c53" />
After
<img width="686" height="153" alt="image" src="https://github.com/user-attachments/assets/dc8b25aa-08a0-411b-9c15-48aaef12a20e" />

