### PR TITLE
Render failed-to-add user translations with React [WPB-27666]

### DIFF
--- a/apps/webapp/src/script/components/messagesList/message/failedToAddUsersMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/failedToAddUsersMessage.test.tsx
@@ -18,10 +18,12 @@
  */
 
 import {act, render} from '@testing-library/react';
+import {isNull, isUndefined} from '@sindresorhus/is';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {AddUsersFailure, AddUsersFailureReasons} from '@wireapp/core/lib/conversation';
 import {StyledApp, THEME_ID} from '@wireapp/react-ui-kit';
 
+import de from 'I18n/de-DE.json';
 import en from 'I18n/en-US.json';
 import {FailedToAddUsersMessage as FailedToAddUsersMessageEntity} from 'Repositories/entity/message/failedToAddUsersMessage';
 import {User} from 'Repositories/entity/User';
@@ -52,7 +54,7 @@ type TranslationTestFunction = () => void | Promise<void>;
 type IsolatedTranslationTestFunction = () => Promise<void>;
 
 function withTranslationStrings(
-  strings: typeof en,
+  strings: Record<string, string>,
   testFunction: TranslationTestFunction,
 ): IsolatedTranslationTestFunction {
   return async function runTranslationTest(): Promise<void> {
@@ -88,6 +90,48 @@ function createUser(qualifiedId: QualifiedId, name: string): User {
   const user = new User(qualifiedId.id, qualifiedId.domain, translateForTest);
   user.name(name);
   return user;
+}
+
+function createFailureForReason(users: QualifiedId[], reason: AddUsersFailureReasons): AddUsersFailure {
+  if (reason === AddUsersFailureReasons.NON_FEDERATING_BACKENDS) {
+    return {
+      users,
+      reason,
+      backends: [],
+    };
+  }
+
+  if (reason === AddUsersFailureReasons.UNREACHABLE_BACKENDS) {
+    return {
+      users,
+      reason,
+      backends: ['backend.example'],
+    };
+  }
+
+  return {users, reason};
+}
+
+function findMessageDetailByText(messageDetails: HTMLElement[], text: string): HTMLElement {
+  const matchingMessageDetail = messageDetails.find(messageDetail => messageDetail.textContent?.includes(text));
+
+  if (isUndefined(matchingMessageDetail)) {
+    throw new Error(`Expected a message detail containing: ${text}`);
+  }
+
+  return matchingMessageDetail;
+}
+
+function assertLearnMoreLink(messageDetail: HTMLElement, expectedDataUieName: string): void {
+  const learnMoreLink = messageDetail.querySelector<HTMLAnchorElement>('a');
+
+  if (isNull(learnMoreLink)) {
+    throw new Error('Expected a learn-more link to be rendered');
+  }
+
+  expect(learnMoreLink).toHaveTextContent('Learn more');
+  expect(learnMoreLink).toHaveAttribute('data-uie-name', expectedDataUieName);
+  expect(learnMoreLink).toHaveAttribute('target', '_blank');
 }
 
 describe('FailedToAddUsersMessage', () => {
@@ -487,5 +531,244 @@ describe('FailedToAddUsersMessage', () => {
         expect(messageSummary.querySelector('strong')).toHaveTextContent('participants total=2');
       },
     ),
+  );
+
+  const failedToAddSingularDetailsTestCases = [
+    {
+      reason: AddUsersFailureReasons.NON_FEDERATING_BACKENDS,
+      expectedText: 'Target could not be added to the group as their backends do not federate with each other.',
+      expectedStrongCount: 1,
+      expectedLinkName: 'go-offline-backend',
+    },
+    {
+      reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
+      expectedText: 'Target could not be added to the group as the backend of backend.example could not be reached.',
+      expectedStrongCount: 2,
+      expectedLinkName: 'go-offline-backend',
+    },
+    {
+      reason: AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG,
+      expectedText: 'Target could not be added to the group.',
+      expectedStrongCount: 1,
+      expectedLinkName: 'go-offline-backend',
+    },
+    {
+      reason: AddUsersFailureReasons.NOT_MLS_CAPABLE,
+      expectedText: 'Target could not be added to the meeting. Target may not use a device that is MLS-capable.',
+      expectedStrongCount: 2,
+      expectedLinkName: 'mls-learn-more',
+    },
+  ] as const;
+
+  it.each(failedToAddSingularDetailsTestCases)(
+    'renders singular $reason details through React',
+    ({reason, expectedText, expectedStrongCount, expectedLinkName}): void => {
+      const userState = new UserState();
+      const [targetQualifiedId, otherQualifiedId] = generateQualifiedIds(2, 'test.domain');
+      userState.users([createUser(targetQualifiedId, 'Target'), createUser(otherQualifiedId, 'Other')]);
+
+      const message = createFailedToAddUsersMessages([
+        createFailureForReason([targetQualifiedId], reason),
+        createFailureForReason([otherQualifiedId], AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG),
+      ]);
+
+      const {getByTestId, getAllByTestId} = render(
+        withReactTranslationTheme(<FailedToAddUsersMessage isMessageFocused message={message} userState={userState} />),
+      );
+
+      act(() => {
+        getByTestId('toggle-failed-to-add-users').click();
+      });
+
+      const messageDetail = findMessageDetailByText(getAllByTestId('multi-user-not-added-details'), 'Target');
+      expect(messageDetail).toHaveTextContent(expectedText);
+      expect(messageDetail.querySelectorAll('strong')).toHaveLength(expectedStrongCount);
+      assertLearnMoreLink(messageDetail, expectedLinkName);
+    },
+  );
+
+  const failedToAddPluralDetailsTestCases = [
+    {
+      reason: AddUsersFailureReasons.NON_FEDERATING_BACKENDS,
+      expectedText:
+        'Second, Third and First could not be added to the group as their backends do not federate with each other.',
+      expectedStrongCount: 2,
+      expectedLinkName: 'go-offline-backend',
+    },
+    {
+      reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
+      expectedText:
+        'Second, Third and First could not be added to the group as the backend of backend.example could not be reached.',
+      expectedStrongCount: 3,
+      expectedLinkName: 'go-offline-backend',
+    },
+    {
+      reason: AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG,
+      expectedText: 'Second, Third and First could not be added to the group.',
+      expectedStrongCount: 2,
+      expectedLinkName: 'go-offline-backend',
+    },
+    {
+      reason: AddUsersFailureReasons.NOT_MLS_CAPABLE,
+      expectedText:
+        'Second, Third and First could not be added to the conversation. They may not use devices that are MLS-capable.',
+      expectedStrongCount: 2,
+      expectedLinkName: 'mls-learn-more',
+    },
+  ] as const;
+
+  it.each(failedToAddPluralDetailsTestCases)(
+    'renders plural $reason details through React',
+    ({reason, expectedText, expectedStrongCount, expectedLinkName}): void => {
+      const userState = new UserState();
+      const qualifiedIds = generateQualifiedIds(3, 'test.domain');
+      userState.users([
+        createUser(qualifiedIds[0], 'First'),
+        createUser(qualifiedIds[1], 'Second'),
+        createUser(qualifiedIds[2], 'Third'),
+      ]);
+
+      const message = createFailedToAddUsersMessages([createFailureForReason(qualifiedIds, reason)]);
+
+      const {getByTestId, getAllByTestId} = render(
+        withReactTranslationTheme(<FailedToAddUsersMessage isMessageFocused message={message} userState={userState} />),
+      );
+
+      act(() => {
+        getByTestId('toggle-failed-to-add-users').click();
+      });
+
+      const messageDetail = findMessageDetailByText(getAllByTestId('multi-user-not-added-details'), 'First');
+      expect(messageDetail).toHaveTextContent(expectedText);
+      expect(messageDetail.querySelectorAll('strong')).toHaveLength(expectedStrongCount);
+      assertLearnMoreLink(messageDetail, expectedLinkName);
+    },
+  );
+
+  it(
+    'keeps runtime names and domains opaque in plural details',
+    withTranslationStrings(
+      {
+        ...en,
+        failedToAddParticipantsPluralDetailsOfflineBackend:
+          '<meta name="example" content="value">[bold]{names}[/bold] on {domain}: [bold]{name}[/bold]',
+      },
+      (): void => {
+        const userState = new UserState();
+        const qualifiedIds = generateQualifiedIds(3, 'test.domain');
+        userState.users([
+          createUser(qualifiedIds[0], 'R&D <Test>'),
+          createUser(qualifiedIds[1], '[bold]Admin[/bold]'),
+          createUser(qualifiedIds[2], 'Third'),
+        ]);
+
+        const message = createFailedToAddUsersMessages([
+          {
+            users: qualifiedIds,
+            reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
+            backends: ['backend.<example>'],
+          },
+        ]);
+
+        const {getByTestId} = render(
+          withReactTranslationTheme(
+            <FailedToAddUsersMessage isMessageFocused message={message} userState={userState} />,
+          ),
+        );
+
+        act(() => {
+          getByTestId('toggle-failed-to-add-users').click();
+        });
+
+        const messageDetail = getByTestId('multi-user-not-added-details');
+        expect(messageDetail).toHaveTextContent(
+          '<meta name="example" content="value">[bold]Admin[/bold], Third on backend.<example>: R&D <Test>',
+        );
+        expect(messageDetail.querySelector('meta')).toBeNull();
+        expect(messageDetail.querySelector('test')).toBeNull();
+        expect(messageDetail.querySelector('example')).toBeNull();
+
+        const strongElements = messageDetail.querySelectorAll('strong');
+        expect(strongElements).toHaveLength(2);
+        expect(strongElements[0]).toHaveTextContent('[bold]Admin[/bold], Third');
+        expect(strongElements[1]).toHaveTextContent('R&D <Test>');
+        expect(strongElements[0].querySelector('strong')).toBeNull();
+        expect(strongElements[1].querySelector('strong')).toBeNull();
+        assertLearnMoreLink(messageDetail, 'go-offline-backend');
+      },
+    ),
+  );
+
+  it(
+    'renders repeated runtime names as opaque values in singular details',
+    withTranslationStrings(
+      {
+        ...en,
+        failedToAddParticipantsSingularDetailsNotMlsCapable: '[bold]{name}[/bold] failed. Again [bold]{name}[/bold].',
+      },
+      (): void => {
+        const userState = new UserState();
+        const [targetQualifiedId, otherQualifiedId] = generateQualifiedIds(2, 'test.domain');
+        userState.users([createUser(targetQualifiedId, 'R&D <Test>'), createUser(otherQualifiedId, 'Other')]);
+
+        const message = createFailedToAddUsersMessages([
+          createFailureForReason([targetQualifiedId], AddUsersFailureReasons.NOT_MLS_CAPABLE),
+          createFailureForReason([otherQualifiedId], AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG),
+        ]);
+
+        const {getByTestId, getAllByTestId} = render(
+          withReactTranslationTheme(
+            <FailedToAddUsersMessage isMessageFocused message={message} userState={userState} />,
+          ),
+        );
+
+        act(() => {
+          getByTestId('toggle-failed-to-add-users').click();
+        });
+
+        const messageDetail = findMessageDetailByText(getAllByTestId('multi-user-not-added-details'), 'R&D <Test>');
+        expect(messageDetail).toHaveTextContent('R&D <Test> failed. Again R&D <Test>.');
+        expect(messageDetail.querySelector('test')).toBeNull();
+
+        const strongElements = messageDetail.querySelectorAll('strong');
+        expect(strongElements).toHaveLength(2);
+        expect(strongElements[0]).toHaveTextContent('R&D <Test>');
+        expect(strongElements[1]).toHaveTextContent('R&D <Test>');
+        expect(strongElements[0].querySelector('strong')).toBeNull();
+        expect(strongElements[1].querySelector('strong')).toBeNull();
+        assertLearnMoreLink(messageDetail, 'mls-learn-more');
+      },
+    ),
+  );
+
+  it(
+    'keeps the audited German detail translation compatible with React rendering',
+    withTranslationStrings(de, (): void => {
+      const userState = new UserState();
+      const qualifiedIds = generateQualifiedIds(3, 'test.domain');
+      userState.users([
+        createUser(qualifiedIds[0], 'First'),
+        createUser(qualifiedIds[1], 'Second'),
+        createUser(qualifiedIds[2], 'Third'),
+      ]);
+
+      const message = createFailedToAddUsersMessages([
+        createFailureForReason(qualifiedIds, AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG),
+      ]);
+
+      const {getByTestId} = render(
+        withReactTranslationTheme(<FailedToAddUsersMessage isMessageFocused message={message} userState={userState} />),
+      );
+
+      act(() => {
+        getByTestId('toggle-failed-to-add-users').click();
+      });
+
+      const messageDetail = getByTestId('multi-user-not-added-details');
+      expect(messageDetail).toHaveTextContent('Second, Third und First konnten der Gruppe nicht hinzugefügt werden.');
+      expect(messageDetail).not.toHaveTextContent('__wire_react_translation_');
+      expect(messageDetail.querySelectorAll('strong')).toHaveLength(1);
+      expect(messageDetail.querySelector('strong')).toHaveTextContent('First');
+    }),
   );
 });

--- a/apps/webapp/src/script/components/messagesList/message/failedToAddUsersMessage.test.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/failedToAddUsersMessage.test.tsx
@@ -27,6 +27,7 @@ import {FailedToAddUsersMessage as FailedToAddUsersMessageEntity} from 'Reposito
 import {User} from 'Repositories/entity/User';
 import {UserState} from 'Repositories/user/userState';
 import {generateQualifiedIds} from 'src/script/auth/util/test/testUtil';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {
   createRootContextValueForTest,
   createRootProviderWrapperForTest,
@@ -37,19 +38,53 @@ import {FailedToAddUsersMessage} from './failedToAddUsersMessage';
 import {translateForTest} from 'Util/test/translateForTest';
 
 setStrings({en});
-const rootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate: translate}));
+const legacyRootProviderWrapper = createRootProviderWrapperForTest(createRootContextValueForTest({translate}));
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName): boolean {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
+
+function withTranslationStrings(
+  strings: typeof en,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: strings});
+
+    try {
+      await testFunction();
+    } finally {
+      setStrings({en});
+    }
+  };
+}
 
 function withTheme(component: React.ReactNode): React.ReactElement {
-  return <StyledApp themeId={THEME_ID.DEFAULT}>{rootProviderWrapper({children: component})}</StyledApp>;
+  return <StyledApp themeId={THEME_ID.DEFAULT}>{legacyRootProviderWrapper({children: component})}</StyledApp>;
+}
+
+function withReactTranslationTheme(component: React.ReactNode): React.ReactElement {
+  return (
+    <StyledApp themeId={THEME_ID.DEFAULT}>
+      {reactTranslationRenderingRootProviderWrapper({children: component})}
+    </StyledApp>
+  );
 }
 
 const createFailedToAddUsersMessages = (
   failures: AddUsersFailure[] = [{users: [], backends: [], reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}],
-) => {
+): FailedToAddUsersMessageEntity => {
   return new FailedToAddUsersMessageEntity(failures, Date.now(), translateForTest);
 };
 
