### PR TITLE
Render conversation UI translations with React [WPB-27666]

### DIFF
--- a/apps/webapp/src/script/components/Modals/CreateConversation/ConversationType/ConversationFeature.test.tsx
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/ConversationType/ConversationFeature.test.tsx
@@ -1,0 +1,223 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+import {render} from '@testing-library/react';
+import {isNull, isUndefined} from '@sindresorhus/is';
+
+import en from 'I18n/en-US.json';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {setStrings, translate} from 'Util/localizerUtil';
+
+import {ConversationFeature} from './ConversationFeature';
+
+import {ConversationType} from '../types';
+
+const legacyTranslationRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({translate}),
+);
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName): boolean {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
+
+type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
+type RootProviderWrapper = ReturnType<typeof createRootProviderWrapperForTest>;
+type ExpectFeatureIconCountsOptions = {
+  readonly checkIconCount: number;
+  readonly container: HTMLElement;
+  readonly shieldIconCount: number;
+};
+
+function withTranslationStrings(
+  translationOverrides: Partial<typeof en>,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: {...en, ...translationOverrides}});
+
+    try {
+      await testFunction();
+    } finally {
+      setStrings({});
+    }
+  };
+}
+
+function renderConversationFeature(
+  conversationType: ConversationType,
+  rootProviderWrapper: RootProviderWrapper,
+): ReturnType<typeof render> {
+  return render(
+    withThemeAndRootContext(<ConversationFeature conversationType={conversationType} />, rootProviderWrapper),
+  );
+}
+
+function getFeatureItems(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('[data-uie-name="team-creation-intro-list-item"]'));
+}
+
+function getFeatureItem(featureItems: readonly HTMLElement[], itemIndex: number): HTMLElement {
+  const featureItem = featureItems[itemIndex];
+
+  if (isUndefined(featureItem)) {
+    throw new Error(`Expected feature item at index ${itemIndex}`);
+  }
+
+  return featureItem;
+}
+
+function expectFeatureIconCounts(options: ExpectFeatureIconCountsOptions): void {
+  const {checkIconCount, container, shieldIconCount} = options;
+
+  expect(container.querySelectorAll('svg[viewBox="0 0 16 12"]')).toHaveLength(checkIconCount);
+  expect(container.querySelectorAll('svg[viewBox="0 0 16 16"]')).toHaveLength(shieldIconCount);
+}
+
+function expectLastFeatureHasShieldIcon(featureItems: readonly HTMLElement[]): void {
+  const lastFeatureItem = featureItems[featureItems.length - 1];
+
+  if (isUndefined(lastFeatureItem)) {
+    throw new Error('Expected at least one feature item');
+  }
+
+  const lastFeatureContainer = lastFeatureItem.parentElement;
+
+  if (isNull(lastFeatureContainer)) {
+    throw new Error('Expected the last feature item to have a parent container');
+  }
+
+  expect(lastFeatureContainer.querySelector('svg[viewBox="0 0 16 16"]')).not.toBeNull();
+  expect(lastFeatureContainer.querySelector('svg[viewBox="0 0 16 12"]')).toBeNull();
+}
+
+describe('ConversationFeature', () => {
+  it(
+    'renders the group features through the legacy HTML path',
+    withTranslationStrings({}, () => {
+      const {container} = renderConversationFeature(ConversationType.Group, legacyTranslationRootProviderWrapper);
+      const featureItems = getFeatureItems(container);
+
+      expect(featureItems).toHaveLength(3);
+      expect(featureItems.map(featureItem => featureItem.textContent)).toEqual([
+        'Up to 500 people',
+        'Video conferencing',
+        'Messages and calls are always end-to-end encrypted',
+      ]);
+      expectFeatureIconCounts({checkIconCount: 2, container, shieldIconCount: 1});
+      expectLastFeatureHasShieldIcon(featureItems);
+      expect(getFeatureItem(featureItems, 0)).toHaveAttribute('class', 'subline');
+    }),
+  );
+
+  it(
+    'renders the channel features through the legacy HTML path',
+    withTranslationStrings({}, () => {
+      const {container} = renderConversationFeature(ConversationType.Channel, legacyTranslationRootProviderWrapper);
+      const featureItems = getFeatureItems(container);
+
+      expect(featureItems).toHaveLength(5);
+      expect(featureItems.map(featureItem => featureItem.textContent)).toEqual([
+        'Up to 2000 people',
+        'Public or private channels',
+        'Conversation history',
+        'Video conferencing',
+        'Messages and calls are always end-to-end encrypted',
+      ]);
+      expectFeatureIconCounts({checkIconCount: 4, container, shieldIconCount: 1});
+      expectLastFeatureHasShieldIcon(featureItems);
+    }),
+  );
+
+  it(
+    'renders group feature translations with an opaque capacity and literal unsupported markup',
+    withTranslationStrings(
+      {
+        conversationCommonFeature1: '<meta name="example" content="value">[bold]Up to {capacity} people[/bold]',
+        conversationCommonFeature2: 'Video conferencing',
+        conversationCommonFeature3: 'Messages and calls are always end-to-end encrypted',
+      },
+      () => {
+        const {container} = renderConversationFeature(
+          ConversationType.Group,
+          reactTranslationRenderingRootProviderWrapper,
+        );
+        const featureItems = getFeatureItems(container);
+        const firstFeatureItem = getFeatureItem(featureItems, 0);
+
+        expect(featureItems).toHaveLength(3);
+        expect(featureItems.map(featureItem => featureItem.textContent)).toEqual([
+          '<meta name="example" content="value">Up to 500 people',
+          'Video conferencing',
+          'Messages and calls are always end-to-end encrypted',
+        ]);
+        expect(firstFeatureItem.querySelectorAll('strong')).toHaveLength(1);
+        expect(firstFeatureItem.querySelector('strong')).toHaveTextContent('Up to 500 people');
+        expect(firstFeatureItem.querySelector('meta')).toBeNull();
+        expect(firstFeatureItem).toHaveAttribute('data-uie-name', 'team-creation-intro-list-item');
+        expect(firstFeatureItem).toHaveAttribute('class', 'subline');
+        expectFeatureIconCounts({checkIconCount: 2, container, shieldIconCount: 1});
+        expectLastFeatureHasShieldIcon(featureItems);
+      },
+    ),
+  );
+
+  it(
+    'renders channel feature translations in order with moved capacity and multiple bold regions',
+    withTranslationStrings(
+      {
+        conversationCommonFeature1: '{capacity} participants [bold]maximum[/bold]',
+        channelConversationFeature1: '[bold]Public[/bold] or [bold]private[/bold] channels',
+        channelConversationFeature2: '[bold]Conversation[/bold] history',
+        conversationCommonFeature2: 'Video conferencing',
+        conversationCommonFeature3: 'Messages and calls are always end-to-end encrypted',
+      },
+      () => {
+        const {container} = renderConversationFeature(
+          ConversationType.Channel,
+          reactTranslationRenderingRootProviderWrapper,
+        );
+        const featureItems = getFeatureItems(container);
+
+        expect(featureItems).toHaveLength(5);
+        expect(featureItems.map(featureItem => featureItem.textContent)).toEqual([
+          '2000 participants maximum',
+          'Public or private channels',
+          'Conversation history',
+          'Video conferencing',
+          'Messages and calls are always end-to-end encrypted',
+        ]);
+        expect(getFeatureItem(featureItems, 0).querySelector('strong')).toHaveTextContent('maximum');
+        expect(getFeatureItem(featureItems, 1).querySelectorAll('strong')).toHaveLength(2);
+        expect(getFeatureItem(featureItems, 2).querySelectorAll('strong')).toHaveLength(1);
+        expect(container.querySelector('img')).toBeNull();
+        expectFeatureIconCounts({checkIconCount: 4, container, shieldIconCount: 1});
+        expectLastFeatureHasShieldIcon(featureItems);
+      },
+    ),
+  );
+});

