### PR TITLE
Render device and file restriction translations with React [WPB-27666]

### DIFF
--- a/apps/webapp/src/script/components/messagesList/message/fileTypeRestrictedMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/fileTypeRestrictedMessage.test.tsx
@@ -19,22 +19,50 @@
 
 import {render} from '@testing-library/react';
 
+import en from 'I18n/en-US.json';
 import {FileTypeRestrictedMessage as FileTypeRestrictedMessageEntity} from 'Repositories/entity/message/fileTypeRestrictedMessage';
-import {translateForTest} from 'Util/test/translateForTest';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
 } from 'src/script/page/testSupport/rootContextTestSupport';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {setStrings, translate} from 'Util/localizerUtil';
 
 import {FileTypeRestrictedMessage} from './fileTypeRestrictedMessage';
 
-const rootProviderWrapper = createRootProviderWrapperForTest(
-  createRootContextValueForTest({translate: translateForTest}),
+const legacyTranslationRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate}),
+);
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName) {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
 );
 
-const createFileTypeRestrictedMessage = (
+type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
+
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
+
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
+}
+
+function createFileTypeRestrictedMessage(
   partialFileTypeRestrictedMessage: Partial<FileTypeRestrictedMessageEntity>,
-) => {
+): FileTypeRestrictedMessageEntity {
   const FileTypeRestrictedMessage: Partial<FileTypeRestrictedMessageEntity> = {
     fileExt: 'txt',
     isIncoming: false,
@@ -42,30 +70,309 @@ const createFileTypeRestrictedMessage = (
     ...partialFileTypeRestrictedMessage,
   };
   return FileTypeRestrictedMessage as FileTypeRestrictedMessageEntity;
-};
+}
+
+function getFileTypeRestrictedMessageText(container: HTMLElement): HTMLElement {
+  const messageText = container.querySelector<HTMLElement>('[data-uie-name="filetype-restricted-message-text"]');
+
+  if (messageText === null) {
+    throw new Error('Expected the file type restricted message text to be rendered');
+  }
+
+  return messageText;
+}
 
 describe('FileTypeRestrictedMessage', () => {
-  it('shows incoming message', async () => {
-    const message = createFileTypeRestrictedMessage({
-      isIncoming: true,
-    });
+  it(
+    'preserves incoming legacy rendering and its UIE value',
+    withTranslationStrings(en, () => {
+      const message = createFileTypeRestrictedMessage({
+        isIncoming: true,
+        name: 'Alice',
+      });
 
-    const {getByTestId} = render(<FileTypeRestrictedMessage message={message} />, {wrapper: rootProviderWrapper});
+      const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+        wrapper: legacyTranslationRootProviderWrapper,
+      });
+      const messageText = getFileTypeRestrictedMessageText(container);
 
-    const filetypeRestrictedMessageText = getByTestId('filetype-restricted-message-text');
+      expect(messageText.getAttribute('data-uie-value')).toEqual('incoming');
+      expect(messageText.textContent).toBe('File from\u00A0Alice\u00A0can’t be opened');
+      expect(messageText.querySelector('strong')).toHaveTextContent('Alice');
+    }),
+  );
 
-    expect(filetypeRestrictedMessageText.getAttribute('data-uie-value')).toEqual('incoming');
-  });
+  it(
+    'preserves outgoing legacy rendering and its UIE value',
+    withTranslationStrings(en, () => {
+      const message = createFileTypeRestrictedMessage({
+        fileExt: 'txt',
+        isIncoming: false,
+      });
 
-  it('shows outgoing message', async () => {
-    const message = createFileTypeRestrictedMessage({
-      isIncoming: false,
-    });
+      const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+        wrapper: legacyTranslationRootProviderWrapper,
+      });
+      const messageText = getFileTypeRestrictedMessageText(container);
 
-    const {getByTestId} = render(<FileTypeRestrictedMessage message={message} />, {wrapper: rootProviderWrapper});
+      expect(messageText.getAttribute('data-uie-value')).toEqual('outgoing');
+      expect(messageText.textContent).toBe(
+        'Sharing files with the txt extension is not permitted by your organization',
+      );
+    }),
+  );
 