-function createUser(qualifiedId: QualifiedId, name: string) {
+function createUser(qualifiedId: QualifiedId, name: string): User {
   const user = new User(qualifiedId.id, qualifiedId.domain, translateForTest);
   user.name(name);
   return user;
@@ -300,4 +335,157 @@ describe('FailedToAddUsersMessage', () => {
 
     expect(details3.length).toBeGreaterThanOrEqual(1);
   });
+
+  it(
+    'renders a single-user unreachable-backend summary with opaque runtime text when enabled',
+    withTranslationStrings(en, () => {
+      const userState = new UserState();
+      const [qualifiedId] = generateQualifiedIds(1, 'backend.<example>');
+      const user = createUser(qualifiedId, 'R&D <Test>');
+      userState.users.push(user);
+
+      const message = createFailedToAddUsersMessages([
+        {
+          users: [qualifiedId],
+          reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
+          backends: [],
+        },
+      ]);
+
+      const {getByTestId} = render(
+        withReactTranslationTheme(<FailedToAddUsersMessage isMessageFocused message={message} userState={userState} />),
+      );
+      const messageDetails = getByTestId('1-user-not-added-details');
+      const strongElements = messageDetails.querySelectorAll('strong');
+      const learnMoreLink = getByTestId('go-offline-backend');
+
+      expect(messageDetails).toHaveTextContent(
+        'R&D <Test> could not be added to the group as the backend of backend.<example> could not be reached.',
+      );
+      expect(strongElements).toHaveLength(2);
+      expect(strongElements[0]).toHaveTextContent('R&D <Test>');
+      expect(strongElements[1]).toHaveTextContent('backend.<example>');
+      expect(messageDetails.querySelector('test')).toBeNull();
+      expect(messageDetails.querySelector('example')).toBeNull();
+      expect(learnMoreLink).toHaveTextContent('Learn more');
+      expect(learnMoreLink).toHaveAttribute('data-uie-name', 'go-offline-backend');
+      expect(learnMoreLink).toHaveAttribute('target', '_blank');
+    }),
+  );
+
+  it(
+    'keeps translation-looking and internal-marker-looking names literal when enabled',
+    withTranslationStrings(en, () => {
+      const runtimeNames = [
+        '[bold]Admin[/bold]',
+        '__wire_react_translation_name_start__value__wire_react_translation_name_end__',
+      ];
+
+      for (const runtimeName of runtimeNames) {
+        const userState = new UserState();
+        const [qualifiedId] = generateQualifiedIds(1, 'test.domain');
+        const user = createUser(qualifiedId, runtimeName);
+        userState.users.push(user);
+
+        const message = createFailedToAddUsersMessages([
+          {
+            users: [qualifiedId],
+            reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
+            backends: [],
+          },
+        ]);
+
+        const {getByTestId, unmount} = render(
+          withReactTranslationTheme(
+            <FailedToAddUsersMessage isMessageFocused message={message} userState={userState} />,
+          ),
+        );
+        const messageDetails = getByTestId('1-user-not-added-details');
+        const nameStrongElement = messageDetails.querySelector('strong');
+
+        expect(messageDetails).toHaveTextContent(runtimeName);
+        expect(nameStrongElement).toHaveTextContent(runtimeName);
+        expect(nameStrongElement?.querySelector('strong')).toBeNull();
+
+        unmount();
+      }
+    }),
+  );
+
+  it(
+    'keeps unsupported summary markup as text and preserves translated name and domain placement',
+    withTranslationStrings(
+      {
+        ...en,
+        failedToAddParticipantSingularOfflineBackend:
+          '<img src="example">The backend {domain} rejected [bold]{name}[/bold].',
+      },
+      () => {
+        const userState = new UserState();
+        const [qualifiedId] = generateQualifiedIds(1, '[bold]backend[/bold]');
+        const user = createUser(qualifiedId, 'R&D <Test>');
+        userState.users.push(user);
+
+        const message = createFailedToAddUsersMessages([
+          {
+            users: [qualifiedId],
+            reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
+            backends: [],
+          },
+        ]);
+
+        const {getByTestId} = render(
+          withReactTranslationTheme(
+            <FailedToAddUsersMessage isMessageFocused message={message} userState={userState} />,
+          ),
+        );
+        const messageDetails = getByTestId('1-user-not-added-details');
+
+        expect(messageDetails).toHaveTextContent(
+          '<img src="example">The backend [bold]backend[/bold] rejected R&D <Test>.',
+        );
+        expect(messageDetails.querySelector('img')).toBeNull();
+        expect(messageDetails.querySelectorAll('strong')).toHaveLength(1);
+        expect(messageDetails.querySelector('strong')).toHaveTextContent('R&D <Test>');
+      },
+    ),
+  );
+
+  it(
+    'renders a translator-positioned plural summary through React',
+    withTranslationStrings(
+      {
+        ...en,
+        failedToAddParticipantsPlural:
+          '<meta name="example" content="value">Rejected: [bold]participants total={total}[/bold].',
+      },
+      () => {
+        const userState = new UserState();
+        const qualifiedIds = generateQualifiedIds(2, 'test.domain');
+        userState.users(qualifiedIds.map(qualifiedId => createUser(qualifiedId, qualifiedId.id)));
+
+        const message = createFailedToAddUsersMessages([
+          {
+            users: qualifiedIds,
+            reason: AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG,
+          },
+        ]);
+
+        const {getByTestId} = render(
+          withReactTranslationTheme(
+            <FailedToAddUsersMessage isMessageFocused message={message} userState={userState} />,
+          ),
+        );
+        const messageSummary = getByTestId('element-message-failed-to-add-users');
+
+        expect(messageSummary).toHaveAttribute('data-uie-value', 'multi-users-not-added');
+        expect(messageSummary).toHaveTextContent(
+          '<meta name="example" content="value">Rejected: participants total=2.',
+        );
+        expect(messageSummary.querySelector('meta')).toBeNull();
+        expect(messageSummary.querySelectorAll('strong')).toHaveLength(1);
+        expect(messageSummary.querySelector('strong')).toHaveTextContent('participants total=2');
+      },
+    ),
+  );
 });