--- a/apps/webapp/src/script/components/Modals/CreateConversation/ConversationType/ConversationFeature.tsx
+++ b/apps/webapp/src/script/components/Modals/CreateConversation/ConversationType/ConversationFeature.tsx
@@ -17,10 +17,19 @@
  *
  */
 
+import type {ReactNode} from 'react';
+
 import {ShieldIcon} from '@wireapp/react-ui-kit';
 
 import {CheckIcon} from 'Components/icon';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {useApplicationContext} from 'src/script/page/rootProvider';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {
+  ReactTranslationComponentReplacement,
+  ReactTranslationValueReplacement,
+} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 
 import {
   conversationFeatureContainerCss,
@@ -35,44 +44,199 @@ interface ConversationFeatureProps {
   conversationType: ConversationType;
 }
 
+type ConversationFeatureTranslationKey =
+  | 'conversationCommonFeature1'
+  | 'conversationCommonFeature2'
+  | 'conversationCommonFeature3'
+  | 'channelConversationFeature1'
+  | 'channelConversationFeature2';
+
+type ConversationFeatureTranslationValue = {
+  readonly placeholder: 'capacity';
+  readonly marker: ReturnType<typeof createReactTranslationMarker>;
+  readonly runtimeText: string;
+};
+
+type ConversationFeatureDescriptor = {
+  readonly translationKey: ConversationFeatureTranslationKey;
+  readonly values: readonly ConversationFeatureTranslationValue[];
+};
+
+type RenderConversationFeatureItemOptions = {
+  readonly descriptor: ConversationFeatureDescriptor;
+  readonly isLastFeature: boolean;
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly translate: Translate;
+};
+
 const CHANNEL_CAPACITY = 2000;
 const GROUP_CAPACITY = 500;
 
-export const ConversationFeature = ({conversationType}: ConversationFeatureProps) => {
-  const {translate} = useApplicationContext();
-  const generalFeatures = [
-    translate('conversationCommonFeature1', {
-      capacity: conversationType === ConversationType.Channel ? CHANNEL_CAPACITY : GROUP_CAPACITY,
-    }),
-    translate('conversationCommonFeature2'),
-    translate('conversationCommonFeature3'),
-  ];
-  const channelFeatures = [translate('channelConversationFeature1'), translate('channelConversationFeature2')];
+const conversationFeatureBoldMarker = createReactTranslationMarker('conversation-feature-bold');
+const conversationFeatureCapacityMarker = createReactTranslationMarker('conversation-feature-capacity');
 
-  const features =
-    conversationType === ConversationType.Channel
-      ? generalFeatures.toSpliced(1, 0, ...channelFeatures)
-      : generalFeatures;
+const conversationFeatureComponentReplacements: readonly ReactTranslationComponentReplacement[] = [
+  {
+    start: conversationFeatureBoldMarker.start,
+    end: conversationFeatureBoldMarker.end,
+    render(children): ReactNode {
+      return <strong>{children}</strong>;
+    },
+  },
+];
+
+const conversationFeatureDangerousSubstitutions = {
+  bold: conversationFeatureBoldMarker.start,
+  '/bold': conversationFeatureBoldMarker.end,
+};
+
+function getConversationFeatureCapacity(conversationType: ConversationType): string {
+  if (conversationType === ConversationType.Channel) {
+    return CHANNEL_CAPACITY.toString();
+  }
+
+  return GROUP_CAPACITY.toString();
+}
+
+function createConversationFeatureValue(runtimeText: string): ConversationFeatureTranslationValue {
+  return {
+    placeholder: 'capacity',
+    marker: conversationFeatureCapacityMarker,
+    runtimeText,
+  };
+}
+
+function getConversationFeatureDescriptors(
+  conversationType: ConversationType,
+): readonly ConversationFeatureDescriptor[] {
+  const generalFeatures: readonly ConversationFeatureDescriptor[] = [
+    {
+      translationKey: 'conversationCommonFeature1',
+      values: [createConversationFeatureValue(getConversationFeatureCapacity(conversationType))],
+    },
+    {
+      translationKey: 'conversationCommonFeature2',
+      values: [],
+    },
+    {
+      translationKey: 'conversationCommonFeature3',
+      values: [],
+    },
+  ];
+
+  if (conversationType === ConversationType.Channel) {
+    const channelFeatures: readonly ConversationFeatureDescriptor[] = [
+      {
+        translationKey: 'channelConversationFeature1',
+        values: [],
+      },
+      {
+        translationKey: 'channelConversationFeature2',
+        values: [],
+      },
+    ];
+
+    return generalFeatures.toSpliced(1, 0, ...channelFeatures);
+  }
+
+  return generalFeatures;
+}
+
+function getConversationFeatureMarkerSubstitutions(
+  values: readonly ConversationFeatureTranslationValue[],
+): Record<string, string> {
+  return Object.fromEntries(
+    values.map(value => {
+      return [value.placeholder, value.marker.substitution];
+    }),
+  );
+}
+
+function getConversationFeatureRuntimeSubstitutions(
+  values: readonly ConversationFeatureTranslationValue[],
+): Record<string, string> {
+  return Object.fromEntries(
+    values.map(value => {
+      return [value.placeholder, value.runtimeText];
+    }),
+  );
+}
+
+function renderConversationFeatureReactTranslation(
+  descriptor: ConversationFeatureDescriptor,
+  translate: Translate,
+): ReactNode[] {
+  const translatedText = translate(
+    descriptor.translationKey,
+    getConversationFeatureMarkerSubstitutions(descriptor.values),
+    conversationFeatureDangerousSubstitutions,
+  );
+  const valueReplacements: readonly ReactTranslationValueReplacement[] = descriptor.values.map(value => {
+    return {
+      marker: value.marker,
+      runtimeText: value.runtimeText,
+    };
+  });
+
+  return renderReactTranslation({
+    translatedText,
+    componentReplacements: conversationFeatureComponentReplacements,
+    nodeReplacements: [],
+    valueReplacements,
+  });
+}
+
+function renderConversationFeatureIcon(isLastFeature: boolean): ReactNode {
+  if (isLastFeature) {
+    return <ShieldIcon css={conversationFeatureVerifiedIconCss} />;
+  }
+
+  return <CheckIcon css={conversationFeatureIconCss} />;
+}
+
+function renderConversationFeatureItem(options: RenderConversationFeatureItemOptions): ReactNode {
+  const {descriptor, isLastFeature, isReactTranslationRenderingEnabled, translate} = options;
+
+  if (isReactTranslationRenderingEnabled) {
+    return (
+      <div css={conversationFeatureCss} key={descriptor.translationKey}>
+        {renderConversationFeatureIcon(isLastFeature)}
+        <span className="subline" data-uie-name="team-creation-intro-list-item">
+          {renderConversationFeatureReactTranslation(descriptor, translate)}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div css={conversationFeatureCss} key={descriptor.translationKey}>
+      {renderConversationFeatureIcon(isLastFeature)}
+      <span
+        dangerouslySetInnerHTML={{
+          __html: translate(descriptor.translationKey, getConversationFeatureRuntimeSubstitutions(descriptor.values)),
+        }}
+        className="subline"
+        data-uie-name="team-creation-intro-list-item"
+      />
+    </div>
+  );
+}
+
+export function ConversationFeature({conversationType}: ConversationFeatureProps): ReactNode {
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
+  const isReactTranslationRenderingEnabled = isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName);
+  const featureDescriptors = getConversationFeatureDescriptors(conversationType);
 
   return (
     <div css={conversationFeatureContainerCss}>
-      {features.map((feature, index) => (
-        <div css={conversationFeatureCss} key={feature}>
-          {index < features.length - 1 ? (
-            <CheckIcon css={conversationFeatureIconCss} />
-          ) : (
-            <ShieldIcon css={conversationFeatureVerifiedIconCss} />
-          )}
-
-          <span
-            dangerouslySetInnerHTML={{
-              __html: feature,
-            }}
-            className="subline"
-            data-uie-name="team-creation-intro-list-item"
-          />
-        </div>
-      ))}
+      {featureDescriptors.map((descriptor, featureIndex): ReactNode => {
+        return renderConversationFeatureItem({
+          descriptor,
+          isLastFeature: featureIndex === featureDescriptors.length - 1,
+          isReactTranslationRenderingEnabled,
+          translate,
+        });
+      })}
     </div>
   );
-};
+}

--- a/apps/webapp/src/script/components/titleBar/titleBar.test.tsx
+++ b/apps/webapp/src/script/components/titleBar/titleBar.test.tsx
@@ -21,11 +21,14 @@ import {fireEvent, render, waitFor} from '@testing-library/react';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {amplify} from 'amplify';
 import ko from 'knockout';
+import {isNull} from '@sindresorhus/is';
 
 import {Runtime} from '@wireapp/commons';
 import * as uiKit from '@wireapp/react-ui-kit';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
+import en from 'I18n/en-US.json';
+import ru from 'I18n/ru-RU.json';
 import {TitleBar} from 'Components/titleBar';
 import {CallingRepository} from 'Repositories/calling/CallingRepository';
 import {CallState} from 'Repositories/calling/CallState';
@@ -33,8 +36,15 @@ import {ConversationVerificationState} from 'Repositories/conversation/Conversat
 import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {TeamState} from 'Repositories/team/TeamState';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {withTheme} from 'src/script/auth/util/test/testUtil';
+import {withThemeAndRootContext} from 'src/script/auth/util/test/testUtil';
 import {ContentState} from 'src/script/page/useAppState';
+import {
+  createRootContextValueForTest,
+  createRootProviderWrapperForTest,
+} from 'src/script/page/testSupport/rootContextTestSupport';
+import {setStrings, translate} from 'Util/localizerUtil';
 
 import {TestFactory} from '../../../../test/helper/TestFactory';
 import {PanelState} from '../../page/rightSidebar/rightSidebar';
@@ -54,6 +64,15 @@ jest.mock('Components/calling/useCallAlertState', () => ({
 }));
 
 const mockedUiKit = uiKit as jest.Mocked<typeof uiKit>;
+
+const reactTranslationRenderingRootProviderWrapper = createRootProviderWrapperForTest(
+  createRootContextValueForTest({
+    isFeatureToggleEnabled(featureName): boolean {
+      return featureName === reactTranslationRenderingFeatureToggleName;
+    },
+    translate,
+  }),
+);
 
 jest.spyOn(Runtime, 'isSupportingConferenceCalling').mockReturnValue(true);
 
@@ -95,6 +114,34 @@ const getDefaultProps = (callingRepository: CallingRepository, conversation: Con
   selfUser: new User('', '', translateForTest),
   withBottomDivider: true,
 });