-    const filetypeRestrictedMessageText = getByTestId('filetype-restricted-message-text');
+  it(
+    'renders incoming bold formatting and an opaque runtime name when enabled',
+    withTranslationStrings(en, () => {
+      const message = createFileTypeRestrictedMessage({
+        isIncoming: true,
+        name: 'Alice',
+      });
 
-    expect(filetypeRestrictedMessageText.getAttribute('data-uie-value')).toEqual('outgoing');
-  });
+      const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+      const messageText = getFileTypeRestrictedMessageText(container);
+      const strong = messageText.querySelector('strong');
+
+      expect(messageText.textContent).toBe('File from\u00A0Alice\u00A0can’t be opened');
+      expect(strong).toHaveTextContent('Alice');
+      expect(messageText.textContent).not.toContain('&nbsp;');
+    }),
+  );
+
+  it(
+    'lets the translation move the incoming name outside the bold region',
+    withTranslationStrings(
+      {
+        ...en,
+        fileTypeRestrictedIncoming: 'File owner: {name}. [bold]Opening is blocked.[/bold]',
+      },
+      () => {
+        const message = createFileTypeRestrictedMessage({
+          isIncoming: true,
+          name: 'Alice',
+        });
+
+        const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        const messageText = getFileTypeRestrictedMessageText(container);
+        const strong = messageText.querySelector('strong');
+
+        expect(messageText.textContent).toBe('File owner: Alice. Opening is blocked.');
+        expect(strong).toHaveTextContent('Opening is blocked.');
+        expect(strong?.textContent).not.toContain('Alice');
+      },
+    ),
+  );
+
+  it(
+    'lets the translation move the incoming bold region around the name',
+    withTranslationStrings(
+      {
+        ...en,
+        fileTypeRestrictedIncoming: '[bold]File owner {name} cannot open this file[/bold].',
+      },
+      () => {
+        const message = createFileTypeRestrictedMessage({
+          isIncoming: true,
+          name: 'Alice',
+        });
+
+        const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        const messageText = getFileTypeRestrictedMessageText(container);
+        const strong = messageText.querySelector('strong');
+
+        expect(messageText.textContent).toBe('File owner Alice cannot open this file.');
+        expect(strong).toHaveTextContent('File owner Alice cannot open this file');
+      },
+    ),
+  );
+
+  it(
+    'keeps an HTML-looking incoming name opaque',
+    withTranslationStrings(en, () => {
+      const message = createFileTypeRestrictedMessage({
+        isIncoming: true,
+        name: 'R&D <Test>',
+      });
+
+      const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+      const messageText = getFileTypeRestrictedMessageText(container);
+
+      expect(messageText.textContent).toBe('File from\u00A0R&D <Test>\u00A0can’t be opened');
+      expect(messageText.querySelector('test')).toBeNull();
+    }),
+  );
+
+  it(
+    'keeps a translation-looking incoming name literal without nested strong elements',
+    withTranslationStrings(en, () => {
+      const message = createFileTypeRestrictedMessage({
+        isIncoming: true,
+        name: '[bold]Alice[/bold]',
+      });
+
+      const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+        wrapper: reactTranslationRenderingRootProviderWrapper,
+      });
+      const messageText = getFileTypeRestrictedMessageText(container);
+
+      expect(messageText.textContent).toBe('File from\u00A0[bold]Alice[/bold]\u00A0can’t be opened');
+      expect(messageText.querySelectorAll('strong')).toHaveLength(1);
+      expect(messageText.querySelector('strong')).toHaveTextContent('[bold]Alice[/bold]');
+      expect(messageText.querySelector('strong strong')).toBeNull();
+    }),
+  );
+
+  it(
+    'converts every exact incoming non-breaking-space token to U+00A0',
+    withTranslationStrings(
+      {
+        ...en,
+        fileTypeRestrictedIncoming: 'A&nbsp;&nbsp;[bold]{name}[/bold]&nbsp;B',
+      },
+      () => {
+        const message = createFileTypeRestrictedMessage({
+          isIncoming: true,
+          name: 'Alice',
+        });
+
+        const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        const messageText = getFileTypeRestrictedMessageText(container);
+
+        expect(messageText.textContent).toBe('A\u00A0\u00A0Alice\u00A0B');
+        expect(messageText.textContent).not.toContain('&nbsp;');
+      },
+    ),
+  );
+
+  it(
+    'converts non-breaking-space tokens inside incoming bold formatting',
+    withTranslationStrings(
+      {
+        ...en,
+        fileTypeRestrictedIncoming: 'A[bold]&nbsp;{name}&nbsp;[/bold]B',
+      },
+      () => {
+        const message = createFileTypeRestrictedMessage({
+          isIncoming: true,
+          name: 'Alice',
+        });
+
+        const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        const messageText = getFileTypeRestrictedMessageText(container);
+        const strong = messageText.querySelector('strong');
+
+        expect(messageText.textContent).toBe('A\u00A0Alice\u00A0B');
+        expect(strong?.textContent).toBe('\u00A0Alice\u00A0');
+      },
+    ),
+  );
+
+  it(
+    'keeps unsupported incoming HTML and entities as text',
+    withTranslationStrings(
+      {
+        ...en,
+        fileTypeRestrictedIncoming: '&copy;<img src="example">{name}',
+      },
+      () => {
+        const message = createFileTypeRestrictedMessage({
+          isIncoming: true,
+          name: 'Alice',
+        });
+
+        const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        const messageText = getFileTypeRestrictedMessageText(container);
+
+        expect(messageText.textContent).toBe('&copy;<img src="example">Alice');
+        expect(messageText.querySelector('img')).toBeNull();
+      },
+    ),
+  );
+
+  it(
+    'renders an outgoing extension as opaque React text',
+    withTranslationStrings(
+      {
+        ...en,
+        fileTypeRestrictedOutgoing: 'Extension: {fileExt} is blocked',
+      },
+      () => {
+        const message = createFileTypeRestrictedMessage({
+          fileExt: '<script>',
+          isIncoming: false,
+        });
+
+        const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        const messageText = getFileTypeRestrictedMessageText(container);
+
+        expect(messageText.textContent).toBe('Extension: <script> is blocked');
+        expect(messageText.querySelector('script')).toBeNull();
+      },
+    ),
+  );
+
+  it(
+    'keeps a translation-looking outgoing extension literal',
+    withTranslationStrings(
+      {
+        ...en,
+        fileTypeRestrictedOutgoing: 'Extension: {fileExt} is blocked',
+      },
+      () => {
+        const message = createFileTypeRestrictedMessage({
+          fileExt: '[bold]exe[/bold]',
+          isIncoming: false,
+        });
+
+        const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        const messageText = getFileTypeRestrictedMessageText(container);
+
+        expect(messageText.textContent).toBe('Extension: [bold]exe[/bold] is blocked');
+        expect(messageText.querySelector('strong')).toBeNull();
+      },
+    ),
+  );
+
+  it(
+    'keeps unsupported outgoing HTML and entities as text',
+    withTranslationStrings(
+      {
+        ...en,
+        fileTypeRestrictedOutgoing: '&copy;<img src="example"> {fileExt}',
+      },
+      () => {
+        const message = createFileTypeRestrictedMessage({
+          fileExt: 'exe',
+          isIncoming: false,
+        });
+
+        const {container} = render(<FileTypeRestrictedMessage message={message} />, {
+          wrapper: reactTranslationRenderingRootProviderWrapper,
+        });
+        const messageText = getFileTypeRestrictedMessageText(container);
+
+        expect(messageText.textContent).toBe('&copy;<img src="example"> exe');
+        expect(messageText.querySelector('img')).toBeNull();
+      },
+    ),
+  );
 });

