### PR TITLE
fix(wire-drive): dismiss upload tab indicator on close [WPB-28486] 

### DIFF
--- a/apps/webapp/src/script/components/conversation/conversation.tsx
+++ b/apps/webapp/src/script/components/conversation/conversation.tsx
@@ -80,8 +80,8 @@ import {
   createDraftSharedDriveUploadStrategy,
   createSharedDriveUploadController,
 } from './conversationCells/sharedDriveUploadController';
-import {SharedDriveUploadStatusPopupHost} from './conversationCells/sharedDriveUploadStatusPopupHost';
 import {SharedDriveUploadStatusProvider} from './conversationCells/sharedDriveUploadStatusContext';
+import {SharedDriveUploadStatusPopupHost} from './conversationCells/sharedDriveUploadStatusPopupHost';
 import {ConversationFileDropzone} from './conversationFileDropzone/conversationFileDropzone';
 import {isConversationFileDropAllowed} from './conversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed';
 import {ConversationMessagesWrapper} from './conversationMessagesWrapper/conversationMessagesWrapper';

--- a/apps/webapp/src/script/components/conversation/conversation.tsx
+++ b/apps/webapp/src/script/components/conversation/conversation.tsx
@@ -844,19 +844,18 @@ function ConversationContent({
                 <div className="icon-spinner spin accent-text"></div>
               </div>
             </ConversationMessagesWrapper>
+
+            <SharedDriveUploadStatusPopupHost
+              controller={sharedDriveUploadController}
+              conversationQualifiedId={`${activeConversation.qualifiedId.id}@${activeConversation.qualifiedId.domain}`}
+              isEnabled={isSharedDriveDirectUploadFeatureEnabled}
+              isFileTabActive={isFileTabActive}
+            />
           </SharedDriveUploadStatusProvider>
         )}
 
         {isGiphyModalOpen && inputValue && (
           <Giphy giphyRepository={repositories.giphy} inputValue={inputValue} onClose={closeGiphy} />
-        )}
-        {activeConversation && (
-          <SharedDriveUploadStatusPopupHost
-            controller={sharedDriveUploadController}
-            conversationQualifiedId={`${activeConversation.qualifiedId.id}@${activeConversation.qualifiedId.domain}`}
-            isEnabled={isSharedDriveDirectUploadFeatureEnabled}
-            isFileTabActive={isFileTabActive}
-          />
         )}
       </ConversationFileDropzone>
     </CellsSelfUserDriveRoleProvider>

--- a/apps/webapp/src/script/components/conversation/conversation.tsx
+++ b/apps/webapp/src/script/components/conversation/conversation.tsx
@@ -81,6 +81,7 @@ import {
   createSharedDriveUploadController,
 } from './conversationCells/sharedDriveUploadController';
 import {SharedDriveUploadStatusPopupHost} from './conversationCells/sharedDriveUploadStatusPopupHost';
+import {SharedDriveUploadStatusProvider} from './conversationCells/sharedDriveUploadStatusContext';
 import {ConversationFileDropzone} from './conversationFileDropzone/conversationFileDropzone';
 import {isConversationFileDropAllowed} from './conversationFileDropzone/isConversationFileDropAllowed/isConversationFileDropAllowed';
 import {ConversationMessagesWrapper} from './conversationMessagesWrapper/conversationMessagesWrapper';
