### PR TITLE
Render Legal Hold translations with React [WPB-27666]

### DIFF
--- a/apps/webapp/src/i18n/si-LK.json
+++ b/apps/webapp/src/i18n/si-LK.json
@@ -1278,7 +1278,7 @@
   "legalHoldMessageSendingMissingConsentTitle": "පණිවිඩය යැවීමට නොහැකියි",
   "legalHoldModalPrimaryAction": "පිළිගන්න",
   "legalHoldModalSecondaryAction": "දැන් නොවේ",
-  "legalHoldModalText": "සියළුම අනාගත පණිවිඩ ඇඟිලි සටහන සමඟ උපාංගය මගින් පටිගත කෙරේ:[br][ඇඟිලි සටහන][br]මෙයට සියළුම සංවාදවල මකන, සංශෝධිත සහ ඉබේ මැකෙන පණිවිඩ ඇතුළත් වේ.",
+  "legalHoldModalText": "සියළුම අනාගත පණිවිඩ ඇඟිලි සටහන සමඟ උපාංගය මගින් පටිගත කෙරේ:[br][fingerprint][br]මෙයට සියළුම සංවාදවල මකන, සංශෝධිත සහ ඉබේ මැකෙන පණිවිඩ ඇතුළත් වේ.",
   "legalHoldModalTextPassword": "තහවුරු කිරීමට මුරපදය ඇතුල් කරන්න.",
   "legalHoldModalTitle": "නෛතික රැඳවුමක් ඉල්ලා ඇත",
   "legalHoldSubjects": "නෛතික රැඳවුමට යටත් වේ",

--- a/apps/webapp/src/script/components/Modals/LegalHoldModal/LegalHoldModal.state.ts
+++ b/apps/webapp/src/script/components/Modals/LegalHoldModal/LegalHoldModal.state.ts
@@ -17,12 +17,12 @@
  *
  */
 
+import {isUndefined} from '@sindresorhus/is';
 import {create} from 'zustand';
 
 import {LegalHoldModalType} from 'Components/Modals/LegalHoldModal/LegalHoldModal';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