--- a/apps/webapp/src/script/components/messagesList/message/fileTypeRestrictedMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/fileTypeRestrictedMessage.tsx
@@ -17,36 +17,145 @@
  *
  */
 
+import type {ReactNode} from 'react';
+
 import {FileTypeRestrictedMessage as FileTypeRestrictedMessageEntity} from 'Repositories/entity/message/fileTypeRestrictedMessage';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 
 interface FileTypeRestrictedMessageProps {
   message: FileTypeRestrictedMessageEntity;
 }
 
+type FileTypeRestrictedTranslation =
+  | {
+      readonly kind: 'incoming';
+      readonly name: string;
+    }
+  | {
+      readonly kind: 'outgoing';
+      readonly fileExt: string;
+    };
+
+type RenderFileTypeRestrictedMessageOptions = {
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly translate: Translate;
+  readonly translation: FileTypeRestrictedTranslation;
+};
+
+const fileTypeRestrictedBoldMarker = createReactTranslationMarker('file-type-restricted-bold');
+const fileTypeRestrictedNameMarker = createReactTranslationMarker('file-type-restricted-name');
+const fileTypeRestrictedFileExtMarker = createReactTranslationMarker('file-type-restricted-file-ext');
+const fileTypeRestrictedNonBreakingSpaceMarker = createReactTranslationMarker(
+  'file-type-restricted-non-breaking-space',
+);
+
+function translateFileTypeRestrictedMessage(translate: Translate, translation: FileTypeRestrictedTranslation): string {
+  if (translation.kind === 'incoming') {
+    return translate('fileTypeRestrictedIncoming', {name: translation.name});
+  }
+
+  return translate('fileTypeRestrictedOutgoing', {fileExt: translation.fileExt});
+}
+
+function translateFileTypeRestrictedMessageWithReactMarkers(
+  translate: Translate,
+  translation: FileTypeRestrictedTranslation,
+): string {
+  if (translation.kind === 'incoming') {
+    return translate(
+      'fileTypeRestrictedIncoming',
+      {name: fileTypeRestrictedNameMarker.substitution},
+      {
+        '/bold': fileTypeRestrictedBoldMarker.end,
+        bold: fileTypeRestrictedBoldMarker.start,
+      },
+    );
+  }
+
+  return translate('fileTypeRestrictedOutgoing', {fileExt: fileTypeRestrictedFileExtMarker.substitution});
+}
+
+function replaceFileTypeRestrictedNonBreakingSpaces(translatedText: string): string {
+  return translatedText.replaceAll('&nbsp;', fileTypeRestrictedNonBreakingSpaceMarker.substitution);
+}
+
+function renderFileTypeRestrictedTranslation(
+  translate: Translate,
+  translation: FileTypeRestrictedTranslation,
+): ReactNode[] {
+  const translatedText = replaceFileTypeRestrictedNonBreakingSpaces(
+    translateFileTypeRestrictedMessageWithReactMarkers(translate, translation),
+  );
+  const valueReplacements =
+    translation.kind === 'incoming'
+      ? [{marker: fileTypeRestrictedNameMarker, runtimeText: translation.name}]
+      : [{marker: fileTypeRestrictedFileExtMarker, runtimeText: translation.fileExt}];
+
+  return renderReactTranslation({
+    translatedText,
+    componentReplacements: [
+      {
+        start: fileTypeRestrictedBoldMarker.start,
+        end: fileTypeRestrictedBoldMarker.end,
+        render(children): ReactNode {
+          return <strong>{children}</strong>;
+        },
+      },
+    ],
+    nodeReplacements: [
+      {
+        marker: fileTypeRestrictedNonBreakingSpaceMarker,
+        render(): ReactNode {
+          return '\u00A0';
+        },
+      },
+    ],
+    valueReplacements,
+  });
+}
+
+function renderFileTypeRestrictedMessage(options: RenderFileTypeRestrictedMessageOptions): ReactNode {
+  const {isReactTranslationRenderingEnabled, translate, translation} = options;
+  const dataUieValue = translation.kind === 'incoming' ? 'incoming' : 'outgoing';
+
+  if (isReactTranslationRenderingEnabled) {
+    return (
+      <p
+        className="message-header-label"
+        data-uie-name="filetype-restricted-message-text"
+        data-uie-value={dataUieValue}
+      >
+        {renderFileTypeRestrictedTranslation(translate, translation)}
+      </p>
+    );
+  }
+
+  return (
+    <p
+      className="message-header-label"
+      dangerouslySetInnerHTML={{__html: translateFileTypeRestrictedMessage(translate, translation)}}
+      data-uie-name="filetype-restricted-message-text"
+      data-uie-value={dataUieValue}
+    />
+  );
+}
+
 const FileTypeRestrictedMessage = ({message}: FileTypeRestrictedMessageProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
+  const translation = message.isIncoming
+    ? {kind: 'incoming' as const, name: message.name}
+    : {kind: 'outgoing' as const, fileExt: message.fileExt};
 
   return (
     <div className="message-header" data-uie-name="filetype-restricted-message">
       <div className="message-header-icon">
         <span className="icon-sysmsg-error text-red" />
       </div>
-      {message.isIncoming ? (
-        <p
-          className="message-header-label"
-          dangerouslySetInnerHTML={{__html: translate('fileTypeRestrictedIncoming', {name: message.name})}}
-          data-uie-name="filetype-restricted-message-text"
-          data-uie-value="incoming"
-        />
-      ) : (
-        <p
-          className="message-header-label"
-          dangerouslySetInnerHTML={{__html: translate('fileTypeRestrictedOutgoing', {fileExt: message.fileExt})}}
-          data-uie-name="filetype-restricted-message-text"
-          data-uie-value="outgoing"
-        />
-      )}
+      {renderFileTypeRestrictedMessage({isReactTranslationRenderingEnabled, translate, translation})}
     </div>
   );
 };