+
+type TranslationTestFunction = () => void | Promise<void>;
+type IsolatedTranslationTestFunction = () => Promise<void>;
+
+function withTranslationStrings(
+  translationOverrides: Partial<typeof en>,
+  testFunction: TranslationTestFunction,
+): IsolatedTranslationTestFunction {
+  return async function runTranslationTest(): Promise<void> {
+    setStrings({en: {...en, ...translationOverrides}});
+
+    try {
+      await testFunction();
+    } finally {
+      setStrings({});
+    }
+  };
+}
+
+function getWarningBadge(container: HTMLElement): HTMLElement {
+  const warningBadge = container.querySelector<HTMLElement>('[data-uie-name="status-indication-badge"]');
+
+  if (isNull(warningBadge)) {
+    throw new Error('Expected warning badge to be rendered');
+  }
+
+  return warningBadge;
+}
 
 describe('TitleBar', () => {
   it('subscribes to shortcut PEOPLE and add ADD_PEOPLE events on mount', async () => {
@@ -279,9 +326,113 @@ describe('TitleBar', () => {
       isGroup: ko.pureComputed(() => true),
     });
 
-    const {getByText} = render(withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} />));
+    const {container, getByText} = render(
+      withTheme(<TitleBar {...getDefaultProps(callingRepository, conversation)} />),
+    );
 
     expect(getByText('guestRoomConversationBadge')).toBeDefined();
+    expect(getWarningBadge(container)).toHaveAttribute('data-uie-name', 'status-indication-badge');
+  });
+
+  it(
+    'renders one warning badge bold region with React translation rendering',
+    withTranslationStrings(
+      {
+        guestRoomConversationBadge: '[bold]Guests[/bold] are present',
+      },
+      async () => {
+        const conversation = createConversationEntity({
+          hasDirectGuest: ko.pureComputed(() => true),
+          isGroup: ko.pureComputed(() => true),
+        });
+
+        const {container} = render(
+          withThemeAndRootContext(
+            <TitleBar {...getDefaultProps(callingRepository, conversation)} />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+
+        const warningBadge = getWarningBadge(container);
+        expect(warningBadge).toHaveTextContent('Guests are present');
+        expect(warningBadge.querySelectorAll('strong')).toHaveLength(1);
+        expect(warningBadge.querySelector('strong')).toHaveTextContent('Guests');
+      },
+    ),
+  );
+
+  it(
+    'renders multiple warning badge bold regions and keeps unsupported markup as text',
+    withTranslationStrings(
+      {
+        guestRoomConversationBadgeExternalAndGuest:
+          '<img src="example">[bold]Externals[/bold] and [bold]guests[/bold] are present',
+      },
+      async () => {
+        const conversation = createConversationEntity({
+          hasDirectGuest: ko.pureComputed(() => true),
+          hasExternal: ko.pureComputed(() => true),
+          isGroup: ko.pureComputed(() => true),
+        });
+
+        const {container} = render(
+          withThemeAndRootContext(
+            <TitleBar {...getDefaultProps(callingRepository, conversation)} />,
+            reactTranslationRenderingRootProviderWrapper,
+          ),
+        );
+
+        const warningBadge = getWarningBadge(container);
+        expect(warningBadge).toHaveTextContent('<img src="example">Externals and guests are present');
+        expect(warningBadge.querySelectorAll('strong')).toHaveLength(2);
+        expect(warningBadge.querySelector('img')).toBeNull();
+        expect(warningBadge.querySelectorAll('strong')[0]).toHaveTextContent('Externals');
+        expect(warningBadge.querySelectorAll('strong')[1]).toHaveTextContent('guests');
+      },
+    ),
+  );
+
+  it(
+    'renders the audited malformed Russian warning badge through local compatibility',
+    withTranslationStrings(ru, async () => {
+      const conversation = createConversationEntity({
+        hasFederatedUsers: ko.pureComputed(() => true),
+        isGroup: ko.pureComputed(() => true),
+      });
+
+      const {container} = render(
+        withThemeAndRootContext(
+          <TitleBar {...getDefaultProps(callingRepository, conversation)} />,
+          reactTranslationRenderingRootProviderWrapper,
+        ),
+      );
+
+      const warningBadge = getWarningBadge(container);
+      expect(warningBadge).toHaveTextContent('Присутствуют федеративные пользователи');
+      expect(warningBadge.querySelectorAll('strong')).toHaveLength(1);
+      expect(warningBadge.querySelector('strong')).toHaveTextContent('федеративные пользователи');
+      expect(warningBadge).not.toHaveTextContent('/bold]');
+    }),
+  );
+
+  it('does not render a warning badge when no warning applies in React translation rendering', async () => {
+    const conversation = createConversationEntity({
+      hasDirectGuest: ko.pureComputed(() => false),
+      hasExternal: ko.pureComputed(() => false),
+      hasFederatedUsers: ko.pureComputed(() => false),
+      hasService: ko.pureComputed(() => false),
+      hasApps: ko.pureComputed(() => false),
+      isGroup: ko.pureComputed(() => true),
+    });
+
+    const {container} = render(
+      withThemeAndRootContext(
+        <TitleBar {...getDefaultProps(callingRepository, conversation)} />,
+        reactTranslationRenderingRootProviderWrapper,
+      ),
+    );
+
+    expect(container.querySelector('[data-uie-name="status-indication-badge"]')).toBeNull();
   });
 
   it.each([

--- a/apps/webapp/src/script/components/titleBar/titleBar.tsx
+++ b/apps/webapp/src/script/components/titleBar/titleBar.tsx
@@ -17,8 +17,10 @@
  *
  */
 
+import type {ReactNode} from 'react';
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 
+import {isNonEmptyString} from '@sindresorhus/is';
 import {amplify} from 'amplify';
 import cx from 'classnames';
 import {container} from 'tsyringe';
@@ -37,6 +39,7 @@ import {ConversationFilter} from 'Repositories/conversation/ConversationFilter';
 import {Conversation} from 'Repositories/entity/Conversation';
 import {User} from 'Repositories/entity/User';
 import {TeamState} from 'Repositories/team/TeamState';
+import {reactTranslationRenderingFeatureToggleName} from 'src/script/featureToggles/startupFeatureToggleNames';
 import {RightSidebarParams} from 'src/script/page/appMain';
 import {PanelState} from 'src/script/page/rightSidebar';
 import {useApplicationContext} from 'src/script/page/rootProvider';
@@ -46,6 +49,8 @@ import {CallActions} from 'src/script/view_model/CallingViewModel';
 import {ViewModelRepositories} from 'src/script/view_model/MainViewModel';
 import {useKoSubscribableChildren} from 'Util/componentUtil';
 import {handleKeyDown, KEY} from 'Util/keyboardUtil';
+import {createReactTranslationMarker, renderReactTranslation} from 'Util/localizerUtil/reactLocalizerUtil';
+import type {Translate} from 'Util/localizerUtil/translationTypes';
 import {matchQualifiedIds} from 'Util/qualifiedId';
 import {TIME_IN_MILLIS} from 'Util/timeUtil';
 
@@ -78,7 +83,7 @@ export const TitleBar = ({
   isSharedDriveSearchViewOpen = false,
   onCloseSharedDriveSearchView,
 }: TitleBarProps) => {
-  const {translate} = useApplicationContext();
+  const {isFeatureToggleEnabled, translate} = useApplicationContext();
   const {
     is1to1,
     isRequest,
@@ -135,24 +140,18 @@ export const TitleBar = ({
   // Button is disabled if starting, connecting, or already active
   const isCallButtonDisabled = isReadOnlyConversation || isStartingCallRef.current || isCallConnecting || isCallActive;
 
-  const badgeLabelCopy = useMemo(() => {
+  const badgeTranslationKey = useMemo(() => {
     if (is1to1 && isRequest) {
       return '';
     }
 
-    const translationKey = generateWarningBadgeKey({
+    return generateWarningBadgeKey({
       hasExternal,
       hasFederated: hasFederatedUsers,
       hasGuest: hasDirectGuest,
       hasService: hasService || hasApps,
     });
-
-    if (translationKey) {
-      return translate(translationKey);
-    }
-
-    return '';
-  }, [hasApps, hasDirectGuest, hasExternal, hasFederatedUsers, hasService, is1to1, isRequest, translate]);
+  }, [hasApps, hasDirectGuest, hasExternal, hasFederatedUsers, hasService, is1to1, isRequest]);
 
   const hasCall = useMemo(() => {
     const hasEntities = !!joinedCall;
@@ -406,13 +405,11 @@ export const TitleBar = ({
         )}
       </li>
 
-      {badgeLabelCopy && (
-        <li
-          className="conversation-title-bar-indication-badge"
-          data-uie-name="status-indication-badge"
-          dangerouslySetInnerHTML={{__html: badgeLabelCopy}}
-        />
-      )}
+      {renderWarningBadge({
+        badgeTranslationKey,
+        isReactTranslationRenderingEnabled: isFeatureToggleEnabled(reactTranslationRenderingFeatureToggleName),
+        translate,
+      })}
     </ul>
   );
 };
@@ -434,6 +431,71 @@ type BadgeKeys =
   | 'Apps';
 
 type WarningBadgeKey = '' | 'guestRoomConversationBadge' | `${'guestRoomConversationBadge'}${BadgeKeys}`;
+type NonEmptyWarningBadgeKey = Exclude<WarningBadgeKey, ''>;
+
+type RenderWarningBadgeOptions = {
+  readonly badgeTranslationKey: WarningBadgeKey;
+  readonly isReactTranslationRenderingEnabled: boolean;
+  readonly translate: Translate;
+};
+
+const warningBadgeBoldMarker = createReactTranslationMarker('title-bar-warning-badge-bold');
+
+function getWarningBadgeTranslatedText(translationKey: NonEmptyWarningBadgeKey, translate: Translate): string {
+  const translatedText = translate(translationKey, undefined, {
+    bold: warningBadgeBoldMarker.start,
+    '/bold': warningBadgeBoldMarker.end,
+  });
+
+  if (translationKey === 'guestRoomConversationBadgeFederated') {
+    return translatedText.replace('/bold]', warningBadgeBoldMarker.end);
+  }
+
+  return translatedText;
+}
+
+function renderWarningBadgeTranslation(translationKey: NonEmptyWarningBadgeKey, translate: Translate): ReactNode[] {
+  return renderReactTranslation({
+    translatedText: getWarningBadgeTranslatedText(translationKey, translate),
+    componentReplacements: [
+      {
+        start: warningBadgeBoldMarker.start,
+        end: warningBadgeBoldMarker.end,
+        render(children): ReactNode {
+          return <strong>{children}</strong>;
+        },
+      },
+    ],
+    nodeReplacements: [],
+    valueReplacements: [],
+  });
+}
+
+function renderWarningBadge(options: RenderWarningBadgeOptions): ReactNode {
+  const {badgeTranslationKey, isReactTranslationRenderingEnabled, translate} = options;
+
+  if (isNonEmptyString(badgeTranslationKey) === false) {
+    return null;
+  }
+
+  const nonEmptyBadgeTranslationKey = badgeTranslationKey as NonEmptyWarningBadgeKey;
+
+  if (isReactTranslationRenderingEnabled) {
+    return (
+      <li className="conversation-title-bar-indication-badge" data-uie-name="status-indication-badge">
+        {renderWarningBadgeTranslation(nonEmptyBadgeTranslationKey, translate)}
+      </li>
+    );
+  }
+
+  return (
+    <li
+      className="conversation-title-bar-indication-badge"
+      data-uie-name="status-indication-badge"
+      dangerouslySetInnerHTML={{__html: translate(nonEmptyBadgeTranslationKey)}}
+    />
+  );
+}
 
 export function generateWarningBadgeKey({
   hasFederated,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27666" title="WPB-27666" target="_blank"><img alt="Security" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/13902?size=medium" />WPB-27666</a>  [Web] Text rendering
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This pull request continues the localized rich-text rendering migration from #22411, #22431, #22433, #22444, #22451, #22452, and #22454.

It moves two additional conversation UI translation paths to React-based rendering behind the existing startup feature toggle:

```text
react-translation-rendering
```

### Changes

This batch covers:

* conversation warning badges in the title bar
* conversation feature copy shown during conversation creation

Title-bar warning badges now render translation-authored `[bold]...[/bold]` formatting as React elements instead of treating the translated copy as arbitrary HTML.

Conversation feature copy now follows the same model. Translation-authored formatting is rendered through React, while the runtime capacity value remains ordinary React text and stays separate from translation formatting.

Multiple translated bold regions remain supported, and translators retain control over the placement of formatting and runtime placeholders.