### PR TITLE
fix(wire-drive): retry interrupted uploads [WPB-28307]

### DIFF
--- a/apps/webapp/src/script/repositories/cells/upload/process.test.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.test.ts
@@ -113,11 +113,12 @@ const setup = (
         : Task.resolve<void, never>(undefined);
     },
   };
+  let resource = 0;
   let version = 0;
   let attempt = 0;
   const dependencies: CellsUploadProcessDependencies = {
     gateway,
-    createResourceUuid: () => 'resource-1',
+    createResourceUuid: () => `resource-${++resource}`,
     createVersionUuid: () => `version-${++version}`,
     createAttemptId: () => (duplicateAttemptIds ? 'attempt-1' : `attempt-${++attempt}`),
     createAbortController: () => {
@@ -257,7 +258,7 @@ describe('createCellsUploadProcess', () => {
     const secondRequest = required(fixture.uploads[1]);
     expect(secondRequest.path).toBe(path);
     expect(secondRequest.source.blob).toBe(source.blob);
-    expect(secondRequest.identity).toMatchObject({resourceUuid: 'resource-1', versionId: 'version-2'});
+    expect(secondRequest.identity).toMatchObject({resourceUuid: 'resource-2', versionId: 'version-2'});
     expect(secondRequest.attemptId).toBe('attempt-2');
     const snapshots: string[] = [];
     required(fixture.process.subscribe(snapshot => snapshots.push(snapshot.kind)));

--- a/apps/webapp/src/script/repositories/cells/upload/process.ts
+++ b/apps/webapp/src/script/repositories/cells/upload/process.ts
@@ -234,6 +234,7 @@ export const createCellsUploadProcess = (
     if (resultModule.isErr(result)) {
       return Result.err(result.error);
     }
+    resourceUuid = Maybe.nothing();
     return start();
   };
 

--- a/libraries/api-client/src/cells/cellsStorage/s3Service.test.ts
+++ b/libraries/api-client/src/cells/cellsStorage/s3Service.test.ts
@@ -82,6 +82,21 @@ describe('S3Service', () => {
     handle.mockRestore();
   });
 
+  it('rejects an XHR that completes without an HTTP response', async () => {
+    const handle = jest
+      .spyOn(XhrHttpHandler.prototype, 'handle')
+      .mockResolvedValue({response: {statusCode: 0} as never});
+    const requestHandler = createAbortableXhrHttpHandler(new AbortController().signal);
+
+    try {
+      await expect(requestHandler.handle({} as never)).rejects.toThrow(
+        'XHR request failed before receiving an HTTP response',
+      );
+    } finally {
+      handle.mockRestore();
+    }
+  });
+
   it('aborts the underlying XHR when the upload signal is cancelled', async () => {
     const abortController = new AbortController();
     const xhr = {

--- a/libraries/api-client/src/cells/cellsStorage/s3Service.ts
+++ b/libraries/api-client/src/cells/cellsStorage/s3Service.ts
@@ -35,12 +35,23 @@ interface S3ServiceConfig {
 export const MAX_QUEUE_SIZE = 3;
 export const PART_SIZE = 10 * 1024 * 1024; // 10MB
 
-export const createAbortableXhrHttpHandler = (abortSignal: AbortSignal): XhrHttpHandler => {
+const createReliableXhrHttpHandler = (abortSignal?: AbortSignal): XhrHttpHandler => {
   const requestHandler = new XhrHttpHandler();
   const handle = requestHandler.handle.bind(requestHandler);
-  requestHandler.handle = (request, options) => handle(request, {...(options ?? {}), abortSignal});
+  requestHandler.handle = async (request, options) => {
+    const handlerOptions = abortSignal === undefined ? options : {...(options ?? {}), abortSignal};
+    const result = await handle(request, handlerOptions);
+    if (result.response.statusCode === 0) {
+      throw new Error('XHR request failed before receiving an HTTP response');
+    }
+
+    return result;
+  };
   return requestHandler;
 };
+
+export const createAbortableXhrHttpHandler = (abortSignal: AbortSignal): XhrHttpHandler =>
+  createReliableXhrHttpHandler(abortSignal);
 
 export class S3Service implements CellsStorage {
   private config: S3ServiceConfig;
@@ -158,7 +169,7 @@ export class S3Service implements CellsStorage {
       endpoint: this.config.endpoint,
       forcePathStyle: true,
       region: this.config.region,
-      requestHandler: abortSignal === undefined ? new XhrHttpHandler() : createAbortableXhrHttpHandler(abortSignal),
+      requestHandler: createReliableXhrHttpHandler(abortSignal),
       credentials: async () => {
         if (this.config.apiKey !== undefined && this.config.apiKey.length > 0) {
           return {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28307" title="WPB-28307" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28307</a>  [web] precise progress visual feedback to shared drive upload
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Problem

When a multipart Wire Drive upload lost internet during the final completion request, the XHR handler returned status `0`. The AWS upload flow treated that as success and tried to promote a draft that was never completed.

After fixing that part, retry still reused the resource UUID from the incomplete multipart upload. Cells then rejected the new multipart request with `500 cause(index mpath conflict)`.

## Solution

Treat XHR status `0` as a network failure, so an interrupted multipart completion stays in the upload failure state instead of moving to promotion.

Create a fresh resource UUID when retrying the upload. The retry keeps the original file and path, but it no longer conflicts with state left by the interrupted multipart request.

## DEMO


https://github.com/user-attachments/assets/d4cb7763-4ae8-42f2-94eb-522890b2a6d8



## Reference

[WPB-28307](https://wearezeta.atlassian.net/browse/WPB-28307)


[WPB-28307]: https://wearezeta.atlassian.net/browse/WPB-28307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