--- a/apps/webapp/src/script/components/userDevices/components/deviceDetails/DeviceDetails.test.tsx
+++ b/apps/webapp/src/script/components/userDevices/components/deviceDetails/DeviceDetails.test.tsx
@@ -1,0 +1,275 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+import type {ComponentProps} from 'react';
+
+import {render} from '@testing-library/react';
+
+import en from 'I18n/en-US.json';
+import {ClientEntity} from 'Repositories/client/ClientEntity';
+import type {ClientRepository} from 'Repositories/client';
+import type {CryptographyRepository} from 'Repositories/cryptography/CryptographyRepository';
+import {User} from 'Repositories/entity/User';
+import type {MessageRepository} from 'Repositories/conversation/MessageRepository';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {ConversationState} from 'Repositories/conversation/ConversationState';
+import {setStrings, translate} from 'Util/localizerUtil';
+import type {Logger} from 'Util/logger';
+import {translateForTest} from 'Util/test/translateForTest';
+
+import {Config} from '../../../../Config';
+
+import {DeviceDetails} from './DeviceDetails';
+
+const legacyTranslationRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate}),
+);
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName) {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
+
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
+
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
+}
+
+function createDeviceForTest(): ClientEntity {
+  return new ClientEntity(false, '', 'device-id');
+}
+
+function createUserForTest(userName: string): User {
+  const user = new User('user-id', '', translateForTest);
+  user.name(userName);
+  return user;
+}
+
+function createDeviceDetailsPropertiesForTest(userName: string): ComponentProps<typeof DeviceDetails> {
+  return {
+    clickToShowSelfFingerprint: jest.fn(),
+    clientRepository: {} as unknown as ClientRepository,
+    conversationState: {
+      activeConversation: jest.fn().mockReturnValue(undefined),
+    } as unknown as ConversationState,
+    cryptographyRepository: {
+      getRemoteFingerprint: jest.fn().mockResolvedValue(undefined),
+    } as unknown as CryptographyRepository,
+    device: createDeviceForTest(),
+    logger: {} as unknown as Logger,
+    messageRepository: {} as unknown as MessageRepository,
+    noPadding: false,
+    user: createUserForTest(userName),
+  };
+}
+
+function getDeviceDetailsHeadline(container: HTMLElement): HTMLElement {
+  const headline = container.querySelector<HTMLElement>('.panel__info-text > span');
+
+  if (headline === null) {
+    throw new Error('Expected the device details headline to be rendered');
+  }
+
+  return headline;
+}
+
+describe('DeviceDetails', () => {
+  it(
+    'preserves the legacy headline rendering when React translation rendering is disabled',
+    withTranslationStrings(en, () => {
+      const {container} = render(
+        withThemeAndRootContext(
+          <DeviceDetails {...createDeviceDetailsPropertiesForTest('Alice')} />,
+          legacyTranslationRootProviderWrapper,
+        ),
+      );
+      const headline = getDeviceDetailsHeadline(container);
+
+      expect(headline).toHaveTextContent('Verify that this matches the fingerprint shown on Alice’s device.');
+      expect(headline.querySelector('strong')).toHaveTextContent('Alice’s device');
+    }),
+  );
+
+  it(
+    'renders the headline with translation-controlled strong content when enabled',
+    withTranslationStrings(
+      {
+        ...en,
+        participantDevicesDetailHeadline: 'Verify [bold]the fingerprint for {user} today[/bold].',
+      },
+      () => {
+        const {container} = render(
+          withThemeAndRootContext(
+            <DeviceDetails {...createDeviceDetailsPropertiesForTest('Alice')} />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+        const headline = getDeviceDetailsHeadline(container);
+        const strong = headline.querySelector('strong');
+
+        expect(headline).toHaveTextContent('Verify the fingerprint for Alice today.');
+        expect(strong).toHaveTextContent('the fingerprint for Alice today');
+      },
+    ),
+  );
+
+  it(
+    'allows the translation to move the user outside the bold region',
+    withTranslationStrings(
+      {
+        ...en,
+        participantDevicesDetailHeadline: '{user}: [bold]verify this device fingerprint[/bold]',
+      },
+      () => {
+        const {container} = render(
+          withThemeAndRootContext(
+            <DeviceDetails {...createDeviceDetailsPropertiesForTest('Alice')} />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+        const headline = getDeviceDetailsHeadline(container);
+        const strong = headline.querySelector('strong');
+
+        expect(headline).toHaveTextContent('Alice: verify this device fingerprint');
+        expect(strong).toHaveTextContent('verify this device fingerprint');
+      },
+    ),
+  );
+
+  it(
+    'keeps an HTML-looking user name opaque in the React headline',
+    withTranslationStrings(en, () => {
+      const {container} = render(
+        withThemeAndRootContext(
+          <DeviceDetails {...createDeviceDetailsPropertiesForTest('R&D <Test>')} />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+      const headline = getDeviceDetailsHeadline(container);
+
+      expect(headline).toHaveTextContent('Verify that this matches the fingerprint shown on R&D <Test>’s device.');
+      expect(headline.querySelector('test')).toBeNull();
+    }),
+  );
+
+  it(
+    'keeps translation-looking user names literal without nested strong elements',
+    withTranslationStrings(en, () => {
+      const {container} = render(
+        withThemeAndRootContext(
+          <DeviceDetails {...createDeviceDetailsPropertiesForTest('[bold]Admin[/bold]')} />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+      const headline = getDeviceDetailsHeadline(container);
+
+      expect(headline).toHaveTextContent(
+        'Verify that this matches the fingerprint shown on [bold]Admin[/bold]’s device.',
+      );
+      expect(headline.querySelectorAll('strong')).toHaveLength(1);
+      expect(headline.querySelector('strong')).toHaveTextContent('[bold]Admin[/bold]’s device');
+      expect(headline.querySelector('strong strong')).toBeNull();
+    }),
+  );
+
+  it(
+    'keeps unsupported translation markup as text',
+    withTranslationStrings(
+      {
+        ...en,
+        participantDevicesDetailHeadline: '<img src="example">Verify {user}',
+      },
+      () => {
+        const {container} = render(
+          withThemeAndRootContext(
+            <DeviceDetails {...createDeviceDetailsPropertiesForTest('Alice')} />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+        const headline = getDeviceDetailsHeadline(container);
+
+        expect(headline).toHaveTextContent('<img src="example">Verify Alice');
+        expect(headline.querySelector('img')).toBeNull();
+      },
+    ),
+  );
+
+  it(
+    'does not leak the audited malformed bold marker ordering',
+    withTranslationStrings(
+      {
+        ...en,
+        participantDevicesDetailHeadline: 'Verify the device [/bold] of [bold]{user}.',
+      },
+      () => {
+        const {container} = render(
+          withThemeAndRootContext(
+            <DeviceDetails {...createDeviceDetailsPropertiesForTest('Alice')} />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+        const headline = getDeviceDetailsHeadline(container);
+        const actualText = headline.textContent;
+
+        expect(actualText).toBe('Verify the device  of Alice.');
+        expect(headline.querySelector('strong')).toHaveTextContent('Alice.');
+        expect(headline).not.toHaveTextContent('__wire_react_translation_');
+      },
+    ),
+  );
+
+  it(
+    'keeps the existing how-to link unchanged',
+    withTranslationStrings(en, () => {
+      const {getByText} = render(
+        withThemeAndRootContext(
+          <DeviceDetails {...createDeviceDetailsPropertiesForTest('Alice')} />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+      const howToLink = getByText('How do I do that?');
+      const supportUrl = Config.getConfig().URL.SUPPORT.PRIVACY_VERIFY_FINGERPRINT;
+
+      expect(howToLink.getAttribute('href') ?? undefined).toBe(supportUrl);
+      expect(howToLink).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+      expect(howToLink).toHaveAttribute('target', '_blank');
+      expect(howToLink).toHaveClass('participant-devices__link', 'accent-text');
+    }),
+  );
+});

--- a/apps/webapp/src/script/components/userDevices/components/deviceDetails/DeviceDetails.tsx
+++ b/apps/webapp/src/script/components/userDevices/components/deviceDetails/DeviceDetails.tsx
@@ -18,6 +18,7 @@
  */
 
 import {useEffect, useMemo, useState} from 'react';
+import type {ReactNode} from 'react';
 
 import cx from 'classnames';
 import {container} from 'tsyringe';
@@ -31,9 +32,12 @@ import type {MessageRepository} from 'Repositories/conversation/MessageRepositor
 import type {CryptographyRepository} from 'Repositories/cryptography/CryptographyRepository';
 import type {User} from 'Repositories/entity/User';
 import {WireIdentity} from 'src/script/e2eIdentity';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {MLSDeviceDetails} from 'src/script/page/mainContent/panels/preferences/devicesPreferences/components/mlsDeviceDetails';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 import type {Logger} from 'Util/logger';
 import {splitFingerprint} from 'Util/stringUtil';
 import {toError} from 'Util/toError';
@@ -55,6 +59,80 @@ interface DeviceDetailsProps {
   user: User;
 }
 
+type RenderDeviceDetailsHeadlineOptions = {
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly translate: Translate;
+  readonly userName: string;
+};
+
+const deviceDetailsBoldMarker = createReactTranslationMarker('device-details-bold');
+const deviceDetailsUserMarker = createReactTranslationMarker('device-details-user');
+
+function translateDeviceDetailsHeadline(translate: Translate, userName: string): string {
+  return translate('participantDevicesDetailHeadline', {user: userName});
+}
+
+function translateDeviceDetailsHeadlineWithReactMarkers(translate: Translate): string {
+  return translate(
+    'participantDevicesDetailHeadline',
+    {user: deviceDetailsUserMarker.substitution},
+    {
+      '/bold': deviceDetailsBoldMarker.end,
+      bold: deviceDetailsBoldMarker.start,
+    },
+  );
+}
+
+function normalizeDeviceDetailsHeadlineFormatting(translatedText: string): string {
+  const boldMarkerStartIndex = translatedText.indexOf(deviceDetailsBoldMarker.start);
+  const boldMarkerEndIndex = translatedText.indexOf(deviceDetailsBoldMarker.end);
+
+  if (boldMarkerStartIndex === -1) {
+    return boldMarkerEndIndex === -1 ? translatedText : translatedText.replace(deviceDetailsBoldMarker.end, '');
+  }
+
+  if (boldMarkerEndIndex === -1) {
+    return `${translatedText}${deviceDetailsBoldMarker.end}`;
+  }
+
+  if (boldMarkerStartIndex < boldMarkerEndIndex) {
+    return translatedText;
+  }
+
+  return `${translatedText.replace(deviceDetailsBoldMarker.end, '')}${deviceDetailsBoldMarker.end}`;
+}
+
+function renderDeviceDetailsHeadline(options: RenderDeviceDetailsHeadlineOptions): ReactNode {
+  const {isReactTranslationRenderingEnabled, translate, userName} = options;
+
+  if (isReactTranslationRenderingEnabled) {
+    const translatedText = normalizeDeviceDetailsHeadlineFormatting(
+      translateDeviceDetailsHeadlineWithReactMarkers(translate),
+    );
+
+    return (
+      <span>
+        {renderReactTranslation({
+          translatedText,
+          componentReplacements: [
+            {
+              start: deviceDetailsBoldMarker.start,
+              end: deviceDetailsBoldMarker.end,
+              render(children): ReactNode {
+                return <strong>{children}</strong>;
+              },
+            },
+          ],
+          nodeReplacements: [],
+          valueReplacements: [{marker: deviceDetailsUserMarker, runtimeText: userName}],
+        })}
+      </span>
+    );
+  }
+
+  return <span dangerouslySetInnerHTML={{__html: translateDeviceDetailsHeadline(translate, userName)}} />;
+}
+
 export const DeviceDetails = ({
   device,
   cryptographyRepository,
@@ -67,7 +145,7 @@ export const DeviceDetails = ({
   logger,
   conversationState = container.resolve(ConversationState),
 }: DeviceDetailsProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
   const [fingerprintRemote, setFingerprintRemote] = useState<string>();
   const [isResettingSession, setIsResettingSession] = useState(false);
 
@@ -75,6 +153,7 @@ export const DeviceDetails = ({
 
   const {isVerified} = useKoSubscribableChildren(clientMeta, ['isVerified']);
   const {name: userName} = useKoSubscribableChildren(user, ['name']);
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
 
   useEffect(() => {
     setFingerprintRemote(undefined);
@@ -121,11 +200,7 @@ export const DeviceDetails = ({
         </h3>
 
         <p className="panel__info-text">
-          <span
-            dangerouslySetInnerHTML={{
-              __html: translate('participantDevicesDetailHeadline', {user: userName}),
-            }}
-          />
+          {renderDeviceDetailsHeadline({isReactTranslationRenderingEnabled, translate, userName})}
 
           <a
             className="participant-devices__link accent-text"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27666" title="WPB-27666" target="_blank"><img alt="Security" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/13902?size=medium" />WPB-27666</a>  [Web] Text rendering
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This pull request continues the localized rich-text rendering migration from #22411, #22431, #22433, #22444, and #22451.

It moves two additional translation-rendering paths to React behind the existing startup feature toggle:

```text
react-translation-rendering
```

### Changes

This batch covers:

* the participant device verification headline;
* incoming and outgoing file restriction messages.

The device verification headline now renders translated `[bold]...[/bold]` formatting as React while keeping the participant name as ordinary React text.

File restriction messages now render translated formatting through React as well. Runtime values such as the filename and file extension remain separate from translation formatting.

The incoming file restriction message also preserves the existing `&nbsp;` translation behavior by mapping that exact compatibility token to a non-breaking space without introducing generic HTML or entity parsing.