### PR TITLE
 fix(wire-drive): match shared drive upload status icon [WPB-28307]

### DIFF
--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
@@ -228,6 +228,19 @@ export const sharedDriveUploadStatusPopupRowIconStyles: CSSObject = {
   flex: '0 0 auto',
 };
 
+export const sharedDriveUploadStatusPopupUploadSpinnerStyles: CSSObject = {
+  transformBox: 'fill-box',
+  transformOrigin: 'center',
+  animation: 'shared-drive-upload-spinner 1s linear infinite',
+  '@keyframes shared-drive-upload-spinner': {
+    from: {transform: 'rotate(0deg)'},
+    to: {transform: 'rotate(360deg)'},
+  },
+  '@media (prefers-reduced-motion: reduce)': {
+    animation: 'none',
+  },
+};
+
 export const sharedDriveUploadStatusPopupErrorIconStyles: CSSObject = {
   display: 'flex',
   width: 24,

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
@@ -228,19 +228,6 @@ export const sharedDriveUploadStatusPopupRowIconStyles: CSSObject = {
   flex: '0 0 auto',
 };
 
-export const sharedDriveUploadStatusPopupUploadSpinnerStyles: CSSObject = {
-  transformBox: 'view-box',
-  transformOrigin: '12px 12px',
-  animation: 'shared-drive-upload-spinner 1s linear infinite',
-  '@keyframes shared-drive-upload-spinner': {
-    from: {transform: 'rotate(0deg)'},
-    to: {transform: 'rotate(360deg)'},
-  },
-  '@media (prefers-reduced-motion: reduce)': {
-    animation: 'none',
-  },
-};
-
 export const sharedDriveUploadStatusPopupErrorIconStyles: CSSObject = {
   display: 'flex',
   width: 24,

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.styles.ts
@@ -229,8 +229,8 @@ export const sharedDriveUploadStatusPopupRowIconStyles: CSSObject = {
 };
 
 export const sharedDriveUploadStatusPopupUploadSpinnerStyles: CSSObject = {
-  transformBox: 'fill-box',
-  transformOrigin: 'center',
+  transformBox: 'view-box',
+  transformOrigin: '12px 12px',
   animation: 'shared-drive-upload-spinner 1s linear infinite',
   '@keyframes shared-drive-upload-spinner': {
     from: {transform: 'rotate(0deg)'},

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
@@ -19,7 +19,7 @@
 
 import type {ReactNode} from 'react';
 
-import {AlertIcon, ChevronIcon, CloseIcon, ReloadIcon} from '@wireapp/react-ui-kit';
+import {AlertIcon, ChevronIcon, CloseIcon, ReloadIcon, SharedDriveUploadStatusIcon} from '@wireapp/react-ui-kit';
 
 import {FileTypeIcon} from 'Components/conversation/common/fileTypeIcon/fileTypeIcon';
 import {getFileExtension} from 'Util/util';
@@ -40,7 +40,6 @@ import {
   sharedDriveUploadStatusPopupRowCancelStyles,
   sharedDriveUploadStatusPopupRowFileNameStyles,
   sharedDriveUploadStatusPopupRowIconStyles,
-  sharedDriveUploadStatusPopupUploadSpinnerStyles,
   sharedDriveUploadStatusPopupRowLeadingStyles,
   sharedDriveUploadStatusPopupRowStatusStyles,
   sharedDriveUploadStatusPopupRowStyles,
@@ -74,34 +73,15 @@ interface SharedDriveUploadStatusPopupProps {
   readonly onDismiss?: () => void;
 }
 
-const UploadingStatusIcon = () => (
-  <svg
-    css={sharedDriveUploadStatusPopupRowIconStyles}
-    width="24"
-    height="25"
-    viewBox="0 0 24 25"
-    fill="none"
-    aria-hidden="true"
-    data-uie-name="shared-drive-upload-uploading"
-  >
-    <circle cx="12" cy="12" r="11.25" stroke="var(--accent-color-highlight, #e7f0fa)" strokeWidth="1.5" />
-    <g css={sharedDriveUploadStatusPopupUploadSpinnerStyles}>
-      <path
-        d="M12.2792 0.88967C18.4591 1.03197 23.3536 6.15716 23.2113 12.3371C23.069 18.517 17.9438 23.4115 11.7639 23.2692C9.49701 23.217 7.40313 22.4944 5.66734 21.2952"
-        stroke="var(--accent-color, #0667c8)"
-        strokeWidth="1.5"
-      />
-    </g>
-    <path
-      d="M11.3418 9.91852L7.90336 13.3569L6.97528 12.4289L12.0001 7.40405L17.0249 12.4289L16.0968 13.3569L12.6543 9.91439L12.6543 16.5916L11.3418 16.5916L11.3418 9.91852Z"
-      fill="var(--accent-color, #0667c8)"
-    />
-  </svg>
-);
-
 const statusIcon = (upload: SharedDriveUploadStatus): ReactNode => {
   if (upload.kind === 'uploading') {
-    return <UploadingStatusIcon />;
+    return (
+      <SharedDriveUploadStatusIcon
+        css={sharedDriveUploadStatusPopupRowIconStyles}
+        aria-hidden="true"
+        data-uie-name="shared-drive-upload-uploading"
+      />
+    );
   }
 
   if (upload.kind === 'uploaded') {

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
@@ -19,7 +19,7 @@
 
 import type {ReactNode} from 'react';
 
-import {AlertIcon, ChevronIcon, CloseIcon, ReloadIcon, UploadIcon} from '@wireapp/react-ui-kit';
+import {AlertIcon, ChevronIcon, CloseIcon, ReloadIcon} from '@wireapp/react-ui-kit';
 
 import {FileTypeIcon} from 'Components/conversation/common/fileTypeIcon/fileTypeIcon';
 import {getFileExtension} from 'Util/util';
@@ -40,6 +40,7 @@ import {
   sharedDriveUploadStatusPopupRowCancelStyles,
   sharedDriveUploadStatusPopupRowFileNameStyles,
   sharedDriveUploadStatusPopupRowIconStyles,
+  sharedDriveUploadStatusPopupUploadSpinnerStyles,
   sharedDriveUploadStatusPopupRowLeadingStyles,
   sharedDriveUploadStatusPopupRowStatusStyles,
   sharedDriveUploadStatusPopupRowStyles,
@@ -73,16 +74,34 @@ interface SharedDriveUploadStatusPopupProps {
   readonly onDismiss?: () => void;
 }
 
+const UploadingStatusIcon = () => (
+  <svg
+    css={sharedDriveUploadStatusPopupRowIconStyles}
+    width="24"
+    height="25"
+    viewBox="0 0 24 25"
+    fill="none"
+    aria-hidden="true"
+    data-uie-name="shared-drive-upload-uploading"
+  >
+    <circle cx="12" cy="12" r="11.25" stroke="var(--accent-color-highlight, #e7f0fa)" strokeWidth="1.5" />
+    <g css={sharedDriveUploadStatusPopupUploadSpinnerStyles}>
+      <path
+        d="M12.2792 0.88967C18.4591 1.03197 23.3536 6.15716 23.2113 12.3371C23.069 18.517 17.9438 23.4115 11.7639 23.2692C9.49701 23.217 7.40313 22.4944 5.66734 21.2952"
+        stroke="var(--accent-color, #0667c8)"
+        strokeWidth="1.5"
+      />
+    </g>
+    <path
+      d="M11.3418 9.91852L7.90336 13.3569L6.97528 12.4289L12.0001 7.40405L17.0249 12.4289L16.0968 13.3569L12.6543 9.91439L12.6543 16.5916L11.3418 16.5916L11.3418 9.91852Z"
+      fill="var(--accent-color, #0667c8)"
+    />
+  </svg>
+);
+
 const statusIcon = (upload: SharedDriveUploadStatus): ReactNode => {
   if (upload.kind === 'uploading') {
-    return (
-      <UploadIcon
-        css={sharedDriveUploadStatusPopupRowIconStyles}
-        color="currentColor"
-        aria-hidden="true"
-        data-uie-name="shared-drive-upload-uploading"
-      />
-    );
+    return <UploadingStatusIcon />;
   }
 
   if (upload.kind === 'uploaded') {

--- a/libraries/react-ui-kit/src/dataDisplay/icon/index.ts
+++ b/libraries/react-ui-kit/src/dataDisplay/icon/index.ts
@@ -91,6 +91,7 @@ export * from './settingsIcon';
 export * from './shareLinkIcon';
 export * from './sharedDriveUploadCompletedIcon';
 export * from './sharedDriveUploadSpinnerIcon';
+export * from './sharedDriveUploadStatusIcon';
 export * from './showIcon';
 export * from './signIcon';
 export * from './sortIcon';

--- a/libraries/react-ui-kit/src/dataDisplay/icon/sharedDriveUploadStatusIcon.tsx
+++ b/libraries/react-ui-kit/src/dataDisplay/icon/sharedDriveUploadStatusIcon.tsx
@@ -19,7 +19,7 @@
 
 import type {CSSObject} from '@emotion/react';
 
-import {SVGIcon, SVGIconProps} from './svgIcon';
+import type {SVGIconProps} from './svgIcon';
 
 const spinnerStyles: CSSObject = {
   transformBox: 'view-box',
@@ -35,7 +35,7 @@ const spinnerStyles: CSSObject = {
 };
 
 export const SharedDriveUploadStatusIcon = (props: SVGIconProps) => (
-  <SVGIcon realWidth={24} realHeight={25} {...props}>
+  <svg width="24" height="25" viewBox="0 0 24 25" fill="none" {...props}>
     <circle cx="12" cy="12" r="11.25" fill="none" stroke="var(--accent-color-highlight, #e7f0fa)" strokeWidth="1.5" />
     <g css={spinnerStyles}>
       <path
@@ -48,5 +48,5 @@ export const SharedDriveUploadStatusIcon = (props: SVGIconProps) => (
       d="M11.3418 9.91852L7.90336 13.3569L6.97528 12.4289L12.0001 7.40405L17.0249 12.4289L16.0968 13.3569L12.6543 9.91439L12.6543 16.5916L11.3418 16.5916L11.3418 9.91852Z"
       fill="var(--accent-color, #0667c8)"
     />
-  </SVGIcon>
+  </svg>
 );

--- a/libraries/react-ui-kit/src/dataDisplay/icon/sharedDriveUploadStatusIcon.tsx
+++ b/libraries/react-ui-kit/src/dataDisplay/icon/sharedDriveUploadStatusIcon.tsx
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {CSSObject} from '@emotion/react';
+
+import {SVGIcon, SVGIconProps} from './svgIcon';
+
+const spinnerStyles: CSSObject = {
+  transformBox: 'view-box',
+  transformOrigin: '12px 12px',
+  animation: 'shared-drive-upload-status-spinner 1s linear infinite',
+  '@keyframes shared-drive-upload-status-spinner': {
+    from: {transform: 'rotate(0deg)'},
+    to: {transform: 'rotate(360deg)'},
+  },
+  '@media (prefers-reduced-motion: reduce)': {
+    animation: 'none',
+  },
+};
+
+export const SharedDriveUploadStatusIcon = (props: SVGIconProps) => (
+  <SVGIcon realWidth={24} realHeight={25} {...props}>
+    <circle cx="12" cy="12" r="11.25" fill="none" stroke="var(--accent-color-highlight, #e7f0fa)" strokeWidth="1.5" />
+    <g css={spinnerStyles}>
+      <path
+        d="M12.2792 0.88967C18.4591 1.03197 23.3536 6.15716 23.2113 12.3371C23.069 18.517 17.9438 23.4115 11.7639 23.2692C9.49701 23.217 7.40313 22.4944 5.66734 21.2952"
+        stroke="var(--accent-color, #0667c8)"
+        strokeWidth="1.5"
+      />
+    </g>
+    <path
+      d="M11.3418 9.91852L7.90336 13.3569L6.97528 12.4289L12.0001 7.40405L17.0249 12.4289L16.0968 13.3569L12.6543 9.91439L12.6543 16.5916L11.3418 16.5916L11.3418 9.91852Z"
+      fill="var(--accent-color, #0667c8)"
+    />
+  </SVGIcon>
+);


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28307" title="WPB-28307" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28307</a>  [web] precise progress visual feedback to shared drive upload
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Problem

The upload icon in the shared drive status popup was using the generic black upload glyph. It did not match the design, and there was no visible circular animation while the upload was active.

Task: [WPB-28307](https://wearezeta.atlassian.net/browse/WPB-28307)

## Solution

Replace the generic glyph with the upload icon from the Figma design:

- blue upload arrow
- light blue circular track
- blue progress arc that circulates around the icon
- reduced motion support

The spinner uses the SVG view box as its transform reference, so the arc stays centered while it rotates.

## Verification


https://github.com/user-attachments/assets/a88eca87-90bb-4046-9bfd-01773b1a9946



[WPB-28307]: https://wearezeta.atlassian.net/browse/WPB-28307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