@@ -699,7 +700,7 @@ function ConversationContent({
         inputProps={getInputProps()}
       >
         {activeConversation && (
-          <>
+          <SharedDriveUploadStatusProvider>
             <TitleBar
               repositories={repositories}
               conversation={activeConversation}
@@ -843,7 +844,7 @@ function ConversationContent({
                 <div className="icon-spinner spin accent-text"></div>
               </div>
             </ConversationMessagesWrapper>
-          </>
+          </SharedDriveUploadStatusProvider>
         )}
 
         {isGiphyModalOpen && inputValue && (

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.ts
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatus.ts
@@ -23,6 +23,11 @@ import type {SharedDriveUploadController} from './sharedDriveUploadController';
 
 export type SharedDriveUploadStatusKind = 'uploading' | 'uploaded' | 'failed';
 
+export type DismissedUpload = {
+  readonly conversationQualifiedId: string;
+  readonly uploadId: string;
+};
+
 export type SharedDriveUploadStatus = {
   readonly uploadId: string;
   readonly conversationQualifiedId: string;

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusContext.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusContext.tsx
@@ -1,0 +1,49 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {createContext, type ReactNode, useCallback, useContext, useState} from 'react';
+import {Maybe} from 'true-myth';
+
+import type {DismissedUpload} from './sharedDriveUploadStatus';
+
+type SharedDriveUploadStatusContextValue = {
+  readonly dismissedUpload: Maybe<DismissedUpload>;
+  readonly dismissUpload: (upload: DismissedUpload) => void;
+  readonly isProvided: boolean;
+};
+
+const SharedDriveUploadStatusContext = createContext<SharedDriveUploadStatusContextValue>({
+  dismissedUpload: Maybe.nothing(),
+  dismissUpload: () => undefined,
+  isProvided: false,
+});
+
+interface SharedDriveUploadStatusProviderProps {
+  readonly children: ReactNode;
+  readonly initialDismissedUpload?: Maybe<DismissedUpload>;
+}
+
+export const SharedDriveUploadStatusProvider = ({
+  children,
+  initialDismissedUpload = Maybe.nothing(),
+}: SharedDriveUploadStatusProviderProps) => {
+  const [dismissedUpload, setDismissedUpload] = useState<Maybe<DismissedUpload>>(initialDismissedUpload);
+  const dismissUpload = useCallback((upload: DismissedUpload) => setDismissedUpload(Maybe.just(upload)), []);
+
+  return (
+    <SharedDriveUploadStatusContext.Provider value={{dismissedUpload, dismissUpload, isProvided: true}}>
+      {children}
+    </SharedDriveUploadStatusContext.Provider>
+  );
+};
+
+export const useSharedDriveUploadStatus = (): SharedDriveUploadStatusContextValue => {
+  return useContext(SharedDriveUploadStatusContext);
+};

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusContext.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusContext.tsx
@@ -6,9 +6,19 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
  */
 
 import {createContext, type ReactNode, useCallback, useContext, useState} from 'react';
+
 import {Maybe} from 'true-myth';
 
 import type {DismissedUpload} from './sharedDriveUploadStatus';

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
@@ -25,13 +25,13 @@ import {useApplicationContext} from 'src/script/page/rootProvider';
 import {formatBytes} from 'Util/util';
 
 import type {SharedDriveUploadController} from './sharedDriveUploadController';
-import {getLatestSharedDriveUploadStatus, getSharedDriveUploadStatuses} from './sharedDriveUploadStatus';
+import {
+  getLatestSharedDriveUploadStatus,
+  getSharedDriveUploadStatuses,
+  type DismissedUpload,
+} from './sharedDriveUploadStatus';
+import {useSharedDriveUploadStatus} from './sharedDriveUploadStatusContext';
 import {SharedDriveUploadStatusPopup} from './sharedDriveUploadStatusPopup';
-
-type DismissedUpload = {
-  readonly conversationQualifiedId: string;
-  readonly uploadId: string;
-};
 
 interface SharedDriveUploadStatusPopupHostProps {
   readonly controller: SharedDriveUploadController;
@@ -47,6 +47,7 @@ export const SharedDriveUploadStatusPopupHost = ({
   isFileTabActive,
 }: SharedDriveUploadStatusPopupHostProps) => {
   const {translate} = useApplicationContext();
+  const {dismissedUpload: contextDismissedUpload, dismissUpload: onDismissUpload, isProvided} = useSharedDriveUploadStatus();
   const readStatus = useCallback(
     () => getLatestSharedDriveUploadStatus(controller, conversationQualifiedId),
     [controller, conversationQualifiedId],
@@ -58,7 +59,17 @@ export const SharedDriveUploadStatusPopupHost = ({
   const [isExpanded, setIsExpanded] = useState(false);
   const [cancellingUploadId, setCancellingUploadId] = useState<Maybe<string>>(Maybe.nothing());
   const [retryingUploadId, setRetryingUploadId] = useState<Maybe<string>>(Maybe.nothing());
-  const [dismissedUpload, setDismissedUpload] = useState<Maybe<DismissedUpload>>(Maybe.nothing());
+  const [localDismissedUpload, setLocalDismissedUpload] = useState<Maybe<DismissedUpload>>(
+    Maybe.nothing(),
+  );
+  const dismissedUpload = isProvided ? contextDismissedUpload : localDismissedUpload;
+  const dismissUpload = useCallback(
+    (upload: DismissedUpload) => {
+      setLocalDismissedUpload(Maybe.just(upload));
+      onDismissUpload(upload);
+    },
+    [onDismissUpload],
+  );
   const upload = status.conversationQualifiedId === conversationQualifiedId ? status.upload : readStatus();
   const uploadStatuses = getSharedDriveUploadStatuses(controller, conversationQualifiedId);
   const canDismissUploadStatus =
@@ -75,7 +86,7 @@ export const SharedDriveUploadStatusPopupHost = ({
         return;
       }
 
-      setDismissedUpload(Maybe.just({conversationQualifiedId, uploadId}));
+      dismissUpload({conversationQualifiedId, uploadId});
       setCancellingUploadId(Maybe.just(uploadId));
       const finishCancellation = () =>
         setCancellingUploadId(current =>
@@ -83,7 +94,7 @@ export const SharedDriveUploadStatusPopupHost = ({
         );
       void controller.cancel(uploadId).then(finishCancellation, finishCancellation);
     },
-    [cancellingUploadId, controller, conversationQualifiedId],
+    [cancellingUploadId, controller, conversationQualifiedId, dismissUpload],
   );
 
   const retryUpload = useCallback(
@@ -150,7 +161,7 @@ export const SharedDriveUploadStatusPopupHost = ({
       onToggle={() => setIsExpanded(expanded => !expanded)}
       onCancel={() => cancelUpload(upload.uploadId)}
       onRetry={() => retryUpload(upload.uploadId)}
-      onDismiss={() => setDismissedUpload(Maybe.just({conversationQualifiedId, uploadId: upload.uploadId}))}
+      onDismiss={() => dismissUpload({conversationQualifiedId, uploadId: upload.uploadId})}
     />
   );
 };

--- a/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationCells/sharedDriveUploadStatusPopupHost.tsx
@@ -47,7 +47,11 @@ export const SharedDriveUploadStatusPopupHost = ({
   isFileTabActive,
 }: SharedDriveUploadStatusPopupHostProps) => {
   const {translate} = useApplicationContext();
-  const {dismissedUpload: contextDismissedUpload, dismissUpload: onDismissUpload, isProvided} = useSharedDriveUploadStatus();
+  const {
+    dismissedUpload: contextDismissedUpload,
+    dismissUpload: onDismissUpload,
+    isProvided,
+  } = useSharedDriveUploadStatus();
   const readStatus = useCallback(
     () => getLatestSharedDriveUploadStatus(controller, conversationQualifiedId),
     [controller, conversationQualifiedId],
@@ -59,9 +63,7 @@ export const SharedDriveUploadStatusPopupHost = ({
   const [isExpanded, setIsExpanded] = useState(false);
   const [cancellingUploadId, setCancellingUploadId] = useState<Maybe<string>>(Maybe.nothing());
   const [retryingUploadId, setRetryingUploadId] = useState<Maybe<string>>(Maybe.nothing());
-  const [localDismissedUpload, setLocalDismissedUpload] = useState<Maybe<DismissedUpload>>(
-    Maybe.nothing(),
-  );
+  const [localDismissedUpload, setLocalDismissedUpload] = useState<Maybe<DismissedUpload>>(Maybe.nothing());
   const dismissedUpload = isProvided ? contextDismissedUpload : localDismissedUpload;
   const dismissUpload = useCallback(
     (upload: DismissedUpload) => {

--- a/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.test.tsx
@@ -29,6 +29,7 @@ import {
 import {translateForTest} from 'Util/test/translateForTest';
 
 import type {SharedDriveUploadController} from '../conversationCells/sharedDriveUploadController';
+import type {DismissedUpload} from '../conversationCells/sharedDriveUploadStatus';
 
 import {ConversationTabs} from './conversationTabs';
 import {SharedDriveUploadStatusProvider} from '../conversationCells/sharedDriveUploadStatusContext';
@@ -88,7 +89,7 @@ const createController = (state: UploadState | null = null) => {
 const renderTabs = (
   controller: SharedDriveUploadController,
   isUploadStatusIndicatorEnabled = true,
-  dismissedUpload = Maybe.nothing(),
+  dismissedUpload: Maybe<DismissedUpload> = Maybe.nothing<DismissedUpload>(),
 ) =>
   render(
     <ThemeProvider>
@@ -99,7 +100,6 @@ const renderTabs = (
           conversationQualifiedId={conversationQualifiedId}
           sharedDriveUploadController={controller}
           isUploadStatusIndicatorEnabled={isUploadStatusIndicatorEnabled}
-          dismissedUpload={dismissedUpload}
         />
       </SharedDriveUploadStatusProvider>
     </ThemeProvider>,

--- a/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.test.tsx
@@ -19,6 +19,7 @@
 
 import {act, render} from '@testing-library/react';
 import {ThemeProvider} from '@wireapp/react-ui-kit';
+import {Maybe} from 'true-myth';
 
 import type {UploadState} from 'Repositories/cells/upload';
 import {
@@ -30,6 +31,7 @@ import {translateForTest} from 'Util/test/translateForTest';
 import type {SharedDriveUploadController} from '../conversationCells/sharedDriveUploadController';
 
 import {ConversationTabs} from './conversationTabs';
+import {SharedDriveUploadStatusProvider} from '../conversationCells/sharedDriveUploadStatusContext';
 
 const conversationQualifiedId = {id: 'conversation', domain: 'example.com'};
 const conversationQualifiedIdString = 'conversation@example.com';
@@ -83,16 +85,23 @@ const createController = (state: UploadState | null = null) => {
   };
 };
 
-const renderTabs = (controller: SharedDriveUploadController, isUploadStatusIndicatorEnabled = true) =>
+const renderTabs = (
+  controller: SharedDriveUploadController,
+  isUploadStatusIndicatorEnabled = true,
+  dismissedUpload = Maybe.nothing(),
+) =>
   render(
     <ThemeProvider>
-      <ConversationTabs
+      <SharedDriveUploadStatusProvider initialDismissedUpload={dismissedUpload}>
+        <ConversationTabs
         activeTabIndex={0}
         onIndexChange={jest.fn()}
         conversationQualifiedId={conversationQualifiedId}
         sharedDriveUploadController={controller}
         isUploadStatusIndicatorEnabled={isUploadStatusIndicatorEnabled}
-      />
+        dismissedUpload={dismissedUpload}
+        />
+      </SharedDriveUploadStatusProvider>
     </ThemeProvider>,
     {wrapper: createRootProviderWrapperForTest(createRootContextValueForTest({translate: translateForTest}))},
   );
@@ -138,6 +147,14 @@ describe('ConversationTabs', () => {
     expect(view.getByTestId('shared-drive-tab-upload-completed')).toBeInTheDocument();
     expect(view.getByRole('status')).toHaveTextContent('cells.uploadStatus.failed');
     expect(view.queryByTestId('shared-drive-tab-upload-uploading')).not.toBeInTheDocument();
+  });
+
+  it('does not render a dismissed shared drive upload indicator', () => {
+    const {controller} = createController(uploadedState);
+    const view = renderTabs(controller, true, Maybe.just({conversationQualifiedId: conversationQualifiedIdString, uploadId: 'upload-1'}));
+
+    expect(view.queryByTestId('shared-drive-tab-upload-completed')).not.toBeInTheDocument();
+    expect(view.queryByRole('status')).not.toBeInTheDocument();
   });
 
   it('does not render a shared drive upload icon when the indicator is disabled', () => {

--- a/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.test.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.test.tsx
@@ -94,12 +94,12 @@ const renderTabs = (
     <ThemeProvider>
       <SharedDriveUploadStatusProvider initialDismissedUpload={dismissedUpload}>
         <ConversationTabs
-        activeTabIndex={0}
-        onIndexChange={jest.fn()}
-        conversationQualifiedId={conversationQualifiedId}
-        sharedDriveUploadController={controller}
-        isUploadStatusIndicatorEnabled={isUploadStatusIndicatorEnabled}
-        dismissedUpload={dismissedUpload}
+          activeTabIndex={0}
+          onIndexChange={jest.fn()}
+          conversationQualifiedId={conversationQualifiedId}
+          sharedDriveUploadController={controller}
+          isUploadStatusIndicatorEnabled={isUploadStatusIndicatorEnabled}
+          dismissedUpload={dismissedUpload}
         />
       </SharedDriveUploadStatusProvider>
     </ThemeProvider>,
@@ -151,7 +151,11 @@ describe('ConversationTabs', () => {
 
   it('does not render a dismissed shared drive upload indicator', () => {
     const {controller} = createController(uploadedState);
-    const view = renderTabs(controller, true, Maybe.just({conversationQualifiedId: conversationQualifiedIdString, uploadId: 'upload-1'}));
+    const view = renderTabs(
+      controller,
+      true,
+      Maybe.just({conversationQualifiedId: conversationQualifiedIdString, uploadId: 'upload-1'}),
+    );
 
     expect(view.queryByTestId('shared-drive-tab-upload-completed')).not.toBeInTheDocument();
     expect(view.queryByRole('status')).not.toBeInTheDocument();

--- a/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.tsx
@@ -19,6 +19,8 @@
 
 import {useCallback, KeyboardEvent, MouseEvent, useEffect, useState} from 'react';
 
+import {maybe} from 'true-myth';
+
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {stringifyQualifiedId} from '@wireapp/core/lib/util/qualifiedIdUtil';
 
@@ -30,10 +32,8 @@ import {createNavigate, createNavigateKeyboard} from 'src/script/router/routerBi
 import {KEY} from 'Util/keyboardUtil';
 
 import type {SharedDriveUploadController} from '../conversationCells/sharedDriveUploadController';
-import {
-  getLatestSharedDriveUploadStatus,
-  type SharedDriveUploadStatus,
-} from '../conversationCells/sharedDriveUploadStatus';
+import {getLatestSharedDriveUploadStatus, type SharedDriveUploadStatus} from '../conversationCells/sharedDriveUploadStatus';
+import {useSharedDriveUploadStatus} from '../conversationCells/sharedDriveUploadStatusContext';
 
 interface ConversationTabsProps {
   activeTabIndex: number;
@@ -58,6 +58,7 @@ export const ConversationTabs = ({
   isUploadStatusIndicatorEnabled,
 }: ConversationTabsProps) => {
   const {translate} = useApplicationContext();
+  const {dismissedUpload} = useSharedDriveUploadStatus();
   const filesUrl = generateConversationUrl({...conversationQualifiedId, filePath: FILE_PATH});
   const messagesUrl = generateConversationUrl(conversationQualifiedId);
   const conversationQualifiedIdString = stringifyQualifiedId(conversationQualifiedId);
@@ -66,6 +67,10 @@ export const ConversationTabs = ({
     [sharedDriveUploadController, conversationQualifiedIdString],
   );
   const [uploadStatus, setUploadStatus] = useState<SharedDriveUploadStatus | null>(readUploadStatus);
+  const isUploadDismissed =
+    maybe.isJust(dismissedUpload) &&
+    dismissedUpload.value.conversationQualifiedId === conversationQualifiedIdString &&
+    uploadStatus?.uploadId === dismissedUpload.value.uploadId;
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLButtonElement>) => {
@@ -130,7 +135,7 @@ export const ConversationTabs = ({
           id="files"
           label={translate('conversationDetailsActionCellsTitle')}
           isActive={activeTabIndex === 1}
-          uploadStatus={isUploadStatusIndicatorEnabled ? uploadStatus : null}
+          uploadStatus={isUploadStatusIndicatorEnabled && !isUploadDismissed ? uploadStatus : null}
           onClick={event => {
             createNavigate(filesUrl)(event);
             onIndexChange(1);

--- a/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.tsx
+++ b/apps/webapp/src/script/components/conversation/conversationTabs/conversationTabs.tsx
@@ -19,10 +19,9 @@
 
 import {useCallback, KeyboardEvent, MouseEvent, useEffect, useState} from 'react';
 
-import {maybe} from 'true-myth';
-
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {stringifyQualifiedId} from '@wireapp/core/lib/util/qualifiedIdUtil';
+import {maybe} from 'true-myth';
 
 import {SharedDriveUploadCompletedIcon, SharedDriveUploadSpinnerIcon} from '@wireapp/react-ui-kit';
 
@@ -32,7 +31,10 @@ import {createNavigate, createNavigateKeyboard} from 'src/script/router/routerBi
 import {KEY} from 'Util/keyboardUtil';
 
 import type {SharedDriveUploadController} from '../conversationCells/sharedDriveUploadController';
-import {getLatestSharedDriveUploadStatus, type SharedDriveUploadStatus} from '../conversationCells/sharedDriveUploadStatus';
+import {
+  getLatestSharedDriveUploadStatus,
+  type SharedDriveUploadStatus,
+} from '../conversationCells/sharedDriveUploadStatus';
 import {useSharedDriveUploadStatus} from '../conversationCells/sharedDriveUploadStatusContext';
 
 interface ConversationTabsProps {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28486" title="WPB-28486" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28486</a>  [web] add a close/dismiss button once all progress is idle
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Problem

When a direct upload finishes, the upload popup shows a close button. Closing it removes the popup, but the completed upload indicator stays in the Files tab:

`data-testid="shared-drive-tab-upload-completed"`

That makes the upload look like it is still waiting for attention.

Jira: https://wearezeta.atlassian.net/browse/WPB-28486

## Solution

The popup and the Files tab now use the same conversation-scoped React context for dismissed upload state.

When the close button is clicked, the upload is dismissed in both places. The indicator still appears for new uploads, since they have a different upload ID.

## DEMO


https://github.com/user-attachments/assets/51b85089-1c87-4da7-bd40-7076d40be05e

