### PR TITLE
feat: add a close/dismiss button once all progress is idle(WPB-28486)

### DIFF
--- a/apps/webapp/src/i18n/en-US.json
+++ b/apps/webapp/src/i18n/en-US.json
@@ -580,6 +580,7 @@
   "cells.tagsModal.validationError.comma": "Tag names cannot contain commas",
   "cells.unavailableFile": "File not available",
   "cells.unavailableFilePreview": "Couldn't generate preview",
+  "cells.uploadStatus.closeAriaLabel": "Close upload status",
   "cells.uploadStatus.collapse": "Hide upload details",
   "cells.uploadStatus.destination": "to {destination}",
   "cells.uploadStatus.expand": "Show upload details",

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.ts
@@ -78,14 +78,20 @@ export const toSharedDriveUploadStatus = (
   };
 };
 
+export const getSharedDriveUploadStatuses = (
+  controller: SharedDriveUploadController,
+  conversationQualifiedId: string,
+): SharedDriveUploadStatus[] =>
+  controller.snapshots(conversationQualifiedId).flatMap(snapshot => {
+    const status = toSharedDriveUploadStatus(snapshot, conversationQualifiedId);
+    return status ? [status] : [];
+  });
+
 export const getLatestSharedDriveUploadStatus = (
   controller: SharedDriveUploadController,
   conversationQualifiedId: string,
 ): SharedDriveUploadStatus | null => {
-  const statuses = controller.snapshots(conversationQualifiedId).flatMap(snapshot => {
-    const status = toSharedDriveUploadStatus(snapshot, conversationQualifiedId);
-    return status ? [status] : [];
-  });
+  const statuses = getSharedDriveUploadStatuses(controller, conversationQualifiedId);
 
   return statuses[statuses.length - 1] ?? null;
 };

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.test.tsx
@@ -62,6 +62,7 @@ const renderPopup = (
         toggleLabel={isExpanded ? 'Hide upload details' : 'Show upload details'}
         cancelLabel="Cancel"
         dismissLabel="Close"
+        dismissAriaLabel="Close upload status"
         retryLabel="Retry"
         isCancelling={false}
         isRetrying={isRetrying}
@@ -375,20 +376,21 @@ describe('SharedDriveUploadStatusPopup', () => {
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
-  it('invokes dismiss from the failed file row', async () => {
+  it('invokes dismiss from the uploaded header action', async () => {
     const user = userEvent.setup();
     const onDismiss = jest.fn();
     render(
       <ThemeProvider>
         <SharedDriveUploadStatusPopup
-          upload={{...upload, kind: 'failed', canCancel: false, canRetry: true}}
-          title="Upload failed report.pdf"
-          statusLabel="Couldn’t upload file"
+          upload={{...upload, kind: 'uploaded', isTransferActive: false, canCancel: false, canRetry: false}}
+          title="Uploaded report.pdf"
+          statusLabel="Uploaded 4 KB"
           destination="to Shared Drive"
-          isExpanded
-          toggleLabel="Hide upload details"
+          isExpanded={false}
+          toggleLabel="Show upload details"
           cancelLabel="Cancel"
           dismissLabel="Close"
+          dismissAriaLabel="Close upload status"
           retryLabel="Retry"
           isCancelling={false}
           isRetrying={false}
@@ -400,9 +402,21 @@ describe('SharedDriveUploadStatusPopup', () => {
       </ThemeProvider>,
     );
 
-    await user.click(screen.getByRole('button', {name: 'Close'}));
+    const headerClose = within(screen.getByTestId('shared-drive-upload-status-header')).getByRole('button', {
+      name: 'Close upload status',
+    });
+    expect(headerClose).toHaveTextContent('Close');
+    expect(headerClose).toHaveAttribute('data-uie-name', 'shared-drive-upload-header-dismiss');
+
+    await user.click(headerClose);
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['uploading', 'failed'] as const)('does not show close while %s status is actionable', kind => {
+    renderPopup(kind, true);
+
+    expect(screen.queryByRole('button', {name: 'Close upload status'})).not.toBeInTheDocument();
   });
 
   it('disables retry while a failed upload is being retried', () => {

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopup.tsx
@@ -64,6 +64,8 @@ interface SharedDriveUploadStatusPopupProps {
   readonly toggleLabel: string;
   readonly cancelLabel: string;
   readonly dismissLabel?: string;
+  readonly dismissAriaLabel?: string;
+  readonly canDismiss?: boolean;
   readonly retryLabel: string;
   readonly isCancelling: boolean;
   readonly isRetrying: boolean;
@@ -116,6 +118,8 @@ export const SharedDriveUploadStatusPopup = ({
   toggleLabel,
   cancelLabel,
   dismissLabel = cancelLabel,
+  dismissAriaLabel = dismissLabel,
+  canDismiss = upload.kind === 'uploaded',
   retryLabel,
   isCancelling,
   isRetrying,
@@ -194,6 +198,17 @@ export const SharedDriveUploadStatusPopup = ({
               {cancelLabel}
             </button>
           )}
+          {canDismiss && (
+            <button
+              type="button"
+              css={sharedDriveUploadStatusPopupHeaderCancelStyles}
+              aria-label={dismissAriaLabel}
+              data-uie-name="shared-drive-upload-header-dismiss"
+              onClick={() => onDismiss?.()}
+            >
+              {dismissLabel}
+            </button>
+          )}
           <button
             type="button"
             css={sharedDriveUploadStatusPopupToggleStyles}
@@ -240,21 +255,6 @@ export const SharedDriveUploadStatusPopup = ({
               onClick={onRetry}
             >
               <ReloadIcon
-                css={sharedDriveUploadStatusPopupRowActionIconStyles}
-                color="currentColor"
-                aria-hidden="true"
-              />
-            </button>
-          )}
-          {upload.canRetry && (
-            <button
-              type="button"
-              css={sharedDriveUploadStatusPopupRowActionButtonStyles}
-              aria-label={dismissLabel}
-              data-uie-name="shared-drive-upload-dismiss"
-              onClick={() => onDismiss?.()}
-            >
-              <CloseIcon
                 css={sharedDriveUploadStatusPopupRowActionIconStyles}
                 color="currentColor"
                 aria-hidden="true"

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.test.tsx
@@ -183,6 +183,40 @@ describe('SharedDriveUploadStatusPopupHost', () => {
     await waitFor(() => expect(view.queryByRole('status')).not.toBeInTheDocument());
   });
 
+  it('dismisses a successful upload from the header close action', async () => {
+    const user = userEvent.setup();
+    const controller = createController(uploadedState);
+    const view = renderHost(controller, conversationQualifiedId);
+
+    const close = within(view.getByTestId('shared-drive-upload-status-header')).getByRole('button', {
+      name: 'cells.uploadStatus.closeAriaLabel',
+    });
+    expect(close).toHaveTextContent('fileCardDefaultCloseButtonLabel');
+
+    await user.click(close);
+
+    expect(view.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('does not show close for a failed upload because retry is still actionable', () => {
+    const controller = createController(failedState);
+    const view = renderHost(controller, conversationQualifiedId);
+
+    expect(view.queryByRole('button', {name: 'cells.uploadStatus.closeAriaLabel'})).not.toBeInTheDocument();
+  });
+
+  it('does not show close when the latest upload succeeded but another upload is still actionable', () => {
+    const controller = createController(uploadedState);
+    controller.snapshots.mockImplementation(scope =>
+      scope === conversationQualifiedId ? [failedState, uploadedState] : [],
+    );
+
+    const view = renderHost(controller, conversationQualifiedId);
+
+    expect(view.getByText('cells.uploadStatus.uploaded')).toBeInTheDocument();
+    expect(view.queryByRole('button', {name: 'cells.uploadStatus.closeAriaLabel'})).not.toBeInTheDocument();
+  });
+
   it('calls retry for a failed upload and prevents concurrent retries', async () => {
     const user = userEvent.setup();
     const controller = createController(failedState);

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
@@ -25,7 +25,7 @@ import {useApplicationContext} from 'src/script/page/rootProvider';
 import {formatBytes} from 'Util/util';
 
 import type {SharedDriveUploadController} from './sharedDriveUploadController';
-import {getLatestSharedDriveUploadStatus} from './sharedDriveUploadStatus';
+import {getLatestSharedDriveUploadStatus, getSharedDriveUploadStatuses} from './sharedDriveUploadStatus';
 import {SharedDriveUploadStatusPopup} from './sharedDriveUploadStatusPopup';
 
 type DismissedUpload = {
@@ -60,6 +60,9 @@ export const SharedDriveUploadStatusPopupHost = ({
   const [retryingUploadId, setRetryingUploadId] = useState<Maybe<string>>(Maybe.nothing());
   const [dismissedUpload, setDismissedUpload] = useState<Maybe<DismissedUpload>>(Maybe.nothing());
   const upload = status.conversationQualifiedId === conversationQualifiedId ? status.upload : readStatus();
+  const uploadStatuses = getSharedDriveUploadStatuses(controller, conversationQualifiedId);
+  const canDismissUploadStatus =
+    upload !== null && uploadStatuses.length > 0 && uploadStatuses.every(({kind}) => kind === 'uploaded');
   const isUploadDismissed =
     maybe.isJust(dismissedUpload) &&
     dismissedUpload.value.conversationQualifiedId === conversationQualifiedId &&
@@ -139,6 +142,8 @@ export const SharedDriveUploadStatusPopupHost = ({
       toggleLabel={translate(isExpanded ? 'cells.uploadStatus.collapse' : 'cells.uploadStatus.expand')}
       cancelLabel={translate('conversationAssetUploadCancel')}
       dismissLabel={translate('fileCardDefaultCloseButtonLabel')}
+      dismissAriaLabel={translate('cells.uploadStatus.closeAriaLabel')}
+      canDismiss={canDismissUploadStatus}
       retryLabel={translate('conversationFilePreviewErrorRetry')}
       isCancelling={maybe.isJust(cancellingUploadId) && cancellingUploadId.value === upload.uploadId}
       isRetrying={maybe.isJust(retryingUploadId) && retryingUploadId.value === upload.uploadId}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28486" title="WPB-28486" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28486</a>  [web] add a close/dismiss button once all progress is idle
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Added a dismiss action for the shared drive upload status UI once there is nothing actionable left.

- Shows a header Close button in the same location/style as Cancel only when all current upload statuses for the conversation are successful.
- Keeps Cancel for active uploads and does not show Close for failed uploads because Retry is still actionable.
- Adds an accessible label: Close upload status.
- Adds test coverage for successful dismissal, hiding Close while uploads are actionable, and the mixed-state case where one upload succeeded but another is still actionable.

<img width="479" height="151" alt="Screenshot 2026-09-11 at 13 59 35" src="https://github.com/user-attachments/assets/f3b09b35-83a0-4981-bc43-c67995dc5c3b" />
<img width="466" height="157" alt="Screenshot 2026-09-11 at 13 50 06" src="https://github.com/user-attachments/assets/ebc07ea6-cc72-4920-8542-819590ff0ce8" />