--- a/apps/webapp/src/script/components/messagesList/message/failedToAddUsersMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/failedToAddUsersMessage.tsx
@@ -18,7 +18,9 @@
  */
 
 import {useMemo, useState} from 'react';
+import type {ReactNode} from 'react';
 
+import {isUndefined} from '@sindresorhus/is';
 import {AddUsersFailure, AddUsersFailureReasons} from '@wireapp/core/lib/conversation';
 import {container} from 'tsyringe';
 
@@ -30,9 +32,12 @@ import {FailedToAddUsersMessage as FailedToAddUsersMessageEntity} from 'Reposito
 import {User} from 'Repositories/entity/User';
 import {UserState} from 'Repositories/user/userState';
 import {Config} from 'src/script/Config';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
-import type {TranslationKey} from 'Util/localizerUtil';
+import type {Translate, TranslationKey} from 'Util/localizerUtil';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {ReactTranslationMarker} from 'Util/localizerUtil/reactLocalizerUtil';
 import {matchQualifiedIds} from 'Util/qualifiedId';
 
 import {backendErrorLink, warning} from './contentMessage/warnings/warnings.styles';
@@ -97,7 +102,217 @@ const singularTranslationKeyByReason = {
   [AddUsersFailureReasons.NOT_MLS_CAPABLE]: 'failedToAddParticipantSingularNotMlsCapable',
 } as const satisfies Record<AddUsersFailureReasons, TranslationKey>;
 