-import {splitFingerprint} from 'Util/stringUtil';
 
 type LegalHoldModalState = {
   type: LegalHoldModalType | null;
@@ -80,17 +80,12 @@ const useLegalHoldModalState = create<LegalHoldModalState>((set, get) => ({
   isOpen: false,
   isSelfInfo: false,
   setFingerprint: fingerprint => {
-    const formattedFingerprint =
-      fingerprint !== undefined && fingerprint !== ''
-        ? splitFingerprint(fingerprint)
-            .map(part => `<span>${part} </span>`)
-            .join('')
-        : '';
+    const normalizedFingerprint = isUndefined(fingerprint) ? '' : fingerprint;
 
     return set(state => ({
       ...state,
-      fingerprint: formattedFingerprint,
-      isOpen: !!formattedFingerprint,
+      fingerprint: normalizedFingerprint,
+      isOpen: normalizedFingerprint !== '',
     }));
   },
   setIsLoading: isLoading =>
@@ -114,19 +109,14 @@ const useLegalHoldModalState = create<LegalHoldModalState>((set, get) => ({
       users,
     })),
   showRequestModal: (initialize = false, showLoading = false, fingerprint) => {
-    const formattedFingerprint =
-      fingerprint !== undefined && fingerprint !== ''
-        ? splitFingerprint(fingerprint)
-            .map(part => `<span>${part} </span>`)
-            .join('')
-        : '';
+    const normalizedFingerprint = isUndefined(fingerprint) ? '' : fingerprint;
 
     return set(state => ({
       ...state,
-      fingerprint: formattedFingerprint,
+      fingerprint: normalizedFingerprint,
       isInitialized: initialize,
       isLoading: showLoading,
-      isOpen: showLoading || !!formattedFingerprint,
+      isOpen: showLoading || normalizedFingerprint !== '',
       type: LegalHoldModalType.REQUEST,
     }));
   },

--- a/apps/webapp/src/script/components/Modals/LegalHoldModal/LegalHoldModal.test.tsx
+++ b/apps/webapp/src/script/components/Modals/LegalHoldModal/LegalHoldModal.test.tsx
@@ -17,9 +17,13 @@
  *
  */
 
-import {act, render} from '@testing-library/react';
+import {act, render, waitFor} from '@testing-library/react';
+import {ClientClassification} from '@wireapp/api-client/lib/client/';
 import type {QualifiedId} from '@wireapp/api-client/lib/user/';
 
+import en from 'I18n/en-US.json';
+import si from 'I18n/si-LK.json';
+import {ClientEntity} from 'Repositories/client/ClientEntity';
 import {useLegalHoldModalState} from 'Components/Modals/LegalHoldModal/LegalHoldModal.state';
 import {CallingRepository} from 'Repositories/calling/CallingRepository';
 import {ClientRepository} from 'Repositories/client';
@@ -31,13 +35,16 @@ import {User} from 'Repositories/entity/User';
 import {SearchRepository} from 'Repositories/search/searchRepository';
 import {TeamRepository} from 'Repositories/team/TeamRepository';
 import {UserRepository} from 'Repositories/user/userRepository';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {translateForTest} from 'Util/test/translateForTest';
+import {setStrings, translate} from 'Util/localizerUtil';
+import {splitFingerprint} from 'Util/stringUtil';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
 
-import {LegalHoldModal, LegalHoldModalType} from './LegalHoldModal';
+import {LegalHoldModal, LegalHoldModalProps, LegalHoldModalType} from './LegalHoldModal';
 
 import {TestFactory} from '../../../../../test/helper/TestFactory';
 import {CONVERSATION_PROTOCOL} from '@wireapp/api-client/lib/team';
@@ -48,6 +55,58 @@ let callRepository: CallingRepository;
 const rootProviderWrapper = createRootProviderWrapperForTest(
   createRootContextValueForTest({translate: translateForTest}),
 );
+const legacyTranslationRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate}),
+);
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName) {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
+
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
+
+    try {
+      await testFunction();
+    } finally {
+      act((): void => {
+        useLegalHoldModalState.getState().closeModal();
+      });
+      setStrings({en});
+    }
+  };
+}
+
+function createLegalHoldUser(): User {
+  const legalHoldUser = new User('legal-hold-user', '', translateForTest);
+  const legalHoldClient = new ClientEntity(false, null, 'legal-hold-client');
+  legalHoldClient.class = ClientClassification.LEGAL_HOLD;
+  legalHoldUser.devices([legalHoldClient]);
+
+  return legalHoldUser;
+}
+
+function createOthersDescriptionProps(): LegalHoldModalProps {
+  const props = defaultProps();
+  props.conversationRepository = {
+    getAllUsersInConversation: function getAllUsersInConversation(): Promise<User[]> {
+      return Promise.resolve([createLegalHoldUser()]);
+    },
+  } as unknown as ConversationRepository;
+
+  return props;
+}
 
 beforeAll(() => {
   testFactory.exposeCallingActors().then(injectedCallingRepository => {
@@ -66,29 +125,388 @@ const defaultProps = () => ({
     updateAllClients: (conversation: Conversation, blockSystemMessage: boolean): Promise<void> => Promise.resolve(),
   } as MessageRepository,
   searchRepository: new SearchRepository(userRepository),
-  teamRepository: {} as TeamRepository,
+  teamRepository: {
+    isSelfConnectedTo: function isSelfConnectedTo(): boolean {
+      return false;
+    },
+  } as unknown as TeamRepository,
   selfUser: new User('mocked-id', '', translateForTest),
 });
 
 describe('LegalHoldModal', () => {
-  it('is showRequestModal', () => {
-    render(<LegalHoldModal {...defaultProps()} />, {wrapper: rootProviderWrapper});
-    act(() => {
-      useLegalHoldModalState.getState().showRequestModal();
-    });
+  it('is showRequestModal', (): void => {
+    try {
+      render(<LegalHoldModal {...defaultProps()} />, {wrapper: rootProviderWrapper});
+      act((): void => {
+        useLegalHoldModalState.getState().showRequestModal();
+      });
 
-    expect(useLegalHoldModalState.getState().type).toBe(LegalHoldModalType.REQUEST);
+      expect(useLegalHoldModalState.getState().type).toBe(LegalHoldModalType.REQUEST);
+    } finally {
+      act((): void => {
+        useLegalHoldModalState.getState().closeModal();
+      });
+    }
   });
 
-  it('is showUser', async () => {
-    const props = defaultProps();
-    await render(<LegalHoldModal {...props} />, {wrapper: rootProviderWrapper});
-    const selfConversation = new Conversation(props.selfUser.id, '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
+  it('is showUser', async (): Promise<void> => {
+    try {
+      const props = defaultProps();
+      await render(<LegalHoldModal {...props} />, {wrapper: rootProviderWrapper});
+      const selfConversation = new Conversation(props.selfUser.id, '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest);
 
-    await act(() => {
-      useLegalHoldModalState.getState().showUsers(false, selfConversation);
-    });
+      await act(async (): Promise<void> => {
+        useLegalHoldModalState.getState().showUsers(false, selfConversation);
+      });
 
-    await expect(useLegalHoldModalState.getState().type).toBe(LegalHoldModalType.USERS);
+      expect(useLegalHoldModalState.getState().type).toBe(LegalHoldModalType.USERS);
+    } finally {
+      act((): void => {
+        useLegalHoldModalState.getState().closeModal();
+      });
+    }
   });
+
+  it(
+    'preserves request rendering when React translation rendering is disabled',
+    withTranslationStrings({...en, legalHoldModalText: 'Before[br][fingerprint]After'}, async (): Promise<void> => {
+      const fingerprint = 'A1B2';
+      const expectedFingerprintRepresentation = splitFingerprint(fingerprint)
+        .map(fingerprintPart => {
+          return `${fingerprintPart} `;
+        })
+        .join('');
+      const {getByTestId} = render(<LegalHoldModal {...defaultProps()} />, {
+        wrapper: legacyTranslationRootProviderWrapper,
+      });
+
+      act((): void => {
+        useLegalHoldModalState.getState().showRequestModal(false, false, fingerprint);
+      });
+
+      const statusText = await waitFor((): HTMLElement => {
+        return getByTestId('status-modal-text');
+      });
+
+      expect(statusText.querySelectorAll('br')).toHaveLength(1);
+      expect(statusText.querySelectorAll('.legal-hold-modal__fingerprint')).toHaveLength(1);
+      expect(statusText.querySelector('.legal-hold-modal__fingerprint')?.textContent).toBe(
+        expectedFingerprintRepresentation,
+      );
+    }),
+  );
+
+  it(
+    'renders request markers as React nodes when enabled',
+    withTranslationStrings(en, async (): Promise<void> => {
+      const fingerprint = 'A1B2C3D4';
+      const expectedFingerprintParts = splitFingerprint(fingerprint);
+      const expectedFingerprintRepresentation = expectedFingerprintParts
+        .map(fingerprintPart => {
+          return `${fingerprintPart} `;
+        })
+        .join('');
+      const {getByTestId} = render(<LegalHoldModal {...defaultProps()} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+
+      act((): void => {
+        useLegalHoldModalState.getState().showRequestModal(false, false, fingerprint);
+      });
+
+      const statusText = await waitFor((): HTMLElement => {
+        return getByTestId('status-modal-text');
+      });
+      const fingerprintElement = statusText.querySelector('.legal-hold-modal__fingerprint');
+
+      expect(statusText.querySelectorAll('br')).toHaveLength(2);
+      expect(statusText.querySelectorAll('.legal-hold-modal__fingerprint')).toHaveLength(1);
+      expect(fingerprintElement).toHaveClass('legal-hold-modal__fingerprint');
+      expect(fingerprintElement).toHaveAttribute('data-uie-name', 'status-modal-fingerprint');
+      expect(fingerprintElement?.textContent).toBe(expectedFingerprintRepresentation);
+
+      const fingerprintPartElements = fingerprintElement?.querySelectorAll('span');
+      expect(fingerprintPartElements).toHaveLength(expectedFingerprintParts.length);
+      expectedFingerprintParts.forEach((fingerprintPart, fingerprintPartIndex) => {
+        expect(fingerprintPartElements?.[fingerprintPartIndex]?.textContent).toBe(`${fingerprintPart} `);
+      });
+    }),
+  );
+
+  it(
+    'preserves fingerprint presentation between legacy and React rendering',
+    withTranslationStrings({...en, legalHoldModalText: 'Before[br][fingerprint]After'}, async (): Promise<void> => {
+      const fingerprint = 'A1B2C3D4E5F6G7H8';
+      const expectedFingerprintRepresentation = splitFingerprint(fingerprint)
+        .map(fingerprintPart => {
+          return `${fingerprintPart} `;
+        })
+        .join('');
+
+      const legacyRender = render(<LegalHoldModal {...defaultProps()} />, {
+        wrapper: legacyTranslationRootProviderWrapper,
+      });
+      act((): void => {
+        useLegalHoldModalState.getState().showRequestModal(false, false, fingerprint);
+      });
+      const legacyStatusText = await waitFor((): HTMLElement => {
+        return legacyRender.getByTestId('status-modal-text');
+      });
+      const legacyFingerprintRepresentation = legacyStatusText.querySelector(
+        '.legal-hold-modal__fingerprint',
+      )?.textContent;
+
+      legacyRender.unmount();
+      act((): void => {
+        useLegalHoldModalState.getState().closeModal();
+      });
+
+      const reactRender = render(<LegalHoldModal {...defaultProps()} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+      act((): void => {
+        useLegalHoldModalState.getState().showRequestModal(false, false, fingerprint);
+      });
+      const reactStatusText = await waitFor((): HTMLElement => {
+        return reactRender.getByTestId('status-modal-text');
+      });
+      const reactFingerprintElement = reactStatusText.querySelector('.legal-hold-modal__fingerprint');
+      const reactFingerprintRepresentation = reactFingerprintElement?.textContent;
+
+      expect(legacyFingerprintRepresentation).toBe(expectedFingerprintRepresentation);
+      expect(reactFingerprintRepresentation).toBe(legacyFingerprintRepresentation);
+      expect(reactFingerprintElement?.querySelectorAll('span')).toHaveLength(splitFingerprint(fingerprint).length);
+
+      reactRender.unmount();
+    }),
+  );
+
+  it(
+    'keeps HTML-looking fingerprint text opaque in the React request rendering',
+    withTranslationStrings(en, async (): Promise<void> => {
+      const htmlLookingFingerprint = 'AB<CD>&EF';
+      const expectedFingerprintRepresentation = splitFingerprint(htmlLookingFingerprint)
+        .map(fingerprintPart => {
+          return `${fingerprintPart} `;
+        })
+        .join('');
+      const {getByTestId} = render(<LegalHoldModal {...defaultProps()} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+
+      act((): void => {
+        useLegalHoldModalState.getState().showRequestModal(false, false, htmlLookingFingerprint);
+      });
+
+      const statusText = await waitFor((): HTMLElement => {
+        return getByTestId('status-modal-text');
+      });
+      const fingerprintElement = statusText.querySelector('.legal-hold-modal__fingerprint');
+
+      expect(fingerprintElement?.textContent).toBe(expectedFingerprintRepresentation);
+      expect(fingerprintElement?.querySelector('cd')).toBeNull();
+      expect(statusText.querySelector('img')).toBeNull();
+    }),
+  );
+
+  it(
+    'keeps translation-looking fingerprint text opaque in the React request rendering',
+    withTranslationStrings(en, async (): Promise<void> => {
+      const translationLookingFingerprint = '[link]fingerprint[/link]';
+      const expectedFingerprintRepresentation = splitFingerprint(translationLookingFingerprint)
+        .map(fingerprintPart => {
+          return `${fingerprintPart} `;
+        })
+        .join('');
+      const {getByTestId} = render(<LegalHoldModal {...defaultProps()} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+
+      act((): void => {
+        useLegalHoldModalState.getState().showRequestModal(false, false, translationLookingFingerprint);
+      });
+
+      const statusText = await waitFor((): HTMLElement => {
+        return getByTestId('status-modal-text');
+      });
+      const fingerprintElement = statusText.querySelector('.legal-hold-modal__fingerprint');
+
+      expect(fingerprintElement?.textContent).toBe(expectedFingerprintRepresentation);
+      expect(fingerprintElement?.querySelector('a')).toBeNull();
+    }),
+  );
+
+  it(
+    'keeps request marker placement under translation control',
+    withTranslationStrings(
+      {...en, legalHoldModalText: '[fingerprint][br]is the recording-device fingerprint.'},
+      async (): Promise<void> => {
+        const fingerprint = 'A1B2';
+        const expectedFingerprintRepresentation = splitFingerprint(fingerprint)
+          .map(fingerprintPart => {
+            return `${fingerprintPart} `;
+          })
+          .join('');
+        const {getByTestId} = render(<LegalHoldModal {...defaultProps()} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+
+        act((): void => {
+          useLegalHoldModalState.getState().showRequestModal(false, false, fingerprint);
+        });
+
+        const statusText = await waitFor((): HTMLElement => {
+          return getByTestId('status-modal-text');
+        });
+        const requestParagraph = statusText.querySelector('p');
+
+        expect(requestParagraph?.firstElementChild).toHaveClass('legal-hold-modal__fingerprint');
+        expect(requestParagraph?.querySelector('br')).toBeInTheDocument();
+        expect(requestParagraph?.textContent).toBe(
+          `${expectedFingerprintRepresentation}is the recording-device fingerprint.`,
+        );
+      },
+    ),
+  );
+
+  it(
+    'leaves unsupported request markup as text',
+    withTranslationStrings(
+      {...en, legalHoldModalText: 'Before<img src="example">[br]After'},
+      async (): Promise<void> => {
+        const {getByTestId} = render(<LegalHoldModal {...defaultProps()} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+
+        act((): void => {
+          useLegalHoldModalState.getState().showRequestModal(false, false, 'A1B2');
+        });
+
+        const statusText = await waitFor((): HTMLElement => {
+          return getByTestId('status-modal-text');
+        });
+
+        expect(statusText).toHaveTextContent('Before<img src="example">After');
+        expect(statusText.querySelector('img')).toBeNull();
+      },
+    ),
+  );
+
+  it('keeps the Sinhala fingerprint marker in the translation protocol', (): void => {
+    expect(si.legalHoldModalText).toContain('[fingerprint]');
+    expect(si.legalHoldModalText).not.toContain('[ඇඟිලි සටහන]');
+  });
+
+  it(
+    'preserves both Legal Hold descriptions in the legacy HTML path',
+    withTranslationStrings(
+      {
+        ...en,
+        legalHoldDescriptionSelf: 'Self before<br />Self after',
+        legalHoldDescriptionOthers: 'Others before<br />Others after',
+      },
+      async (): Promise<void> => {
+        const selfRender = render(<LegalHoldModal {...defaultProps()} />, {
+          wrapper: legacyTranslationRootProviderWrapper,
+        });
+        act((): void => {
+          useLegalHoldModalState.getState().showUsers(false);
+        });
+        const selfDescription = await waitFor((): HTMLElement => {
+          return selfRender.getByTestId('status-modal-text');
+        });
+
+        expect(selfDescription).toHaveTextContent('Self beforeSelf after');
+        expect(selfDescription.querySelectorAll('br')).toHaveLength(1);
+        selfRender.unmount();
+        act((): void => {
+          useLegalHoldModalState.getState().closeModal();
+        });
+
+        const othersRender = render(<LegalHoldModal {...createOthersDescriptionProps()} />, {
+          wrapper: legacyTranslationRootProviderWrapper,
+        });
+        act((): void => {
+          useLegalHoldModalState
+            .getState()
+            .showUsers(false, new Conversation('conversation-id', '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest));
+        });
+        const othersDescription = await waitFor((): HTMLElement => {
+          return othersRender.getByTestId('status-modal-text');
+        });
+
+        expect(othersDescription).toHaveTextContent('Others beforeOthers after');
+        expect(othersDescription.querySelectorAll('br')).toHaveLength(1);
+      },
+    ),
+  );
+
+  it(
+    'renders both Legal Hold descriptions with exact React line-break compatibility',
+    withTranslationStrings(
+      {
+        ...en,
+        legalHoldDescriptionSelf: 'Self before<br />Self after',
+        legalHoldDescriptionOthers: 'Others before<br />Others after',
+      },
+      async (): Promise<void> => {
+        const selfRender = render(<LegalHoldModal {...defaultProps()} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        act((): void => {
+          useLegalHoldModalState.getState().showUsers(false);
+        });
+        const selfDescription = await waitFor((): HTMLElement => {
+          return selfRender.getByTestId('status-modal-text');
+        });
+
+        expect(selfDescription).toHaveTextContent('Self beforeSelf after');
+        expect(selfDescription.querySelectorAll('br')).toHaveLength(1);
+        selfRender.unmount();
+        act((): void => {
+          useLegalHoldModalState.getState().closeModal();
+        });
+
+        const othersRender = render(<LegalHoldModal {...createOthersDescriptionProps()} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        act((): void => {
+          useLegalHoldModalState
+            .getState()
+            .showUsers(false, new Conversation('conversation-id', '', CONVERSATION_PROTOCOL.PROTEUS, translateForTest));
+        });
+        const othersDescription = await waitFor((): HTMLElement => {
+          return othersRender.getByTestId('status-modal-text');
+        });
+
+        expect(othersDescription).toHaveTextContent('Others beforeOthers after');
+        expect(othersDescription.querySelectorAll('br')).toHaveLength(1);
+      },
+    ),
+  );
+
+  it(
+    'leaves unsupported Legal Hold description markup and newlines as text',
+    withTranslationStrings(
+      {
+        ...en,
+        legalHoldDescriptionSelf: 'Before<img src="example">\n\nAfter',
+      },
+      async (): Promise<void> => {
+        const {getByTestId} = render(<LegalHoldModal {...defaultProps()} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        act((): void => {
+          useLegalHoldModalState.getState().showUsers(false);
+        });
+        const description = await waitFor((): HTMLElement => {
+          return getByTestId('status-modal-text');
+        });
+
+        expect(description.textContent).toBe('Before<img src="example">\n\nAfter');
+        expect(description.querySelector('img')).toBeNull();
+        expect(description.querySelector('br')).toBeNull();
+      },
+    ),
+  );
 });

--- a/apps/webapp/src/script/components/Modals/LegalHoldModal/LegalHoldModal.tsx
+++ b/apps/webapp/src/script/components/Modals/LegalHoldModal/LegalHoldModal.tsx
@@ -17,8 +17,9 @@
  *
  */
 
-import {FC, useCallback, useEffect, useRef, useState} from 'react';
+import {FC, ReactNode, useCallback, useEffect, useRef, useState} from 'react';
 
+import {isUndefined} from '@sindresorhus/is';
 import {LegalHoldMemberStatus} from '@wireapp/api-client/lib/team/legalhold/';
 import cx from 'classnames';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
@@ -36,14 +37,92 @@ import {CryptographyRepository} from 'Repositories/cryptography/CryptographyRepo
 import {User} from 'Repositories/entity/User';
 import {SearchRepository} from 'Repositories/search/searchRepository';
 import {TeamRepository} from 'Repositories/team/TeamRepository';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {handleEnterDown} from 'Util/keyboardUtil';
+import {
+  createReactTranslationMarker,
+  renderReactTranslation,
+  replaceReactComponents,
+} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
+import {splitFingerprint} from 'Util/stringUtil';
 import {toError} from 'Util/toError';
 import {isErrorWithCode} from 'Util/typePredicateUtil';
 
 import {useLegalHoldModalState} from './LegalHoldModal.state';
 
 const DISABLE_SUBMIT_TEXT_LENGTH = 1;
+const legalHoldModalLineBreakMarker = createReactTranslationMarker('legal-hold-modal-line-break');
+const legalHoldModalFingerprintMarker = createReactTranslationMarker('legal-hold-modal-fingerprint');
+
+const legalHoldDescriptionReactReplacements = [
+  {
+    exactMatch: '<br />',
+    render(): ReactNode {
+      return <br />;
+    },
+  },
+];
+
+type RenderLegalHoldModalRequestTextOptions = {
+  readonly fingerprint: string;
+  readonly translate: Translate;
+};
+
+function formatFingerprintForLegacyRendering(fingerprint: string): string {
+  return splitFingerprint(fingerprint)
+    .map(part => {
+      return `<span>${part} </span>`;
+    })
+    .join('');
+}
+
+function renderLegalHoldModalRequestText(options: RenderLegalHoldModalRequestTextOptions): ReactNode[] {
+  const {fingerprint, translate} = options;
+  const translatedText = translate('legalHoldModalText', undefined, {
+    br: legalHoldModalLineBreakMarker.substitution,
+    fingerprint: legalHoldModalFingerprintMarker.substitution,
+  });
+
+  return renderReactTranslation({
+    translatedText,
+    componentReplacements: [],
+    nodeReplacements: [
+      {
+        marker: legalHoldModalLineBreakMarker,
+        render(): ReactNode {
+          return <br />;
+        },
+      },
+      {
+        marker: legalHoldModalFingerprintMarker,
+        render(): ReactNode {
+          return (
+            <span className="legal-hold-modal__fingerprint" data-uie-name="status-modal-fingerprint">
+              {splitFingerprint(fingerprint).map((fingerprintPart, fingerprintPartIndex) => {
+                return <span key={fingerprintPartIndex}>{fingerprintPart} </span>;
+              })}
+            </span>
+          );
+        },
+      },
+    ],
+    valueReplacements: [],
+  });
+}
+
+type RenderLegalHoldDescriptionOptions = {
+  readonly isSelfInfo: boolean;
+  readonly translate: Translate;
+};
+
+function renderLegalHoldDescription(options: RenderLegalHoldDescriptionOptions): ReactNode {
+  const {isSelfInfo, translate} = options;
+  const translatedText = isSelfInfo ? translate('legalHoldDescriptionSelf') : translate('legalHoldDescriptionOthers');
+
+  return replaceReactComponents(translatedText, legalHoldDescriptionReactReplacements);
+}
 
 export enum LegalHoldModalType {
   REQUEST = 'request',
@@ -69,7 +148,7 @@ const LegalHoldModal: FC<LegalHoldModalProps> = ({
   cryptographyRepository,
   messageRepository,
 }) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
   const skipShowUsersRef = useRef(false);
 
   const {
@@ -92,6 +171,8 @@ const LegalHoldModal: FC<LegalHoldModalProps> = ({
 
   const isRequest = type === LegalHoldModalType.REQUEST;
   const isUsers = type === LegalHoldModalType.USERS;
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
+  const currentFingerprint = isUndefined(fingerprint) ? '' : fingerprint;
 
   const [isPending, setIsPending] = useState<boolean>(false);
   const [isSendingApprove, setIsSendingApprove] = useState<boolean>(false);
@@ -339,14 +420,18 @@ const LegalHoldModal: FC<LegalHoldModalProps> = ({
         {isRequest && (
           <>
             <div className="modal__text" data-uie-name="status-modal-text">
-              <p
-                dangerouslySetInnerHTML={{
-                  __html: translate('legalHoldModalText', undefined, {
-                    br: '<br>',
-                    fingerprint: `<span class="legal-hold-modal__fingerprint" data-uie-name="status-modal-fingerprint">${fingerprint}</span>`,
-                  }),
-                }}
-              />
+              {isReactTranslationRenderingEnabled ? (
+                <p>{renderLegalHoldModalRequestText({fingerprint: currentFingerprint, translate})}</p>
+              ) : (
+                <p
+                  dangerouslySetInnerHTML={{
+                    __html: translate('legalHoldModalText', undefined, {
+                      br: '<br>',
+                      fingerprint: `<span class="legal-hold-modal__fingerprint" data-uie-name="status-modal-fingerprint">${formatFingerprintForLegacyRendering(currentFingerprint)}</span>`,
+                    }),
+                  }}
+                />
+              )}
 
               {requiresPassword && <div>{translate('legalHoldModalTextPassword')}</div>}
             </div>
@@ -408,15 +493,21 @@ const LegalHoldModal: FC<LegalHoldModalProps> = ({
                   {translate('legalHoldHeadline')}
                 </div>
 
-                <p
-                  className="legal-hold-modal__info"
-                  data-uie-name="status-modal-text"
-                  dangerouslySetInnerHTML={{
-                    __html: isSelfInfo
-                      ? translate('legalHoldDescriptionSelf')
-                      : translate('legalHoldDescriptionOthers'),
-                  }}
-                />
+                {isReactTranslationRenderingEnabled ? (
+                  <p className="legal-hold-modal__info" data-uie-name="status-modal-text">
+                    {renderLegalHoldDescription({isSelfInfo, translate})}
+                  </p>
+                ) : (
+                  <p
+                    className="legal-hold-modal__info"
+                    data-uie-name="status-modal-text"
+                    dangerouslySetInnerHTML={{
+                      __html: isSelfInfo
+                        ? translate('legalHoldDescriptionSelf')
+                        : translate('legalHoldDescriptionOthers'),
+                    }}
+                  />
+                )}
 
                 <div className="legal-hold-modal__subjects">{translate('legalHoldSubjects')}</div>
 

--- a/apps/webapp/src/script/components/Modals/UserModal/UserModal.test.tsx
+++ b/apps/webapp/src/script/components/Modals/UserModal/UserModal.test.tsx
@@ -17,13 +17,20 @@
  *
  */
 
-import {render, waitFor} from '@testing-library/react';
+import {act, render, waitFor} from '@testing-library/react';
+import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
+import en from 'I18n/en-US.json';
+import {ConnectionEntity} from 'Repositories/connection/connectionEntity';
 import {User} from 'Repositories/entity/User';
 import {TeamState} from 'Repositories/team/TeamState';
 import {UserRepository} from 'Repositories/user/userRepository';
+import {Config} from 'src/script/Config';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
 import {translateForTest} from 'Util/test/translateForTest';
+import {setStrings, translate} from 'Util/localizerUtil';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
@@ -31,12 +38,100 @@ import {
 import {Core} from 'src/script/service/coreSingleton';
 
 import {UserModal, UserModalProps} from './UserModal';
-import {showUserModal} from './UserModal.state';
+import {showUserModal, useUserModalState} from './UserModal.state';
 
 describe('UserModal', () => {
   const rootProviderWrapper = createRootProviderWrapperForTest(
     createRootContextValueForTest({translate: translateForTest}),
   );
+  const legacyTranslationRootProviderWrapper = createRootProviderWrapperForTest(
+    createRootContextValueForTest({translate}),
+  );
+  const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+    createRootContextValueForTest({
+      isFeatureToggleEnabled(featureName): boolean {
+        return featureName === reactTranslationRenderingFeatureToggleName;
+      },
+      translate,
+    }),
+  );
+
+  type TranslationTestFunction = () => void | Promise<void>;
+  type IsolatedTranslationTestFunction = () => Promise<void>;
+  const legalHoldBlockUrl = 'https://support.example/legal-hold-block';
+
+  function withTranslationStrings(
+    strings: typeof en,
+    testFunction: TranslationTestFunction,
+  ): IsolatedTranslationTestFunction {
+    return async function runTranslationTest(): Promise<void> {
+      setStrings({en: strings});
+
+      try {
+        await testFunction();
+      } finally {
+        act((): void => {
+          useUserModalState.getState().resetState();
+        });
+        setStrings({en});
+      }
+    };
+  }
+
+  function withLegalHoldConfiguration(testFunction: TranslationTestFunction): IsolatedTranslationTestFunction {
+    return async function runLegalHoldConfigurationTest(): Promise<void> {
+      const originalConfig = Config.getConfig();
+      const configWithTestValues = {
+        ...originalConfig,
+        URL: {
+          ...originalConfig.URL,
+          SUPPORT: {
+            ...originalConfig.URL.SUPPORT,
+            LEGAL_HOLD_BLOCK: legalHoldBlockUrl,
+          },
+        },
+      };
+      const configSpy = jest.spyOn(Config, 'getConfig').mockReturnValue(configWithTestValues);
+
+      try {
+        await testFunction();
+      } finally {
+        configSpy.mockRestore();
+      }
+    };
+  }
+
+  function createUser(isBlockedForLegalHold: boolean): User {
+    const user = new User('mock-id', '', translateForTest);
+    user.name('Test User');
+
+    if (isBlockedForLegalHold) {
+      const connection = new ConnectionEntity();
+      connection.status(ConnectionStatus.MISSING_LEGAL_HOLD_CONSENT);
+      user.connection(connection);
+    }
+
+    return user;
+  }
+
+  function createUserModalProps(user: User): UserModalProps {
+    return {
+      core: {} as Core,
+      teamState: {} as TeamState,
+      userRepository: {
+        refreshUser: jest.fn(async (): Promise<User> => {
+          return user;
+        }),
+      } as unknown as UserRepository,
+      selfUser: new User('', '', translateForTest),
+    };
+  }
+
+  function showTestUserModal(user: User): void {
+    act((): void => {
+      showUserModal(user.qualifiedId);
+    });
+  }
 
   it('correctly fetches user from user repository', async () => {
     jest.useFakeTimers();
@@ -85,5 +180,138 @@ describe('UserModal', () => {
     await waitFor(() => {
       expect(getByTestId('status-modal-text')).toBeInstanceOf(HTMLDivElement);
     });
+  });
+
+  it(
+    'preserves the blocked Legal Hold message in the legacy HTML path',
+    withLegalHoldConfiguration(
+      withTranslationStrings(
+        {...en, modalUserBlockedForLegalHold: 'Blocked: [link]Learn more[/link]'},
+        async (): Promise<void> => {
+          const user = createUser(true);
+          const {getByTestId} = render(
+            withThemeAndRootContext(
+              <UserModal {...createUserModalProps(user)} />,
+              legacyTranslationRootProviderWrapper,
+            ),
+          );
+          showTestUserModal(user);
+
+          const blockedMessage = await waitFor((): HTMLElement => {
+            return getByTestId('status-blocked-legal-hold');
+          });
+
+          expect(blockedMessage).toHaveTextContent('Blocked: Learn more');
+          expect(blockedMessage.querySelector('a')).toHaveAttribute(
+            'href',
+            Config.getConfig().URL.SUPPORT.LEGAL_HOLD_BLOCK,
+          );
+        },
+      ),
+    ),
+  );
+
+  it(
+    'renders the blocked Legal Hold message as a React link when enabled',
+    withLegalHoldConfiguration(
+      withTranslationStrings(
+        {...en, modalUserBlockedForLegalHold: 'Blocked: [link]Read about Legal Hold[/link]'},
+        async (): Promise<void> => {
+          const user = createUser(true);
+          const {getByTestId} = render(
+            withThemeAndRootContext(
+              <UserModal {...createUserModalProps(user)} />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+          showTestUserModal(user);
+
+          const blockedMessage = await waitFor((): HTMLElement => {
+            return getByTestId('status-blocked-legal-hold');
+          });
+          const blockedMessageLink = blockedMessage.querySelector('a');
+
+          expect(blockedMessageLink).toBeInTheDocument();
+          expect(blockedMessageLink).toHaveTextContent('Read about Legal Hold');
+          expect(blockedMessageLink).toHaveAttribute('href', Config.getConfig().URL.SUPPORT.LEGAL_HOLD_BLOCK);
+          expect(blockedMessageLink).toHaveAttribute('target', '_blank');
+          expect(blockedMessageLink).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+          expect(blockedMessageLink).toHaveAttribute('data-uie-name', 'read-more-legal-hold');
+        },
+      ),
+    ),
+  );
+
+  it(
+    'keeps the blocked Legal Hold link placement under translation control',
+    withLegalHoldConfiguration(
+      withTranslationStrings(
+        {...en, modalUserBlockedForLegalHold: '[link]Read about Legal Hold[/link] This user is blocked.'},
+        async (): Promise<void> => {
+          const user = createUser(true);
+          const {getByTestId} = render(
+            withThemeAndRootContext(
+              <UserModal {...createUserModalProps(user)} />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+          showTestUserModal(user);
+
+          const blockedMessage = await waitFor((): HTMLElement => {
+            return getByTestId('status-blocked-legal-hold');
+          });
+
+          expect(blockedMessage.firstElementChild).toBeInstanceOf(HTMLAnchorElement);
+          expect(blockedMessage).toHaveTextContent('Read about Legal Hold This user is blocked.');
+        },
+      ),
+    ),
+  );
+
+  it(
+    'leaves unsupported blocked Legal Hold markup as text',
+    withLegalHoldConfiguration(
+      withTranslationStrings(
+        {...en, modalUserBlockedForLegalHold: 'Before[link]<img src="example">Read[/link]After'},
+        async (): Promise<void> => {
+          const user = createUser(true);
+          const {getByTestId} = render(
+            withThemeAndRootContext(
+              <UserModal {...createUserModalProps(user)} />,
+              reactTranslationRenderingRootProviderWrapper,
+            ),
+          );
+          showTestUserModal(user);
+
+          const blockedMessage = await waitFor((): HTMLElement => {
+            return getByTestId('status-blocked-legal-hold');
+          });
+
+          expect(blockedMessage).toHaveTextContent('Before<img src="example">ReadAfter');
+          expect(blockedMessage.querySelector('img')).toBeNull();
+        },
+      ),
+    ),
+  );
+
+  it('renders normal UserActions for users who are not blocked for Legal Hold', async (): Promise<void> => {
+    try {
+      const user = createUser(false);
+      const {getByTestId, queryByTestId} = render(
+        withThemeAndRootContext(<UserModal {...createUserModalProps(user)} />, rootProviderWrapper),
+      );
+      showTestUserModal(user);
+
+      await waitFor((): HTMLElement => {
+        return getByTestId('do-send-request');
+      });
+
+      expect(queryByTestId('status-blocked-legal-hold')).toBeNull();
+      expect(getByTestId('do-send-request')).toBeInTheDocument();
+    } finally {
+      act((): void => {
+        useUserModalState.getState().resetState();
+      });
+    }
   });
 });

--- a/apps/webapp/src/script/components/Modals/UserModal/UserModal.tsx
+++ b/apps/webapp/src/script/components/Modals/UserModal/UserModal.tsx
@@ -33,10 +33,13 @@ import {UserDetails} from 'Components/panel/userDetails';
 import {User} from 'Repositories/entity/User';
 import {TeamState} from 'Repositories/team/TeamState';
 import {UserRepository} from 'Repositories/user/userRepository';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {handleKeyDown, KEY} from 'Util/keyboardUtil';
 import {replaceLink} from 'Util/localizerUtil';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 
 import {useUserModalState} from './UserModal.state';
 import {
@@ -61,13 +64,53 @@ export interface UserModalProps {
 }
 
 const brandName = Config.getConfig().BRAND_NAME;
+const legalHoldLinkMarker = createReactTranslationMarker('legal-hold-link');
+
+type RenderBlockedForLegalHoldMessageOptions = {
+  readonly legalHoldBlockUrl: string;
+  readonly translate: Translate;
+};
+
+function renderBlockedForLegalHoldMessage(options: RenderBlockedForLegalHoldMessageOptions): ReactNode[] {
+  const {legalHoldBlockUrl, translate} = options;
+  const translatedText = translate('modalUserBlockedForLegalHold', undefined, {
+    link: legalHoldLinkMarker.start,
+    '/link': legalHoldLinkMarker.end,
+  });
+
+  return renderReactTranslation({
+    translatedText,
+    componentReplacements: [
+      {
+        start: legalHoldLinkMarker.start,
+        end: legalHoldLinkMarker.end,
+        render(children): ReactNode {
+          return (
+            <a
+              data-uie-name="read-more-legal-hold"
+              href={legalHoldBlockUrl}
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              {children}
+            </a>
+          );
+        },
+      },
+    ],
+    nodeReplacements: [],
+    valueReplacements: [],
+  });
+}
 
 interface UserModalUserActionsSectionProps {
   user: User;
   onAction: () => void;
   isSelfActivated: boolean;
   selfUser: User;
-  blockedForLegalHoldMessageHtml: string;
+  isReactTranslationRenderingEnabled: boolean;
+  legalHoldBlockUrl: string;
+  translate: Translate;
 }
 
 const UserModalUserActionsSection = ({
@@ -75,17 +118,33 @@ const UserModalUserActionsSection = ({
   onAction,
   isSelfActivated,
   selfUser,
-  blockedForLegalHoldMessageHtml,
+  isReactTranslationRenderingEnabled,
+  legalHoldBlockUrl,
+  translate,
 }: UserModalUserActionsSectionProps) => {
   const {isBlockedLegalHold} = useKoSubscribableChildren(user, ['isBlockedLegalHold']);
   const {mainViewModel} = useApplicationContext();
 
   if (isBlockedLegalHold) {
+    if (isReactTranslationRenderingEnabled) {
+      return (
+        <div className="modal__message" data-uie-name="status-blocked-legal-hold">
+          {renderBlockedForLegalHoldMessage({legalHoldBlockUrl, translate})}
+        </div>
+      );
+    }
+
     return (
       <div
         className="modal__message"
         data-uie-name="status-blocked-legal-hold"
-        dangerouslySetInnerHTML={{__html: blockedForLegalHoldMessageHtml}}
+        dangerouslySetInnerHTML={{
+          __html: translate(
+            'modalUserBlockedForLegalHold',
+            undefined,
+            replaceLink(legalHoldBlockUrl, '', 'read-more-legal-hold'),
+          ),
+        }}
       />
     );
   }
@@ -177,7 +236,9 @@ const UserModal = ({
   core = container.resolve(Core),
   teamState = container.resolve(TeamState),
 }: UserModalProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
+  const legalHoldBlockUrl = Config.getConfig().URL.SUPPORT.LEGAL_HOLD_BLOCK;
   const onClose = useUserModalState(state => state.onClose);
   const userId = useUserModalState(state => state.userId);
   const resetState = useUserModalState(state => state.resetState);
@@ -229,9 +290,6 @@ const UserModal = ({
       setUserNotFound(false);
     };
   }, [userId, userRepository]);
-
-  const replaceLinkLegalHold = replaceLink(Config.getConfig().URL.SUPPORT.LEGAL_HOLD_BLOCK, '', 'read-more-legal-hold');
-  const blockedForLegalHoldMessageHtml = translate('modalUserBlockedForLegalHold', undefined, replaceLinkLegalHold);
 
   let modalDataUieName = '';
   if (user) {
@@ -292,7 +350,9 @@ const UserModal = ({
               onAction={hide}
               isSelfActivated={isActivatedAccount}
               selfUser={selfUser}
-              blockedForLegalHoldMessageHtml={blockedForLegalHoldMessageHtml}
+              isReactTranslationRenderingEnabled={isReactTranslationRenderingEnabled}
+              legalHoldBlockUrl={legalHoldBlockUrl}
+              translate={translate}
             />
           </>
         )}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27666" title="WPB-27666" target="_blank"><img alt="Security" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/13902?size=medium" />WPB-27666</a>  [Web] Text rendering
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This pull request continues the localized rich-text rendering migration from #22411, #22431, #22433, and #22444.

It moves the remaining direct Legal Hold UI translations to React-based rendering behind the existing startup feature toggle:

```text
react-translation-rendering
```

### Changes

This batch covers:

* Legal Hold request-modal copy
* Legal Hold informational descriptions
* the blocked-for-Legal-Hold message in the user modal

The Legal Hold request message now renders its translated line break and fingerprint placeholder as React nodes. The actual fingerprint remains ordinary React text and is kept separate from translation formatting.

The informational Legal Hold descriptions retain compatibility with their existing `<br />` translation token, which is mapped explicitly to a React line break rather than treating the translation as arbitrary HTML.

The blocked-user Legal Hold message now renders its translated `[link]...[/link]` content as a real React link while keeping the destination and link attributes application-controlled.

### Translation compatibility

The Sinhala `legalHoldModalText` translation is aligned with the shared `[fingerprint]` marker used by the other locales.

The existing French Legal Hold description containing line-break characters remains unchanged and is treated as ordinary translated text.