-const MessageDetails = ({failure, isMessageFocused, allUsers, translate}: MessageDetailsProps) => {
+type FailedToAddTranslationPlaceholder = 'name' | 'names' | 'domain' | 'total';
+
+type FailedToAddTranslationValue = {
+  readonly placeholder: FailedToAddTranslationPlaceholder;
+  readonly marker: ReactTranslationMarker;
+  readonly runtimeText: string;
+};
+
+type RenderFailedToAddTranslationOptions = {
+  readonly translate: Translate;
+  readonly translationKey: TranslationKey;
+  readonly values: readonly FailedToAddTranslationValue[];
+};
+
+const failedToAddBoldMarker = createReactTranslationMarker('failed-to-add-bold');
+const failedToAddNameMarker = createReactTranslationMarker('failed-to-add-name');
+const failedToAddNamesMarker = createReactTranslationMarker('failed-to-add-names');
+const failedToAddDomainMarker = createReactTranslationMarker('failed-to-add-domain');
+const failedToAddTotalMarker = createReactTranslationMarker('failed-to-add-total');
+
+const failedToAddReactTranslationFormatting = {
+  '/bold': failedToAddBoldMarker.end,
+  bold: failedToAddBoldMarker.start,
+};
+
+function getFailedToAddMarkerSubstitutions(values: readonly FailedToAddTranslationValue[]): Record<string, string> {
+  return Object.fromEntries(values.map(({placeholder, marker}) => [placeholder, marker.substitution]));
+}
+
+function getFailedToAddRuntimeSubstitutions(values: readonly FailedToAddTranslationValue[]): Record<string, string> {
+  return Object.fromEntries(values.map(({placeholder, runtimeText}) => [placeholder, runtimeText]));
+}
+
+function translateFailedToAddTranslation(options: RenderFailedToAddTranslationOptions): string {
+  const {translate, translationKey, values} = options;
+  return translate(translationKey, getFailedToAddRuntimeSubstitutions(values));
+}
+
+function applyFailedToAddTranslationCompatibility(translationKey: TranslationKey, translatedText: string): string {
+  if (translationKey !== 'failedToAddParticipantsPluralDetailsOfflineForTooLong') {
+    return translatedText;
+  }
+
+  const malformedNamesRegion = `${failedToAddBoldMarker.end}${failedToAddNamesMarker.substitution}${failedToAddBoldMarker.end}`;
+  return translatedText.replace(malformedNamesRegion, failedToAddNamesMarker.substitution);
+}
+
+function renderFailedToAddReactTranslation(options: RenderFailedToAddTranslationOptions): ReactNode[] {
+  const {translate, translationKey, values} = options;
+  const translatedText = applyFailedToAddTranslationCompatibility(
+    translationKey,
+    translate(translationKey, getFailedToAddMarkerSubstitutions(values), failedToAddReactTranslationFormatting),
+  );
+
+  return renderReactTranslation({
+    translatedText,
+    componentReplacements: [
+      {
+        start: failedToAddBoldMarker.start,
+        end: failedToAddBoldMarker.end,
+        render(children): ReactNode {
+          return <strong>{children}</strong>;
+        },
+      },
+    ],
+    nodeReplacements: [],
+    valueReplacements: values.map(({marker, runtimeText}) => ({marker, runtimeText})),
+  });
+}
+
+type RenderFailedToAddSingleUserSummaryOptions = {
+  readonly firstUser: User | undefined;
+  readonly failure: AddUsersFailure;
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly learnMore: ReactNode;
+  readonly totalNumberOfUsers: number;
+  readonly translate: Translate;
+};
+
+function renderFailedToAddSingleUserSummary(options: RenderFailedToAddSingleUserSummaryOptions): ReactNode {
+  const {failure, firstUser, isReactTranslationRenderingEnabled, learnMore, totalNumberOfUsers, translate} = options;
+
+  if (totalNumberOfUsers > 1 || isUndefined(firstUser)) {
+    return null;
+  }
+
+  const runtimeUserName = getUserNameWithTranslate(firstUser, translate);
+  const translationKey = singularTranslationKeyByReason[failure.reason];
+  let translationContent: ReactNode;
+
+  if (isReactTranslationRenderingEnabled === true) {
+    if (reasonToMessageDataMap[failure.reason].translationLabel === 'OfflineBackend') {
+      translationContent = (
+        <span css={warning}>
+          {renderFailedToAddReactTranslation({
+            translate,
+            translationKey,
+            values: [
+              {
+                placeholder: 'name',
+                marker: failedToAddNameMarker,
+                runtimeText: runtimeUserName,
+              },
+              {
+                placeholder: 'domain',
+                marker: failedToAddDomainMarker,
+                runtimeText: firstUser.domain,
+              },
+            ],
+          })}
+        </span>
+      );
+    } else {
+      translationContent = (
+        <span css={warning}>
+          {renderFailedToAddReactTranslation({
+            translate,
+            translationKey,
+            values: [
+              {
+                placeholder: 'name',
+                marker: failedToAddNameMarker,
+                runtimeText: runtimeUserName,
+              },
+            ],
+          })}
+        </span>
+      );
+    }
+  } else {
+    translationContent = (
+      <span
+        css={warning}
+        dangerouslySetInnerHTML={{
+          __html: translateFailedToAddTranslation({
+            translate,
+            translationKey,
+            values: [
+              {
+                placeholder: 'name',
+                marker: failedToAddNameMarker,
+                runtimeText: runtimeUserName,
+              },
+              {
+                placeholder: 'domain',
+                marker: failedToAddDomainMarker,
+                runtimeText: firstUser.domain,
+              },
+            ],
+          }),
+        }}
+      />
+    );
+  }
+
+  return (
+    <p data-uie-name="1-user-not-added-details" data-uie-value={firstUser.id}>
+      {translationContent}
+      {learnMore}
+    </p>
+  );
+}
+
+type RenderFailedToAddPluralSummaryOptions = {
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly totalNumberOfUsers: number;
+  readonly translate: Translate;
+};
+
+function renderFailedToAddPluralSummary(options: RenderFailedToAddPluralSummaryOptions): ReactNode {
+  const {isReactTranslationRenderingEnabled, totalNumberOfUsers, translate} = options;
+
+  if (totalNumberOfUsers <= 1) {
+    return null;
+  }
+
+  const values = [
+    {
+      placeholder: 'total' as const,
+      marker: failedToAddTotalMarker,
+      runtimeText: totalNumberOfUsers.toString(),
+    },
+  ];
+
+  if (isReactTranslationRenderingEnabled === true) {
+    return (
+      <p css={warning}>
+        {renderFailedToAddReactTranslation({
+          translate,
+          translationKey: 'failedToAddParticipantsPlural',
+          values,
+        })}
+      </p>
+    );
+  }
+
+  return (
+    <p
+      css={warning}
+      dangerouslySetInnerHTML={{
+        __html: translateFailedToAddTranslation({
+          translate,
+          translationKey: 'failedToAddParticipantsPlural',
+          values,
+        }),
+      }}
+    />
+  );
+}
+
+function MessageDetails({failure, isMessageFocused, allUsers, translate}: MessageDetailsProps): ReactNode {
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
 
   const {users: userIds, reason} = failure;
@@ -134,7 +349,7 @@ const MessageDetails = ({failure, isMessageFocused, allUsers, translate}: Messag
     </>
   );
 
-  const getText = (): string => {
+  function getText(): string {
     if (baseTranslationKey === 'failedToAddParticipantsSingularDetails') {
       if (translationLabel === 'OfflineBackend') {
         return translate(singularDetailsTranslationKeyByReason[reason], {
@@ -170,7 +385,7 @@ const MessageDetails = ({failure, isMessageFocused, allUsers, translate}: Messag
     }
 
     return '';
-  };
+  }
 
   const text = getText();
 
@@ -187,14 +402,15 @@ const MessageDetails = ({failure, isMessageFocused, allUsers, translate}: Messag
       {learnMoreLink}
     </p>
   );
-};
+}
 
-const FailedToAddUsersMessage = ({
+function FailedToAddUsersMessage({
   isMessageFocused,
   message,
   userState = container.resolve(UserState),
-}: FailedToAddUsersMessageProps) => {
-  const {translate} = useApplicationContext();
+}: FailedToAddUsersMessageProps): ReactNode {
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
 
   const [isOpen, setIsOpen] = useState(false);
@@ -243,28 +459,19 @@ const FailedToAddUsersMessage = ({
           data-uie-name="element-message-failed-to-add-users"
           data-uie-value={totalNumberOfUsers <= 1 ? '1-user-not-added' : 'multi-users-not-added'}
         >
-          {totalNumberOfUsers <= 1 && firstUser && (
-            <p data-uie-name="1-user-not-added-details" data-uie-value={firstUser.id}>
-              <span
-                css={warning}
-                dangerouslySetInnerHTML={{
-                  __html: translate(singularTranslationKeyByReason[failures[0].reason], {
-                    name: getUserNameWithTranslate(firstUser, translate),
-                    domain: firstUser.domain,
-                  }),
-                }}
-              />
-              {learnMore}
-            </p>
-          )}
-          {totalNumberOfUsers > 1 && (
-            <p
-              css={warning}
-              dangerouslySetInnerHTML={{
-                __html: translate('failedToAddParticipantsPlural', {total: totalNumberOfUsers.toString()}),
-              }}
-            />
-          )}
+          {renderFailedToAddSingleUserSummary({
+            failure: failures[0],
+            firstUser,
+            isReactTranslationRenderingEnabled,
+            learnMore,
+            totalNumberOfUsers,
+            translate,
+          })}
+          {renderFailedToAddPluralSummary({
+            isReactTranslationRenderingEnabled,
+            totalNumberOfUsers,
+            translate,
+          })}
         </div>
         <p className="message-body-actions">
           <MessageTime
@@ -303,6 +510,6 @@ const FailedToAddUsersMessage = ({
       </div>
     </>
   );
-};
+}
 
 export {FailedToAddUsersMessage};

--- a/apps/webapp/src/script/components/messagesList/message/failedToAddUsersMessage.tsx
+++ b/apps/webapp/src/script/components/messagesList/message/failedToAddUsersMessage.tsx
@@ -78,7 +78,8 @@ interface MessageDetailsProps {
   failure: AddUsersFailure;
   isMessageFocused: boolean;
   allUsers: User[];
-  translate: (translationKey: TranslationKey, replacements?: Record<string, string>) => string;
+  isReactTranslationRenderingEnabled: boolean;
+  translate: Translate;
 }
 
 const singularDetailsTranslationKeyByReason = {
@@ -312,7 +313,121 @@ function renderFailedToAddPluralSummary(options: RenderFailedToAddPluralSummaryO
   );
 }
 
-function MessageDetails({failure, isMessageFocused, allUsers, translate}: MessageDetailsProps): ReactNode {
+type RenderFailedToAddDetailsTranslationOptions = {
+  readonly domain: string | undefined;
+  readonly failure: AddUsersFailure;
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly translate: Translate;
+  readonly users: readonly User[];
+};
+
+function renderFailedToAddDetailsTranslation(options: RenderFailedToAddDetailsTranslationOptions): ReactNode {
+  const {domain, failure, isReactTranslationRenderingEnabled, translate, users} = options;
+  const {reason} = failure;
+  const {translationLabel} = reasonToMessageDataMap[reason];
+  const runtimeUserName = getUserNameWithTranslate(users[0], translate);
+  let translationKey: TranslationKey;
+  let translationValues: readonly FailedToAddTranslationValue[];
+
+  if (users.length === 1) {
+    translationKey = singularDetailsTranslationKeyByReason[reason];
+
+    if (translationLabel === 'OfflineBackend') {
+      translationValues = [
+        {
+          placeholder: 'name',
+          marker: failedToAddNameMarker,
+          runtimeText: runtimeUserName,
+        },
+        {
+          placeholder: 'domain',
+          marker: failedToAddDomainMarker,
+          runtimeText: domain as string,
+        },
+      ];
+    } else {
+      translationValues = [
+        {
+          placeholder: 'name',
+          marker: failedToAddNameMarker,
+          runtimeText: runtimeUserName,
+        },
+      ];
+    }
+  } else {
+    translationKey = pluralDetailsTranslationKeyByReason[reason];
+    const runtimeNames = users
+      .slice(1)
+      .map(user => getUserNameWithTranslate(user, translate))
+      .join(', ');
+
+    if (translationLabel === 'OfflineBackend') {
+      translationValues = [
+        {
+          placeholder: 'name',
+          marker: failedToAddNameMarker,
+          runtimeText: runtimeUserName,
+        },
+        {
+          placeholder: 'names',
+          marker: failedToAddNamesMarker,
+          runtimeText: runtimeNames,
+        },
+        {
+          placeholder: 'domain',
+          marker: failedToAddDomainMarker,
+          runtimeText: domain as string,
+        },
+      ];
+    } else {
+      translationValues = [
+        {
+          placeholder: 'name',
+          marker: failedToAddNameMarker,
+          runtimeText: runtimeUserName,
+        },
+        {
+          placeholder: 'names',
+          marker: failedToAddNamesMarker,
+          runtimeText: runtimeNames,
+        },
+      ];
+    }
+  }
+
+  if (isReactTranslationRenderingEnabled === true) {
+    return (
+      <span css={warning}>
+        {renderFailedToAddReactTranslation({
+          translate,
+          translationKey,
+          values: translationValues,
+        })}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      css={warning}
+      dangerouslySetInnerHTML={{
+        __html: translateFailedToAddTranslation({
+          translate,
+          translationKey,
+          values: translationValues,
+        }),
+      }}
+    />
+  );
+}
+
+function MessageDetails({
+  failure,
+  isMessageFocused,
+  allUsers,
+  isReactTranslationRenderingEnabled,
+  translate,
+}: MessageDetailsProps): ReactNode {
   const messageFocusedTabIndex = useMessageFocusedTabIndex(isMessageFocused);
 
   const {users: userIds, reason} = failure;
@@ -325,13 +440,10 @@ function MessageDetails({failure, isMessageFocused, allUsers, translate}: Messag
     return users;
   }, [allUsers, userIds]);
 
-  const baseTranslationKey =
-    users.length === 1 ? 'failedToAddParticipantsSingularDetails' : 'failedToAddParticipantsPluralDetails';
-
   const uniqueDomains = 'backends' in failure ? Array.from(new Set(failure.backends)) : undefined;
   const domainStr = uniqueDomains && uniqueDomains.join(', ');
 
-  const {link, translationLabel} = reasonToMessageDataMap[reason];
+  const {link} = reasonToMessageDataMap[reason];
 
   const learnMoreLink = (
     <>
@@ -349,56 +461,15 @@ function MessageDetails({failure, isMessageFocused, allUsers, translate}: Messag
     </>
   );
 
-  function getText(): string {
-    if (baseTranslationKey === 'failedToAddParticipantsSingularDetails') {
-      if (translationLabel === 'OfflineBackend') {
-        return translate(singularDetailsTranslationKeyByReason[reason], {
-          name: getUserNameWithTranslate(users[0], translate),
-          domain: domainStr as string,
-        });
-      }
-
-      return translate(singularDetailsTranslationKeyByReason[reason], {
-        name: getUserNameWithTranslate(users[0], translate),
-      });
-    }
-
-    if (baseTranslationKey === 'failedToAddParticipantsPluralDetails') {
-      if (translationLabel === 'OfflineBackend') {
-        return translate(pluralDetailsTranslationKeyByReason[reason], {
-          name: getUserNameWithTranslate(users[0], translate),
-          names: users
-            .slice(1)
-            .map(user => getUserNameWithTranslate(user, translate))
-            .join(', '),
-          domain: domainStr as string,
-        });
-      }
-
-      return translate(pluralDetailsTranslationKeyByReason[reason], {
-        name: getUserNameWithTranslate(users[0], translate),
-        names: users
-          .slice(1)
-          .map(user => getUserNameWithTranslate(user, translate))
-          .join(', '),
-      });
-    }
-
-    return '';
-  }
-
-  const text = getText();
-
   return (
     <p data-uie-name="multi-user-not-added-details" data-uie-value={domainStr}>
-      {text && (
-        <span
-          css={warning}
-          dangerouslySetInnerHTML={{
-            __html: text,
-          }}
-        />
-      )}
+      {renderFailedToAddDetailsTranslation({
+        domain: domainStr,
+        failure,
+        isReactTranslationRenderingEnabled,
+        translate,
+        users,
+      })}
       {learnMoreLink}
     </p>
   );
@@ -487,6 +558,7 @@ function FailedToAddUsersMessage({
             <MessageDetails
               allUsers={allUsers}
               isMessageFocused={isMessageFocused}
+              isReactTranslationRenderingEnabled={isReactTranslationRenderingEnabled}
               key={index}
               failure={failure}
               translate={translate}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27666" title="WPB-27666" target="_blank"><img alt="Security" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/13902?size=medium" />WPB-27666</a>  [Web] Text rendering
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This pull request continues the localized rich-text rendering migration from #22411, #22431, #22433, #22444, #22451, and #22452.

It moves the failed-to-add-user message translations to React-based rendering behind the existing startup feature toggle:

```text
react-translation-rendering
```

### Changes

This batch covers:

* single-user failure summaries
* multi-user failure summaries
* expanded failure details for all supported failure reasons

Translation-authored `[bold]...[/bold]` formatting is rendered as React while runtime values such as user names, joined user names, backend domains, and participant counts remain ordinary React text.

Multiple translated bold regions and repeated runtime placeholders remain supported without allowing runtime values to participate in translation formatting.

The existing Learn More links remain separate React components and retain their current destinations, styling, focus behavior, and UIE attributes.